### PR TITLE
chore: fixed issue with filtering for v1 apis

### DIFF
--- a/frontend/src/components/PipelinesDialog.tsx
+++ b/frontend/src/components/PipelinesDialog.tsx
@@ -58,6 +58,7 @@ const PipelinesDialog: React.FC<PipelinesDialogProps> = (props): JSX.Element | n
       <ResourceSelector
         {...props}
         filterLabel='Filter pipelines'
+        isV1={true}
         listApi={async (...args) => {
           if (buildInfo?.apiServerMultiUser && view === NamespacedAndSharedTab.NAMESPACED) {
             args.push('NAMESPACE');

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -331,6 +331,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
                 {...this.props}
                 title='Choose a pipeline version'
                 filterLabel='Filter pipeline versions'
+                isV1={true}
                 listApi={async (...args) => {
                   const response = await Apis.pipelineServiceApi.listPipelineVersions(
                     'PIPELINE',
@@ -402,6 +403,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
                 {...this.props}
                 title='Choose an experiment'
                 filterLabel='Filter experiments'
+                isV1={true}
                 listApi={async (
                   page_token?: string,
                   page_size?: number,

--- a/frontend/src/pages/ResourceSelector.tsx
+++ b/frontend/src/pages/ResourceSelector.tsx
@@ -47,6 +47,7 @@ export interface ResourceSelectorProps extends RouteComponentProps {
   title?: string;
   toolbarActionMap?: ToolbarActionMap;
   updateDialog: (dialogProps: DialogProps) => void;
+  isV1?: boolean;
 }
 
 interface ResourceSelectorState {
@@ -79,7 +80,7 @@ class ResourceSelector extends React.Component<ResourceSelectorProps, ResourceSe
         {title && <Toolbar actions={toolbarActionMap} breadcrumbs={[]} pageTitle={title} />}
 
         <CustomTable
-          isCalledByV1={false}
+          isCalledByV1={!!this.props.isV1}
           columns={columns}
           rows={rows}
           selectedIds={selectedIds}

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -144,6 +144,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -253,6 +254,7 @@ exports[`NewRun arriving from pipeline details page indicates that a pipeline is
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -633,6 +635,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -742,6 +745,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -1122,6 +1126,7 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -1231,6 +1236,7 @@ exports[`NewRun changes title and form if the new run will recur, based on the r
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -1629,6 +1635,7 @@ exports[`NewRun changes title and form to default state if the new run is a one-
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -1738,6 +1745,7 @@ exports[`NewRun changes title and form to default state if the new run is a one-
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -2118,6 +2126,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -2227,6 +2236,7 @@ exports[`NewRun fetches the associated pipeline if one is present in the query p
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -2605,6 +2615,7 @@ exports[`NewRun renders the new run page 1`] = `
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -2714,6 +2725,7 @@ exports[`NewRun renders the new run page 1`] = `
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -3094,6 +3106,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -3203,6 +3216,7 @@ exports[`NewRun starting a new recurring run includes additional trigger input f
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -3601,6 +3615,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {
@@ -3710,6 +3725,7 @@ exports[`NewRun updates the run's state with the associated experiment if one is
             }
           }
           initialSortColumn="created_at"
+          isV1={true}
           listApi={[Function]}
           location={
             Object {


### PR DESCRIPTION
**Description of your changes:**
Fixes #12155 

Add an `isV1` flag to `ResourceSelector` so its `CustomTable` can emit v1-compatible filters using op instead of the v2-only operation.

Update every v1-backed selector in the legacy New Run flow (pipeline picker, pipeline-version picker, and experiment picker) to pass isV1={true}.

Refresh the corresponding snapshots to reflect the new prop values.

**Testing**

`npm test -- NewRun.test.tsx`
`npm test -- PipelinesDialog.test.tsx`

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
