### PR TITLE
feat(sdk/backend): Support forwarding task configuration to external workloads

### DIFF
--- a/.github/workflows/kfp-samples.yml
+++ b/.github/workflows/kfp-samples.yml
@@ -115,6 +115,7 @@ jobs:
         if: ${{ steps.forward-api-port.outcome == 'success' }}
         env:
           KFP_MULTI_USER: ${{ matrix.mode == 'multi-user' }}
+          PULL_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           python3 -u ./samples/v2/sample_test.py
         continue-on-error: true

--- a/.github/workflows/readthedocs-builds.yml
+++ b/.github/workflows/readthedocs-builds.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install protobuf dependencies & kfp-pipeline-spec
+        id: install-protobuf-deps
+        uses: ./.github/actions/protobuf
+        with:
+          generate_golang_proto: "false"
+
       - name: Install Dependencies
         run: |
           pip install -r docs/sdk/requirements.txt

--- a/.github/workflows/sdk-upgrade.yml
+++ b/.github/workflows/sdk-upgrade.yml
@@ -24,5 +24,11 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Install protobuf dependencies & kfp-pipeline-spec
+        id: install-protobuf-deps
+        uses: ./.github/actions/protobuf
+        with:
+          generate_golang_proto: "false"
+
       - name: Run SDK upgrade tests
         run: ./test/presubmit-test-sdk-upgrade.sh

--- a/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
+++ b/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
@@ -110,6 +110,9 @@ const (
 	// Indicates that a parameter is a TaskFinalStatus type; these types can only accept inputs
 	// specified by InputParameterSpec.task_final_status
 	ParameterType_TASK_FINAL_STATUS ParameterType_ParameterTypeEnum = 7
+	// Indicates that a parameter is a TaskConfig type; these types are
+	// injected by the backend to provide the configuration set on the task.
+	ParameterType_TASK_CONFIG ParameterType_ParameterTypeEnum = 8
 )
 
 // Enum value maps for ParameterType_ParameterTypeEnum.
@@ -123,6 +126,7 @@ var (
 		5: "LIST",
 		6: "STRUCT",
 		7: "TASK_FINAL_STATUS",
+		8: "TASK_CONFIG",
 	}
 	ParameterType_ParameterTypeEnum_value = map[string]int32{
 		"PARAMETER_TYPE_ENUM_UNSPECIFIED": 0,
@@ -133,6 +137,7 @@ var (
 		"LIST":                            5,
 		"STRUCT":                          6,
 		"TASK_FINAL_STATUS":               7,
+		"TASK_CONFIG":                     8,
 	}
 )
 
