### PR TITLE
feat(sdk): validate component variables and function calls in compiler

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -1285,6 +1285,129 @@ class TestWriteToFileTypes(parameterized.TestCase):
 
 class TestCompileComponent(parameterized.TestCase):
 
+    def test_validate_component_funcs_and_vars(self):
+        """Test that validation catches unimported/undefined functions and closure variables (functions and non-functions)."""
+
+        import os
+
+        @dsl.component
+        def component_with_module_imported_outside():
+            # This should raise an error, as os is imported
+            # in the script (above), but not in the component
+            os.getcwd()
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Component component_with_module_imported_outside uses names that are neither defined nor imported in the function: \['os'\]"
+        ):
+            compiler.Compiler().compile(
+                pipeline_func=component_with_module_imported_outside,
+                package_path='/tmp/pipeline.yaml',
+                validate=True)
+
+        def outside_func():
+            pass
+
+        # disable yapf formatting to keep multiline component
+        # yapf: disable
+        @dsl.component(
+            packages_to_install='numpy'
+        ) # yapf: enable
+        def component_with_func_defined_outside():
+            outside_func()
+
+        # This should raise an error since outside_func is not imported or defined in component
+        with self.assertRaisesRegex(ValueError,
+                                    r"Component component_with_func_defined_outside uses names that are neither defined nor imported in the function: \['outside_func'\]"):
+            compiler.Compiler().compile(
+                pipeline_func=component_with_func_defined_outside,
+                package_path='/tmp/pipeline.yaml',
+                validate=True)
+
+        # disable yapf formatting to keep multiline component
+        # yapf: disable
+        @dsl.component(
+            base_image='python:3.11'
+        ) # yapf: enable
+        def component_with_defined_func():
+            def helper():
+                pass
+            helper()  # This function is defined in the component
+
+        # This should not raise an error
+        with tempfile.TemporaryDirectory() as tmpdir:
+            compiler.Compiler().compile(
+                pipeline_func=component_with_defined_func,
+                package_path=os.path.join(tmpdir, 'pipeline.yaml'),
+                validate=True)
+
+        @dsl.component
+        def component_with_imported_func():
+            import math
+            math.sqrt(4)  # This function is imported
+
+        # This should not raise an error
+        with tempfile.TemporaryDirectory() as tmpdir:
+            compiler.Compiler().compile(
+                pipeline_func=component_with_imported_func,
+                package_path=os.path.join(tmpdir, 'pipeline.yaml'),
+                validate=True)
+
+        # Test closure variable that is not a function
+        outside_var = 42
+        @dsl.component
+        def component_with_closure_var():
+            return outside_var
+        with self.assertRaisesRegex(ValueError,
+                                    r"Component component_with_closure_var uses names that are neither defined nor imported in the function: \['outside_var'\]"):
+            compiler.Compiler().compile(
+                pipeline_func=component_with_closure_var,
+                package_path='/tmp/pipeline.yaml',
+                validate=True)
+
+        # Test that validate=True works for a non-python (YAML-based) component
+        with tempfile.TemporaryDirectory() as tmpdir:
+            compiler.Compiler().compile(
+                pipeline_func=VALID_PRODUCER_COMPONENT_SAMPLE,
+                package_path=os.path.join(tmpdir, 'pipeline.yaml'),
+                validate=True)
+
+        # Test that validate=True works for a pipeline with a faulty component
+        @dsl.pipeline
+        def pipeline_with_faulty_component(input_var: str):
+            good_comp1 = component_with_imported_func()
+            good_comp2 = VALID_PRODUCER_COMPONENT_SAMPLE(input_param=input_var)
+            bad_comp1 = component_with_func_defined_outside().after(good_comp1)
+            good_comp3 = component_with_defined_func().after(bad_comp1)
+
+        # This should raise an error since component_with_func_defined_outside uses outside_func
+        with self.assertRaisesRegex(ValueError,
+                                    r"Component component_with_func_defined_outside uses names that are neither defined nor imported in the function: \['outside_func'\]"):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                compiler.Compiler().compile(
+                    pipeline_func=pipeline_with_faulty_component,
+                    package_path=os.path.join(tmpdir, 'pipeline.yaml'),
+                    validate=True)
+
+        # Test that validate=True works for a pipeline with a faulty component
+        # under a parallelFor loop
+        @dsl.pipeline
+        def pipeline_with_faulty_component(input_var: str):
+            good_comp1 = component_with_imported_func()
+            with dsl.ParallelFor([1,2,3]) as item:
+                good_comp2 = VALID_PRODUCER_COMPONENT_SAMPLE(input_param=input_var)
+                bad_comp1 = component_with_func_defined_outside().after(good_comp1)
+                good_comp3 = component_with_defined_func().after(bad_comp1)
+
+        # This should raise an error since component_with_func_defined_outside uses outside_func
+        with self.assertRaisesRegex(ValueError,
+                                    r"Component component_with_func_defined_outside uses names that are neither defined nor imported in the function: \['outside_func'\]"):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                compiler.Compiler().compile(
+                    pipeline_func=pipeline_with_faulty_component,
+                    package_path=os.path.join(tmpdir, 'pipeline.yaml'),
+                    validate=True)
+
     @parameterized.parameters(['.json', '.yaml', '.yml'])
     def test_compile_component_simple(self, extension: str):
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -35,10 +35,11 @@ from kfp.dsl import placeholders
 from kfp.dsl import structures
 from kfp.dsl import tasks_group
 from kfp.dsl import utils
