### PR TITLE
feat(backend) implement retryStrategy for nested pipelines 

### DIFF
--- a/backend/src/v2/compiler/argocompiler/argo_test.go
+++ b/backend/src/v2/compiler/argocompiler/argo_test.go
@@ -100,6 +100,23 @@ func Test_argo_compiler(t *testing.T) {
 			argoYAMLPath:     "testdata/hello_world_cache_disabled.yaml",
 			compilerOptions:  argocompiler.Options{CacheDisabled: true},
 		},
+		// nested pipeline with retry policy set at the sub-pipeline level
+		{
+			jobPath:          "../testdata/nested_pipeline_pipeline_retry.json",
+			platformSpecPath: "",
+			argoYAMLPath:     "testdata/nested_pipeline_pipeline_retry.yaml",
+		},
+		// nested pipeline with retry policy set at the sub-component level.
+		{
+			jobPath:          "../testdata/nested_pipeline_sub_component_retry.json",
+			platformSpecPath: "",
+			argoYAMLPath:     "testdata/nested_pipeline_sub_component_retry.yaml",
+		},
+		{
+			jobPath:          "../testdata/nested_pipeline_all_level_retry.json",
+			platformSpecPath: "",
+			argoYAMLPath:     "testdata/nested_pipeline_all_level_retry.yaml",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%+v", tt), func(t *testing.T) {

--- a/backend/src/v2/compiler/argocompiler/container_test.go
+++ b/backend/src/v2/compiler/argocompiler/container_test.go
@@ -58,8 +58,8 @@ func TestAddContainerExecutorTemplate(t *testing.T) {
 					},
 				},
 			}
-
-			c.addContainerExecutorTemplate("test-ref", "comp-test-ref")
+			//todo: update "root" input
+			c.addContainerExecutorTemplate("root", "test-ref", "comp-test-ref")
 			assert.NotEmpty(t, "system-container-impl", "Template name should not be empty")
 
 			executorTemplate, exists := c.templates["system-container-impl"]

