### PR TITLE
feat(sdk): Add Docker runner support for KFP workspaces

### DIFF
--- a/sdk/python/kfp/local/docker_task_handler_test.py
+++ b/sdk/python/kfp/local/docker_task_handler_test.py
@@ -93,55 +93,137 @@ class TestRunDockerContainer(DockerMockTestCase):
 class TestDockerTaskHandler(DockerMockTestCase):
 
     def test_get_volumes_to_mount(self):
-        handler = docker_task_handler.DockerTaskHandler(
-            image='alpine',
-            full_command=['echo', 'foo'],
-            pipeline_root=os.path.abspath('my_root'),
-            runner=local.DockerRunner(),
-        )
-        volumes = handler.get_volumes_to_mount()
-        self.assertEqual(
-            volumes, {
-                os.path.abspath('my_root'): {
-                    'bind': os.path.abspath('my_root'),
-                    'mode': 'rw'
-                }
-            })
-
-    def test_run(self):
-        handler = docker_task_handler.DockerTaskHandler(
-            image='alpine',
-            full_command=['echo', 'foo'],
-            pipeline_root=os.path.abspath('my_root'),
-            runner=local.DockerRunner(),
-        )
-
-        handler.run()
-        self.mocked_docker_client.containers.run.assert_called_once_with(
-            image='alpine:latest',
-            command=['echo', 'foo'],
-            detach=True,
-            stdout=True,
-            stderr=True,
-            volumes={
-                os.path.abspath('my_root'): {
-                    'bind': os.path.abspath('my_root'),
-                    'mode': 'rw'
-                }
-            },
-        )
-
-    def test_pipeline_root_relpath(self):
-        with self.assertRaisesRegex(
-                ValueError,
-                r"'pipeline_root' should be an absolute path to correctly construct the volume mount specification\."
-        ):
-            docker_task_handler.DockerTaskHandler(
+        # Mock LocalExecutionConfig.instance to be None (no workspace configured)
+        with mock.patch('kfp.local.config.LocalExecutionConfig.instance', None):
+            handler = docker_task_handler.DockerTaskHandler(
                 image='alpine',
                 full_command=['echo', 'foo'],
-                pipeline_root='my_relpath',
+                pipeline_root=os.path.abspath('my_root'),
                 runner=local.DockerRunner(),
-            ).run()
+            )
+            volumes = handler.get_volumes_to_mount()
+            self.assertEqual(
+                volumes, {
+                    os.path.abspath('my_root'): {
+                        'bind': os.path.abspath('my_root'),
+                        'mode': 'rw'
+                    }
+                })
+
+    def test_get_volumes_to_mount_with_workspace(self):
+        # Mock the LocalExecutionConfig to have a workspace_root
+        with mock.patch('kfp.local.config.LocalExecutionConfig.instance'
+                       ) as mock_instance:
+            mock_instance.workspace_root = '/tmp/test-workspace'
+
+            handler = docker_task_handler.DockerTaskHandler(
+                image='alpine',
+                full_command=['echo', 'foo'],
+                pipeline_root=os.path.abspath('my_root'),
+                runner=local.DockerRunner(),
+            )
+            volumes = handler.get_volumes_to_mount()
+
+            expected_volumes = {
+                os.path.abspath('my_root'): {
+                    'bind': os.path.abspath('my_root'),
+                    'mode': 'rw'
+                },
+                '/tmp/test-workspace': {
+                    'bind': '/kfp-workspace',
+                    'mode': 'rw'
+                }
+            }
+            self.assertEqual(volumes, expected_volumes)
+
+    def test_get_volumes_to_mount_with_relative_workspace(self):
+        # Mock the LocalExecutionConfig to have a relative workspace_root
+        with mock.patch('kfp.local.config.LocalExecutionConfig.instance'
+                       ) as mock_instance:
+            mock_instance.workspace_root = 'test-workspace'
+
+            handler = docker_task_handler.DockerTaskHandler(
+                image='alpine',
+                full_command=['echo', 'foo'],
+                pipeline_root=os.path.abspath('my_root'),
+                runner=local.DockerRunner(),
+            )
+            volumes = handler.get_volumes_to_mount()
+
+            # The relative workspace path should be converted to absolute
+            abs_workspace_path = os.path.abspath('test-workspace')
+            expected_volumes = {
+                os.path.abspath('my_root'): {
+                    'bind': os.path.abspath('my_root'),
+                    'mode': 'rw'
+                },
+                abs_workspace_path: {
+                    'bind': '/kfp-workspace',
+                    'mode': 'rw'
+                }
+            }
+            self.assertEqual(volumes, expected_volumes)
+
+    def test_get_volumes_to_mount_without_workspace(self):
+        # Mock the LocalExecutionConfig to have no workspace_root
+        with mock.patch('kfp.local.config.LocalExecutionConfig.instance'
+                       ) as mock_instance:
+            mock_instance.workspace_root = None
+
+            handler = docker_task_handler.DockerTaskHandler(
+                image='alpine',
+                full_command=['echo', 'foo'],
+                pipeline_root=os.path.abspath('my_root'),
+                runner=local.DockerRunner(),
+            )
+            volumes = handler.get_volumes_to_mount()
+
+            expected_volumes = {
+                os.path.abspath('my_root'): {
+                    'bind': os.path.abspath('my_root'),
+                    'mode': 'rw'
+                }
+            }
+            self.assertEqual(volumes, expected_volumes)
+
+    def test_run(self):
+        # Mock LocalExecutionConfig.instance to be None (no workspace configured)
+        with mock.patch('kfp.local.config.LocalExecutionConfig.instance', None):
+            handler = docker_task_handler.DockerTaskHandler(
+                image='alpine',
+                full_command=['echo', 'foo'],
+                pipeline_root=os.path.abspath('my_root'),
+                runner=local.DockerRunner(),
+            )
+
+            handler.run()
+            self.mocked_docker_client.containers.run.assert_called_once_with(
+                image='alpine:latest',
+                command=['echo', 'foo'],
+                detach=True,
+                stdout=True,
+                stderr=True,
+                volumes={
+                    os.path.abspath('my_root'): {
+                        'bind': os.path.abspath('my_root'),
+                        'mode': 'rw'
+                    }
+                },
+            )
+
+    def test_pipeline_root_relpath(self):
+        # Mock LocalExecutionConfig.instance to be None (no workspace configured)
+        with mock.patch('kfp.local.config.LocalExecutionConfig.instance', None):
+            with self.assertRaisesRegex(
+                    ValueError,
+                    r"'pipeline_root' should be an absolute path to correctly construct the volume mount specification\."
+            ):
+                docker_task_handler.DockerTaskHandler(
+                    image='alpine',
+                    full_command=['echo', 'foo'],
+                    pipeline_root='my_relpath',
+                    runner=local.DockerRunner(),
+                ).run()
 
 
 class TestAddLatestTagIfNotPresent(unittest.TestCase):

