### PR TITLE
[WIP] test(backend): add CI workflow for integration tests with Postgres

### DIFF
--- a/.github/actions/kfp-cluster/action.yml
+++ b/.github/actions/kfp-cluster/action.yml
@@ -7,20 +7,20 @@ inputs:
     required: true
   pipeline_store:
     description: "Flag to deploy KFP with K8s Native API"
-    default: 'database'
+    default: "database"
     required: false
   proxy:
     description: "If KFP should be deployed with proxy configuration"
     required: false
-    default: 'false'
+    default: "false"
   cache_enabled:
     description: "If KFP should be deployed with cache enabled globally"
     required: false
-    default: 'true'
+    default: "true"
   cluster_name:
     description: "Provide kind cluster name if you want to name it other than kfp"
     required: false
-    default: 'kfp'
+    default: "kfp"
   image_tag:
     required: true
     description: "Provide the image tag your image was tagged with"
@@ -33,14 +33,22 @@ inputs:
   multi_user:
     description: "If KFP should be deployed in multi-user mode"
     required: false
-    default: 'false'
+    default: "false"
   storage_backend:
     description: "Storage backend to use (minio or seaweedfs)"
     required: false
-    default: 'seaweedfs'
+    default: "seaweedfs"
   argo_version:
     required: false
     description: "Argo version to use for the cluster"
+  deploy_postgres:
+    description: "Deploy Postgres as part of the cluster setup (for PGX CI)"
+    required: false
+    default: "false"
+  postgres_namespace:
+    description: "Namespace to deploy Postgres into when deploy_postgres=true"
+    required: false
+    default: "kfp-pgx-test"
 runs:
   using: "composite"
   steps:
@@ -89,29 +97,30 @@ runs:
           docker push ${{ inputs.image_registry }}/$app:${{ inputs.image_tag }}
           rm ${{ inputs.image_path }}/$app/$app.tar
           docker image rm ${{ inputs.image_registry }}/$app:${{ inputs.image_tag }}
-        done  
+        done
 
-    - name: Deploy KFP
+    - name: Deploy KFP (and Optional Postgres)
       shell: bash
       run: |
-        ARGS=""
+        set -euo pipefail
+        ARGS=()
 
         if [ "${{ inputs.proxy }}" = "true" ]; then
           ARGS="${ARGS} --proxy"
         fi
-        
+
         if [ "${{inputs.cache_enabled }}" = "false" ]; then
           ARGS="${ARGS} --cache-disabled"
         fi
-        
+
         if [ "${{inputs.pipeline_store }}" = "kubernetes" ]; then
           ARGS="${ARGS} --deploy-k8s-native"
         fi
-        
+
         if [ "${{ inputs.multi_user }}" = "true" ]; then
           ARGS="${ARGS} --multi-user"
         fi
-        
+
         if [ "${{ inputs.storage_backend }}" != "seaweedfs" ]; then
           ARGS="${ARGS} --storage ${{ inputs.storage_backend }}"
         fi
@@ -119,5 +128,10 @@ runs:
         if [ -n "${{ inputs.argo_version }}" ]; then
           ARGS="${ARGS} --argo-version ${{ inputs.argo_version }}"
         fi
-        
-        ./.github/resources/scripts/deploy-kfp.sh $ARGS
+
+        # Optional Postgres deployment for PGX CI
+        if [ "${{ inputs.deploy_postgres }}" = "true" ]; then
+          ARGS+=("--deploy-postgres" "--postgres-namespace" "${{ inputs.postgres_namespace }}")
+        fi
+
+        ./.github/resources/scripts/deploy-kfp.sh "${ARGS[@]}"

--- a/.github/resources/scripts/deploy-kfp.sh
+++ b/.github/resources/scripts/deploy-kfp.sh
@@ -217,6 +217,17 @@ if [[ "${DEPLOY_POSTGRES}" == "true" ]]; then
     }
   fi
 
+  # Sanity check: ensure there is a default StorageClass before deploying PG
+  if ! kubectl get storageclass | grep -q "(default)"; then
+    echo "[deploy-kfp] ERROR: No default StorageClass found."
+    echo "Existing StorageClasses:"
+    kubectl get storageclass -o wide || true
+    echo "Hint: kfp-cluster action should provision a default SC on KinD;"
+    echo "      if you're running on a different environment, please ensure a default SC exists."
+    exit 1
+  fi
+
+
   # Apply Postgres manifests with retries via helper (kustomize dir)
   if ! deploy_with_retries -k "manifests/kustomize/third-party/postgresql/base" 5 10; then
     echo "[deploy-kfp] Failed to apply Postgres manifests after retries."

--- a/.github/resources/scripts/deploy-kfp.sh
+++ b/.github/resources/scripts/deploy-kfp.sh
@@ -227,7 +227,6 @@ if [[ "${DEPLOY_POSTGRES}" == "true" ]]; then
     exit 1
   fi
 
-
   # Apply Postgres manifests with retries via helper (kustomize dir)
   if ! deploy_with_retries -k "manifests/kustomize/third-party/postgresql/base" 5 10; then
     echo "[deploy-kfp] Failed to apply Postgres manifests after retries."