--- a/backend/src/v2/compiler/argocompiler/testdata/nested_pipeline_all_level_retry.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/nested_pipeline_all_level_retry.yaml
@@ -1,0 +1,520 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  creationTimestamp: null
+  generateName: hello-world-
+spec:
+  arguments:
+    parameters:
+      - name: components-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603
+        value: '{"executorLabel":"exec-component-a"}'
+      - name: implementations-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603
+        value: '{"args":["--executor_input","{{$}}","--function_to_execute","component_a"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.13.0'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        component_a():\n    print(''Component A'')\n\n"],"image":"python:3.9"}'
+      - name: components-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23
+        value: '{"executorLabel":"exec-component-b"}'
+      - name: implementations-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23
+        value: '{"args":["--executor_input","{{$}}","--function_to_execute","component_b"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.13.0'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        component_b():\n    print (''Component B'')\n\n"],"image":"python:3.9"}'
+      - name: components-comp-nested-pipeline
+        value: '{"dag":{"tasks":{"component-a":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-a"},"taskInfo":{"name":"component-a"}},"component-b":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-b"},"retryPolicy":{"backoffDuration":"0s","backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":2},"taskInfo":{"name":"component-b"}}}}}'
+      - name: components-root
+        value: '{"dag":{"tasks":{"nested-pipeline":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-nested-pipeline"},"retryPolicy":{"backoffDuration":"0s","backoffFactor":1,"backoffMaxDuration":"1800s","maxRetryCount":1},"taskInfo":{"name":"nested-pipeline"}}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  serviceAccountName: pipeline-runner
+  templates:
+    - container:
+        args:
+          - --type
+          - CONTAINER
+          - --pipeline_name
+          - hello-world
+          - --run_id
+          - '{{workflow.uid}}'
+          - --run_name
+          - '{{workflow.name}}'
+          - --run_display_name
+          - ''
+          - --dag_execution_id
+          - '{{inputs.parameters.parent-dag-id}}'
+          - --component
+          - '{{inputs.parameters.component}}'
+          - --task
+          - '{{inputs.parameters.task}}'
+          - --container
+          - '{{inputs.parameters.container}}'
+          - --iteration_index
+          - '{{inputs.parameters.iteration-index}}'
+          - --cached_decision_path
+          - '{{outputs.parameters.cached-decision.path}}'
+          - --pod_spec_patch_path
+          - '{{outputs.parameters.pod-spec-patch.path}}'
+          - --condition_path
+          - '{{outputs.parameters.condition.path}}'
+          - --kubernetes_config
+          - '{{inputs.parameters.kubernetes-config}}'
+          - --http_proxy
+          - ""
+          - --https_proxy
+          - ""
+          - --no_proxy
+          - ""
+        command:
+          - driver
+        image: ghcr.io/kubeflow/kfp-driver
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+      inputs:
+        parameters:
+          - name: component
+          - name: task
+          - name: container
+          - name: parent-dag-id
+          - default: "-1"
+            name: iteration-index
+          - default: ""
+            name: kubernetes-config
+      name: system-container-driver
+      outputs:
+        parameters:
+          - name: pod-spec-patch
+            valueFrom:
+              default: ""
+              path: /tmp/outputs/pod-spec-patch
+          - default: "false"
+            name: cached-decision
+            valueFrom:
+              default: "false"
+              path: /tmp/outputs/cached-decision
+          - name: condition
+            valueFrom:
+              default: "true"
+              path: /tmp/outputs/condition
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{inputs.parameters.pod-spec-patch}}'
+            name: executor
+            template: system-container-impl
+            when: '{{inputs.parameters.cached-decision}} != true'
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+          - default: "false"
+            name: cached-decision
+      name: system-container-executor
+      outputs: {}
+    - container:
+        command:
+          - should-be-overridden-during-runtime
+        env:
+          - name: KFP_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KFP_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+        envFrom:
+          - configMapRef:
+              name: metadata-grpc-configmap
+              optional: true
+        image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+        name: ""
+        resources: {}
+        volumeMounts:
+          - mountPath: /kfp-launcher
+            name: kfp-launcher
+          - mountPath: /gcs
+            name: gcs-scratch
+          - mountPath: /s3
+            name: s3-scratch
+          - mountPath: /minio
+            name: minio-scratch
+          - mountPath: /.local
+            name: dot-local-scratch
+          - mountPath: /.cache
+            name: dot-cache-scratch
+          - mountPath: /.config
+            name: dot-config-scratch
+      initContainers:
+        - args:
+            - --copy
+            - /kfp-launcher/launch
+          command:
+            - launcher-v2
+          image: ghcr.io/kubeflow/kfp-launcher
+          name: kfp-launcher
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+          volumeMounts:
+            - mountPath: /kfp-launcher
+              name: kfp-launcher
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+      name: system-container-impl
+      outputs: {}
+      podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+      volumes:
+        - emptyDir: {}
+          name: kfp-launcher
+        - emptyDir: {}
+          name: gcs-scratch
+        - emptyDir: {}
+          name: s3-scratch
+        - emptyDir: {}
+          name: minio-scratch
+        - emptyDir: {}
+          name: dot-local-scratch
+        - emptyDir: {}
+          name: dot-cache-scratch
+        - emptyDir: {}
+          name: dot-config-scratch
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{inputs.parameters.pod-spec-patch}}'
+                - name: retry-max-count
+                  value: '{{inputs.parameters.retry-max-count}}'
+                - name: retry-backoff-duration
+                  value: '{{inputs.parameters.retry-backoff-duration}}'
+                - name: retry-backoff-factor
+                  value: '{{inputs.parameters.retry-backoff-factor}}'
+                - name: retry-backoff-max-duration
+                  value: '{{inputs.parameters.retry-backoff-max-duration}}'
+            name: executor
+            template: retry-system-container-impl
+            when: '{{inputs.parameters.cached-decision}} != true'
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+          - default: "false"
+            name: cached-decision
+          - default: "0"
+            name: retry-max-count
+          - default: "0"
+            name: retry-backoff-duration
+          - default: "0"
+            name: retry-backoff-factor
+          - default: "0"
+            name: retry-backoff-max-duration
+      name: retry-system-container-executor
+      outputs: {}
+    - container:
+        command:
+          - should-be-overridden-during-runtime
+        env:
+          - name: KFP_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KFP_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+        envFrom:
+          - configMapRef:
+              name: metadata-grpc-configmap
+              optional: true
+        image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+        name: ""
+        resources: {}
+        volumeMounts:
+          - mountPath: /kfp-launcher
+            name: kfp-launcher
+          - mountPath: /gcs
+            name: gcs-scratch
+          - mountPath: /s3
+            name: s3-scratch
+          - mountPath: /minio
+            name: minio-scratch
+          - mountPath: /.local
+            name: dot-local-scratch
+          - mountPath: /.cache
+            name: dot-cache-scratch
+          - mountPath: /.config
+            name: dot-config-scratch
+      initContainers:
+        - args:
+            - --copy
+            - /kfp-launcher/launch
+          command:
+            - launcher-v2
+          image: ghcr.io/kubeflow/kfp-launcher
+          name: kfp-launcher
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+          volumeMounts:
+            - mountPath: /kfp-launcher
+              name: kfp-launcher
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+          - name: retry-max-count
+          - name: retry-backoff-duration
+          - name: retry-backoff-factor
+          - name: retry-backoff-max-duration
+      name: retry-system-container-impl
+      outputs: {}
+      podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+      retryStrategy:
+        backoff:
+          duration: '{{inputs.parameters.retry-backoff-duration}}'
+          factor: '{{inputs.parameters.retry-backoff-factor}}'
+          maxDuration: '{{inputs.parameters.retry-backoff-max-duration}}'
+        limit: '{{inputs.parameters.retry-max-count}}'
+      volumes:
+        - emptyDir: {}
+          name: kfp-launcher
+        - emptyDir: {}
+          name: gcs-scratch
+        - emptyDir: {}
+          name: s3-scratch
+        - emptyDir: {}
+          name: minio-scratch
+        - emptyDir: {}
+          name: dot-local-scratch
+        - emptyDir: {}
+          name: dot-cache-scratch
+        - emptyDir: {}
+          name: dot-config-scratch
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603}}'
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-a"},"taskInfo":{"name":"component-a"}}'
+                - name: container
+                  value: '{{workflow.parameters.implementations-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603}}'
+                - name: parent-dag-id
+                  value: '{{inputs.parameters.parent-dag-id}}'
+            name: component-a-driver
+            template: system-container-driver
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{tasks.component-a-driver.outputs.parameters.pod-spec-patch}}'
+                - default: "false"
+                  name: cached-decision
+                  value: '{{tasks.component-a-driver.outputs.parameters.cached-decision}}'
+            depends: component-a-driver.Succeeded
+            name: component-a
+            template: system-container-executor
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23}}'
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-b"},"retryPolicy":{"backoffDuration":"0s","backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":2},"taskInfo":{"name":"component-b"}}'
+                - name: container
+                  value: '{{workflow.parameters.implementations-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23}}'
+                - name: parent-dag-id
+                  value: '{{inputs.parameters.parent-dag-id}}'
+            name: component-b-driver
+            template: system-container-driver
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{tasks.component-b-driver.outputs.parameters.pod-spec-patch}}'
+                - default: "false"
+                  name: cached-decision
+                  value: '{{tasks.component-b-driver.outputs.parameters.cached-decision}}'
+                - name: retry-max-count
+                  value: "2"
+                - name: retry-backoff-duration
+                  value: "0"
+                - name: retry-backoff-factor
+                  value: "2"
+                - name: retry-backoff-max-duration
+                  value: "3600"
+            depends: component-b-driver.Succeeded
+            name: component-b
+            template: retry-system-container-executor
+      inputs:
+        parameters:
+          - name: parent-dag-id
+          - name: retry-max-count
+          - name: retry-backoff-duration
+          - name: retry-backoff-factor
+          - name: retry-backoff-max-duration
+      name: comp-nested-pipeline
+      outputs: { }
+      retryStrategy:
+        backoff:
+          duration: '{{inputs.parameters.retry-backoff-duration}}'
+          factor: '{{inputs.parameters.retry-backoff-factor}}'
+          maxDuration: '{{inputs.parameters.retry-backoff-max-duration}}'
+        limit: '{{inputs.parameters.retry-max-count}}'
+    - container:
+        args:
+          - --type
+          - '{{inputs.parameters.driver-type}}'
+          - --pipeline_name
+          - hello-world
+          - --run_id
+          - '{{workflow.uid}}'
+          - --run_name
+          - '{{workflow.name}}'
+          - --run_display_name
+          - ''
+          - --dag_execution_id
+          - '{{inputs.parameters.parent-dag-id}}'
+          - --component
+          - '{{inputs.parameters.component}}'
+          - --task
+          - '{{inputs.parameters.task}}'
+          - --runtime_config
+          - '{{inputs.parameters.runtime-config}}'
+          - --iteration_index
+          - '{{inputs.parameters.iteration-index}}'
+          - --execution_id_path
+          - '{{outputs.parameters.execution-id.path}}'
+          - --iteration_count_path
+          - '{{outputs.parameters.iteration-count.path}}'
+          - --condition_path
+          - '{{outputs.parameters.condition.path}}'
+          - --http_proxy
+          - ""
+          - --https_proxy
+          - ""
+          - --no_proxy
+          - ""
+        command:
+          - driver
+        image: ghcr.io/kubeflow/kfp-driver
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+      inputs:
+        parameters:
+          - name: component
+          - default: ""
+            name: runtime-config
+          - default: ""
+            name: task
+          - default: "0"
+            name: parent-dag-id
+          - default: "-1"
+            name: iteration-index
+          - default: DAG
+            name: driver-type
+      name: system-dag-driver
+      outputs:
+        parameters:
+          - name: execution-id
+            valueFrom:
+              path: /tmp/outputs/execution-id
+          - name: iteration-count
+            valueFrom:
+              default: "0"
+              path: /tmp/outputs/iteration-count
+          - name: condition
+            valueFrom:
+              default: "true"
+              path: /tmp/outputs/condition
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-comp-nested-pipeline}}'
+                - name: parent-dag-id
+                  value: '{{inputs.parameters.parent-dag-id}}'
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-nested-pipeline"},"retryPolicy":{"backoffDuration":"0s","backoffFactor":1,"backoffMaxDuration":"1800s","maxRetryCount":1},"taskInfo":{"name":"nested-pipeline"}}'
+            name: nested-pipeline-driver
+            template: system-dag-driver
+          - arguments:
+              parameters:
+                - name: parent-dag-id
+                  value: '{{tasks.nested-pipeline-driver.outputs.parameters.execution-id}}'
+                - name: condition
+                  value: '{{tasks.nested-pipeline-driver.outputs.parameters.condition}}'
+                - name: retry-max-count
+                  value: "1"
+                - name: retry-backoff-duration
+                  value: "0"
+                - name: retry-backoff-factor
+                  value: "1"
+                - name: retry-backoff-max-duration
+                  value: "1800"
+            depends: nested-pipeline-driver.Succeeded
+            name: nested-pipeline
+            template: comp-nested-pipeline
+      inputs:
+        parameters:
+          - name: parent-dag-id
+      name: root
+      outputs: {}
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-root}}'
+                - name: runtime-config
+                  value: '{}'
+                - name: driver-type
+                  value: ROOT_DAG
+            name: root-driver
+            template: system-dag-driver
+          - arguments:
+              parameters:
+                - name: parent-dag-id
+                  value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+                - name: condition
+                  value: ""
+            depends: root-driver.Succeeded
+            name: root
+            template: root
+      inputs: {}
+      name: entrypoint
+      outputs: {}

