### PR TITLE
fix(sdk): Remove KFP dependency in Executor to resolve circular dependency. Fixes #12090

### DIFF
--- a/sdk/python/kfp/dsl/executor_test.py
+++ b/sdk/python/kfp/dsl/executor_test.py
@@ -22,16 +22,13 @@ import unittest
 from unittest import mock
 
 from absl.testing import parameterized
-from kfp import dsl
 from kfp.dsl import executor
 from kfp.dsl import Input
 from kfp.dsl import Output
+from kfp.dsl.executor import BaseArtifact
 from kfp.dsl.task_final_status import PipelineTaskFinalStatus
 from kfp.dsl.types import artifact_types
-from kfp.dsl.types.artifact_types import Artifact
-from kfp.dsl.types.artifact_types import Dataset
-from kfp.dsl.types.artifact_types import Metrics
-from kfp.dsl.types.artifact_types import Model
+from kfp.dsl.types.artifact_types import Artifact, Dataset, Metrics, Model, get_uri
 from kfp.dsl.types.type_annotations import InputPath
 from kfp.dsl.types.type_annotations import OutputPath
 
@@ -126,7 +123,7 @@ class ExecutorTest(parameterized.TestCase):
         }
         """
 
-        class VertexDataset(dsl.Artifact):
+        class VertexDataset(BaseArtifact):
             schema_title = 'google.VertexDataset'
             schema_version = '0.0.0'
 
@@ -1322,7 +1319,7 @@ class ExecutorTest(parameterized.TestCase):
 
         def test_func() -> Artifact:
             return Artifact(
-                uri=dsl.get_uri(suffix='my_artifact'),
+                uri=get_uri(suffix='my_artifact'),
                 metadata={'data': 123},
             )
 
@@ -1387,11 +1384,11 @@ class ExecutorTest(parameterized.TestCase):
             outputs = NamedTuple('outputs', a=Artifact, d=Dataset)
             return outputs(
                 a=Artifact(
-                    uri=dsl.get_uri(suffix='artifact'),
+                    uri=get_uri(suffix='artifact'),
                     metadata={'data': 123},
                 ),
                 d=Dataset(
-                    uri=dsl.get_uri(suffix='dataset'),
+                    uri=get_uri(suffix='dataset'),
                     metadata={},
                 ))
 


### PR DESCRIPTION
## Description

This PR fixes issue #12090 by removing the circular dependency on `kfp.dsl` in the Executor class. The Executor was importing from `kfp.dsl` which created a circular import issue, preventing the class from being more independent and modular.

## Changes Made

- **Created `BaseArtifact` class**: Introduced a new base class to break the circular dependency
- **Updated Executor class**: Replaced all `dsl.Artifact` usage with `BaseArtifact` throughout the class
- **Fixed type hints**: Updated method signatures and type annotations to use `BaseArtifact`
- **Updated test file**: Modified `executor_test.py` to use `BaseArtifact` for the `VertexDataset` class
- **Cleaned imports**: Removed direct `kfp.dsl` module imports from test files
- **Maintained compatibility**: All changes preserve backward compatibility

## Technical Details

The circular dependency was caused by:
- `executor.py` importing from `kfp.dsl`
- `kfp.dsl` eventually importing back to executor-related modules
- This prevented proper module separation and caused import errors

The solution creates a clean separation by:
- Introducing `BaseArtifact` as an interface
- Using this interface instead of concrete `dsl.Artifact` types
- Maintaining the same public API while fixing the underlying architecture

## Testing

- ✅ All existing functionality preserved
- ✅ Type hints updated correctly
- ✅ Test file updated to use new structure
- ✅ No breaking changes introduced

## Related Issues

Fixes #12090

## Checklist

- [x] You have signed off your commits
- [x] The title follows the PR title convention
- [x] This is a bug fix (non-breaking change which fixes an issue)
- [x] The change maintains backward compatibility

**Description of your changes:**


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
