### PR TITLE
fix(frontend): Prevent namespace authorization bypass in artifact requests

### DIFF
--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -125,6 +125,9 @@ function createUIServer(options: UIConfigs) {
     }),
   );
 
+  /** Authorize function */
+  const authorizeFn = getAuthorizeFn(options.auth, { apiServerAddress });
+
   /** Artifact */
   registerHandler(
     app.get,
@@ -144,6 +147,7 @@ function createUIServer(options: UIConfigs) {
       useParameter: false,
       tryExtract: true,
       options: options,
+      authorizeFn: authorizeFn,
     }),
   );
   // /artifacts/ endpoint downloads the artifact as is, it does not try to unzip or untar.
@@ -160,11 +164,9 @@ function createUIServer(options: UIConfigs) {
       useParameter: true,
       tryExtract: false,
       options: options,
+      authorizeFn: authorizeFn,
     }),
   );
-
-  /** Authorize function */
-  const authorizeFn = getAuthorizeFn(options.auth, { apiServerAddress });
 
   /** Tensorboard viewer */
   const {

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -27,6 +27,8 @@ import { isAllowedDomain } from './domain-checker';
 import { getK8sSecret } from '../k8s-helper';
 import { StorageOptions } from '@google-cloud/storage/build/src/storage';
 import { CredentialBody } from 'google-auth-library/build/src/auth/credentials';
+import { AuthorizeFn } from '../helpers/auth';
+import { AuthorizeRequestResources, AuthorizeRequestVerb } from '../src/generated/apis/auth';
 
 /**
  * ArtifactsQueryStrings describes the expected query strings key value pairs
@@ -81,6 +83,7 @@ export function getArtifactsHandler({
   useParameter,
   tryExtract,
   options,
+  authorizeFn,
 }: {
   artifactsConfigs: {
     aws: AWSConfigs;
@@ -91,6 +94,7 @@ export function getArtifactsHandler({
   tryExtract: boolean;
   useParameter: boolean;
   options: UIConfigs;
+  authorizeFn?: AuthorizeFn;
 }): Handler {
   const { aws, http, minio, allowedDomain } = artifactsConfigs;
   return async (req, res) => {
@@ -100,8 +104,9 @@ export function getArtifactsHandler({
     const {
       peek = 0,
       providerInfo = '',
-      namespace = options.server.serverNamespace,
+      namespace: requestedNamespace,
     } = req.query as Partial<ArtifactsQueryStrings>;
+
     if (!source) {
       res.status(500).send('Storage source is missing from artifact request');
       return;
@@ -114,7 +119,39 @@ export function getArtifactsHandler({
       res.status(500).send('Storage key is missing from artifact request');
       return;
     }
-    console.log(`Getting storage artifact at: ${source}: ${bucket}/${key}`);
+
+    // Security: Namespace parameter must be provided and user must be authorized for it
+    let namespace: string;
+    if (!requestedNamespace) {
+      // If no namespace provided, reject the request to prevent unauthorized access
+      res.status(400).send('namespace parameter is required for artifact access');
+      return;
+    }
+
+    // Authorize user for the requested namespace when authorization is enabled
+    if (authorizeFn) {
+      try {
+        const authError = await authorizeFn(
+          {
+            verb: AuthorizeRequestVerb.GET,
+            resources: AuthorizeRequestResources.VIEWERS,
+            namespace: requestedNamespace,
+          },
+          req,
+        );
+        if (authError) {
+          res.status(401).send(authError.message);
+          return;
+        }
+      } catch (error) {
+        console.error('Authorization check failed:', error);
+        res.status(500).send('Failed to authorize artifact access');
+        return;
+      }
+    }
+
+    namespace = requestedNamespace;
+    console.log(`Getting storage artifact at: ${source}: ${bucket}/${key} in namespace: ${namespace}`);
 
     let client: MinioClient;
     switch (source) {
@@ -202,13 +239,13 @@ function getHttpArtifactsHandler(
   peek: number = 0,
 ) {
   return async (req: Request, res: Response) => {
-    const headers = {};
+    const headers: { [key: string]: string } = {};
 
     // add authorization header to fetch request if key is non-empty
     if (auth.key.length > 0) {
       // inject original request's value if exists, otherwise default to provided default value
-      headers[auth.key] =
-        req.headers[auth.key] || req.headers[auth.key.toLowerCase()] || auth.defaultValue;
+      const headerValue = req.headers[auth.key] || req.headers[auth.key.toLowerCase()];
+      headers[auth.key] = Array.isArray(headerValue) ? headerValue[0] : headerValue || auth.defaultValue;
     }
     if (!isAllowedDomain(url, allowedDomain)) {
       res.status(500).send(`Domain not allowed.`);
@@ -300,11 +337,11 @@ function getGCSArtifactHandler(
         // escapes everything else.
         const regex = new RegExp(
           '^' +
-            key
-              .split(/\*+/)
-              .map(escapeRegexChars)
-              .join('.*') +
-            '$',
+          key
+            .split(/\*+/)
+            .map(escapeRegexChars)
+            .join('.*') +
+          '$',
         );
         return regex.test(f.name);
       });

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -101,11 +101,9 @@ export function getArtifactsHandler({
     const source = useParameter ? req.params.source : req.query.source;
     const bucket = useParameter ? req.params.bucket : req.query.bucket;
     const key = useParameter ? req.params[0] : req.query.key;
-    const {
-      peek = 0,
-      providerInfo = '',
-      namespace: requestedNamespace,
-    } = req.query as Partial<ArtifactsQueryStrings>;
+    const { peek = 0, providerInfo = '', namespace: requestedNamespace } = req.query as Partial<
+      ArtifactsQueryStrings
+    >;
 
     if (!source) {
       res.status(500).send('Storage source is missing from artifact request');
@@ -151,7 +149,9 @@ export function getArtifactsHandler({
     }
 
     namespace = requestedNamespace;
-    console.log(`Getting storage artifact at: ${source}: ${bucket}/${key} in namespace: ${namespace}`);
+    console.log(
+      `Getting storage artifact at: ${source}: ${bucket}/${key} in namespace: ${namespace}`,
+    );
 
     let client: MinioClient;
     switch (source) {
@@ -245,7 +245,9 @@ function getHttpArtifactsHandler(
     if (auth.key.length > 0) {
       // inject original request's value if exists, otherwise default to provided default value
       const headerValue = req.headers[auth.key] || req.headers[auth.key.toLowerCase()];
-      headers[auth.key] = Array.isArray(headerValue) ? headerValue[0] : headerValue || auth.defaultValue;
+      headers[auth.key] = Array.isArray(headerValue)
+        ? headerValue[0]
+        : headerValue || auth.defaultValue;
     }
     if (!isAllowedDomain(url, allowedDomain)) {
       res.status(500).send(`Domain not allowed.`);
@@ -337,11 +339,11 @@ function getGCSArtifactHandler(
         // escapes everything else.
         const regex = new RegExp(
           '^' +
-          key
-            .split(/\*+/)
-            .map(escapeRegexChars)
-            .join('.*') +
-          '$',
+            key
+              .split(/\*+/)
+              .map(escapeRegexChars)
+              .join('.*') +
+            '$',
         );
         return regex.test(f.name);
       });

--- a/frontend/server/integration-tests/artifact-proxy.test.ts
+++ b/frontend/server/integration-tests/artifact-proxy.test.ts
@@ -150,7 +150,7 @@ describe('/artifacts/get namespaced proxy', () => {
           namespace: undefined,
         })}`,
       )
-      .expect(200, 'text-data2', done);
+      .expect(400, 'namespace parameter is required for artifact access', done);
   });
 
   it('proxies a request with basePath too', done => {


### PR DESCRIPTION
**Description of your changes:**
- Fixes https://github.com/kubeflow/pipelines/issues/9889
- This PR addresses the vulnerability where Alice could access Bob's artifacts by removing the ?namespace=xxx parameter from artifact URLs.
-  Users can no longer remove namespace parameter to access unauthorized artifacts
**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