--- a/backend/src/v2/compiler/argocompiler/testdata/nested_pipeline_pipeline_retry.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/nested_pipeline_pipeline_retry.yaml
@@ -1,0 +1,421 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  creationTimestamp: null
+  generateName: hello-world-
+spec:
+  arguments:
+    parameters:
+      - name: components-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603
+        value: '{"executorLabel":"exec-component-a"}'
+      - name: implementations-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603
+        value: '{"args":["--executor_input","{{$}}","--function_to_execute","component_a"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.13.0'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        component_a():\n    print(''Component A'')\n\n"],"image":"python:3.9"}'
+      - name: components-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23
+        value: '{"executorLabel":"exec-component-b"}'
+      - name: implementations-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23
+        value: '{"args":["--executor_input","{{$}}","--function_to_execute","component_b"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.13.0'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        component_b():\n    print (''Component B'')\n\n"],"image":"python:3.9"}'
+      - name: components-comp-nested-pipeline
+        value: '{"dag":{"tasks":{"component-a":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-a-2"},"taskInfo":{"name":"component-a"}},"component-b":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-b"},"taskInfo":{"name":"component-b"}}}}}'
+      - name: components-root
+        value: '{"dag":{"tasks":{"component-a":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-a"},"taskInfo":{"name":"component-a"}},"nested-pipeline":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-nested-pipeline"},"retryPolicy":{"backoffDuration":"0s","backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":2},"taskInfo":{"name":"nested-pipeline"}}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  serviceAccountName: pipeline-runner
+  templates:
+    - container:
+        args:
+          - --type
+          - CONTAINER
+          - --pipeline_name
+          - hello-world
+          - --run_id
+          - '{{workflow.uid}}'
+          - --run_name
+          - '{{workflow.name}}'
+          - --run_display_name
+          - ''
+          - --dag_execution_id
+          - '{{inputs.parameters.parent-dag-id}}'
+          - --component
+          - '{{inputs.parameters.component}}'
+          - --task
+          - '{{inputs.parameters.task}}'
+          - --container
+          - '{{inputs.parameters.container}}'
+          - --iteration_index
+          - '{{inputs.parameters.iteration-index}}'
+          - --cached_decision_path
+          - '{{outputs.parameters.cached-decision.path}}'
+          - --pod_spec_patch_path
+          - '{{outputs.parameters.pod-spec-patch.path}}'
+          - --condition_path
+          - '{{outputs.parameters.condition.path}}'
+          - --kubernetes_config
+          - '{{inputs.parameters.kubernetes-config}}'
+          - --http_proxy
+          - ""
+          - --https_proxy
+          - ""
+          - --no_proxy
+          - ""
+        command:
+          - driver
+        image: ghcr.io/kubeflow/kfp-driver
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+      inputs:
+        parameters:
+          - name: component
+          - name: task
+          - name: container
+          - name: parent-dag-id
+          - default: "-1"
+            name: iteration-index
+          - default: ""
+            name: kubernetes-config
+      name: system-container-driver
+      outputs:
+        parameters:
+          - name: pod-spec-patch
+            valueFrom:
+              default: ""
+              path: /tmp/outputs/pod-spec-patch
+          - default: "false"
+            name: cached-decision
+            valueFrom:
+              default: "false"
+              path: /tmp/outputs/cached-decision
+          - name: condition
+            valueFrom:
+              default: "true"
+              path: /tmp/outputs/condition
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{inputs.parameters.pod-spec-patch}}'
+            name: executor
+            template: system-container-impl
+            when: '{{inputs.parameters.cached-decision}} != true'
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+          - default: "false"
+            name: cached-decision
+      name: system-container-executor
+      outputs: {}
+    - container:
+        command:
+          - should-be-overridden-during-runtime
+        env:
+          - name: KFP_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KFP_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+        envFrom:
+          - configMapRef:
+              name: metadata-grpc-configmap
+              optional: true
+        image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+        name: ""
+        resources: {}
+        volumeMounts:
+          - mountPath: /kfp-launcher
+            name: kfp-launcher
+          - mountPath: /gcs
+            name: gcs-scratch
+          - mountPath: /s3
+            name: s3-scratch
+          - mountPath: /minio
+            name: minio-scratch
+          - mountPath: /.local
+            name: dot-local-scratch
+          - mountPath: /.cache
+            name: dot-cache-scratch
+          - mountPath: /.config
+            name: dot-config-scratch
+      initContainers:
+        - args:
+            - --copy
+            - /kfp-launcher/launch
+          command:
+            - launcher-v2
+          image: ghcr.io/kubeflow/kfp-launcher
+          name: kfp-launcher
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+          volumeMounts:
+            - mountPath: /kfp-launcher
+              name: kfp-launcher
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+      name: system-container-impl
+      outputs: {}
+      podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+      volumes:
+        - emptyDir: {}
+          name: kfp-launcher
+        - emptyDir: {}
+          name: gcs-scratch
+        - emptyDir: {}
+          name: s3-scratch
+        - emptyDir: {}
+          name: minio-scratch
+        - emptyDir: {}
+          name: dot-local-scratch
+        - emptyDir: {}
+          name: dot-cache-scratch
+        - emptyDir: {}
+          name: dot-config-scratch
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603}}'
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-a-2"},"taskInfo":{"name":"component-a"}}'
+                - name: container
+                  value: '{{workflow.parameters.implementations-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603}}'
+                - name: parent-dag-id
+                  value: '{{inputs.parameters.parent-dag-id}}'
+            name: component-a-driver
+            template: system-container-driver
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{tasks.component-a-driver.outputs.parameters.pod-spec-patch}}'
+                - default: "false"
+                  name: cached-decision
+                  value: '{{tasks.component-a-driver.outputs.parameters.cached-decision}}'
+            depends: component-a-driver.Succeeded
+            name: component-a
+            template: system-container-executor
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23}}'
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-b"},"taskInfo":{"name":"component-b"}}'
+                - name: container
+                  value: '{{workflow.parameters.implementations-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23}}'
+                - name: parent-dag-id
+                  value: '{{inputs.parameters.parent-dag-id}}'
+            name: component-b-driver
+            template: system-container-driver
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{tasks.component-b-driver.outputs.parameters.pod-spec-patch}}'
+                - default: "false"
+                  name: cached-decision
+                  value: '{{tasks.component-b-driver.outputs.parameters.cached-decision}}'
+            depends: component-b-driver.Succeeded
+            name: component-b
+            template: system-container-executor
+      inputs:
+        parameters:
+          - name: parent-dag-id
+          - name: retry-max-count
+          - name: retry-backoff-duration
+          - name: retry-backoff-factor
+          - name: retry-backoff-max-duration
+      name: comp-nested-pipeline
+      outputs: {}
+      retryStrategy:
+        backoff:
+          duration: '{{inputs.parameters.retry-backoff-duration}}'
+          factor: '{{inputs.parameters.retry-backoff-factor}}'
+          maxDuration: '{{inputs.parameters.retry-backoff-max-duration}}'
+        limit: '{{inputs.parameters.retry-max-count}}'
+    - container:
+        args:
+          - --type
+          - '{{inputs.parameters.driver-type}}'
+          - --pipeline_name
+          - hello-world
+          - --run_id
+          - '{{workflow.uid}}'
+          - --run_name
+          - '{{workflow.name}}'
+          - --run_display_name
+          - ''
+          - --dag_execution_id
+          - '{{inputs.parameters.parent-dag-id}}'
+          - --component
+          - '{{inputs.parameters.component}}'
+          - --task
+          - '{{inputs.parameters.task}}'
+          - --runtime_config
+          - '{{inputs.parameters.runtime-config}}'
+          - --iteration_index
+          - '{{inputs.parameters.iteration-index}}'
+          - --execution_id_path
+          - '{{outputs.parameters.execution-id.path}}'
+          - --iteration_count_path
+          - '{{outputs.parameters.iteration-count.path}}'
+          - --condition_path
+          - '{{outputs.parameters.condition.path}}'
+          - --http_proxy
+          - ""
+          - --https_proxy
+          - ""
+          - --no_proxy
+          - ""
+        command:
+          - driver
+        image: ghcr.io/kubeflow/kfp-driver
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+      inputs:
+        parameters:
+          - name: component
+          - default: ""
+            name: runtime-config
+          - default: ""
+            name: task
+          - default: "0"
+            name: parent-dag-id
+          - default: "-1"
+            name: iteration-index
+          - default: DAG
+            name: driver-type
+      name: system-dag-driver
+      outputs:
+        parameters:
+          - name: execution-id
+            valueFrom:
+              path: /tmp/outputs/execution-id
+          - name: iteration-count
+            valueFrom:
+              default: "0"
+              path: /tmp/outputs/iteration-count
+          - name: condition
+            valueFrom:
+              default: "true"
+              path: /tmp/outputs/condition
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603}}'
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-a"},"taskInfo":{"name":"component-a"}}'
+                - name: container
+                  value: '{{workflow.parameters.implementations-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603}}'
+                - name: parent-dag-id
+                  value: '{{inputs.parameters.parent-dag-id}}'
+            name: component-a-driver
+            template: system-container-driver
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{tasks.component-a-driver.outputs.parameters.pod-spec-patch}}'
+                - default: "false"
+                  name: cached-decision
+                  value: '{{tasks.component-a-driver.outputs.parameters.cached-decision}}'
+            depends: component-a-driver.Succeeded
+            name: component-a
+            template: system-container-executor
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-comp-nested-pipeline}}'
+                - name: parent-dag-id
+                  value: '{{inputs.parameters.parent-dag-id}}'
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-nested-pipeline"},"retryPolicy":{"backoffDuration":"0s","backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":2},"taskInfo":{"name":"nested-pipeline"}}'
+            name: nested-pipeline-driver
+            template: system-dag-driver
+          - arguments:
+              parameters:
+                - name: parent-dag-id
+                  value: '{{tasks.nested-pipeline-driver.outputs.parameters.execution-id}}'
+                - name: condition
+                  value: '{{tasks.nested-pipeline-driver.outputs.parameters.condition}}'
+                - name: retry-max-count
+                  value: "2"
+                - name: retry-backoff-duration
+                  value: "0"
+                - name: retry-backoff-factor
+                  value: "2"
+                - name: retry-backoff-max-duration
+                  value: "3600"
+            depends: nested-pipeline-driver.Succeeded
+            name: nested-pipeline
+            template: comp-nested-pipeline
+      inputs:
+        parameters:
+          - name: parent-dag-id
+      name: root
+      outputs: {}
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-root}}'
+                - name: runtime-config
+                  value: '{}'
+                - name: driver-type
+                  value: ROOT_DAG
+            name: root-driver
+            template: system-dag-driver
+          - arguments:
+              parameters:
+                - name: parent-dag-id
+                  value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+                - name: condition
+                  value: ""
+            depends: root-driver.Succeeded
+            name: root
+            template: root
+      inputs: {}
+      metadata:
+      name: entrypoint
+      outputs: {}

