### PR TITLE
fix(docs): Fix local development after the SeaweedFS migration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -130,8 +130,8 @@ server locally:
       "env": {
         "POD_NAMESPACE": "kubeflow",
         "DBCONFIG_MYSQLCONFIG_HOST": "localhost",
-        "MINIO_SERVICE_SERVICE_HOST": "localhost",
-        "MINIO_SERVICE_SERVICE_PORT": "9000",
+        "OBJECTSTORECONFIG_HOST": "localhost",
+        "OBJECTSTORECONFIG_PORT": "9000",
         "METADATA_GRPC_SERVICE_SERVICE_HOST": "localhost",
         "METADATA_GRPC_SERVICE_SERVICE_PORT": "8080",
         "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": "localhost",
@@ -244,8 +244,8 @@ VSCode configuration:
             "env": {
                 "POD_NAMESPACE": "kubeflow",
                 "DBCONFIG_MYSQLCONFIG_HOST": "localhost",
-                "MINIO_SERVICE_SERVICE_HOST": "localhost",
-                "MINIO_SERVICE_SERVICE_PORT": "9000",
+                "OBJECTSTORECONFIG_HOST": "localhost",
+                "OBJECTSTORECONFIG_PORT": "9000",
                 "METADATA_GRPC_SERVICE_SERVICE_HOST": "localhost",
                 "METADATA_GRPC_SERVICE_SERVICE_PORT": "8080",
                 "ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST": "localhost",
@@ -268,8 +268,8 @@ GoLand configuration:
    |----------------------------------------------|-----------|
    | POD_NAMESPACE                                | kubeflow  |
    | DBCONFIG_MYSQLCONFIG_HOST                    | localhost |
-   | MINIO_SERVICE_SERVICE_HOST                   | localhost |
-   | MINIO_SERVICE_SERVICE_PORT                   | 9000      |
+   | OBJECTSTORECONFIG_HOST                       | localhost |
+   | OBJECTSTORECONFIG_PORT                       | 9000      |
    | METADATA_GRPC_SERVICE_SERVICE_HOST           | localhost |
    | METADATA_GRPC_SERVICE_SERVICE_PORT           | 8080      |
    | ML_PIPELINE_VISUALIZATIONSERVER_SERVICE_HOST | localhost |

--- a/manifests/kustomize/env/dev-kind/kustomization.yaml
+++ b/manifests/kustomize/env/dev-kind/kustomization.yaml
@@ -64,7 +64,7 @@ patches:
         - $patch: replace
         - port: 9000
           protocol: TCP
-          targetPort: 9000
+          targetPort: 8333
           nodePort: 30900
       type: NodePort
 - patch: |-
@@ -164,3 +164,67 @@ patches:
       - ml-pipeline-reverse-proxy
       - ml-pipeline-reverse-proxy.$(kfp-namespace)
       - ml-pipeline-reverse-proxy.$(kfp-namespace).svc
+- patch: |-
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: default-allow-same-namespace
+      namespace: kubeflow
+    spec:
+      podSelector: {}
+      ingress:
+      - from:
+        - podSelector: {}
+      - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        ports:
+        - port: 3000
+          protocol: TCP
+        - port: 3306
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
+        - port: 9000
+          protocol: TCP
+        - port: 8888
+          protocol: TCP
+      policyTypes:
+      - Ingress
+- patch: |-
+    apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: seaweedfs
+      namespace: kubeflow
+    spec:
+      ingress:
+      - from:
+        - namespaceSelector:
+            matchExpressions:
+            - key: app.kubernetes.io/part-of
+              operator: In
+              values:
+              - kubeflow-profile
+        ports:
+        - port: 8333
+      - from:
+        - namespaceSelector:
+            matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: In
+              values:
+              - istio-system
+      - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        ports:
+        - port: 8333
+      podSelector:
+        matchExpressions:
+        - key: app
+          operator: In
+          values:
+          - seaweedfs
+      policyTypes:
+      - Ingress


### PR DESCRIPTION
**Description of your changes:**

The network policies were preventing the node ports from being accessible from localhost. Additionally, the environment variables changed for how to configure object store host and port.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
