### PR TITLE
chore: ignore adding pb2.py files for kfp-k8s docs

### DIFF
--- a/kubernetes_platform/python/create_release_branch.sh
+++ b/kubernetes_platform/python/create_release_branch.sh
@@ -51,7 +51,6 @@ else
     git add $PKG_ROOT/docs/.readthedocs.yml
     git add $REPO_ROOT/.readthedocs.yml
     git add $REPO_ROOT/kubernetes_platform/.gitignore
-    git add $REPO_ROOT/*_pb2.py
 
     echo "Next steps:"
     echo "1. Inspect and commit the modified files."


### PR DESCRIPTION
**Description of your changes:**

we always include the pb2  files now so this will fail if we try to run the create_release_branch.sh script 
