### PR TITLE
feat(frontend): Add custom credential provider 

### DIFF
--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -36,6 +36,12 @@ export interface MinioClientOptionsWithOptionalSecrets extends Partial<MinioClie
   endPoint: string;
 }
 
+export interface Credentials {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+}
+
 /**
  * Create minio client for s3 compatible storage
  *
@@ -51,17 +57,40 @@ export interface MinioClientOptionsWithOptionalSecrets extends Partial<MinioClie
  *
  * @param config minio client options where `accessKey` and `secretKey` are optional.
  * @param providerType provider type ('s3' or 'minio')
- * @param authorizeFn
- * @param req
+ * @param providerInfoString
  * @param namespace
- * @param providerInfoString?? json string container optional provider info
+ * @param customCredentialProvider An optional function which can be added to resolve credentials from a non-standard source. Useful
+ * for enterprises who may have bespoke credential retrieval processes or for refreshing short-lived tokens.
  */
 export async function createMinioClient(
   config: MinioClientOptionsWithOptionalSecrets,
   providerType: string,
   providerInfoString?: string,
   namespace?: string,
+  customCredentialProvider?: () => Promise<Credentials> | Credentials,
 ) {
+  if (customCredentialProvider) {
+    try {
+      const creds = await customCredentialProvider();
+
+      if (creds && creds.accessKeyId && creds.secretAccessKey) {
+        return new MinioClient({
+          ...config,
+          accessKey: creds.accessKeyId,
+          secretKey: creds.secretAccessKey,
+          sessionToken: creds.sessionToken,
+        });
+      } else {
+        console.warn(
+          'Custom credential resolver returned incomplete credentials, falling back to default chain',
+        );
+      }
+    } catch (error) {
+      console.error('Custom credential resolver failed:', error);
+      console.warn('Falling back to default credential resolution chain');
+    }
+  }
+
   if (providerInfoString) {
     const providerInfo = parseJSONString<S3ProviderInfo>(providerInfoString);
     if (!providerInfo) {


### PR DESCRIPTION
**Description of your changes:**
This PR adds a custom credential provider to the minio client instantiation for the node server handling artifact uploads.

Currently, the credential resolution is limited to:
- Static configuration
- Provider info strings  
- AWS credential chain

This doesn't fully support enterprise environments that use:
- Custom credential APIs
- Dynamic or short lived (rotating) credentials

The change is small, focused, and fully backward compatible without any code changes to any existing minio client creation logic.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).