### PR TITLE
feat(sdk): Add Support for Docker Container Run Arguments

### DIFF
--- a/sdk/python/kfp/local/config.py
+++ b/sdk/python/kfp/local/config.py
@@ -45,18 +45,143 @@ class SubprocessRunner:
     use_venv: bool = True
 
 
-@dataclasses.dataclass
 class DockerRunner:
     """Runner that indicates that local tasks should be run as a Docker
     container."""
+    DOCKER_CONTAINER_RUN_ARGS = {
+        # for available run parameters:
+        # https://docker-py.readthedocs.io/en/stable/containers.html
+        'image',
+        'command',
+        'auto_remove',
+        'blkio_weight_device',
+        'blkio_weight',
+        'cap_add',
+        'cap_drop',
+        'cgroup_parent',
+        'cgroupns',
+        'cpu_count',
+        'cpu_percent',
+        'cpu_period',
+        'cpu_quota',
+        'cpu_rt_period',
+        'cpu_rt_runtime',
+        'cpu_shares',
+        'cpuset_cpus',
+        'cpuset_mems',
+        'detach',
+        'device_cgroup_rules',
+        'device_read_bps',
+        'device_read_iops',
+        'device_write_bps',
+        'device_write_iops',
+        'devices',
+        'device_requests',
+        'dns',
+        'dns_opt',
+        'dns_search',
+        'domainname',
+        'entrypoint',
+        'environment',
+        'extra_hosts',
+        'group_add',
+        'healthcheck',
+        'hostname',
+        'init',
+        'init_path',
+        'ipc_mode',
+        'isolation',
+        'kernel_memory',
+        'labels',
+        'links',
+        'log_config',
+        'lxc_conf',
+        'mac_address',
+        'mem_limit',
+        'mem_reservation',
+        'mem_swappiness',
+        'memswap_limit',
+        'mounts',
+        'name',
+        'nano_cpus',
+        'network',
+        'network_disabled',
+        'network_mode',
+        'networking_config',
+        'oom_kill_disable',
+        'oom_score_adj',
+        'pid_mode',
+        'pids_limit',
+        'platform',
+        'ports',
+        'privileged',
+        'publish_all_ports',
+        'read_only',
+        'remove',
+        'restart_policy',
+        'runtime',
+        'security_opt',
+        'shm_size',
+        'stdin_open',
+        'stdout',
+        'stderr',
+        'stop_signal',
+        'storage_opt',
+        'stream',
+        'sysctls',
+        'tmpfs',
+        'tty',
+        'ulimits',
+        'use_config_proxy',
+        'user',
+        'userns_mode',
+        'uts_mode',
+        'version',
+        'volume_driver',
+        'volumes',
+        'working_dir',
+    }
 
-    def __post_init__(self):
+    def __init__(self, **container_run_args):
+        """Runner constructor, taking any arguments to propagate to
+        `containers.run` in the `docker` SDK.
+
+        Args:
+            **container_run_args: Keyword arguments that comport with `containers.run` in the `docker` SDK, with some exceptions (see below).
+
+        `containers.run` arguments are supported with the following exceptions:
+        - image
+        - command
+        - volumes
+
+        Raises:
+            ImportError: Raised when `docker` is not installed
+            ValueError: Raised when unsupported `containers.run` arguments are supplied
+        """
         try:
             import docker  # noqa
         except ImportError as e:
             raise ImportError(
                 f"Package 'docker' must be installed to use {DockerRunner.__name__!r}. Install it using 'pip install docker'."
             ) from e
+
+        unsupported_args = container_run_args.keys(
+        ) - self.DOCKER_CONTAINER_RUN_ARGS
+
+        if unsupported_args:
+            raise ValueError(
+                f"Unsupported `docker run` arguments, see Package `docker` for details: {', '.join(unsupported_args)}"
+            )
+
+        excess_args: set = set(['image', 'command', 'volumes'
+                               ]) & container_run_args.keys()
+
+        if excess_args:
+            raise ValueError(
+                f"The following docker run arguments should not be specififed: {', '.join(excess_args)}"
+            )
+
+        self.container_run_args = container_run_args
 
 
 class LocalExecutionConfig:

