### PR TITLE
fix(tools): Fix a typo in convert_to_k8s_format

### DIFF
--- a/tools/k8s-native/migration.py
+++ b/tools/k8s-native/migration.py
@@ -133,9 +133,9 @@ def convert_to_k8s_format(pipeline, pipeline_versions, add_prefix, namespace):
             "annotations": {
                 "pipelines.kubeflow.org/original-id": original_id,
             },
-            "spec": {
-                "displayName": display_name
-            }
+        },
+        "spec": {
+            "displayName": display_name
         }
     }
     k8s_objects.append(pipeline_obj)


### PR DESCRIPTION
**Description of your changes:**

Previously, display name was being set incorrectly in the metadata field.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 