### PR TITLE
test generating backend proto go code

### DIFF
--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -55,6 +55,18 @@ jobs:
         working-directory: ./backend/src/crd/kubernetes
         run: make generate manifests
 
+      - name: Generate backend proto code v1beta1
+        working-directory: ./backend/api
+        env:
+          API_VERSION: v2beta1
+        run: make generate
+
+      - name: Generate backend proto code v1beta1
+        working-directory: ./backend/api
+        env:
+          API_VERSION: v1beta1
+        run: make generate
+
       - name: Check for Changes
         run: make check-diff
 

--- a/backend/api/build_kfp_server_api_python_package.sh
+++ b/backend/api/build_kfp_server_api_python_package.sh
@@ -58,6 +58,10 @@ java -jar "$codegen_file" generate -g python -t "$CURRENT_DIR/$API_VERSION/pytho
     "packageUrl": "https://github.com/kubeflow/pipelines"
 }')
 
+echo "Removing unnecessary GitLab and TravisCI generated files"
+rm $CURRENT_DIR/$API_VERSION/python_http_client/.gitlab-ci.yml
+rm $CURRENT_DIR/$API_VERSION/python_http_client/.travis.yml
+
 echo "Copying LICENSE to $DIR"
 cp "$CURRENT_DIR/../../LICENSE" "$DIR"
 


### PR DESCRIPTION
We don't currently test generating backend proto code, we need to ensure this is is always up to date

This change also includes cleaning up come CI files that tend to get pulled in when running the automated release scripts. 