-from kfp.dsl.types import artifact_types
 from kfp.dsl.types import type_utils
 from kfp.pipeline_spec import pipeline_spec_pb2
 import yaml
+
+GroupOrTaskType = Union[tasks_group.TasksGroup, pipeline_task.PipelineTask]
 
 # must be defined here to avoid circular imports
 group_type_to_dsl_class = {
@@ -1219,10 +1220,9 @@ def build_spec_by_group(
     group: tasks_group.TasksGroup,
     inputs: Mapping[str, List[Tuple[pipeline_channel.PipelineChannel, str]]],
     outputs: DefaultDict[str, Dict[str, pipeline_channel.PipelineChannel]],
-    dependencies: Dict[str, List[compiler_utils.GroupOrTaskType]],
+    dependencies: Dict[str, List[GroupOrTaskType]],
     rootgroup_name: str,
-    task_name_to_parent_groups: Mapping[str,
-                                        List[compiler_utils.GroupOrTaskType]],
+    task_name_to_parent_groups: Mapping[str, List[GroupOrTaskType]],
     group_name_to_parent_groups: Mapping[str, List[tasks_group.TasksGroup]],
     name_to_for_loop_group: Mapping[str, tasks_group.ParallelFor],
     platform_spec: pipeline_spec_pb2.PlatformSpec,


### PR DESCRIPTION
KFP python-based components require that any functions and variables they use are either imported or defined within the component function. However, this was never validated, making it possible to define pipelines/components that pass formatting/linting checks and kfp compilation, but then fail during runtime.

When a pipeline fails during runtime, it can be a major problem as time and money are wasted on resources and developers are forced to troubleshoot otherwise preventable issues. This new validation solves the problem.

Note that the scope of this feature is not comprehensive validation. However, it does set a foundation for further work in this area.

**Description of your changes:**

I added variable and function call validation to compiler to check that variables and functions are either properly imported or defined within components.  Also added tests to make sure the new feature is working.

I added an optional `validate` parameter to `kfp.compiler.Compiler().compile` with default `False`. When set to `True`, the compiler validates that all variables and functions used by any component function in a pipeline, are either defined inside the function, or they are properly imported within their respective components.  The flag is meant to make the feature fully backwards compatible, with the idea that this can be further incorporated later (perhaps on the next major/minor release), by making the flag default to True.

For example, the following code would fail compilation (as expected), since `os` is imported outside of the component (the script is valid Python, so linting doesn't pick it up)
```python
from kfp.compiler import Compiler

import kfp
from kfp.dsl import component
import os

@component
def mycomp(var1: str):
  # os not imported here as it should be
  os.getcwd()

# compile will fail with validate=True
# saving developer headaches later
Compiler().compile(mycomp, 'mycomp.yaml', validate=True)
```
This PR also created error messaging. The error message when `python comp.py` is run will be:
```python
  return component_factory.create_component_from_func(
Traceback (most recent call last):
  File "/Users/ddowler/Code/Sandbox/temp-validate-component/comp.py", line 15, in <module>
    Compiler().compile(mycomp, 'mycomp.yaml', validate=True) 
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ddowler/Code/Kubeflow/pipelines/sdk/python/kfp/compiler/compiler.py", line 87, in compile
    compiler_utils.validate_component(pipeline_func)
  File "/Users/ddowler/Code/Kubeflow/pipelines/sdk/python/kfp/compiler/compiler_utils.py", line 982, in validate_component
    validate_component_imports(component)
  File "/Users/ddowler/Code/Kubeflow/pipelines/sdk/python/kfp/compiler/compiler_utils.py", line 968, in validate_component_imports
    raise ValueError(
ValueError: Component mycomp uses functions that are neither defined nor imported: {'os.getcwd', 'print', 'os'}
```

Without this feature, it is possible to compile a component that uses functions defined outside its context; despite the compile succeeding, the component fails to run. This can be a huge problem, as a component with a bad function call could be several layers deep in a pipeline, and time and money are wasted before the error hits during runtime.

Without this feature (or setting `validate=False`), the above code example will compile successfully, but the component would fail at runtime since  the `os` module is not properly imported within the component code.
 
Note: I used Cursor to assist with some development. This helped in some areas, however, the AI struggled significantly, in particular with nested Python functions and their closure scopes, as well as with some specific KFP SDK understanding.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
