### PR TITLE
add new KFP maintainers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,8 @@ approvers:
   - droctothorpe
   - HumairAK
   - james-jwu
+  - mprahl
+  - zazulam
 reviewers:
   - chensun
   - HumairAK


### PR DESCRIPTION
**Description of your changes:**

As per the conversation in the KFP community call on July 16, 2025 (see recording of announcement [here](https://youtu.be/wvGctNDiF2E?feature=shared&t=196)), I nominate @mprahl and @zazulam for KFP maintainers. Both individuals have been very involved in, and helping shape, the KFP community and project in the past. 

Amongst many other contributions, @mprahl has been key in instrumenting various major architectural decisions in KFP both with implementation and architecture and system design. He has not only contributed many PRs in his own right, but he has also become a valuable gatekeeper and reviewer of various initiatives brought forth by other members of the community. 

Similarly, @zazulam has been a big contributor to the overall KFP project, acting as an approver for different areas of the KFP project. He has been instrumental in closing many regression gaps with KFP v1 in v2. He is a key contributor to the KFP sdk and backend. He is a great representative of various KFP users in his org and brings with him valuable user perspectives. 

Both candidates are also very present within the community calls, and slack, providing strong opinions in the direction of the project, whilst also providing assistance to others.

I am excited to see these two become maintainers and continue to help shape the future of the KFP project, roadmap, and nurture the community going forward alongside the other maintainers. 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
