### PR TITLE
chore(test): Update cache test timeout and polling intervals

### DIFF
--- a/backend/test/v2/integration/cache_test.go
+++ b/backend/test/v2/integration/cache_test.go
@@ -157,7 +157,7 @@ func (s *CacheTestSuite) TestCacheRecurringRun() {
 		}
 
 		return false
-	}, 3*time.Minute, 10*time.Second)
+	}, 4*time.Minute, 5*time.Second)
 
 	contextsFilterQuery := fmt.Sprintf("name = '%s'", allRuns[1].RunID)
 


### PR DESCRIPTION
**Description of your changes:**
Adjusted the timeout from 3 to 4 minutes and the polling interval from 10 to 5 seconds in the cache integration test. This ensures more robust testing by allowing sufficient time for operations to complete while increasing polling frequency.

This change aims to fix the [flakiness](https://github.com/kubeflow/pipelines/actions/runs/15027471234/job/42231657464) in the test.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