--- a/sdk/python/kfp/local/pipeline_orchestrator_test.py
+++ b/sdk/python/kfp/local/pipeline_orchestrator_test.py
@@ -718,6 +718,28 @@ class TestRunLocalPipeline(testing_utilities.LocalRunnerEnvironmentTestCase):
             self.assertEqual(task.output, 'Test workspace functionality!')
             self.assert_output_dir_contents(1, 2)
 
+    def test_docker_runner_workspace_functionality(self):
+        import tempfile
+
+        # Create temporary directory for workspace
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace_root = os.path.join(temp_dir, 'workspace')
+            os.makedirs(workspace_root, exist_ok=True)
+
+            # Test that DockerRunner can be initialized with workspace
+            local.init(
+                local.DockerRunner(),
+                pipeline_root=ROOT_FOR_TESTING,
+                workspace_root=workspace_root)
+
+            # Verify that the workspace is properly configured
+            self.assertEqual(
+                local.config.LocalExecutionConfig.instance.workspace_root,
+                workspace_root)
+            self.assertEqual(
+                type(local.config.LocalExecutionConfig.instance.runner),
+                local.DockerRunner)
+
 
 class TestFstringContainerComponent(
         testing_utilities.LocalRunnerEnvironmentTestCase):


### PR DESCRIPTION
**Description of your changes:**

This PR extends workspace functionality to DockerRunner, enabling Docker containers to access shared workspace storage during local pipeline execution. 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