--- a/backend/src/v2/compiler/argocompiler/testdata/nested_pipeline_sub_component_retry.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/nested_pipeline_sub_component_retry.yaml
@@ -1,0 +1,502 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  creationTimestamp: null
+  generateName: hello-world-
+spec:
+  arguments:
+    parameters:
+      - name: components-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603
+        value: '{"executorLabel":"exec-component-a"}'
+      - name: implementations-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603
+        value: '{"args":["--executor_input","{{$}}","--function_to_execute","component_a"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.13.0'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        component_a():\n    print(''Component A'')\n\n"],"image":"python:3.9"}'
+      - name: components-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23
+        value: '{"executorLabel":"exec-component-b"}'
+      - name: implementations-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23
+        value: '{"args":["--executor_input","{{$}}","--function_to_execute","component_b"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.13.0'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        component_b():\n    print (''Component B'')\n\n"],"image":"python:3.9"}'
+      - name: components-comp-nested-pipeline
+        value: '{"dag":{"tasks":{"component-a":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-a"},"taskInfo":{"name":"component-a"}},"component-b":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-b"},"retryPolicy":{"backoffDuration":"0s","backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":2},"taskInfo":{"name":"component-b"}}}}}'
+      - name: components-root
+        value: '{"dag":{"tasks":{"nested-pipeline":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-nested-pipeline"},"taskInfo":{"name":"nested-pipeline"}}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  serviceAccountName: pipeline-runner
+  templates:
+    - container:
+        args:
+          - --type
+          - CONTAINER
+          - --pipeline_name
+          - hello-world
+          - --run_id
+          - '{{workflow.uid}}'
+          - --run_name
+          - '{{workflow.name}}'
+          - --run_display_name
+          - ''
+          - --dag_execution_id
+          - '{{inputs.parameters.parent-dag-id}}'
+          - --component
+          - '{{inputs.parameters.component}}'
+          - --task
+          - '{{inputs.parameters.task}}'
+          - --container
+          - '{{inputs.parameters.container}}'
+          - --iteration_index
+          - '{{inputs.parameters.iteration-index}}'
+          - --cached_decision_path
+          - '{{outputs.parameters.cached-decision.path}}'
+          - --pod_spec_patch_path
+          - '{{outputs.parameters.pod-spec-patch.path}}'
+          - --condition_path
+          - '{{outputs.parameters.condition.path}}'
+          - --kubernetes_config
+          - '{{inputs.parameters.kubernetes-config}}'
+          - --http_proxy
+          - ""
+          - --https_proxy
+          - ""
+          - --no_proxy
+          - ""
+        command:
+          - driver
+        image: ghcr.io/kubeflow/kfp-driver
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+      inputs:
+        parameters:
+          - name: component
+          - name: task
+          - name: container
+          - name: parent-dag-id
+          - default: "-1"
+            name: iteration-index
+          - default: ""
+            name: kubernetes-config
+      name: system-container-driver
+      outputs:
+        parameters:
+          - name: pod-spec-patch
+            valueFrom:
+              default: ""
+              path: /tmp/outputs/pod-spec-patch
+          - default: "false"
+            name: cached-decision
+            valueFrom:
+              default: "false"
+              path: /tmp/outputs/cached-decision
+          - name: condition
+            valueFrom:
+              default: "true"
+              path: /tmp/outputs/condition
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{inputs.parameters.pod-spec-patch}}'
+            name: executor
+            template: system-container-impl
+            when: '{{inputs.parameters.cached-decision}} != true'
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+          - default: "false"
+            name: cached-decision
+      name: system-container-executor
+      outputs: {}
+    - container:
+        command:
+          - should-be-overridden-during-runtime
+        env:
+          - name: KFP_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KFP_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+        envFrom:
+          - configMapRef:
+              name: metadata-grpc-configmap
+              optional: true
+        image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+        name: ""
+        resources: {}
+        volumeMounts:
+          - mountPath: /kfp-launcher
+            name: kfp-launcher
+          - mountPath: /gcs
+            name: gcs-scratch
+          - mountPath: /s3
+            name: s3-scratch
+          - mountPath: /minio
+            name: minio-scratch
+          - mountPath: /.local
+            name: dot-local-scratch
+          - mountPath: /.cache
+            name: dot-cache-scratch
+          - mountPath: /.config
+            name: dot-config-scratch
+      initContainers:
+        - args:
+            - --copy
+            - /kfp-launcher/launch
+          command:
+            - launcher-v2
+          image: ghcr.io/kubeflow/kfp-launcher
+          name: kfp-launcher
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+          volumeMounts:
+            - mountPath: /kfp-launcher
+              name: kfp-launcher
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+      name: system-container-impl
+      outputs: {}
+      podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+      volumes:
+        - emptyDir: {}
+          name: kfp-launcher
+        - emptyDir: {}
+          name: gcs-scratch
+        - emptyDir: {}
+          name: s3-scratch
+        - emptyDir: {}
+          name: minio-scratch
+        - emptyDir: {}
+          name: dot-local-scratch
+        - emptyDir: {}
+          name: dot-cache-scratch
+        - emptyDir: {}
+          name: dot-config-scratch
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{inputs.parameters.pod-spec-patch}}'
+                - name: retry-max-count
+                  value: '{{inputs.parameters.retry-max-count}}'
+                - name: retry-backoff-duration
+                  value: '{{inputs.parameters.retry-backoff-duration}}'
+                - name: retry-backoff-factor
+                  value: '{{inputs.parameters.retry-backoff-factor}}'
+                - name: retry-backoff-max-duration
+                  value: '{{inputs.parameters.retry-backoff-max-duration}}'
+            name: executor
+            template: retry-system-container-impl
+            when: '{{inputs.parameters.cached-decision}} != true'
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+          - default: "false"
+            name: cached-decision
+          - default: "0"
+            name: retry-max-count
+          - default: "0"
+            name: retry-backoff-duration
+          - default: "0"
+            name: retry-backoff-factor
+          - default: "0"
+            name: retry-backoff-max-duration
+      name: retry-system-container-executor
+      outputs: {}
+    - container:
+        command:
+          - should-be-overridden-during-runtime
+        env:
+          - name: KFP_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KFP_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+        envFrom:
+          - configMapRef:
+              name: metadata-grpc-configmap
+              optional: true
+        image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+        name: ""
+        resources: {}
+        volumeMounts:
+          - mountPath: /kfp-launcher
+            name: kfp-launcher
+          - mountPath: /gcs
+            name: gcs-scratch
+          - mountPath: /s3
+            name: s3-scratch
+          - mountPath: /minio
+            name: minio-scratch
+          - mountPath: /.local
+            name: dot-local-scratch
+          - mountPath: /.cache
+            name: dot-cache-scratch
+          - mountPath: /.config
+            name: dot-config-scratch
+      initContainers:
+        - args:
+            - --copy
+            - /kfp-launcher/launch
+          command:
+            - launcher-v2
+          image: ghcr.io/kubeflow/kfp-launcher
+          name: kfp-launcher
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+          volumeMounts:
+            - mountPath: /kfp-launcher
+              name: kfp-launcher
+      inputs:
+        parameters:
+          - name: pod-spec-patch
+          - name: retry-max-count
+          - name: retry-backoff-duration
+          - name: retry-backoff-factor
+          - name: retry-backoff-max-duration
+      name: retry-system-container-impl
+      outputs: {}
+      podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+      retryStrategy:
+        backoff:
+          duration: '{{inputs.parameters.retry-backoff-duration}}'
+          factor: '{{inputs.parameters.retry-backoff-factor}}'
+          maxDuration: '{{inputs.parameters.retry-backoff-max-duration}}'
+        limit: '{{inputs.parameters.retry-max-count}}'
+      volumes:
+        - emptyDir: {}
+          name: kfp-launcher
+        - emptyDir: {}
+          name: gcs-scratch
+        - emptyDir: {}
+          name: s3-scratch
+        - emptyDir: {}
+          name: minio-scratch
+        - emptyDir: {}
+          name: dot-local-scratch
+        - emptyDir: {}
+          name: dot-cache-scratch
+        - emptyDir: {}
+          name: dot-config-scratch
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603}}'
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-a"},"taskInfo":{"name":"component-a"}}'
+                - name: container
+                  value: '{{workflow.parameters.implementations-c76def800bcb5189543541034eefac9210e827c15dd15b6de8ea4c45c233f603}}'
+                - name: parent-dag-id
+                  value: '{{inputs.parameters.parent-dag-id}}'
+            name: component-a-driver
+            template: system-container-driver
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{tasks.component-a-driver.outputs.parameters.pod-spec-patch}}'
+                - default: "false"
+                  name: cached-decision
+                  value: '{{tasks.component-a-driver.outputs.parameters.cached-decision}}'
+            depends: component-a-driver.Succeeded
+            name: component-a
+            template: system-container-executor
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23}}'
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-component-b"},"retryPolicy":{"backoffDuration":"0s","backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":2},"taskInfo":{"name":"component-b"}}'
+                - name: container
+                  value: '{{workflow.parameters.implementations-1a8bd1be9f10fe6fd3a429c49087a6cf42986d8e5a4f3eb99a60bba174470e23}}'
+                - name: parent-dag-id
+                  value: '{{inputs.parameters.parent-dag-id}}'
+            name: component-b-driver
+            template: system-container-driver
+          - arguments:
+              parameters:
+                - name: pod-spec-patch
+                  value: '{{tasks.component-b-driver.outputs.parameters.pod-spec-patch}}'
+                - default: "false"
+                  name: cached-decision
+                  value: '{{tasks.component-b-driver.outputs.parameters.cached-decision}}'
+                - name: retry-max-count
+                  value: "2"
+                - name: retry-backoff-duration
+                  value: "0"
+                - name: retry-backoff-factor
+                  value: "2"
+                - name: retry-backoff-max-duration
+                  value: "3600"
+            depends: component-b-driver.Succeeded
+            name: component-b
+            template: retry-system-container-executor
+      inputs:
+        parameters:
+          - name: parent-dag-id
+      name: comp-nested-pipeline
+      outputs: { }
+    - container:
+        args:
+          - --type
+          - '{{inputs.parameters.driver-type}}'
+          - --pipeline_name
+          - hello-world
+          - --run_id
+          - '{{workflow.uid}}'
+          - --run_name
+          - '{{workflow.name}}'
+          - --run_display_name
+          - ''
+          - --dag_execution_id
+          - '{{inputs.parameters.parent-dag-id}}'
+          - --component
+          - '{{inputs.parameters.component}}'
+          - --task
+          - '{{inputs.parameters.task}}'
+          - --runtime_config
+          - '{{inputs.parameters.runtime-config}}'
+          - --iteration_index
+          - '{{inputs.parameters.iteration-index}}'
+          - --execution_id_path
+          - '{{outputs.parameters.execution-id.path}}'
+          - --iteration_count_path
+          - '{{outputs.parameters.iteration-count.path}}'
+          - --condition_path
+          - '{{outputs.parameters.condition.path}}'
+          - --http_proxy
+          - ""
+          - --https_proxy
+          - ""
+          - --no_proxy
+          - ""
+        command:
+          - driver
+        image: ghcr.io/kubeflow/kfp-driver
+        name: ""
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+      inputs:
+        parameters:
+          - name: component
+          - default: ""
+            name: runtime-config
+          - default: ""
+            name: task
+          - default: "0"
+            name: parent-dag-id
+          - default: "-1"
+            name: iteration-index
+          - default: DAG
+            name: driver-type
+      name: system-dag-driver
+      outputs:
+        parameters:
+          - name: execution-id
+            valueFrom:
+              path: /tmp/outputs/execution-id
+          - name: iteration-count
+            valueFrom:
+              default: "0"
+              path: /tmp/outputs/iteration-count
+          - name: condition
+            valueFrom:
+              default: "true"
+              path: /tmp/outputs/condition
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-comp-nested-pipeline}}'
+                - name: parent-dag-id
+                  value: '{{inputs.parameters.parent-dag-id}}'
+                - name: task
+                  value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-nested-pipeline"},"taskInfo":{"name":"nested-pipeline"}}'
+            name: nested-pipeline-driver
+            template: system-dag-driver
+          - arguments:
+              parameters:
+                - name: parent-dag-id
+                  value: '{{tasks.nested-pipeline-driver.outputs.parameters.execution-id}}'
+                - name: condition
+                  value: '{{tasks.nested-pipeline-driver.outputs.parameters.condition}}'
+            depends: nested-pipeline-driver.Succeeded
+            name: nested-pipeline
+            template: comp-nested-pipeline
+      inputs:
+        parameters:
+          - name: parent-dag-id
+      name: root
+      outputs: {}
+    - dag:
+        tasks:
+          - arguments:
+              parameters:
+                - name: component
+                  value: '{{workflow.parameters.components-root}}'
+                - name: runtime-config
+                  value: '{}'
+                - name: driver-type
+                  value: ROOT_DAG
+            name: root-driver
+            template: system-dag-driver
+          - arguments:
+              parameters:
+                - name: parent-dag-id
+                  value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+                - name: condition
+                  value: ""
+            depends: root-driver.Succeeded
+            name: root
+            template: root
+      inputs: {}
+      name: entrypoint
+      outputs: {}

