### PR TITLE
feat(backend): update Argo Workflow Compiler to create workspace PVCs

### DIFF
--- a/backend/src/apiserver/config/config.json
+++ b/backend/src/apiserver/config/config.json
@@ -24,5 +24,14 @@
   "CacheEnabled": "true",
   "CRON_SCHEDULE_TIMEZONE": "UTC",
   "CACHE_IMAGE": "ghcr.io/containerd/busybox",
-  "CACHE_NODE_RESTRICTIONS": "false"
+  "CACHE_NODE_RESTRICTIONS": "false",
+  "Workspace": {
+    "size": "100Gi",
+    "VolumeClaimTemplateSpec": {
+      "accessModes": [
+        "ReadWriteOnce"
+      ],
+      "storageClassName": "standard-csi"
+    }
+  }
 }

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -97,7 +97,7 @@ func createPipelineVersion(pipelineId string, name string, description string, u
 	}
 	paramsJSON := "[{\"name\":\"param1\"}]"
 	spec := pipelineSpec
-	tmpl, err := template.New([]byte(pipelineSpec), false)
+	tmpl, err := template.New([]byte(pipelineSpec), false, nil)
 	if err != nil {
 		spec = pipelineSpec
 	} else {
@@ -674,13 +674,13 @@ func TestCreatePipelineOrVersion_V2PipelineName(t *testing.T) {
 			require.Nil(t, err)
 			bytes, err := manager.GetPipelineVersionTemplate(version.UUID)
 			require.Nil(t, err)
-			tmpl, err := template.New(bytes, true)
+			tmpl, err := template.New(bytes, true, nil)
 			require.Nil(t, err)
 			assert.Equal(t, test.pipelineName, tmpl.V2PipelineName())
 
 			bytes, err = manager.GetPipelineLatestTemplate(createdPipeline.UUID)
 			require.Nil(t, err)
-			tmpl, err = template.New(bytes, true)
+			tmpl, err = template.New(bytes, true, nil)
 			require.Nil(t, err)
 			assert.Equal(t, test.pipelineName, tmpl.V2PipelineName())
 		})

