### PR TITLE
feat(backend/sdk): define and use dsl.WORKSPACE_PATH_PLACEHOLDER for workspace access

### DIFF
--- a/backend/src/v2/compiler/visitor.go
+++ b/backend/src/v2/compiler/visitor.go
@@ -111,11 +111,13 @@ func (state *pipelineDFS) dfs(name string, component *pipelinespec.ComponentSpec
 
 		// Add kubernetes spec to annotation
 		if state.kubernetesSpec != nil && state.kubernetesSpec.DeploymentSpec != nil {
-			kubernetesExecSpec, ok := state.kubernetesSpec.DeploymentSpec.Executors[executorLabel]
-			if ok {
-				err := state.visitor.AddKubernetesSpec(name, kubernetesExecSpec)
-				if err != nil {
-					return componentError(fmt.Errorf("failed to add Kubernetes spec for %s: %w", name, err))
+			if state.kubernetesSpec.DeploymentSpec.Executors != nil {
+				kubernetesExecSpec, ok := state.kubernetesSpec.DeploymentSpec.Executors[executorLabel]
+				if ok {
+					err := state.visitor.AddKubernetesSpec(name, kubernetesExecSpec)
+					if err != nil {
+						return componentError(fmt.Errorf("failed to add Kubernetes spec for %s: %w", name, err))
+					}
 				}
 			}
 		}

--- a/backend/src/v2/component/constants.go
+++ b/backend/src/v2/component/constants.go
@@ -25,4 +25,8 @@ const (
 	// Env vars in metadata-grpc-configmap
 	EnvMetadataHost = "METADATA_GRPC_SERVICE_HOST"
 	EnvMetadataPort = "METADATA_GRPC_SERVICE_PORT"
+
+	// Workspace-related constants
+	WorkspaceVolumeName = "kfp-workspace"
+	WorkspaceMountPath  = "/kfp-workspace"
 )

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 	k8score "k8s.io/api/core/v1"
 	k8sres "k8s.io/apimachinery/pkg/api/resource"
 )
@@ -320,7 +321,74 @@ func initPodSpecPatch(
 
 	addModelcarsToPodSpec(executorInput.GetInputs().GetArtifacts(), userEnvVar, podSpec)
 
+	if needsWorkspaceMount(executorInput) {
+		// Validate that no user volume mounts conflict with the workspace
+		if err := validateVolumeMounts(podSpec); err != nil {
+			return nil, fmt.Errorf("failed to validate volume mounts: %w", err)
+		}
+
+		// Uses Argo template variable to reference the PVC created by volumeClaimTemplates
+		// Argo resolves {{workflow.name}}-kfp-workspace to the actual PVC name at runtime
+		pvcName := "{{workflow.name}}-" + component.WorkspaceVolumeName
+
+		addWorkspaceMount(podSpec, pvcName)
+	}
+
 	return podSpec, nil
+}
+
+// needsWorkspaceMount checks if the component needs workspace mounting based on input parameters and artifacts.
+func needsWorkspaceMount(executorInput *pipelinespec.ExecutorInput) bool {
+	// Check if any input parameter is the workspace path placeholder
+	for _, param := range executorInput.GetInputs().GetParameterValues() {
+		if strVal, ok := param.GetKind().(*structpb.Value_StringValue); ok {
+			if strings.Contains(strVal.StringValue, "{{$.workspace_path}}") {
+				return true
+			}
+
+			if strings.HasPrefix(strVal.StringValue, component.WorkspaceMountPath) {
+				return true
+			}
+		}
+	}
+
+	// Check if any input artifact has workspace metadata
+	for _, artifactList := range executorInput.GetInputs().GetArtifacts() {
+		if len(artifactList.Artifacts) == 0 {
+			continue
+		}
+		// first artifact is used, as the list is expected to contain a single artifact
+		artifact := artifactList.Artifacts[0]
+		if artifact.Metadata != nil {
+			if workspaceVal, ok := artifact.Metadata.Fields["_kfp_workspace"]; ok {
+				if boolVal, ok := workspaceVal.GetKind().(*structpb.Value_BoolValue); ok && boolVal.BoolValue {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// addWorkspaceMount adds the workspace volume mount to the pod spec if needed.
+func addWorkspaceMount(podSpec *k8score.PodSpec, pvcName string) {
+	workspaceVolume := k8score.Volume{
+		Name: component.WorkspaceVolumeName,
+		VolumeSource: k8score.VolumeSource{
+			PersistentVolumeClaim: &k8score.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvcName,
+			},
+		},
+	}
+
+	workspaceVolumeMount := k8score.VolumeMount{
+		Name:      component.WorkspaceVolumeName,
+		MountPath: component.WorkspaceMountPath,
+	}
+
+	podSpec.Volumes = append(podSpec.Volumes, workspaceVolume)
+	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, workspaceVolumeMount)
 }
 
 // addModelcarsToPodSpec will patch the pod spec if there are any input artifacts in the Modelcar format.
@@ -524,4 +592,21 @@ func provisionOutputs(
 	}
 
 	return outputs
+}
+
+func validateVolumeMounts(podSpec *k8score.PodSpec) error {
+	// Validate that no user volume mounts conflict with the workspace mount path or volume name
+	for _, container := range podSpec.Containers {
+		for _, mount := range container.VolumeMounts {
+			if strings.HasPrefix(mount.MountPath, component.WorkspaceMountPath) {
+				return fmt.Errorf("user volume mount at %s conflicts with workspace mount at %s", mount.MountPath, component.WorkspaceMountPath)
+			}
+
+			if mount.Name == component.WorkspaceVolumeName {
+				return fmt.Errorf("user volume mount name %s conflicts with workspace volume name %s", mount.Name, component.WorkspaceVolumeName)
+			}
+		}
+	}
+
+	return nil
 }

--- a/proposals/11875-pipeline-workspace/README.md
+++ b/proposals/11875-pipeline-workspace/README.md
@@ -509,7 +509,7 @@ kind: Workflow
 spec:
   volumeClaimTemplates:
     - metadata:
-        name: kfp-workspace-46f1d52e-c72b-42fc-88ae-789edf7c33fd # The suffix is the run ID
+        name: kfp-workspace
       spec:
         accessModes:
           - ReadWriteMany
@@ -564,8 +564,9 @@ When an input artifact is from a workspace, an input parameter is `dsl.WORKSPACE
 parameter is a component output result that is a path to the workspace (e.g. starts with `/kfp-workspace`), the driver
 should set the volume mount of the KFP workspace in the `Pod` spec patch.
 
-Lastly, the Driver should disallow user mounted volumes in or under `/kfp-workspace` as this could lead to confusing
-behavior.
+Lastly, the Driver should disallow user mounted volumes in or under `/kfp-workspace` as this could lead to confusing behavior. The validation should check for:
+1. Volume mount paths that conflict with the workspace mount path (`/kfp-workspace`)
+2. Volume mount names that conflict with the workspace volume name (`kfp-workspace`)
 
 #### Launcher
 

--- a/samples/v2/pipeline_with_workspace.py
+++ b/samples/v2/pipeline_with_workspace.py
@@ -1,0 +1,77 @@
+# Copyright 2025 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A pipeline using workspace functionality."""
+from kfp import dsl
+
+
+@dsl.component
+def write_to_workspace(workspace_path: str) -> str:
+    """Write a file to the workspace."""   
+    import os
+    
+    # Create a file in the workspace
+    file_path = os.path.join(workspace_path, "data", "test_file.txt")
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    
+    with open(file_path, "w") as f:
+        f.write("Hello from workspace!")
+    
+    print(f"Wrote file to: {file_path}")
+    return file_path
+
+
+@dsl.component
+def read_from_workspace(file_path: str) -> str:
+    """Read a file from the workspace using the provided file path."""    
+    import os
+    
+    if os.path.exists(file_path):
+        with open(file_path, "r") as f:
+            content = f.read()
+        print(f"Read content from: {file_path}")
+        print(f"Content: {content}")
+        assert content == "Hello from workspace!"
+        return content
+    else:
+        print(f"File not found at: {file_path}")
+        return "File not found"
+
+
+@dsl.pipeline(
+    name="pipeline-with-workspace",
+    description="A pipeline that demonstrates workspace functionality",
+    pipeline_config=dsl.PipelineConfig(
+        workspace=dsl.WorkspaceConfig(
+            size='1Gi',
+            kubernetes=dsl.KubernetesWorkspaceConfig(
+                pvcSpecPatch={'storageClassName': 'standard'}
+            )
+        ),
+    ),
+)
+def pipeline_with_workspace() -> str:
+    """A pipeline using workspace functionality with write and read components."""
+    
+    # Write to workspace
+    write_task = write_to_workspace(
+        workspace_path=dsl.WORKSPACE_PATH_PLACEHOLDER
+    )
+    
+    # Read from workspace
+    read_task = read_from_workspace(
+        file_path=write_task.output
+    )
+    
+    return read_task.output

--- a/samples/v2/sample_test.py
+++ b/samples/v2/sample_test.py
@@ -74,6 +74,7 @@ import nested_pipeline_opt_inputs_parent_level
 import nested_pipeline_opt_inputs_nil
 import nested_pipeline_opt_input_child_level
 import pipeline_with_pod_metadata
+import pipeline_with_workspace
 from modelcar import modelcar
 
 
@@ -212,7 +213,8 @@ class SampleTest(unittest.TestCase):
             TestCase(pipeline_func=nested_pipeline_opt_inputs_parent_level.nested_pipeline_opt_inputs_parent_level),
             TestCase(pipeline_func=nested_pipeline_opt_input_child_level.nested_pipeline_opt_input_child_level),
             TestCase(pipeline_func=nested_pipeline_opt_inputs_nil.nested_pipeline_opt_inputs_nil),
-            TestCase(pipeline_func=pipeline_with_pod_metadata.pipeline_with_pod_metadata)
+            TestCase(pipeline_func=pipeline_with_pod_metadata.pipeline_with_pod_metadata),
+            TestCase(pipeline_func=pipeline_with_workspace.pipeline_with_workspace),
         ]
 
         with ThreadPoolExecutor() as executor:

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -40,6 +40,7 @@ __all__ = [
     'PIPELINE_ROOT_PLACEHOLDER',
     'PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER',
     'PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER',
+    'WORKSPACE_PATH_PLACEHOLDER',
 ]
 import os
 
@@ -206,6 +207,23 @@ PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER = '{{$.pipeline_job_schedule_time_utc
             print_op(
                 msg='Job scheduled at:',
                 value=dsl.PIPELINE_JOB_SCHEDULE_TIME_UTC,
+            )
+"""
+
+WORKSPACE_PATH_PLACEHOLDER = '{{$.workspace_path}}'
+"""A placeholder used to obtain the path to the shared workspace within a component.
+    
+    Example:
+      ::
+
+        @dsl.pipeline(
+            pipeline_config=dsl.PipelineConfig(
+                workspace=dsl.WorkspaceConfig(size='100Gi'),
+            ),
+        )
+        def my_pipeline():
+            clone_repo_task = clone_repo(
+                workspacePath=dsl.WORKSPACE_PATH_PLACEHOLDER, repo='https://github.com/example/repo',
             )
 """
 

--- a/sdk/python/kfp/dsl/constants.py
+++ b/sdk/python/kfp/dsl/constants.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Constants."""
 
+# Workspace-related constants
+WORKSPACE_MOUNT_PATH = '/kfp-workspace'
+
 # Unit constants for k8s size string.
 _E = 10**18  # Exa
 _EI = 1 << 60  # Exa: power-of-two approximate

--- a/sdk/python/kfp/local/config_test.py
+++ b/sdk/python/kfp/local/config_test.py
@@ -29,6 +29,7 @@ class LocalRunnerConfigTest(unittest.TestCase):
         """Test instance attributes with one constructor call."""
         config.LocalExecutionConfig(
             pipeline_root='my/local/root',
+            workspace_root='/tmp/test-workspace',
             runner=local.SubprocessRunner(use_venv=True),
             raise_on_error=True,
         )
@@ -36,6 +37,7 @@ class LocalRunnerConfigTest(unittest.TestCase):
         instance = config.LocalExecutionConfig.instance
 
         self.assertEqual(instance.pipeline_root, 'my/local/root')
+        self.assertEqual(instance.workspace_root, '/tmp/test-workspace')
         self.assertEqual(instance.runner, local.SubprocessRunner(use_venv=True))
         self.assertIs(instance.raise_on_error, True)
 
@@ -43,11 +45,13 @@ class LocalRunnerConfigTest(unittest.TestCase):
         """Test instance attributes with multiple constructor calls."""
         config.LocalExecutionConfig(
             pipeline_root='my/local/root',
+            workspace_root='/tmp/test-workspace-1',
             runner=local.SubprocessRunner(),
             raise_on_error=True,
         )
         config.LocalExecutionConfig(
             pipeline_root='other/local/root',
+            workspace_root='/tmp/test-workspace-2',
             runner=local.SubprocessRunner(use_venv=False),
             raise_on_error=False,
         )
@@ -55,6 +59,7 @@ class LocalRunnerConfigTest(unittest.TestCase):
         instance = config.LocalExecutionConfig.instance
 
         self.assertEqual(instance.pipeline_root, 'other/local/root')
+        self.assertEqual(instance.workspace_root, '/tmp/test-workspace-2')
         self.assertEqual(instance.runner,
                          local.SubprocessRunner(use_venv=False))
         self.assertFalse(instance.raise_on_error, False)
@@ -62,6 +67,7 @@ class LocalRunnerConfigTest(unittest.TestCase):
     def test_validate_success(self):
         config.LocalExecutionConfig(
             pipeline_root='other/local/root',
+            workspace_root='/tmp/test-workspace',
             runner=local.SubprocessRunner(use_venv=False),
             raise_on_error=False,
         )


### PR DESCRIPTION
**Description of your changes:**

This resolves https://github.com/kubeflow/pipelines/issues/12077

**Summary**

**SDK Change:**
    Added a new placeholder constant:
    dsl.WORKSPACE_PATH_PLACEHOLDER = "/kfp-workspace"

 **Container Driver Change:**
  - Detects if any input parameter equals dsl.WORKSPACE_PATH_PLACEHOLDER. 
  - Also detects if any input or output path starts with /kfp-workspace. 
  - If matched, the driver injects the volume mount for the shared workspace PVC into the Pod spec.



**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