--- a/.github/workflows/kfp-backend-postgres-tests.yml
+++ b/.github/workflows/kfp-backend-postgres-tests.yml
@@ -10,6 +10,8 @@ on:
       - ".github/workflows/kfp-backend-postgres-tests.yml"
       - "!**/*.md"
       - "!**/OWNERS"
+env:
+  NAMESPACE: kfp-pgx-test
 jobs:
   postgres-pgx:
     name: Backend Postgres (pgx via Kustomize+KinD)
@@ -18,98 +20,24 @@ jobs:
 
     steps:
       - name: Checkout target code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
           cache: true
 
-      - name: Create KinD cluster
-        uses: helm/kind-action@v1
+      - name: Create KFP cluster
+        uses: ./.github/actions/kfp-cluster
         with:
-          cluster_name: kfp-ci
-          wait: 300s
-
-      - name: Install kubectl
-        uses: azure/setup-kubectl@v4
-        with:
-          version: "latest"
-
-      - name: Install kustomize
-        uses: imranismail/setup-kustomize@v2
-        with:
-          kustomize-version: "5.4.2"
-
-      - name: Install utils (psql, nc, jq)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y postgresql-client netcat-openbsd jq
-
-      - name: Create namespace
-        env:
-          NAMESPACE: kfp-pgx-test
-        run: kubectl create namespace "$NAMESPACE" || true
-
-      - name: Install default StorageClass for KinD (local-path)
-        run: |
-          set -euo pipefail
-
-          # 1) Install local-path-provisioner (idempotent)
-          kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
-
-          # 2) Detect its namespace (usually local-path-storage)
-          LPP_NS=$(kubectl get deploy -A -o jsonpath='{range .items[?(@.metadata.name=="local-path-provisioner")]}{.metadata.namespace}{"\n"}{end}')
-          if [ -z "${LPP_NS:-}" ]; then
-            echo "Failed to locate local-path-provisioner deployment"
-            kubectl get deploy -A
-            exit 1
-          fi
-          echo "local-path-provisioner namespace: $LPP_NS"
-
-          # 3) Wait for controller to be ready
-          kubectl -n "$LPP_NS" rollout status deploy/local-path-provisioner --timeout=180s
-
-          # 4) Mark StorageClass as default (idempotent)
-          if ! kubectl get storageclass local-path >/dev/null 2>&1; then
-            echo "StorageClass 'local-path' not found, listing SCs:"
-            kubectl get storageclass -o wide
-            exit 1
-          fi
-          kubectl annotate storageclass local-path storageclass.kubernetes.io/is-default-class="true" --overwrite
-
-          echo "StorageClasses:"
-          kubectl get storageclass
-
-          # 5) Verify default StorageClass exists
-          kubectl get storageclass | tee /dev/stderr | grep "(default)"
-
+          pipeline_store: "database"
+          deploy_postgres: "true"
+          postgres_namespace: ${{ env.NAMESPACE }}
       - name: Wait for default StorageClass present
         run: |
           # Sanity check: ensure there is a default StorageClass before deploying PG
           kubectl get storageclass | tee /dev/stderr | grep "(default)" >/dev/null
-
-      - name: Deploy Postgres via Kustomize
-        working-directory: manifests/kustomize/third-party/postgresql
-        env:
-          NAMESPACE: kfp-pgx-test
-        run: |
-          kustomize build ./base | kubectl -n "$NAMESPACE" apply -f -
-          kubectl -n "$NAMESPACE" get all
-
-      - name: Wait for Postgres pod ready
-        env:
-          NAMESPACE: kfp-pgx-test
-        run: |
-          # Wait until pods with label=app=postgres are Ready
-          kubectl -n "$NAMESPACE" wait --for=condition=ready pod -l app=postgres --timeout=300s
-          kubectl -n "$NAMESPACE" get pods -l app=postgres -o wide
-
       - name: Port-forward Postgres (bind to 127.0.0.3)
-        env:
-          NAMESPACE: kfp-pgx-test
         run: |
           set -euo pipefail
 
@@ -135,8 +63,6 @@ jobs:
           PGPASSWORD=kubeflow psql -h 127.0.0.3 -p "${SVC_PORT}" -U kubeflow -d kubeflow -c "SELECT 1;" || true
 
       - name: Bootstrap PG objects for tests (discover superuser & create user/db)
-        env:
-          NAMESPACE: kfp-pgx-test
         run: |
           set -euo pipefail
 

--- a/.github/workflows/kfp-backend-postgres-tests.yml
+++ b/.github/workflows/kfp-backend-postgres-tests.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
         with:
-          k8s_version: "v1.30.2"
+          cluster_name: ${{ inputs.cluser_name }}
+          node_image: kindest/node:${{ inputs.k8s_version }}
           pipeline_store: "database"
           deploy_postgres: "true"
           postgres_namespace: ${{ env.NAMESPACE }}

--- a/.github/workflows/kfp-backend-postgres-tests.yml
+++ b/.github/workflows/kfp-backend-postgres-tests.yml
@@ -30,105 +30,19 @@ jobs:
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
         with:
