### PR TITLE
feat(backend): support for optional input parameters in nested pipelines

### DIFF
--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -195,6 +195,7 @@ func drive() (err error) {
 		PipelineLogLevel: *logLevel,
 		PublishLogs:      *publishLogs,
 		CacheDisabled:    *cacheDisabledFlag,
+		DriverType:       *driverType,
 	}
 	var execution *driver.Execution
 	var driverErr error

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -65,6 +65,8 @@ type Options struct {
 	PublishLogs string
 
 	CacheDisabled bool
+
+	DriverType string
 }
 
 // Identifying information used for error messages

--- a/backend/src/v2/driver/resolve.go
+++ b/backend/src/v2/driver/resolve.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-var ErrResolvedParameterNull = errors.New("the resolvead input parameter is null")
+var ErrResolvedParameterNull = errors.New("the resolved input parameter is null")
 
 // resolveUpstreamOutputsConfig is just a config struct used to store the input
 // parameters of the resolveUpstreamParameters and resolveUpstreamArtifacts
@@ -142,6 +142,9 @@ func resolveInputs(
 		}
 		return nil
 	}
+	// Track parameters set to nil by the driver (for the case in which optional pipeline input parameters are not
+	// included, and default value is nil).
+	parametersSetNilByDriver := map[string]bool{}
 	handleParamTypeValidationAndConversion := func() error {
 		// TODO(Bobgy): verify whether there are inputs not in the inputs spec.
 		for name, spec := range inputsSpec.GetParameters() {
@@ -179,6 +182,10 @@ func resolveInputs(
 			case pipelinespec.ParameterType_STRING:
 				_, isValueString := value.GetKind().(*structpb.Value_StringValue)
 				if !isValueString {
+					// If parameter was set to nil by driver, allow input parameter to have a nil value.
+					if parametersSetNilByDriver[name] {
+						continue
+					}
 					// TODO(Bobgy): discuss whether we want to allow auto type conversion
 					// all parameter types can be consumed as JSON string
 					text, err := metadata.PbValueToText(value)
@@ -193,6 +200,10 @@ func resolveInputs(
 				}
 				switch v := value.GetKind().(type) {
 				case *structpb.Value_NullValue:
+					// If parameter was set to nil by driver, allow input parameter to have a nil value.
+					if parametersSetNilByDriver[name] {
+						continue
+					}
 					return fmt.Errorf("got null for input parameter %q", name)
 				case *structpb.Value_StringValue:
 					// TODO(Bobgy): consider whether we support parsing string as JSON for any other types.
@@ -269,7 +280,26 @@ func resolveInputs(
 		}
 		return inputs, nil
 	}
+	// A DAG driver (not Root DAG driver) indicates this is likely the start of a nested pipeline.
+	// Handle omitted optional pipeline input parameters similar to how they are handled on the root pipeline.
+	isDagDriver := opts.DriverType == "DAG"
+	if isDagDriver {
+		for name, paramSpec := range opts.Component.GetInputDefinitions().GetParameters() {
+			_, ok := task.Inputs.GetParameters()[name]
+			if !ok && paramSpec.IsOptional {
+				if paramSpec.GetDefaultValue() != nil {
+					// If no value was input, pass along the default value to the component.
+					inputs.ParameterValues[name] = paramSpec.GetDefaultValue()
+				} else {
+					//  If no default value is set, pass along the null value to the component.
+					//	This is analogous to a pipeline run being submitted without optional pipeline input parameters.
+					inputs.ParameterValues[name] = structpb.NewNullValue()
+					parametersSetNilByDriver[name] = true
+				}
 
+			}
+		}
+	}
 	// Handle parameters.
 	for name, paramSpec := range task.GetInputs().GetParameters() {
 		v, err := resolveInputParameter(ctx, dag, pipeline, opts, mlmd, paramSpec, inputParams)

--- a/samples/v2/nested_pipeline_opt_input_child_level.py
+++ b/samples/v2/nested_pipeline_opt_input_child_level.py
@@ -1,0 +1,60 @@
+
+from kfp import compiler
+from kfp import dsl
+
+
+@dsl.component()
+def component_a_str(componentInputStr: str = None):
+    if componentInputStr != 'Input - pipeline':
+        raise ValueError(f"componentInputStr should be 'Input - pipeline' but is {componentInputStr}")
+
+
+@dsl.component()
+def component_b_str(componentInputStr: str = None):
+    if componentInputStr != 'Input 2 - nested pipeline':
+        raise ValueError(f"componentInputStr should be 'Input 2 - nested pipeline' but is {componentInputStr}")
+
+@dsl.component()
+def component_a_int(componentInputInt: int = None):
+    if componentInputInt != 1:
+        raise ValueError(f"componentInputInt should be 1 but is {componentInputInt}")
+
+@dsl.component()
+def component_b_int(componentInputInt: int = None):
+    if componentInputInt != 0:
+        raise ValueError(f"componentInputInt should be 0 but is {componentInputInt}")
+
+@dsl.component()
+def component_a_bool(componentInputBool: bool = None):
+    if componentInputBool != True:
+        raise ValueError(f"componentInputBool should be True but is {componentInputBool}")
+
+@dsl.component()
+def component_b_bool(componentInputBool: bool = None):
+    if componentInputBool != False:
+        raise ValueError(f"componentInputBool should be False but is {componentInputBool}")
+
+@dsl.pipeline()
+def nested_pipeline(nestedInputStr1: str = 'Input 1 - nested pipeline',  nestedInputStr2: str = 'Input 2 - nested pipeline',
+                        nestedInputInt1: int = 0, nestedInputInt2: int = 0,
+                        nestedInputBool1: bool = False, nestedInputBool2: bool = False):
+    component_a_str(componentInputStr=nestedInputStr1).set_caching_options(False)
+    component_b_str(componentInputStr=nestedInputStr2).set_caching_options(False)
+
+    component_a_int(componentInputInt=nestedInputInt1).set_caching_options(False)
+    component_b_int(componentInputInt=nestedInputInt2).set_caching_options(False)
+
+    component_a_bool(componentInputBool=nestedInputBool1).set_caching_options(False)
+    component_b_bool(componentInputBool=nestedInputBool2).set_caching_options(False)
+
+
+@dsl.pipeline()
+def nested_pipeline_opt_input_child_level():
+    # validate that input value overrides default value, and that when input is not provided, default is used.
+    nested_pipeline(nestedInputStr1='Input - pipeline', nestedInputInt1=1, nestedInputBool1=True).set_caching_options(False)
+
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(pipeline_func=nested_pipeline_opt_input_child_level, package_path=__file__.replace('.py', '_compiled.yaml'))
+

--- a/samples/v2/nested_pipeline_opt_inputs_nil.py
+++ b/samples/v2/nested_pipeline_opt_inputs_nil.py
@@ -1,0 +1,35 @@
+
+from kfp import compiler
+from kfp import dsl
+
+
+@dsl.component()
+def component_str(componentInput: str = None):
+    if componentInput is not None:
+        raise ValueError(f"componentInput should be None but is {componentInput}")
+
+@dsl.component()
+def component_int(componentInput: int = None):
+    if componentInput is not None:
+        raise ValueError(f"componentInput should be None but is {componentInput}")
+
+@dsl.component()
+def component_bool(componentInput: bool = None):
+    if componentInput is not None:
+        raise ValueError(f"componentInput should be None but is {componentInput}")
+
+@dsl.pipeline()
+def nested_pipeline(nestedInputStr: str = None, nestedInputInt: int = None, nestedInputBool: bool = None):
+    component_str(componentInput=nestedInputStr).set_caching_options(False)
+    component_int(componentInput=nestedInputInt).set_caching_options(False)
+    component_bool(componentInput=nestedInputBool).set_caching_options(False)
+
+
+@dsl.pipeline()
+def nested_pipeline_opt_inputs_nil():
+    nested_pipeline().set_caching_options(False)
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(pipeline_func=nested_pipeline_opt_inputs_nil, package_path=__file__.replace('.py', '_compiled.yaml'))
+

--- a/samples/v2/nested_pipeline_opt_inputs_parent_level.py
+++ b/samples/v2/nested_pipeline_opt_inputs_parent_level.py
@@ -1,0 +1,58 @@
+from typing import Optional
+
+from kfp import compiler, dsl
+
+
+@dsl.component()
+def component_nil_str_default(componentInput: str = None):
+    if componentInput != 'Input - parent pipeline':
+        raise ValueError(f"componentInput should be 'Input - parent pipeline' but is {componentInput}")
+
+@dsl.component()
+def component_str_default(componentInput: str = 'Input - component'):
+    if componentInput != 'Input - parent pipeline':
+        raise ValueError(f"componentInput should be 'Input - parent pipeline' but is {componentInput}")
+
+@dsl.component()
+def component_nil_int_default(componentInput: int = None):
+    if componentInput != 1:
+        raise ValueError(f"componentInput should be 1 but is {componentInput}")
+
+@dsl.component()
+def component_int_default(componentInput: int = 0):
+    if componentInput != 1:
+        raise ValueError(f"componentInput should be 1 but is {componentInput}")
+
+@dsl.component()
+def component_nil_bool_default(componentInput: bool = None):
+    if componentInput != True:
+        raise ValueError(f"componentInput should be True but is {componentInput}")
+
+@dsl.component()
+def component_bool_default(componentInput: bool = False):
+    if componentInput != True:
+        raise ValueError(f"componentInput should be True but is {componentInput}")
+
+@dsl.pipeline()
+def nested_pipeline_non_nil_defaults(nestedInputStr: str = 'Input - nested pipeline', nestedInputInt: int = 0, nestedInputBool: bool = False):
+    component_str_default(componentInput=nestedInputStr).set_caching_options(False)
+    component_int_default(componentInput=nestedInputInt).set_caching_options(False)
+    component_bool_default(componentInput=nestedInputBool).set_caching_options(False)
+
+@dsl.pipeline()
+def nested_pipeline_nil_defaults(nestedInputStr: str = 'Input - nested pipeline', nestedInputInt: int = None, nestedInputBool: bool = None):
+    component_nil_str_default(componentInput=nestedInputStr).set_caching_options(False)
+    component_nil_int_default(componentInput=nestedInputInt).set_caching_options(False)
+    component_nil_bool_default(componentInput=nestedInputBool).set_caching_options(False)
+
+
+@dsl.pipeline()
+def nested_pipeline_opt_inputs_parent_level(inputStr: str = 'Input - parent pipeline', inputInt: int = 1, inputBool: bool = True):
+    # verifies that the parent pipeline input overrides both nested pipeline-level and component-level default values.
+    nested_pipeline_non_nil_defaults(nestedInputStr=inputStr, nestedInputInt=inputInt, nestedInputBool=inputBool).set_caching_options(False)
+    # verifies that the parent pipeline input overrides both nested pipeline-level & component-level nil default input values.
+    nested_pipeline_nil_defaults(nestedInputStr=inputStr, nestedInputInt=inputInt, nestedInputBool=inputBool).set_caching_options(False)
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(pipeline_func=nested_pipeline_opt_inputs_parent_level, package_path=__file__.replace(".py", "_compiled.yaml"))
+

--- a/samples/v2/sample_test.py
+++ b/samples/v2/sample_test.py
@@ -42,6 +42,9 @@ import two_step_pipeline_containerized
 import yaml
 import pipeline_with_retry
 import pipeline_with_input_status_state
+import nested_pipeline_opt_inputs_parent_level
+import nested_pipeline_opt_inputs_nil
+import nested_pipeline_opt_input_child_level
 
 _MINUTE = 60  # seconds
 _DEFAULT_TIMEOUT = 10 * _MINUTE
@@ -174,6 +177,9 @@ class SampleTest(unittest.TestCase):
                 pipeline_func=collected_parameters.collected_param_pipeline),
             TestCase(pipeline_func=pipeline_with_retry.retry_pipeline),
             TestCase(pipeline_func=pipeline_with_input_status_state.status_state_pipeline),
+            TestCase(pipeline_func=nested_pipeline_opt_inputs_parent_level.nested_pipeline_opt_inputs_parent_level),
+            TestCase(pipeline_func=nested_pipeline_opt_input_child_level.nested_pipeline_opt_input_child_level),
+            TestCase(pipeline_func=nested_pipeline_opt_inputs_nil.nested_pipeline_opt_inputs_nil),
         ]
 
         with ThreadPoolExecutor() as executor:


### PR DESCRIPTION
**Description of your changes:**
Resolves optional input parameters for components of a nested pipeline. RuntimeConfigs updated to include inputs from nested pipeline components in addition to root pipeline. Task-level inputs are resolved with the input passed in by the corresponding component. 
fixes #11957

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
