### PR TITLE
fix(ui): Disable caching for AWS credential files

### DIFF
--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -111,7 +111,7 @@ export async function createMinioClient(
     // AWS S3 with credentials from provider chain
     if (isAWSS3Endpoint(config.endPoint)) {
       try {
-        const credentials = fromNodeProviderChain({ignoreCache: true});
+        const credentials = fromNodeProviderChain({ ignoreCache: true });
         const awsCredentials = await credentials();
         if (awsCredentials) {
           const {

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -111,7 +111,7 @@ export async function createMinioClient(
     // AWS S3 with credentials from provider chain
     if (isAWSS3Endpoint(config.endPoint)) {
       try {
-        const credentials = fromNodeProviderChain();
+        const credentials = fromNodeProviderChain({ignoreCache: true});
         const awsCredentials = await credentials();
         if (awsCredentials) {
           const {


### PR DESCRIPTION
**Description of your changes:**

This change modifies the AWS credential resolver to not cache the credentials that are taken from [ini files](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html). More information about this config can be found [here](https://github.com/aws/aws-sdk-js-v3/blob/756643ecd734b143ded1f46997ca7c3488cda313/packages/credential-provider-ini/src/fromIni.ts#L51-L55).

Context (why is this change necessary): When using AWS Assumed Roles, credentials/tokens are shortlived. The credentials file is routinely updated so that expired credentials are not used. This change forces the credential provider to always pull the latest credentials from disk, otherwise, expired credentials could be used from the cache.

**Testing**

1. I have a deployment of Kubeflow running on my local machine. ([steps](https://github.com/kubeflow/pipelines/tree/master/frontend#deploy-kfp))
2. I deploy the UI (frontend and node.js backend) from my terminal. ([steps](https://github.com/aws/aws-sdk-js-v3/blob/756643ecd734b143ded1f46997ca7c3488cda313/packages/credential-provider-ini/src/fromIni.ts#L51-L55))
3. I configure my Kubeflow deployment with AWS S3. The backend server has direct access to my AWS credentials file. While the server is running, I can verify that the caching is disabled by modifying my credentials file. Based on the credentials file, access to artifacts in the Kubeflow UI will fail or pass. I have also double checked this with some logging.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