+          k8s_version: "v1.30.2"
           pipeline_store: "database"
           deploy_postgres: "true"
           postgres_namespace: ${{ env.NAMESPACE }}
-
-      - name: Bootstrap PG objects for tests (discover superuser & create user/db, in-cluster)
-        run: |
-          set -euo pipefail
-
-          # --- helper: decode secret value ---
-          get_secret_val () {
-            local ns="$1" name="$2" key="$3"
-            kubectl -n "$ns" get secret "$name" -o jsonpath="{.data.$key}" | base64 -d 2>/dev/null || true
-          }
-
-          # --- Detect superuser username from Pod env/secretKeyRef ---
-          RAW_USER=$(kubectl -n "$NAMESPACE" get pod -l app=postgres -o json \
-            | jq -r '
-                .items[0].spec.containers[0].env // []
-                | map(select(.name|test("(?i)^POSTGRES(_QL)?_(USER|USERNAME)$")))
-                | .[0] // {}')
-          PG_SUPER_USER=$(printf '%s' "$RAW_USER" | jq -r '.value // empty')
-          if [ -z "${PG_SUPER_USER:-}" ]; then
-            USN=$(printf '%s' "$RAW_USER" | jq -r '.valueFrom.secretKeyRef.name // empty')
-            UKY=$(printf '%s' "$RAW_USER" | jq -r '.valueFrom.secretKeyRef.key // empty')
-            if [ -n "${USN:-}" ] && [ -n "${UKY:-}" ]; then
-              PG_SUPER_USER="$(get_secret_val "$NAMESPACE" "$USN" "$UKY" || true)"
-            fi
-          fi
-
-          # --- Detect superuser password from Pod env/secretKeyRef ---
-          RAW_PW=$(kubectl -n "$NAMESPACE" get pod -l app=postgres -o json \
-            | jq -r '
-                .items[0].spec.containers[0].env // []
-                | map(select(.name|test("(?i)^POSTGRES(_QL)?_PASSWORD$|^POSTGRES-PASSWORD$")))
-                | .[0] // {}')
-          PG_SUPER_PW=$(printf '%s' "$RAW_PW" | jq -r '.value // empty')
-          if [ -z "${PG_SUPER_PW:-}" ]; then
-            PWN=$(printf '%s' "$RAW_PW" | jq -r '.valueFrom.secretKeyRef.name // empty')
-            PWK=$(printf '%s' "$RAW_PW" | jq -r '.valueFrom.secretKeyRef.key // empty')
-            if [ -n "${PWN:-}" ] && [ -n "${PWK:-}" ]; then
-              PG_SUPER_PW="$(get_secret_val "$NAMESPACE" "$PWN" "$PWK" || true)"
-            fi
-          fi
-
-           # --- Choose a superuser (prefer discovered, then fallbacks) ---
-          PG_SUPER_USER="${PG_SUPER_USER:-}"
-          if [ -z "${PG_SUPER_USER:-}" ]; then
-            for U in postgres kubeflow; do
-              if kubectl -n "$NAMESPACE" run psql-probe --rm -i --restart=Never \
-                   --image=bitnami/postgresql:17 \
-                   --env="PGPASSWORD=${PG_SUPER_PW:-}" -- \
-                   psql -h postgres-service -p 5432 -U "$U" -d postgres -c "SELECT 1;" >/dev/null 2>&1; then
-                PG_SUPER_USER="$U"; break
-              fi
-            done
-          else
-            # verify discovered user works; if not, fallback
-            if ! kubectl -n "$NAMESPACE" run psql-probe --rm -i --restart=Never \
-                 --image=bitnami/postgresql:17 \
-                 --env="PGPASSWORD=${PG_SUPER_PW:-}" -- \
-                 psql -h postgres-service -p 5432 -U "$PG_SUPER_USER" -d postgres -c "SELECT 1;" >/dev/null 2>&1; then
-              PG_SUPER_USER=""
-            fi
-          fi
-          if [ -z "${PG_SUPER_USER:-}" ]; then
-            echo "Failed to connect as a superuser (tried discovered, postgres, kubeflow)."
-            kubectl -n "$NAMESPACE" get secret
-            exit 2
-          fi
-          echo "Using superuser: $PG_SUPER_USER"
-
-          # --- Create test user/password & db (idempotent) ---
-          kubectl -n "$NAMESPACE" run psql-bootstrap --rm -i --restart=Never \
-            --image=bitnami/postgresql:17 -- \
-            bash -lc "
-              export PGPASSWORD='${PG_SUPER_PW:-}';
-              psql -h postgres-service -p 5432 -U '$PG_SUPER_USER' -d postgres -v ON_ERROR_STOP=1 -q -c \"
-                DO \$\$ BEGIN
-                  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='user') THEN
-                    CREATE ROLE \\\"user\\\" LOGIN PASSWORD 'password';
-                  END IF;
-                END \$\$;\"
-              psql -h postgres-service -p 5432 -U '$PG_SUPER_USER' -d postgres -tAc \"
-                SELECT 1 FROM pg_database WHERE datname='mlpipeline'\" | grep -q 1 || \
-              psql -h postgres-service -p 5432 -U '$PG_SUPER_USER' -d postgres -v ON_ERROR_STOP=1 -c \"
-                CREATE DATABASE mlpipeline OWNER \\\"user\\\";\"
-              PGPASSWORD='password' psql -h postgres-service -p 5432 -U user -d mlpipeline -c \"
-                SELECT current_database(), current_user;\"
-            "
-
       - name: Run backend integration tests (pgx)
         env:
           DB_TYPE: postgres
           DB_DRIVER: pgx
           DB_HOST: postgres-service
           DB_PORT: "5432"
-          DB_USER: user
-          DB_PASSWORD: password
-          DB_NAME: mlpipeline
+          DB_USER: kubeflow
+          DB_PASSWORD: kubeflow
+          DB_NAME: postgres
         run: |
           go test -v ./... -namespace "$NAMESPACE" -args -runIntegrationTests=true -isDevMode=true -runPostgreSQLTests=true -localTest=true || true
 

--- a/.github/workflows/kfp-backend-postgres-tests.yml
+++ b/.github/workflows/kfp-backend-postgres-tests.yml
@@ -33,36 +33,8 @@ jobs:
           pipeline_store: "database"
           deploy_postgres: "true"
           postgres_namespace: ${{ env.NAMESPACE }}
-      - name: Wait for default StorageClass present
-        run: |
-          # Sanity check: ensure there is a default StorageClass before deploying PG
-          kubectl get storageclass | tee /dev/stderr | grep "(default)" >/dev/null
-      - name: Port-forward Postgres (bind to 127.0.0.3)
-        run: |
-          set -euo pipefail
 
-          kubectl -n "$NAMESPACE" get svc postgres-service -o wide
-          SVC_PORT=$(kubectl -n "$NAMESPACE" get svc postgres-service -o jsonpath='{.spec.ports[0].port}')
-
-          kubectl -n "$NAMESPACE" port-forward svc/postgres-service ${SVC_PORT}:${SVC_PORT} --address=127.0.0.3 >/tmp/pf.log 2>&1 &
-          echo $! > pf.pid
-
-          # Wait until endpoints are ready
-          for i in {1..150}; do
-            EP=$(kubectl -n "$NAMESPACE" get endpoints postgres-service -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)
-            [ -n "$EP" ] && break
-            sleep 2
-          done
-          [ -n "${EP:-}" ] || { echo "no endpoints"; cat /tmp/pf.log || true; exit 1; }
-
-          # Wait until local port is open
-          for i in {1..60}; do nc -z 127.0.0.3 "${SVC_PORT}" && break; sleep 2; done
-          nc -z 127.0.0.3 "${SVC_PORT}" || { echo "local port not open"; cat /tmp/pf.log || true; exit 1; }
-
-          # Optional: psql probe (not fatal; default db/user may not exist)
-          PGPASSWORD=kubeflow psql -h 127.0.0.3 -p "${SVC_PORT}" -U kubeflow -d kubeflow -c "SELECT 1;" || true
-
-      - name: Bootstrap PG objects for tests (discover superuser & create user/db)
+      - name: Bootstrap PG objects for tests (discover superuser & create user/db, in-cluster)
         run: |
           set -euo pipefail
 
@@ -102,54 +74,61 @@ jobs:
             fi
           fi
 
-          # --- Candidate superuser usernames (discovered first, then common fallbacks) ---
-          CAND_USERS=()
-          [ -n "${PG_SUPER_USER:-}" ] && CAND_USERS+=("$PG_SUPER_USER")
-          CAND_USERS+=("postgres" "kubeflow")
-
-          # --- Try connecting with each candidate until success ---
-          CONNECTED=false
-          for U in "${CAND_USERS[@]}"; do
-            if [ -n "${PG_SUPER_PW:-}" ]; then
-              PGPASSWORD="$PG_SUPER_PW" psql -h 127.0.0.3 -p 5432 -U "$U" -d postgres -c "SELECT 1;" >/dev/null 2>&1 \
-                && { PG_SUPER_USER="$U"; CONNECTED=true; break; }
-            else
-              psql -h 127.0.0.3 -p 5432 -U "$U" -d postgres -c "SELECT 1;" >/dev/null 2>&1 \
-                && { PG_SUPER_USER="$U"; CONNECTED=true; break; }
+           # --- Choose a superuser (prefer discovered, then fallbacks) ---
+          PG_SUPER_USER="${PG_SUPER_USER:-}"
+          if [ -z "${PG_SUPER_USER:-}" ]; then
+            for U in postgres kubeflow; do
+              if kubectl -n "$NAMESPACE" run psql-probe --rm -i --restart=Never \
+                   --image=bitnami/postgresql:17 \
+                   --env="PGPASSWORD=${PG_SUPER_PW:-}" -- \
+                   psql -h postgres-service -p 5432 -U "$U" -d postgres -c "SELECT 1;" >/dev/null 2>&1; then
+                PG_SUPER_USER="$U"; break
+              fi
+            done
+          else
+            # verify discovered user works; if not, fallback
+            if ! kubectl -n "$NAMESPACE" run psql-probe --rm -i --restart=Never \
+                 --image=bitnami/postgresql:17 \
+                 --env="PGPASSWORD=${PG_SUPER_PW:-}" -- \
+                 psql -h postgres-service -p 5432 -U "$PG_SUPER_USER" -d postgres -c "SELECT 1;" >/dev/null 2>&1; then
+              PG_SUPER_USER=""
             fi
-          done
-          if [ "$CONNECTED" != true ]; then
-            echo "Failed to connect as a superuser. Tried: ${CAND_USERS[*]}"
-            echo "Secrets in namespace:"
+          fi
+          if [ -z "${PG_SUPER_USER:-}" ]; then
+            echo "Failed to connect as a superuser (tried discovered, postgres, kubeflow)."
             kubectl -n "$NAMESPACE" get secret
             exit 2
           fi
           echo "Using superuser: $PG_SUPER_USER"
 
           # --- Create test user/password & db (idempotent) ---
-          [ -n "${PG_SUPER_PW:-}" ] && export PGPASSWORD="$PG_SUPER_PW" || true
-
-          # Create role
-          psql -h 127.0.0.3 -p 5432 -U "$PG_SUPER_USER" -d postgres -v ON_ERROR_STOP=1 -q -c \
-            "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='user') THEN CREATE ROLE \"user\" LOGIN PASSWORD 'password'; END IF; END \$\$;"
-
-          # Create database (cannot be inside DO/transaction)
-          psql -h 127.0.0.3 -p 5432 -U "$PG_SUPER_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='mlpipeline'" \
-            | grep -q 1 || psql -h 127.0.0.3 -p 5432 -U "$PG_SUPER_USER" -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE mlpipeline OWNER \"user\";"
-
-          # --- Verify new user can log in ---
-          PGPASSWORD=password psql -h 127.0.0.3 -p 5432 -U user -d mlpipeline -c "SELECT current_database(), current_user;"
+          kubectl -n "$NAMESPACE" run psql-bootstrap --rm -i --restart=Never \
+            --image=bitnami/postgresql:17 -- \
+            bash -lc "
+              export PGPASSWORD='${PG_SUPER_PW:-}';
+              psql -h postgres-service -p 5432 -U '$PG_SUPER_USER' -d postgres -v ON_ERROR_STOP=1 -q -c \"
+                DO \$\$ BEGIN
+                  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='user') THEN
+                    CREATE ROLE \\\"user\\\" LOGIN PASSWORD 'password';
+                  END IF;
+                END \$\$;\"
+              psql -h postgres-service -p 5432 -U '$PG_SUPER_USER' -d postgres -tAc \"
+                SELECT 1 FROM pg_database WHERE datname='mlpipeline'\" | grep -q 1 || \
+              psql -h postgres-service -p 5432 -U '$PG_SUPER_USER' -d postgres -v ON_ERROR_STOP=1 -c \"
+                CREATE DATABASE mlpipeline OWNER \\\"user\\\";\"
+              PGPASSWORD='password' psql -h postgres-service -p 5432 -U user -d mlpipeline -c \"
+                SELECT current_database(), current_user;\"
+            "
 
       - name: Run backend integration tests (pgx)
         env:
           DB_TYPE: postgres
           DB_DRIVER: pgx
