### PR TITLE
feat(backend): Add CLI flags to support Kubernetes native API implementation

### DIFF
--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -117,6 +117,7 @@ type ClientManager struct {
 // Options to pass to Client Manager initialization
 type Options struct {
 	UsePipelineKubernetesStorage bool
+	GlobalKubernetesWebhookMode  bool
 	Context                      context.Context
 	WaitGroup                    *sync.WaitGroup
 }
@@ -210,7 +211,7 @@ func (c *ClientManager) init(options *Options) error {
 
 	var pipelineStoreForRef storage.PipelineStoreInterface
 
-	if options.UsePipelineKubernetesStorage || common.IsOnlyKubernetesWebhookMode() {
+	if options.UsePipelineKubernetesStorage || options.GlobalKubernetesWebhookMode {
 		glog.Info("Initializing controller client...")
 		restConfig, err := util.GetKubernetesConfig()
 		if err != nil {
@@ -219,7 +220,7 @@ func (c *ClientManager) init(options *Options) error {
 
 		var cacheConfig map[string]cache.Config
 
-		if !common.IsMultiUserMode() && common.GetPodNamespace() != "" && !common.IsOnlyKubernetesWebhookMode() {
+		if !common.IsMultiUserMode() && common.GetPodNamespace() != "" && !options.GlobalKubernetesWebhookMode {
 			cacheConfig = map[string]cache.Config{common.GetPodNamespace(): {}}
 		}
 
@@ -259,7 +260,7 @@ func (c *ClientManager) init(options *Options) error {
 
 		c.controllerClient = controllerClient
 		c.controllerClientNoCache = controllerClientNoCache
-		if common.IsOnlyKubernetesWebhookMode() {
+		if options.GlobalKubernetesWebhookMode {
 			return nil
 		}
 

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -32,7 +32,6 @@ const (
 	KubeflowUserIDPrefix                    string = "KUBEFLOW_USERID_PREFIX"
 	UpdatePipelineVersionByDefault          string = "AUTO_UPDATE_PIPELINE_DEFAULT_VERSION"
 	TokenReviewAudience                     string = "TOKEN_REVIEW_AUDIENCE"
-	GlobalKubernetesWebhookMode             string = "GLOBAL_KUBERNETES_WEBHOOK_MODE"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {
@@ -127,8 +126,4 @@ func GetKubeflowUserIDPrefix() string {
 
 func GetTokenReviewAudience() string {
 	return GetStringConfigWithDefault(TokenReviewAudience, DefaultTokenReviewAudience)
-}
-
-func IsOnlyKubernetesWebhookMode() bool {
-	return GetBoolConfigWithDefault(GlobalKubernetesWebhookMode, false)
 }


### PR DESCRIPTION
**Description of your changes:**

- Introduces two new CLI flags to enable support for the Kubernetes native API implementation.

- Converts pipeline names and versions to Kubernetes-compatible format before creating them as resources in Kubernetes.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
