### PR TITLE
chore: handle empty tolerations dict/lists parrameterization 

### DIFF
--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -841,8 +841,8 @@ func extendPodSpecPatch(
 						}
 						k8sTolerations = append(k8sTolerations, k8sTolerationsList...)
 					} else {
-						return fmt.Errorf("encountered unexpected toleration proto value, "+
-							"must be either struct or list type: %w", err)
+						return fmt.Errorf("encountered unexpected toleration proto value, " +
+							"must be either struct or list type.")
 					}
 				} else {
 					k8sToleration.Key = toleration.Key

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -2065,6 +2065,29 @@ func Test_extendPodSpecPatch_Tolerations(t *testing.T) {
 				}),
 			},
 		},
+
+		{
+			"Valid - toleration json - empty component input",
+			&kubernetesplatform.KubernetesExecutorConfig{
+				Tolerations: []*kubernetesplatform.Toleration{
+					{
+						TolerationJson: inputParamComponent("param_1"),
+					},
+				},
+			},
+			&k8score.PodSpec{
+				Containers: []k8score.Container{
+					{
+						Name: "main",
+					},
+				},
+				Tolerations: nil,
+			},
+			map[string]*structpb.Value{
+				"param_1": validValueStructOrPanic(map[string]interface{}{}),
+			},
+		},
+
 		{
 			"Valid - toleration json - multiple input types",
 			&kubernetesplatform.KubernetesExecutorConfig{
@@ -2290,6 +2313,28 @@ func Test_extendPodSpecPatch_Tolerations(t *testing.T) {
 					"effect":            "NoSchedule",
 					"tolerationSeconds": 3604,
 				}),
+			},
+		},
+
+		{
+			"Valid - toleration json - empty toleration list",
+			&kubernetesplatform.KubernetesExecutorConfig{
+				Tolerations: []*kubernetesplatform.Toleration{
+					{
+						TolerationJson: inputParamComponent("param_1"),
+					},
+				},
+			},
+			&k8score.PodSpec{
+				Containers: []k8score.Container{
+					{
+						Name: "main",
+					},
+				},
+				Tolerations: nil,
+			},
+			map[string]*structpb.Value{
+				"param_1": validListOfStructsOrPanic([]map[string]interface{}{}),
 			},
 		},
 	}


### PR DESCRIPTION
**Description of your changes:**

We want to be able to handle empty cases for tolerations/node selector gracefully. In the case of non lists (i.e. just one toleration struct), the empty case will fail currently with:

```
message: 'task ''my-pipeline-bmkd5.root.some-component.executor'' errored: Pod "my-pipeline-bmkd5-system-container-impl-4081191241" is invalid: spec.tolerations[0].operator: Invalid value: "": operator must be Exists when `key` is empty, which means "match all values and all keys"'
```

Tolerations list case is handled already implicitly but we just wrap it with an explicit check, and also add some test cases in this pr. 



**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

