### PR TITLE
chore(backend): correct node id for metrics reporting

### DIFF
--- a/backend/src/agent/persistence/worker/metrics_reporter_test.go
+++ b/backend/src/agent/persistence/worker/metrics_reporter_test.go
@@ -172,7 +172,7 @@ func TestReportMetrics_Succeed(t *testing.T) {
 	pipelineFake.StubArtifact(
 		&api.ReadArtifactRequest{
 			RunId:        "run-1",
-			NodeId:       "MY_NAME-template-1-1",
+			NodeId:       "node-1",
 			ArtifactName: "mlpipeline-metrics",
 		},
 		&api.ReadArtifactResponse{
@@ -190,12 +190,12 @@ func TestReportMetrics_Succeed(t *testing.T) {
 		Metrics: []*api.RunMetric{
 			{
 				Name:   "accuracy",
-				NodeId: "MY_NAME-template-1-1",
+				NodeId: "node-1",
 				Value:  &api.RunMetric_NumberValue{NumberValue: 0.77},
 			},
 			{
 				Name:   "logloss",
-				NodeId: "MY_NAME-template-1-1",
+				NodeId: "node-1",
 				Value:  &api.RunMetric_NumberValue{NumberValue: 1.2},
 			},
 		},
@@ -235,7 +235,7 @@ func TestReportMetrics_EmptyArchive_Fail(t *testing.T) {
 	pipelineFake.StubArtifact(
 		&api.ReadArtifactRequest{
 			RunId:        "run-1",
-			NodeId:       "MY_NAME-template-1-1",
+			NodeId:       "node-1",
 			ArtifactName: "mlpipeline-metrics",
 		},
 		&api.ReadArtifactResponse{
@@ -263,7 +263,7 @@ func TestReportMetrics_MultipleFilesInArchive_Fail(t *testing.T) {
 		Status: workflowapi.WorkflowStatus{
 			Nodes: map[string]workflowapi.NodeStatus{
 				"node-1": {
-					ID:           "MY_NAME-template-1-1",
+					ID:           "node-1",
 					TemplateName: "template-1",
 					Phase:        workflowapi.NodeSucceeded,
 					Outputs: &workflowapi.Outputs{
@@ -279,7 +279,7 @@ func TestReportMetrics_MultipleFilesInArchive_Fail(t *testing.T) {
 	pipelineFake.StubArtifact(
 		&api.ReadArtifactRequest{
 			RunId:        "run-1",
-			NodeId:       "MY_NAME-template-1-1",
+			NodeId:       "node-1",
 			ArtifactName: "mlpipeline-metrics",
 		},
 		&api.ReadArtifactResponse{
@@ -322,7 +322,7 @@ func TestReportMetrics_InvalidMetricsJSON_Fail(t *testing.T) {
 	pipelineFake.StubArtifact(
 		&api.ReadArtifactRequest{
 			RunId:        "run-1",
-			NodeId:       "MY_NAME-template-1-1",
+			NodeId:       "node-1",
 			ArtifactName: "mlpipeline-metrics",
 		},
 		&api.ReadArtifactResponse{
@@ -376,7 +376,7 @@ func TestReportMetrics_InvalidMetricsJSON_PartialFail(t *testing.T) {
 	pipelineFake.StubArtifact(
 		&api.ReadArtifactRequest{
 			RunId:        "run-1",
-			NodeId:       "MY_NAME-template-1-1",
+			NodeId:       "node-1",
 			ArtifactName: "mlpipeline-metrics",
 		},
 		&api.ReadArtifactResponse{
@@ -385,7 +385,7 @@ func TestReportMetrics_InvalidMetricsJSON_PartialFail(t *testing.T) {
 	pipelineFake.StubArtifact(
 		&api.ReadArtifactRequest{
 			RunId:        "run-1",
-			NodeId:       "MY_NAME-template-2-2",
+			NodeId:       "node-2",
 			ArtifactName: "mlpipeline-metrics",
 		},
 		&api.ReadArtifactResponse{
@@ -402,12 +402,12 @@ func TestReportMetrics_InvalidMetricsJSON_PartialFail(t *testing.T) {
 		Metrics: []*api.RunMetric{
 			{
 				Name:   "accuracy",
-				NodeId: "MY_NAME-template-2-2",
+				NodeId: "node-2",
 				Value:  &api.RunMetric_NumberValue{NumberValue: 0.77},
 			},
 			{
 				Name:   "logloss",
-				NodeId: "MY_NAME-template-2-2",
+				NodeId: "node-2",
 				Value:  &api.RunMetric_NumberValue{NumberValue: 1.2},
 			},
 		},
@@ -446,7 +446,7 @@ func TestReportMetrics_CorruptedArchiveFile_Fail(t *testing.T) {
 	pipelineFake.StubArtifact(
 		&api.ReadArtifactRequest{
 			RunId:        "run-1",
-			NodeId:       "MY_NAME-template-1-1",
+			NodeId:       "node-1",
 			ArtifactName: "mlpipeline-metrics",
 		},
 		&api.ReadArtifactResponse{
@@ -490,7 +490,7 @@ func TestReportMetrics_MultiplMetricErrors_TransientErrowWin(t *testing.T) {
 	pipelineFake.StubArtifact(
 		&api.ReadArtifactRequest{
 			RunId:        "run-1",
-			NodeId:       "MY_NAME-template-1-1",
+			NodeId:       "node-1",
 			ArtifactName: "mlpipeline-metrics",
 		},
 		&api.ReadArtifactResponse{
@@ -553,7 +553,7 @@ func TestReportMetrics_Unauthorized(t *testing.T) {
 	pipelineFake.StubArtifact(
 		&api.ReadArtifactRequest{
 			RunId:        "run-1",
-			NodeId:       "MY_NAME-template-1-1",
+			NodeId:       "node-1",
 			ArtifactName: "mlpipeline-metrics",
 		},
 		&api.ReadArtifactResponse{

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -513,7 +513,7 @@ func collectNodeMetricsOrNil(runID string, nodeStatus *workflowapi.NodeStatus, r
 		return nil, err
 	}
 
-	retrievedNodeID := RetrievePodName(wf, *nodeStatus)
+	retrievedNodeID := nodeStatus.ID
 	// Proto json lib requires a proto message before unmarshal data from JSON. We use
 	// ReportRunMetricsRequest as a workaround to hold user's metrics, which is a superset of what
 	// user can provide.
@@ -579,7 +579,7 @@ func readNodeMetricsJSONOrEmpty(runID string, nodeStatus *workflowapi.NodeStatus
 
 	artifactRequest := &api.ReadArtifactRequest{
 		RunId:        runID,
-		NodeId:       RetrievePodName(*wf, *nodeStatus),
+		NodeId:       nodeStatus.ID,
 		ArtifactName: metricsArtifactName,
 	}
 	artifactResponse, err := retrieveArtifact(artifactRequest)


### PR DESCRIPTION
**Description of your changes:**

This fixes metrics reporting for v1 pipeline runs that log metrics. Previously the wrong node id was sent to the api server.

You can verify this with this sample pipeline: 

<details><summary>sample.py</summary>
<p>

```python
from typing import NamedTuple

import kfp
from kfp import dsl
from kfp.components import create_component_from_func


# Step 1: Define a Python function as a component
def train_op() -> NamedTuple('Outputs', [('mlpipeline_metrics', 'Metrics')]):
    import json
    import random
    from pathlib import Path

    # Generate a dummy metric (accuracy)
    accuracy = random.uniform(0.7, 0.99)

    # Write metrics to the designated file
    metrics = {
        "metrics": [
            {
                "name": "accuracy",
                "numberValue": accuracy,
                "format": "PERCENTAGE"
            }
        ]
    }

    # KFP convention: write metrics.json to /mlpipeline-metrics.json
    # Path("/mlpipeline-metrics.json").write_text(json.dumps(metrics))

    return [json.dumps(metrics)]


# Step 2: Convert function to KFP component
train_component = create_component_from_func(
    func=train_op,
    base_image="python:3.9"
)


# Step 3: Define the pipeline
@dsl.pipeline(
    name="Simple Metric Logging Pipeline",
    description="A minimal example that logs a single metric."
)
def simple_pipeline():
    train_task = train_component()


# Step 4: Compile the pipeline
if __name__ == "__main__":
    kfp.compiler.Compiler().compile(
        pipeline_func=simple_pipeline,
        package_path="simple_pipeline.yaml"
    )

```

</p>
</details> 


Here's the resulting json if you query this run: 

<details><summary>sample.json</summary>
<p>

```json
{
  "run": {
    "id": "aee677a3-c3a1-47a2-bbbb-81821f47c447",
    "name": "Run of simple_pipeline (261da)",
    "pipeline_spec": {}, # omitted
    "resource_references": [
      {
        "key": {
          "type": "EXPERIMENT",
          "id": "fa3653ac-312d-46bc-a67a-a9eaab61c779"
        },
        "relationship": "OWNER"
      },
      {
        "key": {
          "type": "PIPELINE_VERSION",
          "id": "428f5c85-d0c6-4062-b795-76b846272c59"
        },
        "relationship": "CREATOR"
      }
    ],
    "service_account": "pipeline-runner",
    "created_at": "2025-09-03T19:50:04Z",
    "scheduled_at": "2025-09-03T19:50:04Z",
    "finished_at": "2025-09-03T19:50:14Z",
    "status": "Succeeded",
    "metrics": [
      {
        "name": "accuracy",
        "node_id": "simple-metric-logging-pipeline-gxltq-train-op-3397519976",
        "number_value": 0.7160825905928586,
        "format": "PERCENTAGE"
      }
    ]
  },
  "pipeline_runtime": { } # omitted
}
```

</p>
</details> 



**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