--- a/backend/src/v2/compiler/testdata/nested_pipeline_all_level_retry.json
+++ b/backend/src/v2/compiler/testdata/nested_pipeline_all_level_retry.json
@@ -1,0 +1,118 @@
+{
+  "pipelineSpec": {
+    "components": {
+      "comp-component-a": {
+        "executorLabel": "exec-component-a"
+      },
+      "comp-component-b": {
+        "executorLabel": "exec-component-b"
+      },
+      "comp-nested-pipeline": {
+        "dag": {
+          "tasks": {
+            "component-a": {
+              "cachingOptions": {
+                "enableCache": true
+              },
+              "componentRef": {
+                "name": "comp-component-a"
+              },
+              "taskInfo": {
+                "name": "component-a"
+              }
+            },
+            "component-b": {
+              "cachingOptions": {
+                "enableCache": true
+              },
+              "componentRef": {
+                "name": "comp-component-b"
+              },
+              "retryPolicy": {
+                "backoffDuration": "0s",
+                "backoffFactor": 2,
+                "backoffMaxDuration": "3600s",
+                "maxRetryCount": 2
+              },
+              "taskInfo": {
+                "name": "component-b"
+              }
+            }
+          }
+        }
+      }
+    },
+    "deploymentSpec": {
+      "executors": {
+        "exec-component-a": {
+          "container": {
+            "args": [
+              "--executor_input",
+              "{{$}}",
+              "--function_to_execute",
+              "component_a"
+            ],
+            "command": [
+              "sh",
+              "-c",
+              "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"$0\" \"$@\"\n",
+              "sh",
+              "-ec",
+              "program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\" > \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n",
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef component_a():\n    print('Component A')\n\n"
+            ],
+            "image": "python:3.9"
+          }
+        },
+        "exec-component-b": {
+          "container": {
+            "args": [
+              "--executor_input",
+              "{{$}}",
+              "--function_to_execute",
+              "component_b"
+            ],
+            "command": [
+              "sh",
+              "-c",
+              "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"$0\" \"$@\"\n",
+              "sh",
+              "-ec",
+              "program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\" > \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n",
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef component_b():\n    print ('Component B')\n\n"
+            ],
+            "image": "python:3.9"
+          }
+        }
+      }
+    },
+    "pipelineInfo": {
+      "name": "hello-world"
+    },
+    "root": {
+      "dag": {
+        "tasks": {
+          "nested-pipeline": {
+            "cachingOptions": {
+              "enableCache": true
+            },
+            "componentRef": {
+              "name": "comp-nested-pipeline"
+            },
+            "retryPolicy": {
+              "backoffDuration": "0s",
+              "backoffFactor": 1,
+              "backoffMaxDuration": "1800s",
+              "maxRetryCount": 1
+            },
+            "taskInfo": {
+              "name": "nested-pipeline"
+            }
+          }
+        }
+      }
+    },
+    "schemaVersion": "2.1.0",
+    "sdkVersion": "kfp-2.13.0"
+  }
+}