--- a/sdk/python/kfp/local/config_test.py
+++ b/sdk/python/kfp/local/config_test.py
@@ -131,6 +131,23 @@ class TestDockerRunner(unittest.TestCase):
             ):
                 local.DockerRunner()
 
+    def test_good_container_args(self):
+        local.DockerRunner(network_mode='none')
+
+    def test_unknown_container_args(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Unsupported `docker run` arguments, see Package `docker` for details: .*'
+        ):
+            local.DockerRunner(image='spaghetti', favorite_vegetable='zucchini')
+
+    def test_excess_container_args(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r'The following docker run arguments should not be specififed: .*'
+        ):
+            local.DockerRunner(image='spaghetti')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/local/docker_task_handler.py
+++ b/sdk/python/kfp/local/docker_task_handler.py
@@ -58,7 +58,7 @@ class DockerTaskHandler(task_handler_interface.ITaskHandler):
                 image=self.image,
                 command=self.full_command,
                 volumes=volumes,
-            )
+                **self.runner.container_run_args)
         finally:
             client.close()
         return status.Status.SUCCESS if return_code == 0 else status.Status.FAILURE
@@ -70,12 +70,9 @@ def add_latest_tag_if_not_present(image: str) -> str:
     return image
 
 
-def run_docker_container(
-    client: 'docker.DockerClient',
-    image: str,
-    command: List[str],
-    volumes: Dict[str, Any],
-) -> int:
+def run_docker_container(client: 'docker.DockerClient', image: str,
+                         command: List[str], volumes: Dict[str, Any],
+                         **container_run_args) -> int:
     image = add_latest_tag_if_not_present(image=image)
     image_exists = any(
         image in existing_image.tags for existing_image in client.images.list())
@@ -93,7 +90,7 @@ def run_docker_container(
         stdout=True,
         stderr=True,
         volumes=volumes,
-    )
+        **container_run_args)
     for line in container.logs(stream=True):
         # the inner logs should already have trailing \n
         # we do not need to add another


### PR DESCRIPTION
**Description of your changes:**
At the time of this writing, the KFP SDK local pipeline run functionality doesn't support authentication mechanisms, [as documented here](https://www.kubeflow.org/docs/components/pipelines/user-guides/core-functions/execute-kfp-pipelines-locally/). For cloud platforms such as GCP, authentication just involves [supplying authentication files to the runtime filesystem of the container](https://cloud.google.com/docs/authentication/application-default-credentials?hl=en#personal). 

Docker's [container running interface](https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.run) already supports everything necessary for the developer to propagate such credentials to the container runtime, so as far as the above is concerned, this PR seeks to collect such runtime configurations in the `DockerRunner` object and propagate them to the `containers.run` invocation.

In writing this, I realize that the implementation only supports supplying the same run configurations to all containers in the pipeline, which has limited flexibility. In comporting with the existing interface for local runs, I don't believe there's a simple means of propagating different run configurations for different containers, but I believe that this proposed update to the existing interface does provide for a lot.

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

**Testing:**
```py
from kfp import local
from kfp import dsl
from docker.types import Mount

local.init(
    runner=local.DockerRunner(
        mounts=[Mount(source="/home/usr/credentials", target="/credentials")],
        environment={"GOOGLE_APPLICATION_CREDENTIALS": "/credentials/google-creds.json"}
    )
)

@dsl.component
def print_credentials():
    # obviously, this is just for proving the functionality
    with open('/credentials/google-creds.json', 'r') as f:
        print(f.read())

# or run it in a pipeline
@dsl.pipeline
def pipeline():
    print_credentials()

pipeline_task = pipeline()
```