### PR TITLE
[WIP] Isolate GormDBDataType() impact from varchar length changes

### DIFF
--- a/backend/src/apiserver/client/sql.go
+++ b/backend/src/apiserver/client/sql.go
@@ -22,11 +22,9 @@ import (
 )
 
 const (
-	MYSQL_TEXT_FORMAT      string = "longtext not null"
-	MYSQL_TEXT_FORMAT_NULL string = "longtext"
-	MYSQL_EXIST_ERROR      string = "database exists"
+	//nolint:staticcheck // allow legacy ALL_CAPS constant name
+	MYSQL_EXIST_ERROR string = "database exists"
 
-	PGX_TEXT_FORMAT string = "text"
 	PGX_EXIST_ERROR string = "already exists"
 )
 

--- a/backend/src/apiserver/client_manager/client_manager_test.go
+++ b/backend/src/apiserver/client_manager/client_manager_test.go
@@ -1,0 +1,12 @@
+package clientmanager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAllowedTable(t *testing.T) {
+	assert.True(t, isAllowedTable("pipeline"))
+	assert.False(t, isAllowedTable("users"))
+}

--- a/backend/src/apiserver/model/common.go
+++ b/backend/src/apiserver/model/common.go
@@ -1,10 +1,10 @@
-// Copyright 2019 The Kubeflow Authors
+// Copyright 2025 The Kubeflow Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+// https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,6 +14,17 @@
 
 package model
 
