### PR TITLE
chore(test): Update Kubernetes versions in workflows to 1.31 and 1.33. Fixes #11937

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: Initialization tests v1 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: Initialization tests v2 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: API integration tests v1 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: API integration tests v2 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: API integration tests v2 with proxy - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
@@ -244,7 +244,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: Frontend Integration Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code
@@ -293,7 +293,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: Basic Sample Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-kubernetes-execution-tests.yml
+++ b/.github/workflows/kfp-kubernetes-execution-tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: kfp-kubernetes execution tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-samples.yml
+++ b/.github/workflows/kfp-samples.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: KFP Samples - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/.github/workflows/kfp-webhooks.yml
+++ b/.github/workflows/kfp-webhooks.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: KFP Webhooks - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: Periodic Functional Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/sdk-execution.yml
+++ b/.github/workflows/sdk-execution.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: KFP SDK Execution Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.30.2", "v1.31.0" ]
+        k8s_version: [ "v1.30.13", "v1.33.1" ]
     name: KFP upgrade tests - K8s ${{ matrix.k8s_version }}
 
     steps:


### PR DESCRIPTION
**Description of your changes:**

Fixes #11937

Updates the Kind cluster Kubernetes versions in all GitHub workflows from [v1.29.2, v1.30.2, v1.31.0] to [v1.30.13, v1.33.1] to use the lowest and highest supported versions as requested in issue #11937.

Updated workflows:

- .github/workflows/periodic.yml
- .github/workflows/kfp-webhooks.yml
- .github/workflows/e2e-test.yml
- .github/workflows/upgrade-test.yml
- .github/workflows/kfp-kubernetes-execution-tests.yml
- .github/workflows/kfp-samples.yml
- .github/workflows/sdk-execution.yml

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

**Testing**

- [x] Verified that both kindest/node:v1.30.13 and kindest/node:v1.33.1 images are available in Kind v0.29.0 release (https://github.com/kubernetes-sigs/kind/releases)