### PR TITLE
fix(backend): omit unknown fields in json marshaling

### DIFF
--- a/backend/src/apiserver/common/utils.go
+++ b/backend/src/apiserver/common/utils.go
@@ -20,6 +20,9 @@ import (
 	"regexp"
 	"strings"
 
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"go.uber.org/zap/zapcore"
 )
@@ -142,4 +145,23 @@ func ParseLogLevel(logLevel string) (zapcore.Level, error) {
 func FileExists(filePath string) bool {
 	_, err := os.Stat(filePath)
 	return !os.IsNotExist(err)
+}
+
+// CustomMarshaler will create a custom marshaler to use snake_case
+// for proto field names, and allow the api server to error on
+// invalid fields.
+func CustomMarshaler() *runtime.JSONPb {
+	return &runtime.JSONPb{
+		MarshalOptions: protojson.MarshalOptions{
+			// This allows us to use proto field names which are
+			// in snake_case format
+			UseProtoNames:   true,
+			EmitUnpopulated: false,
+		},
+		UnmarshalOptions: protojson.UnmarshalOptions{
+			// We want to allow the api server to error on
+			// invalid fields
+			DiscardUnknown: false,
+		},
+	}
 }

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -27,8 +27,6 @@ import (
 	"strings"
 	"sync"
 
-	"google.golang.org/protobuf/encoding/protojson"
-
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
@@ -281,26 +279,9 @@ func startHttpProxy(resourceManager *resource.ResourceManager, usePipelinesKuber
 		pipelineStore = "database"
 	}
 
-	// Create gRPC HTTP MUX and register.
-	// Create a custom marshaler to use snake_case
-	customMarshaler := &runtime.JSONPb{
-		MarshalOptions: protojson.MarshalOptions{
-			// This allows us to use proto field names which are
-			// in snake_case format
-			UseProtoNames: true,
-			// Also emit fields that are zero-valued
-			// This is the same behavior as the default marshaler.
-			EmitUnpopulated: true,
-		},
-		UnmarshalOptions: protojson.UnmarshalOptions{
-			// We want to allow the api server to error on
-			// invalid fields
-			DiscardUnknown: false,
-		},
-	}
 	runtimeMux := runtime.NewServeMux(
 		runtime.WithIncomingHeaderMatcher(grpcCustomMatcher),
-		runtime.WithMarshalerOption(runtime.MIMEWildcard, customMarshaler))
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, common.CustomMarshaler()))
 	registerHttpHandlerFromEndpoint(apiv1beta1.RegisterPipelineServiceHandlerFromEndpoint, "PipelineService", ctx, runtimeMux)
 	registerHttpHandlerFromEndpoint(apiv1beta1.RegisterExperimentServiceHandlerFromEndpoint, "ExperimentService", ctx, runtimeMux)
 	registerHttpHandlerFromEndpoint(apiv1beta1.RegisterJobServiceHandlerFromEndpoint, "JobService", ctx, runtimeMux)

