### PR TITLE
feat(sdk): Add support for compiling pipelines to Kubernetes native format in SDK

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+* feat(sdk): Add support for compiling pipelines to Kubernetes native format in SDK (#12012)
+
 ## Breaking changes
 
 ## Deprecations

--- a/sdk/python/kfp/compiler/__init__.py
+++ b/sdk/python/kfp/compiler/__init__.py
@@ -16,5 +16,7 @@ definitions."""
 
 __all__ = [
     'Compiler',
+    'KubernetesManifestOptions',
 ]
 from kfp.compiler.compiler import Compiler
+from kfp.compiler.compiler_utils import KubernetesManifestOptions

--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -20,6 +20,7 @@ https://docs.google.com/document/d/1PUDuSQ8vmeKSBloli53mp7GIvzekaY7sggg6ywy35Dk/
 from typing import Any, Dict, Optional
 
 from kfp.compiler import pipeline_spec_builder as builder
+from kfp.compiler.compiler_utils import KubernetesManifestOptions
 from kfp.dsl import base_component
 from kfp.dsl.types import type_utils
 
@@ -53,6 +54,9 @@ class Compiler:
         pipeline_name: Optional[str] = None,
         pipeline_parameters: Optional[Dict[str, Any]] = None,
         type_check: bool = True,
+        kubernetes_manifest_options: Optional[
+            'KubernetesManifestOptions'] = None,
+        kubernetes_manifest_format: bool = False,
     ) -> None:
         """Compiles the pipeline or component function into IR YAML.
 
@@ -62,6 +66,8 @@ class Compiler:
             pipeline_name: Name of the pipeline.
             pipeline_parameters: Map of parameter names to argument values.
             type_check: Whether to enable type checking of component interfaces during compilation.
+            kubernetes_manifest_options: KubernetesManifestOptions object for Kubernetes manifest output during pipeline compilation.
+            kubernetes_manifest_format: Output the compiled pipeline as a Kubernetes manifest.
         """
 
         with type_utils.TypeCheckManager(enable=type_check):
@@ -83,4 +89,6 @@ class Compiler:
                 pipeline_description=pipeline_func.description,
                 platform_spec=pipeline_func.platform_spec,
                 package_path=package_path,
+                kubernetes_manifest_options=kubernetes_manifest_options,
+                kubernetes_manifest_format=kubernetes_manifest_format,
             )

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -31,6 +31,7 @@ from kfp import dsl
 from kfp.cli import cli
 from kfp.compiler import compiler
 from kfp.compiler import compiler_utils
+from kfp.compiler.compiler_utils import KubernetesManifestOptions
 from kfp.dsl import Artifact
 from kfp.dsl import ContainerSpec
 from kfp.dsl import Dataset
@@ -1034,6 +1035,102 @@ implementation:
                 dag_task = pipeline_spec['root']['dag']['tasks'][
                     'empty-component']
                 self.assertTrue('inputs' not in dag_task)
+
+    def test_compile_with_kubernetes_manifest_format(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+
+            @dsl.pipeline(name='my-pipeline')
+            def my_pipeline(input1: str):
+                print_op(message=input1)
+
+            pipeline_name = 'test-pipeline'
+            pipeline_display_name = 'Test Pipeline'
+            pipeline_version_name = 'test-pipeline-v1'
+            pipeline_version_display_name = 'Test Pipeline Version'
+            namespace = 'test-ns'
+
+            package_path = os.path.join(tmpdir, 'pipeline.yaml')
+
+            # Test with include_pipeline_manifest=True
+            kubernetes_manifest_options = KubernetesManifestOptions(
+                pipeline_name=pipeline_name,
+                pipeline_display_name=pipeline_display_name,
+                pipeline_version_name=pipeline_version_name,
+                pipeline_version_display_name=pipeline_version_display_name,
+                namespace=namespace,
+                include_pipeline_manifest=True)
+
+            compiler.Compiler().compile(
+                pipeline_func=my_pipeline,
+                package_path=package_path,
+                kubernetes_manifest_options=kubernetes_manifest_options,
+                kubernetes_manifest_format=True,
+            )
+
+            with open(package_path, 'r') as f:
+                documents = list(yaml.safe_load_all(f))
+
+            # Should have both Pipeline and PipelineVersion manifests
+            self.assertEqual(len(documents), 2)
+
+            # Check Pipeline manifest
+            pipeline_manifest = documents[0]
+            self.assertEqual(pipeline_manifest['kind'], 'Pipeline')
+            self.assertEqual(pipeline_manifest['metadata']['name'],
+                             pipeline_name)
+            self.assertEqual(pipeline_manifest['spec']['displayName'],
+                             pipeline_display_name)
+            self.assertEqual(pipeline_manifest['metadata']['namespace'],
+                             namespace)
+
+            # Check PipelineVersion manifest
+            pipeline_version_manifest = documents[1]
+            self.assertEqual(pipeline_version_manifest['kind'],
+                             'PipelineVersion')
+            self.assertEqual(pipeline_version_manifest['metadata']['name'],
+                             pipeline_version_name)
+            self.assertEqual(pipeline_version_manifest['spec']['displayName'],
+                             pipeline_version_display_name)
+            self.assertEqual(pipeline_version_manifest['spec']['pipelineName'],
+                             pipeline_name)
+            self.assertEqual(pipeline_version_manifest['metadata']['namespace'],
+                             namespace)
+
+            # Test with include_pipeline_manifest=False
+            package_path2 = os.path.join(tmpdir, 'pipeline2.yaml')
+            kubernetes_manifest_options2 = KubernetesManifestOptions(
+                pipeline_name=pipeline_name,
+                pipeline_display_name=pipeline_display_name,
+                pipeline_version_name=pipeline_version_name,
+                pipeline_version_display_name=pipeline_version_display_name,
+                namespace=namespace,
+                include_pipeline_manifest=False)
+
+            compiler.Compiler().compile(
+                pipeline_func=my_pipeline,
+                package_path=package_path2,
+                kubernetes_manifest_options=kubernetes_manifest_options2,
+                kubernetes_manifest_format=True,
+            )
+
+            with open(package_path2, 'r') as f:
+                documents2 = list(yaml.safe_load_all(f))
+
+            # Should have only PipelineVersion manifest
+            self.assertEqual(len(documents2), 1)
+
+            # Check PipelineVersion manifest
+            pipeline_version_manifest2 = documents2[0]
+            self.assertEqual(pipeline_version_manifest2['kind'],
+                             'PipelineVersion')
+            self.assertEqual(pipeline_version_manifest2['metadata']['name'],
+                             pipeline_version_name)
+            self.assertEqual(pipeline_version_manifest2['spec']['displayName'],
+                             pipeline_version_display_name)
+            self.assertEqual(pipeline_version_manifest2['spec']['pipelineName'],
+                             pipeline_name)
+            self.assertEqual(
+                pipeline_version_manifest2['metadata']['namespace'], namespace)
 
 
 class TestCompilePipelineCaching(unittest.TestCase):
@@ -4050,9 +4147,6 @@ class TestPlatformConfig(unittest.TestCase):
             def outer():
                 task = inner()
                 foo_platform_set_bar_feature(task, 12)
-
-
-class TestPipelineWorkspaceConfig(unittest.TestCase):
 
     def test_pipeline_with_workspace_config(self):
         """Test that pipeline config correctly sets the workspace field."""

--- a/sdk/python/kfp/compiler/compiler_utils.py
+++ b/sdk/python/kfp/compiler/compiler_utils.py
@@ -15,7 +15,8 @@
 
 import collections
 import copy
-from typing import DefaultDict, Dict, List, Mapping, Set, Tuple, Union
+from typing import (DefaultDict, Dict, List, Mapping, Optional, Set, Tuple,
+                    Union)
 
 from kfp import dsl
 from kfp.dsl import constants
@@ -863,3 +864,73 @@ def _memory_to_float(memory: str) -> float:
         memory = float(memory) / constants._G
 
     return memory
+
+
+class KubernetesManifestOptions:
+    """Options for Kubernetes manifest output during pipeline compilation.
+
+    Args:
+        pipeline_name: Name for the Pipeline resource (defaults to pipeline_spec.pipeline_info.name).
+        pipeline_display_name: Display name for the Pipeline resource (defaults to pipeline_name).
+        pipeline_version_name: Name for the PipelineVersion resource (defaults to pipeline_name).
+        pipeline_version_display_name: Display name for the PipelineVersion resource (defaults to pipeline_display_name).
+        namespace: Kubernetes namespace for the resources (optional).
+        include_pipeline_manifest: Whether to include the Pipeline manifest (default: False).
+    """
+
+    def __init__(
+        self,
+        pipeline_name: Optional[str] = None,
+        pipeline_display_name: Optional[str] = None,
+        pipeline_version_name: Optional[str] = None,
+        pipeline_version_display_name: Optional[str] = None,
+        namespace: Optional[str] = None,
+        include_pipeline_manifest: bool = False,
+    ):
+        self.pipeline_name = pipeline_name
+        self.pipeline_display_name = pipeline_display_name
+        self.pipeline_version_name = pipeline_version_name
+        self.pipeline_version_display_name = pipeline_version_display_name
+        self.namespace = namespace
+        self.include_pipeline_manifest = include_pipeline_manifest
+        self._pipeline_spec = None
+
+    def set_pipeline_spec(self, pipeline_spec):
+        self._pipeline_spec = pipeline_spec
+
+    @property
+    def pipeline_name(self) -> Optional[str]:
+        if self._pipeline_name is not None:
+            return self._pipeline_name
+        if self._pipeline_spec is not None:
+            return self._pipeline_spec.pipeline_info.name
+        return None
+
+    @pipeline_name.setter
+    def pipeline_name(self, value: Optional[str]):
+        self._pipeline_name = value
+
+    @property
+    def pipeline_display_name(self) -> Optional[str]:
+        return self._pipeline_display_name or self.pipeline_name
+
+    @pipeline_display_name.setter
+    def pipeline_display_name(self, value: Optional[str]):
+        self._pipeline_display_name = value
+
+    @property
+    def pipeline_version_name(self) -> Optional[str]:
+        return self._pipeline_version_name or self.pipeline_name
+
+    @pipeline_version_name.setter
+    def pipeline_version_name(self, value: Optional[str]):
+        self._pipeline_version_name = value
+
+    @property
+    def pipeline_version_display_name(self) -> Optional[str]:
+        return (self._pipeline_version_display_name or
+                self.pipeline_version_name or self.pipeline_display_name)
+
+    @pipeline_version_display_name.setter
+    def pipeline_version_display_name(self, value: Optional[str]):
+        self._pipeline_version_display_name = value

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -3,6 +3,7 @@
 # pip-compile --no-emit-index-url requirements.in
 
 click==8.1.8
+click-option-group==0.5.7
 docstring-parser>=0.7.3,<1
 # Pin google-api-core version for the bug fixing in 1.31.5
 # https://github.com/googleapis/python-api-core/releases/tag/v1.31.5

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -15,6 +15,8 @@ charset-normalizer==3.4.2
     # via requests
 click==8.1.8
     # via -r requirements.in
+click-option-group==0.5.7
+    # via -r requirements.in
 docstring-parser==0.16
     # via -r requirements.in
 google-api-core==2.24.2


### PR DESCRIPTION
**Description of your changes:**

Resolves [12054](https://github.com/kubeflow/pipelines/issues/12054)

This PR introduces the ability to compile Kubeflow Pipelines into Kubernetes-native custom resource manifests. It adds an option to the KFP SDK to generate output in the Pipeline and PipelineVersion manifest formats.

**Usage:** 
Install the updated SDK and compile a sample pipeline to produce a YAML file formatted as Kubernetes native resources. 
```
kfp dsl compile \
  --py my_pipeline.py \
  --output my_pipeline.yaml \
  --kubernetes-manifest-format\
  --pipeline-name my-pipeline \
  --pipeline-display-name "My Pipeline" \
  --pipeline-version-name v1 \
  --pipeline-version-display-name "Version 1" \
  --namespace my-namespace \
  --include-pipeline-manifest
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
