### PR TITLE
fix(backend): Fix mutating webhook when pipeline name label value is too long

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Free up disk space
+        run: ./.github/resources/scripts/free-disk-space.sh
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/backend/src/apiserver/webhook/pipelineversion_webhook.go
+++ b/backend/src/apiserver/webhook/pipelineversion_webhook.go
@@ -155,7 +155,13 @@ func (p *PipelineVersionsWebhook) Default(ctx context.Context, obj runtime.Objec
 
 	// Labels for efficient querying
 	pipelineVersion.Labels["pipelines.kubeflow.org/pipeline-id"] = string(pipeline.UID)
-	pipelineVersion.Labels["pipelines.kubeflow.org/pipeline"] = pipeline.Name
+
+	name := pipeline.Name
+	if len(name) > 63 {
+		name = name[:63]
+	}
+
+	pipelineVersion.Labels["pipelines.kubeflow.org/pipeline"] = name
 
 	trueVal := true
 

--- a/backend/src/apiserver/webhook/pipelineversion_webhook_test.go
+++ b/backend/src/apiserver/webhook/pipelineversion_webhook_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/kubeflow/pipelines/backend/src/crd/kubernetes/v2beta1"
 	k8sapi "github.com/kubeflow/pipelines/backend/src/crd/kubernetes/v2beta1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,7 +222,7 @@ func TestPipelineVersionWebhook_MutatingUpdate_FixesOwnersRef(t *testing.T) {
 			Labels:     map[string]string{"version": "v2"},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion: v2beta1.GroupVersion.String(),
+					APIVersion: k8sapi.GroupVersion.String(),
 					Kind:       "Pipeline",
 					Name:       "test-pipeline2",
 					UID:        badUID,
@@ -292,4 +291,43 @@ func TestPipelineVersionWebhook_ValidateCreate_WithPlatformSpec(t *testing.T) {
 	}
 	_, err := pipelineWebhook.ValidateCreate(context.TODO(), pipelineVersion)
 	assert.NoError(t, err, "Expected no error for a valid PipelineVersion with platform spec")
+}
+
+func TestPipelineVersionWebhook_Default_TruncatesLongPipelineNameLabel(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, k8sapi.AddToScheme(scheme))
+
+	longName := "pipeline-name-0123456789012345678901234567890123456789012345678901234567890"
+	expectedTrunc := longName[:63]
+
+	fakeClient := k8sfake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&k8sapi.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      longName,
+				Namespace: "default",
+				UID:       uuid.NewUUID(),
+			},
+		}).Build()
+
+	webhook := &PipelineVersionsWebhook{Client: fakeClient, ClientNoCache: fakeClient}
+
+	pipelineVersion := &k8sapi.PipelineVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline-v1",
+			Namespace: "default",
+		},
+		Spec: k8sapi.PipelineVersionSpec{
+			PipelineName: longName,
+			PipelineSpec: k8sapi.IRSpec{
+				Value: json.RawMessage("{}"),
+			},
+		},
+	}
+
+	require.NoError(t, webhook.Default(context.TODO(), pipelineVersion))
+
+	got, ok := pipelineVersion.Labels["pipelines.kubeflow.org/pipeline"]
+	require.True(t, ok, "expected pipeline label to be set")
+	assert.Equal(t, expectedTrunc, got)
 }


### PR DESCRIPTION
**Description of your changes:**

This just truncates the label value to 63 characters if it's too long. Since this is a label for convenience and not relied upon in the code for filtering, this is a safe change.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