--- a/backend/src/v2/compiler/testdata/nested_pipeline_pipeline_retry.json
+++ b/backend/src/v2/compiler/testdata/nested_pipeline_pipeline_retry.json
@@ -1,0 +1,146 @@
+{
+  "pipelineSpec": {
+    "components": {
+      "comp-component-a": {
+        "executorLabel": "exec-component-a"
+      },
+      "comp-component-a-2": {
+        "executorLabel": "exec-component-a-2"
+      },
+      "comp-component-b": {
+        "executorLabel": "exec-component-b"
+      },
+      "comp-nested-pipeline": {
+        "dag": {
+          "tasks": {
+            "component-a": {
+              "cachingOptions": {
+                "enableCache": true
+              },
+              "componentRef": {
+                "name": "comp-component-a-2"
+              },
+              "taskInfo": {
+                "name": "component-a"
+              }
+            },
+            "component-b": {
+              "cachingOptions": {
+                "enableCache": true
+              },
+              "componentRef": {
+                "name": "comp-component-b"
+              },
+              "taskInfo": {
+                "name": "component-b"
+              }
+            }
+          }
+        }
+      }
+    },
+    "deploymentSpec": {
+      "executors": {
+        "exec-component-a": {
+          "container": {
+            "args": [
+              "--executor_input",
+              "{{$}}",
+              "--function_to_execute",
+              "component_a"
+            ],
+            "command": [
+              "sh",
+              "-c",
+              "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"$0\" \"$@\"\n",
+              "sh",
+              "-ec",
+              "program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\" > \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n",
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef component_a():\n    print('Component A')\n\n"
+            ],
+            "image": "python:3.9"
+          }
+        },
+        "exec-component-a-2": {
+          "container": {
+            "args": [
+              "--executor_input",
+              "{{$}}",
+              "--function_to_execute",
+              "component_a"
+            ],
+            "command": [
+              "sh",
+              "-c",
+              "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"$0\" \"$@\"\n",
+              "sh",
+              "-ec",
+              "program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\" > \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n",
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef component_a():\n    print('Component A')\n\n"
+            ],
+            "image": "python:3.9"
+          }
+        },
+        "exec-component-b": {
+          "container": {
+            "args": [
+              "--executor_input",
+              "{{$}}",
+              "--function_to_execute",
+              "component_b"
+            ],
+            "command": [
+              "sh",
+              "-c",
+              "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"$0\" \"$@\"\n",
+              "sh",
+              "-ec",
+              "program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\" > \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n",
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef component_b():\n    print ('Component B')\n\n"
+            ],
+            "image": "python:3.9"
+          }
+        }
+      }
+    },
+    "pipelineInfo": {
+      "name": "hello-world"
+    },
+    "root": {
+      "dag": {
+        "tasks": {
+          "component-a": {
+            "cachingOptions": {
+              "enableCache": true
+            },
+            "componentRef": {
+              "name": "comp-component-a"
+            },
+            "taskInfo": {
+              "name": "component-a"
+            }
+          },
+          "nested-pipeline": {
+            "cachingOptions": {
+              "enableCache": true
+            },
+            "componentRef": {
+              "name": "comp-nested-pipeline"
+            },
+            "retryPolicy": {
+              "backoffDuration": "0s",
+              "backoffFactor": 2,
+              "backoffMaxDuration": "3600s",
+              "maxRetryCount": 2
+            },
+            "taskInfo": {
+              "name": "nested-pipeline"
+            }
+          }
+        }
+      }
+    },
+    "schemaVersion": "2.1.0",
+    "sdkVersion": "kfp-2.13.0"
+  }
+}

