### PR TITLE
docs(frontend): added build instruction to readme

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -55,11 +55,12 @@ kubectl -n kubeflow scale --replicas=0 deployment/ml-pipeline-ui
 
 You can confirm that the previous [http://127.0.0.1:3000] link no longer works.
 
-Now navigate to the KFP frontend folder and install your NPM dependencies: 
+Now navigate to the KFP frontend folder, install and build your NPM dependencies: 
 
 ```bash
 cd ${WORKING_DIRECTORY}/frontend
 npm ci
+npm run build
 ```
 
 Now run the following: 


### PR DESCRIPTION
**Description of your changes:**
After running the `npm ci` command, running `npm run build` is needed. Without it, you would run into this error if you run `npm run start:proxy-and-server`: `Error: ENOENT: no such file or directory, open '/Users/user/pipelines/frontend/build/index.html'`.  I added this extra step in the readme.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
