### PR TITLE
[WIP] refactor(backend): InitDBClient returns (db, sqBuilder) for centralized SQL builder injection

### DIFF
--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -264,7 +264,7 @@ func (c *ClientManager) init(options *Options) error {
 
 	glog.Info("Initializing client manager")
 	glog.Info("Initializing DB client...")
-	db := InitDBClient(common.GetDurationConfig(initConnectionTimeout))
+	db, _ := InitDBClient(common.GetDurationConfig(initConnectionTimeout))
 	db.SetConnMaxLifetime(common.GetDurationConfig(dbConMaxLifeTime))
 	glog.Info("DB client initialized successfully")
 
@@ -314,7 +314,7 @@ func (c *ClientManager) Close() {
 	c.db.Close()
 }
 
-func InitDBClient(initConnectionTimeout time.Duration) *storage.DB {
+func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, SQLDialect) {
 	// Allowed driverName values:
 	// 1) To use MySQL, use `mysql`
 	// 2) To use PostgreSQL, use `pgx`
@@ -360,7 +360,7 @@ func InitDBClient(initConnectionTimeout time.Duration) *storage.DB {
 	if err != nil {
 		glog.Fatalf("Failed to retrieve *sql.DB from gorm.DB. Error: %v", err)
 	}
-	return storage.NewDB(newdb, storage.NewMySQLDialect())
+	return storage.NewDB(newdb, storage.NewMySQLDialect()), dialect
 }
 
 // Initializes Database driver. Use `driverName` to indicate which type of DB to use:

--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -360,6 +360,11 @@ func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, SQLDialect)
 	if err != nil {
 		glog.Fatalf("Failed to retrieve *sql.DB from gorm.DB. Error: %v", err)
 	}
+	// TODO(kaikaila):
+	// storage.DB still takes storage.SQLDialect for legacy raw-SQL helpers.
+	// Once dialect becomes an isolated package and
+	// all *_stores use dialect package + Squirrel,
+	// drop this storage.NewMySQLDialect() argument and delete storage.SQLDialect.
 	return storage.NewDB(newdb, storage.NewMySQLDialect()), dialect
 }
 

--- a/backend/test/integration/db_test.go
+++ b/backend/test/integration/db_test.go
@@ -50,8 +50,9 @@ func (s *DBTestSuite) TestInitDBClient_MySQL() {
 	// The default port-forwarding IP address that test uses is different compared to production
 	viper.Set("DBConfig.MySQLConfig.Host", "localhost")
 	duration, _ := time.ParseDuration("1m")
-	db := cm.InitDBClient(duration)
+	db, dialect := cm.InitDBClient(duration)
 	assert.NotNil(t, db)
+	assert.Equal(t, "mysql", dialect.Name)
 }
 
 // Test PostgreSQL initializes correctly
@@ -68,8 +69,9 @@ func (s *DBTestSuite) TestInitDBClient_PostgreSQL() {
 	viper.Set("DBConfig.PostgreSQLConfig.User", "user")
 	viper.Set("DBConfig.PostgreSQLConfig.Password", "password")
 	duration, _ := time.ParseDuration("1m")
-	db := cm.InitDBClient(duration)
+	db, dialect := cm.InitDBClient(duration)
 	assert.NotNil(t, db)
+	assert.Equal(t, "pgx", dialect.Name)
 }
 
 func TestDB(t *testing.T) {


### PR DESCRIPTION
What
- Change InitDBClient to return a preconfigured Squirrel StatementBuilderType alongside the DB handle:
InitDBClient(...) -> (db, statementBuilder [, dialect])
- Update the minimal call sites to accept the new return value(s).
- No query/behavior changes in this PR.

Why

Centralize SQL builder configuration (placeholder format, quoting via builder) so that follow-up store refactors can use an injected builder instead of ad-hoc configuration. This is a surgical step that reduces risk and keeps subsequent PRs focused per store.

Scope
- Touches client_manager.go (function signature + return path) and the few callers that receive the new value(s).
- Out of scope: store SQL rewrites, filter extraction, schema/model changes.

Backward compatibility
- MySQL: No behavior change (queries and schema remain identical).
- Postgres (pgx): No functional changes yet; this is prep work only.

Testing
- Backend (MySQL) tests remain green (no behavioral deltas expected).
- Postgres (pgx) CI job (currently allowed to fail) should not regress.

Notes
- This PR is intentionally small to keep review surface minimal.
- Follow-ups will switch individual stores to the injected statementBuilder (and dialect).

Part of #12063.