--- a/backend/src/v2/compiler/testdata/nested_pipeline_sub_component_retry.json
+++ b/backend/src/v2/compiler/testdata/nested_pipeline_sub_component_retry.json
@@ -1,0 +1,112 @@
+{
+  "pipelineSpec": {
+    "components": {
+      "comp-component-a": {
+        "executorLabel": "exec-component-a"
+      },
+      "comp-component-b": {
+        "executorLabel": "exec-component-b"
+      },
+      "comp-nested-pipeline": {
+        "dag": {
+          "tasks": {
+            "component-a": {
+              "cachingOptions": {
+                "enableCache": true
+              },
+              "componentRef": {
+                "name": "comp-component-a"
+              },
+              "taskInfo": {
+                "name": "component-a"
+              }
+            },
+            "component-b": {
+              "cachingOptions": {
+                "enableCache": true
+              },
+              "componentRef": {
+                "name": "comp-component-b"
+              },
+              "retryPolicy": {
+                "backoffDuration": "0s",
+                "backoffFactor": 2,
+                "backoffMaxDuration": "3600s",
+                "maxRetryCount": 2
+              },
+              "taskInfo": {
+                "name": "component-b"
+              }
+            }
+          }
+        }
+      }
+    },
+    "deploymentSpec": {
+      "executors": {
+        "exec-component-a": {
+          "container": {
+            "args": [
+              "--executor_input",
+              "{{$}}",
+              "--function_to_execute",
+              "component_a"
+            ],
+            "command": [
+              "sh",
+              "-c",
+              "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"$0\" \"$@\"\n",
+              "sh",
+              "-ec",
+              "program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\" > \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n",
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef component_a():\n    print('Component A')\n\n"
+            ],
+            "image": "python:3.9"
+          }
+        },
+        "exec-component-b": {
+          "container": {
+            "args": [
+              "--executor_input",
+              "{{$}}",
+              "--function_to_execute",
+              "component_b"
+            ],
+            "command": [
+              "sh",
+              "-c",
+              "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0' '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"$0\" \"$@\"\n",
+              "sh",
+              "-ec",
+              "program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\" > \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n",
+              "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef component_b():\n    print ('Component B')\n\n"
+            ],
+            "image": "python:3.9"
+          }
+        }
+      }
+    },
+    "pipelineInfo": {
+      "name": "hello-world"
+    },
+    "root": {
+      "dag": {
+        "tasks": {
+          "nested-pipeline": {
+            "cachingOptions": {
+              "enableCache": true
+            },
+            "componentRef": {
+              "name": "comp-nested-pipeline"
+            },
+            "taskInfo": {
+              "name": "nested-pipeline"
+            }
+          }
+        }
+      }
+    },
+    "schemaVersion": "2.1.0",
+    "sdkVersion": "kfp-2.13.0"
+  }
+}