@@ -161,6 +166,81 @@ func (x ParameterType_ParameterTypeEnum) Number() protoreflect.EnumNumber {
 // Deprecated: Use ParameterType_ParameterTypeEnum.Descriptor instead.
 func (ParameterType_ParameterTypeEnum) EnumDescriptor() ([]byte, []int) {
 	return file_pipeline_spec_proto_rawDescGZIP(), []int{10, 0}
+}
+
+type TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum int32
+
+const (
+	// Throwaway default value.
+	TaskConfigPassthroughType_NONE TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum = 0
+	// Indicates that the resource limits and requests should be passed through to the external workload.
+	// Be cautious about also setting apply_to_task=true since that will double the resources required for
+	// the task.
+	TaskConfigPassthroughType_RESOURCES TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum = 1
+	// Indicates that the environment variables should be passed through to the external workload.
+	// It is generally safe to always set apply_to_task=true on this field.
+	TaskConfigPassthroughType_ENV TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum = 2
+	// Indicates that the Kubernetes node affinity should be passed through to the external workload.
+	TaskConfigPassthroughType_KUBERNETES_AFFINITY TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum = 3
+	// Indicates that the Kubernetes node tolerations should be passed through to the external workload.
+	TaskConfigPassthroughType_KUBERNETES_TOLERATIONS TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum = 4
+	// Indicates that the Kubernetes node selector should be passed through to the external workload.
+	TaskConfigPassthroughType_KUBERNETES_NODE_SELECTOR TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum = 5
+	// Indicates that the Kubernetes persistent volumes and ConfigMaps/Secrets mounted as volumes should be
+	// passed through to the external workload. Be sure that when setting apply_to_task=true, the volumes are
+	// ReadWriteMany or ReadOnlyMany or else the task's pod may not start.
+	// This is useful when the task prepares a shared volume for the external workload or defines output artifact
+	// (e.g. dsl.Model) that is created by the external workload.
+	TaskConfigPassthroughType_KUBERNETES_VOLUMES TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum = 6
+)
+
+// Enum value maps for TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum.
+var (
+	TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum_name = map[int32]string{
+		0: "NONE",
+		1: "RESOURCES",
+		2: "ENV",
+		3: "KUBERNETES_AFFINITY",
+		4: "KUBERNETES_TOLERATIONS",
+		5: "KUBERNETES_NODE_SELECTOR",
+		6: "KUBERNETES_VOLUMES",
+	}
+	TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum_value = map[string]int32{
+		"NONE":                     0,
+		"RESOURCES":                1,
+		"ENV":                      2,
+		"KUBERNETES_AFFINITY":      3,
+		"KUBERNETES_TOLERATIONS":   4,
+		"KUBERNETES_NODE_SELECTOR": 5,
+		"KUBERNETES_VOLUMES":       6,
+	}
+)
+
+func (x TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum) Enum() *TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum {
+	p := new(TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum)
+	*p = x
+	return p
+}
+
+func (x TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum) Descriptor() protoreflect.EnumDescriptor {
+	return file_pipeline_spec_proto_enumTypes[2].Descriptor()
+}
+
+func (TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum) Type() protoreflect.EnumType {
+	return &file_pipeline_spec_proto_enumTypes[2]
+}
+
+func (x TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum.Descriptor instead.
+func (TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum) EnumDescriptor() ([]byte, []int) {
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{11, 0}
 }
 
 // An enum defines the trigger strategy of when the task will be ready to be
@@ -207,11 +287,11 @@ func (x PipelineTaskSpec_TriggerPolicy_TriggerStrategy) String() string {
 }
 
 func (PipelineTaskSpec_TriggerPolicy_TriggerStrategy) Descriptor() protoreflect.EnumDescriptor {
-	return file_pipeline_spec_proto_enumTypes[2].Descriptor()
+	return file_pipeline_spec_proto_enumTypes[3].Descriptor()
 }
 
 func (PipelineTaskSpec_TriggerPolicy_TriggerStrategy) Type() protoreflect.EnumType {
-	return &file_pipeline_spec_proto_enumTypes[2]
+	return &file_pipeline_spec_proto_enumTypes[3]
 }
 
 func (x PipelineTaskSpec_TriggerPolicy_TriggerStrategy) Number() protoreflect.EnumNumber {
@@ -220,7 +300,7 @@ func (x PipelineTaskSpec_TriggerPolicy_TriggerStrategy) Number() protoreflect.En
 
 // Deprecated: Use PipelineTaskSpec_TriggerPolicy_TriggerStrategy.Descriptor instead.
 func (PipelineTaskSpec_TriggerPolicy_TriggerStrategy) EnumDescriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{11, 1, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{13, 1, 0}
 }
 
 type PipelineStateEnum_PipelineTaskState int32
@@ -304,11 +384,11 @@ func (x PipelineStateEnum_PipelineTaskState) String() string {
 }
 
 func (PipelineStateEnum_PipelineTaskState) Descriptor() protoreflect.EnumDescriptor {
-	return file_pipeline_spec_proto_enumTypes[3].Descriptor()
+	return file_pipeline_spec_proto_enumTypes[4].Descriptor()
 }
 
 func (PipelineStateEnum_PipelineTaskState) Type() protoreflect.EnumType {
-	return &file_pipeline_spec_proto_enumTypes[3]
+	return &file_pipeline_spec_proto_enumTypes[4]
 }
 
 func (x PipelineStateEnum_PipelineTaskState) Number() protoreflect.EnumNumber {
@@ -317,7 +397,7 @@ func (x PipelineStateEnum_PipelineTaskState) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use PipelineStateEnum_PipelineTaskState.Descriptor instead.
 func (PipelineStateEnum_PipelineTaskState) EnumDescriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{26, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{28, 0}
 }
 
 // The spec of a pipeline job.
@@ -519,8 +599,10 @@ type ComponentSpec struct {
 	Implementation isComponentSpec_Implementation `protobuf_oneof:"implementation"`
 	// Supports platform-specific component features.
 	SinglePlatformSpecs []*SinglePlatformSpec `protobuf:"bytes,5,rep,name=single_platform_specs,json=singlePlatformSpecs,proto3" json:"single_platform_specs,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// Specifies the task configurations that can be passed through to an external workload.
+	TaskConfigPassthroughs []*TaskConfigPassthrough `protobuf:"bytes,6,rep,name=task_config_passthroughs,json=taskConfigPassthroughs,proto3" json:"task_config_passthroughs,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *ComponentSpec) Reset() {
@@ -595,6 +677,13 @@ func (x *ComponentSpec) GetExecutorLabel() string {
 func (x *ComponentSpec) GetSinglePlatformSpecs() []*SinglePlatformSpec {
 	if x != nil {
 		return x.SinglePlatformSpecs
+	}
+	return nil
+}
+
+func (x *ComponentSpec) GetTaskConfigPassthroughs() []*TaskConfigPassthrough {
+	if x != nil {
+		return x.TaskConfigPassthroughs
 	}
 	return nil
 }
@@ -1031,6 +1120,95 @@ func (*ParameterType) Descriptor() ([]byte, []int) {
 	return file_pipeline_spec_proto_rawDescGZIP(), []int{10}
 }
 
+// Represents the task configurations that can be passed through to an external workload.
+type TaskConfigPassthroughType struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TaskConfigPassthroughType) Reset() {
+	*x = TaskConfigPassthroughType{}
+	mi := &file_pipeline_spec_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TaskConfigPassthroughType) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaskConfigPassthroughType) ProtoMessage() {}
+
+func (x *TaskConfigPassthroughType) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_spec_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaskConfigPassthroughType.ProtoReflect.Descriptor instead.
+func (*TaskConfigPassthroughType) Descriptor() ([]byte, []int) {
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{11}
+}
+
+type TaskConfigPassthrough struct {
+	state         protoimpl.MessageState                                  `protogen:"open.v1"`
+	Field         TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum `protobuf:"varint,1,opt,name=field,proto3,enum=ml_pipelines.TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum" json:"field,omitempty"`
+	ApplyToTask   bool                                                    `protobuf:"varint,2,opt,name=apply_to_task,json=applyToTask,proto3" json:"apply_to_task,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TaskConfigPassthrough) Reset() {
+	*x = TaskConfigPassthrough{}
+	mi := &file_pipeline_spec_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TaskConfigPassthrough) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TaskConfigPassthrough) ProtoMessage() {}
+
+func (x *TaskConfigPassthrough) ProtoReflect() protoreflect.Message {
+	mi := &file_pipeline_spec_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TaskConfigPassthrough.ProtoReflect.Descriptor instead.
+func (*TaskConfigPassthrough) Descriptor() ([]byte, []int) {
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *TaskConfigPassthrough) GetField() TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum {
+	if x != nil {
+		return x.Field
+	}
+	return TaskConfigPassthroughType_NONE
+}
+
+func (x *TaskConfigPassthrough) GetApplyToTask() bool {
+	if x != nil {
+		return x.ApplyToTask
+	}
+	return false
+}
+
 // The spec of a pipeline task.
 type PipelineTaskSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1084,7 +1262,7 @@ type PipelineTaskSpec struct {
 
 func (x *PipelineTaskSpec) Reset() {
 	*x = PipelineTaskSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[11]
+	mi := &file_pipeline_spec_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1096,7 +1274,7 @@ func (x *PipelineTaskSpec) String() string {
 func (*PipelineTaskSpec) ProtoMessage() {}
 
 func (x *PipelineTaskSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[11]
+	mi := &file_pipeline_spec_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1109,7 +1287,7 @@ func (x *PipelineTaskSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineTaskSpec.ProtoReflect.Descriptor instead.
 func (*PipelineTaskSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{11}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *PipelineTaskSpec) GetTaskInfo() *PipelineTaskInfo {
@@ -1226,7 +1404,7 @@ type ArtifactIteratorSpec struct {
 
 func (x *ArtifactIteratorSpec) Reset() {
 	*x = ArtifactIteratorSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[12]
+	mi := &file_pipeline_spec_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1238,7 +1416,7 @@ func (x *ArtifactIteratorSpec) String() string {
 func (*ArtifactIteratorSpec) ProtoMessage() {}
 
 func (x *ArtifactIteratorSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[12]
+	mi := &file_pipeline_spec_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1251,7 +1429,7 @@ func (x *ArtifactIteratorSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArtifactIteratorSpec.ProtoReflect.Descriptor instead.
 func (*ArtifactIteratorSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{12}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ArtifactIteratorSpec) GetItems() *ArtifactIteratorSpec_ItemsSpec {
@@ -1283,7 +1461,7 @@ type ParameterIteratorSpec struct {
 
 func (x *ParameterIteratorSpec) Reset() {
 	*x = ParameterIteratorSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[13]
+	mi := &file_pipeline_spec_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1295,7 +1473,7 @@ func (x *ParameterIteratorSpec) String() string {
 func (*ParameterIteratorSpec) ProtoMessage() {}
 
 func (x *ParameterIteratorSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[13]
+	mi := &file_pipeline_spec_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1308,7 +1486,7 @@ func (x *ParameterIteratorSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ParameterIteratorSpec.ProtoReflect.Descriptor instead.
 func (*ParameterIteratorSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{13}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ParameterIteratorSpec) GetItems() *ParameterIteratorSpec_ItemsSpec {
@@ -1336,7 +1514,7 @@ type ComponentRef struct {
 
 func (x *ComponentRef) Reset() {
 	*x = ComponentRef{}
-	mi := &file_pipeline_spec_proto_msgTypes[14]
+	mi := &file_pipeline_spec_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1348,7 +1526,7 @@ func (x *ComponentRef) String() string {
 func (*ComponentRef) ProtoMessage() {}
 
 func (x *ComponentRef) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[14]
+	mi := &file_pipeline_spec_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1361,7 +1539,7 @@ func (x *ComponentRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ComponentRef.ProtoReflect.Descriptor instead.
 func (*ComponentRef) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{14}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ComponentRef) GetName() string {
@@ -1389,7 +1567,7 @@ type PipelineInfo struct {
 
 func (x *PipelineInfo) Reset() {
 	*x = PipelineInfo{}
-	mi := &file_pipeline_spec_proto_msgTypes[15]
+	mi := &file_pipeline_spec_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1401,7 +1579,7 @@ func (x *PipelineInfo) String() string {
 func (*PipelineInfo) ProtoMessage() {}
 
 func (x *PipelineInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[15]
+	mi := &file_pipeline_spec_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1414,7 +1592,7 @@ func (x *PipelineInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineInfo.ProtoReflect.Descriptor instead.
 func (*PipelineInfo) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{15}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *PipelineInfo) GetName() string {
@@ -1456,7 +1634,7 @@ type ArtifactTypeSchema struct {
 
 func (x *ArtifactTypeSchema) Reset() {
 	*x = ArtifactTypeSchema{}
-	mi := &file_pipeline_spec_proto_msgTypes[16]
+	mi := &file_pipeline_spec_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1468,7 +1646,7 @@ func (x *ArtifactTypeSchema) String() string {
 func (*ArtifactTypeSchema) ProtoMessage() {}
 
 func (x *ArtifactTypeSchema) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[16]
+	mi := &file_pipeline_spec_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1481,7 +1659,7 @@ func (x *ArtifactTypeSchema) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArtifactTypeSchema.ProtoReflect.Descriptor instead.
 func (*ArtifactTypeSchema) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{16}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ArtifactTypeSchema) GetKind() isArtifactTypeSchema_Kind {
@@ -1574,7 +1752,7 @@ type PipelineTaskInfo struct {
 
 func (x *PipelineTaskInfo) Reset() {
 	*x = PipelineTaskInfo{}
-	mi := &file_pipeline_spec_proto_msgTypes[17]
+	mi := &file_pipeline_spec_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1586,7 +1764,7 @@ func (x *PipelineTaskInfo) String() string {
 func (*PipelineTaskInfo) ProtoMessage() {}
 
 func (x *PipelineTaskInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[17]
+	mi := &file_pipeline_spec_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1599,7 +1777,7 @@ func (x *PipelineTaskInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineTaskInfo.ProtoReflect.Descriptor instead.
 func (*PipelineTaskInfo) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{17}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *PipelineTaskInfo) GetName() string {
@@ -1627,7 +1805,7 @@ type ValueOrRuntimeParameter struct {
 
 func (x *ValueOrRuntimeParameter) Reset() {
 	*x = ValueOrRuntimeParameter{}
-	mi := &file_pipeline_spec_proto_msgTypes[18]
+	mi := &file_pipeline_spec_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1639,7 +1817,7 @@ func (x *ValueOrRuntimeParameter) String() string {
 func (*ValueOrRuntimeParameter) ProtoMessage() {}
 
 func (x *ValueOrRuntimeParameter) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[18]
+	mi := &file_pipeline_spec_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1652,7 +1830,7 @@ func (x *ValueOrRuntimeParameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ValueOrRuntimeParameter.ProtoReflect.Descriptor instead.
 func (*ValueOrRuntimeParameter) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{18}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ValueOrRuntimeParameter) GetValue() isValueOrRuntimeParameter_Value {
@@ -1730,7 +1908,7 @@ type PipelineDeploymentConfig struct {
 
 func (x *PipelineDeploymentConfig) Reset() {
 	*x = PipelineDeploymentConfig{}
-	mi := &file_pipeline_spec_proto_msgTypes[19]
+	mi := &file_pipeline_spec_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1742,7 +1920,7 @@ func (x *PipelineDeploymentConfig) String() string {
 func (*PipelineDeploymentConfig) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[19]
+	mi := &file_pipeline_spec_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1755,7 +1933,7 @@ func (x *PipelineDeploymentConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineDeploymentConfig.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *PipelineDeploymentConfig) GetExecutors() map[string]*PipelineDeploymentConfig_ExecutorSpec {
@@ -1780,7 +1958,7 @@ type Value struct {
 
 func (x *Value) Reset() {
 	*x = Value{}
-	mi := &file_pipeline_spec_proto_msgTypes[20]
+	mi := &file_pipeline_spec_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1792,7 +1970,7 @@ func (x *Value) String() string {
 func (*Value) ProtoMessage() {}
 
 func (x *Value) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[20]
+	mi := &file_pipeline_spec_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1805,7 +1983,7 @@ func (x *Value) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Value.ProtoReflect.Descriptor instead.
 func (*Value) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{20}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Value) GetValue() isValue_Value {
@@ -1894,7 +2072,7 @@ type RuntimeArtifact struct {
 
 func (x *RuntimeArtifact) Reset() {
 	*x = RuntimeArtifact{}
-	mi := &file_pipeline_spec_proto_msgTypes[21]
+	mi := &file_pipeline_spec_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1906,7 +2084,7 @@ func (x *RuntimeArtifact) String() string {
 func (*RuntimeArtifact) ProtoMessage() {}
 
 func (x *RuntimeArtifact) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[21]
+	mi := &file_pipeline_spec_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1919,7 +2097,7 @@ func (x *RuntimeArtifact) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RuntimeArtifact.ProtoReflect.Descriptor instead.
 func (*RuntimeArtifact) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{21}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *RuntimeArtifact) GetName() string {
@@ -1977,7 +2155,7 @@ type ArtifactList struct {
 
 func (x *ArtifactList) Reset() {
 	*x = ArtifactList{}
-	mi := &file_pipeline_spec_proto_msgTypes[22]
+	mi := &file_pipeline_spec_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1989,7 +2167,7 @@ func (x *ArtifactList) String() string {
 func (*ArtifactList) ProtoMessage() {}
 
 func (x *ArtifactList) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[22]
+	mi := &file_pipeline_spec_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2002,7 +2180,7 @@ func (x *ArtifactList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArtifactList.ProtoReflect.Descriptor instead.
 func (*ArtifactList) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{22}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ArtifactList) GetArtifacts() []*RuntimeArtifact {
@@ -2049,7 +2227,7 @@ type ExecutorInput struct {
 
 func (x *ExecutorInput) Reset() {
 	*x = ExecutorInput{}
-	mi := &file_pipeline_spec_proto_msgTypes[23]
+	mi := &file_pipeline_spec_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2061,7 +2239,7 @@ func (x *ExecutorInput) String() string {
 func (*ExecutorInput) ProtoMessage() {}
 
 func (x *ExecutorInput) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[23]
+	mi := &file_pipeline_spec_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2074,7 +2252,7 @@ func (x *ExecutorInput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutorInput.ProtoReflect.Descriptor instead.
 func (*ExecutorInput) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{23}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ExecutorInput) GetInputs() *ExecutorInput_Inputs {
@@ -2110,7 +2288,7 @@ type ExecutorOutput struct {
 
 func (x *ExecutorOutput) Reset() {
 	*x = ExecutorOutput{}
-	mi := &file_pipeline_spec_proto_msgTypes[24]
+	mi := &file_pipeline_spec_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2122,7 +2300,7 @@ func (x *ExecutorOutput) String() string {
 func (*ExecutorOutput) ProtoMessage() {}
 
 func (x *ExecutorOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[24]
+	mi := &file_pipeline_spec_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2135,7 +2313,7 @@ func (x *ExecutorOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutorOutput.ProtoReflect.Descriptor instead.
 func (*ExecutorOutput) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{24}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{26}
 }
 
 // Deprecated: Marked as deprecated in pipeline_spec.proto.
@@ -2188,7 +2366,7 @@ type PipelineTaskFinalStatus struct {
 
 func (x *PipelineTaskFinalStatus) Reset() {
 	*x = PipelineTaskFinalStatus{}
-	mi := &file_pipeline_spec_proto_msgTypes[25]
+	mi := &file_pipeline_spec_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2200,7 +2378,7 @@ func (x *PipelineTaskFinalStatus) String() string {
 func (*PipelineTaskFinalStatus) ProtoMessage() {}
 
 func (x *PipelineTaskFinalStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[25]
+	mi := &file_pipeline_spec_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2213,7 +2391,7 @@ func (x *PipelineTaskFinalStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineTaskFinalStatus.ProtoReflect.Descriptor instead.
 func (*PipelineTaskFinalStatus) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{25}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *PipelineTaskFinalStatus) GetState() string {
@@ -2268,7 +2446,7 @@ type PipelineStateEnum struct {
 
 func (x *PipelineStateEnum) Reset() {
 	*x = PipelineStateEnum{}
-	mi := &file_pipeline_spec_proto_msgTypes[26]
+	mi := &file_pipeline_spec_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2280,7 +2458,7 @@ func (x *PipelineStateEnum) String() string {
 func (*PipelineStateEnum) ProtoMessage() {}
 
 func (x *PipelineStateEnum) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[26]
+	mi := &file_pipeline_spec_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2293,7 +2471,7 @@ func (x *PipelineStateEnum) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineStateEnum.ProtoReflect.Descriptor instead.
 func (*PipelineStateEnum) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{26}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{28}
 }
 
 // Spec for all platforms; second document in IR
@@ -2307,7 +2485,7 @@ type PlatformSpec struct {
 
 func (x *PlatformSpec) Reset() {
 	*x = PlatformSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[27]
+	mi := &file_pipeline_spec_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2319,7 +2497,7 @@ func (x *PlatformSpec) String() string {
 func (*PlatformSpec) ProtoMessage() {}
 
 func (x *PlatformSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[27]
+	mi := &file_pipeline_spec_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2332,7 +2510,7 @@ func (x *PlatformSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlatformSpec.ProtoReflect.Descriptor instead.
 func (*PlatformSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{27}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *PlatformSpec) GetPlatforms() map[string]*SinglePlatformSpec {
@@ -2358,7 +2536,7 @@ type SinglePlatformSpec struct {
 
 func (x *SinglePlatformSpec) Reset() {
 	*x = SinglePlatformSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[28]
+	mi := &file_pipeline_spec_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2370,7 +2548,7 @@ func (x *SinglePlatformSpec) String() string {
 func (*SinglePlatformSpec) ProtoMessage() {}
 
 func (x *SinglePlatformSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[28]
+	mi := &file_pipeline_spec_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2383,7 +2561,7 @@ func (x *SinglePlatformSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SinglePlatformSpec.ProtoReflect.Descriptor instead.
 func (*SinglePlatformSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{28}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SinglePlatformSpec) GetDeploymentSpec() *PlatformDeploymentConfig {
@@ -2425,7 +2603,7 @@ type PlatformDeploymentConfig struct {
 
 func (x *PlatformDeploymentConfig) Reset() {
 	*x = PlatformDeploymentConfig{}
-	mi := &file_pipeline_spec_proto_msgTypes[29]
+	mi := &file_pipeline_spec_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2437,7 +2615,7 @@ func (x *PlatformDeploymentConfig) String() string {
 func (*PlatformDeploymentConfig) ProtoMessage() {}
 
 func (x *PlatformDeploymentConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[29]
+	mi := &file_pipeline_spec_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2450,7 +2628,7 @@ func (x *PlatformDeploymentConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PlatformDeploymentConfig.ProtoReflect.Descriptor instead.
 func (*PlatformDeploymentConfig) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{29}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *PlatformDeploymentConfig) GetExecutors() map[string]*structpb.Struct {
@@ -2474,7 +2652,7 @@ type WorkspaceConfig struct {
 
 func (x *WorkspaceConfig) Reset() {
 	*x = WorkspaceConfig{}
-	mi := &file_pipeline_spec_proto_msgTypes[30]
+	mi := &file_pipeline_spec_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2486,7 +2664,7 @@ func (x *WorkspaceConfig) String() string {
 func (*WorkspaceConfig) ProtoMessage() {}
 
 func (x *WorkspaceConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[30]
+	mi := &file_pipeline_spec_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2499,7 +2677,7 @@ func (x *WorkspaceConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WorkspaceConfig.ProtoReflect.Descriptor instead.
 func (*WorkspaceConfig) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{30}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *WorkspaceConfig) GetSize() string {
@@ -2530,7 +2708,7 @@ type KubernetesWorkspaceConfig struct {
 
 func (x *KubernetesWorkspaceConfig) Reset() {
 	*x = KubernetesWorkspaceConfig{}
-	mi := &file_pipeline_spec_proto_msgTypes[31]
+	mi := &file_pipeline_spec_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2542,7 +2720,7 @@ func (x *KubernetesWorkspaceConfig) String() string {
 func (*KubernetesWorkspaceConfig) ProtoMessage() {}
 
 func (x *KubernetesWorkspaceConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[31]
+	mi := &file_pipeline_spec_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2555,7 +2733,7 @@ func (x *KubernetesWorkspaceConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KubernetesWorkspaceConfig.ProtoReflect.Descriptor instead.
 func (*KubernetesWorkspaceConfig) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{31}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *KubernetesWorkspaceConfig) GetPvcSpecPatch() *structpb.Struct {
@@ -2584,7 +2762,7 @@ type PipelineConfig struct {
 
 func (x *PipelineConfig) Reset() {
 	*x = PipelineConfig{}
-	mi := &file_pipeline_spec_proto_msgTypes[32]
+	mi := &file_pipeline_spec_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2596,7 +2774,7 @@ func (x *PipelineConfig) String() string {
 func (*PipelineConfig) ProtoMessage() {}
 
 func (x *PipelineConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[32]
+	mi := &file_pipeline_spec_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2609,7 +2787,7 @@ func (x *PipelineConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineConfig.ProtoReflect.Descriptor instead.
 func (*PipelineConfig) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{32}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *PipelineConfig) GetSemaphoreKey() string {
@@ -2662,7 +2840,7 @@ type PipelineJob_RuntimeConfig struct {
 
 func (x *PipelineJob_RuntimeConfig) Reset() {
 	*x = PipelineJob_RuntimeConfig{}
-	mi := &file_pipeline_spec_proto_msgTypes[34]
+	mi := &file_pipeline_spec_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2674,7 +2852,7 @@ func (x *PipelineJob_RuntimeConfig) String() string {
 func (*PipelineJob_RuntimeConfig) ProtoMessage() {}
 
 func (x *PipelineJob_RuntimeConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[34]
+	mi := &file_pipeline_spec_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2727,7 +2905,7 @@ type PipelineSpec_RuntimeParameter struct {
 
 func (x *PipelineSpec_RuntimeParameter) Reset() {
 	*x = PipelineSpec_RuntimeParameter{}
-	mi := &file_pipeline_spec_proto_msgTypes[37]
+	mi := &file_pipeline_spec_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2739,7 +2917,7 @@ func (x *PipelineSpec_RuntimeParameter) String() string {
 func (*PipelineSpec_RuntimeParameter) ProtoMessage() {}
 
 func (x *PipelineSpec_RuntimeParameter) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[37]
+	mi := &file_pipeline_spec_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2783,7 +2961,7 @@ type DagOutputsSpec_ArtifactSelectorSpec struct {
 
 func (x *DagOutputsSpec_ArtifactSelectorSpec) Reset() {
 	*x = DagOutputsSpec_ArtifactSelectorSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[40]
+	mi := &file_pipeline_spec_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2795,7 +2973,7 @@ func (x *DagOutputsSpec_ArtifactSelectorSpec) String() string {
 func (*DagOutputsSpec_ArtifactSelectorSpec) ProtoMessage() {}
 
 func (x *DagOutputsSpec_ArtifactSelectorSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[40]
+	mi := &file_pipeline_spec_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2838,7 +3016,7 @@ type DagOutputsSpec_DagOutputArtifactSpec struct {
 
 func (x *DagOutputsSpec_DagOutputArtifactSpec) Reset() {
 	*x = DagOutputsSpec_DagOutputArtifactSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[41]
+	mi := &file_pipeline_spec_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2850,7 +3028,7 @@ func (x *DagOutputsSpec_DagOutputArtifactSpec) String() string {
 func (*DagOutputsSpec_DagOutputArtifactSpec) ProtoMessage() {}
 
 func (x *DagOutputsSpec_DagOutputArtifactSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[41]
+	mi := &file_pipeline_spec_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2887,7 +3065,7 @@ type DagOutputsSpec_ParameterSelectorSpec struct {
 
 func (x *DagOutputsSpec_ParameterSelectorSpec) Reset() {
 	*x = DagOutputsSpec_ParameterSelectorSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[43]
+	mi := &file_pipeline_spec_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2899,7 +3077,7 @@ func (x *DagOutputsSpec_ParameterSelectorSpec) String() string {
 func (*DagOutputsSpec_ParameterSelectorSpec) ProtoMessage() {}
 
 func (x *DagOutputsSpec_ParameterSelectorSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[43]
+	mi := &file_pipeline_spec_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2939,7 +3117,7 @@ type DagOutputsSpec_ParameterSelectorsSpec struct {
 
 func (x *DagOutputsSpec_ParameterSelectorsSpec) Reset() {
 	*x = DagOutputsSpec_ParameterSelectorsSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[44]
+	mi := &file_pipeline_spec_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2951,7 +3129,7 @@ func (x *DagOutputsSpec_ParameterSelectorsSpec) String() string {
 func (*DagOutputsSpec_ParameterSelectorsSpec) ProtoMessage() {}
 
 func (x *DagOutputsSpec_ParameterSelectorsSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[44]
+	mi := &file_pipeline_spec_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2984,7 +3162,7 @@ type DagOutputsSpec_MapParameterSelectorsSpec struct {
 
 func (x *DagOutputsSpec_MapParameterSelectorsSpec) Reset() {
 	*x = DagOutputsSpec_MapParameterSelectorsSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[45]
+	mi := &file_pipeline_spec_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2996,7 +3174,7 @@ func (x *DagOutputsSpec_MapParameterSelectorsSpec) String() string {
 func (*DagOutputsSpec_MapParameterSelectorsSpec) ProtoMessage() {}
 
 func (x *DagOutputsSpec_MapParameterSelectorsSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[45]
+	mi := &file_pipeline_spec_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3039,7 +3217,7 @@ type DagOutputsSpec_DagOutputParameterSpec struct {
 
 func (x *DagOutputsSpec_DagOutputParameterSpec) Reset() {
 	*x = DagOutputsSpec_DagOutputParameterSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[46]
+	mi := &file_pipeline_spec_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3051,7 +3229,7 @@ func (x *DagOutputsSpec_DagOutputParameterSpec) String() string {
 func (*DagOutputsSpec_DagOutputParameterSpec) ProtoMessage() {}
 
 func (x *DagOutputsSpec_DagOutputParameterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[46]
+	mi := &file_pipeline_spec_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3138,7 +3316,7 @@ type ComponentInputsSpec_ArtifactSpec struct {
 
 func (x *ComponentInputsSpec_ArtifactSpec) Reset() {
 	*x = ComponentInputsSpec_ArtifactSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[49]
+	mi := &file_pipeline_spec_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3150,7 +3328,7 @@ func (x *ComponentInputsSpec_ArtifactSpec) String() string {
 func (*ComponentInputsSpec_ArtifactSpec) ProtoMessage() {}
 
 func (x *ComponentInputsSpec_ArtifactSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[49]
+	mi := &file_pipeline_spec_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3225,7 +3403,7 @@ type ComponentInputsSpec_ParameterSpec struct {
 
 func (x *ComponentInputsSpec_ParameterSpec) Reset() {
 	*x = ComponentInputsSpec_ParameterSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[50]
+	mi := &file_pipeline_spec_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3237,7 +3415,7 @@ func (x *ComponentInputsSpec_ParameterSpec) String() string {
 func (*ComponentInputsSpec_ParameterSpec) ProtoMessage() {}
 
 func (x *ComponentInputsSpec_ParameterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[50]
+	mi := &file_pipeline_spec_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3314,7 +3492,7 @@ type ComponentOutputsSpec_ArtifactSpec struct {
 
 func (x *ComponentOutputsSpec_ArtifactSpec) Reset() {
 	*x = ComponentOutputsSpec_ArtifactSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[53]
+	mi := &file_pipeline_spec_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3326,7 +3504,7 @@ func (x *ComponentOutputsSpec_ArtifactSpec) String() string {
 func (*ComponentOutputsSpec_ArtifactSpec) ProtoMessage() {}
 
 func (x *ComponentOutputsSpec_ArtifactSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[53]
+	mi := &file_pipeline_spec_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3405,7 +3583,7 @@ type ComponentOutputsSpec_ParameterSpec struct {
 
 func (x *ComponentOutputsSpec_ParameterSpec) Reset() {
 	*x = ComponentOutputsSpec_ParameterSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[54]
+	mi := &file_pipeline_spec_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3417,7 +3595,7 @@ func (x *ComponentOutputsSpec_ParameterSpec) String() string {
 func (*ComponentOutputsSpec_ParameterSpec) ProtoMessage() {}
 
 func (x *ComponentOutputsSpec_ParameterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[54]
+	mi := &file_pipeline_spec_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3469,7 +3647,7 @@ type TaskInputsSpec_InputArtifactSpec struct {
 
 func (x *TaskInputsSpec_InputArtifactSpec) Reset() {
 	*x = TaskInputsSpec_InputArtifactSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[59]
+	mi := &file_pipeline_spec_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3481,7 +3659,7 @@ func (x *TaskInputsSpec_InputArtifactSpec) String() string {
 func (*TaskInputsSpec_InputArtifactSpec) ProtoMessage() {}
 
 func (x *TaskInputsSpec_InputArtifactSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[59]
+	mi := &file_pipeline_spec_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3588,7 +3766,7 @@ type TaskInputsSpec_InputParameterSpec struct {
 
 func (x *TaskInputsSpec_InputParameterSpec) Reset() {
 	*x = TaskInputsSpec_InputParameterSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[60]
+	mi := &file_pipeline_spec_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3600,7 +3778,7 @@ func (x *TaskInputsSpec_InputParameterSpec) String() string {
 func (*TaskInputsSpec_InputParameterSpec) ProtoMessage() {}
 
 func (x *TaskInputsSpec_InputParameterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[60]
+	mi := &file_pipeline_spec_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3714,7 +3892,7 @@ type TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec struct {
 
 func (x *TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec) Reset() {
 	*x = TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[63]
+	mi := &file_pipeline_spec_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3726,7 +3904,7 @@ func (x *TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec) String() strin
 func (*TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec) ProtoMessage() {}
 
 func (x *TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[63]
+	mi := &file_pipeline_spec_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3770,7 +3948,7 @@ type TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec struct {
 
 func (x *TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec) Reset() {
 	*x = TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[64]
+	mi := &file_pipeline_spec_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3782,7 +3960,7 @@ func (x *TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec) String() str
 func (*TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec) ProtoMessage() {}
 
 func (x *TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[64]
+	mi := &file_pipeline_spec_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3825,7 +4003,7 @@ type TaskInputsSpec_InputParameterSpec_TaskFinalStatus struct {
 
 func (x *TaskInputsSpec_InputParameterSpec_TaskFinalStatus) Reset() {
 	*x = TaskInputsSpec_InputParameterSpec_TaskFinalStatus{}
-	mi := &file_pipeline_spec_proto_msgTypes[65]
+	mi := &file_pipeline_spec_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3837,7 +4015,7 @@ func (x *TaskInputsSpec_InputParameterSpec_TaskFinalStatus) String() string {
 func (*TaskInputsSpec_InputParameterSpec_TaskFinalStatus) ProtoMessage() {}
 
 func (x *TaskInputsSpec_InputParameterSpec_TaskFinalStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[65]
+	mi := &file_pipeline_spec_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3877,7 +4055,7 @@ type TaskOutputsSpec_OutputArtifactSpec struct {
 
 func (x *TaskOutputsSpec_OutputArtifactSpec) Reset() {
 	*x = TaskOutputsSpec_OutputArtifactSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[66]
+	mi := &file_pipeline_spec_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3889,7 +4067,7 @@ func (x *TaskOutputsSpec_OutputArtifactSpec) String() string {
 func (*TaskOutputsSpec_OutputArtifactSpec) ProtoMessage() {}
 
 func (x *TaskOutputsSpec_OutputArtifactSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[66]
+	mi := &file_pipeline_spec_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3937,7 +4115,7 @@ type TaskOutputsSpec_OutputParameterSpec struct {
 
 func (x *TaskOutputsSpec_OutputParameterSpec) Reset() {
 	*x = TaskOutputsSpec_OutputParameterSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[67]
+	mi := &file_pipeline_spec_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3949,7 +4127,7 @@ func (x *TaskOutputsSpec_OutputParameterSpec) String() string {
 func (*TaskOutputsSpec_OutputParameterSpec) ProtoMessage() {}
 
 func (x *TaskOutputsSpec_OutputParameterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[67]
+	mi := &file_pipeline_spec_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3985,7 +4163,7 @@ type PipelineTaskSpec_CachingOptions struct {
 
 func (x *PipelineTaskSpec_CachingOptions) Reset() {
 	*x = PipelineTaskSpec_CachingOptions{}
-	mi := &file_pipeline_spec_proto_msgTypes[72]
+	mi := &file_pipeline_spec_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3997,7 +4175,7 @@ func (x *PipelineTaskSpec_CachingOptions) String() string {
 func (*PipelineTaskSpec_CachingOptions) ProtoMessage() {}
 
 func (x *PipelineTaskSpec_CachingOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[72]
+	mi := &file_pipeline_spec_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4010,7 +4188,7 @@ func (x *PipelineTaskSpec_CachingOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineTaskSpec_CachingOptions.ProtoReflect.Descriptor instead.
 func (*PipelineTaskSpec_CachingOptions) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{11, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{13, 0}
 }
 
 func (x *PipelineTaskSpec_CachingOptions) GetEnableCache() bool {
@@ -4051,7 +4229,7 @@ type PipelineTaskSpec_TriggerPolicy struct {
 
 func (x *PipelineTaskSpec_TriggerPolicy) Reset() {
 	*x = PipelineTaskSpec_TriggerPolicy{}
-	mi := &file_pipeline_spec_proto_msgTypes[73]
+	mi := &file_pipeline_spec_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4063,7 +4241,7 @@ func (x *PipelineTaskSpec_TriggerPolicy) String() string {
 func (*PipelineTaskSpec_TriggerPolicy) ProtoMessage() {}
 
 func (x *PipelineTaskSpec_TriggerPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[73]
+	mi := &file_pipeline_spec_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4076,7 +4254,7 @@ func (x *PipelineTaskSpec_TriggerPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineTaskSpec_TriggerPolicy.ProtoReflect.Descriptor instead.
 func (*PipelineTaskSpec_TriggerPolicy) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{11, 1}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{13, 1}
 }
 
 func (x *PipelineTaskSpec_TriggerPolicy) GetCondition() string {
@@ -4114,7 +4292,7 @@ type PipelineTaskSpec_RetryPolicy struct {
 
 func (x *PipelineTaskSpec_RetryPolicy) Reset() {
 	*x = PipelineTaskSpec_RetryPolicy{}
-	mi := &file_pipeline_spec_proto_msgTypes[74]
+	mi := &file_pipeline_spec_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4126,7 +4304,7 @@ func (x *PipelineTaskSpec_RetryPolicy) String() string {
 func (*PipelineTaskSpec_RetryPolicy) ProtoMessage() {}
 
 func (x *PipelineTaskSpec_RetryPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[74]
+	mi := &file_pipeline_spec_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4139,7 +4317,7 @@ func (x *PipelineTaskSpec_RetryPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineTaskSpec_RetryPolicy.ProtoReflect.Descriptor instead.
 func (*PipelineTaskSpec_RetryPolicy) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{11, 2}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{13, 2}
 }
 
 func (x *PipelineTaskSpec_RetryPolicy) GetMaxRetryCount() int32 {
@@ -4183,7 +4361,7 @@ type PipelineTaskSpec_IteratorPolicy struct {
 
 func (x *PipelineTaskSpec_IteratorPolicy) Reset() {
 	*x = PipelineTaskSpec_IteratorPolicy{}
-	mi := &file_pipeline_spec_proto_msgTypes[75]
+	mi := &file_pipeline_spec_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4195,7 +4373,7 @@ func (x *PipelineTaskSpec_IteratorPolicy) String() string {
 func (*PipelineTaskSpec_IteratorPolicy) ProtoMessage() {}
 
 func (x *PipelineTaskSpec_IteratorPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[75]
+	mi := &file_pipeline_spec_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4208,7 +4386,7 @@ func (x *PipelineTaskSpec_IteratorPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineTaskSpec_IteratorPolicy.ProtoReflect.Descriptor instead.
 func (*PipelineTaskSpec_IteratorPolicy) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{11, 3}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{13, 3}
 }
 
 func (x *PipelineTaskSpec_IteratorPolicy) GetParallelismLimit() int32 {
@@ -4232,7 +4410,7 @@ type ArtifactIteratorSpec_ItemsSpec struct {
 
 func (x *ArtifactIteratorSpec_ItemsSpec) Reset() {
 	*x = ArtifactIteratorSpec_ItemsSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[76]
+	mi := &file_pipeline_spec_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4244,7 +4422,7 @@ func (x *ArtifactIteratorSpec_ItemsSpec) String() string {
 func (*ArtifactIteratorSpec_ItemsSpec) ProtoMessage() {}
 
 func (x *ArtifactIteratorSpec_ItemsSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[76]
+	mi := &file_pipeline_spec_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4257,7 +4435,7 @@ func (x *ArtifactIteratorSpec_ItemsSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ArtifactIteratorSpec_ItemsSpec.ProtoReflect.Descriptor instead.
 func (*ArtifactIteratorSpec_ItemsSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{12, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{14, 0}
 }
 
 func (x *ArtifactIteratorSpec_ItemsSpec) GetInputArtifact() string {
@@ -4285,7 +4463,7 @@ type ParameterIteratorSpec_ItemsSpec struct {
 
 func (x *ParameterIteratorSpec_ItemsSpec) Reset() {
 	*x = ParameterIteratorSpec_ItemsSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[77]
+	mi := &file_pipeline_spec_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4297,7 +4475,7 @@ func (x *ParameterIteratorSpec_ItemsSpec) String() string {
 func (*ParameterIteratorSpec_ItemsSpec) ProtoMessage() {}
 
 func (x *ParameterIteratorSpec_ItemsSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[77]
+	mi := &file_pipeline_spec_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4310,7 +4488,7 @@ func (x *ParameterIteratorSpec_ItemsSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ParameterIteratorSpec_ItemsSpec.ProtoReflect.Descriptor instead.
 func (*ParameterIteratorSpec_ItemsSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{13, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{15, 0}
 }
 
 func (x *ParameterIteratorSpec_ItemsSpec) GetKind() isParameterIteratorSpec_ItemsSpec_Kind {
@@ -4382,7 +4560,7 @@ type PipelineDeploymentConfig_PipelineContainerSpec struct {
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec) Reset() {
 	*x = PipelineDeploymentConfig_PipelineContainerSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[78]
+	mi := &file_pipeline_spec_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4394,7 +4572,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec) String() string {
 func (*PipelineDeploymentConfig_PipelineContainerSpec) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[78]
+	mi := &file_pipeline_spec_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4407,7 +4585,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec) ProtoReflect() protoref
 
 // Deprecated: Use PipelineDeploymentConfig_PipelineContainerSpec.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_PipelineContainerSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 0}
 }
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec) GetImage() string {
@@ -4479,7 +4657,7 @@ type PipelineDeploymentConfig_ImporterSpec struct {
 
 func (x *PipelineDeploymentConfig_ImporterSpec) Reset() {
 	*x = PipelineDeploymentConfig_ImporterSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[79]
+	mi := &file_pipeline_spec_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4491,7 +4669,7 @@ func (x *PipelineDeploymentConfig_ImporterSpec) String() string {
 func (*PipelineDeploymentConfig_ImporterSpec) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig_ImporterSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[79]
+	mi := &file_pipeline_spec_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4504,7 +4682,7 @@ func (x *PipelineDeploymentConfig_ImporterSpec) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use PipelineDeploymentConfig_ImporterSpec.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_ImporterSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 1}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 1}
 }
 
 func (x *PipelineDeploymentConfig_ImporterSpec) GetArtifactUri() *ValueOrRuntimeParameter {
@@ -4567,7 +4745,7 @@ type PipelineDeploymentConfig_ResolverSpec struct {
 
 func (x *PipelineDeploymentConfig_ResolverSpec) Reset() {
 	*x = PipelineDeploymentConfig_ResolverSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[80]
+	mi := &file_pipeline_spec_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4579,7 +4757,7 @@ func (x *PipelineDeploymentConfig_ResolverSpec) String() string {
 func (*PipelineDeploymentConfig_ResolverSpec) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig_ResolverSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[80]
+	mi := &file_pipeline_spec_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4592,7 +4770,7 @@ func (x *PipelineDeploymentConfig_ResolverSpec) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use PipelineDeploymentConfig_ResolverSpec.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_ResolverSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 2}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 2}
 }
 
 func (x *PipelineDeploymentConfig_ResolverSpec) GetOutputArtifactQueries() map[string]*PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec {
@@ -4620,7 +4798,7 @@ type PipelineDeploymentConfig_AIPlatformCustomJobSpec struct {
 
 func (x *PipelineDeploymentConfig_AIPlatformCustomJobSpec) Reset() {
 	*x = PipelineDeploymentConfig_AIPlatformCustomJobSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[81]
+	mi := &file_pipeline_spec_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4632,7 +4810,7 @@ func (x *PipelineDeploymentConfig_AIPlatformCustomJobSpec) String() string {
 func (*PipelineDeploymentConfig_AIPlatformCustomJobSpec) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig_AIPlatformCustomJobSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[81]
+	mi := &file_pipeline_spec_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4645,7 +4823,7 @@ func (x *PipelineDeploymentConfig_AIPlatformCustomJobSpec) ProtoReflect() protor
 
 // Deprecated: Use PipelineDeploymentConfig_AIPlatformCustomJobSpec.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_AIPlatformCustomJobSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 3}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 3}
 }
 
 func (x *PipelineDeploymentConfig_AIPlatformCustomJobSpec) GetCustomJob() *structpb.Struct {
@@ -4671,7 +4849,7 @@ type PipelineDeploymentConfig_ExecutorSpec struct {
 
 func (x *PipelineDeploymentConfig_ExecutorSpec) Reset() {
 	*x = PipelineDeploymentConfig_ExecutorSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[82]
+	mi := &file_pipeline_spec_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4683,7 +4861,7 @@ func (x *PipelineDeploymentConfig_ExecutorSpec) String() string {
 func (*PipelineDeploymentConfig_ExecutorSpec) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig_ExecutorSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[82]
+	mi := &file_pipeline_spec_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4696,7 +4874,7 @@ func (x *PipelineDeploymentConfig_ExecutorSpec) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use PipelineDeploymentConfig_ExecutorSpec.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_ExecutorSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 4}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 4}
 }
 
 func (x *PipelineDeploymentConfig_ExecutorSpec) GetSpec() isPipelineDeploymentConfig_ExecutorSpec_Spec {
@@ -4799,7 +4977,7 @@ type PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle struct {
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle) Reset() {
 	*x = PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle{}
-	mi := &file_pipeline_spec_proto_msgTypes[84]
+	mi := &file_pipeline_spec_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4811,7 +4989,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle) String() stri
 func (*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[84]
+	mi := &file_pipeline_spec_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4824,7 +5002,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle) ProtoReflect(
 
 // Deprecated: Use PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 0, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 0, 0}
 }
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle) GetPreCacheCheck() *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec {
@@ -4886,7 +5064,7 @@ type PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec struct {
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) Reset() {
 	*x = PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[85]
+	mi := &file_pipeline_spec_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4898,7 +5076,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) String() s
 func (*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[85]
+	mi := &file_pipeline_spec_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4911,7 +5089,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) ProtoRefle
 
 // Deprecated: Use PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 0, 1}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 0, 1}
 }
 
 // Deprecated: Marked as deprecated in pipeline_spec.proto.
@@ -5004,7 +5182,7 @@ type PipelineDeploymentConfig_PipelineContainerSpec_EnvVar struct {
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_EnvVar) Reset() {
 	*x = PipelineDeploymentConfig_PipelineContainerSpec_EnvVar{}
-	mi := &file_pipeline_spec_proto_msgTypes[86]
+	mi := &file_pipeline_spec_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5016,7 +5194,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec_EnvVar) String() string 
 func (*PipelineDeploymentConfig_PipelineContainerSpec_EnvVar) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_EnvVar) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[86]
+	mi := &file_pipeline_spec_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5029,7 +5207,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec_EnvVar) ProtoReflect() p
 
 // Deprecated: Use PipelineDeploymentConfig_PipelineContainerSpec_EnvVar.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_PipelineContainerSpec_EnvVar) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 0, 2}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 0, 2}
 }
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_EnvVar) GetName() string {
@@ -5059,7 +5237,7 @@ type PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec struct {
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec) Reset() {
 	*x = PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec{}
-	mi := &file_pipeline_spec_proto_msgTypes[87]
+	mi := &file_pipeline_spec_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5071,7 +5249,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec) String()
 func (*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[87]
+	mi := &file_pipeline_spec_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5084,7 +5262,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec) ProtoRef
 
 // Deprecated: Use PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 0, 0, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 0, 0, 0}
 }
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec) GetCommand() []string {
@@ -5128,7 +5306,7 @@ type PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConf
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig) Reset() {
 	*x = PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig{}
-	mi := &file_pipeline_spec_proto_msgTypes[88]
+	mi := &file_pipeline_spec_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5141,7 +5319,7 @@ func (*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorCo
 }
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[88]
+	mi := &file_pipeline_spec_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5154,7 +5332,7 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_Accelerator
 
 // Deprecated: Use PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 0, 1, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 0, 1, 0}
 }
 
 // Deprecated: Marked as deprecated in pipeline_spec.proto.
@@ -5209,7 +5387,7 @@ type PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec struct {
 
 func (x *PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec) Reset() {
 	*x = PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec{}
-	mi := &file_pipeline_spec_proto_msgTypes[91]
+	mi := &file_pipeline_spec_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5221,7 +5399,7 @@ func (x *PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec) String() strin
 func (*PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec) ProtoMessage() {}
 
 func (x *PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[91]
+	mi := &file_pipeline_spec_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5234,7 +5412,7 @@ func (x *PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec) ProtoReflect()
 
 // Deprecated: Use PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec.ProtoReflect.Descriptor instead.
 func (*PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{19, 2, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{21, 2, 0}
 }
 
 func (x *PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec) GetFilter() string {
@@ -5269,7 +5447,7 @@ type ExecutorInput_Inputs struct {
 
 func (x *ExecutorInput_Inputs) Reset() {
 	*x = ExecutorInput_Inputs{}
-	mi := &file_pipeline_spec_proto_msgTypes[95]
+	mi := &file_pipeline_spec_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5281,7 +5459,7 @@ func (x *ExecutorInput_Inputs) String() string {
 func (*ExecutorInput_Inputs) ProtoMessage() {}
 
 func (x *ExecutorInput_Inputs) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[95]
+	mi := &file_pipeline_spec_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5294,7 +5472,7 @@ func (x *ExecutorInput_Inputs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutorInput_Inputs.ProtoReflect.Descriptor instead.
 func (*ExecutorInput_Inputs) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{23, 0}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{25, 0}
 }
 
 // Deprecated: Marked as deprecated in pipeline_spec.proto.
@@ -5331,7 +5509,7 @@ type ExecutorInput_OutputParameter struct {
 
 func (x *ExecutorInput_OutputParameter) Reset() {
 	*x = ExecutorInput_OutputParameter{}
-	mi := &file_pipeline_spec_proto_msgTypes[96]
+	mi := &file_pipeline_spec_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5343,7 +5521,7 @@ func (x *ExecutorInput_OutputParameter) String() string {
 func (*ExecutorInput_OutputParameter) ProtoMessage() {}
 
 func (x *ExecutorInput_OutputParameter) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[96]
+	mi := &file_pipeline_spec_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5356,7 +5534,7 @@ func (x *ExecutorInput_OutputParameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutorInput_OutputParameter.ProtoReflect.Descriptor instead.
 func (*ExecutorInput_OutputParameter) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{23, 1}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{25, 1}
 }
 
 func (x *ExecutorInput_OutputParameter) GetOutputFile() string {
@@ -5385,7 +5563,7 @@ type ExecutorInput_Outputs struct {
 
 func (x *ExecutorInput_Outputs) Reset() {
 	*x = ExecutorInput_Outputs{}
-	mi := &file_pipeline_spec_proto_msgTypes[97]
+	mi := &file_pipeline_spec_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5397,7 +5575,7 @@ func (x *ExecutorInput_Outputs) String() string {
 func (*ExecutorInput_Outputs) ProtoMessage() {}
 
 func (x *ExecutorInput_Outputs) ProtoReflect() protoreflect.Message {
-	mi := &file_pipeline_spec_proto_msgTypes[97]
+	mi := &file_pipeline_spec_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5410,7 +5588,7 @@ func (x *ExecutorInput_Outputs) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExecutorInput_Outputs.ProtoReflect.Descriptor instead.
 func (*ExecutorInput_Outputs) Descriptor() ([]byte, []int) {
-	return file_pipeline_spec_proto_rawDescGZIP(), []int{23, 2}
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{25, 2}
 }
 
 func (x *ExecutorInput_Outputs) GetParameters() map[string]*ExecutorInput_OutputParameter {
@@ -5479,13 +5657,14 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\rdefault_value\x18\x02 \x01(\v2\x13.ml_pipelines.ValueR\fdefaultValue\x1aZ\n" +
 	"\x0fComponentsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x121\n" +
-	"\x05value\x18\x02 \x01(\v2\x1b.ml_pipelines.ComponentSpecR\x05value:\x028\x01\"\xee\x02\n" +
+	"\x05value\x18\x02 \x01(\v2\x1b.ml_pipelines.ComponentSpecR\x05value:\x028\x01\"\xcd\x03\n" +
 	"\rComponentSpec\x12N\n" +
 	"\x11input_definitions\x18\x01 \x01(\v2!.ml_pipelines.ComponentInputsSpecR\x10inputDefinitions\x12Q\n" +
 	"\x12output_definitions\x18\x02 \x01(\v2\".ml_pipelines.ComponentOutputsSpecR\x11outputDefinitions\x12)\n" +
 	"\x03dag\x18\x03 \x01(\v2\x15.ml_pipelines.DagSpecH\x00R\x03dag\x12'\n" +
 	"\x0eexecutor_label\x18\x04 \x01(\tH\x00R\rexecutorLabel\x12T\n" +
-	"\x15single_platform_specs\x18\x05 \x03(\v2 .ml_pipelines.SinglePlatformSpecR\x13singlePlatformSpecsB\x10\n" +
+	"\x15single_platform_specs\x18\x05 \x03(\v2 .ml_pipelines.SinglePlatformSpecR\x13singlePlatformSpecs\x12]\n" +
+	"\x18task_config_passthroughs\x18\x06 \x03(\v2#.ml_pipelines.TaskConfigPassthroughR\x16taskConfigPassthroughsB\x10\n" +
 	"\x0eimplementation\"\xd3\x01\n" +
 	"\aDagSpec\x126\n" +
 	"\x05tasks\x18\x01 \x03(\v2 .ml_pipelines.DagSpec.TasksEntryR\x05tasks\x126\n" +
@@ -5642,8 +5821,8 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\n" +
 	"\x06DOUBLE\x10\x02\x12\n" +
 	"\n" +
-	"\x06STRING\x10\x03\x1a\x02\x18\x01:\x02\x18\x01\"\xb7\x01\n" +
-	"\rParameterType\"\xa5\x01\n" +
+	"\x06STRING\x10\x03\x1a\x02\x18\x01:\x02\x18\x01\"\xc8\x01\n" +
+	"\rParameterType\"\xb6\x01\n" +
 	"\x11ParameterTypeEnum\x12#\n" +
 	"\x1fPARAMETER_TYPE_ENUM_UNSPECIFIED\x10\x00\x12\x11\n" +
 	"\rNUMBER_DOUBLE\x10\x01\x12\x12\n" +
@@ -5654,7 +5833,20 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\x04LIST\x10\x05\x12\n" +
 	"\n" +
 	"\x06STRUCT\x10\x06\x12\x15\n" +
-	"\x11TASK_FINAL_STATUS\x10\a\"\xfe\n" +
+	"\x11TASK_FINAL_STATUS\x10\a\x12\x0f\n" +
+	"\vTASK_CONFIG\x10\b\"\xca\x01\n" +
+	"\x19TaskConfigPassthroughType\"\xac\x01\n" +
+	"\x1dTaskConfigPassthroughTypeEnum\x12\b\n" +
+	"\x04NONE\x10\x00\x12\r\n" +
+	"\tRESOURCES\x10\x01\x12\a\n" +
+	"\x03ENV\x10\x02\x12\x17\n" +
+	"\x13KUBERNETES_AFFINITY\x10\x03\x12\x1a\n" +
+	"\x16KUBERNETES_TOLERATIONS\x10\x04\x12\x1c\n" +
+	"\x18KUBERNETES_NODE_SELECTOR\x10\x05\x12\x16\n" +
+	"\x12KUBERNETES_VOLUMES\x10\x06\"\x98\x01\n" +
+	"\x15TaskConfigPassthrough\x12[\n" +
+	"\x05field\x18\x01 \x01(\x0e2E.ml_pipelines.TaskConfigPassthroughType.TaskConfigPassthroughTypeEnumR\x05field\x12\"\n" +
+	"\rapply_to_task\x18\x02 \x01(\bR\vapplyToTask\"\xfe\n" +
 	"\n" +
 	"\x10PipelineTaskSpec\x12;\n" +
 	"\ttask_info\x18\x01 \x01(\v2\x1e.ml_pipelines.PipelineTaskInfoR\btaskInfo\x124\n" +
@@ -5935,274 +6127,279 @@ func file_pipeline_spec_proto_rawDescGZIP() []byte {
 	return file_pipeline_spec_proto_rawDescData
 }
 
-var file_pipeline_spec_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
-var file_pipeline_spec_proto_msgTypes = make([]protoimpl.MessageInfo, 108)
+var file_pipeline_spec_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_pipeline_spec_proto_msgTypes = make([]protoimpl.MessageInfo, 110)
 var file_pipeline_spec_proto_goTypes = []any{
-	(PrimitiveType_PrimitiveTypeEnum)(0),                // 0: ml_pipelines.PrimitiveType.PrimitiveTypeEnum
-	(ParameterType_ParameterTypeEnum)(0),                // 1: ml_pipelines.ParameterType.ParameterTypeEnum
-	(PipelineTaskSpec_TriggerPolicy_TriggerStrategy)(0), // 2: ml_pipelines.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
-	(PipelineStateEnum_PipelineTaskState)(0),            // 3: ml_pipelines.PipelineStateEnum.PipelineTaskState
-	(*PipelineJob)(nil),                                 // 4: ml_pipelines.PipelineJob
-	(*PipelineSpec)(nil),                                // 5: ml_pipelines.PipelineSpec
-	(*ComponentSpec)(nil),                               // 6: ml_pipelines.ComponentSpec
-	(*DagSpec)(nil),                                     // 7: ml_pipelines.DagSpec
-	(*DagOutputsSpec)(nil),                              // 8: ml_pipelines.DagOutputsSpec
-	(*ComponentInputsSpec)(nil),                         // 9: ml_pipelines.ComponentInputsSpec
-	(*ComponentOutputsSpec)(nil),                        // 10: ml_pipelines.ComponentOutputsSpec
-	(*TaskInputsSpec)(nil),                              // 11: ml_pipelines.TaskInputsSpec
-	(*TaskOutputsSpec)(nil),                             // 12: ml_pipelines.TaskOutputsSpec
-	(*PrimitiveType)(nil),                               // 13: ml_pipelines.PrimitiveType
-	(*ParameterType)(nil),                               // 14: ml_pipelines.ParameterType
-	(*PipelineTaskSpec)(nil),                            // 15: ml_pipelines.PipelineTaskSpec
-	(*ArtifactIteratorSpec)(nil),                        // 16: ml_pipelines.ArtifactIteratorSpec
-	(*ParameterIteratorSpec)(nil),                       // 17: ml_pipelines.ParameterIteratorSpec
-	(*ComponentRef)(nil),                                // 18: ml_pipelines.ComponentRef
-	(*PipelineInfo)(nil),                                // 19: ml_pipelines.PipelineInfo
-	(*ArtifactTypeSchema)(nil),                          // 20: ml_pipelines.ArtifactTypeSchema
-	(*PipelineTaskInfo)(nil),                            // 21: ml_pipelines.PipelineTaskInfo
-	(*ValueOrRuntimeParameter)(nil),                     // 22: ml_pipelines.ValueOrRuntimeParameter
-	(*PipelineDeploymentConfig)(nil),                    // 23: ml_pipelines.PipelineDeploymentConfig
-	(*Value)(nil),                                       // 24: ml_pipelines.Value
-	(*RuntimeArtifact)(nil),                             // 25: ml_pipelines.RuntimeArtifact
-	(*ArtifactList)(nil),                                // 26: ml_pipelines.ArtifactList
-	(*ExecutorInput)(nil),                               // 27: ml_pipelines.ExecutorInput
-	(*ExecutorOutput)(nil),                              // 28: ml_pipelines.ExecutorOutput
-	(*PipelineTaskFinalStatus)(nil),                     // 29: ml_pipelines.PipelineTaskFinalStatus
-	(*PipelineStateEnum)(nil),                           // 30: ml_pipelines.PipelineStateEnum
-	(*PlatformSpec)(nil),                                // 31: ml_pipelines.PlatformSpec
-	(*SinglePlatformSpec)(nil),                          // 32: ml_pipelines.SinglePlatformSpec
-	(*PlatformDeploymentConfig)(nil),                    // 33: ml_pipelines.PlatformDeploymentConfig
-	(*WorkspaceConfig)(nil),                             // 34: ml_pipelines.WorkspaceConfig
-	(*KubernetesWorkspaceConfig)(nil),                   // 35: ml_pipelines.KubernetesWorkspaceConfig
-	(*PipelineConfig)(nil),                              // 36: ml_pipelines.PipelineConfig
-	nil,                                                 // 37: ml_pipelines.PipelineJob.LabelsEntry
-	(*PipelineJob_RuntimeConfig)(nil),                   // 38: ml_pipelines.PipelineJob.RuntimeConfig
-	nil,                                                 // 39: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
-	nil,                                                 // 40: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
-	(*PipelineSpec_RuntimeParameter)(nil),               // 41: ml_pipelines.PipelineSpec.RuntimeParameter
-	nil,                                                 // 42: ml_pipelines.PipelineSpec.ComponentsEntry
-	nil,                                                 // 43: ml_pipelines.DagSpec.TasksEntry
-	(*DagOutputsSpec_ArtifactSelectorSpec)(nil),         // 44: ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
-	(*DagOutputsSpec_DagOutputArtifactSpec)(nil),        // 45: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
-	nil, // 46: ml_pipelines.DagOutputsSpec.ArtifactsEntry
-	(*DagOutputsSpec_ParameterSelectorSpec)(nil),     // 47: ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	(*DagOutputsSpec_ParameterSelectorsSpec)(nil),    // 48: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
-	(*DagOutputsSpec_MapParameterSelectorsSpec)(nil), // 49: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec
-	(*DagOutputsSpec_DagOutputParameterSpec)(nil),    // 50: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
-	nil,                                      // 51: ml_pipelines.DagOutputsSpec.ParametersEntry
-	nil,                                      // 52: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
-	(*ComponentInputsSpec_ArtifactSpec)(nil), // 53: ml_pipelines.ComponentInputsSpec.ArtifactSpec
-	(*ComponentInputsSpec_ParameterSpec)(nil), // 54: ml_pipelines.ComponentInputsSpec.ParameterSpec
-	nil, // 55: ml_pipelines.ComponentInputsSpec.ArtifactsEntry
-	nil, // 56: ml_pipelines.ComponentInputsSpec.ParametersEntry
-	(*ComponentOutputsSpec_ArtifactSpec)(nil),  // 57: ml_pipelines.ComponentOutputsSpec.ArtifactSpec
-	(*ComponentOutputsSpec_ParameterSpec)(nil), // 58: ml_pipelines.ComponentOutputsSpec.ParameterSpec
-	nil,                                      // 59: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
-	nil,                                      // 60: ml_pipelines.ComponentOutputsSpec.ParametersEntry
-	nil,                                      // 61: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
-	nil,                                      // 62: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
-	(*TaskInputsSpec_InputArtifactSpec)(nil), // 63: ml_pipelines.TaskInputsSpec.InputArtifactSpec
-	(*TaskInputsSpec_InputParameterSpec)(nil), // 64: ml_pipelines.TaskInputsSpec.InputParameterSpec
-	nil, // 65: ml_pipelines.TaskInputsSpec.ParametersEntry
-	nil, // 66: ml_pipelines.TaskInputsSpec.ArtifactsEntry
-	(*TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec)(nil),   // 67: ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
-	(*TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec)(nil), // 68: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
-	(*TaskInputsSpec_InputParameterSpec_TaskFinalStatus)(nil),         // 69: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
-	(*TaskOutputsSpec_OutputArtifactSpec)(nil),                        // 70: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
-	(*TaskOutputsSpec_OutputParameterSpec)(nil),                       // 71: ml_pipelines.TaskOutputsSpec.OutputParameterSpec
-	nil,                                     // 72: ml_pipelines.TaskOutputsSpec.ParametersEntry
-	nil,                                     // 73: ml_pipelines.TaskOutputsSpec.ArtifactsEntry
-	nil,                                     // 74: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
-	nil,                                     // 75: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
-	(*PipelineTaskSpec_CachingOptions)(nil), // 76: ml_pipelines.PipelineTaskSpec.CachingOptions
-	(*PipelineTaskSpec_TriggerPolicy)(nil),  // 77: ml_pipelines.PipelineTaskSpec.TriggerPolicy
-	(*PipelineTaskSpec_RetryPolicy)(nil),    // 78: ml_pipelines.PipelineTaskSpec.RetryPolicy
-	(*PipelineTaskSpec_IteratorPolicy)(nil), // 79: ml_pipelines.PipelineTaskSpec.IteratorPolicy
-	(*ArtifactIteratorSpec_ItemsSpec)(nil),  // 80: ml_pipelines.ArtifactIteratorSpec.ItemsSpec
-	(*ParameterIteratorSpec_ItemsSpec)(nil), // 81: ml_pipelines.ParameterIteratorSpec.ItemsSpec
-	(*PipelineDeploymentConfig_PipelineContainerSpec)(nil),   // 82: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
-	(*PipelineDeploymentConfig_ImporterSpec)(nil),            // 83: ml_pipelines.PipelineDeploymentConfig.ImporterSpec
-	(*PipelineDeploymentConfig_ResolverSpec)(nil),            // 84: ml_pipelines.PipelineDeploymentConfig.ResolverSpec
-	(*PipelineDeploymentConfig_AIPlatformCustomJobSpec)(nil), // 85: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
-	(*PipelineDeploymentConfig_ExecutorSpec)(nil),            // 86: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
-	nil, // 87: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
-	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle)(nil),                      // 88: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
-	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec)(nil),                   // 89: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
-	(*PipelineDeploymentConfig_PipelineContainerSpec_EnvVar)(nil),                         // 90: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
-	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec)(nil),                 // 91: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
-	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig)(nil), // 92: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
-	nil, // 93: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
-	nil, // 94: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
-	(*PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec)(nil), // 95: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
-	nil,                                   // 96: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
-	nil,                                   // 97: ml_pipelines.RuntimeArtifact.PropertiesEntry
-	nil,                                   // 98: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
-	(*ExecutorInput_Inputs)(nil),          // 99: ml_pipelines.ExecutorInput.Inputs
-	(*ExecutorInput_OutputParameter)(nil), // 100: ml_pipelines.ExecutorInput.OutputParameter
-	(*ExecutorInput_Outputs)(nil),         // 101: ml_pipelines.ExecutorInput.Outputs
-	nil,                                   // 102: ml_pipelines.ExecutorInput.Inputs.ParametersEntry
-	nil,                                   // 103: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
-	nil,                                   // 104: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
-	nil,                                   // 105: ml_pipelines.ExecutorInput.Outputs.ParametersEntry
-	nil,                                   // 106: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
-	nil,                                   // 107: ml_pipelines.ExecutorOutput.ParametersEntry
-	nil,                                   // 108: ml_pipelines.ExecutorOutput.ArtifactsEntry
-	nil,                                   // 109: ml_pipelines.ExecutorOutput.ParameterValuesEntry
-	nil,                                   // 110: ml_pipelines.PlatformSpec.PlatformsEntry
-	nil,                                   // 111: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
-	(*structpb.Struct)(nil),               // 112: google.protobuf.Struct
-	(*structpb.Value)(nil),                // 113: google.protobuf.Value
-	(*status.Status)(nil),                 // 114: google.rpc.Status
-	(*durationpb.Duration)(nil),           // 115: google.protobuf.Duration
+	(PrimitiveType_PrimitiveTypeEnum)(0),                         // 0: ml_pipelines.PrimitiveType.PrimitiveTypeEnum
+	(ParameterType_ParameterTypeEnum)(0),                         // 1: ml_pipelines.ParameterType.ParameterTypeEnum
+	(TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum)(0), // 2: ml_pipelines.TaskConfigPassthroughType.TaskConfigPassthroughTypeEnum
+	(PipelineTaskSpec_TriggerPolicy_TriggerStrategy)(0),          // 3: ml_pipelines.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
+	(PipelineStateEnum_PipelineTaskState)(0),                     // 4: ml_pipelines.PipelineStateEnum.PipelineTaskState
+	(*PipelineJob)(nil),                                          // 5: ml_pipelines.PipelineJob
+	(*PipelineSpec)(nil),                                         // 6: ml_pipelines.PipelineSpec
+	(*ComponentSpec)(nil),                                        // 7: ml_pipelines.ComponentSpec
+	(*DagSpec)(nil),                                              // 8: ml_pipelines.DagSpec
+	(*DagOutputsSpec)(nil),                                       // 9: ml_pipelines.DagOutputsSpec
+	(*ComponentInputsSpec)(nil),                                  // 10: ml_pipelines.ComponentInputsSpec
+	(*ComponentOutputsSpec)(nil),                                 // 11: ml_pipelines.ComponentOutputsSpec
+	(*TaskInputsSpec)(nil),                                       // 12: ml_pipelines.TaskInputsSpec
+	(*TaskOutputsSpec)(nil),                                      // 13: ml_pipelines.TaskOutputsSpec
+	(*PrimitiveType)(nil),                                        // 14: ml_pipelines.PrimitiveType
+	(*ParameterType)(nil),                                        // 15: ml_pipelines.ParameterType
+	(*TaskConfigPassthroughType)(nil),                            // 16: ml_pipelines.TaskConfigPassthroughType
+	(*TaskConfigPassthrough)(nil),                                // 17: ml_pipelines.TaskConfigPassthrough
+	(*PipelineTaskSpec)(nil),                                     // 18: ml_pipelines.PipelineTaskSpec
+	(*ArtifactIteratorSpec)(nil),                                 // 19: ml_pipelines.ArtifactIteratorSpec
+	(*ParameterIteratorSpec)(nil),                                // 20: ml_pipelines.ParameterIteratorSpec
+	(*ComponentRef)(nil),                                         // 21: ml_pipelines.ComponentRef
+	(*PipelineInfo)(nil),                                         // 22: ml_pipelines.PipelineInfo
+	(*ArtifactTypeSchema)(nil),                                   // 23: ml_pipelines.ArtifactTypeSchema
+	(*PipelineTaskInfo)(nil),                                     // 24: ml_pipelines.PipelineTaskInfo
+	(*ValueOrRuntimeParameter)(nil),                              // 25: ml_pipelines.ValueOrRuntimeParameter
+	(*PipelineDeploymentConfig)(nil),                             // 26: ml_pipelines.PipelineDeploymentConfig
+	(*Value)(nil),                                                // 27: ml_pipelines.Value
+	(*RuntimeArtifact)(nil),                                      // 28: ml_pipelines.RuntimeArtifact
+	(*ArtifactList)(nil),                                         // 29: ml_pipelines.ArtifactList
+	(*ExecutorInput)(nil),                                        // 30: ml_pipelines.ExecutorInput
+	(*ExecutorOutput)(nil),                                       // 31: ml_pipelines.ExecutorOutput
+	(*PipelineTaskFinalStatus)(nil),                              // 32: ml_pipelines.PipelineTaskFinalStatus
+	(*PipelineStateEnum)(nil),                                    // 33: ml_pipelines.PipelineStateEnum
+	(*PlatformSpec)(nil),                                         // 34: ml_pipelines.PlatformSpec
+	(*SinglePlatformSpec)(nil),                                   // 35: ml_pipelines.SinglePlatformSpec
+	(*PlatformDeploymentConfig)(nil),                             // 36: ml_pipelines.PlatformDeploymentConfig
+	(*WorkspaceConfig)(nil),                                      // 37: ml_pipelines.WorkspaceConfig
+	(*KubernetesWorkspaceConfig)(nil),                            // 38: ml_pipelines.KubernetesWorkspaceConfig
+	(*PipelineConfig)(nil),                                       // 39: ml_pipelines.PipelineConfig
+	nil,                                                          // 40: ml_pipelines.PipelineJob.LabelsEntry
+	(*PipelineJob_RuntimeConfig)(nil),                            // 41: ml_pipelines.PipelineJob.RuntimeConfig
+	nil,                                                          // 42: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
+	nil,                                                          // 43: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
+	(*PipelineSpec_RuntimeParameter)(nil),                        // 44: ml_pipelines.PipelineSpec.RuntimeParameter
+	nil,                                                          // 45: ml_pipelines.PipelineSpec.ComponentsEntry
+	nil,                                                          // 46: ml_pipelines.DagSpec.TasksEntry
+	(*DagOutputsSpec_ArtifactSelectorSpec)(nil),                  // 47: ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
+	(*DagOutputsSpec_DagOutputArtifactSpec)(nil),                 // 48: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
+	nil, // 49: ml_pipelines.DagOutputsSpec.ArtifactsEntry
+	(*DagOutputsSpec_ParameterSelectorSpec)(nil),     // 50: ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	(*DagOutputsSpec_ParameterSelectorsSpec)(nil),    // 51: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
+	(*DagOutputsSpec_MapParameterSelectorsSpec)(nil), // 52: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec
+	(*DagOutputsSpec_DagOutputParameterSpec)(nil),    // 53: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
+	nil,                                      // 54: ml_pipelines.DagOutputsSpec.ParametersEntry
+	nil,                                      // 55: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
+	(*ComponentInputsSpec_ArtifactSpec)(nil), // 56: ml_pipelines.ComponentInputsSpec.ArtifactSpec
+	(*ComponentInputsSpec_ParameterSpec)(nil), // 57: ml_pipelines.ComponentInputsSpec.ParameterSpec
+	nil, // 58: ml_pipelines.ComponentInputsSpec.ArtifactsEntry
+	nil, // 59: ml_pipelines.ComponentInputsSpec.ParametersEntry
+	(*ComponentOutputsSpec_ArtifactSpec)(nil),  // 60: ml_pipelines.ComponentOutputsSpec.ArtifactSpec
+	(*ComponentOutputsSpec_ParameterSpec)(nil), // 61: ml_pipelines.ComponentOutputsSpec.ParameterSpec
+	nil,                                      // 62: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
+	nil,                                      // 63: ml_pipelines.ComponentOutputsSpec.ParametersEntry
+	nil,                                      // 64: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
+	nil,                                      // 65: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
+	(*TaskInputsSpec_InputArtifactSpec)(nil), // 66: ml_pipelines.TaskInputsSpec.InputArtifactSpec
+	(*TaskInputsSpec_InputParameterSpec)(nil), // 67: ml_pipelines.TaskInputsSpec.InputParameterSpec
+	nil, // 68: ml_pipelines.TaskInputsSpec.ParametersEntry
+	nil, // 69: ml_pipelines.TaskInputsSpec.ArtifactsEntry
+	(*TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec)(nil),   // 70: ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
+	(*TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec)(nil), // 71: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
+	(*TaskInputsSpec_InputParameterSpec_TaskFinalStatus)(nil),         // 72: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
+	(*TaskOutputsSpec_OutputArtifactSpec)(nil),                        // 73: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
+	(*TaskOutputsSpec_OutputParameterSpec)(nil),                       // 74: ml_pipelines.TaskOutputsSpec.OutputParameterSpec
+	nil,                                     // 75: ml_pipelines.TaskOutputsSpec.ParametersEntry
+	nil,                                     // 76: ml_pipelines.TaskOutputsSpec.ArtifactsEntry
+	nil,                                     // 77: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
+	nil,                                     // 78: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
+	(*PipelineTaskSpec_CachingOptions)(nil), // 79: ml_pipelines.PipelineTaskSpec.CachingOptions
+	(*PipelineTaskSpec_TriggerPolicy)(nil),  // 80: ml_pipelines.PipelineTaskSpec.TriggerPolicy
+	(*PipelineTaskSpec_RetryPolicy)(nil),    // 81: ml_pipelines.PipelineTaskSpec.RetryPolicy
+	(*PipelineTaskSpec_IteratorPolicy)(nil), // 82: ml_pipelines.PipelineTaskSpec.IteratorPolicy
+	(*ArtifactIteratorSpec_ItemsSpec)(nil),  // 83: ml_pipelines.ArtifactIteratorSpec.ItemsSpec
+	(*ParameterIteratorSpec_ItemsSpec)(nil), // 84: ml_pipelines.ParameterIteratorSpec.ItemsSpec
+	(*PipelineDeploymentConfig_PipelineContainerSpec)(nil),   // 85: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
+	(*PipelineDeploymentConfig_ImporterSpec)(nil),            // 86: ml_pipelines.PipelineDeploymentConfig.ImporterSpec
+	(*PipelineDeploymentConfig_ResolverSpec)(nil),            // 87: ml_pipelines.PipelineDeploymentConfig.ResolverSpec
+	(*PipelineDeploymentConfig_AIPlatformCustomJobSpec)(nil), // 88: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
+	(*PipelineDeploymentConfig_ExecutorSpec)(nil),            // 89: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
+	nil, // 90: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
+	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle)(nil),                      // 91: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
+	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec)(nil),                   // 92: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
+	(*PipelineDeploymentConfig_PipelineContainerSpec_EnvVar)(nil),                         // 93: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
+	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec)(nil),                 // 94: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
+	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig)(nil), // 95: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
+	nil, // 96: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
+	nil, // 97: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
+	(*PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec)(nil), // 98: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
+	nil,                                   // 99: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
+	nil,                                   // 100: ml_pipelines.RuntimeArtifact.PropertiesEntry
+	nil,                                   // 101: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
+	(*ExecutorInput_Inputs)(nil),          // 102: ml_pipelines.ExecutorInput.Inputs
+	(*ExecutorInput_OutputParameter)(nil), // 103: ml_pipelines.ExecutorInput.OutputParameter
+	(*ExecutorInput_Outputs)(nil),         // 104: ml_pipelines.ExecutorInput.Outputs
+	nil,                                   // 105: ml_pipelines.ExecutorInput.Inputs.ParametersEntry
+	nil,                                   // 106: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
+	nil,                                   // 107: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
+	nil,                                   // 108: ml_pipelines.ExecutorInput.Outputs.ParametersEntry
+	nil,                                   // 109: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
+	nil,                                   // 110: ml_pipelines.ExecutorOutput.ParametersEntry
+	nil,                                   // 111: ml_pipelines.ExecutorOutput.ArtifactsEntry
+	nil,                                   // 112: ml_pipelines.ExecutorOutput.ParameterValuesEntry
+	nil,                                   // 113: ml_pipelines.PlatformSpec.PlatformsEntry
+	nil,                                   // 114: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
+	(*structpb.Struct)(nil),               // 115: google.protobuf.Struct
+	(*structpb.Value)(nil),                // 116: google.protobuf.Value
+	(*status.Status)(nil),                 // 117: google.rpc.Status
+	(*durationpb.Duration)(nil),           // 118: google.protobuf.Duration
 }
 var file_pipeline_spec_proto_depIdxs = []int32{
-	112, // 0: ml_pipelines.PipelineJob.pipeline_spec:type_name -> google.protobuf.Struct
-	37,  // 1: ml_pipelines.PipelineJob.labels:type_name -> ml_pipelines.PipelineJob.LabelsEntry
-	38,  // 2: ml_pipelines.PipelineJob.runtime_config:type_name -> ml_pipelines.PipelineJob.RuntimeConfig
-	19,  // 3: ml_pipelines.PipelineSpec.pipeline_info:type_name -> ml_pipelines.PipelineInfo
-	112, // 4: ml_pipelines.PipelineSpec.deployment_spec:type_name -> google.protobuf.Struct
-	42,  // 5: ml_pipelines.PipelineSpec.components:type_name -> ml_pipelines.PipelineSpec.ComponentsEntry
-	6,   // 6: ml_pipelines.PipelineSpec.root:type_name -> ml_pipelines.ComponentSpec
-	9,   // 7: ml_pipelines.ComponentSpec.input_definitions:type_name -> ml_pipelines.ComponentInputsSpec
-	10,  // 8: ml_pipelines.ComponentSpec.output_definitions:type_name -> ml_pipelines.ComponentOutputsSpec
-	7,   // 9: ml_pipelines.ComponentSpec.dag:type_name -> ml_pipelines.DagSpec
-	32,  // 10: ml_pipelines.ComponentSpec.single_platform_specs:type_name -> ml_pipelines.SinglePlatformSpec
-	43,  // 11: ml_pipelines.DagSpec.tasks:type_name -> ml_pipelines.DagSpec.TasksEntry
-	8,   // 12: ml_pipelines.DagSpec.outputs:type_name -> ml_pipelines.DagOutputsSpec
-	46,  // 13: ml_pipelines.DagOutputsSpec.artifacts:type_name -> ml_pipelines.DagOutputsSpec.ArtifactsEntry
-	51,  // 14: ml_pipelines.DagOutputsSpec.parameters:type_name -> ml_pipelines.DagOutputsSpec.ParametersEntry
-	55,  // 15: ml_pipelines.ComponentInputsSpec.artifacts:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactsEntry
-	56,  // 16: ml_pipelines.ComponentInputsSpec.parameters:type_name -> ml_pipelines.ComponentInputsSpec.ParametersEntry
-	59,  // 17: ml_pipelines.ComponentOutputsSpec.artifacts:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
-	60,  // 18: ml_pipelines.ComponentOutputsSpec.parameters:type_name -> ml_pipelines.ComponentOutputsSpec.ParametersEntry
-	65,  // 19: ml_pipelines.TaskInputsSpec.parameters:type_name -> ml_pipelines.TaskInputsSpec.ParametersEntry
-	66,  // 20: ml_pipelines.TaskInputsSpec.artifacts:type_name -> ml_pipelines.TaskInputsSpec.ArtifactsEntry
-	72,  // 21: ml_pipelines.TaskOutputsSpec.parameters:type_name -> ml_pipelines.TaskOutputsSpec.ParametersEntry
-	73,  // 22: ml_pipelines.TaskOutputsSpec.artifacts:type_name -> ml_pipelines.TaskOutputsSpec.ArtifactsEntry
-	21,  // 23: ml_pipelines.PipelineTaskSpec.task_info:type_name -> ml_pipelines.PipelineTaskInfo
-	11,  // 24: ml_pipelines.PipelineTaskSpec.inputs:type_name -> ml_pipelines.TaskInputsSpec
-	76,  // 25: ml_pipelines.PipelineTaskSpec.caching_options:type_name -> ml_pipelines.PipelineTaskSpec.CachingOptions
-	18,  // 26: ml_pipelines.PipelineTaskSpec.component_ref:type_name -> ml_pipelines.ComponentRef
-	77,  // 27: ml_pipelines.PipelineTaskSpec.trigger_policy:type_name -> ml_pipelines.PipelineTaskSpec.TriggerPolicy
-	16,  // 28: ml_pipelines.PipelineTaskSpec.artifact_iterator:type_name -> ml_pipelines.ArtifactIteratorSpec
-	17,  // 29: ml_pipelines.PipelineTaskSpec.parameter_iterator:type_name -> ml_pipelines.ParameterIteratorSpec
-	78,  // 30: ml_pipelines.PipelineTaskSpec.retry_policy:type_name -> ml_pipelines.PipelineTaskSpec.RetryPolicy
-	79,  // 31: ml_pipelines.PipelineTaskSpec.iterator_policy:type_name -> ml_pipelines.PipelineTaskSpec.IteratorPolicy
-	80,  // 32: ml_pipelines.ArtifactIteratorSpec.items:type_name -> ml_pipelines.ArtifactIteratorSpec.ItemsSpec
-	81,  // 33: ml_pipelines.ParameterIteratorSpec.items:type_name -> ml_pipelines.ParameterIteratorSpec.ItemsSpec
-	24,  // 34: ml_pipelines.ValueOrRuntimeParameter.constant_value:type_name -> ml_pipelines.Value
-	113, // 35: ml_pipelines.ValueOrRuntimeParameter.constant:type_name -> google.protobuf.Value
-	87,  // 36: ml_pipelines.PipelineDeploymentConfig.executors:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
-	20,  // 37: ml_pipelines.RuntimeArtifact.type:type_name -> ml_pipelines.ArtifactTypeSchema
-	97,  // 38: ml_pipelines.RuntimeArtifact.properties:type_name -> ml_pipelines.RuntimeArtifact.PropertiesEntry
-	98,  // 39: ml_pipelines.RuntimeArtifact.custom_properties:type_name -> ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
-	112, // 40: ml_pipelines.RuntimeArtifact.metadata:type_name -> google.protobuf.Struct
-	25,  // 41: ml_pipelines.ArtifactList.artifacts:type_name -> ml_pipelines.RuntimeArtifact
-	99,  // 42: ml_pipelines.ExecutorInput.inputs:type_name -> ml_pipelines.ExecutorInput.Inputs
-	101, // 43: ml_pipelines.ExecutorInput.outputs:type_name -> ml_pipelines.ExecutorInput.Outputs
-	107, // 44: ml_pipelines.ExecutorOutput.parameters:type_name -> ml_pipelines.ExecutorOutput.ParametersEntry
-	108, // 45: ml_pipelines.ExecutorOutput.artifacts:type_name -> ml_pipelines.ExecutorOutput.ArtifactsEntry
-	109, // 46: ml_pipelines.ExecutorOutput.parameter_values:type_name -> ml_pipelines.ExecutorOutput.ParameterValuesEntry
-	114, // 47: ml_pipelines.PipelineTaskFinalStatus.error:type_name -> google.rpc.Status
-	110, // 48: ml_pipelines.PlatformSpec.platforms:type_name -> ml_pipelines.PlatformSpec.PlatformsEntry
-	33,  // 49: ml_pipelines.SinglePlatformSpec.deployment_spec:type_name -> ml_pipelines.PlatformDeploymentConfig
-	112, // 50: ml_pipelines.SinglePlatformSpec.config:type_name -> google.protobuf.Struct
-	36,  // 51: ml_pipelines.SinglePlatformSpec.pipelineConfig:type_name -> ml_pipelines.PipelineConfig
-	111, // 52: ml_pipelines.PlatformDeploymentConfig.executors:type_name -> ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
-	35,  // 53: ml_pipelines.WorkspaceConfig.kubernetes:type_name -> ml_pipelines.KubernetesWorkspaceConfig
-	112, // 54: ml_pipelines.KubernetesWorkspaceConfig.pvc_spec_patch:type_name -> google.protobuf.Struct
-	34,  // 55: ml_pipelines.PipelineConfig.workspace:type_name -> ml_pipelines.WorkspaceConfig
-	39,  // 56: ml_pipelines.PipelineJob.RuntimeConfig.parameters:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
-	40,  // 57: ml_pipelines.PipelineJob.RuntimeConfig.parameter_values:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
-	24,  // 58: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry.value:type_name -> ml_pipelines.Value
-	113, // 59: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry.value:type_name -> google.protobuf.Value
-	0,   // 60: ml_pipelines.PipelineSpec.RuntimeParameter.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
-	24,  // 61: ml_pipelines.PipelineSpec.RuntimeParameter.default_value:type_name -> ml_pipelines.Value
-	6,   // 62: ml_pipelines.PipelineSpec.ComponentsEntry.value:type_name -> ml_pipelines.ComponentSpec
-	15,  // 63: ml_pipelines.DagSpec.TasksEntry.value:type_name -> ml_pipelines.PipelineTaskSpec
-	44,  // 64: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec.artifact_selectors:type_name -> ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
-	45,  // 65: ml_pipelines.DagOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
-	47,  // 66: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec.parameter_selectors:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	52,  // 67: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.mapped_parameters:type_name -> ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
-	47,  // 68: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_parameter:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	48,  // 69: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_oneof:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
-	50,  // 70: ml_pipelines.DagOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
-	47,  // 71: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	20,  // 72: ml_pipelines.ComponentInputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
-	0,   // 73: ml_pipelines.ComponentInputsSpec.ParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
-	1,   // 74: ml_pipelines.ComponentInputsSpec.ParameterSpec.parameter_type:type_name -> ml_pipelines.ParameterType.ParameterTypeEnum
-	113, // 75: ml_pipelines.ComponentInputsSpec.ParameterSpec.default_value:type_name -> google.protobuf.Value
-	53,  // 76: ml_pipelines.ComponentInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactSpec
-	54,  // 77: ml_pipelines.ComponentInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ParameterSpec
-	20,  // 78: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
-	61,  // 79: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
-	62,  // 80: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.custom_properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
-	112, // 81: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.metadata:type_name -> google.protobuf.Struct
-	0,   // 82: ml_pipelines.ComponentOutputsSpec.ParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
-	1,   // 83: ml_pipelines.ComponentOutputsSpec.ParameterSpec.parameter_type:type_name -> ml_pipelines.ParameterType.ParameterTypeEnum
-	57,  // 84: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec
-	58,  // 85: ml_pipelines.ComponentOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ParameterSpec
-	22,  // 86: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	22,  // 87: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	67,  // 88: ml_pipelines.TaskInputsSpec.InputArtifactSpec.task_output_artifact:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
-	68,  // 89: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_output_parameter:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
-	22,  // 90: ml_pipelines.TaskInputsSpec.InputParameterSpec.runtime_value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	69,  // 91: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_final_status:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
-	64,  // 92: ml_pipelines.TaskInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec
-	63,  // 93: ml_pipelines.TaskInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec
-	20,  // 94: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
-	74,  // 95: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
-	75,  // 96: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.custom_properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
-	0,   // 97: ml_pipelines.TaskOutputsSpec.OutputParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
-	71,  // 98: ml_pipelines.TaskOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputParameterSpec
-	70,  // 99: ml_pipelines.TaskOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
-	22,  // 100: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	22,  // 101: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	2,   // 102: ml_pipelines.PipelineTaskSpec.TriggerPolicy.strategy:type_name -> ml_pipelines.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
-	115, // 103: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_duration:type_name -> google.protobuf.Duration
-	115, // 104: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_max_duration:type_name -> google.protobuf.Duration
-	88,  // 105: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.lifecycle:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
-	89,  // 106: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.resources:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
-	90,  // 107: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.env:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
-	22,  // 108: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.artifact_uri:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	20,  // 109: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.type_schema:type_name -> ml_pipelines.ArtifactTypeSchema
-	93,  // 110: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
-	94,  // 111: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.custom_properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
-	112, // 112: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.metadata:type_name -> google.protobuf.Struct
-	96,  // 113: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.output_artifact_queries:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
-	112, // 114: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec.custom_job:type_name -> google.protobuf.Struct
-	82,  // 115: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.container:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
-	83,  // 116: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.importer:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec
-	84,  // 117: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.resolver:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec
-	85,  // 118: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.custom_job:type_name -> ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
-	86,  // 119: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
-	91,  // 120: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.pre_cache_check:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
-	92,  // 121: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.accelerator:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
-	22,  // 122: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	22,  // 123: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	95,  // 124: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
-	24,  // 125: ml_pipelines.RuntimeArtifact.PropertiesEntry.value:type_name -> ml_pipelines.Value
-	24,  // 126: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry.value:type_name -> ml_pipelines.Value
-	102, // 127: ml_pipelines.ExecutorInput.Inputs.parameters:type_name -> ml_pipelines.ExecutorInput.Inputs.ParametersEntry
-	103, // 128: ml_pipelines.ExecutorInput.Inputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
-	104, // 129: ml_pipelines.ExecutorInput.Inputs.parameter_values:type_name -> ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
-	105, // 130: ml_pipelines.ExecutorInput.Outputs.parameters:type_name -> ml_pipelines.ExecutorInput.Outputs.ParametersEntry
-	106, // 131: ml_pipelines.ExecutorInput.Outputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
-	24,  // 132: ml_pipelines.ExecutorInput.Inputs.ParametersEntry.value:type_name -> ml_pipelines.Value
-	26,  // 133: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
-	113, // 134: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry.value:type_name -> google.protobuf.Value
-	100, // 135: ml_pipelines.ExecutorInput.Outputs.ParametersEntry.value:type_name -> ml_pipelines.ExecutorInput.OutputParameter
-	26,  // 136: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
-	24,  // 137: ml_pipelines.ExecutorOutput.ParametersEntry.value:type_name -> ml_pipelines.Value
-	26,  // 138: ml_pipelines.ExecutorOutput.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
-	113, // 139: ml_pipelines.ExecutorOutput.ParameterValuesEntry.value:type_name -> google.protobuf.Value
-	32,  // 140: ml_pipelines.PlatformSpec.PlatformsEntry.value:type_name -> ml_pipelines.SinglePlatformSpec
-	112, // 141: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry.value:type_name -> google.protobuf.Struct
-	142, // [142:142] is the sub-list for method output_type
-	142, // [142:142] is the sub-list for method input_type
-	142, // [142:142] is the sub-list for extension type_name
-	142, // [142:142] is the sub-list for extension extendee
-	0,   // [0:142] is the sub-list for field type_name
+	115, // 0: ml_pipelines.PipelineJob.pipeline_spec:type_name -> google.protobuf.Struct
+	40,  // 1: ml_pipelines.PipelineJob.labels:type_name -> ml_pipelines.PipelineJob.LabelsEntry
+	41,  // 2: ml_pipelines.PipelineJob.runtime_config:type_name -> ml_pipelines.PipelineJob.RuntimeConfig
+	22,  // 3: ml_pipelines.PipelineSpec.pipeline_info:type_name -> ml_pipelines.PipelineInfo
+	115, // 4: ml_pipelines.PipelineSpec.deployment_spec:type_name -> google.protobuf.Struct
+	45,  // 5: ml_pipelines.PipelineSpec.components:type_name -> ml_pipelines.PipelineSpec.ComponentsEntry
+	7,   // 6: ml_pipelines.PipelineSpec.root:type_name -> ml_pipelines.ComponentSpec
+	10,  // 7: ml_pipelines.ComponentSpec.input_definitions:type_name -> ml_pipelines.ComponentInputsSpec
+	11,  // 8: ml_pipelines.ComponentSpec.output_definitions:type_name -> ml_pipelines.ComponentOutputsSpec
+	8,   // 9: ml_pipelines.ComponentSpec.dag:type_name -> ml_pipelines.DagSpec
+	35,  // 10: ml_pipelines.ComponentSpec.single_platform_specs:type_name -> ml_pipelines.SinglePlatformSpec
+	17,  // 11: ml_pipelines.ComponentSpec.task_config_passthroughs:type_name -> ml_pipelines.TaskConfigPassthrough
+	46,  // 12: ml_pipelines.DagSpec.tasks:type_name -> ml_pipelines.DagSpec.TasksEntry
+	9,   // 13: ml_pipelines.DagSpec.outputs:type_name -> ml_pipelines.DagOutputsSpec
+	49,  // 14: ml_pipelines.DagOutputsSpec.artifacts:type_name -> ml_pipelines.DagOutputsSpec.ArtifactsEntry
+	54,  // 15: ml_pipelines.DagOutputsSpec.parameters:type_name -> ml_pipelines.DagOutputsSpec.ParametersEntry
+	58,  // 16: ml_pipelines.ComponentInputsSpec.artifacts:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactsEntry
+	59,  // 17: ml_pipelines.ComponentInputsSpec.parameters:type_name -> ml_pipelines.ComponentInputsSpec.ParametersEntry
+	62,  // 18: ml_pipelines.ComponentOutputsSpec.artifacts:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
+	63,  // 19: ml_pipelines.ComponentOutputsSpec.parameters:type_name -> ml_pipelines.ComponentOutputsSpec.ParametersEntry
+	68,  // 20: ml_pipelines.TaskInputsSpec.parameters:type_name -> ml_pipelines.TaskInputsSpec.ParametersEntry
+	69,  // 21: ml_pipelines.TaskInputsSpec.artifacts:type_name -> ml_pipelines.TaskInputsSpec.ArtifactsEntry
+	75,  // 22: ml_pipelines.TaskOutputsSpec.parameters:type_name -> ml_pipelines.TaskOutputsSpec.ParametersEntry
+	76,  // 23: ml_pipelines.TaskOutputsSpec.artifacts:type_name -> ml_pipelines.TaskOutputsSpec.ArtifactsEntry
+	2,   // 24: ml_pipelines.TaskConfigPassthrough.field:type_name -> ml_pipelines.TaskConfigPassthroughType.TaskConfigPassthroughTypeEnum
+	24,  // 25: ml_pipelines.PipelineTaskSpec.task_info:type_name -> ml_pipelines.PipelineTaskInfo
+	12,  // 26: ml_pipelines.PipelineTaskSpec.inputs:type_name -> ml_pipelines.TaskInputsSpec
+	79,  // 27: ml_pipelines.PipelineTaskSpec.caching_options:type_name -> ml_pipelines.PipelineTaskSpec.CachingOptions
+	21,  // 28: ml_pipelines.PipelineTaskSpec.component_ref:type_name -> ml_pipelines.ComponentRef
+	80,  // 29: ml_pipelines.PipelineTaskSpec.trigger_policy:type_name -> ml_pipelines.PipelineTaskSpec.TriggerPolicy
+	19,  // 30: ml_pipelines.PipelineTaskSpec.artifact_iterator:type_name -> ml_pipelines.ArtifactIteratorSpec
+	20,  // 31: ml_pipelines.PipelineTaskSpec.parameter_iterator:type_name -> ml_pipelines.ParameterIteratorSpec
+	81,  // 32: ml_pipelines.PipelineTaskSpec.retry_policy:type_name -> ml_pipelines.PipelineTaskSpec.RetryPolicy
+	82,  // 33: ml_pipelines.PipelineTaskSpec.iterator_policy:type_name -> ml_pipelines.PipelineTaskSpec.IteratorPolicy
+	83,  // 34: ml_pipelines.ArtifactIteratorSpec.items:type_name -> ml_pipelines.ArtifactIteratorSpec.ItemsSpec
+	84,  // 35: ml_pipelines.ParameterIteratorSpec.items:type_name -> ml_pipelines.ParameterIteratorSpec.ItemsSpec
+	27,  // 36: ml_pipelines.ValueOrRuntimeParameter.constant_value:type_name -> ml_pipelines.Value
+	116, // 37: ml_pipelines.ValueOrRuntimeParameter.constant:type_name -> google.protobuf.Value
+	90,  // 38: ml_pipelines.PipelineDeploymentConfig.executors:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
+	23,  // 39: ml_pipelines.RuntimeArtifact.type:type_name -> ml_pipelines.ArtifactTypeSchema
+	100, // 40: ml_pipelines.RuntimeArtifact.properties:type_name -> ml_pipelines.RuntimeArtifact.PropertiesEntry
+	101, // 41: ml_pipelines.RuntimeArtifact.custom_properties:type_name -> ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
+	115, // 42: ml_pipelines.RuntimeArtifact.metadata:type_name -> google.protobuf.Struct
+	28,  // 43: ml_pipelines.ArtifactList.artifacts:type_name -> ml_pipelines.RuntimeArtifact
+	102, // 44: ml_pipelines.ExecutorInput.inputs:type_name -> ml_pipelines.ExecutorInput.Inputs
+	104, // 45: ml_pipelines.ExecutorInput.outputs:type_name -> ml_pipelines.ExecutorInput.Outputs
+	110, // 46: ml_pipelines.ExecutorOutput.parameters:type_name -> ml_pipelines.ExecutorOutput.ParametersEntry
+	111, // 47: ml_pipelines.ExecutorOutput.artifacts:type_name -> ml_pipelines.ExecutorOutput.ArtifactsEntry
+	112, // 48: ml_pipelines.ExecutorOutput.parameter_values:type_name -> ml_pipelines.ExecutorOutput.ParameterValuesEntry
+	117, // 49: ml_pipelines.PipelineTaskFinalStatus.error:type_name -> google.rpc.Status
+	113, // 50: ml_pipelines.PlatformSpec.platforms:type_name -> ml_pipelines.PlatformSpec.PlatformsEntry
+	36,  // 51: ml_pipelines.SinglePlatformSpec.deployment_spec:type_name -> ml_pipelines.PlatformDeploymentConfig
+	115, // 52: ml_pipelines.SinglePlatformSpec.config:type_name -> google.protobuf.Struct
+	39,  // 53: ml_pipelines.SinglePlatformSpec.pipelineConfig:type_name -> ml_pipelines.PipelineConfig
+	114, // 54: ml_pipelines.PlatformDeploymentConfig.executors:type_name -> ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
+	38,  // 55: ml_pipelines.WorkspaceConfig.kubernetes:type_name -> ml_pipelines.KubernetesWorkspaceConfig
+	115, // 56: ml_pipelines.KubernetesWorkspaceConfig.pvc_spec_patch:type_name -> google.protobuf.Struct
+	37,  // 57: ml_pipelines.PipelineConfig.workspace:type_name -> ml_pipelines.WorkspaceConfig
+	42,  // 58: ml_pipelines.PipelineJob.RuntimeConfig.parameters:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
+	43,  // 59: ml_pipelines.PipelineJob.RuntimeConfig.parameter_values:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
+	27,  // 60: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry.value:type_name -> ml_pipelines.Value
+	116, // 61: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry.value:type_name -> google.protobuf.Value
+	0,   // 62: ml_pipelines.PipelineSpec.RuntimeParameter.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
+	27,  // 63: ml_pipelines.PipelineSpec.RuntimeParameter.default_value:type_name -> ml_pipelines.Value
+	7,   // 64: ml_pipelines.PipelineSpec.ComponentsEntry.value:type_name -> ml_pipelines.ComponentSpec
+	18,  // 65: ml_pipelines.DagSpec.TasksEntry.value:type_name -> ml_pipelines.PipelineTaskSpec
+	47,  // 66: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec.artifact_selectors:type_name -> ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
+	48,  // 67: ml_pipelines.DagOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
+	50,  // 68: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec.parameter_selectors:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	55,  // 69: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.mapped_parameters:type_name -> ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
+	50,  // 70: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_parameter:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	51,  // 71: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_oneof:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
+	53,  // 72: ml_pipelines.DagOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
+	50,  // 73: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	23,  // 74: ml_pipelines.ComponentInputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
+	0,   // 75: ml_pipelines.ComponentInputsSpec.ParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
+	1,   // 76: ml_pipelines.ComponentInputsSpec.ParameterSpec.parameter_type:type_name -> ml_pipelines.ParameterType.ParameterTypeEnum
+	116, // 77: ml_pipelines.ComponentInputsSpec.ParameterSpec.default_value:type_name -> google.protobuf.Value
+	56,  // 78: ml_pipelines.ComponentInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactSpec
+	57,  // 79: ml_pipelines.ComponentInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ParameterSpec
+	23,  // 80: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
+	64,  // 81: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
+	65,  // 82: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.custom_properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
+	115, // 83: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.metadata:type_name -> google.protobuf.Struct
+	0,   // 84: ml_pipelines.ComponentOutputsSpec.ParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
+	1,   // 85: ml_pipelines.ComponentOutputsSpec.ParameterSpec.parameter_type:type_name -> ml_pipelines.ParameterType.ParameterTypeEnum
+	60,  // 86: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec
+	61,  // 87: ml_pipelines.ComponentOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ParameterSpec
+	25,  // 88: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	25,  // 89: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	70,  // 90: ml_pipelines.TaskInputsSpec.InputArtifactSpec.task_output_artifact:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
+	71,  // 91: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_output_parameter:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
+	25,  // 92: ml_pipelines.TaskInputsSpec.InputParameterSpec.runtime_value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	72,  // 93: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_final_status:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
+	67,  // 94: ml_pipelines.TaskInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec
+	66,  // 95: ml_pipelines.TaskInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec
+	23,  // 96: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
+	77,  // 97: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
+	78,  // 98: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.custom_properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
+	0,   // 99: ml_pipelines.TaskOutputsSpec.OutputParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
+	74,  // 100: ml_pipelines.TaskOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputParameterSpec
+	73,  // 101: ml_pipelines.TaskOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
+	25,  // 102: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	25,  // 103: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	3,   // 104: ml_pipelines.PipelineTaskSpec.TriggerPolicy.strategy:type_name -> ml_pipelines.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
+	118, // 105: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_duration:type_name -> google.protobuf.Duration
+	118, // 106: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_max_duration:type_name -> google.protobuf.Duration
+	91,  // 107: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.lifecycle:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
+	92,  // 108: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.resources:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
+	93,  // 109: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.env:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
+	25,  // 110: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.artifact_uri:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	23,  // 111: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.type_schema:type_name -> ml_pipelines.ArtifactTypeSchema
+	96,  // 112: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
+	97,  // 113: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.custom_properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
+	115, // 114: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.metadata:type_name -> google.protobuf.Struct
+	99,  // 115: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.output_artifact_queries:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
+	115, // 116: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec.custom_job:type_name -> google.protobuf.Struct
+	85,  // 117: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.container:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
+	86,  // 118: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.importer:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec
+	87,  // 119: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.resolver:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec
+	88,  // 120: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.custom_job:type_name -> ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
+	89,  // 121: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
+	94,  // 122: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.pre_cache_check:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
+	95,  // 123: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.accelerator:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
+	25,  // 124: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	25,  // 125: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	98,  // 126: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
+	27,  // 127: ml_pipelines.RuntimeArtifact.PropertiesEntry.value:type_name -> ml_pipelines.Value
+	27,  // 128: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry.value:type_name -> ml_pipelines.Value
+	105, // 129: ml_pipelines.ExecutorInput.Inputs.parameters:type_name -> ml_pipelines.ExecutorInput.Inputs.ParametersEntry
+	106, // 130: ml_pipelines.ExecutorInput.Inputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
+	107, // 131: ml_pipelines.ExecutorInput.Inputs.parameter_values:type_name -> ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
+	108, // 132: ml_pipelines.ExecutorInput.Outputs.parameters:type_name -> ml_pipelines.ExecutorInput.Outputs.ParametersEntry
+	109, // 133: ml_pipelines.ExecutorInput.Outputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
+	27,  // 134: ml_pipelines.ExecutorInput.Inputs.ParametersEntry.value:type_name -> ml_pipelines.Value
+	29,  // 135: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
+	116, // 136: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry.value:type_name -> google.protobuf.Value
+	103, // 137: ml_pipelines.ExecutorInput.Outputs.ParametersEntry.value:type_name -> ml_pipelines.ExecutorInput.OutputParameter
+	29,  // 138: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
+	27,  // 139: ml_pipelines.ExecutorOutput.ParametersEntry.value:type_name -> ml_pipelines.Value
+	29,  // 140: ml_pipelines.ExecutorOutput.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
+	116, // 141: ml_pipelines.ExecutorOutput.ParameterValuesEntry.value:type_name -> google.protobuf.Value
+	35,  // 142: ml_pipelines.PlatformSpec.PlatformsEntry.value:type_name -> ml_pipelines.SinglePlatformSpec
+	115, // 143: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry.value:type_name -> google.protobuf.Struct
+	144, // [144:144] is the sub-list for method output_type
+	144, // [144:144] is the sub-list for method input_type
+	144, // [144:144] is the sub-list for extension type_name
+	144, // [144:144] is the sub-list for extension extendee
+	0,   // [0:144] is the sub-list for field type_name
 }
 
 func init() { file_pipeline_spec_proto_init() }
@@ -6214,47 +6411,47 @@ func file_pipeline_spec_proto_init() {
 		(*ComponentSpec_Dag)(nil),
 		(*ComponentSpec_ExecutorLabel)(nil),
 	}
-	file_pipeline_spec_proto_msgTypes[11].OneofWrappers = []any{
+	file_pipeline_spec_proto_msgTypes[13].OneofWrappers = []any{
 		(*PipelineTaskSpec_ArtifactIterator)(nil),
 		(*PipelineTaskSpec_ParameterIterator)(nil),
 	}
-	file_pipeline_spec_proto_msgTypes[16].OneofWrappers = []any{
+	file_pipeline_spec_proto_msgTypes[18].OneofWrappers = []any{
 		(*ArtifactTypeSchema_SchemaTitle)(nil),
 		(*ArtifactTypeSchema_SchemaUri)(nil),
 		(*ArtifactTypeSchema_InstanceSchema)(nil),
 	}
-	file_pipeline_spec_proto_msgTypes[18].OneofWrappers = []any{
+	file_pipeline_spec_proto_msgTypes[20].OneofWrappers = []any{
 		(*ValueOrRuntimeParameter_ConstantValue)(nil),
 		(*ValueOrRuntimeParameter_RuntimeParameter)(nil),
 		(*ValueOrRuntimeParameter_Constant)(nil),
 	}
-	file_pipeline_spec_proto_msgTypes[20].OneofWrappers = []any{
+	file_pipeline_spec_proto_msgTypes[22].OneofWrappers = []any{
 		(*Value_IntValue)(nil),
 		(*Value_DoubleValue)(nil),
 		(*Value_StringValue)(nil),
 	}
-	file_pipeline_spec_proto_msgTypes[30].OneofWrappers = []any{}
-	file_pipeline_spec_proto_msgTypes[31].OneofWrappers = []any{}
 	file_pipeline_spec_proto_msgTypes[32].OneofWrappers = []any{}
-	file_pipeline_spec_proto_msgTypes[46].OneofWrappers = []any{
+	file_pipeline_spec_proto_msgTypes[33].OneofWrappers = []any{}
+	file_pipeline_spec_proto_msgTypes[34].OneofWrappers = []any{}
+	file_pipeline_spec_proto_msgTypes[48].OneofWrappers = []any{
 		(*DagOutputsSpec_DagOutputParameterSpec_ValueFromParameter)(nil),
 		(*DagOutputsSpec_DagOutputParameterSpec_ValueFromOneof)(nil),
 	}
-	file_pipeline_spec_proto_msgTypes[59].OneofWrappers = []any{
+	file_pipeline_spec_proto_msgTypes[61].OneofWrappers = []any{
 		(*TaskInputsSpec_InputArtifactSpec_TaskOutputArtifact)(nil),
 		(*TaskInputsSpec_InputArtifactSpec_ComponentInputArtifact)(nil),
 	}
-	file_pipeline_spec_proto_msgTypes[60].OneofWrappers = []any{
+	file_pipeline_spec_proto_msgTypes[62].OneofWrappers = []any{
 		(*TaskInputsSpec_InputParameterSpec_TaskOutputParameter)(nil),
 		(*TaskInputsSpec_InputParameterSpec_RuntimeValue)(nil),
 		(*TaskInputsSpec_InputParameterSpec_ComponentInputParameter)(nil),
 		(*TaskInputsSpec_InputParameterSpec_TaskFinalStatus_)(nil),
 	}
-	file_pipeline_spec_proto_msgTypes[77].OneofWrappers = []any{
+	file_pipeline_spec_proto_msgTypes[79].OneofWrappers = []any{
 		(*ParameterIteratorSpec_ItemsSpec_Raw)(nil),
 		(*ParameterIteratorSpec_ItemsSpec_InputParameter)(nil),
 	}
-	file_pipeline_spec_proto_msgTypes[82].OneofWrappers = []any{
+	file_pipeline_spec_proto_msgTypes[84].OneofWrappers = []any{
 		(*PipelineDeploymentConfig_ExecutorSpec_Container)(nil),
 		(*PipelineDeploymentConfig_ExecutorSpec_Importer)(nil),
 		(*PipelineDeploymentConfig_ExecutorSpec_Resolver)(nil),
@@ -6265,8 +6462,8 @@ func file_pipeline_spec_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pipeline_spec_proto_rawDesc), len(file_pipeline_spec_proto_rawDesc)),
-			NumEnums:      4,
-			NumMessages:   108,
+			NumEnums:      5,
+			NumMessages:   110,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/v2alpha1/pipeline_spec.proto
+++ b/api/v2alpha1/pipeline_spec.proto
@@ -95,6 +95,8 @@ message ComponentSpec {
   }
   // Supports platform-specific component features.
   repeated SinglePlatformSpec single_platform_specs = 5;
+  // Specifies the task configurations that can be passed through to an external workload.
+  repeated TaskConfigPassthrough task_config_passthroughs = 6;
 }
 
 // A DAG contains multiple tasks.
@@ -442,7 +444,43 @@ message ParameterType {
     // Indicates that a parameter is a TaskFinalStatus type; these types can only accept inputs
     // specified by InputParameterSpec.task_final_status
     TASK_FINAL_STATUS = 7;
+    // Indicates that a parameter is a TaskConfig type; these types are
+    // injected by the backend to provide the configuration set on the task.
+    TASK_CONFIG = 8;
   }
+}
+
+
+// Represents the task configurations that can be passed through to an external workload.
+message TaskConfigPassthroughType {
+  enum TaskConfigPassthroughTypeEnum {
+    // Throwaway default value.
+    NONE = 0;
+    // Indicates that the resource limits and requests should be passed through to the external workload.
+    // Be cautious about also setting apply_to_task=true since that will double the resources required for
+    // the task.
+    RESOURCES = 1;
+    // Indicates that the environment variables should be passed through to the external workload.
+    // It is generally safe to always set apply_to_task=true on this field.
+    ENV = 2;
+    // Indicates that the Kubernetes node affinity should be passed through to the external workload.
+    KUBERNETES_AFFINITY = 3;
+    // Indicates that the Kubernetes node tolerations should be passed through to the external workload.
+    KUBERNETES_TOLERATIONS = 4;
+    // Indicates that the Kubernetes node selector should be passed through to the external workload.
+    KUBERNETES_NODE_SELECTOR = 5;
+    // Indicates that the Kubernetes persistent volumes and ConfigMaps/Secrets mounted as volumes should be
+    // passed through to the external workload. Be sure that when setting apply_to_task=true, the volumes are
+    // ReadWriteMany or ReadOnlyMany or else the task's pod may not start.
+    // This is useful when the task prepares a shared volume for the external workload or defines output artifact
+    // (e.g. dsl.Model) that is created by the external workload.
+    KUBERNETES_VOLUMES = 6;
+  }
+}
+
+message TaskConfigPassthrough {
+  TaskConfigPassthroughType.TaskConfigPassthroughTypeEnum field = 1;
+  bool apply_to_task = 2;
 }
 
 // The spec of a pipeline task.

--- a/backend/src/v2/driver/container.go
+++ b/backend/src/v2/driver/container.go
@@ -27,6 +27,8 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/v2/expression"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func validateContainer(opts Options) (err error) {
@@ -146,7 +148,6 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 
 	// TODO(Bobgy): change execution state to pending, because this is driver, execution hasn't started.
 	createdExecution, err := mlmd.CreateExecution(ctx, pipeline, ecfg)
-
 	if err != nil {
 		return execution, err
 	}
@@ -182,6 +183,8 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 		glog.Info("Cache disabled globally at the server level.")
 	}
 
+	taskConfig := &TaskConfig{}
+
 	podSpec, err := initPodSpecPatch(
 		opts.Container,
 		opts.Component,
@@ -192,6 +195,7 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 		opts.PipelineLogLevel,
 		opts.PublishLogs,
 		strconv.FormatBool(opts.CacheDisabled),
+		taskConfig,
 	)
 	if err != nil {
 		return execution, err
@@ -201,11 +205,66 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch input parameters from execution: %w", err)
 		}
-		err = extendPodSpecPatch(ctx, podSpec, opts, dag, pipeline, mlmd, inputParams)
+		err = extendPodSpecPatch(ctx, podSpec, opts, dag, pipeline, mlmd, inputParams, taskConfig)
 		if err != nil {
 			return execution, err
 		}
 	}
+
+	// Handle replacing any dsl.TaskConfig inputs with the taskConfig. This is done here because taskConfig is
+	// populated by initPodSpecPatch and extendPodSpecPatch.
+	taskConfigInputs := map[string]bool{}
+	for inputName := range opts.Component.GetInputDefinitions().GetParameters() {
+		compParam := opts.Component.GetInputDefinitions().GetParameters()[inputName]
+		if compParam != nil && compParam.GetParameterType() == pipelinespec.ParameterType_TASK_CONFIG {
+			taskConfigInputs[inputName] = true
+		}
+	}
+
+	if len(taskConfigInputs) > 0 {
+		taskConfigBytes, err := json.Marshal(taskConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal Kubernetes passthrough info: %w", err)
+		}
+
+		taskConfigStruct := &structpb.Struct{}
+		err = protojson.Unmarshal(taskConfigBytes, taskConfigStruct)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal Kubernetes passthrough info: %w", err)
+		}
+
+		for inputName := range taskConfigInputs {
+			executorInput.Inputs.ParameterValues[inputName] = &structpb.Value{
+				Kind: &structpb.Value_StructValue{StructValue: taskConfigStruct},
+			}
+		}
+
+		ecfg.InputParameters = executorInput.Inputs.ParameterValues
+
+		// Overwrite the --executor_input argument in the podSpec container command with the updated executorInput
+		executorInputJSON, err := protojson.Marshal(executorInput)
+		if err != nil {
+			return execution, fmt.Errorf("JSON marshaling executor input: %w", err)
+		}
+
+		for index, container := range podSpec.Containers {
+			if container.Name == "main" {
+				cmd := container.Command
+				for i := 0; i < len(cmd)-1; i++ {
+					if cmd[i] == "--executor_input" {
+						podSpec.Containers[index].Command[i+1] = string(executorInputJSON)
+
+						break
+					}
+				}
+
+				break
+			}
+		}
+
+		execution.ExecutorInput = executorInput
+	}
+
 	podSpecPatchBytes, err := json.Marshal(podSpec)
 	if err != nil {
 		return execution, fmt.Errorf("JSON marshaling pod spec patch: %w", err)

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -72,6 +72,17 @@ type Options struct {
 	TaskName string // the original name of the task, used for input resolution
 }
 
+// TaskConfig needs to stay aligned with the TaskConfig in the SDK.
+type TaskConfig struct {
+	Affinity     *k8score.Affinity            `json:"affinity"`
+	Tolerations  []k8score.Toleration         `json:"tolerations"`
+	NodeSelector map[string]string            `json:"nodeSelector"`
+	Env          []k8score.EnvVar             `json:"env"`
+	Volumes      []k8score.Volume             `json:"volumes"`
+	VolumeMounts []k8score.VolumeMount        `json:"volumeMounts"`
+	Resources    k8score.ResourceRequirements `json:"resources"`
+}
+
 // Identifying information used for error messages
 func (o Options) info() string {
 	msg := fmt.Sprintf("pipelineName=%v, runID=%v", o.PipelineName, o.RunID)
@@ -149,6 +160,49 @@ func getPodResource(
 	return &q, nil
 }
 
+// getTaskConfigOptions inspects the component's task config passthroughs and returns two maps:
+// 1) fields enabled for passthrough
+// 2) fields that should apply to the task pod
+//
+// If the component does not specify a passthrough, then all fields apply to the task pod and no fields are passthrough
+// enabled.
+func getTaskConfigOptions(
+	componentSpec *pipelinespec.ComponentSpec,
+) (map[pipelinespec.TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum]bool,
+	map[pipelinespec.TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum]bool,
+) {
+	passthroughEnabled := map[pipelinespec.TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum]bool{}
+	// setOnTask contains all possible fields even if they are not in the passthrough list.
+	setOnPod := map[pipelinespec.TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum]bool{
+		pipelinespec.TaskConfigPassthroughType_RESOURCES:                true,
+		pipelinespec.TaskConfigPassthroughType_ENV:                      true,
+		pipelinespec.TaskConfigPassthroughType_KUBERNETES_AFFINITY:      true,
+		pipelinespec.TaskConfigPassthroughType_KUBERNETES_TOLERATIONS:   true,
+		pipelinespec.TaskConfigPassthroughType_KUBERNETES_NODE_SELECTOR: true,
+		pipelinespec.TaskConfigPassthroughType_KUBERNETES_VOLUMES:       true,
+	}
+
+	if componentSpec == nil {
+		return passthroughEnabled, setOnPod
+	}
+
+	// If the component specifies a passthrough, then we don't set fields on the pod unless apply_to_task
+	// is true.
+	if len(componentSpec.GetTaskConfigPassthroughs()) != 0 {
+		for field := range setOnPod {
+			passthroughEnabled[field] = false
+		}
+	}
+
+	for _, pt := range componentSpec.GetTaskConfigPassthroughs() {
+		field := pt.GetField()
+		passthroughEnabled[field] = true
+		setOnPod[field] = pt.GetApplyToTask()
+	}
+
+	return passthroughEnabled, setOnPod
+}
+
 // initPodSpecPatch generates a strategic merge patch for pod spec, it is merged
 // to container base template generated in compiler/container.go. Therefore, only
 // dynamic values are patched here. The volume mounts / configmap mounts are
@@ -163,6 +217,7 @@ func initPodSpecPatch(
 	pipelineLogLevel string,
 	publishLogs string,
 	cacheDisabled string,
+	taskConfig *TaskConfig,
 ) (*k8score.PodSpec, error) {
 	executorInputJSON, err := protojson.Marshal(executorInput)
 	if err != nil {
@@ -180,6 +235,13 @@ func initPodSpecPatch(
 	}
 
 	userEnvVar = append(userEnvVar, proxy.GetConfig().GetEnvVars()...)
+
+	setOnTaskConfig, setOnPod := getTaskConfigOptions(componentSpec)
+
+	// Always set setOnTaskConfig to an empty map if taskConfig is nil to avoid nil pointer dereference.
+	if taskConfig == nil {
+		setOnTaskConfig = map[pipelinespec.TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum]bool{}
+	}
 
 	userCmdArgs := make([]string, 0, len(container.Command)+len(container.Args))
 	userCmdArgs = append(userCmdArgs, container.Command...)
@@ -308,18 +370,33 @@ func initPodSpecPatch(
 	if err != nil {
 		return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
 	}
+
 	podSpec := &k8score.PodSpec{
 		Containers: []k8score.Container{{
-			Name:      "main", // argo task user container is always called "main"
-			Command:   launcherCmd,
-			Args:      userCmdArgs,
-			Image:     containerImage,
-			Resources: res,
-			Env:       userEnvVar,
+			Name:    "main", // argo task user container is always called "main"
+			Command: launcherCmd,
+			Args:    userCmdArgs,
+			Image:   containerImage,
 		}},
 	}
 
-	addModelcarsToPodSpec(executorInput.GetInputs().GetArtifacts(), userEnvVar, podSpec)
+	if setOnTaskConfig[pipelinespec.TaskConfigPassthroughType_ENV] {
+		taskConfig.Env = userEnvVar
+	}
+
+	if setOnPod[pipelinespec.TaskConfigPassthroughType_ENV] {
+		podSpec.Containers[0].Env = userEnvVar
+	}
+
+	if setOnTaskConfig[pipelinespec.TaskConfigPassthroughType_RESOURCES] {
+		taskConfig.Resources = res
+	}
+
+	if setOnPod[pipelinespec.TaskConfigPassthroughType_RESOURCES] {
+		podSpec.Containers[0].Resources = res
+	}
+
+	addModelcarsToPodSpec(executorInput.GetInputs().GetArtifacts(), podSpec.Containers[0].Env, podSpec)
 
 	if needsWorkspaceMount(executorInput) {
 		// Validate that no user volume mounts conflict with the workspace
@@ -331,7 +408,17 @@ func initPodSpecPatch(
 		// Argo resolves {{workflow.name}}-kfp-workspace to the actual PVC name at runtime
 		pvcName := "{{workflow.name}}-" + component.WorkspaceVolumeName
 
-		addWorkspaceMount(podSpec, pvcName)
+		workspaceVolume, workspaceVolumeMount := getWorkspaceMount(pvcName)
+
+		if setOnTaskConfig[pipelinespec.TaskConfigPassthroughType_KUBERNETES_VOLUMES] {
+			taskConfig.Volumes = append(taskConfig.Volumes, workspaceVolume)
+			taskConfig.VolumeMounts = append(taskConfig.VolumeMounts, workspaceVolumeMount)
+		}
+
+		if setOnPod[pipelinespec.TaskConfigPassthroughType_KUBERNETES_VOLUMES] {
+			podSpec.Volumes = append(podSpec.Volumes, workspaceVolume)
+			podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, workspaceVolumeMount)
+		}
 	}
 
 	return podSpec, nil
@@ -371,8 +458,8 @@ func needsWorkspaceMount(executorInput *pipelinespec.ExecutorInput) bool {
 	return false
 }
 
-// addWorkspaceMount adds the workspace volume mount to the pod spec if needed.
-func addWorkspaceMount(podSpec *k8score.PodSpec, pvcName string) {
+// getWorkspaceMount gets the workspace volume and volume mount.
+func getWorkspaceMount(pvcName string) (k8score.Volume, k8score.VolumeMount) {
 	workspaceVolume := k8score.Volume{
 		Name: component.WorkspaceVolumeName,
 		VolumeSource: k8score.VolumeSource{
@@ -387,8 +474,7 @@ func addWorkspaceMount(podSpec *k8score.PodSpec, pvcName string) {
 		MountPath: component.WorkspaceMountPath,
 	}
 
-	podSpec.Volumes = append(podSpec.Volumes, workspaceVolume)
-	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, workspaceVolumeMount)
+	return workspaceVolume, workspaceVolumeMount
 }
 
 // addModelcarsToPodSpec will patch the pod spec if there are any input artifacts in the Modelcar format.

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -14,6 +14,7 @@
 package driver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -261,6 +263,8 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			taskConfig := &TaskConfig{}
+
 			podSpec, err := initPodSpecPatch(
 				tt.args.container,
 				tt.args.componentSpec,
@@ -271,6 +275,7 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				tt.args.pipelineLogLevel,
 				tt.args.publishLogs,
 				"false",
+				taskConfig,
 			)
 			if tt.wantErr {
 				assert.Nil(t, podSpec)
@@ -282,6 +287,9 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Contains(t, string(podSpecString), tt.want)
 			}
+
+			assert.Empty(t, taskConfig.Resources.Limits)
+			assert.Empty(t, taskConfig.Resources.Requests)
 		})
 	}
 }
@@ -370,6 +378,8 @@ func Test_initPodSpecPatch_resource_placeholders(t *testing.T) {
 		},
 	}
 
+	taskConfig := &TaskConfig{}
+
 	podSpec, err := initPodSpecPatch(
 		containerSpec,
 		componentSpec,
@@ -380,6 +390,7 @@ func Test_initPodSpecPatch_resource_placeholders(t *testing.T) {
 		"1",
 		"false",
 		"false",
+		taskConfig,
 	)
 	assert.Nil(t, err)
 	assert.Len(t, podSpec.Containers, 1)
@@ -390,6 +401,9 @@ func Test_initPodSpecPatch_resource_placeholders(t *testing.T) {
 	assert.Equal(t, k8sres.MustParse("100Mi"), res.Requests[k8score.ResourceMemory])
 	assert.Equal(t, k8sres.MustParse("500Mi"), res.Limits[k8score.ResourceMemory])
 	assert.Equal(t, k8sres.MustParse("1"), res.Limits[k8score.ResourceName("nvidia.com/gpu")])
+
+	assert.Empty(t, taskConfig.Resources.Limits)
+	assert.Empty(t, taskConfig.Resources.Requests)
 }
 
 func Test_initPodSpecPatch_legacy_resources(t *testing.T) {
@@ -410,6 +424,7 @@ func Test_initPodSpecPatch_legacy_resources(t *testing.T) {
 	}
 	componentSpec := &pipelinespec.ComponentSpec{}
 	executorInput := &pipelinespec.ExecutorInput{}
+	taskConfig := &TaskConfig{}
 
 	podSpec, err := initPodSpecPatch(
 		containerSpec,
@@ -421,6 +436,7 @@ func Test_initPodSpecPatch_legacy_resources(t *testing.T) {
 		"1",
 		"false",
 		"false",
+		taskConfig,
 	)
 	assert.Nil(t, err)
 	assert.Len(t, podSpec.Containers, 1)
@@ -431,6 +447,9 @@ func Test_initPodSpecPatch_legacy_resources(t *testing.T) {
 	assert.Equal(t, k8sres.MustParse("100Mi"), res.Requests[k8score.ResourceMemory])
 	assert.Equal(t, k8sres.MustParse("500Mi"), res.Limits[k8score.ResourceMemory])
 	assert.Equal(t, k8sres.MustParse("1"), res.Limits[k8score.ResourceName("nvidia.com/gpu")])
+
+	assert.Empty(t, taskConfig.Resources.Limits)
+	assert.Empty(t, taskConfig.Resources.Requests)
 }
 
 func Test_initPodSpecPatch_modelcar_input_artifact(t *testing.T) {
@@ -453,6 +472,7 @@ func Test_initPodSpecPatch_modelcar_input_artifact(t *testing.T) {
 			},
 		},
 	}
+	taskConfig := &TaskConfig{}
 
 	podSpec, err := initPodSpecPatch(
 		containerSpec,
@@ -464,6 +484,7 @@ func Test_initPodSpecPatch_modelcar_input_artifact(t *testing.T) {
 		"1",
 		"false",
 		"false",
+		taskConfig,
 	)
 	assert.Nil(t, err)
 
@@ -487,6 +508,9 @@ func Test_initPodSpecPatch_modelcar_input_artifact(t *testing.T) {
 	assert.Equal(t, podSpec.Containers[1].VolumeMounts[0].Name, "oci-0")
 	assert.Equal(t, podSpec.Containers[1].VolumeMounts[0].MountPath, "/oci/registry.domain.local_my-model:latest")
 	assert.Equal(t, podSpec.Containers[1].VolumeMounts[0].SubPath, "registry.domain.local_my-model:latest")
+
+	assert.Empty(t, taskConfig.Resources.Limits)
+	assert.Empty(t, taskConfig.Resources.Requests)
 }
 
 // Validate that setting publishLogs to true propagates to the driver container
@@ -503,6 +527,7 @@ func Test_initPodSpecPatch_publishLogs(t *testing.T) {
 		"1",
 		"true",
 		"false",
+		nil,
 	)
 	assert.Nil(t, err)
 	cmd := podSpec.Containers[0].Command
@@ -513,7 +538,6 @@ func Test_initPodSpecPatch_publishLogs(t *testing.T) {
 			assert.Equal(t, cmd[idx+1], "true")
 		}
 	}
-
 }
 
 func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
@@ -614,6 +638,8 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			taskConfig := &TaskConfig{}
+
 			podSpec, err := initPodSpecPatch(
 				tt.args.container,
 				tt.args.componentSpec,
@@ -624,6 +650,7 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 				tt.args.pipelineLogLevel,
 				tt.args.publishLogs,
 				"false",
+				taskConfig,
 			)
 			assert.Nil(t, err)
 			assert.NotEmpty(t, podSpec)
@@ -635,8 +662,63 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 			if tt.notWant != "" {
 				assert.NotContains(t, string(podSpecString), tt.notWant)
 			}
+
+			assert.Empty(t, taskConfig.Resources.Limits)
+			assert.Empty(t, taskConfig.Resources.Requests)
 		})
 	}
+}
+
+func Test_initPodSpecPatch_TaskConfig_ForwardsResourcesOnly(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+
+	containerSpec := &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{
+		Image:   "python:3.9",
+		Args:    []string{"--function_to_execute", "add"},
+		Command: []string{"sh", "-ec", "python3 -m kfp.components.executor_main"},
+		Resources: &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec{
+			ResourceCpuLimit:      "2.0",
+			ResourceMemoryLimit:   "1.5",
+			ResourceCpuRequest:    "1.0",
+			ResourceMemoryRequest: "0.65G",
+		},
+	}
+	componentSpec := &pipelinespec.ComponentSpec{
+		TaskConfigPassthroughs: []*pipelinespec.TaskConfigPassthrough{
+			{
+				Field:       pipelinespec.TaskConfigPassthroughType_RESOURCES,
+				ApplyToTask: false,
+			},
+		},
+	}
+	executorInput := &pipelinespec.ExecutorInput{}
+
+	taskCfg := &TaskConfig{}
+	podSpec, err := initPodSpecPatch(
+		containerSpec,
+		componentSpec,
+		executorInput,
+		27,
+		"test",
+		"0254beba-0be4-4065-8d97-7dc5e3adf300",
+		"1",
+		"false",
+		"false",
+		taskCfg,
+	)
+	assert.Nil(t, err)
+	assert.NotNil(t, podSpec)
+	assert.Len(t, podSpec.Containers, 1)
+
+	assert.Empty(t, podSpec.Containers[0].Resources.Requests)
+	assert.Empty(t, podSpec.Containers[0].Resources.Limits)
+
+	// Forwarded resources captured in TaskConfig
+	res := taskCfg.Resources
+	assert.True(t, res.Requests[k8score.ResourceCPU].Equal(k8sres.MustParse("1")))
+	assert.True(t, res.Limits[k8score.ResourceCPU].Equal(k8sres.MustParse("2")))
+	assert.True(t, res.Requests[k8score.ResourceMemory].Equal(k8sres.MustParse("0.65G")))
+	assert.True(t, res.Limits[k8score.ResourceMemory].Equal(k8sres.MustParse("1.5")))
 }
 
 func Test_initPodSpecPatch_inputTaskFinalStatus(t *testing.T) {
@@ -682,6 +764,7 @@ func Test_initPodSpecPatch_inputTaskFinalStatus(t *testing.T) {
 		"1",
 		"false",
 		"false",
+		nil,
 	)
 	require.Nil(t, err)
 
@@ -829,49 +912,29 @@ func TestNeedsWorkspaceMount(t *testing.T) {
 	}
 }
 
-func TestAddWorkspaceMount(t *testing.T) {
-	podSpec := &k8score.PodSpec{
-		Containers: []k8score.Container{
-			{
-				Name: "main",
-			},
-		},
-	}
-
+func TestGetWorkspaceMount(t *testing.T) {
 	pvcName := "test-workflow-kfp-workspace"
 
-	addWorkspaceMount(podSpec, pvcName)
+	workspaceVolume, workspaceVolumeMount := getWorkspaceMount(pvcName)
 
-	// Check that volume was added
-	if len(podSpec.Volumes) != 1 {
-		t.Errorf("Expected 1 volume, got %d", len(podSpec.Volumes))
+	if workspaceVolume.Name != "kfp-workspace" {
+		t.Errorf("Expected volume name kfp-workspace, got %s", workspaceVolume.Name)
 	}
 
-	volume := podSpec.Volumes[0]
-	if volume.Name != "kfp-workspace" {
-		t.Errorf("Expected volume name kfp-workspace, got %s", volume.Name)
-	}
-
-	if volume.PersistentVolumeClaim == nil {
+	if workspaceVolume.PersistentVolumeClaim == nil {
 		t.Error("Expected PersistentVolumeClaim to be set")
 	}
 
-	if volume.PersistentVolumeClaim.ClaimName != pvcName {
-		t.Errorf("Expected claim name %s, got %s", pvcName, volume.PersistentVolumeClaim.ClaimName)
+	if workspaceVolume.PersistentVolumeClaim.ClaimName != pvcName {
+		t.Errorf("Expected claim name %s, got %s", pvcName, workspaceVolume.PersistentVolumeClaim.ClaimName)
 	}
 
-	// Check that volume mount was added
-	if len(podSpec.Containers[0].VolumeMounts) != 1 {
-		t.Errorf("Expected 1 volume mount, got %d", len(podSpec.Containers[0].VolumeMounts))
+	if workspaceVolumeMount.Name != "kfp-workspace" {
+		t.Errorf("Expected volume mount name kfp-workspace, got %s", workspaceVolumeMount.Name)
 	}
 
-	volumeMount := podSpec.Containers[0].VolumeMounts[0]
-	if volumeMount.Name != "kfp-workspace" {
-		t.Errorf("Expected volume mount name kfp-workspace, got %s", volumeMount.Name)
-	}
-
-	if volumeMount.MountPath != "/kfp-workspace" {
-		t.Errorf("Expected mount path /kfp-workspace, got %s", volumeMount.MountPath)
+	if workspaceVolumeMount.MountPath != "/kfp-workspace" {
+		t.Errorf("Expected mount path /kfp-workspace, got %s", workspaceVolumeMount.MountPath)
 	}
 }
 
@@ -961,5 +1024,403 @@ func TestValidateVolumeMounts(t *testing.T) {
 				t.Errorf("Expected no error but got: %v", err)
 			}
 		})
+	}
+}
+
+func TestWorkspaceMount_PassthroughVolumes_CaptureOnly(t *testing.T) {
+	containerSpec := &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{Image: "python:3.9"}
+	componentSpec := &pipelinespec.ComponentSpec{
+		TaskConfigPassthroughs: []*pipelinespec.TaskConfigPassthrough{
+			{
+				Field:       pipelinespec.TaskConfigPassthroughType_KUBERNETES_VOLUMES,
+				ApplyToTask: false,
+			},
+		},
+	}
+	executorInput := &pipelinespec.ExecutorInput{
+		Inputs: &pipelinespec.ExecutorInput_Inputs{
+			ParameterValues: map[string]*structpb.Value{
+				"workspace_param": {Kind: &structpb.Value_StringValue{StringValue: "{{$.workspace_path}}"}},
+			},
+		},
+	}
+	taskCfg := &TaskConfig{}
+	podSpec, err := initPodSpecPatch(
+		containerSpec, componentSpec, executorInput,
+		27, "test", "run", "1", "false", "false", taskCfg,
+	)
+	assert.Nil(t, err)
+
+	// Should not mount workspace to pod (no volumes on pod), only capture to TaskConfig
+	assert.Empty(t, podSpec.Volumes)
+	assert.Empty(t, podSpec.Containers[0].VolumeMounts)
+	assert.NotEmpty(t, taskCfg.Volumes)
+	assert.NotEmpty(t, taskCfg.VolumeMounts)
+
+	if assert.Len(t, taskCfg.Volumes, 1) {
+		assert.Equal(t, "kfp-workspace", taskCfg.Volumes[0].Name)
+		if assert.NotNil(t, taskCfg.Volumes[0].PersistentVolumeClaim) {
+			assert.Equal(t, "{{workflow.name}}-kfp-workspace", taskCfg.Volumes[0].PersistentVolumeClaim.ClaimName)
+		}
+	}
+
+	if assert.Len(t, taskCfg.VolumeMounts, 1) {
+		assert.Equal(t, "kfp-workspace", taskCfg.VolumeMounts[0].Name)
+		assert.Equal(t, "/kfp-workspace", taskCfg.VolumeMounts[0].MountPath)
+	}
+}
+
+func TestWorkspaceMount_PassthroughVolumes_ApplyAndCapture(t *testing.T) {
+	containerSpec := &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{Image: "python:3.9"}
+	componentSpec := &pipelinespec.ComponentSpec{
+		TaskConfigPassthroughs: []*pipelinespec.TaskConfigPassthrough{
+			{
+				Field:       pipelinespec.TaskConfigPassthroughType_KUBERNETES_VOLUMES,
+				ApplyToTask: true,
+			},
+		},
+	}
+	executorInput := &pipelinespec.ExecutorInput{
+		Inputs: &pipelinespec.ExecutorInput_Inputs{
+			ParameterValues: map[string]*structpb.Value{
+				"workspace_param": {Kind: &structpb.Value_StringValue{StringValue: "{{$.workspace_path}}"}},
+			},
+		},
+	}
+	taskCfg := &TaskConfig{}
+	podSpec, err := initPodSpecPatch(
+		containerSpec, componentSpec, executorInput,
+		27, "test", "run", "1", "false", "false", taskCfg,
+	)
+	assert.Nil(t, err)
+	// Should mount workspace to pod and also capture to TaskConfig
+	assert.NotEmpty(t, podSpec.Volumes)
+	assert.NotEmpty(t, podSpec.Containers[0].VolumeMounts)
+	assert.NotEmpty(t, taskCfg.Volumes)
+	assert.NotEmpty(t, taskCfg.VolumeMounts)
+
+	if assert.Len(t, podSpec.Volumes, 1) {
+		assert.Equal(t, "kfp-workspace", podSpec.Volumes[0].Name)
+		if assert.NotNil(t, podSpec.Volumes[0].PersistentVolumeClaim) {
+			assert.Equal(t, "{{workflow.name}}-kfp-workspace", podSpec.Volumes[0].PersistentVolumeClaim.ClaimName)
+		}
+	}
+
+	if assert.Len(t, podSpec.Containers, 1) {
+		if assert.Len(t, podSpec.Containers[0].VolumeMounts, 1) {
+			assert.Equal(t, "kfp-workspace", podSpec.Containers[0].VolumeMounts[0].Name)
+			assert.Equal(t, "/kfp-workspace", podSpec.Containers[0].VolumeMounts[0].MountPath)
+		}
+	}
+
+	if assert.Len(t, taskCfg.Volumes, 1) {
+		assert.Equal(t, "kfp-workspace", taskCfg.Volumes[0].Name)
+		if assert.NotNil(t, taskCfg.Volumes[0].PersistentVolumeClaim) {
+			assert.Equal(t, "{{workflow.name}}-kfp-workspace", taskCfg.Volumes[0].PersistentVolumeClaim.ClaimName)
+		}
+	}
+
+	if assert.Len(t, taskCfg.VolumeMounts, 1) {
+		assert.Equal(t, "kfp-workspace", taskCfg.VolumeMounts[0].Name)
+		assert.Equal(t, "/kfp-workspace", taskCfg.VolumeMounts[0].MountPath)
+	}
+}
+
+func Test_initPodSpecPatch_TaskConfig_Env_Passthrough_CaptureOnly(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+	containerSpec := &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{
+		Image: "python:3.9",
+		Env: []*pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec_EnvVar{{
+			Name:  "FOO",
+			Value: "bar",
+		}},
+	}
+	componentSpec := &pipelinespec.ComponentSpec{
+		TaskConfigPassthroughs: []*pipelinespec.TaskConfigPassthrough{
+			{Field: pipelinespec.TaskConfigPassthroughType_ENV, ApplyToTask: false},
+		},
+	}
+	executorInput := &pipelinespec.ExecutorInput{}
+	taskCfg := &TaskConfig{}
+	podSpec, err := initPodSpecPatch(
+		containerSpec,
+		componentSpec,
+		executorInput,
+		27,
+		"test",
+		"run",
+		"1",
+		"false",
+		"false",
+		taskCfg,
+	)
+	assert.Nil(t, err)
+
+	// Env should be captured to TaskConfig only, not applied to pod
+	assert.Empty(t, podSpec.Containers[0].Env)
+
+	if assert.Len(t, taskCfg.Env, 1) {
+		assert.Equal(t, "FOO", taskCfg.Env[0].Name)
+		assert.Equal(t, "bar", taskCfg.Env[0].Value)
+	}
+}
+
+func Test_initPodSpecPatch_TaskConfig_Resources_Passthrough_ApplyAndCapture(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+	containerSpec := &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{
+		Image:   "python:3.9",
+		Args:    []string{"--function_to_execute", "add"},
+		Command: []string{"sh", "-ec", "python3 -m kfp.components.executor_main"},
+		Resources: &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec{
+			CpuLimit:      2.0,
+			MemoryLimit:   1.5,
+			CpuRequest:    1.0,
+			MemoryRequest: 0.65,
+		},
+	}
+	componentSpec := &pipelinespec.ComponentSpec{
+		TaskConfigPassthroughs: []*pipelinespec.TaskConfigPassthrough{
+			{Field: pipelinespec.TaskConfigPassthroughType_RESOURCES, ApplyToTask: true},
+		},
+	}
+	executorInput := &pipelinespec.ExecutorInput{}
+	taskCfg := &TaskConfig{}
+	podSpec, err := initPodSpecPatch(
+		containerSpec,
+		componentSpec,
+		executorInput,
+		27,
+		"test",
+		"run",
+		"1",
+		"false",
+		"false",
+		taskCfg,
+	)
+	assert.Nil(t, err)
+	// Resources should be both on pod and in TaskConfig
+	assert.NotEmpty(t, podSpec.Containers[0].Resources.Requests)
+	assert.NotEmpty(t, podSpec.Containers[0].Resources.Limits)
+	assert.NotEmpty(t, taskCfg.Resources.Requests)
+	assert.NotEmpty(t, taskCfg.Resources.Limits)
+
+	resPod := podSpec.Containers[0].Resources
+	assert.Equal(t, k8sres.MustParse("1"), resPod.Requests[k8score.ResourceCPU])
+	assert.Equal(t, k8sres.MustParse("2"), resPod.Limits[k8score.ResourceCPU])
+	assert.Equal(t, k8sres.MustParse("0.65G"), resPod.Requests[k8score.ResourceMemory])
+	assert.Equal(t, k8sres.MustParse("1.5G"), resPod.Limits[k8score.ResourceMemory])
+
+	resCfg := taskCfg.Resources
+	assert.Equal(t, k8sres.MustParse("1"), resCfg.Requests[k8score.ResourceCPU])
+	assert.Equal(t, k8sres.MustParse("2"), resCfg.Limits[k8score.ResourceCPU])
+	assert.Equal(t, k8sres.MustParse("0.65G"), resCfg.Requests[k8score.ResourceMemory])
+	assert.Equal(t, k8sres.MustParse("1.5G"), resCfg.Limits[k8score.ResourceMemory])
+}
+
+func Test_initPodSpecPatch_TaskConfig_Affinity_NodeSelector_Tolerations_Passthrough(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+
+	containerSpec := &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{Image: "python:3.9"}
+	componentSpec := &pipelinespec.ComponentSpec{
+		TaskConfigPassthroughs: []*pipelinespec.TaskConfigPassthrough{
+			{Field: pipelinespec.TaskConfigPassthroughType_KUBERNETES_AFFINITY, ApplyToTask: false},
+			{Field: pipelinespec.TaskConfigPassthroughType_KUBERNETES_NODE_SELECTOR, ApplyToTask: false},
+			{Field: pipelinespec.TaskConfigPassthroughType_KUBERNETES_TOLERATIONS, ApplyToTask: false},
+		},
+	}
+
+	secs := int64(3600)
+	k8sExecCfg := &kubernetesplatform.KubernetesExecutorConfig{
+		NodeSelector: &kubernetesplatform.NodeSelector{Labels: map[string]string{"disktype": "ssd"}},
+		Tolerations: []*kubernetesplatform.Toleration{{
+			Key:               "example-key",
+			Operator:          "Exists",
+			Effect:            "NoExecute",
+			TolerationSeconds: &secs,
+		}},
+		NodeAffinity: []*kubernetesplatform.NodeAffinityTerm{{
+			MatchExpressions: []*kubernetesplatform.SelectorRequirement{{
+				Key:      "zone",
+				Operator: "In",
+				Values:   []string{"us-west-1"},
+			}},
+		}},
+	}
+
+	opts := Options{
+		PipelineName:             "p",
+		RunID:                    "r",
+		Component:                componentSpec,
+		Container:                containerSpec,
+		KubernetesExecutorConfig: k8sExecCfg,
+	}
+
+	executorInput := &pipelinespec.ExecutorInput{Inputs: &pipelinespec.ExecutorInput_Inputs{ParameterValues: map[string]*structpb.Value{}}}
+
+	taskCfg := &TaskConfig{}
+
+	podSpec, err := initPodSpecPatch(
+		containerSpec,
+		componentSpec,
+		executorInput,
+		27,
+		"test",
+		"run",
+		"1",
+		"false",
+		"false",
+		taskCfg,
+	)
+	assert.Nil(t, err)
+
+	err = extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		opts,
+		nil,
+		nil,
+		nil,
+		map[string]*structpb.Value{},
+		taskCfg,
+	)
+	assert.Nil(t, err)
+
+	assert.Nil(t, podSpec.Affinity)
+	assert.Empty(t, podSpec.NodeSelector)
+	assert.Empty(t, podSpec.Tolerations)
+
+	assert.Equal(t, map[string]string{"disktype": "ssd"}, taskCfg.NodeSelector)
+	if assert.Len(t, taskCfg.Tolerations, 1) {
+		assert.Equal(t, "example-key", taskCfg.Tolerations[0].Key)
+		assert.Equal(t, k8score.TaintEffect("NoExecute"), taskCfg.Tolerations[0].Effect)
+		if assert.NotNil(t, taskCfg.Tolerations[0].TolerationSeconds) {
+			assert.Equal(t, int64(3600), *taskCfg.Tolerations[0].TolerationSeconds)
+		}
+	}
+
+	if assert.NotNil(t, taskCfg.Affinity) && assert.NotNil(t, taskCfg.Affinity.NodeAffinity) {
+		if assert.NotNil(t, taskCfg.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution) {
+			terms := taskCfg.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			if assert.NotEmpty(t, terms) && assert.NotEmpty(t, terms[0].MatchExpressions) {
+				expr := terms[0].MatchExpressions[0]
+				assert.Equal(t, "zone", expr.Key)
+				assert.Equal(t, k8score.NodeSelectorOpIn, expr.Operator)
+				assert.Equal(t, []string{"us-west-1"}, expr.Values)
+			}
+		}
+	}
+}
+
+func Test_initPodSpecPatch_TaskConfig_Affinity_NodeSelector_Tolerations_ApplyAndCapture(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+
+	containerSpec := &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{Image: "python:3.9"}
+	componentSpec := &pipelinespec.ComponentSpec{
+		TaskConfigPassthroughs: []*pipelinespec.TaskConfigPassthrough{
+			{Field: pipelinespec.TaskConfigPassthroughType_KUBERNETES_AFFINITY, ApplyToTask: true},
+			{Field: pipelinespec.TaskConfigPassthroughType_KUBERNETES_NODE_SELECTOR, ApplyToTask: true},
+			{Field: pipelinespec.TaskConfigPassthroughType_KUBERNETES_TOLERATIONS, ApplyToTask: true},
+		},
+	}
+
+	secs := int64(3600)
+	weight := int32(100)
+	k8sExecCfg := &kubernetesplatform.KubernetesExecutorConfig{
+		NodeSelector: &kubernetesplatform.NodeSelector{Labels: map[string]string{"disktype": "ssd"}},
+		Tolerations: []*kubernetesplatform.Toleration{{
+			Key:               "example-key",
+			Operator:          "Exists",
+			Effect:            "NoExecute",
+			TolerationSeconds: &secs,
+		}},
+		NodeAffinity: []*kubernetesplatform.NodeAffinityTerm{{
+			MatchExpressions: []*kubernetesplatform.SelectorRequirement{{
+				Key:      "zone",
+				Operator: "In",
+				Values:   []string{"us-west-1"},
+			}},
+			Weight: &weight,
+		}},
+	}
+
+	opts := Options{
+		PipelineName:             "p",
+		RunID:                    "r",
+		Component:                componentSpec,
+		Container:                containerSpec,
+		KubernetesExecutorConfig: k8sExecCfg,
+	}
+
+	executorInput := &pipelinespec.ExecutorInput{Inputs: &pipelinespec.ExecutorInput_Inputs{ParameterValues: map[string]*structpb.Value{}}}
+	taskCfg := &TaskConfig{}
+
+	podSpec, err := initPodSpecPatch(
+		containerSpec,
+		componentSpec,
+		executorInput,
+		27,
+		"test",
+		"run",
+		"1",
+		"false",
+		"false",
+		taskCfg,
+	)
+	assert.Nil(t, err)
+
+	err = extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		opts,
+		nil,
+		nil,
+		nil,
+		map[string]*structpb.Value{},
+		taskCfg,
+	)
+	assert.Nil(t, err)
+
+	assert.Equal(t, map[string]string{"disktype": "ssd"}, podSpec.NodeSelector)
+	if assert.Len(t, podSpec.Tolerations, 1) {
+		assert.Equal(t, "example-key", podSpec.Tolerations[0].Key)
+		assert.Equal(t, k8score.TaintEffect("NoExecute"), podSpec.Tolerations[0].Effect)
+		if assert.NotNil(t, podSpec.Tolerations[0].TolerationSeconds) {
+			assert.Equal(t, int64(3600), *podSpec.Tolerations[0].TolerationSeconds)
+		}
+	}
+
+	if assert.NotNil(t, podSpec.Affinity) && assert.NotNil(t, podSpec.Affinity.NodeAffinity) {
+		prefs := podSpec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		if assert.NotEmpty(t, prefs) {
+			assert.Equal(t, int32(100), prefs[0].Weight)
+			if assert.NotEmpty(t, prefs[0].Preference.MatchExpressions) {
+				expr := prefs[0].Preference.MatchExpressions[0]
+				assert.Equal(t, "zone", expr.Key)
+				assert.Equal(t, k8score.NodeSelectorOpIn, expr.Operator)
+				assert.Equal(t, []string{"us-west-1"}, expr.Values)
+			}
+		}
+	}
+
+	assert.Equal(t, map[string]string{"disktype": "ssd"}, taskCfg.NodeSelector)
+	if assert.Len(t, taskCfg.Tolerations, 1) {
+		assert.Equal(t, "example-key", taskCfg.Tolerations[0].Key)
+		assert.Equal(t, k8score.TaintEffect("NoExecute"), taskCfg.Tolerations[0].Effect)
+		if assert.NotNil(t, taskCfg.Tolerations[0].TolerationSeconds) {
+			assert.Equal(t, int64(3600), *taskCfg.Tolerations[0].TolerationSeconds)
+		}
+	}
+
+	if assert.NotNil(t, taskCfg.Affinity) && assert.NotNil(t, taskCfg.Affinity.NodeAffinity) {
+		prefs := taskCfg.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		if assert.NotEmpty(t, prefs) {
+			assert.Equal(t, int32(100), prefs[0].Weight)
+			if assert.NotEmpty(t, prefs[0].Preference.MatchExpressions) {
+				expr := prefs[0].Preference.MatchExpressions[0]
+				assert.Equal(t, "zone", expr.Key)
+				assert.Equal(t, k8score.NodeSelectorOpIn, expr.Operator)
+				assert.Equal(t, []string{"us-west-1"}, expr.Values)
+			}
+		}
 	}
 }

--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -214,6 +214,8 @@ func Test_makePodSpecPatch_nodeSelector(t *testing.T) {
 					Name: "main",
 				},
 			}}
+			taskConfig := &TaskConfig{}
+
 			err := extendPodSpecPatch(
 				context.Background(),
 				got,
@@ -222,10 +224,12 @@ func Test_makePodSpecPatch_nodeSelector(t *testing.T) {
 				nil,
 				nil,
 				tt.inputParams,
+				taskConfig,
 			)
 			assert.Nil(t, err)
 			assert.NotNil(t, got)
 			assert.Equal(t, tt.expected, got)
+			assert.Empty(t, taskConfig.NodeSelector)
 		})
 	}
 }
@@ -601,6 +605,8 @@ func Test_extendPodSpecPatch_Secret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			taskConfig := &TaskConfig{}
+
 			err := extendPodSpecPatch(
 				context.Background(),
 				tt.podSpec,
@@ -609,9 +615,14 @@ func Test_extendPodSpecPatch_Secret(t *testing.T) {
 				nil,
 				nil,
 				tt.inputParams,
+				taskConfig,
 			)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected, tt.podSpec)
+
+			assert.Empty(t, taskConfig.Volumes)
+			assert.Empty(t, taskConfig.VolumeMounts)
+			assert.Empty(t, taskConfig.Env)
 		})
 	}
 }
@@ -703,7 +714,8 @@ func Test_extendPodSpecPatch_ConfigMap(t *testing.T) {
 						VolumeSource: k8score.VolumeSource{
 							ConfigMap: &k8score.ConfigMapVolumeSource{
 								LocalObjectReference: k8score.LocalObjectReference{Name: "cm1"},
-								Optional:             &[]bool{false}[0]},
+								Optional:             &[]bool{false}[0],
+							},
 						},
 					},
 				},
@@ -856,7 +868,8 @@ func Test_extendPodSpecPatch_ConfigMap(t *testing.T) {
 						VolumeSource: k8score.VolumeSource{
 							ConfigMap: &k8score.ConfigMapVolumeSource{
 								LocalObjectReference: k8score.LocalObjectReference{Name: "cm-name"},
-								Optional:             &[]bool{true}[0]},
+								Optional:             &[]bool{true}[0],
+							},
 						},
 					},
 				},
@@ -1001,6 +1014,8 @@ func Test_extendPodSpecPatch_ConfigMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			taskConfig := &TaskConfig{}
+
 			err := extendPodSpecPatch(
 				context.Background(),
 				tt.podSpec,
@@ -1009,9 +1024,14 @@ func Test_extendPodSpecPatch_ConfigMap(t *testing.T) {
 				nil,
 				nil,
 				tt.inputParams,
+				taskConfig,
 			)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected, tt.podSpec)
+
+			assert.Empty(t, taskConfig.Volumes)
+			assert.Empty(t, taskConfig.VolumeMounts)
+			assert.Empty(t, taskConfig.Env)
 		})
 	}
 }
@@ -1168,6 +1188,8 @@ func Test_extendPodSpecPatch_EmptyVolumeMount(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			taskConfig := &TaskConfig{}
+
 			err := extendPodSpecPatch(
 				context.Background(),
 				tt.podSpec,
@@ -1176,9 +1198,13 @@ func Test_extendPodSpecPatch_EmptyVolumeMount(t *testing.T) {
 				nil,
 				nil,
 				map[string]*structpb.Value{},
+				taskConfig,
 			)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected, tt.podSpec)
+
+			assert.Empty(t, taskConfig.Volumes)
+			assert.Empty(t, taskConfig.VolumeMounts)
 		})
 	}
 }
@@ -1298,6 +1324,7 @@ func Test_extendPodSpecPatch_ImagePullSecrets(t *testing.T) {
 				nil,
 				nil,
 				tt.inputParams,
+				nil,
 			)
 			assert.Nil(t, err)
 			assert.NotNil(t, got)
@@ -1726,6 +1753,8 @@ func Test_extendPodSpecPatch_Tolerations(t *testing.T) {
 					Name: "main",
 				},
 			}}
+			taskConfig := &TaskConfig{}
+
 			err := extendPodSpecPatch(
 				context.Background(),
 				got,
@@ -1734,10 +1763,13 @@ func Test_extendPodSpecPatch_Tolerations(t *testing.T) {
 				nil,
 				nil,
 				tt.inputParams,
+				taskConfig,
 			)
 			assert.Nil(t, err)
 			assert.NotNil(t, got)
 			assert.Equal(t, tt.expected, got)
+
+			assert.Empty(t, taskConfig.Tolerations)
 		})
 	}
 }
@@ -1828,6 +1860,8 @@ func Test_extendPodSpecPatch_FieldPathAsEnv(t *testing.T) {
 					Name: "main",
 				},
 			}}
+			taskConfig := &TaskConfig{}
+
 			err := extendPodSpecPatch(
 				context.Background(),
 				got,
@@ -1836,10 +1870,13 @@ func Test_extendPodSpecPatch_FieldPathAsEnv(t *testing.T) {
 				nil,
 				nil,
 				map[string]*structpb.Value{},
+				taskConfig,
 			)
 			assert.Nil(t, err)
 			assert.NotNil(t, got)
 			assert.Equal(t, tt.expected, got)
+
+			assert.Empty(t, taskConfig.Env)
 		})
 	}
 }
@@ -1906,6 +1943,7 @@ func Test_extendPodSpecPatch_ActiveDeadlineSeconds(t *testing.T) {
 				nil,
 				nil,
 				map[string]*structpb.Value{},
+				nil,
 			)
 			assert.Nil(t, err)
 			assert.NotNil(t, got)
@@ -1995,6 +2033,7 @@ func Test_extendPodSpecPatch_ImagePullPolicy(t *testing.T) {
 				nil,
 				nil,
 				map[string]*structpb.Value{},
+				nil,
 			)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected, tt.podSpec)
@@ -2182,6 +2221,8 @@ func Test_extendPodSpecPatch_GenericEphemeralVolume(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			taskConfig := &TaskConfig{}
+
 			err := extendPodSpecPatch(
 				context.Background(),
 				tt.podSpec,
@@ -2190,9 +2231,13 @@ func Test_extendPodSpecPatch_GenericEphemeralVolume(t *testing.T) {
 				nil,
 				nil,
 				map[string]*structpb.Value{},
+				taskConfig,
 			)
 			assert.Nil(t, err)
 			assert.Equal(t, tt.expected, tt.podSpec)
+
+			assert.Empty(t, taskConfig.Volumes)
+			assert.Empty(t, taskConfig.VolumeMounts)
 		})
 	}
 }
@@ -2480,6 +2525,8 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := &k8score.PodSpec{Containers: []k8score.Container{{Name: "main"}}}
+			taskConfig := &TaskConfig{}
+
 			err := extendPodSpecPatch(
 				context.Background(),
 				got,
@@ -2488,6 +2535,7 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T) {
 				nil,
 				nil,
 				tt.inputParams,
+				taskConfig,
 			)
 			assert.NoError(t, err)
 
@@ -2506,7 +2554,157 @@ func Test_extendPodSpecPatch_NodeAffinity(t *testing.T) {
 				// For empty JSON case, affinity should not be set
 				assert.Nil(t, got.Affinity)
 			}
+
+			assert.Empty(t, taskConfig.Affinity)
 		})
+	}
+}
+
+func Test_extendPodSpecPatch_TaskConfig_CapturesAndApplies(t *testing.T) {
+	podSpec := &k8score.PodSpec{Containers: []k8score.Container{{Name: "main"}}}
+	cfg := &kubernetesplatform.KubernetesExecutorConfig{
+		NodeSelector: &kubernetesplatform.NodeSelector{Labels: map[string]string{"disktype": "ssd"}},
+		Tolerations: []*kubernetesplatform.Toleration{{
+			Key:               "example-key",
+			Operator:          "Exists",
+			Effect:            "NoExecute",
+			TolerationSeconds: int64Ptr(3600),
+		}},
+		SecretAsVolume: []*kubernetesplatform.SecretAsVolume{{
+			SecretName: "secret1",
+			MountPath:  "/data/secret",
+		}},
+		PvcMount: []*kubernetesplatform.PvcMount{{
+			MountPath:        "/data",
+			PvcNameParameter: inputParamConstant("kubernetes-task-config-pvc"),
+		}},
+		SecretAsEnv: []*kubernetesplatform.SecretAsEnv{{
+			SecretName: "my-secret",
+			KeyToEnv: []*kubernetesplatform.SecretAsEnv_SecretKeyToEnvMap{{
+				SecretKey: "password",
+				EnvVar:    "SECRET_VAR",
+			}},
+		}},
+		FieldPathAsEnv: []*kubernetesplatform.FieldPathAsEnv{{
+			Name:      "KFP_RUN_NAME",
+			FieldPath: "metadata.annotations['pipelines.kubeflow.org/run_name']",
+		}},
+		NodeAffinity: []*kubernetesplatform.NodeAffinityTerm{{
+			MatchExpressions: []*kubernetesplatform.SelectorRequirement{{
+				Key:      "disktype",
+				Operator: "In",
+				Values:   []string{"ssd"},
+			}},
+		}},
+	}
+
+	// Configure passthroughs according to expectations:
+	// - Volumes and Env: capture and apply to pod (apply_to_task=true)
+	// - NodeSelector, Tolerations, Affinity: capture only (apply_to_task=false)
+	comp := &pipelinespec.ComponentSpec{
+		TaskConfigPassthroughs: []*pipelinespec.TaskConfigPassthrough{
+			{Field: pipelinespec.TaskConfigPassthroughType_KUBERNETES_VOLUMES, ApplyToTask: true},
+			{Field: pipelinespec.TaskConfigPassthroughType_ENV, ApplyToTask: true},
+			{Field: pipelinespec.TaskConfigPassthroughType_KUBERNETES_NODE_SELECTOR, ApplyToTask: false},
+			{Field: pipelinespec.TaskConfigPassthroughType_KUBERNETES_TOLERATIONS, ApplyToTask: false},
+			{Field: pipelinespec.TaskConfigPassthroughType_KUBERNETES_AFFINITY, ApplyToTask: false},
+		},
+	}
+
+	taskCfg := &TaskConfig{}
+	err := extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		Options{KubernetesExecutorConfig: cfg, Component: comp},
+		nil,
+		nil,
+		nil,
+		map[string]*structpb.Value{},
+		taskCfg,
+	)
+	assert.NoError(t, err)
+
+	assert.Nil(t, podSpec.NodeSelector)
+	assert.Len(t, podSpec.Tolerations, 0)
+	assert.Empty(t, podSpec.Containers[0].Resources.Limits)
+	assert.Empty(t, podSpec.Containers[0].Resources.Requests)
+
+	if assert.GreaterOrEqual(t, len(podSpec.Containers[0].VolumeMounts), 1) {
+		foundSecretMount := false
+		foundPvcMount := false
+		for _, m := range podSpec.Containers[0].VolumeMounts {
+			if m.Name == "secret1" && m.MountPath == "/data/secret" {
+				foundSecretMount = true
+			}
+			if m.Name == "kubernetes-task-config-pvc" && m.MountPath == "/data" {
+				foundPvcMount = true
+			}
+		}
+
+		assert.True(t, foundSecretMount)
+		assert.True(t, foundPvcMount)
+	}
+
+	foundSecretEnv := false
+	foundFieldPathEnv := false
+	for _, e := range podSpec.Containers[0].Env {
+		if e.Name == "SECRET_VAR" && e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+			if e.ValueFrom.SecretKeyRef.Name == "my-secret" && e.ValueFrom.SecretKeyRef.Key == "password" {
+				foundSecretEnv = true
+			}
+		}
+		if e.Name == "KFP_RUN_NAME" && e.ValueFrom != nil && e.ValueFrom.FieldRef != nil {
+			if e.ValueFrom.FieldRef.FieldPath == "metadata.annotations['pipelines.kubeflow.org/run_name']" {
+				foundFieldPathEnv = true
+			}
+		}
+	}
+
+	assert.True(t, foundSecretEnv)
+	assert.True(t, foundFieldPathEnv)
+
+	assert.Equal(t, map[string]string{"disktype": "ssd"}, taskCfg.NodeSelector)
+	assert.Len(t, taskCfg.Tolerations, 1)
+	assert.Equal(t, "example-key", taskCfg.Tolerations[0].Key)
+	assert.Equal(t, "NoExecute", string(taskCfg.Tolerations[0].Effect))
+	assert.Equal(t, int64(3600), *taskCfg.Tolerations[0].TolerationSeconds)
+
+	if assert.NotEmpty(t, taskCfg.Volumes) && assert.NotEmpty(t, taskCfg.VolumeMounts) {
+		foundSecretVol := false
+		foundPvcVol := false
+		for _, v := range taskCfg.Volumes {
+			if v.Name == "secret1" && v.Secret != nil {
+				foundSecretVol = true
+			}
+			if v.Name == "kubernetes-task-config-pvc" && v.PersistentVolumeClaim != nil && v.PersistentVolumeClaim.ClaimName == "kubernetes-task-config-pvc" {
+				foundPvcVol = true
+			}
+		}
+		assert.True(t, foundSecretVol)
+		assert.True(t, foundPvcVol)
+	}
+
+	foundSecretEnv = false
+	foundFieldPathEnv = false
+	for _, e := range taskCfg.Env {
+		if e.Name == "SECRET_VAR" && e.ValueFrom != nil && e.ValueFrom.SecretKeyRef != nil {
+			if e.ValueFrom.SecretKeyRef.Name == "my-secret" && e.ValueFrom.SecretKeyRef.Key == "password" {
+				foundSecretEnv = true
+			}
+		}
+		if e.Name == "KFP_RUN_NAME" && e.ValueFrom != nil && e.ValueFrom.FieldRef != nil {
+			if e.ValueFrom.FieldRef.FieldPath == "metadata.annotations['pipelines.kubeflow.org/run_name']" {
+				foundFieldPathEnv = true
+			}
+		}
+	}
+	assert.True(t, foundSecretEnv)
+	assert.True(t, foundFieldPathEnv)
+
+	if assert.NotNil(t, taskCfg.Affinity) && assert.NotNil(t, taskCfg.Affinity.NodeAffinity) {
+		if assert.NotNil(t, taskCfg.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution) {
+			assert.Greater(t, len(taskCfg.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms), 0)
+		}
 	}
 }
 
@@ -2548,4 +2746,71 @@ func int64Ptr(val int64) *int64 {
 
 func int32Ptr(val int32) *int32 {
 	return &val
+}
+
+func Test_extendPodSpecPatch_PvcMounts_Passthrough_NotAppliedToPod(t *testing.T) {
+	podSpec := &k8score.PodSpec{Containers: []k8score.Container{{Name: "main"}}}
+	cfg := &kubernetesplatform.KubernetesExecutorConfig{
+		PvcMount: []*kubernetesplatform.PvcMount{{
+			MountPath:        "/data",
+			PvcNameParameter: inputParamConstant("my-pvc"),
+		}},
+	}
+	comp := &pipelinespec.ComponentSpec{
+		TaskConfigPassthroughs: []*pipelinespec.TaskConfigPassthrough{{
+			Field:       pipelinespec.TaskConfigPassthroughType_KUBERNETES_VOLUMES,
+			ApplyToTask: false,
+		}},
+	}
+	taskCfg := &TaskConfig{}
+	err := extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		Options{KubernetesExecutorConfig: cfg, Component: comp},
+		nil,
+		nil,
+		nil,
+		map[string]*structpb.Value{},
+		taskCfg,
+	)
+	assert.NoError(t, err)
+
+	assert.Empty(t, podSpec.Volumes)
+	assert.Empty(t, podSpec.Containers[0].VolumeMounts)
+
+	assert.NotEmpty(t, taskCfg.Volumes)
+	assert.NotEmpty(t, taskCfg.VolumeMounts)
+}
+
+func Test_extendPodSpecPatch_PvcMounts_Passthrough_AppliedToPod(t *testing.T) {
+	podSpec := &k8score.PodSpec{Containers: []k8score.Container{{Name: "main"}}}
+	cfg := &kubernetesplatform.KubernetesExecutorConfig{
+		PvcMount: []*kubernetesplatform.PvcMount{{
+			MountPath:        "/data",
+			PvcNameParameter: inputParamConstant("my-pvc"),
+		}},
+	}
+	comp := &pipelinespec.ComponentSpec{
+		TaskConfigPassthroughs: []*pipelinespec.TaskConfigPassthrough{{
+			Field:       pipelinespec.TaskConfigPassthroughType_KUBERNETES_VOLUMES,
+			ApplyToTask: true,
+		}},
+	}
+	taskCfg := &TaskConfig{}
+	err := extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		Options{KubernetesExecutorConfig: cfg, Component: comp},
+		nil,
+		nil,
+		nil,
+		map[string]*structpb.Value{},
+		taskCfg,
+	)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, podSpec.Volumes)
+	assert.NotEmpty(t, podSpec.Containers[0].VolumeMounts)
+	assert.NotEmpty(t, taskCfg.Volumes)
+	assert.NotEmpty(t, taskCfg.VolumeMounts)
 }

--- a/backend/test/proto_tests/testdata/generated-1791485/pipeline_spec.json
+++ b/backend/test/proto_tests/testdata/generated-1791485/pipeline_spec.json
@@ -68,7 +68,8 @@
           }
         }
       },
-      "single_platform_specs":  []
+      "single_platform_specs":  [],
+      "task_config_passthroughs":  []
     }
   },
   "root":  {
@@ -107,7 +108,8 @@
       }
     },
     "executor_label":  "root-executor",
-    "single_platform_specs":  []
+    "single_platform_specs":  [],
+    "task_config_passthroughs":  []
   },
   "default_pipeline_root":  ""
 }

--- a/samples/v2/sample_test.py
+++ b/samples/v2/sample_test.py
@@ -79,6 +79,7 @@ import pipeline_with_pod_metadata
 import pipeline_with_workspace
 from modelcar import modelcar
 import pipeline_with_utils
+import task_config
 
 
 _MINUTE = 60  # seconds
@@ -255,6 +256,7 @@ class SampleTest(unittest.TestCase):
             TestCase(pipeline_func=pipeline_with_pod_metadata.pipeline_with_pod_metadata),
             TestCase(pipeline_func=pipeline_with_workspace.pipeline_with_workspace),
             TestCase(pipeline_func=pipeline_with_utils.pipeline_with_utils),
+            TestCase(pipeline_func=task_config.pipeline_task_config),
         ]
 
         with ThreadPoolExecutor() as executor:

--- a/samples/v2/task_config.py
+++ b/samples/v2/task_config.py
@@ -1,0 +1,176 @@
+# Copyright 2025 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from kfp import dsl
+from kfp import compiler
+from kfp import kubernetes
+
+
+@dsl.component(
+    task_config_passthroughs=[
+        dsl.TaskConfigPassthrough(field=dsl.TaskConfigField.ENV, apply_to_task=True),
+        dsl.TaskConfigField.RESOURCES,
+        dsl.TaskConfigField.KUBERNETES_VOLUMES,
+        dsl.TaskConfigField.KUBERNETES_NODE_SELECTOR,
+        dsl.TaskConfigField.KUBERNETES_TOLERATIONS,
+        dsl.TaskConfigField.KUBERNETES_AFFINITY,
+    ],
+    kfp_package_path='git+https://github.com/kubeflow/pipelines@refs/pull/12185/merge#egg=kfp&subdirectory=sdk/python',
+)
+def echo_task_config(workspace_path: str, task_config: dsl.TaskConfig):
+    import dataclasses
+    import os
+    import pprint
+
+    assert task_config is not None
+
+    actual = dataclasses.asdict(task_config)
+    pprint.pprint(actual)
+
+    workspace_pvc_name = None
+    for volume in actual['volumes']:
+        if volume['name'] == 'kfp-workspace':
+            workspace_pvc_name = volume['persistentVolumeClaim']['claimName']
+            break
+    assert workspace_pvc_name is not None
+
+    expected = {
+        'affinity': {
+            'nodeAffinity': {
+                'requiredDuringSchedulingIgnoredDuringExecution': {
+                    'nodeSelectorTerms': [{
+                        'matchExpressions': [{
+                            'key': 'disktype',
+                            'operator': 'In',
+                            'values': ['ssd']
+                        }]
+                    }]
+                }
+            }
+        },
+        'env': [{
+            'name': 'ENV1',
+            'value': 'val1'
+        }, {
+            'name': 'ENV2',
+            'value': 'val2'
+        }],
+        'node_selector': {
+            'disktype': 'ssd'
+        },
+        'resources': {
+            'limits': {
+                'cpu': '100m',
+                'memory': '100Mi',
+                'nvidia.com/gpu': '1'
+            },
+            'requests': {
+                'cpu': '100m',
+                'memory': '100Mi'
+            }
+        },
+        'tolerations': [{
+            'effect': 'NoExecute',
+            'key': 'example-key',
+            'operator': 'Exists',
+            'tolerationSeconds': 3600
+        }],
+        'volume_mounts': [{
+            'mountPath': '/kfp-workspace',
+            'name': 'kfp-workspace'
+        }, {
+            'mountPath': '/data',
+            'name': 'kubernetes-task-config-pvc'
+        }],
+        'volumes': [{
+            'name': 'kfp-workspace',
+            'persistentVolumeClaim': {
+                'claimName': workspace_pvc_name
+            }
+        }, {
+            'name': 'kubernetes-task-config-pvc',
+            'persistentVolumeClaim': {
+                'claimName': 'kubernetes-task-config-pvc'
+            }
+        }]
+    }
+
+    assert actual == expected
+
+    assert os.getenv('ENV1') == 'val1'
+    assert os.getenv('ENV2') == 'val2'
+
+
+@dsl.pipeline(
+    name='task-config',
+    description='A simple intro pipeline',
+    pipeline_config=dsl.PipelineConfig(
+        workspace=dsl.WorkspaceConfig(
+            size='5Mi',
+            kubernetes=dsl.KubernetesWorkspaceConfig(
+                pvcSpecPatch={"storageClassName": "standard"}))))
+def pipeline_task_config():
+    """Pipeline that leverages dsl.TaskConfig."""
+    pvc1 = kubernetes.CreatePVC(
+        pvc_name='kubernetes-task-config-pvc',
+        access_modes=['ReadWriteOnce'],
+        size='5Mi',
+        storage_class_name='standard',
+    ).set_caching_options(False)
+    echo_task_config_task = echo_task_config(
+        workspace_path=dsl.WORKSPACE_PATH_PLACEHOLDER).set_caching_options(
+            False).set_cpu_request('100m').set_memory_request(
+                '100Mi').set_cpu_limit('100m').set_memory_limit(
+                    '100Mi').set_accelerator_type(
+                        'nvidia.com/gpu').set_accelerator_limit(1)
+
+    kubernetes.mount_pvc(
+        echo_task_config_task,
+        pvc_name=pvc1.outputs['name'],
+        mount_path='/data',
+    )
+
+    kubernetes.add_node_selector(
+        echo_task_config_task,
+        label_key='disktype',
+        label_value='ssd',
+    )
+
+    kubernetes.add_toleration(
+        echo_task_config_task,
+        key='example-key',
+        operator='Exists',
+        effect='NoExecute',
+        toleration_seconds=3600,
+    )
+
+    kubernetes.add_node_affinity(
+        echo_task_config_task,
+        match_expressions=[{
+            'key': 'disktype',
+            'operator': 'In',
+            'values': ['ssd']
+        }])
+
+    echo_task_config_task.set_env_variable(name='ENV1', value='val1')
+    echo_task_config_task.set_env_variable(name='ENV2', value='val2')
+
+    delete_pvc1 = kubernetes.DeletePVC(pvc_name=pvc1.outputs['name']).after(
+        echo_task_config_task).set_caching_options(False)
+
+
+if __name__ == "__main__":
+    # execute only if run as a script
+    compiler.Compiler().compile(
+        pipeline_func=pipeline_task_config,
+        package_path=__file__.replace('.py', '.yaml'))

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     'InputPath',
     'OutputPath',
     'PipelineTaskFinalStatus',
+    'TaskConfig',
     'Artifact',
     'ClassificationMetrics',
     'Dataset',
@@ -44,6 +45,7 @@ __all__ = [
 ]
 import os
 
+from kfp.dsl.task_config import TaskConfig
 from kfp.dsl.task_final_status import PipelineTaskFinalStatus
 from kfp.dsl.types.artifact_types import Artifact
 from kfp.dsl.types.artifact_types import ClassificationMetrics
@@ -283,6 +285,8 @@ Example:
 # compile-time only dependencies
 if os.environ.get('_KFP_RUNTIME', 'false') != 'true':
     from kfp.dsl.component_decorator import component
+    from kfp.dsl.component_task_config import TaskConfigField
+    from kfp.dsl.component_task_config import TaskConfigPassthrough
     from kfp.dsl.container_component_decorator import container_component
     # TODO: Collected should be moved to pipeline_channel.py, consistent with OneOf
     from kfp.dsl.for_loop import Collected
@@ -307,5 +311,6 @@ if os.environ.get('_KFP_RUNTIME', 'false') != 'true':
         'ContainerSpec', 'Condition', 'If', 'Elif', 'Else', 'OneOf',
         'ExitHandler', 'ParallelFor', 'Collected', 'IfPresentPlaceholder',
         'ConcatPlaceholder', 'PipelineTask', 'PipelineConfig',
-        'WorkspaceConfig', 'KubernetesWorkspaceConfig'
+        'WorkspaceConfig', 'KubernetesWorkspaceConfig', 'TaskConfigField',
+        'TaskConfigPassthrough'
     ])

--- a/sdk/python/kfp/dsl/component_task_config.py
+++ b/sdk/python/kfp/dsl/component_task_config.py
@@ -1,0 +1,53 @@
+"""Definition for TaskConfig."""
+
+import dataclasses
+from enum import IntEnum
+
+from kfp.pipeline_spec import pipeline_spec_pb2
+
+
+class TaskConfigField(IntEnum):
+    # Indicates that the resource limits and requests should be passed through to the external workload.
+    # Be cautious about also setting apply_to_task=True since that will double the resources required
+    # for the task.
+    RESOURCES = (
+        pipeline_spec_pb2.TaskConfigPassthroughType
+        .TaskConfigPassthroughTypeEnum.RESOURCES)
+    # Indicates that the environment variables should be passed through to the external workload.
+    # It is generally safe to always set apply_to_task=True on this field.
+    ENV = (
+        pipeline_spec_pb2.TaskConfigPassthroughType
+        .TaskConfigPassthroughTypeEnum.ENV)
+    # Indicates that the Kubernetes node affinity should be passed through to the external workload.
+    KUBERNETES_AFFINITY = (
+        pipeline_spec_pb2.TaskConfigPassthroughType
+        .TaskConfigPassthroughTypeEnum.KUBERNETES_AFFINITY)
+    # Indicates that the Kubernetes node tolerations should be passed through to the external workload.
+    KUBERNETES_TOLERATIONS = (
+        pipeline_spec_pb2.TaskConfigPassthroughType
+        .TaskConfigPassthroughTypeEnum.KUBERNETES_TOLERATIONS)
+    # Indicates that the Kubernetes node selector should be passed through to the external workload.
+    KUBERNETES_NODE_SELECTOR = (
+        pipeline_spec_pb2.TaskConfigPassthroughType
+        .TaskConfigPassthroughTypeEnum.KUBERNETES_NODE_SELECTOR)
+    # Indicates that the Kubernetes persistent volumes and ConfigMaps/Secrets mounted as volumes should be passed
+    # through to the external workload. Be sure that when setting apply_to_task=True, the volumes are ReadWriteMany or ReadOnlyMany or else
+    # the task's pod may not start.
+    # This is useful when the task prepares a shared volume for the external workload or defines output artifact
+    # (e.g. dsl.Model) that is created by the external workload.
+    KUBERNETES_VOLUMES = (
+        pipeline_spec_pb2.TaskConfigPassthroughType
+        .TaskConfigPassthroughTypeEnum.KUBERNETES_VOLUMES)
+
+
+@dataclasses.dataclass
+class TaskConfigPassthrough:
+    field: TaskConfigField
+    apply_to_task: bool = False
+
+    def to_proto(self) -> pipeline_spec_pb2.TaskConfigPassthrough:
+        """Converts this object to its proto representation."""
+        proto = pipeline_spec_pb2.TaskConfigPassthrough()
+        proto.field = int(self.field)
+        proto.apply_to_task = self.apply_to_task
+        return proto

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -26,8 +26,10 @@ import kfp
 from kfp.dsl import placeholders
 from kfp.dsl import utils
 from kfp.dsl import v1_structures
+from kfp.dsl.component_task_config import TaskConfigPassthrough
 from kfp.dsl.container_component_artifact_channel import \
     ContainerComponentArtifactChannel
+from kfp.dsl.task_config import TaskConfig
 from kfp.dsl.types import artifact_types
 from kfp.dsl.types import type_annotations
 from kfp.dsl.types import type_utils
@@ -223,7 +225,9 @@ def spec_type_is_parameter(type_: str) -> bool:
     in_memory_type = type_annotations.maybe_strip_optional_from_annotation_string(
         type_utils.get_canonical_name_for_outer_generic(type_))
 
-    return in_memory_type in type_utils.IN_MEMORY_SPEC_TYPE_TO_IR_TYPE or in_memory_type == 'PipelineTaskFinalStatus'
+    return (in_memory_type in type_utils.IN_MEMORY_SPEC_TYPE_TO_IR_TYPE or
+            in_memory_type == 'PipelineTaskFinalStatus' or
+            in_memory_type == 'TaskConfig')
 
 
 @dataclasses.dataclass
@@ -570,6 +574,8 @@ class ComponentSpec:
     outputs: Optional[Dict[str, OutputSpec]] = None
     platform_spec: pipeline_spec_pb2.PlatformSpec = dataclasses.field(
         default_factory=pipeline_spec_pb2.PlatformSpec)
+    # Optional passthroughs for TaskConfig fields
+    task_config_passthroughs: Optional[List[TaskConfigPassthrough]] = None
 
     def __post_init__(self) -> None:
         self._transform_name()

--- a/sdk/python/kfp/dsl/task_config.py
+++ b/sdk/python/kfp/dsl/task_config.py
@@ -1,0 +1,118 @@
+"""Definition for TaskConfig."""
+
+import dataclasses
+from typing import Any, Dict, List, Optional
+
+
+# TaskConfig needs to stay aligned with the TaskConfig in backend/src/v2/driver/driver.go.
+@dataclasses.dataclass
+class TaskConfig:
+    """Configurations for a task.
+
+    Annotate a component parameter with this type when you want the task's
+    runtime configuration to be forwarded to an external workload and optionally applied to the
+    task's own pod. This is useful when the task launches another Kubernetes resource (for example,
+    a Kubeflow Trainer job).
+
+    This is an empty value by default and is populated if the component is annotated with
+    task_config_passthroughs.
+
+    All fields are optional and map 1:1 to fragments of the Kubernetes Pod
+    spec. These fields have values as Python dictionaries/lists that conform to the
+    Kubernetes JSON schema.
+
+    Example:
+      ::
+
+        @dsl.component(
+            packages_to_install=["kubernetes"],
+            task_config_passthroughs=[
+                dsl.TaskConfigField.RESOURCES,
+                dsl.TaskConfigField.KUBERNETES_TOLERATIONS,
+                dsl.TaskConfigField.KUBERNETES_NODE_SELECTOR,
+                dsl.TaskConfigField.KUBERNETES_AFFINITY,
+                dsl.TaskConfigPassthrough(field=dsl.TaskConfigField.ENV, apply_to_task=True),
+                dsl.TaskConfigPassthrough(field=dsl.TaskConfigField.KUBERNETES_VOLUMES, apply_to_task=True),
+            ],
+        )
+        def train(num_nodes: int, workspace_path: str, output_model: dsl.Output[dsl.Model], task_config: dsl.TaskConfig):
+            import os
+            import shutil
+            from kubernetes import client as k8s_client, config
+            config.load_incluster_config()
+
+            with open(
+                    "/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r"
+                ) as ns_file:
+                    namespace = ns_file.readline()
+
+            train_job_script = "with open('/kfp-workspace/model', 'w') as f: f.write('hello')"
+
+            dataset_path = os.path.join(workspace_path, "dataset")
+            with open(dataset_path, "w") as f:
+                f.write("Prepare dataset here...")
+
+            train_job = {
+                    "apiVersion": "trainer.kubeflow.org/v1alpha1",
+                    "kind": "TrainJob",
+                    "metadata": {"name": f"kfp-train-job", "namespace": namespace},
+                    "spec": {
+                        "runtimeRef": {"name": "torch-distributed"},
+                        "trainer": {
+                            "numNodes": num_nodes,
+                            "resourcesPerNode": task_config.resources,
+                            "env": task_config.env,
+                            "command": ["python", "-c", train_job_script],
+                        },
+                        "podSpecOverrides": [
+                            {
+                                "targetJobs": [{"name": "node"}],
+                                "volumes": task_config.volumes,
+                                "containers": [
+                                    {
+                                        "name": "node",
+                                        "volumeMounts": task_config.volume_mounts,
+                                    }
+                                ],
+                                "nodeSelector": task_config.node_selector,
+                                "tolerations": task_config.tolerations,
+                            }
+                        ],
+                    },
+                }
+            print(train_job)
+            api_client = k8s_client.ApiClient()
+            custom_objects_api = k8s_client.CustomObjectsApi(api_client)
+            response = custom_objects_api.create_namespaced_custom_object(
+                group="trainer.kubeflow.org",
+                version="v1alpha1",
+                namespace=namespace,
+                plural="trainjobs",
+                body=train_job,
+            )
+            job_name = response["metadata"]["name"]
+            print(f"TrainJob {job_name} created successfully")
+
+            print("Polling train job code goes here...")
+
+            print("Copying output model")
+            shutil.copy(os.path.join(workspace_path, "model"), output_model.path)
+
+        @dsl.pipeline
+        def example_task_config():
+            train_task = train(num_nodes=1, workspace_path=dsl.WORKSPACE_PATH_PLACEHOLDER)
+            train_task.set_cpu_request("1")
+            train_task.set_memory_request("20Gi")
+            train_task.set_cpu_limit("2")
+            train_task.set_memory_limit("50Gi")
+            train_task.set_accelerator_type("nvidia.com/gpu")
+            train_task.set_accelerator_limit("1")
+    """
+
+    affinity: Optional[Dict[str, Any]] = None
+    tolerations: Optional[List[Dict[str, Any]]] = None
+    node_selector: Optional[Dict[str, str]] = None
+    env: Optional[List[Dict[str, Any]]] = None
+    volumes: Optional[List[Dict[str, Any]]] = None
+    volume_mounts: Optional[List[Dict[str, Any]]] = None
+    resources: Optional[Dict[str, Any]] = None

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -20,6 +20,7 @@ import warnings
 
 import kfp
 from kfp.dsl import task_final_status
+from kfp.dsl.task_config import TaskConfig
 from kfp.dsl.types import artifact_types
 from kfp.dsl.types import type_annotations
 
@@ -146,6 +147,18 @@ def is_task_final_status_type(type_name: Optional[Union[str, dict]]) -> bool:
         type_name == task_final_status.PipelineTaskFinalStatus.__name__)
 
 
+def is_task_config_type(type_name: Optional[Union[str, dict]]) -> bool:
+    """Check if a ComponentSpec I/O type is TaskConfig.
+
+    Args:
+      type_name: type name of the ComponentSpec I/O type.
+
+    Returns:
+      True if the type name is 'TaskConfig'.
+    """
+    return isinstance(type_name, str) and (type_name == TaskConfig.__name__)
+
+
 def is_parameter_type(type_name: Optional[Union[str, dict]]) -> bool:
     """Check if a ComponentSpec I/O type is considered as a parameter type.
 
@@ -163,7 +176,8 @@ def is_parameter_type(type_name: Optional[Union[str, dict]]) -> bool:
         return False
 
     return type_name.lower(
-    ) in PARAMETER_TYPES_MAPPING or is_task_final_status_type(type_name)
+    ) in PARAMETER_TYPES_MAPPING or is_task_final_status_type(
+        type_name) or is_task_config_type(type_name)
 
 
 def bundled_artifact_to_artifact_proto(
@@ -195,8 +209,8 @@ def get_parameter_type(
     Raises:
       AttributeError: if type_name is not a string type.
     """
-    # Special handling for PipelineTaskFinalStatus, treat it as Dict type.
-    if is_task_final_status_type(param_type):
+    # Special handling for PipelineTaskFinalStatus and TaskConfig, treat them as Dict type.
+    if is_task_final_status_type(param_type) or is_task_config_type(param_type):
         param_type = 'dict'
     if type(param_type) == type:
         type_name = param_type.__name__
@@ -461,6 +475,7 @@ IR_TYPE_TO_IN_MEMORY_SPEC_TYPE = {
     'STRUCT': 'Dict',
     'BOOLEAN': 'Boolean',
     'TASK_FINAL_STATUS': task_final_status.PipelineTaskFinalStatus.__name__,
+    'TASK_CONFIG': TaskConfig.__name__,
 }
 
 IR_TYPE_TO_COMMENT_TYPE_STRING = {
@@ -471,6 +486,7 @@ IR_TYPE_TO_COMMENT_TYPE_STRING = {
     'STRUCT': dict.__name__,
     'BOOLEAN': bool.__name__,
     'TASK_FINAL_STATUS': task_final_status.PipelineTaskFinalStatus.__name__,
+    'TASK_CONFIG': TaskConfig.__name__,
 }
 
 IN_MEMORY_SPEC_TYPE_TO_IR_TYPE = {


### PR DESCRIPTION
**Description of your changes:**

This PR introduces a powerful new feature that allows KFP tasks to forward their task configuration (resources, environment variables, node selectors, tolerations, affinity, volumes) to external workloads like Kubeflow TrainJobs, rather than applying them only to the task pod itself. This is particularly valuable for scenarios where the KFP task is launching another Kubernetes workload (e.g. `TrainJob`, `Job`, etc).

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
