### PR TITLE
chore: Migrate busybox images form registory.k8s.io to ghcr

### DIFF
--- a/backend/src/apiserver/config/config.json
+++ b/backend/src/apiserver/config/config.json
@@ -23,6 +23,6 @@
   "DEFAULTPIPELINERUNNERSERVICEACCOUNT": "pipeline-runner",
   "CacheEnabled": "true",
   "CRON_SCHEDULE_TIMEZONE": "UTC",
-  "CACHE_IMAGE": "registry.k8s.io/busybox",
+  "CACHE_IMAGE": "ghcr.io/containerd/busybox",
   "CACHE_NODE_RESTRICTIONS": "false"
 }

--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -167,7 +167,7 @@ func MutatePodIfCached(req *v1beta1.AdmissionRequest, clientMgr ClientManagerInt
 
 		// Image selected from Google Container Register(gcr) for it small size, gcr since there
 		// is not image pull rate limit. For more info see issue: https://github.com/kubeflow/pipelines/issues/4099
-		image := "registry.k8s.io/busybox"
+		image := "ghcr.io/containerd/busybox"
 		if v, ok := os.LookupEnv("CACHE_IMAGE"); ok {
 			image = v
 		}

--- a/backend/src/cache/server/mutation_test.go
+++ b/backend/src/cache/server/mutation_test.go
@@ -198,7 +198,7 @@ func TestDefaultImage(t *testing.T) {
 	patchOperation, err := MutatePodIfCached(&fakeAdmissionRequest, fakeClientManager)
 	assert.Nil(t, err)
 	container := patchOperation[0].Value.([]corev1.Container)[0]
-	require.Equal(t, "registry.k8s.io/busybox", container.Image)
+	require.Equal(t, "ghcr.io/containerd/busybox", container.Image)
 }
 
 func TestSetImage(t *testing.T) {

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/cache.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/cache.yaml
@@ -190,7 +190,7 @@ data:
   mysql_driver: "mysql"
   mysql_host: "mysql"
   mysql_port: "3306"
-  cache_image: "registry.k8s.io/busybox"
+  cache_image: "ghcr.io/containerd/busybox"
   cache_node_restrictions: "false"
 ---
 apiVersion: apps/v1

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -63,8 +63,8 @@ data:
   ## cacheImage is the image that the mutating webhook will use to patch
   ## cached steps with. Will be used to echo a message announcing that 
   ## the cached step result will be used. If not set it will default to 
-  ## 'registry.k8s.io/busybox'
-  cacheImage: "registry.k8s.io/busybox"
+  ## 'ghcr.io/containerd/busybox'
+  cacheImage: "ghcr.io/containerd/busybox"
   ## cacheNodeRestrictions the dummy container runing if output is cached
   ## will run with the same affinity and node selector as the default pipeline
   ## step. This is defaulted to 'false' to allow the pod to be scheduled on 

--- a/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
@@ -63,8 +63,8 @@ data:
   ## cacheImage is the image that the mutating webhook will use to patch
   ## cached steps with. Will be used to echo a message announcing that 
   ## the cached step result will be used. If not set it will default to 
-  ## 'registry.k8s.io/busybox'
-  cacheImage: "registry.k8s.io/busybox"
+  ## 'ghcr.io/containerd/busybox'
+  cacheImage: "ghcr.io/containerd/busybox"
   ## cacheNodeRestrictions the dummy container runing if output is cached
   ## will run with the same affinity and node selector as the default pipeline
   ## step. This is defaulted to 'false' to allow the pod to be scheduled on 

--- a/samples/test/placeholder_concat.py
+++ b/samples/test/placeholder_concat.py
@@ -23,7 +23,7 @@ inputs:
 - {name: input_two, type: String}
 implementation:
   container:
-    image: registry.k8s.io/busybox
+    image: ghcr.io/containerd/busybox
     command:
     - sh
     - -ec

--- a/samples/test/placeholder_if_v2.py
+++ b/samples/test/placeholder_if_v2.py
@@ -22,7 +22,7 @@ inputs:
 - {name: optional_input_2, type: String, optional: true}
 implementation:
   container:
-    image: registry.k8s.io/busybox
+    image: ghcr.io/containerd/busybox
     command:
     - echo
     args:


### PR DESCRIPTION
**Description of your changes:**
- Fixes https://github.com/kubeflow/manifests/issues/3171
- Migrated busybox images form `registry.k8s.io/busybox` to `ghcr.io/containerd/busybox`
- `registry.k8s.io/busybox` uses the Docker Image Schema 1 format, which is an outdated image format that has been deprecated.
 ```
harshvir@msi:~/manifests$ docker pull registry.k8s.io/busybox
Using default tag: latest
latest: Pulling from busybox
Docker Image Format v1 and Docker Image manifest version 2, schema 1 support has been removed. Suggest the author of registry.k8s.io/busybox:latest to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