--- a/samples/v2/pipeline_with_retry.py
+++ b/samples/v2/pipeline_with_retry.py
@@ -17,12 +17,31 @@ def print_op(text: str) -> str:
     print(text)
     return text
 
+@dsl.pipeline
+def nested_pipeline():
+    subtask1 = verify_retries(retries='{{retries}}').set_retry(num_retries=2)
+    subtask2 = print_op(text='test').set_retry(num_retries=0)
+    subtask3 = print_op(text='test').set_retry(num_retries=2, backoff_duration="1s", backoff_factor=1, backoff_max_duration="1s")
+
+@dsl.pipeline
+def nested_pipeline_simple(retries: str) -> bool:
+    # if successful, check that the number of retries is correct.
+    subtask = print_op(text='test')
+    if retries != '2':
+        raise Exception('Number of retries has not reached two yet.')
+    return True
 
 @dsl.pipeline()
 def retry_pipeline():
     task1 = verify_retries(retries="{{retries}}").set_retry(num_retries=2)
-    task2 = print_op(text='test').set_retry(num_retries=2, backoff_duration="1 second", backoff_factor=1, backoff_max_duration="1 second")
+    task2 = print_op(text='test').set_retry(num_retries=2, backoff_duration="1s", backoff_factor=1, backoff_max_duration="1s")
     task3 = print_op(text='test').set_retry(num_retries=0)
+    nested_pipeline()
+
+    #handle the above arguments at a pipeline level.
+    task5 = nested_pipeline_simple().set_retry(num_retries=2)
+    task6 = nested_pipeline_simple().set_retry(num_retries=2, backoff_duration="1s", backoff_factor=1, backoff_max_duration="1s")
+    task7 = nested_pipeline().set_retry(num_retries=0)
 
 if __name__ == '__main__':
     compiler.Compiler.compile(

--- a/samples/v2/sample_test.py
+++ b/samples/v2/sample_test.py
@@ -122,7 +122,7 @@ class SampleTest(unittest.TestCase):
         """Runs once before all tests."""
         print('Deploying pre-requisites....')
         for p in PREREQS:
-            deploy_k8s_yaml(_KFP_NAMESPACE, p)
+            delete_k8s_yaml(_KFP_NAMESPACE, p)
         print('Done deploying pre-requisites.')
 
     @classmethod


### PR DESCRIPTION
**Description of your changes:**
This PR implements retries for nested pipelines at both the pipeline and component level. Components that are set with a retry policy under a nested pipeline take in retry parameters from their parent DAG task. When a nested pipeline contains a retry policy, its corresponding dag template contains a RetryStrategy set at the dag level (as opposed to component-level retry strategies, which are set on the container template). Components that are set with a retry policy under a nested pipeline take in retry parameters from their parent DAG task.

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
