### PR TITLE
Fix failing backend test

### DIFF
--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -17,7 +17,6 @@ package objectstore
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
 	"testing"
 
@@ -206,53 +205,6 @@ func Test_bucketConfig_KeyFromURI(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("bucketConfig.keyFromURI() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_GetMinioDefaultEndpoint(t *testing.T) {
-	defer func() {
-		os.Unsetenv("MINIO_SERVICE_SERVICE_HOST")
-		os.Unsetenv("MINIO_SERVICE_SERVICE_PORT")
-	}()
-	tests := []struct {
-		name                string
-		minioServiceHostEnv string
-		minioServicePortEnv string
-		want                string
-	}{
-		{
-			name:                "In full Kubeflow, KFP multi-user mode on",
-			minioServiceHostEnv: "",
-			minioServicePortEnv: "",
-			want:                "minio-service.kubeflow:9000",
-		},
-		{
-			name:                "In KFP standalone without multi-user mode",
-			minioServiceHostEnv: "1.2.3.4",
-			minioServicePortEnv: "4321",
-			want:                "1.2.3.4:4321",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.minioServiceHostEnv != "" {
-				os.Setenv("MINIO_SERVICE_SERVICE_HOST", tt.minioServiceHostEnv)
-			} else {
-				os.Unsetenv("MINIO_SERVICE_SERVICE_HOST")
-			}
-			if tt.minioServicePortEnv != "" {
-				os.Setenv("MINIO_SERVICE_SERVICE_PORT", tt.minioServicePortEnv)
-			} else {
-				os.Unsetenv("MINIO_SERVICE_SERVICE_PORT")
-			}
-			got := MinioDefaultEndpoint()
-			if got != tt.want {
-				t.Errorf(
-					"MinioDefaultEndpoint() = %q, want %q\nwhen MINIO_SERVICE_SERVICE_HOST=%q MINIO_SERVICE_SERVICE_PORT=%q",
-					got, tt.want, tt.minioServiceHostEnv, tt.minioServicePortEnv,
-				)
 			}
 		})
 	}


### PR DESCRIPTION
- part of https://github.com/kubeflow/pipelines/pull/11965
- Remove `Test_GetMinioDefaultEndpoint` cause the corresponding remove `GetMinioDefaultEndpointfunction is also removed in last PR