### PR TITLE
chore(backend): upgrade mysql to 8.4

### DIFF
--- a/developer_guide.md
+++ b/developer_guide.md
@@ -131,7 +131,7 @@ Check [this](https://github.com/kubeflow/pipelines/blob/master/test/README.md) p
 You can inspect mysql database directly by running:
 
 ```bash
-kubectl run -it --rm --image=gcr.io/ml-pipeline/mysql:5.6 --restart=Never mysql-client -- mysql -h mysql
+kubectl run -it --rm --image=docker.io/library/mysql:8.4 --restart=Never mysql-client -- mysql -h mysql
 mysql> use mlpipeline;
 mysql> select * from jobs;
 ```

--- a/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
@@ -37,18 +37,18 @@ spec:
         # mysql_native_password plugin implements native authentication; that is, authentication based on the password 
         # hashing method in use from before the introduction of pluggable authentication in MySQL 8.0.
         #
-        # As default_authentication_plugin option is deprecated in MySQL 8.0.27 this needs to be replaced with
-        # appropriate authentication_policy in the next upgrade. See more details:
-        # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_default_authentication_plugin
-        # https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_authentication_policy
-        - --default-authentication-plugin=mysql_native_password
+        # The mysql_native_password authentication plugin is deprecated as of MySQL 8.0.34, disabled by default
+        # in MySQL 8.4, and removed as of MySQL 9.0.0:
+        # https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html
+        - --authentication-policy=mysql_native_password
+        - --mysql-native-password=ON
         # Disable binlog as the logs grow fast and eat up all disk spaces eventually. And KFP doesn't currently utilize binlog.
         # https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#option_mysqld_log-bin
         - --disable-log-bin
         env:
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: "true"
-        image: gcr.io/ml-pipeline/mysql:8.0.26
+        image: mysql:8.4
         name: mysql
         ports:
         - containerPort: 3306


### PR DESCRIPTION
**Description of your changes:**

This switches to the docker hosted mysql. Based on some quick research, it seems github action runners are exempt from docker rate limiting: [[1]](https://github.com/docker/hub-feedback/issues/2414#issuecomment-2744665417)

Note that there have been some hiccups in the past though: [[1]](https://github.com/actions/runner-images/issues/1445#issuecomment-2413558369)

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
