### PR TITLE
fix(sdk): Configurable component compile time imports

### DIFF
--- a/sdk/python/kfp/dsl/component_decorator.py
+++ b/sdk/python/kfp/dsl/component_decorator.py
@@ -29,7 +29,8 @@ def component(func: Optional[Callable] = None,
               install_kfp_package: bool = True,
               kfp_package_path: Optional[str] = None,
               pip_trusted_hosts: Optional[List[str]] = None,
-              use_venv: bool = False):
+              use_venv: bool = False,
+              compile_time_imports: bool = False):
     """Decorator for Python-function based components.
 
     A KFP component can either be a lightweight component or a containerized
@@ -79,6 +80,8 @@ def component(func: Optional[Callable] = None,
         use_venv: Specifies if the component should be executed in a virtual environment.
             The environment will be created in a temporary directory and will inherit the system site packages.
             This is useful in restricted environments where most of the system is read-only.
+        compile_time_imports: When true this will include imports in the kfp.dsl package traditionally used only at
+        compile time. Set this value to true when you need compile time imports at runtime. By default, this is false because skipping compile time imports improves component execution times.
 
     Returns:
         A component task factory that can be used in pipeline definitions.
@@ -121,7 +124,9 @@ def component(func: Optional[Callable] = None,
             install_kfp_package=install_kfp_package,
             kfp_package_path=kfp_package_path,
             pip_trusted_hosts=pip_trusted_hosts,
-            use_venv=use_venv)
+            use_venv=use_venv,
+            compile_time_imports=compile_time_imports
+        )
 
     return component_factory.create_component_from_func(
         func,
@@ -133,4 +138,6 @@ def component(func: Optional[Callable] = None,
         install_kfp_package=install_kfp_package,
         kfp_package_path=kfp_package_path,
         pip_trusted_hosts=pip_trusted_hosts,
-        use_venv=use_venv)
+        use_venv=use_venv,
+        compile_time_imports=compile_time_imports,
+    )

--- a/sdk/python/kfp/dsl/component_decorator_test.py
+++ b/sdk/python/kfp/dsl/component_decorator_test.py
@@ -149,3 +149,21 @@ class TestComponentDecorator(unittest.TestCase):
         # TODO: ideally should be the canonical type string, rather than the specific annotation as string, but both work
         self.assertEqual(comp.component_spec.outputs['Output'].type,
                          'typing.List[str]')
+
+    def test_with_compile_time_imports(self):
+
+        @component(base_image='python:3.9', compile_time_imports=True)
+        def hello_world(text: str) -> str:
+            return text
+
+        self.assertIsInstance(hello_world, python_component.PythonComponent)
+        self.assertTrue("_KFP_RUNTIME=false" in hello_world.component_spec.implementation.container.command[5])
+
+    def test_with_compile_time_imports_defaults_false(self):
+
+        @component(base_image='python:3.9')
+        def hello_world(text: str) -> str:
+            return text
+
+        self.assertIsInstance(hello_world, python_component.PythonComponent)
+        self.assertTrue("_KFP_RUNTIME=true" in hello_world.component_spec.implementation.container.command[5])

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -486,7 +486,7 @@ CONTAINERIZED_PYTHON_COMPONENT_COMMAND = [
 
 
 def _get_command_and_args_for_lightweight_component(
-        func: Callable) -> Tuple[List[str], List[str]]:
+        func: Callable, include_compile_time_imports: bool = False) -> Tuple[List[str], List[str]]:
     imports_source = [
         'import kfp',
         'from kfp import dsl',
@@ -507,7 +507,7 @@ def _get_command_and_args_for_lightweight_component(
                     program_path=$(mktemp -d)
 
                     printf "%s" "$0" > "$program_path/ephemeral_component.py"
-                    _KFP_RUNTIME=true python3 -m {EXECUTOR_MODULE} \
+                    _KFP_RUNTIME={'false' if include_compile_time_imports else 'true'} python3 -m {EXECUTOR_MODULE} \
                         --component_module_path \
                         "$program_path/ephemeral_component.py" \
                         "$@"
@@ -548,6 +548,7 @@ def create_component_from_func(
     kfp_package_path: Optional[str] = None,
     pip_trusted_hosts: Optional[List[str]] = None,
     use_venv: bool = False,
+    compile_time_imports: bool = False,
 ) -> python_component.PythonComponent:
     """Implementation for the @component decorator.
 
@@ -584,7 +585,7 @@ def create_component_from_func(
             function_name=func.__name__,)
     else:
         command, args = _get_command_and_args_for_lightweight_component(
-            func=func)
+            func=func, include_compile_time_imports=compile_time_imports)
 
     component_spec = extract_component_interface(func)
     component_spec.implementation = structures.Implementation(

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -337,5 +337,21 @@ class TestPythonEOLWarning(unittest.TestCase):
                 pass
 
 
+class TestCompileTimeImports(unittest.TestCase):
+
+    def test_get_command_and_args_with_compile_time_imports(self):
+        def hello_world():
+            print("test function")
+
+        command, args = component_factory._get_command_and_args_for_lightweight_component(func=hello_world, include_compile_time_imports=True)
+        self.assertTrue("_KFP_RUNTIME=false" in command[2])
+
+    def test_get_command_and_args_default_without_compile_time_imports(self):
+        def hello_world():
+            print("test function")
+
+        command, args = component_factory._get_command_and_args_for_lightweight_component(func=hello_world)
+        self.assertTrue("_KFP_RUNTIME=true" in command[2])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of your changes:**
Add a configurable compile time import flag for kfp components. When attempting to import a compile time dependency at runtime the following error is thrown: `ImportError cannot import name `PipelineTask` from `kfp.dsl`.

See the following example pipeline which replicates this issue: 

```python
import kfp
from kfp.dsl import component, pipeline

@component(
	base_image="python:3.9-slim"
)
def hello_world() -> str:
        # Compile time import used at runtime
	from kfp.kubernetes import node_selector

	return "Hello, World from Kubeflow Pipelines!"


@pipeline(
	name="hello-world-pipeline",
	description="A simple hello world pipeline for KFP v2"
)
def hello_world_pipeline():
	"""Define the pipeline workflow."""
	hello_task = hello_world()


if __name__ == "__main__":
	kfp.compiler.Compiler().compile(
		pipeline_func=hello_world_pipeline,
		package_path="hello_world_pipeline.yaml"
	)

```

This change makes the `_KFP_RUNTIME=true` portion of the IR spec configurable so that compile time imports can be used at runtime if desired. The `compile_time_imports` flag on the component decorator defaults to false so it won't disrupt any existing pipeline configurations or change existing functionality. It's purely opt-in. Here is an example utilizing it with a component:

```python
import kfp
from kfp.dsl import component, pipeline

@component(
	base_image="python:3.9-slim" ,
        compile_time_imports=True
)
def hello_world() -> str:
        # Now this works as expected
	from kfp.kubernetes import node_selector

	return "Hello, World from Kubeflow Pipelines!"
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