--- a/backend/test/integration/job_api_test.go
+++ b/backend/test/integration/job_api_test.go
@@ -554,7 +554,6 @@ func (s *JobApiTestSuite) checkHelloWorldJob(t *testing.T, job *job_model.APIJob
 			PipelineID:       job.PipelineSpec.PipelineID,
 			PipelineName:     job.PipelineSpec.PipelineName,
 			WorkflowManifest: job.PipelineSpec.WorkflowManifest,
-			Parameters:       []*job_model.APIParameter{},
 		},
 		ResourceReferences: []*job_model.APIResourceReference{
 			{
@@ -571,7 +570,6 @@ func (s *JobApiTestSuite) checkHelloWorldJob(t *testing.T, job *job_model.APIJob
 		CreatedAt:      job.CreatedAt,
 		UpdatedAt:      job.UpdatedAt,
 		Status:         job.Status,
-		Mode:           job_model.JobModeUNKNOWNMODE.Pointer(),
 	}
 
 	assert.True(t, test.VerifyJobResourceReferences(job.ResourceReferences, expectedJob.ResourceReferences))
@@ -613,7 +611,6 @@ func (s *JobApiTestSuite) checkArgParamsJob(t *testing.T, job *job_model.APIJob,
 		CreatedAt:      job.CreatedAt,
 		UpdatedAt:      job.UpdatedAt,
 		Status:         job.Status,
-		Mode:           job_model.JobModeUNKNOWNMODE.Pointer(),
 	}
 	assert.True(t, test.VerifyJobResourceReferences(job.ResourceReferences, expectedJob.ResourceReferences))
 	expectedJob.ResourceReferences = job.ResourceReferences

--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -377,7 +377,6 @@ func (s *RunApiTestSuite) checkTerminatedRunDetail(t *testing.T, runDetail *run_
 			PipelineID:       runDetail.Run.PipelineSpec.PipelineID,
 			PipelineName:     runDetail.Run.PipelineSpec.PipelineName,
 			WorkflowManifest: runDetail.Run.PipelineSpec.WorkflowManifest,
-			Parameters:       []*run_model.APIParameter{},
 		},
 		ResourceReferences: []*run_model.APIResourceReference{
 			{
@@ -389,11 +388,9 @@ func (s *RunApiTestSuite) checkTerminatedRunDetail(t *testing.T, runDetail *run_
 				Name: pipelineVersionName, Relationship: run_model.APIRelationshipCREATOR.Pointer(),
 			},
 		},
-		CreatedAt:    runDetail.Run.CreatedAt,
-		ScheduledAt:  runDetail.Run.ScheduledAt,
-		FinishedAt:   runDetail.Run.FinishedAt,
-		Metrics:      []*run_model.APIRunMetric{},
-		StorageState: run_model.APIRunStorageStateSTORAGESTATEAVAILABLE.Pointer(),
+		CreatedAt:   runDetail.Run.CreatedAt,
+		ScheduledAt: runDetail.Run.ScheduledAt,
+		FinishedAt:  runDetail.Run.FinishedAt,
 	}
 
 	verifyRunDetails(t, runDetail, expectedRun)
@@ -428,7 +425,6 @@ func (s *RunApiTestSuite) checkHelloWorldRunDetail(t *testing.T, runDetail *run_
 			PipelineID:       runDetail.Run.PipelineSpec.PipelineID,
 			PipelineName:     runDetail.Run.PipelineSpec.PipelineName,
 			WorkflowManifest: runDetail.Run.PipelineSpec.WorkflowManifest,
-			Parameters:       []*run_model.APIParameter{},
 		},
 		ResourceReferences: []*run_model.APIResourceReference{
 			{
@@ -440,11 +436,9 @@ func (s *RunApiTestSuite) checkHelloWorldRunDetail(t *testing.T, runDetail *run_
 				Name: pipelineVersionName, Relationship: run_model.APIRelationshipCREATOR.Pointer(),
 			},
 		},
-		CreatedAt:    runDetail.Run.CreatedAt,
-		ScheduledAt:  runDetail.Run.ScheduledAt,
-		FinishedAt:   runDetail.Run.FinishedAt,
-		Metrics:      []*run_model.APIRunMetric{},
-		StorageState: run_model.APIRunStorageStateSTORAGESTATEAVAILABLE.Pointer(),
+		CreatedAt:   runDetail.Run.CreatedAt,
+		ScheduledAt: runDetail.Run.ScheduledAt,
+		FinishedAt:  runDetail.Run.FinishedAt,
 	}
 
 	verifyRunDetails(t, runDetail, expectedRun)
@@ -478,11 +472,9 @@ func (s *RunApiTestSuite) checkArgParamsRunDetail(t *testing.T, runDetail *run_m
 				Name: experimentName, Relationship: run_model.APIRelationshipOWNER.Pointer(),
 			},
 		},
-		CreatedAt:    runDetail.Run.CreatedAt,
-		ScheduledAt:  runDetail.Run.ScheduledAt,
-		FinishedAt:   runDetail.Run.FinishedAt,
-		Metrics:      []*run_model.APIRunMetric{},
-		StorageState: run_model.APIRunStorageStateSTORAGESTATEAVAILABLE.Pointer(),
+		CreatedAt:   runDetail.Run.CreatedAt,
+		ScheduledAt: runDetail.Run.ScheduledAt,
+		FinishedAt:  runDetail.Run.FinishedAt,
 	}
 
 	verifyRunDetails(t, runDetail, expectedRun)

