### PR TITLE
chore(tests): fix KFP SDK tests

### DIFF
--- a/test/presubmit-tests-sdk.sh
+++ b/test/presubmit-tests-sdk.sh
@@ -20,13 +20,10 @@ python3 -m venv venv
 source venv/bin/activate
 
 python3 -m pip install --upgrade pip
+python3 -m pip install -r sdk/python/requirements.txt
+python3 -m pip install -r sdk/python/requirements-dev.txt
 python3 -m pip install setuptools
 python3 -m pip install coveralls==1.9.2
-python3 -m pip install $(grep 'absl-py==' sdk/python/requirements-dev.txt)
-python3 -m pip install $(grep 'docker==' sdk/python/requirements-dev.txt)
-python3 -m pip install $(grep 'pytest==' sdk/python/requirements-dev.txt)
-python3 -m pip install $(grep 'pytest-xdist==' sdk/python/requirements-dev.txt)
-python3 -m pip install $(grep 'pytest-cov==' sdk/python/requirements-dev.txt)
 python3 -m pip install --upgrade protobuf
 
 python3 -m pip install sdk/python


### PR DESCRIPTION
KFP SDK tests stopped working due to [`click` 8.2.0](https://github.com/pallets/click/releases/tag/8.2.0), which changed its behaviour.

> If help is shown because no_args_is_help is enabled (defaults to True for groups, False for commands), the exit code is 2 instead of 0. https://github.com/pallets/click/pull/1489 https://github.com/pallets/click/pull/1489

The above change makes tests that verify exit code fail.

This PR changes how dependencies are installed, so the tests run with the correct dependency ([8.1.8](https://github.com/kubeflow/pipelines/blob/5bc1a9bed1482ed55291f2de293e21efd7f3670e/sdk/python/requirements.txt#L16)).

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