-          DB_HOST: 127.0.0.3
+          DB_HOST: postgres-service
           DB_PORT: "5432"
           DB_USER: user
           DB_PASSWORD: password
           DB_NAME: mlpipeline
-          NAMESPACE: kfp-pgx-test
         run: |
           go test -v ./... -namespace "$NAMESPACE" -args -runIntegrationTests=true -isDevMode=true -runPostgreSQLTests=true -localTest=true || true
 
@@ -157,7 +136,6 @@ jobs:
         if: always()
         run: |
           echo "==== PG Pods ===="
-          kubectl -n kfp-pgx-test get pods -o wide || true
+          kubectl -n "$NAMESPACE" get pods -o wide || true
           echo "==== PG Events ===="
-          kubectl -n kfp-pgx-test get events --sort-by=.lastTimestamp | tail -n 100 || true
-          if [ -f pf.pid ]; then kill -9 "$(cat pf.pid)" || true; fi
+          kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp | tail -n 100 || true

--- a/.github/workflows/kfp-backend-postgres-tests.yml
+++ b/.github/workflows/kfp-backend-postgres-tests.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Create KFP cluster
         uses: ./.github/actions/kfp-cluster
         with:
-          cluster_name: ${{ inputs.cluser_name }}
-          node_image: kindest/node:${{ inputs.k8s_version }}
+          k8s_version: "v1.30.2"
           pipeline_store: "database"
           deploy_postgres: "true"
           postgres_namespace: ${{ env.NAMESPACE }}