--- a/backend/test/integration/upgrade_test.go
+++ b/backend/test/integration/upgrade_test.go
@@ -440,7 +440,6 @@ func (s *UpgradeTests) VerifyJobs() {
 			PipelineID:       pipeline.ID,
 			PipelineName:     "hello-world.yaml",
 			WorkflowManifest: job.PipelineSpec.WorkflowManifest,
-			Parameters:       []*job_model.APIParameter{},
 		},
 		ResourceReferences: []*job_model.APIResourceReference{
 			{
@@ -455,7 +454,6 @@ func (s *UpgradeTests) VerifyJobs() {
 		CreatedAt:      job.CreatedAt,
 		UpdatedAt:      job.UpdatedAt,
 		Status:         job.Status,
-		Mode:           job_model.JobModeUNKNOWNMODE.Pointer(),
 	}
 
 	assert.True(t, test.VerifyJobResourceReferences(job.ResourceReferences, expectedJob.ResourceReferences), "Inconsistent resource references: %v does not contain %v", job.ResourceReferences, expectedJob.ResourceReferences)
@@ -610,7 +608,6 @@ func checkHelloWorldRunDetail(t *testing.T, runDetail *run_model.APIRunDetail) {
 			PipelineID:       runDetail.Run.PipelineSpec.PipelineID,
 			PipelineName:     "hello-world.yaml",
 			WorkflowManifest: runDetail.Run.PipelineSpec.WorkflowManifest,
-			Parameters:       []*run_model.APIParameter{},
 		},
 		ResourceReferences: []*run_model.APIResourceReference{
 			{
@@ -622,8 +619,6 @@ func checkHelloWorldRunDetail(t *testing.T, runDetail *run_model.APIRunDetail) {
 		CreatedAt:      runDetail.Run.CreatedAt,
 		ScheduledAt:    runDetail.Run.ScheduledAt,
 		FinishedAt:     runDetail.Run.FinishedAt,
-		Metrics:        []*run_model.APIRunMetric{},
-		StorageState:   run_model.APIRunStorageStateSTORAGESTATEAVAILABLE.Pointer(),
 	}
 	assert.True(t, test.VerifyRunResourceReferences(runDetail.Run.ResourceReferences, expectedRun.ResourceReferences), "Run's res references %v does not include %v", runDetail.Run.ResourceReferences, expectedRun.ResourceReferences)
 	expectedRun.ResourceReferences = runDetail.Run.ResourceReferences


### PR DESCRIPTION
**Description of your changes:**

[This change](https://github.com/kubeflow/pipelines/commit/cc35187dff270008c6bef505c828f442773ec97d) introduced a breaking change where the API was setting default values for unknown fields, this has side effects that break certain elements of the UI - namely the namespace field for experiments struct is set to `""` instead of simply omitted, which prevents artifacts from being previewed, see before and after of the experiments struct: 

Before this fix (but post proto changes): 
```json
{
  "experiment_id": "18e06f92-3c6c-43d2-a5d4-6208c602c1ce",
  "display_name": "Default",
  "description": "All runs created without specifying an experiment will be grouped here.",
  "created_at": "2025-08-02T22:03:06Z",
  "namespace": "",    <---- this is added when we don't omit unknown fields
  "storage_state": "AVAILABLE",
  "last_run_created_at": "2025-08-02T22:07:41Z"
}

```

After this fix: 

```json
{
  "experiment_id": "18e06f92-3c6c-43d2-a5d4-6208c602c1ce",
  "display_name": "Default",
  "description": "All runs created without specifying an experiment will be grouped here.",
  "created_at": "2025-08-02T22:03:06Z",
  "storage_state": "AVAILABLE",
  "last_run_created_at": "2025-08-02T22:07:41Z"
}

```

The latter is identical to the json returned prior to [this](https://github.com/kubeflow/pipelines/commit/cc35187dff270008c6bef505c828f442773ec97d) change. 

A test is included to ensure reduce the chances of this happening again. 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

