### PR TITLE
feat(backend): Add configuration to conditionally disable shared pipeline resources

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -32,10 +32,15 @@ const (
 	KubeflowUserIDPrefix                    string = "KUBEFLOW_USERID_PREFIX"
 	UpdatePipelineVersionByDefault          string = "AUTO_UPDATE_PIPELINE_DEFAULT_VERSION"
 	TokenReviewAudience                     string = "TOKEN_REVIEW_AUDIENCE"
+	RequireNamespaceForPipelines            string = "REQUIRE_NAMESPACE_FOR_PIPELINES"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {
 	return GetBoolConfigWithDefault(UpdatePipelineVersionByDefault, true)
+}
+
+func IsNamespaceRequiredForPipelines() bool {
+	return GetBoolConfigWithDefault(RequireNamespaceForPipelines, false)
 }
 
 func GetStringConfig(configName string) string {

--- a/backend/src/apiserver/server/pipeline_server.go
+++ b/backend/src/apiserver/server/pipeline_server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/list"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/validation"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -121,6 +122,10 @@ type PipelineServerV1 struct {
 // Applies common logic on v1beta1 and v2beta1 API.
 func (s *BasePipelineServer) createPipeline(ctx context.Context, pipeline *model.Pipeline) (*model.Pipeline, error) {
 	pipeline.Namespace = s.resourceManager.ReplaceNamespace(pipeline.Namespace)
+	err := validation.ValidateNamespaceRequired(pipeline.Namespace)
+	if err != nil {
+		return nil, err
+	}
 
 	if pipeline.Name == "" {
 		return nil, util.NewInvalidInputError("name is required")
@@ -151,6 +156,10 @@ func (s *BasePipelineServer) createPipelineAndPipelineVersion(ctx context.Contex
 	}
 
 	pipeline.Namespace = s.resourceManager.ReplaceNamespace(pipeline.Namespace)
+	err := validation.ValidateNamespaceRequired(pipeline.Namespace)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Check authorization
 	resourceAttributes := &authorizationv1.ResourceAttributes{
@@ -328,6 +337,9 @@ func (s *PipelineServer) GetPipeline(ctx context.Context, request *apiv2beta1.Ge
 // Applies common logic on v1beta1 and v2beta1 API.
 func (s *BasePipelineServer) getPipelineByName(ctx context.Context, name string, namespace string, apiRequestVersion string) (*model.Pipeline, *model.PipelineVersion, error) {
 	namespace = s.resourceManager.ReplaceNamespace(namespace)
+	if err := validation.ValidateNamespaceRequired(namespace); err != nil {
+		return nil, nil, err
+	}
 	resourceAttributes := &authorizationv1.ResourceAttributes{
 		Namespace: namespace,
 		Name:      name,
@@ -389,6 +401,9 @@ func (s *PipelineServer) GetPipelineByName(ctx context.Context, request *apiv2be
 func (s *BasePipelineServer) listPipelines(ctx context.Context, namespace string, pageToken string, pageSize int32, sortBy string, opts *list.Options, apiRequestVersion string) ([]*model.Pipeline, []*model.PipelineVersion, int, string, error) {
 	// Fill in the default namespace
 	namespace = s.resourceManager.ReplaceNamespace(namespace)
+	if err := validation.ValidateNamespaceRequired(namespace); err != nil {
+		return nil, nil, 0, "", err
+	}
 	resourceAttributes := &authorizationv1.ResourceAttributes{
 		Namespace: namespace,
 		Verb:      common.RbacResourceVerbList,

--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -115,6 +115,11 @@ func (s *PipelineUploadServer) uploadPipeline(api_version string, w http.Respons
 		return
 	}
 	pipelineNamespace = s.resourceManager.ReplaceNamespace(pipelineNamespace)
+	err = validation.ValidateNamespaceRequired(pipelineNamespace)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	resourceAttributes := &authorizationv1.ResourceAttributes{
 		Namespace: pipelineNamespace,
 		Verb:      common.RbacResourceVerbCreate,
@@ -252,6 +257,12 @@ func (s *PipelineUploadServer) uploadPipelineVersion(api_version string, w http.
 	namespace, err := s.resourceManager.FetchNamespaceFromPipelineId(pipelineId)
 	if err != nil {
 		s.writeErrorToResponse(w, http.StatusBadRequest, util.Wrap(err, "Failed to create a pipeline version due to error reading namespace"))
+		return
+	}
+
+	err = validation.ValidateNamespaceRequired(namespace)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/backend/src/apiserver/validation/namespace.go
+++ b/backend/src/apiserver/validation/namespace.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+)
+
+// ValidateNamespaceRequired validates that a namespace is provided when required by configuration.
+// This ensures consistent authorization behavior across all KFP resources.
+// Only validates in multi-user mode, since single-user mode always uses empty namespaces by design.
+func ValidateNamespaceRequired(namespace string) error {
+	if common.IsMultiUserMode() && common.IsNamespaceRequiredForPipelines() && namespace == "" {
+		return util.NewInvalidInputError("Namespace is required for pipeline operations")
+	}
+	return nil
+}


### PR DESCRIPTION
**Description of your changes:**
This PR will add a new configuration option for Kubeflow to optionally disable the ability to upload pipelines to the "shared" space (achieved by setting `namespace` to `None`/`""`).

This config will default to the same behaviour as right now (allowing shared pipelines) so this should not be a breaking change for existing users.


I was curious about the possibility of even doing this which is why I started drafting the code change up front.

I have now opened this PR early to share the idea; if you are open to merging this change I can implement the relevant tests and any other bits that are needed in order to get this in. 

I summarised the problem I am trying to solve with this in the [CNCF Slack group](https://cloud-native.slack.com/archives/C073W572LA2/p1756370497489509); I've copied the important bits below:

<details>
<summary>problem statement</summary>

I'm working in an environment where we want to deploy Kubeflow in a multi-tenant way; where I can isolate access to each tenant based on the authorisation of the logged in user. 
For example I have a single Kubeflow instance, with 3 tenants that need to use it - "Project A", "Project B", and "Project C".

Alice and Alex work on A, Bob works on B, and Charlie works on C. Users that work on a particular project should not have access to resources for an other project.

To implement this, I have created KubeFlow Profiles for "Proj-A", "Proj-B", and "Proj-C". As the notebook instances within those profiles don't have access controls (and after reading [previous threads on this matter](https://cloud-native.slack.com/archives/C073W562HFY/p1725981979787589?thread_ts=1725779249.393399&cid=C073W562HFY)), I have also created "child" profiles for each of my users - "Alice-A", "Alex-A", "Bob-B", "Charlie-C". So Alice has access to "Proj-A" and "Alice-A" (and the rest follow similarly)

I had hoped to have each user work in notebooks in their private profiles and, once they have created a pipeline that they think is worth using longer-term, they "publish" it to the project's main profile.

In my testing of this setup I have realised that:
1. ~I can't find a way to allow a notebook in profile "Alice-A" to upload/publish a pipeline to "Proj-A"'s private pipeline space~
    - I solved this with the kind guidance of `Julius von Kohout`
2. They can upload to the Shared space (by setting `namespace=None` in the `upload` API call), but unfortunately, any profile in the kubeflow instance can access them - I want to avoid this possibility (whether done by accident or otherwise).

</details>


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
