### PR TITLE
fix(sdk): Resolves issue when using ParallelFor with param and depending tasks

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -838,6 +838,23 @@ implementation:
                 with dsl.ParallelFor(items=single_param_task.output) as item:
                     print_and_return(text=item)
 
+    def test_compile_parallel_for_with_param_and_depending_task(self):
+
+        @dsl.component
+        def print_op(s: str):
+            print(s)
+
+        @dsl.pipeline
+        def my_pipeline(param: str):
+            with dsl.ParallelFor(items=['a', 'b']) as item:
+                parallel_tasks = print_op(s=item)
+            print_op(s=param).after(parallel_tasks)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            output_yaml = os.path.join(tempdir, 'result.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=my_pipeline, package_path=output_yaml)
+
     def test_cannot_compile_parallel_for_with_single_artifact(self):
 
         with self.assertRaisesRegex(

--- a/sdk/python/kfp/compiler/compiler_utils.py
+++ b/sdk/python/kfp/compiler/compiler_utils.py
@@ -761,7 +761,9 @@ def get_dependencies(
                 # then make this validation dsl.Collected-aware
                 elif isinstance(upstream_parent_group, tasks_group.ParallelFor):
                     upstream_tasks_that_downstream_consumers_from = [
-                        channel.task.name for channel in task._channel_inputs
+                        channel.task.name
+                        for channel in task._channel_inputs
+                        if channel.task is not None
                     ]
                     has_data_exchange = upstream_task.name in upstream_tasks_that_downstream_consumers_from
                     # don't raise for .after


### PR DESCRIPTION
**Description of your changes:**

Fixes: #10592.

`compiler_utils.get_dependencies` function validates `name` attribute each task in `_channel_inputs`. The bug is that it tries to retrieve the `name` attribute even if the task is `None`.

A similar fix was already introduced in another PR #11476. However, the contributor has not responded to the requests to rebase and to add tests for months.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
