### PR TITLE
chore: fix import order in 6 files (baseline formatting)

### DIFF
--- a/backend/test/v2/api/logger/logger.go
+++ b/backend/test/v2/api/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+
 	"github.com/onsi/ginkgo/v2"
 )
 

--- a/backend/test/v2/api/matcher/custom_matcher.go
+++ b/backend/test/v2/api/matcher/custom_matcher.go
@@ -16,8 +16,9 @@ package matcher
 
 import (
 	"fmt"
-	"github.com/onsi/ginkgo/v2"
 	"reflect"
+
+	"github.com/onsi/ginkgo/v2"
 
 	"github.com/onsi/gomega"
 )

--- a/backend/test/v2/api/matcher/pipeline_matcher.go
+++ b/backend/test/v2/api/matcher/pipeline_matcher.go
@@ -2,8 +2,9 @@ package matcher
 
 import (
 	"fmt"
-	"github.com/kubeflow/pipelines/backend/src/apiserver/template"
 	"time"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/template"
 
 	"github.com/kubeflow/pipelines/backend/test/v2/api/logger"
 	"github.com/onsi/ginkgo/v2"

--- a/backend/test/v2/api/test_context.go
+++ b/backend/test/v2/api/test_context.go
@@ -1,9 +1,10 @@
 package api
 
 import (
+	"time"
+
 	upload_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service"
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_model"
-	"time"
 )
 
 type TestContext struct {

--- a/backend/test/v2/api/utils/config_utils.go
+++ b/backend/test/v2/api/utils/config_utils.go
@@ -15,11 +15,12 @@
 package test
 
 import (
-	"github.com/kubeflow/pipelines/backend/test/v2/api/logger"
 	"io"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/kubeflow/pipelines/backend/test/v2/api/logger"
 
 	"github.com/cenkalti/backoff"
 	"github.com/pkg/errors"

--- a/backend/test/v2/api/utils/file_utils.go
+++ b/backend/test/v2/api/utils/file_utils.go
@@ -15,16 +15,17 @@
 package test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
+
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/server"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/template"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
-	"os"
-	"path/filepath"
 	"sigs.k8s.io/yaml"
-	"strings"
 
 	"github.com/kubeflow/pipelines/backend/test/v2/api/logger"
 	"github.com/onsi/gomega"


### PR DESCRIPTION
Context:
- Local pre-commit runs `golangci-lint fmt` and reorders imports in 6 legacy files on every commit.
- CI only runs `golangci-lint run --new-from-rev HEAD` and reports 0 issues, so these legacy files stayed as-is in main.

What this PR does:
- Reorders imports in the 6 files to align with the formatter expectations.
- No functional changes; formatting-only baseline to avoid unrelated diffs in future feature PRs.

Notes:
- After this baseline formatting, local pre-commit will no longer pull these files into unrelated commits.