-type DefaultExperiment struct {
-	DefaultExperimentId string `gorm:"column:DefaultExperimentId; not null; primaryKey;"`
+import "gorm.io/gorm"
+
+// LongTextByDialect returns the correct database column type for large text
+// fields according to the current GORM dialector.
+// For MySQL it returns "longtext", and for PostgreSQL it returns "text".
+func LongTextByDialect(db *gorm.DB) string {
+	switch db.Name() {
+	case "mysql":
+		return "longtext"
+	case "postgres", "pgx":
+		return "text"
+	}
+	return ""
 }

--- a/backend/src/apiserver/model/db_status.go
+++ b/backend/src/apiserver/model/db_status.go
@@ -15,5 +15,5 @@
 package model
 
 type DBStatus struct {
-	HaveSamplesLoaded bool `gorm:"column:HaveSamplesLoaded; not null; primary_key;"`
+	HaveSamplesLoaded bool `gorm:"column:HaveSamplesLoaded; not null; primaryKey;"`
 }

--- a/backend/src/apiserver/model/experiment.go
+++ b/backend/src/apiserver/model/experiment.go
@@ -15,12 +15,12 @@
 package model
 
 type Experiment struct {
-	UUID                  string       `gorm:"column:UUID; not null; primary_key;"`
-	Name                  string       `gorm:"column:Name; not null; unique_index:idx_name_namespace;"`
+	UUID                  string       `gorm:"column:UUID; not null; primaryKey;"`
+	Name                  string       `gorm:"column:Name; not null; uniqueIndex:idx_name_namespace; type:varchar(128);"`
 	Description           string       `gorm:"column:Description; not null;"`
 	CreatedAtInSec        int64        `gorm:"column:CreatedAtInSec; not null;"`
 	LastRunCreatedAtInSec int64        `gorm:"column:LastRunCreatedAtInSec; not null;"`
-	Namespace             string       `gorm:"column:Namespace; not null; unique_index:idx_name_namespace;"`
+	Namespace             string       `gorm:"column:Namespace; not null; uniqueIndex:idx_name_namespace; type:varchar(63)"`
 	StorageState          StorageState `gorm:"column:StorageState; not null;"`
 }
 

--- a/backend/src/apiserver/model/job.go
+++ b/backend/src/apiserver/model/job.go
@@ -86,7 +86,7 @@ func (s StatusState) ToV2() StatusState {
 }
 
 type Job struct {
-	UUID           string `gorm:"column:UUID; not null; primary_key;"`
+	UUID           string `gorm:"column:UUID; not null; primaryKey;"`
 	DisplayName    string `gorm:"column:DisplayName; not null;"` /* The name that user provides. Can contain special characters*/
 	K8SName        string `gorm:"column:Name; not null;"`        /* The name of the K8s resource. Follow regex '[a-z0-9]([-a-z0-9]*[a-z0-9])?'*/
 	Namespace      string `gorm:"column:Namespace; not null;"`
@@ -98,9 +98,15 @@ type Job struct {
 	UpdatedAtInSec int64  `gorm:"column:UpdatedAtInSec; default:0;"`
 	Enabled        bool   `gorm:"column:Enabled; not null;"`
 	ExperimentId   string `gorm:"column:ExperimentUUID; not null;"`
+
 	// ResourceReferences are deprecated. Use Namespace, ExperimentId
 	// PipelineSpec.PipelineId, PipelineSpec.PipelineVersionId
-	ResourceReferences []*ResourceReference
+
+	// ResourceReferences are logical links to other KFP resources.
+	// These references are not unidirectional (i.e., no clear ownership),
+	// so we avoid declaring a foreign key. The field is excluded from GORM mapping
+	// to prevent auto-inferred relations and schema validation errors.
+	ResourceReferences []*ResourceReference `gorm:"-"`
 	Trigger
 	PipelineSpec
 	Conditions string `gorm:"column:Conditions; not null;"`

--- a/backend/src/apiserver/model/pipeline_spec.go
+++ b/backend/src/apiserver/model/pipeline_spec.go
@@ -14,6 +14,11 @@
 
 package model
 
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
 type PipelineSpec struct {
 	// Parent pipeline's id.
 	PipelineId string `gorm:"column:PipelineId; not null;"`
@@ -27,22 +32,30 @@ type PipelineSpec struct {
 	PipelineName string `gorm:"column:PipelineName; not null;"`
 
 	// Pipeline YAML definition. This is the pipeline interface for creating a pipeline.
-	// Set size to 65535 so it will be stored as longtext.
-	// https://dev.mysql.com/doc/refman/8.0/en/column-count-limit.html
-	// TODO(gkcalat): consider increasing the size limit > 32MB (<4GB for MySQL, and <1GB for PostgreSQL).
-	PipelineSpecManifest string `gorm:"column:PipelineSpecManifest; size:33554432;"`
+	// Stored as longtext to support large manifests (up to 4GB in MySQL).
+	// https://dev.mysql.com/doc/refman/8.0/en/blob.html
+	// TODO(kaikaila): consider enforcing a soft limit if needed for performance.
+	PipelineSpecManifest string `gorm:"column:PipelineSpecManifest;"`
 
 	// Argo workflow YAML definition. This is the Argo Spec converted from Pipeline YAML.
 	// This is deprecated. Use the pipeline ID, pipeline version ID, or pipeline spec manifest.
-	WorkflowSpecManifest string `gorm:"column:WorkflowSpecManifest; size:33554432;"`
+	WorkflowSpecManifest string `gorm:"column:WorkflowSpecManifest;"`
 
 	// Store parameters key-value pairs as serialized string.
 	// This field is only used for V1 API. For V2, use the `Parameters` field in RuntimeConfig.
 	// At most one of the fields `Parameters` and `RuntimeConfig` can be non-empty
 	// This string stores an array of map[string]value. For example:
 	//  {"param1": Value1} will be stored as [{"name": "param1", "value":"value1"}].
-	Parameters string `gorm:"column:Parameters; size:65535;"`
+	Parameters string `gorm:"column:Parameters;"`
 
 	// Runtime config of the pipeline, only used for v2 template in API v1beta1 API.
 	RuntimeConfig
+}
+
+func (PipelineSpec) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	switch field.Name {
+	case "PipelineSpecManifest", "WorkflowSpecManifest", "Parameters":
+		return LongTextByDialect(db)
+	}
+	return ""
 }

--- a/backend/src/apiserver/model/resource_reference.go
+++ b/backend/src/apiserver/model/resource_reference.go
@@ -14,6 +14,11 @@
 
 package model
 
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
 const (
 	NamespaceResourceType       ResourceType = "Namespace"
 	ExperimentResourceType      ResourceType = "Experiment"
@@ -168,7 +173,14 @@ type ResourceReference struct {
 	Relationship Relationship `gorm:"column:Relationship; not null;"`
 
 	// JSON-encoded metadata blob about the reference
-	Payload string `gorm:"column:Payload; not null; type:text"`
+	Payload string `gorm:"column:Payload; not null;"`
+}
+
+func (ResourceReference) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	if field.Name == "Payload" {
+		return LongTextByDialect(db)
+	}
+	return ""
 }
 
 type ReferenceKey struct {

--- a/backend/src/apiserver/model/resource_reference.go
+++ b/backend/src/apiserver/model/resource_reference.go
@@ -147,27 +147,28 @@ type ResourceType string
 type Relationship string
 
 // Resource reference table models the relationship between resources in a loosely coupled way.
+// This model has a composite primary key consisting of ResourceUUID, ResourceType, and ReferenceType.
 type ResourceReference struct {
 	// ID of the resource object
-	ResourceUUID string `gorm:"column:ResourceUUID; not null; primary_key;"`
+	ResourceUUID string `gorm:"column:ResourceUUID; not null; primaryKey;"`
 
 	// The type of the resource object
-	ResourceType ResourceType `gorm:"column:ResourceType; not null; primary_key; index:referencefilter;"`
+	ResourceType ResourceType `gorm:"column:ResourceType; not null; primaryKey; index:referencefilter;"`
 
-	// The ID of the resource that been referenced to.
+	// The ID of the referenced resource.
 	ReferenceUUID string `gorm:"column:ReferenceUUID; not null; index:referencefilter;"`
 
-	// The name of the resource that been referenced to.
+	// The name of the referenced resource.
 	ReferenceName string `gorm:"column:ReferenceName; not null;"`
 
-	// The type of the resource that been referenced to.
-	ReferenceType ResourceType `gorm:"column:ReferenceType; not null; primary_key; index:referencefilter;"`
+	// The type of the referenced resource.
+	ReferenceType ResourceType `gorm:"column:ReferenceType; not null; primaryKey; index:referencefilter;"`
 
-	// The relationship between the resource object and the resource that been referenced to.
+	// The relationship between the resource object and the referenced resource.
 	Relationship Relationship `gorm:"column:Relationship; not null;"`
 
-	// The json formatted blob of the resource reference.
-	Payload string `gorm:"column:Payload; not null; size:65535;"`
+	// JSON-encoded metadata blob about the reference
+	Payload string `gorm:"column:Payload; not null; type:text"`
 }
 
 type ReferenceKey struct {

--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -311,7 +311,7 @@ type RunDetails struct {
 	// Conditions were deprecated. Use State instead.
 	Conditions         string           `gorm:"column:Conditions; type:varchar(191); not null;  index:experimentuuid_conditions_finishedatinsec,priority:2;index:namespace_conditions_finishedatinsec,priority:2"`
 	State              RuntimeState     `gorm:"column:State; default:null;"`
-	StateHistoryString string           `gorm:"column:StateHistory; default:null; type: text;"`
+	StateHistoryString string           `gorm:"column:StateHistory; default:null;"`
 	StateHistory       []*RuntimeStatus `gorm:"-;"`
 	// Serialized runtime details of a run in v2beta1
 	PipelineRuntimeManifest string `gorm:"column:PipelineRuntimeManifest; not null;"`
@@ -324,7 +324,7 @@ type RunDetails struct {
 
 func (RunDetails) GormDBDataType(db *gorm.DB, field *schema.Field) string {
 	switch field.Name {
-	case "PipelineRuntimeManifest", "WorkflowRuntimeManifest":
+	case "StateHistoryString", "PipelineRuntimeManifest", "WorkflowRuntimeManifest":
 		return LongTextByDialect(db)
 	}
 	return ""
@@ -336,7 +336,14 @@ type RunMetric struct {
 	Name        string  `gorm:"column:Name; not null; primaryKey;"`
 	NumberValue float64 `gorm:"column:NumberValue;"`
 	Format      string  `gorm:"column:Format;"`
-	Payload     string  `gorm:"column:Payload; not null; type: text;"`
+	Payload     string  `gorm:"column:Payload; not null;"`
+}
+
+func (RunMetric) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	if field.Name == "Payload" {
+		return LongTextByDialect(db)
+	}
+	return ""
 }
 
 type RuntimeStatus struct {

--- a/backend/src/apiserver/model/runtime_config.go
+++ b/backend/src/apiserver/model/runtime_config.go
@@ -14,12 +14,25 @@
 
 package model
 
+import (
+	"gorm.io/gorm"
+	"gorm.io/gorm/schema"
+)
+
 type RuntimeConfig struct {
 	// Store parameters key-value pairs as serialized string.
-	Parameters string `gorm:"column:RuntimeParameters; size:65535;"`
+	Parameters string `gorm:"column:RuntimeParameters;"`
 
 	// A path in a object store bucket which will be treated as the root
 	// output directory of the pipeline. It is used by the system to
 	// generate the paths of output artifacts. Ref:(https://www.kubeflow.org/docs/components/pipelines/pipeline-root/)
-	PipelineRoot string `gorm:"column:PipelineRoot; size:65535;"`
+	PipelineRoot string `gorm:"column:PipelineRoot;"`
+}
+
+func (RuntimeConfig) GormDBDataType(db *gorm.DB, field *schema.Field) string {
+	switch field.Name {
+	case "Parameters", "PipelineRoot":
+		return LongTextByDialect(db)
+	}
+	return ""
 }

--- a/backend/src/apiserver/model/task.go
+++ b/backend/src/apiserver/model/task.go
@@ -38,13 +38,13 @@ type Task struct {
 	Name               string           `gorm:"column:Name; default:null"`
 	ParentTaskId       string           `gorm:"column:ParentTaskUUID; default:null"`
 	State              RuntimeState     `gorm:"column:State; default:null;"`
-	StateHistoryString string           `gorm:"column:StateHistory; default:null; type:text;"`
-	MLMDInputs         string           `gorm:"column:MLMDInputs; default:null; type:text;"`
-	MLMDOutputs        string           `gorm:"column:MLMDOutputs; default:null; type:text;"`
-	ChildrenPodsString string           `gorm:"column:ChildrenPods; default:null; type:text;"`
+	StateHistoryString string           `gorm:"column:StateHistory; default:null;"`
+	MLMDInputs         string           `gorm:"column:MLMDInputs; default:null;"`
+	MLMDOutputs        string           `gorm:"column:MLMDOutputs; default:null;"`
+	ChildrenPodsString string           `gorm:"column:ChildrenPods; default:null;"`
 	StateHistory       []*RuntimeStatus `gorm:"-;"`
 	ChildrenPods       []string         `gorm:"-;"`
-	Payload            string           `gorm:"column:Payload; default:null; type:text;"`
+	Payload            string           `gorm:"column:Payload; default:null;"`
 }
 
 func (Task) GormDBDataType(db *gorm.DB, field *schema.Field) string {

--- a/backend/src/apiserver/storage/experiment_store.go
+++ b/backend/src/apiserver/storage/experiment_store.go
@@ -196,8 +196,8 @@ func (s *ExperimentStore) scanRows(rows *sql.Rows) ([]*model.Experiment, error) 
 	var experiments []*model.Experiment
 	for rows.Next() {
 		var uuid, name, description, namespace, storageState string
-		var createdAtInSec sql.NullInt64
-		var lastRunCreatedAtInSec sql.NullInt64
+		var createdAtInSec int64
+		var lastRunCreatedAtInSec int64
 		err := rows.Scan(&uuid, &name, &description, &createdAtInSec, &lastRunCreatedAtInSec, &namespace, &storageState)
 		if err != nil {
 			return experiments, err
@@ -206,8 +206,8 @@ func (s *ExperimentStore) scanRows(rows *sql.Rows) ([]*model.Experiment, error) 
 			UUID:                  uuid,
 			Name:                  name,
 			Description:           description,
-			CreatedAtInSec:        createdAtInSec.Int64,
-			LastRunCreatedAtInSec: lastRunCreatedAtInSec.Int64,
+			CreatedAtInSec:        createdAtInSec,
+			LastRunCreatedAtInSec: lastRunCreatedAtInSec,
 			Namespace:             namespace,
 			StorageState:          model.StorageState(storageState).ToV2(),
 		}

--- a/backend/src/cache/client_manager.go
+++ b/backend/src/cache/client_manager.go
@@ -24,11 +24,12 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/golang/glog"
-	"github.com/jinzhu/gorm"
 	"github.com/kubeflow/pipelines/backend/src/cache/client"
 	"github.com/kubeflow/pipelines/backend/src/cache/model"
 	"github.com/kubeflow/pipelines/backend/src/cache/storage"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
 )
 
 const (
@@ -51,7 +52,12 @@ func (c *ClientManager) KubernetesCoreClient() client.KubernetesCoreInterface {
 }
 
 func (c *ClientManager) Close() {
-	c.db.Close()
+	sqlDB, err := c.db.DB.DB()
+	if err != nil {
+		log.Printf("Failed to retrieve underlying sql.DB: %v", err)
+		return
+	}
+	sqlDB.Close()
 }
 
 func (c *ClientManager) init(params WhSvrDBParameters, clientParams util.ClientParameters) {
@@ -77,22 +83,22 @@ func initDBClient(params WhSvrDBParameters, initConnectionTimeout time.Duration)
 
 	// db is safe for concurrent use by multiple goroutines
 	// and maintains its own pool of idle connections.
-	db, err := gorm.Open(driverName, arg)
+	db, err := gorm.Open(mysql.Open(arg), &gorm.Config{})
 	util.TerminateIfError(err)
 
 	// Create table
-	response := db.AutoMigrate(&model.ExecutionCache{})
-	if response.Error != nil {
+	err = db.AutoMigrate(&model.ExecutionCache{})
+	if err != nil {
 		glog.Fatalf("Failed to initialize the databases.")
 	}
 
-	response = db.Model(&model.ExecutionCache{}).ModifyColumn("ExecutionOutput", "longtext")
-	if response.Error != nil {
-		glog.Fatalf("Failed to update the execution output type. Error: %s", response.Error)
+	err = db.Migrator().AlterColumn(&model.ExecutionCache{}, "ExecutionOutput")
+	if err != nil {
+		glog.Fatalf("Failed to update the execution output type. Error: %s", err)
 	}
-	response = db.Model(&model.ExecutionCache{}).ModifyColumn("ExecutionTemplate", "longtext not null")
-	if response.Error != nil {
-		glog.Fatalf("Failed to update the execution template type. Error: %s", response.Error)
+	err = db.Migrator().AlterColumn(&model.ExecutionCache{}, "ExecutionTemplate")
+	if err != nil {
+		glog.Fatalf("Failed to update the execution template type. Error: %s", err)
 	}
 
 	var tableNames []string

--- a/backend/src/cache/model/execution_cache.go
+++ b/backend/src/cache/model/execution_cache.go
@@ -15,7 +15,7 @@
 package model
 
 type ExecutionCache struct {
-	ID                int64  `gorm:"column:ID; not null; primary_key; AUTO_INCREMENT; index:composite_id_idx"`
+	ID                int64  `gorm:"column:ID; not null; primaryKey; AUTO_INCREMENT; index:composite_id_idx"`
 	ExecutionCacheKey string `gorm:"column:ExecutionCacheKey; not null; index:idx_cache_key;"`
 	ExecutionTemplate string `gorm:"column:ExecutionTemplate; not null;"`
 	ExecutionOutput   string `gorm:"column:ExecutionOutput; not null;"`

--- a/backend/src/cache/server/client_manager_fake.go
+++ b/backend/src/cache/server/client_manager_fake.go
@@ -67,7 +67,11 @@ func (f *FakeClientManager) DB() *storage.DB {
 }
 
 func (f *FakeClientManager) Close() error {
-	return f.db.Close()
+	sqlDB, err := f.db.DB.DB()
+	if err != nil {
+		return err
+	}
+	return sqlDB.Close()
 }
 
 func (f *FakeClientManager) KubernetesCoreClient() client.KubernetesCoreInterface {

--- a/backend/src/cache/storage/db.go
+++ b/backend/src/cache/storage/db.go
@@ -15,7 +15,7 @@
 package storage
 
 import (
-	"github.com/jinzhu/gorm"
+	"gorm.io/gorm"
 )
 
 // DB a struct wrapping plain sql library with SQL dialect, to solve any feature

--- a/backend/src/cache/storage/db_fake.go
+++ b/backend/src/cache/storage/db_fake.go
@@ -18,19 +18,22 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"github.com/jinzhu/gorm"
 	"github.com/kubeflow/pipelines/backend/src/cache/model"
-	_ "github.com/mattn/go-sqlite3"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func NewFakeDB() (*DB, error) {
 	// Initialize GORM
-	db, err := gorm.Open("sqlite3", ":memory:")
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("Could not create the GORM database: %v", err)
 	}
 	// Create tables
-	db.AutoMigrate(&model.ExecutionCache{})
+	err = db.AutoMigrate(&model.ExecutionCache{})
+	if err != nil {
+		return nil, fmt.Errorf("AutoMigrate failed: %v", err)
+	}
 
 	return NewDB(db), nil
 }

--- a/backend/src/cache/storage/execution_cache_store_test.go
+++ b/backend/src/cache/storage/execution_cache_store_test.go
@@ -24,6 +24,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func closeDB(t *testing.T, db *DB) {
+	sqlDB, err := db.DB.DB()
+	require.NoError(t, err)
+	sqlDB.Close()
+}
+
 func createExecutionCache(cacheKey string, cacheOutput string) *model.ExecutionCache {
 	return &model.ExecutionCache{
 		ExecutionCacheKey: cacheKey,
@@ -37,7 +43,7 @@ func createExecutionCache(cacheKey string, cacheOutput string) *model.ExecutionC
 
 func TestCreateExecutionCache(t *testing.T) {
 	db := NewFakeDBOrFatal()
-	defer db.Close()
+	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch())
 	executionCacheExpected := model.ExecutionCache{
 		ID:                1,
@@ -70,7 +76,7 @@ func TestCreateExecutionCacheWithDuplicateRecord(t *testing.T) {
 		EndedAtInSec:      1,
 	}
 	db := NewFakeDBOrFatal()
-	defer db.Close()
+	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch())
 	executionCacheStore.CreateExecutionCache(executionCache)
 	cache, err := executionCacheStore.CreateExecutionCache(executionCache)
@@ -80,7 +86,7 @@ func TestCreateExecutionCacheWithDuplicateRecord(t *testing.T) {
 
 func TestGetExecutionCache(t *testing.T) {
 	db := NewFakeDBOrFatal()
-	defer db.Close()
+	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch())
 
 	executionCacheStore.CreateExecutionCache(createExecutionCache("testKey", "testOutput"))
@@ -102,7 +108,7 @@ func TestGetExecutionCache(t *testing.T) {
 
 func TestGetExecutionCacheWithEmptyCacheEntry(t *testing.T) {
 	db := NewFakeDBOrFatal()
-	defer db.Close()
+	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch())
 
 	executionCacheStore.CreateExecutionCache(createExecutionCache("testKey", "testOutput"))
@@ -114,7 +120,7 @@ func TestGetExecutionCacheWithEmptyCacheEntry(t *testing.T) {
 
 func TestGetExecutionCacheWithLatestCacheEntry(t *testing.T) {
 	db := NewFakeDBOrFatal()
-	defer db.Close()
+	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch())
 
 	executionCacheStore.CreateExecutionCache(createExecutionCache("testKey", "testOutput"))
@@ -137,7 +143,7 @@ func TestGetExecutionCacheWithLatestCacheEntry(t *testing.T) {
 
 func TestGetExecutionCacheWithExpiredDatabaseCacheStaleness(t *testing.T) {
 	db := NewFakeDBOrFatal()
-	defer db.Close()
+	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch())
 	executionCacheToPersist := &model.ExecutionCache{
 		ExecutionCacheKey: "testKey",
@@ -155,7 +161,7 @@ func TestGetExecutionCacheWithExpiredDatabaseCacheStaleness(t *testing.T) {
 
 func TestGetExecutionCacheWithExpiredAnnotationCacheStaleness(t *testing.T) {
 	db := NewFakeDBOrFatal()
-	defer db.Close()
+	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch())
 	executionCacheToPersist := &model.ExecutionCache{
 		ExecutionCacheKey: "testKey",
@@ -175,7 +181,7 @@ func TestGetExecutionCacheWithExpiredAnnotationCacheStaleness(t *testing.T) {
 
 func TestGetExecutionCacheWithExpiredMaximumCacheStaleness(t *testing.T) {
 	db := NewFakeDBOrFatal()
-	defer db.Close()
+	defer closeDB(t, db)
 	executionCacheStore := NewExecutionCacheStore(db, util.NewFakeTimeForEpoch())
 	executionCacheToPersist := &model.ExecutionCache{
 		ExecutionCacheKey: "testKey",

--- a/backend/test/integration/db_test.go
+++ b/backend/test/integration/db_test.go
@@ -71,6 +71,7 @@ func (s *DBTestSuite) TestInitDBClient_MySQL() {
 		t.Fatalf("failed to open gorm.DB for MySQL: %v", err)
 	}
 	// Verify composite unique constraint and index on the Pipeline model
+	cm.EnsureUniqueCompositeIndex(gdb, &model.Pipeline{}, "namespace_name")
 	verifyCompositeIndex(t, gdb, &model.Pipeline{}, "namespace_name")
 }
 
@@ -99,6 +100,7 @@ func (s *DBTestSuite) TestInitDBClient_PostgreSQL() {
 		t.Fatalf("failed to open gorm.DB for PostgreSQL: %v", err)
 	}
 	// Verify composite unique constraint and index on the Pipeline model
+	cm.EnsureUniqueCompositeIndex(gdb, &model.Pipeline{}, "namespace_name")
 	verifyCompositeIndex(s.T(), gdb, &model.Pipeline{}, "namespace_name")
 }
 

--- a/backend/test/integration/db_test.go
+++ b/backend/test/integration/db_test.go
@@ -71,7 +71,6 @@ func (s *DBTestSuite) TestInitDBClient_MySQL() {
 		t.Fatalf("failed to open gorm.DB for MySQL: %v", err)
 	}
 	// Verify composite unique constraint and index on the Pipeline model
-	cm.EnsureUniqueCompositeIndex(gdb, &model.Pipeline{}, "namespace_name")
 	verifyCompositeIndex(t, gdb, &model.Pipeline{}, "namespace_name")
 }
 
@@ -100,7 +99,6 @@ func (s *DBTestSuite) TestInitDBClient_PostgreSQL() {
 		t.Fatalf("failed to open gorm.DB for PostgreSQL: %v", err)
 	}
 	// Verify composite unique constraint and index on the Pipeline model
-	cm.EnsureUniqueCompositeIndex(gdb, &model.Pipeline{}, "namespace_name")
 	verifyCompositeIndex(s.T(), gdb, &model.Pipeline{}, "namespace_name")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -27,13 +27,12 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/jackc/pgx/v5 v5.5.4
-	github.com/jinzhu/gorm v1.9.1
+	github.com/jackc/pgx/v5 v5.5.5
 	github.com/kubeflow/pipelines/api v0.0.0-20250102152816-873e9dedd766
 	github.com/kubeflow/pipelines/kubernetes_platform v0.0.0-20240725205754-d911c8b73b49
 	github.com/kubeflow/pipelines/third_party/ml-metadata v0.0.0-20240416215826-da804407ad31
 	github.com/lestrrat-go/strftime v1.0.4
-	github.com/mattn/go-sqlite3 v1.14.19
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/minio/minio-go/v7 v7.0.94
 	github.com/peterhellberg/duration v0.0.0-20191119133758-ec6baeebcd10
 	github.com/pkg/errors v0.9.1
@@ -53,6 +52,10 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/yaml.v3 v3.0.1
+	gorm.io/driver/mysql v1.5.7
+	gorm.io/driver/postgres v1.5.11
+	gorm.io/driver/sqlite v1.5.7
+	gorm.io/gorm v1.26.1
 	k8s.io/api v0.30.1
 	k8s.io/apimachinery v0.30.1
 	k8s.io/client-go v0.30.1
@@ -98,11 +101,9 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/colinmarc/hdfs/v2 v2.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/denisenkom/go-mssqldb v0.12.3 // indirect
 	github.com/doublerebel/bellows v0.0.0-20160303004610-f177d92a03d3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
-	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
 	github.com/evanphx/json-patch v5.8.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/evilmonkeyinc/jsonpath v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,9 +17,6 @@ cloud.google.com/go/storage v1.43.0 h1:CcxnSohZwizt4LCzQHWvBf1/kvtHUn7gk9QERXPyX
 cloud.google.com/go/storage v1.43.0/go.mod h1:ajvxEa7WmZS1PxvKRq4bq0tFT3vMd502JwstCcYv0Q0=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0/go.mod h1:h6H6c8enJmmocHUbLiiGY6sx7f9i+X3m1CHdd5c6Rdw=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0/go.mod h1:HcM1YX14R7CJcghJGOYCgdezslRSVzqwLf/q+4Y2r/0=
-github.com/Azure/azure-sdk-for-go/sdk/internal v0.7.0/go.mod h1:yqy467j36fJxcRV2TzfVZ1pCb5vxm4BtZPUdYWe/Xo8=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
@@ -129,10 +126,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/denisenkom/go-mssqldb v0.12.3 h1:pBSGx9Tq67pBOTLmxNuirNTeB8Vjmf886Kx+8Y+8shw=
-github.com/denisenkom/go-mssqldb v0.12.3/go.mod h1:k0mtMFOnU+AihqFxPMiF05rtiDrorD1Vrm1KEz5hxDo=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -153,8 +147,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
-github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v5.8.0+incompatible h1:1Av9pn2FyxPdvrWNQszj1g6D6YthSmvCfcN6SYclTJg=
 github.com/evanphx/json-patch v5.8.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -297,6 +289,7 @@ github.com/go-openapi/validate v0.20.1/go.mod h1:b60iJT+xNNLfaQJUqLI7946tYiFEOuE
 github.com/go-openapi/validate v0.20.3 h1:GZPPhhKSZrE8HjB4eEkoYAZmoWA4+tCemSgINH1/vKw=
 github.com/go-openapi/validate v0.20.3/go.mod h1:goDdqVGiigM3jChcrYJxD2joalke3ZXeftD16byIjA4=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
@@ -332,10 +325,6 @@ github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PU
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
-github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
-github.com/golang-sql/sqlexp v0.1.0 h1:ZCD6MBpcuOVfGVqsEmY5/4FtYiKz6tSyUv9LPEDei6A=
-github.com/golang-sql/sqlexp v0.1.0/go.mod h1:J4ad9Vo8ZCWQ2GMrC4UCQy1JpCbwU9m3EOqtpKwwwHI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
 github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
@@ -448,8 +437,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/Y25WS6cokEszi5g+S0QxI/d45PkRi7Nk=
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.5.4 h1:Xp2aQS8uXButQdnCMWNmvx6UysWQQC+u1EoizjguY+8=
-github.com/jackc/pgx/v5 v5.5.4/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
+github.com/jackc/pgx/v5 v5.5.5 h1:amBjrZVmksIdNjxGW/IiIMzxMKZFelXbUoPNb+8sjQw=
+github.com/jackc/pgx/v5 v5.5.5/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jcmturner/aescts/v2 v2.0.0 h1:9YKLH6ey7H4eDBXW8khjYslgyqG2xZikXP0EQFKrle8=
@@ -464,8 +453,6 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/jinzhu/gorm v1.9.1 h1:lDSDtsCt5AGGSKTs8AHlSDbbgif4G4+CKJ8ETBDVHTA=
-github.com/jinzhu/gorm v1.9.1/go.mod h1:Vla75njaFJ8clLU1W44h34PjIkijhjHIYnZxMqCdxqo=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
@@ -535,8 +522,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
-github.com/mattn/go-sqlite3 v1.14.19 h1:fhGleo2h1p8tVChob4I9HpmVFIAkKGpiukdrgQbWfGI=
-github.com/mattn/go-sqlite3 v1.14.19/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
 github.com/minio/crc64nvme v1.0.1 h1:DHQPrYPdqK7jQG/Ls5CTBZWeex/2FMS3G5XGkycuFrY=
@@ -569,7 +556,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
@@ -602,7 +588,6 @@ github.com/peterhellberg/duration v0.0.0-20191119133758-ec6baeebcd10 h1:Jf08dx6h
 github.com/peterhellberg/duration v0.0.0-20191119133758-ec6baeebcd10/go.mod h1:x5xjkH61fUOJVgCCDgqNzlJvdLXiYpmMzSuum2FBOaw=
 github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c h1:dAMKvw0MlJT1GshSTtih8C2gDs04w8dReiOGXrGLNoY=
 github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
-github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -753,9 +738,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
@@ -805,8 +788,6 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
-golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
@@ -1014,6 +995,15 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/mysql v1.5.7 h1:MndhOPYOfEp2rHKgkZIhJ16eVUIRf2HmzgoPmh7FCWo=
+gorm.io/driver/mysql v1.5.7/go.mod h1:sEtPWMiqiN1N1cMXoXmBbd8C6/l+TESwriotuRRpkDM=
+gorm.io/driver/postgres v1.5.11 h1:ubBVAfbKEUld/twyKZ0IYn9rSQh448EdelLYk9Mv314=
+gorm.io/driver/postgres v1.5.11/go.mod h1:DX3GReXH+3FPWGrrgffdvCk3DQ1dwDPdmbenSkweRGI=
+gorm.io/driver/sqlite v1.5.7 h1:8NvsrhP0ifM7LX9G4zPB97NwovUakUxc+2V2uuf3Z1I=
+gorm.io/driver/sqlite v1.5.7/go.mod h1:U+J8craQU6Fzkcvu8oLeAQmi50TkwPEhHDEjQZXDah4=
+gorm.io/gorm v1.25.7/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
+gorm.io/gorm v1.26.1 h1:ghB2gUI9FkS46luZtn6DLZ0f6ooBJ5IbVej2ENFDjRw=
+gorm.io/gorm v1.26.1/go.mod h1:8Z33v652h4//uMA76KjeDH8mJXPm1QNCYrMeatR0DOE=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
+++ b/manifests/kustomize/third-party/mysql/base/mysql-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         # Ext4, Btrfs etc. volumes root directories have a lost+found directory that should not be treated as a database.
         # ignore-db-dir option has been deprecated in mysql v5.7.16.
         #
-        # If upgrading MySQL to v8.0 fails, try removing /var/lib/mysql/lost+found folder in 
+        # If upgrading MySQL to v8.0 fails, try removing /var/lib/mysql/lost+found folder in
         # mysql-pv-claim (mysql-persistent-storage):
         #
         # kubectl exec -it <mysql-pod-name> -n kubeflow -- bash
@@ -34,7 +34,7 @@ spec:
         - --datadir
         - /var/lib/mysql
         # MLMD workloads (metadata-grpc-deployment and metadata-writer) depend on mysql_native_password authentication plugin.
-        # mysql_native_password plugin implements native authentication; that is, authentication based on the password 
+        # mysql_native_password plugin implements native authentication; that is, authentication based on the password
         # hashing method in use from before the introduction of pluggable authentication in MySQL 8.0.
         #
         # The mysql_native_password authentication plugin is deprecated as of MySQL 8.0.34, disabled by default


### PR DESCRIPTION
This PR serves as a control group for PR # 12013 to locate the bug.  This PR isolates and tests the CI impact of introducing `GormDBDataType()` without making any changes to varchar lengths.

### Background
In the main `chore/gorm-v2-migration` PR, both `GormDBDataType()` and varchar length adjustments were introduced simultaneously, making it hard to identify the root cause of recent CI failures.

### This PR Includes:
- Only the replacement of `gorm:"type:xxx"` with `gorm:"gormDBDataType:xxx"` using our helper function
- No change to varchar or string field lengths
- No changes to schema constraints or validations

### Purpose:
To test whether `GormDBDataType()` alone causes sample test or integration test failures under MySQL (default CI dialect).

---

Once this PR is marked `ok to test`, we'll be able to confirm whether this refactor is safe in isolation. If it fails, it provides a clear signal that further investigation into `GormDBDataType()` logic is needed.