### PR TITLE
Revert "fix(backend): Guard against panic when MLMD execution publish…

### DIFF
--- a/.github/resources/scripts/kfp-readiness/wait_for_pods.py
+++ b/.github/resources/scripts/kfp-readiness/wait_for_pods.py
@@ -77,7 +77,7 @@ def print_get_pods():
         print(f"An error occurred while running kubectl get pods: {e.stderr}")
 
 
-def check_pods(calm_time=10, timeout=900, retries_after_ready=5):
+def check_pods(calm_time=10, timeout=600, retries_after_ready=5):
     start_time = time.time()
     stable_count = 0
     previous_statuses = {}

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -171,11 +171,6 @@ func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 	var outputArtifacts []*metadata.OutputArtifact
 	status := pb.Execution_FAILED
 	defer func() {
-		if execution == nil {
-			glog.Errorf("Skipping publish since execution is nil. Original err is: %v", err)
-			return
-		}
-
 		if perr := l.publish(ctx, execution, executorOutput, outputArtifacts, status); perr != nil {
 			if err != nil {
 				err = fmt.Errorf("failed to publish execution with error %s after execution failed: %s", perr.Error(), err.Error())
@@ -317,25 +312,17 @@ func (l *LauncherV2) publish(
 	outputArtifacts []*metadata.OutputArtifact,
 	status pb.Execution_State,
 ) (err error) {
-	if execution == nil {
-		return fmt.Errorf("failed to publish results to ML Metadata: execution is nil")
-	}
-
-	var outputParameters map[string]*structpb.Value
-	if executorOutput != nil {
-		outputParameters = executorOutput.GetParameterValues()
-	}
-
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("failed to publish results to ML Metadata: %w", err)
+		}
+	}()
+	outputParameters := executorOutput.GetParameterValues()
 	// TODO(Bobgy): upload output artifacts.
 	// TODO(Bobgy): when adding artifacts, we will need execution.pipeline to be non-nil, because we need
 	// to publish output artifacts to the context too.
 	// return l.metadataClient.PublishExecution(ctx, execution, outputParameters, outputArtifacts, pb.Execution_COMPLETE)
-	err = l.clientManager.MetadataClient().PublishExecution(ctx, execution, outputParameters, outputArtifacts, status)
-	if err != nil {
-		return fmt.Errorf("failed to publish results to ML Metadata: %w", err)
-	}
-
-	return nil
+	return l.clientManager.MetadataClient().PublishExecution(ctx, execution, outputParameters, outputArtifacts, status)
 }
 
 // executeV2 handles placeholder substitution for inputs, calls execute to


### PR DESCRIPTION
…ing fails (#12203)"

This reverts commit a09fc030e9341553bafb68a14bb0789bac8b43b4 because it seems to be causing CI failures in the master branch. 