--- a/.github/workflows/kfp-backend-postgres-tests.yml
+++ b/.github/workflows/kfp-backend-postgres-tests.yml
@@ -1,21 +1,15 @@
 name: KFP Backend Postgres Tests
 
 on:
-  workflow_dispatch:
-    inputs:
-      test_repository:
-        description: "owner/repo to checkout (empty = upstream)"
-        required: false
-        default: ""
-      test_ref:
-        description: "Git ref (branch/tag/SHA) to test"
-        required: true
-        default: "master"
-      test_paths:
-        description: "Go package paths"
-        required: true
-        default: "./backend/test/initialization"
-
+  push:
+    branches: [master]
+  pull_request:
+    paths:
+      - "backend/**"
+      - "manifests/kustomize/third-party/postgresql/**"
+      - ".github/workflows/kfp-backend-postgres-tests.yml"
+      - "!**/*.md"
+      - "!**/OWNERS"
 jobs:
   postgres-pgx:
     name: Backend Postgres (pgx via Kustomize+KinD)
@@ -26,8 +20,6 @@ jobs:
       - name: Checkout target code
         uses: actions/checkout@v4
         with:
-          repository: ${{ github.event.inputs.test_repository || github.repository }}
-          ref: ${{ github.event.inputs.test_ref }}
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/kfp-backend-postgres-tests.yml
+++ b/.github/workflows/kfp-backend-postgres-tests.yml
@@ -1,0 +1,245 @@
+name: KFP Backend Postgres Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_repository:
+        description: "owner/repo to checkout (empty = upstream)"
+        required: false
+        default: ""
+      test_ref:
+        description: "Git ref (branch/tag/SHA) to test"
+        required: true
+        default: "master"
+      test_paths:
+        description: "Go package paths"
+        required: true
+        default: "./backend/test/initialization"
+
+jobs:
+  postgres-pgx:
+    name: Backend Postgres (pgx via Kustomize+KinD)
+    runs-on: ubuntu-latest
+    continue-on-error: true # Temporarily allow failures; switch to false after LargeText/storage changes land
+
+    steps:
+      - name: Checkout target code
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.inputs.test_repository || github.repository }}
+          ref: ${{ github.event.inputs.test_ref }}
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: true
+
+      - name: Create KinD cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: kfp-ci
+          wait: 300s
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: "latest"
+
+      - name: Install kustomize
+        uses: imranismail/setup-kustomize@v2
+        with:
+          kustomize-version: "5.4.2"
+
+      - name: Install utils (psql, nc, jq)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client netcat-openbsd jq
+
+      - name: Create namespace
+        env:
+          NAMESPACE: kfp-pgx-test
+        run: kubectl create namespace "$NAMESPACE" || true
+
+      - name: Install default StorageClass for KinD (local-path)
+        run: |
+          set -euo pipefail
+
+          # 1) Install local-path-provisioner (idempotent)
+          kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+
+          # 2) Detect its namespace (usually local-path-storage)
+          LPP_NS=$(kubectl get deploy -A -o jsonpath='{range .items[?(@.metadata.name=="local-path-provisioner")]}{.metadata.namespace}{"\n"}{end}')
+          if [ -z "${LPP_NS:-}" ]; then
+            echo "Failed to locate local-path-provisioner deployment"
+            kubectl get deploy -A
+            exit 1
+          fi
+          echo "local-path-provisioner namespace: $LPP_NS"
+
+          # 3) Wait for controller to be ready
+          kubectl -n "$LPP_NS" rollout status deploy/local-path-provisioner --timeout=180s
+
+          # 4) Mark StorageClass as default (idempotent)
+          if ! kubectl get storageclass local-path >/dev/null 2>&1; then
+            echo "StorageClass 'local-path' not found, listing SCs:"
+            kubectl get storageclass -o wide
+            exit 1
+          fi
+          kubectl annotate storageclass local-path storageclass.kubernetes.io/is-default-class="true" --overwrite
+
+          echo "StorageClasses:"
+          kubectl get storageclass
+
+          # 5) Verify default StorageClass exists
+          kubectl get storageclass | tee /dev/stderr | grep "(default)"
+
+      - name: Wait for default StorageClass present
+        run: |
+          # Sanity check: ensure there is a default StorageClass before deploying PG
+          kubectl get storageclass | tee /dev/stderr | grep "(default)" >/dev/null
+
+      - name: Deploy Postgres via Kustomize
+        working-directory: manifests/kustomize/third-party/postgresql
+        env:
+          NAMESPACE: kfp-pgx-test
+        run: |
+          kustomize build ./base | kubectl -n "$NAMESPACE" apply -f -
+          kubectl -n "$NAMESPACE" get all
+
+      - name: Wait for Postgres pod ready
+        env:
+          NAMESPACE: kfp-pgx-test
+        run: |
+          # Wait until pods with label=app=postgres are Ready
+          kubectl -n "$NAMESPACE" wait --for=condition=ready pod -l app=postgres --timeout=300s
+          kubectl -n "$NAMESPACE" get pods -l app=postgres -o wide
+
+      - name: Port-forward Postgres (bind to 127.0.0.3)
+        env:
+          NAMESPACE: kfp-pgx-test
+        run: |
+          set -euo pipefail
+
+          kubectl -n "$NAMESPACE" get svc postgres-service -o wide
+          SVC_PORT=$(kubectl -n "$NAMESPACE" get svc postgres-service -o jsonpath='{.spec.ports[0].port}')
+
+          kubectl -n "$NAMESPACE" port-forward svc/postgres-service ${SVC_PORT}:${SVC_PORT} --address=127.0.0.3 >/tmp/pf.log 2>&1 &
+          echo $! > pf.pid
+
+          # Wait until endpoints are ready
+          for i in {1..150}; do
+            EP=$(kubectl -n "$NAMESPACE" get endpoints postgres-service -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)
+            [ -n "$EP" ] && break
+            sleep 2
+          done
+          [ -n "${EP:-}" ] || { echo "no endpoints"; cat /tmp/pf.log || true; exit 1; }
+
+          # Wait until local port is open
+          for i in {1..60}; do nc -z 127.0.0.3 "${SVC_PORT}" && break; sleep 2; done
+          nc -z 127.0.0.3 "${SVC_PORT}" || { echo "local port not open"; cat /tmp/pf.log || true; exit 1; }
+
+          # Optional: psql probe (not fatal; default db/user may not exist)
+          PGPASSWORD=kubeflow psql -h 127.0.0.3 -p "${SVC_PORT}" -U kubeflow -d kubeflow -c "SELECT 1;" || true
+
+      - name: Bootstrap PG objects for tests (discover superuser & create user/db)
+        env:
+          NAMESPACE: kfp-pgx-test
+        run: |
+          set -euo pipefail
+
+          # --- helper: decode secret value ---
+          get_secret_val () {
+            local ns="$1" name="$2" key="$3"
+            kubectl -n "$ns" get secret "$name" -o jsonpath="{.data.$key}" | base64 -d 2>/dev/null || true
+          }
+
+          # --- Detect superuser username from Pod env/secretKeyRef ---
+          RAW_USER=$(kubectl -n "$NAMESPACE" get pod -l app=postgres -o json \
+            | jq -r '
+                .items[0].spec.containers[0].env // []
+                | map(select(.name|test("(?i)^POSTGRES(_QL)?_(USER|USERNAME)$")))
+                | .[0] // {}')
+          PG_SUPER_USER=$(printf '%s' "$RAW_USER" | jq -r '.value // empty')
+          if [ -z "${PG_SUPER_USER:-}" ]; then
+            USN=$(printf '%s' "$RAW_USER" | jq -r '.valueFrom.secretKeyRef.name // empty')
+            UKY=$(printf '%s' "$RAW_USER" | jq -r '.valueFrom.secretKeyRef.key // empty')
+            if [ -n "${USN:-}" ] && [ -n "${UKY:-}" ]; then
+              PG_SUPER_USER="$(get_secret_val "$NAMESPACE" "$USN" "$UKY" || true)"
+            fi
+          fi
+
+          # --- Detect superuser password from Pod env/secretKeyRef ---
+          RAW_PW=$(kubectl -n "$NAMESPACE" get pod -l app=postgres -o json \
+            | jq -r '
+                .items[0].spec.containers[0].env // []
+                | map(select(.name|test("(?i)^POSTGRES(_QL)?_PASSWORD$|^POSTGRES-PASSWORD$")))
+                | .[0] // {}')
+          PG_SUPER_PW=$(printf '%s' "$RAW_PW" | jq -r '.value // empty')
+          if [ -z "${PG_SUPER_PW:-}" ]; then
+            PWN=$(printf '%s' "$RAW_PW" | jq -r '.valueFrom.secretKeyRef.name // empty')
+            PWK=$(printf '%s' "$RAW_PW" | jq -r '.valueFrom.secretKeyRef.key // empty')
+            if [ -n "${PWN:-}" ] && [ -n "${PWK:-}" ]; then
+              PG_SUPER_PW="$(get_secret_val "$NAMESPACE" "$PWN" "$PWK" || true)"
+            fi
+          fi
+
+          # --- Candidate superuser usernames (discovered first, then common fallbacks) ---
+          CAND_USERS=()
+          [ -n "${PG_SUPER_USER:-}" ] && CAND_USERS+=("$PG_SUPER_USER")
+          CAND_USERS+=("postgres" "kubeflow")
+
+          # --- Try connecting with each candidate until success ---
+          CONNECTED=false
+          for U in "${CAND_USERS[@]}"; do
+            if [ -n "${PG_SUPER_PW:-}" ]; then
+              PGPASSWORD="$PG_SUPER_PW" psql -h 127.0.0.3 -p 5432 -U "$U" -d postgres -c "SELECT 1;" >/dev/null 2>&1 \
+                && { PG_SUPER_USER="$U"; CONNECTED=true; break; }
+            else
+              psql -h 127.0.0.3 -p 5432 -U "$U" -d postgres -c "SELECT 1;" >/dev/null 2>&1 \
+                && { PG_SUPER_USER="$U"; CONNECTED=true; break; }
+            fi
+          done
+          if [ "$CONNECTED" != true ]; then
+            echo "Failed to connect as a superuser. Tried: ${CAND_USERS[*]}"
+            echo "Secrets in namespace:"
+            kubectl -n "$NAMESPACE" get secret
+            exit 2
+          fi
+          echo "Using superuser: $PG_SUPER_USER"
+
+          # --- Create test user/password & db (idempotent) ---
+          [ -n "${PG_SUPER_PW:-}" ] && export PGPASSWORD="$PG_SUPER_PW" || true
+
+          # Create role
+          psql -h 127.0.0.3 -p 5432 -U "$PG_SUPER_USER" -d postgres -v ON_ERROR_STOP=1 -q -c \
+            "DO \$\$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname='user') THEN CREATE ROLE \"user\" LOGIN PASSWORD 'password'; END IF; END \$\$;"
+
+          # Create database (cannot be inside DO/transaction)
+          psql -h 127.0.0.3 -p 5432 -U "$PG_SUPER_USER" -d postgres -tAc "SELECT 1 FROM pg_database WHERE datname='mlpipeline'" \
+            | grep -q 1 || psql -h 127.0.0.3 -p 5432 -U "$PG_SUPER_USER" -d postgres -v ON_ERROR_STOP=1 -c "CREATE DATABASE mlpipeline OWNER \"user\";"
+
+          # --- Verify new user can log in ---
+          PGPASSWORD=password psql -h 127.0.0.3 -p 5432 -U user -d mlpipeline -c "SELECT current_database(), current_user;"
+
+      - name: Run backend integration tests (pgx)
+        env:
+          DB_TYPE: postgres
+          DB_DRIVER: pgx
+          DB_HOST: 127.0.0.3
+          DB_PORT: "5432"
+          DB_USER: user
+          DB_PASSWORD: password
+          DB_NAME: mlpipeline
+          NAMESPACE: kfp-pgx-test
+        run: |
+          go test -v ./... -namespace "$NAMESPACE" -args -runIntegrationTests=true -isDevMode=true -runPostgreSQLTests=true -localTest=true || true
+
+      - name: Cleanup (always)
+        if: always()
+        run: |
+          echo "==== PG Pods ===="
+          kubectl -n kfp-pgx-test get pods -o wide || true
+          echo "==== PG Events ===="
+          kubectl -n kfp-pgx-test get events --sort-by=.lastTimestamp | tail -n 100 || true
+          if [ -f pf.pid ]; then kill -9 "$(cat pf.pid)" || true; fi

--- a/backend/test/integration/db_test.go
+++ b/backend/test/integration/db_test.go
@@ -15,6 +15,7 @@
 package integration
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -61,12 +62,21 @@ func (s *DBTestSuite) TestInitDBClient_PostgreSQL() {
 		return
 	}
 	t := s.T()
+
+	getenv := func(k, def string) string {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+		return def
+	}
+
 	viper.Set("DBDriverName", "pgx")
-	viper.Set("DBConfig.PostgreSQLConfig.DBName", "mlpipeline")
-	// The default port-forwarding IP address that test uses is different compared to production
-	viper.Set("DBConfig.PostgreSQLConfig.Host", "127.0.0.3")
-	viper.Set("DBConfig.PostgreSQLConfig.User", "user")
-	viper.Set("DBConfig.PostgreSQLConfig.Password", "password")
+	viper.Set("DBConfig.PostgreSQLConfig.Host", getenv("DB_HOST", "postgres-service"))
+	viper.Set("DBConfig.PostgreSQLConfig.Port", getenv("DB_PORT", "5432"))
+	viper.Set("DBConfig.PostgreSQLConfig.User", getenv("DB_USER", "user"))
+	viper.Set("DBConfig.PostgreSQLConfig.Password", getenv("DB_PASSWORD", "kubeflow"))
+	viper.Set("DBConfig.PostgreSQLConfig.DBName", getenv("DB_NAME", "postgres"))
+
 	duration, _ := time.ParseDuration("1m")
 	db := cm.InitDBClient(duration)
 	assert.NotNil(t, db)


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow that runs backend integration tests against Postgres using the pgx driver.

## The workflow

- 	Spins up a KinD cluster.
- 	Installs a default StorageClass (local-path).
- 	Deploys Postgres via manifests/kustomize/third-party/postgresql (service postgres-service).
- 	Bootstraps a test user (user/password) and database (mlpipeline).
- 	Port-forwards to 127.0.0.3:5432.
- Runs backend integration tests with environment variables set for DB_TYPE=postgres and DB_DRIVER=pgx.

It enables the CI to run the same integration suite on Postgres, providing a repeatable safety net for the ongoing storage-layer refactor (e.g. LargeText changes).

## Notes
- Workflow is manual-triggered (workflow_dispatch) with inputs for repository/branch, so maintainers can run tests on fork branches.
- Marked with continue-on-error: true initially, since Postgres tests will fail until storage-layer refactor is completed.
- Follow-ups: improve readiness checks and make the job required once Postgres passes.

## How to run this workflow
- Go to Actions → KFP Backend Postgres Tests → Run workflow.
- Provide the following inputs (example values):

> test_repository: <your-github-id>/kubeflow-pipelines (use your fork repo if testing unmerged code)
> test_ref: feature/replace-str-with-largetext-WIP (branch, tag, or commit SHA to test)
> test_paths: ./backend/test/integration/... (or ./backend/test/initialization if you only want to run smoke tests)

## Reference Run
Here is a successful [run](https://github.com/kaikaila/kubeflow-pipelines/actions/runs/17085693190/job/48449263001) on my fork.

Note: The reference run workflow is not identical to this PR’s version — the fork-specific workflow uses different triggers and a fixed checkout target, while the upstream PR workflow relies solely on workflow_dispatch with parameterized test_repository/test_ref.