--- a/backend/src/apiserver/server/pipeline_upload_server_test.go
+++ b/backend/src/apiserver/server/pipeline_upload_server_test.go
@@ -195,19 +195,19 @@ func TestUploadPipeline(t *testing.T) {
 }
 
 func TestUploadPipelineV2_NameValidation(t *testing.T) {
-	v2Template, _ := template.New([]byte(v2SpecHelloWorld), true)
+	v2Template, _ := template.New([]byte(v2SpecHelloWorld), true, nil)
 	v2spec := string(v2Template.Bytes())
 
-	v2Template, _ = template.New([]byte(v2SpecHelloWorldDash), true)
+	v2Template, _ = template.New([]byte(v2SpecHelloWorldDash), true, nil)
 	v2specDash := string(v2Template.Bytes())
 
-	v2Template, _ = template.New([]byte(v2SpecHelloWorldCapitalized), true)
+	v2Template, _ = template.New([]byte(v2SpecHelloWorldCapitalized), true, nil)
 	invalidV2specCapitalized := string(v2Template.Bytes())
 
-	v2Template, _ = template.New([]byte(v2SpecHelloWorldDot), true)
+	v2Template, _ = template.New([]byte(v2SpecHelloWorldDot), true, nil)
 	invalidV2specDot := string(v2Template.Bytes())
 
-	v2Template, _ = template.New([]byte(v2SpecHelloWorldLong), true)
+	v2Template, _ = template.New([]byte(v2SpecHelloWorldLong), true, nil)
 	invalidV2specLong := string(v2Template.Bytes())
 
 	tt := []struct {

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 	goyaml "gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -134,18 +135,19 @@ type Template interface {
 }
 
 type RunWorkflowOptions struct {
-	RunId         string
-	RunAt         int64
-	CacheDisabled bool
+	RunId            string
+	RunAt            int64
+	CacheDisabled    bool
+	DefaultWorkspace *corev1.PersistentVolumeClaimSpec
 }
 
-func New(bytes []byte, cacheDisabled bool) (Template, error) {
+func New(bytes []byte, cacheDisabled bool, defaultWorkspace *corev1.PersistentVolumeClaimSpec) (Template, error) {
 	format := inferTemplateFormat(bytes)
 	switch format {
 	case V1:
 		return NewArgoTemplate(bytes)
 	case V2:
-		return NewV2SpecTemplate(bytes, cacheDisabled)
+		return NewV2SpecTemplate(bytes, cacheDisabled, defaultWorkspace)
 	default:
 		return nil, util.NewInvalidInputErrorWithDetails(ErrorInvalidPipelineSpec, "unknown template format")
 	}

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	goyaml "gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -155,6 +156,13 @@ spec:
     container:
       image: docker/whalesay:latest`
 
+var defaultPVC = &corev1.PersistentVolumeClaimSpec{
+	AccessModes: []corev1.PersistentVolumeAccessMode{
+		corev1.ReadWriteMany,
+	},
+	StorageClassName: util.StringPointer("my-storage"),
+}
+
 func TestToSwfCRDResourceGeneratedName_SpecialCharsAndSpace(t *testing.T) {
 	name, err := toSWFCRDResourceGeneratedName("! HaVe ä £unky name")
 	assert.Nil(t, err)
@@ -177,7 +185,7 @@ func TestScheduledWorkflow(t *testing.T) {
 	proxy.InitializeConfigWithEmptyForTests()
 
 	v2SpecHelloWorldYAML := loadYaml(t, "testdata/hello_world.yaml")
-	v2Template, _ := New([]byte(v2SpecHelloWorldYAML), true)
+	v2Template, _ := New([]byte(v2SpecHelloWorldYAML), true, defaultPVC)
 
 	modelJob := &model.Job{
 		K8SName:        "name1",
@@ -285,9 +293,10 @@ func TestNewTemplate_V2(t *testing.T) {
 	err = protojson.Unmarshal(jsonData, &expectedSpec)
 	assert.Nil(t, err)
 	expectedTemplate := &V2Spec{
-		spec: &expectedSpec,
+		spec:             &expectedSpec,
+		defaultWorkspace: defaultPVC,
 	}
-	templateV2Spec, err := New([]byte(template), false)
+	templateV2Spec, err := New([]byte(template), false, defaultPVC)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedTemplate, templateV2Spec)
 }
@@ -313,17 +322,18 @@ func TestNewTemplate_WithPlatformSpec(t *testing.T) {
 	protojson.Unmarshal(jsonData, &expectedPlatformSpec)
 
 	expectedTemplate := &V2Spec{
-		spec:         &expectedPipelineSpec,
-		platformSpec: &expectedPlatformSpec,
+		spec:             &expectedPipelineSpec,
+		platformSpec:     &expectedPlatformSpec,
+		defaultWorkspace: defaultPVC,
 	}
-	templateV2Spec, err := New([]byte(template), false)
+	templateV2Spec, err := New([]byte(template), false, defaultPVC)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedTemplate, templateV2Spec)
 }
 
 func TestNewTemplate_V2_InvalidSchemaVersion(t *testing.T) {
 	template := loadYaml(t, "testdata/hello_world_schema_2_0_0.yaml")
-	_, err := New([]byte(template), true)
+	_, err := New([]byte(template), true, defaultPVC)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "KFP only supports schema version 2.1.0")
 }
@@ -333,9 +343,9 @@ func TestNewTemplate_V2_InvalidSchemaVersion(t *testing.T) {
 // so we verify the parsed object.
 func TestBytes_V2_WithExecutorConfig(t *testing.T) {
 	template := loadYaml(t, "testdata/pipeline_with_volume.yaml")
-	templateV2Spec, _ := New([]byte(template), true)
+	templateV2Spec, _ := New([]byte(template), true, defaultPVC)
 	templateBytes := templateV2Spec.Bytes()
-	newTemplateV2Spec, err := New(templateBytes, true)
+	newTemplateV2Spec, err := New(templateBytes, true, defaultPVC)
 	assert.Nil(t, err)
 	assert.Equal(t, templateV2Spec, newTemplateV2Spec)
 }
@@ -345,9 +355,9 @@ func TestBytes_V2_WithExecutorConfig(t *testing.T) {
 // so we verify the parsed object.
 func TestBytes_V2(t *testing.T) {
 	template := loadYaml(t, "testdata/hello_world.yaml")
-	templateV2Spec, _ := New([]byte(template), true)
+	templateV2Spec, _ := New([]byte(template), true, defaultPVC)
 	templateBytes := templateV2Spec.Bytes()
-	newTemplateV2Spec, err := New(templateBytes, true)
+	newTemplateV2Spec, err := New(templateBytes, true, defaultPVC)
 	assert.Nil(t, err)
 	assert.Equal(t, templateV2Spec, newTemplateV2Spec)
 }

--- a/backend/src/apiserver/webhook/pipelineversion_webhook.go
+++ b/backend/src/apiserver/webhook/pipelineversion_webhook.go
@@ -96,7 +96,7 @@ func (p *PipelineVersionsWebhook) ValidateCreate(
 	}
 
 	// cache enabled or not doesn't matter in this context
-	tmpl, err := template.NewV2SpecTemplate([]byte(modelPipelineVersion.PipelineSpec), false)
+	tmpl, err := template.NewV2SpecTemplate([]byte(modelPipelineVersion.PipelineSpec), false, nil)
 	if err != nil {
 		return nil, newBadRequestError(fmt.Sprintf("The pipeline spec is invalid: %v", err))
 	}

--- a/backend/src/common/client/api_server/v1/pipeline_client.go
+++ b/backend/src/common/client/api_server/v1/pipeline_client.go
@@ -211,7 +211,7 @@ func (c *PipelineClient) GetTemplate(parameters *params.PipelineServiceGetTempla
 	}
 
 	// Unmarshal response
-	return template.New([]byte(response.Payload.Template), true)
+	return template.New([]byte(response.Payload.Template), true, nil)
 }
 
 func (c *PipelineClient) List(parameters *params.PipelineServiceListPipelinesV1Params) (
@@ -361,5 +361,5 @@ func (c *PipelineClient) GetPipelineVersionTemplate(parameters *params.PipelineS
 	}
 
 	// Unmarshal response
-	return template.New([]byte(response.Payload.Template), true)
+	return template.New([]byte(response.Payload.Template), true, nil)
 }

--- a/backend/src/common/util/k8s_patches.go
+++ b/backend/src/common/util/k8s_patches.go
@@ -1,0 +1,57 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	k8score "k8s.io/api/core/v1"
+)
+
+// PatchPVCSpec applies fields from `patch` into `base` where patch has non-zero values.
+// It mutates and returns the `base` spec.
+func PatchPVCSpec(base, patch *k8score.PersistentVolumeClaimSpec) *k8score.PersistentVolumeClaimSpec {
+	if base == nil || patch == nil {
+		return base
+	}
+	if len(patch.AccessModes) > 0 {
+		base.AccessModes = patch.AccessModes
+	}
+	if patch.Selector != nil {
+		base.Selector = patch.Selector.DeepCopy()
+	}
+	if patch.Resources.Requests != nil {
+		if base.Resources.Requests == nil {
+			base.Resources.Requests = make(k8score.ResourceList)
+		}
+		for k, v := range patch.Resources.Requests {
+			base.Resources.Requests[k] = v
+		}
+	}
+	if patch.VolumeName != "" {
+		base.VolumeName = patch.VolumeName
+	}
+	if patch.StorageClassName != nil {
+		base.StorageClassName = patch.StorageClassName
+	}
+	if patch.VolumeMode != nil {
+		base.VolumeMode = patch.VolumeMode
+	}
+	if patch.DataSource != nil {
+		base.DataSource = patch.DataSource.DeepCopy()
+	}
+	if patch.DataSourceRef != nil {
+		base.DataSourceRef = patch.DataSourceRef.DeepCopy()
+	}
+	return base
+}

--- a/backend/src/common/util/k8s_patches_test.go
+++ b/backend/src/common/util/k8s_patches_test.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8score "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestPatchPVCSpec(t *testing.T) {
+	base := &k8score.PersistentVolumeClaimSpec{
+		AccessModes: []k8score.PersistentVolumeAccessMode{"ReadWriteOnce"},
+		Resources: k8score.VolumeResourceRequirements{
+			Requests: k8score.ResourceList{
+				k8score.ResourceStorage: resource.MustParse("10Gi"),
+			},
+		},
+		StorageClassName: strPtr("standard"),
+	}
+
+	t.Run("patch access modes and storage class", func(t *testing.T) {
+		patch := &k8score.PersistentVolumeClaimSpec{
+			AccessModes:      []k8score.PersistentVolumeAccessMode{"ReadWriteMany"},
+			StorageClassName: strPtr("fast-storage"),
+		}
+		result := PatchPVCSpec(base.DeepCopy(), patch)
+		assert.Equal(t, []k8score.PersistentVolumeAccessMode{"ReadWriteMany"}, result.AccessModes)
+		assert.Equal(t, "fast-storage", *result.StorageClassName)
+		assert.Equal(t, resource.MustParse("10Gi"), result.Resources.Requests[k8score.ResourceStorage])
+	})
+
+	t.Run("patch resources", func(t *testing.T) {
+		patch := &k8score.PersistentVolumeClaimSpec{
+			Resources: k8score.VolumeResourceRequirements{
+				Requests: k8score.ResourceList{
+					k8score.ResourceStorage: resource.MustParse("20Gi"),
+				},
+			},
+		}
+		result := PatchPVCSpec(base.DeepCopy(), patch)
+		assert.Equal(t, resource.MustParse("20Gi"), result.Resources.Requests[k8score.ResourceStorage])
+	})
+
+	t.Run("patch is nil", func(t *testing.T) {
+		result := PatchPVCSpec(base.DeepCopy(), nil)
+		assert.Equal(t, base, result)
+	})
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/backend/src/crd/kubernetes/v2beta1/pipelineversion_types.go
+++ b/backend/src/crd/kubernetes/v2beta1/pipelineversion_types.go
@@ -94,7 +94,7 @@ type PipelineVersionList struct {
 }
 
 func FromPipelineVersionModel(pipeline model.Pipeline, pipelineVersion model.PipelineVersion) (*PipelineVersion, error) {
-	v2Spec, err := template.NewV2SpecTemplate([]byte(pipelineVersion.PipelineSpec), false)
+	v2Spec, err := template.NewV2SpecTemplate([]byte(pipelineVersion.PipelineSpec), false, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse the pipeline spec: %w", err)
 	}

--- a/backend/src/v2/compiler/argocompiler/argo_test.go
+++ b/backend/src/v2/compiler/argocompiler/argo_test.go
@@ -101,6 +101,11 @@ func Test_argo_compiler(t *testing.T) {
 			argoYAMLPath:     "testdata/hello_world_cache_disabled.yaml",
 			compilerOptions:  argocompiler.Options{CacheDisabled: true},
 		},
+		{
+			jobPath:          "../testdata/hello_world.json",
+			platformSpecPath: "../testdata/hello_world_pvc_workspace.json",
+			argoYAMLPath:     "testdata/hello_world_pvc_workspace.yaml",
+		},
 		// retry set at pipeline level only.
 		{
 			jobPath:          "../testdata/nested_pipeline_pipeline_retry.json",

--- a/backend/src/v2/compiler/argocompiler/argo_workspace_test.go
+++ b/backend/src/v2/compiler/argocompiler/argo_workspace_test.go
@@ -1,0 +1,452 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocompiler_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	"github.com/kubeflow/pipelines/backend/src/v2/compiler/argocompiler"
+	"google.golang.org/protobuf/types/known/structpb"
+	k8score "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8smeta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetWorkspacePVC(t *testing.T) {
+	tests := []struct {
+		name        string
+		workspace   *pipelinespec.WorkspaceConfig
+		opts        *argocompiler.Options
+		expectedPVC k8score.PersistentVolumeClaim
+		expectError bool
+	}{
+		{
+			name: "workspace with size specified",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "5Gi",
+			},
+			opts: nil,
+			expectedPVC: k8score.PersistentVolumeClaim{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name: "kfp-workspace",
+				},
+				Spec: k8score.PersistentVolumeClaimSpec{
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("5Gi"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "workspace with default size from options",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "", // empty size
+			},
+			opts: &argocompiler.Options{
+				DefaultWorkspaceSize: "20Gi",
+			},
+			expectedPVC: k8score.PersistentVolumeClaim{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name: "kfp-workspace",
+				},
+				Spec: k8score.PersistentVolumeClaimSpec{
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("20Gi"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "workspace with fallback size",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "", // empty size
+			},
+			opts: nil, // no options
+			expectedPVC: k8score.PersistentVolumeClaim{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name: "kfp-workspace",
+				},
+				Spec: k8score.PersistentVolumeClaimSpec{
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("10Gi"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "workspace with default PVC spec from options",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "15Gi",
+			},
+			opts: &argocompiler.Options{
+				DefaultWorkspace: &k8score.PersistentVolumeClaimSpec{
+					AccessModes: []k8score.PersistentVolumeAccessMode{
+						k8score.ReadWriteOnce,
+					},
+					StorageClassName: stringPtr("fast-ssd"),
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("1Gi"), // will be overridden
+						},
+					},
+				},
+			},
+			expectedPVC: k8score.PersistentVolumeClaim{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name: "kfp-workspace",
+				},
+				Spec: k8score.PersistentVolumeClaimSpec{
+					AccessModes: []k8score.PersistentVolumeAccessMode{
+						k8score.ReadWriteOnce,
+					},
+					StorageClassName: stringPtr("fast-ssd"),
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("15Gi"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "workspace with Kubernetes PVC spec patch",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "25Gi",
+				Kubernetes: &pipelinespec.KubernetesWorkspaceConfig{
+					PvcSpecPatch: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"accessModes": structpb.NewListValue(&structpb.ListValue{
+								Values: []*structpb.Value{
+									structpb.NewStringValue("ReadWriteMany"),
+								},
+							}),
+							"storageClassName": structpb.NewStringValue("nfs-storage"),
+						},
+					},
+				},
+			},
+			opts: &argocompiler.Options{
+				DefaultWorkspace: &k8score.PersistentVolumeClaimSpec{
+					AccessModes: []k8score.PersistentVolumeAccessMode{
+						k8score.ReadWriteOnce,
+					},
+					StorageClassName: stringPtr("default-storage"),
+				},
+			},
+			expectedPVC: k8score.PersistentVolumeClaim{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name: "kfp-workspace",
+				},
+				Spec: k8score.PersistentVolumeClaimSpec{
+					AccessModes: []k8score.PersistentVolumeAccessMode{
+						k8score.ReadWriteMany,
+					},
+					StorageClassName: stringPtr("nfs-storage"),
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("25Gi"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "workspace with invalid size",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "invalid-size",
+			},
+			opts:        nil,
+			expectedPVC: k8score.PersistentVolumeClaim{},
+			expectError: true,
+		},
+		{
+			name: "workspace with invalid PVC spec patch",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "10Gi",
+				Kubernetes: &pipelinespec.KubernetesWorkspaceConfig{
+					PvcSpecPatch: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"invalidField": structpb.NewStringValue("invalid"),
+						},
+					},
+				},
+			},
+			opts:        nil,
+			expectedPVC: k8score.PersistentVolumeClaim{},
+			expectError: true,
+		},
+		{
+			name: "workspace with complex PVC spec patch",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "50Gi",
+				Kubernetes: &pipelinespec.KubernetesWorkspaceConfig{
+					PvcSpecPatch: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"accessModes": structpb.NewListValue(&structpb.ListValue{
+								Values: []*structpb.Value{
+									structpb.NewStringValue("ReadWriteOnce"),
+									structpb.NewStringValue("ReadOnlyMany"),
+								},
+							}),
+							"storageClassName": structpb.NewStringValue("premium-ssd"),
+						},
+					},
+				},
+			},
+			opts: &argocompiler.Options{
+				DefaultWorkspace: &k8score.PersistentVolumeClaimSpec{
+					AccessModes: []k8score.PersistentVolumeAccessMode{
+						k8score.ReadWriteOnce,
+					},
+					StorageClassName: stringPtr("default"),
+				},
+			},
+			expectedPVC: k8score.PersistentVolumeClaim{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name: "kfp-workspace",
+				},
+				Spec: k8score.PersistentVolumeClaimSpec{
+					AccessModes: []k8score.PersistentVolumeAccessMode{
+						k8score.ReadWriteOnce,
+						k8score.ReadOnlyMany,
+					},
+					StorageClassName: stringPtr("premium-ssd"),
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("50Gi"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "workspace with nil Kubernetes config",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size:       "30Gi",
+				Kubernetes: nil,
+			},
+			opts: nil,
+			expectedPVC: k8score.PersistentVolumeClaim{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name: "kfp-workspace",
+				},
+				Spec: k8score.PersistentVolumeClaimSpec{
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("30Gi"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "workspace with empty Kubernetes config",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "40Gi",
+				Kubernetes: &pipelinespec.KubernetesWorkspaceConfig{
+					PvcSpecPatch: nil,
+				},
+			},
+			opts: nil,
+			expectedPVC: k8score.PersistentVolumeClaim{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name: "kfp-workspace",
+				},
+				Spec: k8score.PersistentVolumeClaimSpec{
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("40Gi"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := argocompiler.GetWorkspacePVC(tt.workspace, tt.opts)
+			if (err != nil) != tt.expectError {
+				t.Errorf("GetWorkspacePVC() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if !tt.expectError {
+				if diff := cmp.Diff(tt.expectedPVC, got); diff != "" {
+					t.Errorf("GetWorkspacePVC() mismatch (-expected +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestGetWorkspacePVC_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name        string
+		workspace   *pipelinespec.WorkspaceConfig
+		opts        *argocompiler.Options
+		expectError bool
+		errMsg      string
+	}{
+		{
+			name: "workspace with very large size",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "1000Ti",
+			},
+			opts:        nil,
+			expectError: false, // should be valid
+		},
+		{
+			name: "workspace with decimal size",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "1.5Gi",
+			},
+			opts:        nil,
+			expectError: false, // should be valid
+		},
+		{
+			name: "workspace with invalid size format",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "10GB", // should be "10Gi"
+			},
+			opts:        nil,
+			expectError: true,
+		},
+		{
+			name: "workspace with negative size",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "-10Gi",
+			},
+			opts:        nil,
+			expectError: true,
+		},
+		{
+			name: "workspace with malformed PVC spec patch",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "10Gi",
+				Kubernetes: &pipelinespec.KubernetesWorkspaceConfig{
+					PvcSpecPatch: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"resources": structpb.NewStructValue(&structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"requests": structpb.NewStringValue("invalid"), // should be a map
+								},
+							}),
+						},
+					},
+				},
+			},
+			opts:        nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := argocompiler.GetWorkspacePVC(tt.workspace, tt.opts)
+			if (err != nil) != tt.expectError {
+				t.Errorf("getWorkspacePVC() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if tt.expectError && tt.errMsg != "" && err != nil {
+				if err.Error() != tt.errMsg {
+					t.Errorf("getWorkspacePVC() error message = %v, expect %v", err.Error(), tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+// TestGetWorkspacePVC_Integration tests integration scenarios
+func TestGetWorkspacePVC_Integration(t *testing.T) {
+	t.Run("complete workspace configuration", func(t *testing.T) {
+		workspace := &pipelinespec.WorkspaceConfig{
+			Size: "100Gi",
+			Kubernetes: &pipelinespec.KubernetesWorkspaceConfig{
+				PvcSpecPatch: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"accessModes": structpb.NewListValue(&structpb.ListValue{
+							Values: []*structpb.Value{
+								structpb.NewStringValue("ReadWriteOnce"),
+							},
+						}),
+						"storageClassName": structpb.NewStringValue("gp2"),
+					},
+				},
+			},
+		}
+
+		opts := &argocompiler.Options{
+			DefaultWorkspaceSize: "50Gi",
+			DefaultWorkspace: &k8score.PersistentVolumeClaimSpec{
+				AccessModes: []k8score.PersistentVolumeAccessMode{
+					k8score.ReadWriteOnce,
+				},
+				StorageClassName: stringPtr("default"),
+				Resources: k8score.VolumeResourceRequirements{
+					Requests: map[k8score.ResourceName]resource.Quantity{
+						k8score.ResourceStorage: resource.MustParse("10Gi"),
+					},
+				},
+			},
+		}
+
+		pvc, err := argocompiler.GetWorkspacePVC(workspace, opts)
+		if err != nil {
+			t.Fatalf("getWorkspacePVC() unexpected error: %v", err)
+		}
+
+		// Verify the result
+		expected := k8score.PersistentVolumeClaim{
+			ObjectMeta: k8smeta.ObjectMeta{
+				Name: "kfp-workspace",
+			},
+			Spec: k8score.PersistentVolumeClaimSpec{
+				AccessModes: []k8score.PersistentVolumeAccessMode{
+					k8score.ReadWriteOnce,
+				},
+				StorageClassName: stringPtr("gp2"),
+				Resources: k8score.VolumeResourceRequirements{
+					Requests: map[k8score.ResourceName]resource.Quantity{
+						k8score.ResourceStorage: resource.MustParse("100Gi"),
+					},
+				},
+			},
+		}
+
+		if diff := cmp.Diff(expected, pvc); diff != "" {
+			t.Errorf("getWorkspacePVC() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/backend/src/v2/compiler/argocompiler/testdata/hello_world_pvc_workspace.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/hello_world_pvc_workspace.yaml
@@ -1,0 +1,334 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  creationTimestamp: null
+  generateName: hello-world-
+spec:
+  arguments:
+    parameters:
+    - name: components-203fce8adabe0cfa7da54b9d3ff79c772136c926974659b51c378727c7ccdfb7
+      value: '{"executorLabel":"exec-hello-world","inputDefinitions":{"parameters":{"text":{"type":"STRING"}}}}'
+    - name: implementations-203fce8adabe0cfa7da54b9d3ff79c772136c926974659b51c378727c7ccdfb7
+      value: '{"args":["--text","{{$.inputs.parameters[''text'']}}"],"command":["sh","-ec","program_path=$(mktemp)\nprintf
+        \"%s\" \"$0\" \u003e \"$program_path\"\npython3 -u \"$program_path\" \"$@\"\n","def
+        hello_world(text):\n    print(text)\n    return text\n\nimport argparse\n_parser
+        = argparse.ArgumentParser(prog=''Hello world'', description='''')\n_parser.add_argument(\"--text\",
+        dest=\"text\", type=str, required=True, default=argparse.SUPPRESS)\n_parsed_args
+        = vars(_parser.parse_args())\n\n_outputs = hello_world(**_parsed_args)\n"],"image":"python:3.9"}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"hello-world":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-hello-world"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"taskInfo":{"name":"hello-world"}}}},"inputDefinitions":{"parameters":{"text":{"type":"STRING"}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - namespace/n1/pipeline/hello-world
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata: {}
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+        name: executor
+        template: system-container-impl
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+    metadata: {}
+    name: system-container-executor
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+    metadata: {}
+    name: system-container-impl
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-203fce8adabe0cfa7da54b9d3ff79c772136c926974659b51c378727c7ccdfb7}}'
+          - name: task
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-hello-world"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"taskInfo":{"name":"hello-world"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-203fce8adabe0cfa7da54b9d3ff79c772136c926974659b51c378727c7ccdfb7}}'
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: hello-world-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.hello-world-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.hello-world-driver.outputs.parameters.cached-decision}}'
+        depends: hello-world-driver.Succeeded
+        name: hello-world
+        template: system-container-executor
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - namespace/n1/pipeline/hello-world
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata: {}
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{"parameters":{"text":{"stringValue":"hi there"}}}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+  volumeClaimTemplates:
+  - metadata:
+      creationTimestamp: null
+      name: kfp-workspace
+    spec:
+      accessModes:
+      - ReadWriteMany
+      resources:
+        requests:
+          storage: 250Gi
+      storageClassName: super-fast-storage
+    status: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/backend/src/v2/compiler/testdata/hello_world_pvc_workspace.json
+++ b/backend/src/v2/compiler/testdata/hello_world_pvc_workspace.json
@@ -1,0 +1,17 @@
+{
+    "platforms": {
+      "kubernetes": {
+        "pipelineConfig": {
+          "workspace": {
+            "size": "250Gi",
+            "kubernetes": {
+              "pvcSpecPatch": {
+                "accessModes": ["ReadWriteMany"],
+                "storageClassName": "super-fast-storage"
+              }
+            }
+          }
+        }     
+      }
+    }
+  }

--- a/backend/src/v2/compiler/visitor.go
+++ b/backend/src/v2/compiler/visitor.go
@@ -109,10 +109,13 @@ func (state *pipelineDFS) dfs(name string, component *pipelinespec.ComponentSpec
 		}
 
 		// Add kubernetes spec to annotation
-		if state.kubernetesSpec != nil {
+		if state.kubernetesSpec != nil && state.kubernetesSpec.DeploymentSpec != nil {
 			kubernetesExecSpec, ok := state.kubernetesSpec.DeploymentSpec.Executors[executorLabel]
 			if ok {
-				state.visitor.AddKubernetesSpec(name, kubernetesExecSpec)
+				err := state.visitor.AddKubernetesSpec(name, kubernetesExecSpec)
+				if err != nil {
+					return componentError(fmt.Errorf("failed to add Kubernetes spec for %s: %w", name, err))
+				}
 			}
 		}
 

--- a/backend/test/integration/pipeline_api_test.go
+++ b/backend/test/integration/pipeline_api_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // This test suit tests various methods to import pipeline to pipeline system, including
@@ -243,14 +244,20 @@ func (s *PipelineApiTest) TestPipelineAPI() {
 	require.Nil(t, err)
 	bytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	require.Nil(t, err)
-	expected, _ := pipelinetemplate.New(bytes, true)
+	defaultPVC := &corev1.PersistentVolumeClaimSpec{
+		AccessModes: []corev1.PersistentVolumeAccessMode{
+			corev1.ReadWriteMany,
+		},
+		StorageClassName: util.StringPointer("my-storage"),
+	}
+	expected, _ := pipelinetemplate.New(bytes, true, defaultPVC)
 	assert.Equal(t, expected, template)
 
 	template, err = s.pipelineClient.GetTemplate(&params.PipelineServiceGetTemplateParams{ID: v2HelloPipeline.ID})
 	require.Nil(t, err)
 	bytes, err = os.ReadFile("../resources/v2-hello-world.yaml")
 	require.Nil(t, err)
-	expected, _ = pipelinetemplate.New(bytes, true)
+	expected, _ = pipelinetemplate.New(bytes, true, nil)
 	assert.Equal(t, expected, template)
 }
 

--- a/backend/test/integration/pipeline_version_api_test.go
+++ b/backend/test/integration/pipeline_version_api_test.go
@@ -334,7 +334,7 @@ func (s *PipelineVersionApiTest) TestArgoSpec() {
 	require.Nil(t, err)
 	bytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	require.Nil(t, err)
-	expected, err := pipelinetemplate.New(bytes, true)
+	expected, err := pipelinetemplate.New(bytes, true, nil)
 	require.Nil(t, err)
 	assert.Equal(t, expected, template)
 }
@@ -367,7 +367,7 @@ func (s *PipelineVersionApiTest) TestV2Spec() {
 	require.Nil(t, err)
 	bytes, err := os.ReadFile("../resources/v2-hello-world.yaml")
 	require.Nil(t, err)
-	expected, err := pipelinetemplate.New(bytes, true)
+	expected, err := pipelinetemplate.New(bytes, true, nil)
 	require.Nil(t, err)
 	assert.Equal(t, expected, template, "Discrepancy found in template's pipeline name. Created pipeline's name - %s.", pipeline.Name)
 }

--- a/backend/test/integration/upgrade_test.go
+++ b/backend/test/integration/upgrade_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Methods are organized into two types: "prepare" and "verify".
@@ -328,7 +329,13 @@ func (s *UpgradeTests) VerifyPipelines() {
 	require.Nil(t, err)
 	bytes, err := os.ReadFile("../resources/arguments-parameters.yaml")
 	require.Nil(t, err)
-	expected, err := pipelinetemplate.New(bytes, true)
+	defaultPVC := &corev1.PersistentVolumeClaimSpec{
+		AccessModes: []corev1.PersistentVolumeAccessMode{
+			corev1.ReadWriteMany,
+		},
+		StorageClassName: util.StringPointer("my-storage"),
+	}
+	expected, err := pipelinetemplate.New(bytes, true, defaultPVC)
 	require.Nil(t, err)
 	assert.Equal(t, expected, template)
 }


### PR DESCRIPTION
Part of: https://github.com/kubeflow/pipelines/issues/12053
Resolve: https://github.com/kubeflow/pipelines/issues/12058

**Description of your changes:**
- This PR is part of the ongoing work on the [Pipeline Run Workspace feature](https://github.com/kubeflow/pipelines/issues/12053).
- This introduces support for defining default PersistentVolumeClaim (PVC) configurations at the API server level to preconfigure workspace settings for users.
- The compiler automatically injects `volumeClaimTemplates` into Argo Workflows when a workspace is defined in the pipeline.
- Defaults from the API server config are used unless overridden by user-defined settings in the pipeline.
Example config.json -
```
{
  "Workspace": {
    "VolumeClaimTemplateSpec": {
      "accessModes": ["ReadWriteMany"],
      "storageClassName": "my-storage"
    }
  }
}
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
