### PR TITLE
Fix broken Pipeline Root documentation link

### DIFF
--- a/frontend/src/components/NewRunParametersV2.tsx
+++ b/frontend/src/components/NewRunParametersV2.tsx
@@ -242,7 +242,7 @@ function NewRunParametersV2(props: NewRunParametersProps) {
       <div className={commonCss.header}>Pipeline Root</div>
       <div>
         Pipeline Root represents an artifact repository, refer to{' '}
-        <ExternalLink href='https://www.kubeflow.org/docs/components/pipelines/overview/pipeline-root/'>
+        <ExternalLink href='https://www.kubeflow.org/docs/components/pipelines/concepts/pipeline-root/'>
           Pipeline Root Documentation
         </ExternalLink>
         .


### PR DESCRIPTION
- Update URL from /overview/pipeline-root/ to /concepts/pipeline-root/
- Resolves 404 error when users click the documentation link
- Located in frontend/src/components/NewRunParametersV2.tsx line 245

**Description of your changes:**


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
