### PR TITLE
feat(sdk): Add notebook components and embedded artifacts support

### DIFF
--- a/backend/src/apiserver/server/util.go
+++ b/backend/src/apiserver/server/util.go
@@ -44,7 +44,11 @@ func loadFile(fileReader io.Reader, MaxFileLength int) ([]byte, error) {
 		}
 	}
 	if len(pipelineFile) > MaxFileLength {
-		return nil, util.NewInvalidInputError("File size too large. Maximum supported size: %v", MaxFileLength)
+		return nil, util.NewInvalidInputError(
+			"File size too large (%v bytes). Maximum supported size: %v. Consider moving large embedded artifacts or "+
+				"notebooks or Python code into a container image or object store.",
+			len(pipelineFile), MaxFileLength,
+		)
 	}
 	return pipelineFile, nil
 }

--- a/backend/src/apiserver/server/util_test.go
+++ b/backend/src/apiserver/server/util_test.go
@@ -190,3 +190,11 @@ func TestReadPipelineFile_UnknownFileFormat(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Unexpected pipeline file format")
 }
+
+func TestReadPipelineFile_SizeTooLarge_RecommendationIncluded(t *testing.T) {
+	big := strings.Repeat("X", 1024)
+	_, err := ReadPipelineFile("large.yaml", strings.NewReader(big), 10)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "File size too large")
+	assert.Contains(t, err.Error(), "Consider moving large embedded artifacts or notebooks")
+}

--- a/proposals/12238-notebook-component/README.md
+++ b/proposals/12238-notebook-component/README.md
@@ -267,14 +267,15 @@ This feature does not introduce additional security risks beyond those inherent 
 - Large-notebook warning logic.
 - KFP local executing a pipeline with embedded artifacts.
 - KFP local executing a pipeline with notebooks.
+- Large notebook over 1 MB.
+- Failure path: invalid notebook JSON; notebook cell raises execution error.
 
 #### Integration tests
 
-- Execute a pipele with two parameterized notebooks that writes to an output artifact.
+- Execute a pipeline that leverages `embedded_artifact_path`.
+- Execute a pipeline with two parameterized notebooks that writes to an output artifact.
   - One notebook should have no `parameters` cell.
   - The other notebook should have a `parameters` cell with some overrides.
-- Failure path: invalid notebook JSON; notebook cell raises execution error.
-- Large notebook over 1 MB.
 
 ### Graduation Criteria
 

--- a/samples/v2/embedded_artifact.py
+++ b/samples/v2/embedded_artifact.py
@@ -1,0 +1,36 @@
+from kfp import dsl, compiler
+import os
+import tempfile
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    tmpdir_path = os.path.join(tmpdir, "artifact")
+    os.makedirs(tmpdir_path, exist_ok=True)
+    with open(os.path.join(tmpdir_path, "log.txt"), "w", encoding="utf-8") as f:
+        f.write("Hello, world!")
+
+    @dsl.component(embedded_artifact_path=tmpdir_path)
+    def read_embedded_artifact_dir(artifact: dsl.EmbeddedInput[dsl.Dataset]):
+        import os
+
+        with open(os.path.join(artifact.path, "log.txt"), "r", encoding="utf-8") as f:
+            log = f.read()
+
+        assert log == "Hello, world!"
+
+
+    @dsl.component(embedded_artifact_path=os.path.join(tmpdir_path, "log.txt"))
+    def read_embedded_artifact_file(artifact: dsl.EmbeddedInput[dsl.Dataset]):
+        with open(artifact.path, "r", encoding="utf-8") as f:
+            log = f.read()
+
+        assert log == "Hello, world!"
+
+    @dsl.pipeline(name="nb-simple")
+    def pipeline():
+        read_embedded_artifact_dir().set_caching_options(False)
+        read_embedded_artifact_file().set_caching_options(False)
+
+    if __name__ == "__main__":
+        compiler.Compiler().compile(
+            pipeline_func=pipeline, package_path=__file__.replace(".py", ".yaml")
+        )

--- a/samples/v2/notebook_component_mixed.py
+++ b/samples/v2/notebook_component_mixed.py
@@ -1,0 +1,66 @@
+import json
+import os
+
+from kfp import dsl, compiler
+
+
+NB_DIR = os.path.join(os.path.dirname(__file__), "notebooks")
+
+
+@dsl.component
+def preprocess(text: str, dataset: dsl.Output[dsl.Dataset]):
+    import re
+
+    cleaned_text = re.sub(r"\s+", " ", text).strip()
+    with open(dataset.path, "w", encoding="utf-8") as f:
+        f.write(cleaned_text)
+
+
+@dsl.notebook_component(
+    notebook_path=os.path.join(NB_DIR, "nb_train_with_params.ipynb")
+)
+def train_model(cleaned_text: dsl.Input[dsl.Dataset], model: dsl.Output[dsl.Model]):
+    import shutil
+
+    with open(cleaned_text.path, "r", encoding="utf-8") as f:
+        cleaned_text = f.read()
+
+    dsl.run_notebook(cleaned_text=cleaned_text)
+
+    # Notebook writes its model into /tmp/kfp_nb_outputs/model.txt
+    shutil.copy("/tmp/kfp_nb_outputs/model.txt", model.path)
+
+    with open(model.path, "r", encoding="utf-8") as f:
+        model_text = f.read()
+
+    assert model_text == cleaned_text.upper()
+
+
+@dsl.notebook_component(notebook_path=os.path.join(NB_DIR, "nb_eval_metrics.ipynb"))
+def evaluate_model(model_text: dsl.Input[dsl.Model], metrics: dsl.Output[dsl.Metrics]):
+    import json
+
+    with open(model_text.path, "r", encoding="utf-8") as f:
+        model_text = f.read()
+
+    dsl.run_notebook(model_text=model_text)
+    with open("/tmp/kfp_nb_outputs/metrics.json", "r", encoding="utf-8") as f:
+        metrics_dict = json.load(f)
+
+    assert metrics_dict == {"score": float(len(model_text))}
+
+    for metric_name, metric_value in metrics_dict.items():
+        metrics.log_metric(metric_name, metric_value)
+
+
+@dsl.pipeline(name="nb-mixed")
+def pipeline(text: str = "Hello   world"):
+    p = preprocess(text=text).set_caching_options(False)
+    t = train_model(cleaned_text=p.output).set_caching_options(False)
+    evaluate_model(model_text=t.output).set_caching_options(False)
+
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(
+        pipeline_func=pipeline, package_path=__file__.replace(".py", ".yaml")
+    )

--- a/samples/v2/notebook_component_simple.py
+++ b/samples/v2/notebook_component_simple.py
@@ -1,0 +1,27 @@
+from kfp import dsl, compiler
+import os
+
+
+NB_DIR = os.path.join(os.path.dirname(__file__), "notebooks")
+
+
+@dsl.notebook_component(notebook_path=os.path.join(NB_DIR, "nb_train_simple.ipynb"))
+def run_train_notebook(text: str):
+    # text is not defined in the notebook but text2 is defined
+    dsl.run_notebook(text=text)
+
+    with open("/tmp/kfp_nb_outputs/log.txt", "r", encoding="utf-8") as f:
+        log = f.read()
+
+    assert log == text + " " + "default2"
+
+
+@dsl.pipeline(name="nb-simple")
+def pipeline(text: str = "hello"):
+    run_train_notebook(text=text).set_caching_options(False)
+
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(
+        pipeline_func=pipeline, package_path=__file__.replace(".py", ".yaml")
+    )

--- a/samples/v2/notebooks/README.md
+++ b/samples/v2/notebooks/README.md
@@ -1,0 +1,6 @@
+# Sample Notebooks
+
+These are simple notebooks leveraged by the sample pipelines to illustrate native Jupyter Notebook integration:
+
+- [notebook_component_mixed.py](../notebook_component_mixed.py)
+- [notebook_component_simple.py](../notebook_component_simple.py)

--- a/samples/v2/notebooks/nb_eval_metrics.ipynb
+++ b/samples/v2/notebooks/nb_eval_metrics.ipynb
@@ -1,0 +1,38 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "tags": [
+          "parameters"
+        ]
+      },
+      "outputs": [],
+      "source": [
+        "model_text = ''\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os, json\n",
+        "os.makedirs('/tmp/kfp_nb_outputs', exist_ok=True)\n",
+        "metrics = {'score': float(len(model_text))}\n",
+        "print(\"Got score \", metrics[\"score\"])\n",
+        "with open('/tmp/kfp_nb_outputs/metrics.json', 'w', encoding='utf-8') as f:\n",
+        "    json.dump(metrics, f)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/samples/v2/notebooks/nb_train_simple.ipynb
+++ b/samples/v2/notebooks/nb_train_simple.ipynb
@@ -1,0 +1,33 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "text2 = 'default2'"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "os.makedirs('/tmp/kfp_nb_outputs', exist_ok=True)\n",
+        "print(\"Writing to /tmp/kfp_nb_outputs/log.txt\")\n",
+        "with open('/tmp/kfp_nb_outputs/log.txt', 'w', encoding='utf-8') as f:\n",
+        "    f.write(text + \" \" + text2)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/samples/v2/notebooks/nb_train_with_params.ipynb
+++ b/samples/v2/notebooks/nb_train_with_params.ipynb
@@ -1,0 +1,48 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "tags": [
+          "parameters"
+        ]
+      },
+      "outputs": [],
+      "source": [
+        "cleaned_text = 'my cleaned text'\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "os.makedirs('/tmp/kfp_nb_outputs', exist_ok=True)\n",
+        "print(\"Writing to /tmp/kfp_nb_outputs/model.txt\")\n",
+        "with open('/tmp/kfp_nb_outputs/model.txt', 'w', encoding='utf-8') as f:\n",
+        "    f.write(cleaned_text.upper())\n"
+      ]
+    },
+    {
+      "cell_type": "raw",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -42,9 +42,11 @@ __all__ = [
     'PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER',
     'PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER',
     'WORKSPACE_PATH_PLACEHOLDER',
+    'run_notebook',
 ]
 import os
 
+from kfp.dsl.notebook_helpers import run_notebook
 from kfp.dsl.task_config import TaskConfig
 from kfp.dsl.task_final_status import PipelineTaskFinalStatus
 from kfp.dsl.types.artifact_types import Artifact
@@ -56,6 +58,7 @@ from kfp.dsl.types.artifact_types import Markdown
 from kfp.dsl.types.artifact_types import Metrics
 from kfp.dsl.types.artifact_types import Model
 from kfp.dsl.types.artifact_types import SlicedClassificationMetrics
+from kfp.dsl.types.type_annotations import EmbeddedAnnotation
 from kfp.dsl.types.type_annotations import InputAnnotation
 from kfp.dsl.types.type_annotations import InputPath
 from kfp.dsl.types.type_annotations import OutputAnnotation
@@ -257,6 +260,8 @@ Example:
 """
 
 Output = Annotated[T, OutputAnnotation]
+# Runtime-only input for accessing embedded artifacts extracted at runtime.
+EmbeddedInput = Annotated[T, EmbeddedAnnotation]
 """A type generic used to represent an output artifact of type ``T``, where ``T`` is an artifact class. The argument typed with this annotation is provided at runtime by the executing backend and does not need to be passed as an input by the pipeline author (see example).
 
 Use ``Input[Artifact]`` or ``Output[Artifact]`` to indicate whether the enclosed artifact is a component input or output.
@@ -291,6 +296,7 @@ if os.environ.get('_KFP_RUNTIME', 'false') != 'true':
     # TODO: Collected should be moved to pipeline_channel.py, consistent with OneOf
     from kfp.dsl.for_loop import Collected
     from kfp.dsl.importer_node import importer
+    from kfp.dsl.notebook_component_decorator import notebook_component
     from kfp.dsl.pipeline_channel import OneOf
     from kfp.dsl.pipeline_config import KubernetesWorkspaceConfig
     from kfp.dsl.pipeline_config import PipelineConfig
@@ -312,5 +318,5 @@ if os.environ.get('_KFP_RUNTIME', 'false') != 'true':
         'ExitHandler', 'ParallelFor', 'Collected', 'IfPresentPlaceholder',
         'ConcatPlaceholder', 'PipelineTask', 'PipelineConfig',
         'WorkspaceConfig', 'KubernetesWorkspaceConfig', 'TaskConfigField',
-        'TaskConfigPassthrough'
+        'TaskConfigPassthrough', 'notebook_component'
     ])

--- a/sdk/python/kfp/dsl/component_decorator.py
+++ b/sdk/python/kfp/dsl/component_decorator.py
@@ -34,6 +34,7 @@ def component(
     pip_trusted_hosts: Optional[List[str]] = None,
     use_venv: bool = False,
     additional_funcs: Optional[List[Callable]] = None,
+    embedded_artifact_path: Optional[str] = None,
     task_config_passthroughs: Optional[List[Union[TaskConfigPassthrough,
                                                   TaskConfigField]]] = None):
     """Decorator for Python-function based components.
@@ -70,6 +71,16 @@ def component(
             shareable/loadable version of the component spec into this file.
 
             **Warning:** This compilation approach is deprecated.
+        embedded_artifact_path: Optional path to a local file or directory to
+            embed into the component. At runtime the embedded content is
+            extracted into a temporary directory and made available via
+            parameters annotated as ``dsl.EmbeddedInput[T]`` (e.g.,
+            ``dsl.EmbeddedInput[dsl.Dataset]``). For a directory, the injected
+            artifact's ``path`` points to the extraction root (the temporary
+            directory containing the directory's contents). For a single file,
+            the injected artifact's ``path`` points to the extracted file. The
+            extraction root is also prepended to ``sys.path`` to enable
+            importing embedded Python modules.
         install_kfp_package: Specifies if the KFP SDK should add the ``kfp`` Python package to
             ``packages_to_install``. Lightweight Python functions always require
             an installation of KFP in ``base_image`` to work. If you specify
@@ -141,6 +152,7 @@ def component(
             base_image=base_image,
             target_image=target_image,
             packages_to_install=packages_to_install,
+            embedded_artifact_path=embedded_artifact_path,
             pip_index_urls=pip_index_urls,
             output_component_file=output_component_file,
             install_kfp_package=install_kfp_package,
@@ -154,6 +166,7 @@ def component(
         func,
         base_image=base_image,
         target_image=target_image,
+        embedded_artifact_path=embedded_artifact_path,
         packages_to_install=packages_to_install,
         pip_index_urls=pip_index_urls,
         output_component_file=output_component_file,

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -11,11 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
 import dataclasses
+import gzip
 import inspect
+import io
 import itertools
 import pathlib
 import re
+import tarfile
 import textwrap
 from typing import (Any, Callable, Dict, List, Mapping, Optional, Tuple, Type,
                     Union)
@@ -272,6 +276,9 @@ def get_name_to_specs(
         if annotation == inspect._empty:
             raise TypeError(f'Missing type annotation for argument: {name}')
 
+        # Exclude EmbeddedInput[...] from interface (runtime-only)
+        elif type_annotations.is_embedded_input_annotation(annotation):
+            continue
         # is Input[Artifact], Input[List[<Artifact>]], <param> (e.g., str), or InputPath(<param>)
         elif (type_annotations.is_artifact_wrapped_in_Input(annotation) or
               isinstance(
@@ -498,7 +505,9 @@ CONTAINERIZED_PYTHON_COMPONENT_COMMAND = [
 
 def _get_command_and_args_for_lightweight_component(
     func: Callable,
-    additional_funcs: Optional[List[Callable]] = None
+    additional_funcs: Optional[List[Callable]] = None,
+    embedded_artifact_path: Optional[str] = None,
+    _helper_source_template: Optional[str] = None,
 ) -> Tuple[List[str], List[str]]:
     imports_source = [
         'import kfp',
@@ -512,12 +521,55 @@ def _get_command_and_args_for_lightweight_component(
     if additional_funcs:
         additional_funcs_source = '\n\n' + '\n\n'.join(
             _get_function_source_definition(_f) for _f in additional_funcs)
+    # If an embedded_artifact_path is provided, build the archive and generate
+    # a shared extraction helper.
+    helper_source = None
+    if embedded_artifact_path:
+        asset_path = pathlib.Path(embedded_artifact_path)
+        if not asset_path.exists():
+            raise ValueError(
+                f'embedded_artifact_path does not exist: {embedded_artifact_path}'
+            )
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode='w') as tar:
+            if asset_path.is_dir():
+                tar.add(asset_path, arcname='.')
+            else:
+                tar.add(asset_path, arcname=asset_path.name)
+
+        archive_bytes = buf.getvalue()
+
+        compressed_bytes = gzip.compress(archive_bytes)
+        compressed_size_mb = len(compressed_bytes) / (1024 * 1024)
+        if compressed_size_mb > 1:
+            warnings.warn(
+                f'Embedded artifact archive is large ({compressed_size_mb:.1f}MB compressed). '
+                f'Consider moving large assets to a container image or object store.',
+                UserWarning,
+                stacklevel=4)
+
+        archive_b64 = base64.b64encode(compressed_bytes).decode('ascii')
+
+        if _helper_source_template:
+            # Allow callers to inject a custom helper source via a template.
+            # Use literal replacement to avoid str.format interpreting other braces
+            # in the helper source (e.g., f-strings) as format fields.
+            helper_source = _helper_source_template.replace(
+                '{embedded_archive}', archive_b64)
+        else:
+            file_basename = asset_path.name if asset_path.is_file() else None
+            helper_source = _generate_shared_extraction_helper(
+                archive_b64, file_basename)
+
+    helper_block = f'\n\n{helper_source}\n' if helper_source else ''
     source = textwrap.dedent('''
-        {imports_source}{additional_funcs_source}
+        {imports_source}{additional_funcs_source}{helper_block}
 
         {func_source}\n''').format(
         imports_source='\n'.join(imports_source),
         additional_funcs_source=additional_funcs_source,
+        helper_block=helper_block,
         func_source=func_source)
     command = [
         'sh',
@@ -544,6 +596,127 @@ def _get_command_and_args_for_lightweight_component(
     return command, args
 
 
+def _generate_shared_extraction_helper(embedded_archive_b64: str,
+                                       file_basename: Optional[str] = None
+                                      ) -> str:
+    """Generate shared archive extraction helper source code.
+
+    Produces Python source that extracts a tar.gz archive (provided as
+    base64) into a temporary directory, then prepends that directory to
+    sys.path. When a single file was embedded, sets
+    __KFP_EMBEDDED_ASSET_FILE to the extracted file path; otherwise only
+    __KFP_EMBEDDED_ASSET_DIR is set.
+    """
+    file_assignment = ''
+    if file_basename:
+        file_assignment = f"\n__KFP_EMBEDDED_ASSET_FILE = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR, '{file_basename}')\n"
+    return f'''__KFP_EMBEDDED_ARCHIVE_B64 = '{embedded_archive_b64}'
+
+import base64 as __kfp_b64
+import io as __kfp_io
+import os as __kfp_os
+import sys as __kfp_sys
+import tarfile as __kfp_tarfile
+import tempfile as __kfp_tempfile
+
+# Extract embedded archive at import time to ensure sys.path and globals are set
+__kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()
+__KFP_EMBEDDED_ASSET_DIR = __kfp_tmpdir.name
+try:
+    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode('ascii'))
+    with __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode='r:gz') as __kfp_tar:
+        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)
+except Exception as __kfp_e:
+    raise RuntimeError(f'Failed to extract embedded archive: {{__kfp_e}}')
+
+# Always prepend the extracted directory to sys.path for import resolution
+if __KFP_EMBEDDED_ASSET_DIR not in __kfp_sys.path:
+    __kfp_sys.path.insert(0, __KFP_EMBEDDED_ASSET_DIR)
+{file_assignment}
+'''
+
+
+def create_notebook_component_from_func(
+    func: Callable,
+    *,
+    notebook_path: str,
+    base_image: Optional[str] = None,
+    packages_to_install: Optional[List[str]] = None,
+    pip_index_urls: Optional[List[str]] = None,
+    output_component_file: Optional[str] = None,
+    install_kfp_package: bool = True,
+    kfp_package_path: Optional[str] = None,
+    pip_trusted_hosts: Optional[List[str]] = None,
+    use_venv: bool = False,
+    task_config_passthroughs: Optional[List[TaskConfigPassthrough]] = None,
+) -> python_component.PythonComponent:
+    """Builds a notebook-based component by delegating to
+    create_component_from_func.
+
+    Validates the notebook path and constructs a helper source template
+    that executes the embedded notebook at runtime. The common
+    component-building logic is reused by passing the template and the
+    notebook path as an embedded artifact.
+    """
+
+    # Resolve default packages for notebooks when not specified
+    if packages_to_install is None:
+        packages_to_install = [
+            'nbclient>=0.10,<1', 'ipykernel>=6,<7', 'jupyter_client>=7,<9'
+        ]
+
+    # Validate notebook path and determine relpath
+    nb_path = pathlib.Path(notebook_path)
+    if not nb_path.exists():
+        raise ValueError(f'Notebook path does not exist: {notebook_path}')
+
+    if nb_path.is_dir():
+        # Ignore .ipynb_checkpoints directories
+        ipynbs = [
+            p for p in nb_path.rglob('*.ipynb')
+            if p.is_file() and '.ipynb_checkpoints' not in p.parts
+        ]
+        if len(ipynbs) == 0:
+            raise ValueError(
+                f'No .ipynb files found in directory: {notebook_path}')
+        if len(ipynbs) > 1:
+            raise ValueError(
+                f'Multiple .ipynb files found in directory: {notebook_path}. Exactly one is required.'
+            )
+        nb_file = ipynbs[0]
+        notebook_relpath = nb_file.relative_to(nb_path).as_posix()
+    else:
+        if nb_path.suffix.lower() != '.ipynb':
+            raise ValueError(
+                f'Invalid notebook_path (expected .ipynb file): {notebook_path}'
+            )
+        notebook_relpath = nb_path.name
+
+    # Build the helper source template with a placeholder for the embedded archive
+    from kfp.dsl.templates.notebook_executor import \
+        get_notebook_executor_source
+    helper_template = get_notebook_executor_source('{embedded_archive}',
+                                                   notebook_relpath)
+
+    # Delegate to the common component creation using the embedded artifact path
+    return create_component_from_func(
+        func=func,
+        base_image=base_image,
+        target_image=None,
+        embedded_artifact_path=notebook_path,
+        _helper_source_template=helper_template,
+        packages_to_install=packages_to_install or [],
+        pip_index_urls=pip_index_urls,
+        output_component_file=output_component_file,
+        install_kfp_package=install_kfp_package,
+        kfp_package_path=kfp_package_path,
+        pip_trusted_hosts=pip_trusted_hosts,
+        use_venv=use_venv,
+        additional_funcs=None,
+        task_config_passthroughs=task_config_passthroughs,
+    )
+
+
 def _get_command_and_args_for_containerized_component(
         function_name: str) -> Tuple[List[str], List[str]]:
 
@@ -560,6 +733,7 @@ def create_component_from_func(
     func: Callable,
     base_image: Optional[str] = None,
     target_image: Optional[str] = None,
+    embedded_artifact_path: Optional[str] = None,
     packages_to_install: List[str] = None,
     pip_index_urls: Optional[List[str]] = None,
     output_component_file: Optional[str] = None,
@@ -569,6 +743,7 @@ def create_component_from_func(
     use_venv: bool = False,
     additional_funcs: Optional[List[Callable]] = None,
     task_config_passthroughs: Optional[List[TaskConfigPassthrough]] = None,
+    _helper_source_template: Optional[str] = None,
 ) -> python_component.PythonComponent:
     """Implementation for the @component decorator.
 
@@ -594,7 +769,7 @@ def create_component_from_func(
             ("The default base_image used by the @dsl.component decorator will switch from 'python:3.9' to 'python:3.10' on Oct 1, 2025. To ensure your existing components work with versions of the KFP SDK released after that date, you should provide an explicit base_image argument and ensure your component works as intended on Python 3.10."
             ),
             FutureWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
 
     component_image = base_image
@@ -605,7 +780,11 @@ def create_component_from_func(
             function_name=func.__name__,)
     else:
         command, args = _get_command_and_args_for_lightweight_component(
-            func=func, additional_funcs=additional_funcs)
+            func=func,
+            additional_funcs=additional_funcs,
+            embedded_artifact_path=embedded_artifact_path,
+            _helper_source_template=_helper_source_template,
+        )
 
     component_spec = extract_component_interface(func)
     # Attach task_config_passthroughs to the ComponentSpec structure if provided.

--- a/sdk/python/kfp/dsl/notebook_component_decorator.py
+++ b/sdk/python/kfp/dsl/notebook_component_decorator.py
@@ -1,0 +1,100 @@
+"""Decorator for creating notebook-based components.
+
+Uses the existing Python executor. The embedded notebook is executed by
+a helper bound to `dsl.run_notebook(**kwargs)` that users can call
+inside their component function.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Callable, List, Optional
+
+from kfp.dsl import component_factory
+from kfp.dsl.component_task_config import TaskConfigField
+from kfp.dsl.component_task_config import TaskConfigPassthrough
+
+
+def notebook_component(
+    func: Optional[Callable[..., Any]] = None,
+    *,
+    notebook_path: str,
+    base_image: Optional[str] = None,
+    packages_to_install: Optional[List[str]] = None,
+    output_component_file: Optional[str] = None,
+    pip_index_urls: Optional[List[str]] = None,
+    pip_trusted_hosts: Optional[List[str]] = None,
+    use_venv: bool = False,
+    kfp_package_path: Optional[str] = None,
+    install_kfp_package: bool = True,
+    task_config_passthroughs: Optional[List[TaskConfigPassthrough]] = None,
+):
+    """Decorator to define a Notebook-based KFP component.
+
+    Args:
+        notebook_path: Path to the .ipynb file or a directory containing one to embed and execute.
+        base_image: Base container image for the component.
+        packages_to_install: Runtime-only packages to install inside the
+            component container. When None, defaults to
+            ["nbclient>=0.10,<1", "ipykernel>=6,<7", "jupyter_client>=7,<9"]
+            to ensure the notebook can execute with a Python kernel and client.
+            When [], installs nothing. When non-empty, installs the exact list.
+        output_component_file: Optional path to write the component YAML.
+        pip_index_urls: Optional pip index URLs for installation.
+        pip_trusted_hosts: Optional pip trusted hosts.
+        use_venv: Whether to create and use a venv inside the container.
+        kfp_package_path: Optional KFP package path to install.
+        install_kfp_package: Whether to auto-install KFP when appropriate.
+        task_config_passthroughs: Optional task config passthroughs.
+
+    Parameter injection and execution:
+        - The notebook bytes are embedded in the component. At runtime, the
+          helper binds `dsl.run_notebook(**kwargs)`.
+        - Inside the decorated function body, call `dsl.run_notebook(...)` with
+          keyword arguments for parameters you want available in the notebook
+          (e.g., `dsl.run_notebook(text=my_text)`).
+        - Parameters are injected following Papermill semantics: if the
+          notebook contains a code cell tagged `parameters`, an overriding
+          `injected-parameters` cell is inserted immediately after it; otherwise
+          the injected cell is placed at the top of the notebook before
+          execution.
+        - Notebook outputs you want to expose as KFP outputs should be written
+          by the notebook to known paths, then copied or logged by the function
+          after `dsl.run_notebook(...)` returns.
+    """
+
+    formatted_passthroughs = None
+    if task_config_passthroughs is not None:
+        formatted_passthroughs = [
+            TaskConfigPassthrough(field=p, apply_to_task=False) if isinstance(
+                p, TaskConfigField) else p for p in task_config_passthroughs
+        ]
+
+    if func is None:
+        return functools.partial(
+            component_factory.create_notebook_component_from_func,
+            notebook_path=notebook_path,
+            base_image=base_image,
+            packages_to_install=packages_to_install,
+            output_component_file=output_component_file,
+            pip_index_urls=pip_index_urls,
+            pip_trusted_hosts=pip_trusted_hosts,
+            use_venv=use_venv,
+            kfp_package_path=kfp_package_path,
+            install_kfp_package=install_kfp_package,
+            task_config_passthroughs=formatted_passthroughs,
+        )
+
+    return component_factory.create_notebook_component_from_func(
+        func=func,
+        notebook_path=notebook_path,
+        base_image=base_image,
+        packages_to_install=packages_to_install,
+        output_component_file=output_component_file,
+        pip_index_urls=pip_index_urls,
+        pip_trusted_hosts=pip_trusted_hosts,
+        use_venv=use_venv,
+        kfp_package_path=kfp_package_path,
+        install_kfp_package=install_kfp_package,
+        task_config_passthroughs=formatted_passthroughs,
+    )

--- a/sdk/python/kfp/dsl/notebook_component_decorator_test.py
+++ b/sdk/python/kfp/dsl/notebook_component_decorator_test.py
@@ -1,0 +1,291 @@
+"""Unit tests for notebook components and embedded artifacts."""
+
+import base64
+import io
+import json
+import os
+import tarfile
+import tempfile
+import unittest
+import warnings
+
+from kfp import dsl
+from kfp.dsl import component_factory
+from kfp.dsl.types.artifact_types import Dataset
+
+
+class TestNotebookComponentDecorator(unittest.TestCase):
+
+    def _make_temp_notebook(self, cells_source: str) -> str:
+        nb = {
+            'cells': [{
+                'cell_type': 'code',
+                'execution_count': None,
+                'metadata': {},
+                'outputs': [],
+                'source': cells_source,
+            }],
+            'metadata': {
+                'kernelspec': {
+                    'display_name': 'Python 3',
+                    'language': 'python',
+                    'name': 'python3',
+                },
+                'language_info': {
+                    'name': 'python',
+                    'version': '3.11',
+                },
+            },
+            'nbformat': 4,
+            'nbformat_minor': 5,
+        }
+        tmpdir = tempfile.mkdtemp()
+        nb_path = os.path.join(tmpdir, 'tmp.ipynb')
+        with open(nb_path, 'w', encoding='utf-8') as f:
+            json.dump(nb, f)
+        return nb_path
+
+    def test_notebook_component_default_packages_install(self):
+        nb_path = self._make_temp_notebook(
+            "import os\nos.makedirs('/tmp/kfp_nb_outputs', exist_ok=True)\n")
+
+        @dsl.notebook_component(notebook_path=nb_path)
+        def my_nb(text: str):
+            dsl.run_notebook(text=text)
+
+        container = my_nb.component_spec.implementation.container
+        command = ' '.join(container.command)
+        self.assertIn('nbclient>=0.10,<1', command)
+        self.assertIn('ipykernel>=6,<7', command)
+        self.assertIn('jupyter_client>=7,<9', command)
+
+    def test_notebook_component_no_extra_packages_when_empty_list(self):
+        nb_path = self._make_temp_notebook('pass\n')
+
+        @dsl.notebook_component(notebook_path=nb_path, packages_to_install=[])
+        def my_nb():
+            dsl.run_notebook()
+
+        container = my_nb.component_spec.implementation.container
+        command = ' '.join(container.command)
+        self.assertNotIn('nbclient>=0.10,<1', command)
+        self.assertNotIn('ipykernel>=6,<7', command)
+        self.assertNotIn('jupyter_client>=7,<9', command)
+
+
+class TestNotebookExecutorTemplate(unittest.TestCase):
+
+    def test_template_binds_run_notebook(self):
+        from kfp.dsl.templates.notebook_executor import \
+            get_notebook_executor_source
+
+        source = get_notebook_executor_source('ARCHIVE_B64', 'nb.ipynb')
+        self.assertIn('dsl.run_notebook = kfp_run_notebook', source)
+        self.assertIn('class KFPStreamingNotebookClient(NotebookClient):',
+                      source)
+
+
+class TestNotebookParameterInjection(unittest.TestCase):
+
+    def _make_nb(self, with_parameters_cell: bool) -> dict:
+        import nbformat
+        nb = {
+            'cells': [],
+            'metadata': {
+                'kernelspec': {
+                    'display_name': 'Python 3',
+                    'language': 'python',
+                    'name': 'python3',
+                },
+                'language_info': {
+                    'name': 'python',
+                    'version': '3.11',
+                },
+            },
+            'nbformat': 4,
+            'nbformat_minor': 5,
+        }
+        if with_parameters_cell:
+            nb['cells'].append({
+                'cell_type': 'code',
+                'execution_count': None,
+                'metadata': {
+                    'tags': ['parameters'],
+                },
+                'outputs': [],
+                'source': '# default parameters\n',
+            })
+        # Regular code cell
+        nb['cells'].append({
+            'cell_type': 'code',
+            'execution_count': None,
+            'metadata': {},
+            'outputs': [],
+            'source': 'print("hello")\n',
+        })
+        return nbformat.from_dict(nb)
+
+    def test_injects_after_parameters_cell(self):
+        from kfp.dsl.templates import notebook_executor as nb_exec
+        nb = self._make_nb(with_parameters_cell=True)
+
+        params = {
+            'x': 1,
+            's': 'abc',
+            'd': {
+                'a': 1
+            },
+        }
+
+        getattr(nb_exec, '__kfp_write_parameters_cell')(nb, params)
+
+        # Expect new cell inserted immediately after the parameters cell (index 1)
+        self.assertGreaterEqual(len(nb.get('cells', [])), 2)
+        injected = nb['cells'][1]
+        self.assertEqual(injected.get('cell_type'), 'code')
+        tags = injected.get('metadata', {}).get('tags', []) or []
+        self.assertIn('injected-parameters', tags)
+        src = ''.join(injected.get('source', ''))
+        self.assertIn('import json', src)
+        # Ensure each variable assignment is present
+        self.assertIn('x = json.loads(', src)
+        self.assertIn('s = json.loads(', src)
+        self.assertIn('d = json.loads(', src)
+
+    def test_injects_at_top_when_no_parameters_cell(self):
+        from kfp.dsl.templates import notebook_executor as nb_exec
+        nb = self._make_nb(with_parameters_cell=False)
+
+        getattr(nb_exec, '__kfp_write_parameters_cell')(nb, {'p': 42})
+
+        self.assertGreaterEqual(len(nb.get('cells', [])), 2)
+        injected = nb['cells'][0]
+        self.assertEqual(injected.get('cell_type'), 'code')
+        tags = injected.get('metadata', {}).get('tags', []) or []
+        self.assertIn('injected-parameters', tags)
+        src = ''.join(injected.get('source', ''))
+        self.assertIn('p = json.loads(', src)
+
+
+class TestEmbeddedArtifacts(unittest.TestCase):
+
+    def _make_tar_gz_b64_for_paths(self, root_dir: str) -> str:
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode='w') as tar:
+            tar.add(root_dir, arcname='.')
+        raw_bytes = buf.getvalue()
+        gz_bytes = __import__('gzip').compress(raw_bytes)
+        return base64.b64encode(gz_bytes).decode('ascii')
+
+    def test_shared_extraction_helper_exposes_dir_and_file(self):
+        tmpdir = tempfile.mkdtemp()
+        file_basename = 'data.txt'
+        with open(
+                os.path.join(tmpdir, file_basename), 'w',
+                encoding='utf-8') as f:
+            f.write('hello')
+
+        archive_b64 = self._make_tar_gz_b64_for_paths(tmpdir)
+        helper_src = component_factory._generate_shared_extraction_helper(
+            embedded_archive_b64=archive_b64, file_basename=file_basename)
+
+        g: dict = {}
+        exec(helper_src, g, g)
+        self.assertIn('__KFP_EMBEDDED_ASSET_DIR', g)
+        self.assertIn('__KFP_EMBEDDED_ASSET_FILE', g)
+        self.assertTrue(os.path.isdir(g['__KFP_EMBEDDED_ASSET_DIR']))
+        self.assertTrue(os.path.isfile(g['__KFP_EMBEDDED_ASSET_FILE']))
+        with open(g['__KFP_EMBEDDED_ASSET_FILE'], 'r', encoding='utf-8') as f:
+            self.assertEqual(f.read(), 'hello')
+        # sys.path must include the extracted dir (at position 0 per helper)
+        import sys
+        self.assertIn(g['__KFP_EMBEDDED_ASSET_DIR'], sys.path)
+
+    def test_embedded_input_excluded_from_interface_and_runtime_injected(self):
+
+        def comp_sig(cfg: dsl.EmbeddedInput[Dataset], out: dsl.Output[Dataset]):
+            pass
+
+        spec = component_factory.extract_component_interface(comp_sig)
+        self.assertIsNone(spec.inputs)
+
+        tmpdir = tempfile.mkdtemp()
+        payload_path = os.path.join(tmpdir, 'x.txt')
+        with open(payload_path, 'w', encoding='utf-8') as f:
+            f.write('PAYLOAD')
+
+        def use_embedded(cfg: dsl.EmbeddedInput[Dataset],
+                         out: dsl.Output[Dataset]):
+            import os as _os
+            with open(
+                    _os.path.join(cfg.path, 'x.txt'), 'r',
+                    encoding='utf-8') as _f:
+                data = _f.read()
+            with open(out.path, 'w', encoding='utf-8') as _g:
+                _g.write(data)
+
+        # Build a minimal executor input for a single output artifact
+        executor_input = {
+            'inputs': {},
+            'outputs': {
+                'artifacts': {
+                    'out': {
+                        'artifacts': [{
+                            'name': 'out',
+                            'type': {
+                                'schemaTitle': 'system.Dataset',
+                                'schemaVersion': '0.0.1',
+                            },
+                            'uri': os.path.join(tempfile.mkdtemp(), 'out'),
+                            'metadata': {},
+                        }]
+                    }
+                },
+                'outputFile':
+                    os.path.join(tempfile.mkdtemp(), 'executor_output.json'),
+            },
+        }
+
+        from kfp.dsl import executor as _executor
+
+        # Inject globals emulating extraction helper behavior
+        use_embedded.__globals__['__KFP_EMBEDDED_ASSET_DIR'] = tmpdir
+        e = _executor.Executor(executor_input, function_to_execute=use_embedded)
+        e.execute()
+
+        out_path = e.get_output_artifact_path('out')
+        with open(out_path, 'r', encoding='utf-8') as f:
+            self.assertEqual(f.read(), 'PAYLOAD')
+
+    def test_large_embedded_artifact_emits_warning(self):
+        # Create >1MB of incompressible data so gzip compressed size stays >1MB
+        tmpdir = tempfile.mkdtemp()
+        bigfile = os.path.join(tmpdir, 'big.bin')
+        with open(bigfile, 'wb') as f:
+            f.write(os.urandom(3 * 1024 * 1024))
+
+        @dsl.component(embedded_artifact_path=tmpdir)
+        def dummy():
+            pass
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            _ = dummy
+
+            # Building the component happens at decoration time above; to force
+            # the path through component_factory, explicitly rebuild:
+            def f():
+                pass
+
+            component_factory.create_component_from_func(
+                func=f, embedded_artifact_path=tmpdir)
+            self.assertTrue(
+                any(
+                    isinstance(ww.message, UserWarning) and
+                    'Embedded artifact archive is large' in str(ww.message)
+                    for ww in w),
+                msg='Expected a UserWarning about large embedded artifact')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/dsl/notebook_helpers.py
+++ b/sdk/python/kfp/dsl/notebook_helpers.py
@@ -1,0 +1,35 @@
+"""Notebook-related helper APIs for KFP DSL.
+
+This module provides a stub for `dsl.run_notebook(**kwargs)`. At runtime
+inside `@dsl.notebook_component`, the SDK binds this symbol to a helper
+that executes the embedded notebook with the provided parameters.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def run_notebook(**kwargs: Any) -> None:
+    """Execute the component's embedded Jupyter notebook with injected
+    parameters.
+
+    This is a stub placeholder. Inside a function decorated with
+    `@dsl.notebook_component`, the SDK binds this symbol at runtime to a helper
+    that materializes the embedded notebook, injects a parameters cell from the
+    provided `**kwargs`, and executes the notebook via nbclient.
+
+    Calling this function outside of a notebook component context will raise
+    NotImplementedError.
+
+    Args:
+        **kwargs: Parameter names and values to inject into the notebook's
+            parameters cell.
+
+    Raises:
+        NotImplementedError: Always, unless overridden at runtime inside a
+            notebook component.
+    """
+    raise NotImplementedError(
+        'dsl.run_notebook is only available inside a @dsl.notebook_component at runtime.'
+    )

--- a/sdk/python/kfp/dsl/templates/__init__.py
+++ b/sdk/python/kfp/dsl/templates/__init__.py
@@ -1,0 +1,1 @@
+# Templates package for KFP DSL code generation

--- a/sdk/python/kfp/dsl/templates/notebook_executor.py
+++ b/sdk/python/kfp/dsl/templates/notebook_executor.py
@@ -1,0 +1,258 @@
+"""Template for notebook executor code generation.
+
+This module contains the actual Python functions that get embedded into notebook
+components at runtime. Using inspect.getsource() to convert them to source code
+provides better maintainability, testing, and IDE support.
+
+Note: The template functions import their dependencies locally to avoid requiring
+those dependencies when this module is imported for code generation.
+"""
+
+import inspect
+import textwrap
+
+
+def __kfp_write_parameters_cell(nb, params):
+    """Inject parameters following Papermill semantics.
+
+    - If a cell tagged with 'parameters' exists, insert an overriding
+      'injected-parameters' cell immediately after it.
+    - Otherwise, insert the 'injected-parameters' cell at the top.
+    """
+    import json
+
+    import nbformat
+
+    if not params:
+        return
+
+    # Build the injected parameters cell
+    assignments = []
+    for key, value in params.items():
+        serialized = json.dumps(value)
+        assignments.append(key + ' = json.loads(' + repr(serialized) + ')')
+    source = 'import json\n' + '\n'.join(assignments) + '\n'
+    cell = nbformat.v4.new_code_cell(source=source)
+    cell.metadata.setdefault('tags', [])
+    if 'injected-parameters' not in cell.metadata['tags']:
+        cell.metadata['tags'].append('injected-parameters')
+
+    # Locate the first 'parameters' tagged cell
+    insert_idx = 0
+    for idx, existing in enumerate(nb.get('cells', [])):
+        if existing.get('cell_type') != 'code':
+            continue
+        tags = existing.get('metadata', {}).get('tags', []) or []
+        if 'parameters' in tags:
+            insert_idx = idx + 1
+            break
+
+    nb.cells.insert(insert_idx, cell)
+
+
+def _kfp_stream_single_output(output, cell_idx):
+    """Stream a single notebook output immediately during execution.
+
+    Prints stdout/stderr and text/plain display outputs to the console
+    so users see cell output as it happens (no need to wait until the
+    notebook finishes).
+    """
+    import sys
+    output_type = output.get('output_type')
+
+    if output_type == 'stream':
+        text = output.get('text', '')
+        if text:
+            try:
+                print(f'[nb cell {cell_idx} stream] ', end='', flush=False)
+            except Exception:
+                pass
+            print(text, end='' if text.endswith('\n') else '\n', flush=True)
+    elif output_type == 'error':
+        for line in output.get('traceback', []):
+            print(line, file=sys.stderr, flush=True)
+    else:
+        # Handle display_data and execute_result
+        data = output.get('data', {})
+        if 'text/plain' in data:
+            print(data['text/plain'], flush=True)
+        elif 'application/json' in data:
+            try:
+                import json as __kfp_json
+                parsed = data['application/json']
+                # Some kernels send JSON as string; try to parse if needed
+                if isinstance(parsed, str):
+                    try:
+                        parsed = __kfp_json.loads(parsed)
+                    except Exception:
+                        pass
+                print(
+                    __kfp_json.dumps(parsed, indent=2, ensure_ascii=False),
+                    flush=True)
+            except Exception:
+                # Fallback to raw
+                print(str(data.get('application/json')), flush=True)
+        elif 'text/markdown' in data:
+            # Print markdown as-is; frontends may render, logs will show raw markdown
+            print(data['text/markdown'], flush=True)
+
+
+def kfp_run_notebook(**kwargs):
+    """Execute the embedded notebook with injected parameters.
+
+    Parameters provided via kwargs are injected into the notebook
+    following Papermill semantics (after a parameters cell if present,
+    otherwise at top). Execution uses a Python kernel; nbclient and
+    ipykernel must be available at runtime (installed via
+    packages_to_install for notebook components).
+    """
+    import os
+    import subprocess
+    import sys
+
+    from nbclient import NotebookClient
+    import nbformat
+
+    # Ensure a usable 'python3' kernel is present; install kernelspec if missing
+    print('[KFP Notebook] Checking for Python kernel...', flush=True)
+    try:
+        from jupyter_client.kernelspec import KernelSpecManager  # type: ignore
+        ksm = KernelSpecManager()
+        have_py3 = 'python3' in ksm.find_kernel_specs()
+        if not have_py3:
+            print(
+                '[KFP Notebook] Python3 kernel not found, installing...',
+                flush=True)
+            try:
+                subprocess.run([
+                    sys.executable, '-m', 'ipykernel', 'install', '--user',
+                    '--name', 'python3', '--display-name', 'Python 3'
+                ],
+                               check=True,
+                               stdout=subprocess.DEVNULL,
+                               stderr=subprocess.DEVNULL)
+                print(
+                    '[KFP Notebook] Python3 kernel installed successfully',
+                    flush=True)
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(
+                    "Failed to install 'python3' kernelspec for ipykernel. "
+                    "Ensure ipykernel is available in the environment or include it via packages_to_install. "
+                    f"Error: {e}") from e
+        else:
+            print('[KFP Notebook] Python3 kernel found', flush=True)
+    except ImportError as e:
+        raise RuntimeError(
+            "jupyter_client is not available. Ensure it's installed in the environment or include it via packages_to_install. "
+            f"Error: {e}") from e
+
+    nb_path = os.path.join(__KFP_EMBEDDED_ASSET_DIR, __KFP_NOTEBOOK_REL_PATH)
+
+    try:
+        nb = nbformat.read(nb_path, as_version=4)
+    except Exception as e:
+        raise RuntimeError(
+            f'Failed to read notebook {nb_path}. Ensure it is a valid Jupyter notebook. Error: {e}'
+        ) from e
+
+    try:
+        __kfp_write_parameters_cell(nb, kwargs)
+        print(
+            f'[KFP Notebook] Executing notebook with {len(nb.get("cells", []))} cells',
+            flush=True)
+
+        # Use our custom streaming client for real-time output (defined in the
+        # generated ephemeral source)
+        client = KFPStreamingNotebookClient(
+            nb,
+            timeout=None,
+            allow_errors=False,
+            store_widget_state=False,
+            kernel_name='python3')
+        client.execute(cwd=__KFP_EMBEDDED_ASSET_DIR)
+
+        print('[KFP Notebook] Execution complete', flush=True)
+
+    except Exception as e:
+        raise RuntimeError(f'Notebook execution failed. Error: {e}') from e
+
+
+def get_notebook_executor_source(archive_b64_placeholder: str,
+                                 notebook_relpath_placeholder: str) -> str:
+    """Generate the notebook execution helper source code.
+
+    Uses inspect.getsource() to extract the actual function definitions,
+    providing better maintainability, and includes archive extraction at import.
+
+    Args:
+        archive_b64_placeholder: The base64-encoded gzip-compressed tar archive containing the notebook and assets
+        notebook_relpath_placeholder: The relative path to the notebook within the extracted archive root
+
+    Returns:
+        Python source code for notebook execution helpers
+    """
+    # Get source code for helper functions that don't require nbclient
+    functions = [
+        __kfp_write_parameters_cell, _kfp_stream_single_output, kfp_run_notebook
+    ]
+
+    # Extract and dedent source code for all helper functions
+    function_sources = [
+        textwrap.dedent(inspect.getsource(func)) for func in functions
+    ]
+
+    # Define the streaming client class inline in the generated source to avoid
+    # importing nbclient in the SDK environment.
+    streaming_client_source = textwrap.dedent("""
+        class KFPStreamingNotebookClient(NotebookClient):
+            # Streams outputs in real-time by emitting outputs during message processing.
+            def process_message(self, msg, cell, cell_index):
+                # Call the parent implementation to handle the message normally
+                output = super().process_message(msg, cell, cell_index)
+
+                # If an output was created, stream it immediately
+                if output is not None:
+                    _kfp_stream_single_output(output, cell_index)
+
+                return output
+        """)
+
+    # Combine everything into the final source with archive extraction at import
+    functions_code = streaming_client_source + '\n' + '\n'.join(
+        function_sources)
+    return f"""__KFP_EMBEDDED_ARCHIVE_B64 = '{archive_b64_placeholder}'
+__KFP_NOTEBOOK_REL_PATH = '{notebook_relpath_placeholder}'
+
+import base64 as __kfp_b64
+import gzip as __kfp_gzip
+import io as __kfp_io
+import os as __kfp_os
+import sys as __kfp_sys
+import tarfile as __kfp_tarfile
+import tempfile as __kfp_tempfile
+from nbclient import NotebookClient
+
+# Extract embedded archive at import time to ensure sys.path and globals are set
+print('[KFP] Extracting embedded notebook archive...', flush=True)
+__kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()
+__KFP_EMBEDDED_ASSET_DIR = __kfp_tmpdir.name
+try:
+    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode('ascii'))
+    with __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode='r:gz') as __kfp_tar:
+        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)
+    print(f'[KFP] Notebook archive extracted to: {{__KFP_EMBEDDED_ASSET_DIR}}', flush=True)
+except Exception as __kfp_e:
+    raise RuntimeError(f'Failed to extract embedded notebook archive: {{__kfp_e}}')
+
+# Always prepend the extracted directory to sys.path for import resolution
+if __KFP_EMBEDDED_ASSET_DIR not in __kfp_sys.path:
+    __kfp_sys.path.insert(0, __KFP_EMBEDDED_ASSET_DIR)
+    print(f'[KFP] Added notebook archive directory to Python path', flush=True)
+
+# Optional convenience for generic embedded file variable name
+__KFP_EMBEDDED_ASSET_FILE = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR, __KFP_NOTEBOOK_REL_PATH)
+
+{functions_code}
+
+# Bind helper into dsl namespace so user code can call dsl.run_notebook(...)
+dsl.run_notebook = kfp_run_notebook"""

--- a/sdk/python/kfp/dsl/types/type_annotations.py
+++ b/sdk/python/kfp/dsl/types/type_annotations.py
@@ -125,6 +125,15 @@ class OutputAnnotation:
     """Marker type for output artifacts."""
 
 
+class EmbeddedAnnotation:
+    """Marker type for embedded runtime-only inputs.
+
+    Parameters annotated with ``dsl.EmbeddedInput[T]`` are not part of
+    the component interface and are injected at runtime by the SDK. They
+    provide access to an extracted embedded artifact's filesystem path.
+    """
+
+
 def is_Input_Output_artifact_annotation(typ) -> bool:
     if not hasattr(typ, '__metadata__'):
         return False
@@ -133,6 +142,14 @@ def is_Input_Output_artifact_annotation(typ) -> bool:
         return False
 
     return True
+
+
+def is_embedded_input_annotation(typ) -> bool:
+    """Returns True if typ is of type EmbeddedInput[T]."""
+    if not hasattr(typ, '__metadata__'):
+        return False
+
+    return typ.__metadata__[0] == EmbeddedAnnotation
 
 
 def is_artifact_wrapped_in_Input(typ: Any) -> bool:

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -3,6 +3,7 @@ docformatter==1.4
 docker==5.0.3
 isort==5.10.1
 mypy==0.941
+nbformat==5.10.4
 pip-tools==6.0.0
 pre-commit==2.19.0
 pycln==2.1.1

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -57,6 +57,7 @@ def read_readme() -> str:
 _version = find_version('kfp', 'version.py')
 docker = ['docker']
 kubernetes = [f'kfp-kubernetes=={_version}']
+notebooks = ["nbclient>=0.10,<1", "ipykernel>=6,<7", "jupyter_client>=7,<9"]
 
 setuptools.setup(
     name='kfp',
@@ -78,8 +79,9 @@ setuptools.setup(
     },
     install_requires=get_requirements('requirements.in'),
     extras_require={
-        'all': docker + kubernetes,
+        'all': docker + kubernetes + notebooks,
         'kubernetes': kubernetes,
+        'notebooks': notebooks,
     },
     packages=setuptools.find_packages(exclude=['*test*']),
     classifiers=[

--- a/test_data/compiled-workflows/embedded_artifact.yaml
+++ b/test_data/compiled-workflows/embedded_artifact.yaml
@@ -1,0 +1,400 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  creationTimestamp: null
+  generateName: nb-simple-
+spec:
+  arguments:
+    parameters:
+    - name: components-5d69cab95ea11fe5b7fc72b504229fae1981a9e727e32c375694b2b7f50c0198
+      value: '{"executorLabel":"exec-read-embedded-artifact-dir"}'
+    - name: implementations-5d69cab95ea11fe5b7fc72b504229fae1981a9e727e32c375694b2b7f50c0198
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","read_embedded_artifact_dir"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.14.2'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\n__KFP_EMBEDDED_ARCHIVE_B64
+        = ''H4sIAHnS2mgC/+3UvQ6CMBSG4c5eBe6mnNPSFgYTR0ZvgUSiJiWYipHLF+KgRokTxJ/vWdoASYdyXhnLeLUu2rwsNmUQo6CroZVIJ7d9/5xJsRJRKyZwOjZF6I4X/0mlUdXsq3LJzmTsmDMtKctS7fRMwM+T8fhn9EPtjBGkSRu+W+9mng1Zawx3v2A//1Z182+mnP/qEIqdH/7u3fuvvf9P6L9+7j+j/5P0373uv0X+/6T/vt7Kpm1G7r9NkuH+d/vH/itOSESE/o8uL72vF9G5Dn4zxzgAAAAAAAAAAAAAAAAAfLULZBWkcAAoAAA=''\n\nimport
+        base64 as __kfp_b64\nimport io as __kfp_io\nimport os as __kfp_os\nimport
+        sys as __kfp_sys\nimport tarfile as __kfp_tarfile\nimport tempfile as __kfp_tempfile\n\n#
+        Extract embedded archive at import time to ensure sys.path and globals are
+        set\n__kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()\n__KFP_EMBEDDED_ASSET_DIR
+        = __kfp_tmpdir.name\ntry:\n    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode(''ascii''))\n    with
+        __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode=''r:gz'') as
+        __kfp_tar:\n        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)\nexcept
+        Exception as __kfp_e:\n    raise RuntimeError(f''Failed to extract embedded
+        archive: {__kfp_e}'')\n\n# Always prepend the extracted directory to sys.path
+        for import resolution\nif __KFP_EMBEDDED_ASSET_DIR not in __kfp_sys.path:\n    __kfp_sys.path.insert(0,
+        __KFP_EMBEDDED_ASSET_DIR)\n\n\n\n\ndef read_embedded_artifact_dir(artifact:
+        dsl.EmbeddedInput[dsl.Dataset]):\n    import os\n\n    with open(os.path.join(artifact.path,
+        \"log.txt\"), \"r\", encoding=\"utf-8\") as f:\n        log = f.read()\n\n    assert
+        log == \"Hello, world!\"\n\n"],"image":"python:3.9"}'
+    - name: components-01ce13632e66ae34f254595ff1d1056fc67354b72fc3f5281a7c8e45b3162bdb
+      value: '{"executorLabel":"exec-read-embedded-artifact-file"}'
+    - name: implementations-01ce13632e66ae34f254595ff1d1056fc67354b72fc3f5281a7c8e45b3162bdb
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","read_embedded_artifact_file"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.14.2'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\n__KFP_EMBEDDED_ARCHIVE_B64
+        = ''H4sIAHnS2mgC/+3UsQrCMBDG8cw+Rd2lvWua1g6Co6OvULCokFKpFfv4pog4iZNC9f9b7kgCt9yXOImT9bYaNnW1qzvzEXL3qopY++zHc5VU1USD+YLLua+6MN78p7SImv7Y1CstXKmFamljKctlbmcGv8+3+7gf+o/OGEOdZ5kRK9ape9aH0KuTPHdOwwqG/KfhTzCRfDP/zamrDv71u3f3E7WpvW8X0bXt/G5OHAAAAAAAAAAAAAAAACbnBq/wxAEAKAAA''\n\nimport
+        base64 as __kfp_b64\nimport io as __kfp_io\nimport os as __kfp_os\nimport
+        sys as __kfp_sys\nimport tarfile as __kfp_tarfile\nimport tempfile as __kfp_tempfile\n\n#
+        Extract embedded archive at import time to ensure sys.path and globals are
+        set\n__kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()\n__KFP_EMBEDDED_ASSET_DIR
+        = __kfp_tmpdir.name\ntry:\n    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode(''ascii''))\n    with
+        __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode=''r:gz'') as
+        __kfp_tar:\n        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)\nexcept
+        Exception as __kfp_e:\n    raise RuntimeError(f''Failed to extract embedded
+        archive: {__kfp_e}'')\n\n# Always prepend the extracted directory to sys.path
+        for import resolution\nif __KFP_EMBEDDED_ASSET_DIR not in __kfp_sys.path:\n    __kfp_sys.path.insert(0,
+        __KFP_EMBEDDED_ASSET_DIR)\n\n__KFP_EMBEDDED_ASSET_FILE = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR,
+        ''log.txt'')\n\n\n\n\ndef read_embedded_artifact_file(artifact: dsl.EmbeddedInput[dsl.Dataset]):\n    with
+        open(artifact.path, \"r\", encoding=\"utf-8\") as f:\n        log = f.read()\n\n    assert
+        log == \"Hello, world!\"\n\n"],"image":"python:3.9"}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"read-embedded-artifact-dir":{"cachingOptions":{},"componentRef":{"name":"comp-read-embedded-artifact-dir"},"taskInfo":{"name":"read-embedded-artifact-dir"}},"read-embedded-artifact-file":{"cachingOptions":{},"componentRef":{"name":"comp-read-embedded-artifact-file"},"taskInfo":{"name":"read-embedded-artifact-file"}}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - nb-simple
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: task-name
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata: {}
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+        name: executor
+        template: system-container-impl
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+    metadata: {}
+    name: system-container-executor
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher:latest
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+    metadata: {}
+    name: system-container-impl
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-5d69cab95ea11fe5b7fc72b504229fae1981a9e727e32c375694b2b7f50c0198}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-read-embedded-artifact-dir"},"taskInfo":{"name":"read-embedded-artifact-dir"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-5d69cab95ea11fe5b7fc72b504229fae1981a9e727e32c375694b2b7f50c0198}}'
+          - name: task-name
+            value: read-embedded-artifact-dir
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: read-embedded-artifact-dir-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.read-embedded-artifact-dir-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.read-embedded-artifact-dir-driver.outputs.parameters.cached-decision}}'
+        depends: read-embedded-artifact-dir-driver.Succeeded
+        name: read-embedded-artifact-dir
+        template: system-container-executor
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-01ce13632e66ae34f254595ff1d1056fc67354b72fc3f5281a7c8e45b3162bdb}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-read-embedded-artifact-file"},"taskInfo":{"name":"read-embedded-artifact-file"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-01ce13632e66ae34f254595ff1d1056fc67354b72fc3f5281a7c8e45b3162bdb}}'
+          - name: task-name
+            value: read-embedded-artifact-file
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: read-embedded-artifact-file-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.read-embedded-artifact-file-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.read-embedded-artifact-file-driver.outputs.parameters.cached-decision}}'
+        depends: read-embedded-artifact-file-driver.Succeeded
+        name: read-embedded-artifact-file
+        template: system-container-executor
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - nb-simple
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: ""
+        name: task-name
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata: {}
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/test_data/compiled-workflows/notebook_component_mixed.yaml
+++ b/test_data/compiled-workflows/notebook_component_mixed.yaml
@@ -1,0 +1,614 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  creationTimestamp: null
+  generateName: nb-mixed-
+spec:
+  arguments:
+    parameters:
+    - name: components-43c0d13fb84d9ca119bdf5124174bd3678698b085ea5c314339233390502736a
+      value: '{"executorLabel":"exec-evaluate-model","inputDefinitions":{"artifacts":{"model_text":{"artifactType":{"schemaTitle":"system.Model","schemaVersion":"0.0.1"}}}},"outputDefinitions":{"artifacts":{"metrics":{"artifactType":{"schemaTitle":"system.Metrics","schemaVersion":"0.0.1"}}}}}'
+    - name: implementations-43c0d13fb84d9ca119bdf5124174bd3678698b085ea5c314339233390502736a
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","evaluate_model"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''nbclient\u003e=0.10,\u003c1''
+        ''ipykernel\u003e=6,\u003c7'' ''jupyter_client\u003e=7,\u003c9''  \u0026\u0026  python3
+        -m pip install --quiet --no-warn-script-location ''kfp==2.14.2'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\n__KFP_EMBEDDED_ARCHIVE_B64
+        = ''H4sIACSp1mgC/+2Vy46bMBSGWecpLG9IJEogQGAiRequXXbR3WSEHGISN2BbtukkivLuNYQkk05HlarOqJfzLQz8x+f3wRfwx/74/Sey+0jJiirnVQhOvHQNgii63rd6GEzC0EE75w1otCHKDu/8n0xSVBtW03mYJll2lwVZ6meTOEzvBg7w78OXOf1KqrymRrFC+0zu+fIVzv80jp0gCqIkTK7XE2GcJk6YBNMkmUTTpD3/8TSNHBS85fmvpSKb6uV+P4v/pRwGCOGCVpXGM3RvHxA6dG0v52YvqQ3hQqwo9s4huqNFY5jgeSEabmwH3lTVJWx3E1kRQ6x+drOqIevrKL0miSK2N1UaX+SH/u548RONkY3pkh8uohaNKuiNIa5tlbZmujNojlx3wc+uJ8/e8Te/4S/UyWoplEFCe+iLFtzW6V2DQvs12dIVU3rojk0tx9tS5vak9vauh+iOaZOL7fyzaujoNr0/ynYCDq4uhKLuDJWVIGZYUT68ztBodLxNlIpxM1zgD8KgLhEtsId6u/sF7rQFfvhuvEdmNkhI6/2jYsfnL0v7nrZy97Etn9vJZnw9dxtTvsvcESIalbNb37Zpk/xVU8thb+OhcvRsVW3bTffzfYcrwtcNWdOc8VI82Y6Y223Xrrrcm43oDVujbjExX5ZC1aRd9vhGyGvGhbLyZHCEPyQAAAAAAAAAAAAAAAAAAAAAAAAAAADwp/ANkcfbmgAoAAA=''\n__KFP_NOTEBOOK_REL_PATH
+        = ''nb_eval_metrics.ipynb''\n\nimport base64 as __kfp_b64\nimport gzip as
+        __kfp_gzip\nimport io as __kfp_io\nimport os as __kfp_os\nimport sys as __kfp_sys\nimport
+        tarfile as __kfp_tarfile\nimport tempfile as __kfp_tempfile\nfrom nbclient
+        import NotebookClient\n\n# Extract embedded archive at import time to ensure
+        sys.path and globals are set\nprint(''[KFP] Extracting embedded notebook archive...'',
+        flush=True)\n__kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()\n__KFP_EMBEDDED_ASSET_DIR
+        = __kfp_tmpdir.name\ntry:\n    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode(''ascii''))\n    with
+        __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode=''r:gz'') as
+        __kfp_tar:\n        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)\n    print(f''[KFP]
+        Notebook archive extracted to: {__KFP_EMBEDDED_ASSET_DIR}'', flush=True)\nexcept
+        Exception as __kfp_e:\n    raise RuntimeError(f''Failed to extract embedded
+        notebook archive: {__kfp_e}'')\n\n# Always prepend the extracted directory
+        to sys.path for import resolution\nif __KFP_EMBEDDED_ASSET_DIR not in __kfp_sys.path:\n    __kfp_sys.path.insert(0,
+        __KFP_EMBEDDED_ASSET_DIR)\n    print(f''[KFP] Added notebook archive directory
+        to Python path'', flush=True)\n\n# Optional convenience for generic embedded
+        file variable name\n__KFP_EMBEDDED_ASSET_FILE = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR,
+        __KFP_NOTEBOOK_REL_PATH)\n\n\nclass KFPStreamingNotebookClient(NotebookClient):\n    #
+        Streams outputs in real-time by emitting outputs during message processing.\n    def
+        process_message(self, msg, cell, cell_index):\n        # Call the parent implementation
+        to handle the message normally\n        output = super().process_message(msg,
+        cell, cell_index)\n\n        # If an output was created, stream it immediately\n        if
+        output is not None:\n            _kfp_stream_single_output(output, cell_index)\n\n        return
+        output\n\ndef __kfp_write_parameters_cell(nb, params):\n    \"\"\"Inject parameters
+        following Papermill semantics.\n\n    - If a cell tagged with ''parameters''
+        exists, insert an overriding\n      ''injected-parameters'' cell immediately
+        after it.\n    - Otherwise, insert the ''injected-parameters'' cell at the
+        top.\n    \"\"\"\n    import json\n\n    import nbformat\n\n    if not params:\n        return\n\n    #
+        Build the injected parameters cell\n    assignments = []\n    for key, value
+        in params.items():\n        serialized = json.dumps(value)\n        assignments.append(key
+        + '' = json.loads('' + repr(serialized) + '')'')\n    source = ''import json\\n''
+        + ''\\n''.join(assignments) + ''\\n''\n    cell = nbformat.v4.new_code_cell(source=source)\n    cell.metadata.setdefault(''tags'',
+        [])\n    if ''injected-parameters'' not in cell.metadata[''tags'']:\n        cell.metadata[''tags''].append(''injected-parameters'')\n\n    #
+        Locate the first ''parameters'' tagged cell\n    insert_idx = 0\n    for idx,
+        existing in enumerate(nb.get(''cells'', [])):\n        if existing.get(''cell_type'')
+        != ''code'':\n            continue\n        tags = existing.get(''metadata'',
+        {}).get(''tags'', []) or []\n        if ''parameters'' in tags:\n            insert_idx
+        = idx + 1\n            break\n\n    nb.cells.insert(insert_idx, cell)\n\ndef
+        _kfp_stream_single_output(output, cell_idx):\n    \"\"\"Stream a single notebook
+        output immediately during execution.\n\n    Prints stdout/stderr and text/plain
+        display outputs to the console so users\n    see cell output as it happens
+        (no need to wait until the notebook finishes).\n    \"\"\"\n    import sys\n    output_type
+        = output.get(''output_type'')\n\n    if output_type == ''stream'':\n        text
+        = output.get(''text'', '''')\n        if text:\n            try:\n                print(f''[nb
+        cell {cell_idx} stream] '', end='''', flush=False)\n            except Exception:\n                pass\n            print(text,
+        end='''' if text.endswith(''\\n'') else ''\\n'', flush=True)\n    elif output_type
+        == ''error'':\n        for line in output.get(''traceback'', []):\n            print(line,
+        file=sys.stderr, flush=True)\n    else:\n        # Handle display_data and
+        execute_result\n        data = output.get(''data'', {})\n        if ''text/plain''
+        in data:\n            print(data[''text/plain''], flush=True)\n        elif
+        ''application/json'' in data:\n            try:\n                import json
+        as __kfp_json\n                parsed = data[''application/json'']\n                #
+        Some kernels send JSON as string; try to parse if needed\n                if
+        isinstance(parsed, str):\n                    try:\n                        parsed
+        = __kfp_json.loads(parsed)\n                    except Exception:\n                        pass\n                print(__kfp_json.dumps(parsed,
+        indent=2, ensure_ascii=False), flush=True)\n            except Exception:\n                #
+        Fallback to raw\n                print(str(data.get(''application/json'')),
+        flush=True)\n        elif ''text/markdown'' in data:\n            # Print
+        markdown as-is; frontends may render, logs will show raw markdown\n            print(data[''text/markdown''],
+        flush=True)\n\ndef kfp_run_notebook(**kwargs):\n    \"\"\"Execute the embedded
+        notebook with injected parameters.\n\n    Parameters provided via kwargs are
+        injected into the notebook following\n    Papermill semantics (after a parameters
+        cell if present, otherwise at top).\n    Execution uses a Python kernel; nbclient
+        and ipykernel must be available at\n    runtime (installed via packages_to_install
+        for notebook components).\n    \"\"\"\n    import os\n    import subprocess\n    import
+        sys\n\n    from nbclient import NotebookClient\n    import nbformat\n\n    #
+        Ensure a usable ''python3'' kernel is present; install kernelspec if missing\n    print(''[KFP
+        Notebook] Checking for Python kernel...'', flush=True)\n    try:\n        from
+        jupyter_client.kernelspec import KernelSpecManager  # type: ignore\n        ksm
+        = KernelSpecManager()\n        have_py3 = ''python3'' in ksm.find_kernel_specs()\n        if
+        not have_py3:\n            print(\n                ''[KFP Notebook] Python3
+        kernel not found, installing...'',\n                flush=True)\n            try:\n                subprocess.run([\n                    sys.executable,
+        ''-m'', ''ipykernel'', ''install'', ''--user'',\n                    ''--name'',
+        ''python3'', ''--display-name'', ''Python 3''\n                ],\n                               check=True,\n                               stdout=subprocess.DEVNULL,\n                               stderr=subprocess.DEVNULL)\n                print(\n                    ''[KFP
+        Notebook] Python3 kernel installed successfully'',\n                    flush=True)\n            except
+        subprocess.CalledProcessError as e:\n                raise RuntimeError(\n                    \"Failed
+        to install ''python3'' kernelspec for ipykernel. \"\n                    \"Ensure
+        ipykernel is available in the environment or include it via packages_to_install.
+        \"\n                    f\"Error: {e}\") from e\n        else:\n            print(''[KFP
+        Notebook] Python3 kernel found'', flush=True)\n    except ImportError as e:\n        raise
+        RuntimeError(\n            \"jupyter_client is not available. Ensure it''s
+        installed in the environment or include it via packages_to_install. \"\n            f\"Error:
+        {e}\") from e\n\n    nb_path = os.path.join(__KFP_EMBEDDED_ASSET_DIR, __KFP_NOTEBOOK_REL_PATH)\n\n    try:\n        nb
+        = nbformat.read(nb_path, as_version=4)\n    except Exception as e:\n        raise
+        RuntimeError(\n            f''Failed to read notebook {nb_path}. Ensure it
+        is a valid Jupyter notebook. Error: {e}''\n        ) from e\n\n    try:\n        __kfp_write_parameters_cell(nb,
+        kwargs)\n        print(\n            f''[KFP Notebook] Executing notebook
+        with {len(nb.get(\"cells\", []))} cells'',\n            flush=True)\n\n        #
+        Use our custom streaming client for real-time output (defined in the\n        #
+        generated ephemeral source)\n        client = KFPStreamingNotebookClient(\n            nb,\n            timeout=None,\n            allow_errors=False,\n            store_widget_state=False,\n            kernel_name=''python3'')\n        client.execute(cwd=__KFP_EMBEDDED_ASSET_DIR)\n\n        print(''[KFP
+        Notebook] Execution complete'', flush=True)\n\n    except Exception as e:\n        raise
+        RuntimeError(f''Notebook execution failed. Error: {e}'') from e\n\n\n# Bind
+        helper into dsl namespace so user code can call dsl.run_notebook(...)\ndsl.run_notebook
+        = kfp_run_notebook\n\n\ndef evaluate_model(model_text: dsl.Input[dsl.Model],
+        metrics: dsl.Output[dsl.Metrics]):\n    import json\n\n    with open(model_text.path,
+        \"r\", encoding=\"utf-8\") as f:\n        model_text = f.read()\n\n    dsl.run_notebook(model_text=model_text)\n    with
+        open(\"/tmp/kfp_nb_outputs/metrics.json\", \"r\", encoding=\"utf-8\") as f:\n        metrics_dict
+        = json.load(f)\n\n    assert metrics_dict == {\"score\": float(len(model_text))}\n\n    for
+        metric_name, metric_value in metrics_dict.items():\n        metrics.log_metric(metric_name,
+        metric_value)\n\n"],"image":"python:3.9"}'
+    - name: components-de426933840df1d5b1966245bfd35532f6a11ccaffa3dbb2311a6b7dbf3ec609
+      value: '{"executorLabel":"exec-preprocess","inputDefinitions":{"parameters":{"text":{"parameterType":"STRING"}}},"outputDefinitions":{"artifacts":{"dataset":{"artifactType":{"schemaTitle":"system.Dataset","schemaVersion":"0.0.1"}}}}}'
+    - name: implementations-de426933840df1d5b1966245bfd35532f6a11ccaffa3dbb2311a6b7dbf3ec609
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","preprocess"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.14.2'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\n\n\ndef
+        preprocess(text: str, dataset: dsl.Output[dsl.Dataset]):\n    import re\n\n    cleaned_text
+        = re.sub(r\"\\s+\", \" \", text).strip()\n    with open(dataset.path, \"w\",
+        encoding=\"utf-8\") as f:\n        f.write(cleaned_text)\n\n"],"image":"python:3.9"}'
+    - name: components-0e704495704924f0f854d4c513ac164f987781625d13c72aabf7e58c7fc1d08c
+      value: '{"executorLabel":"exec-train-model","inputDefinitions":{"artifacts":{"cleaned_text":{"artifactType":{"schemaTitle":"system.Dataset","schemaVersion":"0.0.1"}}}},"outputDefinitions":{"artifacts":{"model":{"artifactType":{"schemaTitle":"system.Model","schemaVersion":"0.0.1"}}}}}'
+    - name: implementations-0e704495704924f0f854d4c513ac164f987781625d13c72aabf7e58c7fc1d08c
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","train_model"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''nbclient\u003e=0.10,\u003c1''
+        ''ipykernel\u003e=6,\u003c7'' ''jupyter_client\u003e=7,\u003c9''  \u0026\u0026  python3
+        -m pip install --quiet --no-warn-script-location ''kfp==2.14.2'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\n__KFP_EMBEDDED_ARCHIVE_B64
+        = ''H4sIACSp1mgC/+2VTY/aMBCGc+ZXWLkEJBqSQAJdCanH9tZDpR7KKjKJAxaJbTmTErTiv9cJ4auwWrXartR2noMT3onnneAZcEfu6MNnWn9kNGXa+iN4B567et54cr5vdN8L/MAitfUGVCVQbeyt/5NgRgrgBZv703A2ez/zosgNwsgfh0HPQv55xDIGTbmItxzWsaKaFqXL1U4sX3f+o4mZ8bE3Dv3wfD3gT73Q8kMvCsNgHAWBmf9wGkws4r3l/BdK03X+/HMvxf9SnnqE2AnL89J+IN/MB0Ke2rWTY9gpZkJ2IlNmD48hVrOkAi5FnMhKgHlAVHl+ChcMaEqBGv2YzahAV2eXTms7jgHTpX2SH7u7/SmfrEBV0G5+PImlrHTCrhLaSc6oYGkMrAYyJ06xI51EGslZiKPNwaSzeOVX/o3CeaGkBiJLU+HwLMvSLeiGpVyXfWcEhRptMhWboe0SO0PCal5CLDfzL7pig+vtSnMB/YX9VXPgYkVAkjtJRoV50dyFGhb2TwmaXwUiFRN33c8bTR3OtilGmC/NOM2dCrJ3M2dAaEmyh+ukzZK5W1MT618emFspxXR/MPilU9J0a7/QeN/L9igvNaPmVKwqumKf0mOaU3R/04H3zuymTLO2p3xbxsks5iKTF5XYwrR/4692sJZdwiZRa22LZSZ1QZtum1wJccGF1EYOenv8o0YQBEEQBEEQBEEQBEEQBEEQBEEQBEF+APurSW0AKAAA''\n__KFP_NOTEBOOK_REL_PATH
+        = ''nb_train_with_params.ipynb''\n\nimport base64 as __kfp_b64\nimport gzip
+        as __kfp_gzip\nimport io as __kfp_io\nimport os as __kfp_os\nimport sys as
+        __kfp_sys\nimport tarfile as __kfp_tarfile\nimport tempfile as __kfp_tempfile\nfrom
+        nbclient import NotebookClient\n\n# Extract embedded archive at import time
+        to ensure sys.path and globals are set\nprint(''[KFP] Extracting embedded
+        notebook archive...'', flush=True)\n__kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()\n__KFP_EMBEDDED_ASSET_DIR
+        = __kfp_tmpdir.name\ntry:\n    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode(''ascii''))\n    with
+        __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode=''r:gz'') as
+        __kfp_tar:\n        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)\n    print(f''[KFP]
+        Notebook archive extracted to: {__KFP_EMBEDDED_ASSET_DIR}'', flush=True)\nexcept
+        Exception as __kfp_e:\n    raise RuntimeError(f''Failed to extract embedded
+        notebook archive: {__kfp_e}'')\n\n# Always prepend the extracted directory
+        to sys.path for import resolution\nif __KFP_EMBEDDED_ASSET_DIR not in __kfp_sys.path:\n    __kfp_sys.path.insert(0,
+        __KFP_EMBEDDED_ASSET_DIR)\n    print(f''[KFP] Added notebook archive directory
+        to Python path'', flush=True)\n\n# Optional convenience for generic embedded
+        file variable name\n__KFP_EMBEDDED_ASSET_FILE = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR,
+        __KFP_NOTEBOOK_REL_PATH)\n\n\nclass KFPStreamingNotebookClient(NotebookClient):\n    #
+        Streams outputs in real-time by emitting outputs during message processing.\n    def
+        process_message(self, msg, cell, cell_index):\n        # Call the parent implementation
+        to handle the message normally\n        output = super().process_message(msg,
+        cell, cell_index)\n\n        # If an output was created, stream it immediately\n        if
+        output is not None:\n            _kfp_stream_single_output(output, cell_index)\n\n        return
+        output\n\ndef __kfp_write_parameters_cell(nb, params):\n    \"\"\"Inject parameters
+        following Papermill semantics.\n\n    - If a cell tagged with ''parameters''
+        exists, insert an overriding\n      ''injected-parameters'' cell immediately
+        after it.\n    - Otherwise, insert the ''injected-parameters'' cell at the
+        top.\n    \"\"\"\n    import json\n\n    import nbformat\n\n    if not params:\n        return\n\n    #
+        Build the injected parameters cell\n    assignments = []\n    for key, value
+        in params.items():\n        serialized = json.dumps(value)\n        assignments.append(key
+        + '' = json.loads('' + repr(serialized) + '')'')\n    source = ''import json\\n''
+        + ''\\n''.join(assignments) + ''\\n''\n    cell = nbformat.v4.new_code_cell(source=source)\n    cell.metadata.setdefault(''tags'',
+        [])\n    if ''injected-parameters'' not in cell.metadata[''tags'']:\n        cell.metadata[''tags''].append(''injected-parameters'')\n\n    #
+        Locate the first ''parameters'' tagged cell\n    insert_idx = 0\n    for idx,
+        existing in enumerate(nb.get(''cells'', [])):\n        if existing.get(''cell_type'')
+        != ''code'':\n            continue\n        tags = existing.get(''metadata'',
+        {}).get(''tags'', []) or []\n        if ''parameters'' in tags:\n            insert_idx
+        = idx + 1\n            break\n\n    nb.cells.insert(insert_idx, cell)\n\ndef
+        _kfp_stream_single_output(output, cell_idx):\n    \"\"\"Stream a single notebook
+        output immediately during execution.\n\n    Prints stdout/stderr and text/plain
+        display outputs to the console so users\n    see cell output as it happens
+        (no need to wait until the notebook finishes).\n    \"\"\"\n    import sys\n    output_type
+        = output.get(''output_type'')\n\n    if output_type == ''stream'':\n        text
+        = output.get(''text'', '''')\n        if text:\n            try:\n                print(f''[nb
+        cell {cell_idx} stream] '', end='''', flush=False)\n            except Exception:\n                pass\n            print(text,
+        end='''' if text.endswith(''\\n'') else ''\\n'', flush=True)\n    elif output_type
+        == ''error'':\n        for line in output.get(''traceback'', []):\n            print(line,
+        file=sys.stderr, flush=True)\n    else:\n        # Handle display_data and
+        execute_result\n        data = output.get(''data'', {})\n        if ''text/plain''
+        in data:\n            print(data[''text/plain''], flush=True)\n        elif
+        ''application/json'' in data:\n            try:\n                import json
+        as __kfp_json\n                parsed = data[''application/json'']\n                #
+        Some kernels send JSON as string; try to parse if needed\n                if
+        isinstance(parsed, str):\n                    try:\n                        parsed
+        = __kfp_json.loads(parsed)\n                    except Exception:\n                        pass\n                print(__kfp_json.dumps(parsed,
+        indent=2, ensure_ascii=False), flush=True)\n            except Exception:\n                #
+        Fallback to raw\n                print(str(data.get(''application/json'')),
+        flush=True)\n        elif ''text/markdown'' in data:\n            # Print
+        markdown as-is; frontends may render, logs will show raw markdown\n            print(data[''text/markdown''],
+        flush=True)\n\ndef kfp_run_notebook(**kwargs):\n    \"\"\"Execute the embedded
+        notebook with injected parameters.\n\n    Parameters provided via kwargs are
+        injected into the notebook following\n    Papermill semantics (after a parameters
+        cell if present, otherwise at top).\n    Execution uses a Python kernel; nbclient
+        and ipykernel must be available at\n    runtime (installed via packages_to_install
+        for notebook components).\n    \"\"\"\n    import os\n    import subprocess\n    import
+        sys\n\n    from nbclient import NotebookClient\n    import nbformat\n\n    #
+        Ensure a usable ''python3'' kernel is present; install kernelspec if missing\n    print(''[KFP
+        Notebook] Checking for Python kernel...'', flush=True)\n    try:\n        from
+        jupyter_client.kernelspec import KernelSpecManager  # type: ignore\n        ksm
+        = KernelSpecManager()\n        have_py3 = ''python3'' in ksm.find_kernel_specs()\n        if
+        not have_py3:\n            print(\n                ''[KFP Notebook] Python3
+        kernel not found, installing...'',\n                flush=True)\n            try:\n                subprocess.run([\n                    sys.executable,
+        ''-m'', ''ipykernel'', ''install'', ''--user'',\n                    ''--name'',
+        ''python3'', ''--display-name'', ''Python 3''\n                ],\n                               check=True,\n                               stdout=subprocess.DEVNULL,\n                               stderr=subprocess.DEVNULL)\n                print(\n                    ''[KFP
+        Notebook] Python3 kernel installed successfully'',\n                    flush=True)\n            except
+        subprocess.CalledProcessError as e:\n                raise RuntimeError(\n                    \"Failed
+        to install ''python3'' kernelspec for ipykernel. \"\n                    \"Ensure
+        ipykernel is available in the environment or include it via packages_to_install.
+        \"\n                    f\"Error: {e}\") from e\n        else:\n            print(''[KFP
+        Notebook] Python3 kernel found'', flush=True)\n    except ImportError as e:\n        raise
+        RuntimeError(\n            \"jupyter_client is not available. Ensure it''s
+        installed in the environment or include it via packages_to_install. \"\n            f\"Error:
+        {e}\") from e\n\n    nb_path = os.path.join(__KFP_EMBEDDED_ASSET_DIR, __KFP_NOTEBOOK_REL_PATH)\n\n    try:\n        nb
+        = nbformat.read(nb_path, as_version=4)\n    except Exception as e:\n        raise
+        RuntimeError(\n            f''Failed to read notebook {nb_path}. Ensure it
+        is a valid Jupyter notebook. Error: {e}''\n        ) from e\n\n    try:\n        __kfp_write_parameters_cell(nb,
+        kwargs)\n        print(\n            f''[KFP Notebook] Executing notebook
+        with {len(nb.get(\"cells\", []))} cells'',\n            flush=True)\n\n        #
+        Use our custom streaming client for real-time output (defined in the\n        #
+        generated ephemeral source)\n        client = KFPStreamingNotebookClient(\n            nb,\n            timeout=None,\n            allow_errors=False,\n            store_widget_state=False,\n            kernel_name=''python3'')\n        client.execute(cwd=__KFP_EMBEDDED_ASSET_DIR)\n\n        print(''[KFP
+        Notebook] Execution complete'', flush=True)\n\n    except Exception as e:\n        raise
+        RuntimeError(f''Notebook execution failed. Error: {e}'') from e\n\n\n# Bind
+        helper into dsl namespace so user code can call dsl.run_notebook(...)\ndsl.run_notebook
+        = kfp_run_notebook\n\n\ndef train_model(cleaned_text: dsl.Input[dsl.Dataset],
+        model: dsl.Output[dsl.Model]):\n    import shutil\n\n    with open(cleaned_text.path,
+        \"r\", encoding=\"utf-8\") as f:\n        cleaned_text = f.read()\n\n    dsl.run_notebook(cleaned_text=cleaned_text)\n\n    #
+        Notebook writes its model into /tmp/kfp_nb_outputs/model.txt\n    shutil.copy(\"/tmp/kfp_nb_outputs/model.txt\",
+        model.path)\n\n    with open(model.path, \"r\", encoding=\"utf-8\") as f:\n        model_text
+        = f.read()\n\n    assert model_text == cleaned_text.upper()\n\n"],"image":"python:3.9"}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"evaluate-model":{"cachingOptions":{},"componentRef":{"name":"comp-evaluate-model"},"dependentTasks":["train-model"],"inputs":{"artifacts":{"model_text":{"taskOutputArtifact":{"outputArtifactKey":"model","producerTask":"train-model"}}}},"taskInfo":{"name":"evaluate-model"}},"preprocess":{"cachingOptions":{},"componentRef":{"name":"comp-preprocess"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"taskInfo":{"name":"preprocess"}},"train-model":{"cachingOptions":{},"componentRef":{"name":"comp-train-model"},"dependentTasks":["preprocess"],"inputs":{"artifacts":{"cleaned_text":{"taskOutputArtifact":{"outputArtifactKey":"dataset","producerTask":"preprocess"}}}},"taskInfo":{"name":"train-model"}}}},"inputDefinitions":{"parameters":{"text":{"defaultValue":"Hello   world","isOptional":true,"parameterType":"STRING"}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - nb-mixed
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: task-name
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata: {}
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+        name: executor
+        template: system-container-impl
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+    metadata: {}
+    name: system-container-executor
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher:latest
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+    metadata: {}
+    name: system-container-impl
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-43c0d13fb84d9ca119bdf5124174bd3678698b085ea5c314339233390502736a}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-evaluate-model"},"dependentTasks":["train-model"],"inputs":{"artifacts":{"model_text":{"taskOutputArtifact":{"outputArtifactKey":"model","producerTask":"train-model"}}}},"taskInfo":{"name":"evaluate-model"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-43c0d13fb84d9ca119bdf5124174bd3678698b085ea5c314339233390502736a}}'
+          - name: task-name
+            value: evaluate-model
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        depends: train-model.Succeeded
+        name: evaluate-model-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.evaluate-model-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.evaluate-model-driver.outputs.parameters.cached-decision}}'
+        depends: evaluate-model-driver.Succeeded
+        name: evaluate-model
+        template: system-container-executor
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-de426933840df1d5b1966245bfd35532f6a11ccaffa3dbb2311a6b7dbf3ec609}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-preprocess"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"taskInfo":{"name":"preprocess"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-de426933840df1d5b1966245bfd35532f6a11ccaffa3dbb2311a6b7dbf3ec609}}'
+          - name: task-name
+            value: preprocess
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: preprocess-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.preprocess-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.preprocess-driver.outputs.parameters.cached-decision}}'
+        depends: preprocess-driver.Succeeded
+        name: preprocess
+        template: system-container-executor
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-0e704495704924f0f854d4c513ac164f987781625d13c72aabf7e58c7fc1d08c}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-train-model"},"dependentTasks":["preprocess"],"inputs":{"artifacts":{"cleaned_text":{"taskOutputArtifact":{"outputArtifactKey":"dataset","producerTask":"preprocess"}}}},"taskInfo":{"name":"train-model"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-0e704495704924f0f854d4c513ac164f987781625d13c72aabf7e58c7fc1d08c}}'
+          - name: task-name
+            value: train-model
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        depends: preprocess.Succeeded
+        name: train-model-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.train-model-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.train-model-driver.outputs.parameters.cached-decision}}'
+        depends: train-model-driver.Succeeded
+        name: train-model
+        template: system-container-executor
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - nb-mixed
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: ""
+        name: task-name
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata: {}
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{"parameterValues":{"text":"Hello   world"}}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/test_data/compiled-workflows/notebook_component_simple.yaml
+++ b/test_data/compiled-workflows/notebook_component_simple.yaml
@@ -1,0 +1,433 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  creationTimestamp: null
+  generateName: nb-simple-
+spec:
+  arguments:
+    parameters:
+    - name: components-6cb96369cb79941c813048ffcedc1b2b4dc48a280367899eadca221221c54b92
+      value: '{"executorLabel":"exec-run-train-notebook","inputDefinitions":{"parameters":{"text":{"parameterType":"STRING"}}}}'
+    - name: implementations-6cb96369cb79941c813048ffcedc1b2b4dc48a280367899eadca221221c54b92
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","run_train_notebook"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''nbclient\u003e=0.10,\u003c1''
+        ''ipykernel\u003e=6,\u003c7'' ''jupyter_client\u003e=7,\u003c9''  \u0026\u0026  python3
+        -m pip install --quiet --no-warn-script-location ''kfp==2.14.2'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\n__KFP_EMBEDDED_ARCHIVE_B64
+        = ''H4sIACap1mgC/+2VTW+jMBCGOedXWFxI1S7fJLRSpD3ucQ8r7WFTIQdMYgVsZMYKUdT/voZSKqpWe2pXu51HyIZ3PB/yaITrud7X77T7xmjBlPUu+I+8tft+FD+/93rgh0Fokc76AHQLVJn01uckTEkNvGabYJ2k6W3qJ4kb366DIEoWFvLfI3YZKMpF1vK6qZjLm7PYvcP8r2Iz45EfJUHyvD8SRKFvBYm/SpIwWvlrM//xah1ZxP/I+a8bRQ/V2+f+ZP9HuSwIsXNWVa19R36ZD0IuwzrKGZwbZkx2Lgtm3zyZWMdyDVyKLJdagDkgdFVN5poBLShQo18eJlVqaDQMie4nsZVa5WxKPmjAOgjJhjgFK6muIHTs0Xg/7GPIv1+omRmpgMh2K6aUvX/r1vTICq7apeNB3XjHssnMqI2BnRvCOt5CJo+bH0qzq7l7o7iA5db+qThwsScgyStBvEruXehga79wP3E4ENkw8WruJzdTg3PqCxHmwkyWjaOh/JI6V4S2pLybh+yX0j2Zetiybw65Jlu7f67J0Ku+gnmHzDpc3eyGB5NdUbHXdM8yLko5ycYgaD10sDnDQY4B+0BDY2yxK6Wqad/CeCZkNRdSGTlcPOA/C0EQBEEQBEEQBEEQBEEQBEEQBEEQBPmU/AbrYhlkACgAAA==''\n__KFP_NOTEBOOK_REL_PATH
+        = ''nb_train_simple.ipynb''\n\nimport base64 as __kfp_b64\nimport gzip as
+        __kfp_gzip\nimport io as __kfp_io\nimport os as __kfp_os\nimport sys as __kfp_sys\nimport
+        tarfile as __kfp_tarfile\nimport tempfile as __kfp_tempfile\nfrom nbclient
+        import NotebookClient\n\n# Extract embedded archive at import time to ensure
+        sys.path and globals are set\nprint(''[KFP] Extracting embedded notebook archive...'',
+        flush=True)\n__kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()\n__KFP_EMBEDDED_ASSET_DIR
+        = __kfp_tmpdir.name\ntry:\n    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode(''ascii''))\n    with
+        __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode=''r:gz'') as
+        __kfp_tar:\n        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)\n    print(f''[KFP]
+        Notebook archive extracted to: {__KFP_EMBEDDED_ASSET_DIR}'', flush=True)\nexcept
+        Exception as __kfp_e:\n    raise RuntimeError(f''Failed to extract embedded
+        notebook archive: {__kfp_e}'')\n\n# Always prepend the extracted directory
+        to sys.path for import resolution\nif __KFP_EMBEDDED_ASSET_DIR not in __kfp_sys.path:\n    __kfp_sys.path.insert(0,
+        __KFP_EMBEDDED_ASSET_DIR)\n    print(f''[KFP] Added notebook archive directory
+        to Python path'', flush=True)\n\n# Optional convenience for generic embedded
+        file variable name\n__KFP_EMBEDDED_ASSET_FILE = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR,
+        __KFP_NOTEBOOK_REL_PATH)\n\n\nclass KFPStreamingNotebookClient(NotebookClient):\n    #
+        Streams outputs in real-time by emitting outputs during message processing.\n    def
+        process_message(self, msg, cell, cell_index):\n        # Call the parent implementation
+        to handle the message normally\n        output = super().process_message(msg,
+        cell, cell_index)\n\n        # If an output was created, stream it immediately\n        if
+        output is not None:\n            _kfp_stream_single_output(output, cell_index)\n\n        return
+        output\n\ndef __kfp_write_parameters_cell(nb, params):\n    \"\"\"Inject parameters
+        following Papermill semantics.\n\n    - If a cell tagged with ''parameters''
+        exists, insert an overriding\n      ''injected-parameters'' cell immediately
+        after it.\n    - Otherwise, insert the ''injected-parameters'' cell at the
+        top.\n    \"\"\"\n    import json\n\n    import nbformat\n\n    if not params:\n        return\n\n    #
+        Build the injected parameters cell\n    assignments = []\n    for key, value
+        in params.items():\n        serialized = json.dumps(value)\n        assignments.append(key
+        + '' = json.loads('' + repr(serialized) + '')'')\n    source = ''import json\\n''
+        + ''\\n''.join(assignments) + ''\\n''\n    cell = nbformat.v4.new_code_cell(source=source)\n    cell.metadata.setdefault(''tags'',
+        [])\n    if ''injected-parameters'' not in cell.metadata[''tags'']:\n        cell.metadata[''tags''].append(''injected-parameters'')\n\n    #
+        Locate the first ''parameters'' tagged cell\n    insert_idx = 0\n    for idx,
+        existing in enumerate(nb.get(''cells'', [])):\n        if existing.get(''cell_type'')
+        != ''code'':\n            continue\n        tags = existing.get(''metadata'',
+        {}).get(''tags'', []) or []\n        if ''parameters'' in tags:\n            insert_idx
+        = idx + 1\n            break\n\n    nb.cells.insert(insert_idx, cell)\n\ndef
+        _kfp_stream_single_output(output, cell_idx):\n    \"\"\"Stream a single notebook
+        output immediately during execution.\n\n    Prints stdout/stderr and text/plain
+        display outputs to the console so users\n    see cell output as it happens
+        (no need to wait until the notebook finishes).\n    \"\"\"\n    import sys\n    output_type
+        = output.get(''output_type'')\n\n    if output_type == ''stream'':\n        text
+        = output.get(''text'', '''')\n        if text:\n            try:\n                print(f''[nb
+        cell {cell_idx} stream] '', end='''', flush=False)\n            except Exception:\n                pass\n            print(text,
+        end='''' if text.endswith(''\\n'') else ''\\n'', flush=True)\n    elif output_type
+        == ''error'':\n        for line in output.get(''traceback'', []):\n            print(line,
+        file=sys.stderr, flush=True)\n    else:\n        # Handle display_data and
+        execute_result\n        data = output.get(''data'', {})\n        if ''text/plain''
+        in data:\n            print(data[''text/plain''], flush=True)\n        elif
+        ''application/json'' in data:\n            try:\n                import json
+        as __kfp_json\n                parsed = data[''application/json'']\n                #
+        Some kernels send JSON as string; try to parse if needed\n                if
+        isinstance(parsed, str):\n                    try:\n                        parsed
+        = __kfp_json.loads(parsed)\n                    except Exception:\n                        pass\n                print(__kfp_json.dumps(parsed,
+        indent=2, ensure_ascii=False), flush=True)\n            except Exception:\n                #
+        Fallback to raw\n                print(str(data.get(''application/json'')),
+        flush=True)\n        elif ''text/markdown'' in data:\n            # Print
+        markdown as-is; frontends may render, logs will show raw markdown\n            print(data[''text/markdown''],
+        flush=True)\n\ndef kfp_run_notebook(**kwargs):\n    \"\"\"Execute the embedded
+        notebook with injected parameters.\n\n    Parameters provided via kwargs are
+        injected into the notebook following\n    Papermill semantics (after a parameters
+        cell if present, otherwise at top).\n    Execution uses a Python kernel; nbclient
+        and ipykernel must be available at\n    runtime (installed via packages_to_install
+        for notebook components).\n    \"\"\"\n    import os\n    import subprocess\n    import
+        sys\n\n    from nbclient import NotebookClient\n    import nbformat\n\n    #
+        Ensure a usable ''python3'' kernel is present; install kernelspec if missing\n    print(''[KFP
+        Notebook] Checking for Python kernel...'', flush=True)\n    try:\n        from
+        jupyter_client.kernelspec import KernelSpecManager  # type: ignore\n        ksm
+        = KernelSpecManager()\n        have_py3 = ''python3'' in ksm.find_kernel_specs()\n        if
+        not have_py3:\n            print(\n                ''[KFP Notebook] Python3
+        kernel not found, installing...'',\n                flush=True)\n            try:\n                subprocess.run([\n                    sys.executable,
+        ''-m'', ''ipykernel'', ''install'', ''--user'',\n                    ''--name'',
+        ''python3'', ''--display-name'', ''Python 3''\n                ],\n                               check=True,\n                               stdout=subprocess.DEVNULL,\n                               stderr=subprocess.DEVNULL)\n                print(\n                    ''[KFP
+        Notebook] Python3 kernel installed successfully'',\n                    flush=True)\n            except
+        subprocess.CalledProcessError as e:\n                raise RuntimeError(\n                    \"Failed
+        to install ''python3'' kernelspec for ipykernel. \"\n                    \"Ensure
+        ipykernel is available in the environment or include it via packages_to_install.
+        \"\n                    f\"Error: {e}\") from e\n        else:\n            print(''[KFP
+        Notebook] Python3 kernel found'', flush=True)\n    except ImportError as e:\n        raise
+        RuntimeError(\n            \"jupyter_client is not available. Ensure it''s
+        installed in the environment or include it via packages_to_install. \"\n            f\"Error:
+        {e}\") from e\n\n    nb_path = os.path.join(__KFP_EMBEDDED_ASSET_DIR, __KFP_NOTEBOOK_REL_PATH)\n\n    try:\n        nb
+        = nbformat.read(nb_path, as_version=4)\n    except Exception as e:\n        raise
+        RuntimeError(\n            f''Failed to read notebook {nb_path}. Ensure it
+        is a valid Jupyter notebook. Error: {e}''\n        ) from e\n\n    try:\n        __kfp_write_parameters_cell(nb,
+        kwargs)\n        print(\n            f''[KFP Notebook] Executing notebook
+        with {len(nb.get(\"cells\", []))} cells'',\n            flush=True)\n\n        #
+        Use our custom streaming client for real-time output (defined in the\n        #
+        generated ephemeral source)\n        client = KFPStreamingNotebookClient(\n            nb,\n            timeout=None,\n            allow_errors=False,\n            store_widget_state=False,\n            kernel_name=''python3'')\n        client.execute(cwd=__KFP_EMBEDDED_ASSET_DIR)\n\n        print(''[KFP
+        Notebook] Execution complete'', flush=True)\n\n    except Exception as e:\n        raise
+        RuntimeError(f''Notebook execution failed. Error: {e}'') from e\n\n\n# Bind
+        helper into dsl namespace so user code can call dsl.run_notebook(...)\ndsl.run_notebook
+        = kfp_run_notebook\n\n\ndef run_train_notebook(text: str):\n    # text is
+        not defined in the notebook but text2 is defined\n    dsl.run_notebook(text=text)\n\n    with
+        open(\"/tmp/kfp_nb_outputs/log.txt\", \"r\", encoding=\"utf-8\") as f:\n        log
+        = f.read()\n\n    assert log == text + \" \" + \"default2\"\n\n"],"image":"python:3.9"}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"run-train-notebook":{"cachingOptions":{},"componentRef":{"name":"comp-run-train-notebook"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"taskInfo":{"name":"run-train-notebook"}}}},"inputDefinitions":{"parameters":{"text":{"defaultValue":"hello","isOptional":true,"parameterType":"STRING"}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - nb-simple
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: task-name
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata: {}
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+        name: executor
+        template: system-container-impl
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+    metadata: {}
+    name: system-container-executor
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher:latest
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+    metadata: {}
+    name: system-container-impl
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-6cb96369cb79941c813048ffcedc1b2b4dc48a280367899eadca221221c54b92}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-run-train-notebook"},"inputs":{"parameters":{"text":{"componentInputParameter":"text"}}},"taskInfo":{"name":"run-train-notebook"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-6cb96369cb79941c813048ffcedc1b2b4dc48a280367899eadca221221c54b92}}'
+          - name: task-name
+            value: run-train-notebook
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: run-train-notebook-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.run-train-notebook-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.run-train-notebook-driver.outputs.parameters.cached-decision}}'
+        depends: run-train-notebook-driver.Succeeded
+        name: run-train-notebook
+        template: system-container-executor
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - nb-simple
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: ""
+        name: task-name
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata: {}
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{"parameterValues":{"text":"hello"}}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/test_data/pipeline_files/valid/critical/embedded_artifact.yaml
+++ b/test_data/pipeline_files/valid/critical/embedded_artifact.yaml
@@ -1,0 +1,114 @@
+# PIPELINE DEFINITION
+# Name: nb-simple
+components:
+  comp-read-embedded-artifact-dir:
+    executorLabel: exec-read-embedded-artifact-dir
+  comp-read-embedded-artifact-file:
+    executorLabel: exec-read-embedded-artifact-file
+deploymentSpec:
+  executors:
+    exec-read-embedded-artifact-dir:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - read_embedded_artifact_dir
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.14.2'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\n__KFP_EMBEDDED_ARCHIVE_B64 = 'H4sIAHnS2mgC/+3UvQ6CMBSG4c5eBe6mnNPSFgYTR0ZvgUSiJiWYipHLF+KgRokTxJ/vWdoASYdyXhnLeLUu2rwsNmUQo6CroZVIJ7d9/5xJsRJRKyZwOjZF6I4X/0mlUdXsq3LJzmTsmDMtKctS7fRMwM+T8fhn9EPtjBGkSRu+W+9mng1Zawx3v2A//1Z182+mnP/qEIqdH/7u3fuvvf9P6L9+7j+j/5P0373uv0X+/6T/vt7Kpm1G7r9NkuH+d/vH/itOSESE/o8uL72vF9G5Dn4zxzgAAAAAAAAAAAAAAAAAfLULZBWkcAAoAAA='\n\
+          \nimport base64 as __kfp_b64\nimport io as __kfp_io\nimport os as __kfp_os\n\
+          import sys as __kfp_sys\nimport tarfile as __kfp_tarfile\nimport tempfile\
+          \ as __kfp_tempfile\n\n# Extract embedded archive at import time to ensure\
+          \ sys.path and globals are set\n__kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()\n\
+          __KFP_EMBEDDED_ASSET_DIR = __kfp_tmpdir.name\ntry:\n    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode('ascii'))\n\
+          \    with __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode='r:gz')\
+          \ as __kfp_tar:\n        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)\n\
+          except Exception as __kfp_e:\n    raise RuntimeError(f'Failed to extract\
+          \ embedded archive: {__kfp_e}')\n\n# Always prepend the extracted directory\
+          \ to sys.path for import resolution\nif __KFP_EMBEDDED_ASSET_DIR not in\
+          \ __kfp_sys.path:\n    __kfp_sys.path.insert(0, __KFP_EMBEDDED_ASSET_DIR)\n\
+          \n\n\n\ndef read_embedded_artifact_dir(artifact: dsl.EmbeddedInput[dsl.Dataset]):\n\
+          \    import os\n\n    with open(os.path.join(artifact.path, \"log.txt\"\
+          ), \"r\", encoding=\"utf-8\") as f:\n        log = f.read()\n\n    assert\
+          \ log == \"Hello, world!\"\n\n"
+        image: python:3.9
+    exec-read-embedded-artifact-file:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - read_embedded_artifact_file
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.14.2'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\n__KFP_EMBEDDED_ARCHIVE_B64 = 'H4sIAHnS2mgC/+3UsQrCMBDG8cw+Rd2lvWua1g6Co6OvULCokFKpFfv4pog4iZNC9f9b7kgCt9yXOImT9bYaNnW1qzvzEXL3qopY++zHc5VU1USD+YLLua+6MN78p7SImv7Y1CstXKmFamljKctlbmcGv8+3+7gf+o/OGEOdZ5kRK9ape9aH0KuTPHdOwwqG/KfhTzCRfDP/zamrDv71u3f3E7WpvW8X0bXt/G5OHAAAAAAAAAAAAAAAACbnBq/wxAEAKAAA'\n\
+          \nimport base64 as __kfp_b64\nimport io as __kfp_io\nimport os as __kfp_os\n\
+          import sys as __kfp_sys\nimport tarfile as __kfp_tarfile\nimport tempfile\
+          \ as __kfp_tempfile\n\n# Extract embedded archive at import time to ensure\
+          \ sys.path and globals are set\n__kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()\n\
+          __KFP_EMBEDDED_ASSET_DIR = __kfp_tmpdir.name\ntry:\n    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode('ascii'))\n\
+          \    with __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode='r:gz')\
+          \ as __kfp_tar:\n        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)\n\
+          except Exception as __kfp_e:\n    raise RuntimeError(f'Failed to extract\
+          \ embedded archive: {__kfp_e}')\n\n# Always prepend the extracted directory\
+          \ to sys.path for import resolution\nif __KFP_EMBEDDED_ASSET_DIR not in\
+          \ __kfp_sys.path:\n    __kfp_sys.path.insert(0, __KFP_EMBEDDED_ASSET_DIR)\n\
+          \n__KFP_EMBEDDED_ASSET_FILE = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR,\
+          \ 'log.txt')\n\n\n\n\ndef read_embedded_artifact_file(artifact: dsl.EmbeddedInput[dsl.Dataset]):\n\
+          \    with open(artifact.path, \"r\", encoding=\"utf-8\") as f:\n       \
+          \ log = f.read()\n\n    assert log == \"Hello, world!\"\n\n"
+        image: python:3.9
+pipelineInfo:
+  name: nb-simple
+root:
+  dag:
+    tasks:
+      read-embedded-artifact-dir:
+        cachingOptions: {}
+        componentRef:
+          name: comp-read-embedded-artifact-dir
+        taskInfo:
+          name: read-embedded-artifact-dir
+      read-embedded-artifact-file:
+        cachingOptions: {}
+        componentRef:
+          name: comp-read-embedded-artifact-file
+        taskInfo:
+          name: read-embedded-artifact-file
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.14.2

--- a/test_data/pipeline_files/valid/critical/notebook_component_simple.yaml
+++ b/test_data/pipeline_files/valid/critical/notebook_component_simple.yaml
@@ -1,0 +1,181 @@
+# PIPELINE DEFINITION
+# Name: nb-simple
+# Inputs:
+#    text: str [Default: 'hello']
+components:
+  comp-run-train-notebook:
+    executorLabel: exec-run-train-notebook
+    inputDefinitions:
+      parameters:
+        text:
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-run-train-notebook:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - run_train_notebook
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'nbclient>=0.10,<1'\
+          \ 'ipykernel>=6,<7' 'jupyter_client>=7,<9'  &&  python3 -m pip install --quiet\
+          \ --no-warn-script-location 'kfp==2.14.2' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\n__KFP_EMBEDDED_ARCHIVE_B64 = 'H4sIACap1mgC/+2VTW+jMBCGOedXWFxI1S7fJLRSpD3ucQ8r7WFTIQdMYgVsZMYKUdT/voZSKqpWe2pXu51HyIZ3PB/yaITrud7X77T7xmjBlPUu+I+8tft+FD+/93rgh0Fokc76AHQLVJn01uckTEkNvGabYJ2k6W3qJ4kb366DIEoWFvLfI3YZKMpF1vK6qZjLm7PYvcP8r2Iz45EfJUHyvD8SRKFvBYm/SpIwWvlrM//xah1ZxP/I+a8bRQ/V2+f+ZP9HuSwIsXNWVa19R36ZD0IuwzrKGZwbZkx2Lgtm3zyZWMdyDVyKLJdagDkgdFVN5poBLShQo18eJlVqaDQMie4nsZVa5WxKPmjAOgjJhjgFK6muIHTs0Xg/7GPIv1+omRmpgMh2K6aUvX/r1vTICq7apeNB3XjHssnMqI2BnRvCOt5CJo+bH0qzq7l7o7iA5db+qThwsScgyStBvEruXehga79wP3E4ENkw8WruJzdTg3PqCxHmwkyWjaOh/JI6V4S2pLybh+yX0j2Zetiybw65Jlu7f67J0Ku+gnmHzDpc3eyGB5NdUbHXdM8yLko5ycYgaD10sDnDQY4B+0BDY2yxK6Wqad/CeCZkNRdSGTlcPOA/C0EQBEEQBEEQBEEQBEEQBEEQBEEQBPmU/AbrYhlkACgAAA=='\n\
+          __KFP_NOTEBOOK_REL_PATH = 'nb_train_simple.ipynb'\n\nimport base64 as __kfp_b64\n\
+          import gzip as __kfp_gzip\nimport io as __kfp_io\nimport os as __kfp_os\n\
+          import sys as __kfp_sys\nimport tarfile as __kfp_tarfile\nimport tempfile\
+          \ as __kfp_tempfile\nfrom nbclient import NotebookClient\n\n# Extract embedded\
+          \ archive at import time to ensure sys.path and globals are set\nprint('[KFP]\
+          \ Extracting embedded notebook archive...', flush=True)\n__kfp_tmpdir =\
+          \ __kfp_tempfile.TemporaryDirectory()\n__KFP_EMBEDDED_ASSET_DIR = __kfp_tmpdir.name\n\
+          try:\n    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode('ascii'))\n\
+          \    with __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode='r:gz')\
+          \ as __kfp_tar:\n        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)\n\
+          \    print(f'[KFP] Notebook archive extracted to: {__KFP_EMBEDDED_ASSET_DIR}',\
+          \ flush=True)\nexcept Exception as __kfp_e:\n    raise RuntimeError(f'Failed\
+          \ to extract embedded notebook archive: {__kfp_e}')\n\n# Always prepend\
+          \ the extracted directory to sys.path for import resolution\nif __KFP_EMBEDDED_ASSET_DIR\
+          \ not in __kfp_sys.path:\n    __kfp_sys.path.insert(0, __KFP_EMBEDDED_ASSET_DIR)\n\
+          \    print(f'[KFP] Added notebook archive directory to Python path', flush=True)\n\
+          \n# Optional convenience for generic embedded file variable name\n__KFP_EMBEDDED_ASSET_FILE\
+          \ = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR, __KFP_NOTEBOOK_REL_PATH)\n\
+          \n\nclass KFPStreamingNotebookClient(NotebookClient):\n    # Streams outputs\
+          \ in real-time by emitting outputs during message processing.\n    def process_message(self,\
+          \ msg, cell, cell_index):\n        # Call the parent implementation to handle\
+          \ the message normally\n        output = super().process_message(msg, cell,\
+          \ cell_index)\n\n        # If an output was created, stream it immediately\n\
+          \        if output is not None:\n            _kfp_stream_single_output(output,\
+          \ cell_index)\n\n        return output\n\ndef __kfp_write_parameters_cell(nb,\
+          \ params):\n    \"\"\"Inject parameters following Papermill semantics.\n\
+          \n    - If a cell tagged with 'parameters' exists, insert an overriding\n\
+          \      'injected-parameters' cell immediately after it.\n    - Otherwise,\
+          \ insert the 'injected-parameters' cell at the top.\n    \"\"\"\n    import\
+          \ json\n\n    import nbformat\n\n    if not params:\n        return\n\n\
+          \    # Build the injected parameters cell\n    assignments = []\n    for\
+          \ key, value in params.items():\n        serialized = json.dumps(value)\n\
+          \        assignments.append(key + ' = json.loads(' + repr(serialized) +\
+          \ ')')\n    source = 'import json\\n' + '\\n'.join(assignments) + '\\n'\n\
+          \    cell = nbformat.v4.new_code_cell(source=source)\n    cell.metadata.setdefault('tags',\
+          \ [])\n    if 'injected-parameters' not in cell.metadata['tags']:\n    \
+          \    cell.metadata['tags'].append('injected-parameters')\n\n    # Locate\
+          \ the first 'parameters' tagged cell\n    insert_idx = 0\n    for idx, existing\
+          \ in enumerate(nb.get('cells', [])):\n        if existing.get('cell_type')\
+          \ != 'code':\n            continue\n        tags = existing.get('metadata',\
+          \ {}).get('tags', []) or []\n        if 'parameters' in tags:\n        \
+          \    insert_idx = idx + 1\n            break\n\n    nb.cells.insert(insert_idx,\
+          \ cell)\n\ndef _kfp_stream_single_output(output, cell_idx):\n    \"\"\"\
+          Stream a single notebook output immediately during execution.\n\n    Prints\
+          \ stdout/stderr and text/plain display outputs to the console so users\n\
+          \    see cell output as it happens (no need to wait until the notebook finishes).\n\
+          \    \"\"\"\n    import sys\n    output_type = output.get('output_type')\n\
+          \n    if output_type == 'stream':\n        text = output.get('text', '')\n\
+          \        if text:\n            try:\n                print(f'[nb cell {cell_idx}\
+          \ stream] ', end='', flush=False)\n            except Exception:\n     \
+          \           pass\n            print(text, end='' if text.endswith('\\n')\
+          \ else '\\n', flush=True)\n    elif output_type == 'error':\n        for\
+          \ line in output.get('traceback', []):\n            print(line, file=sys.stderr,\
+          \ flush=True)\n    else:\n        # Handle display_data and execute_result\n\
+          \        data = output.get('data', {})\n        if 'text/plain' in data:\n\
+          \            print(data['text/plain'], flush=True)\n        elif 'application/json'\
+          \ in data:\n            try:\n                import json as __kfp_json\n\
+          \                parsed = data['application/json']\n                # Some\
+          \ kernels send JSON as string; try to parse if needed\n                if\
+          \ isinstance(parsed, str):\n                    try:\n                 \
+          \       parsed = __kfp_json.loads(parsed)\n                    except Exception:\n\
+          \                        pass\n                print(__kfp_json.dumps(parsed,\
+          \ indent=2, ensure_ascii=False), flush=True)\n            except Exception:\n\
+          \                # Fallback to raw\n                print(str(data.get('application/json')),\
+          \ flush=True)\n        elif 'text/markdown' in data:\n            # Print\
+          \ markdown as-is; frontends may render, logs will show raw markdown\n  \
+          \          print(data['text/markdown'], flush=True)\n\ndef kfp_run_notebook(**kwargs):\n\
+          \    \"\"\"Execute the embedded notebook with injected parameters.\n\n \
+          \   Parameters provided via kwargs are injected into the notebook following\n\
+          \    Papermill semantics (after a parameters cell if present, otherwise\
+          \ at top).\n    Execution uses a Python kernel; nbclient and ipykernel must\
+          \ be available at\n    runtime (installed via packages_to_install for notebook\
+          \ components).\n    \"\"\"\n    import os\n    import subprocess\n    import\
+          \ sys\n\n    from nbclient import NotebookClient\n    import nbformat\n\n\
+          \    # Ensure a usable 'python3' kernel is present; install kernelspec if\
+          \ missing\n    print('[KFP Notebook] Checking for Python kernel...', flush=True)\n\
+          \    try:\n        from jupyter_client.kernelspec import KernelSpecManager\
+          \  # type: ignore\n        ksm = KernelSpecManager()\n        have_py3 =\
+          \ 'python3' in ksm.find_kernel_specs()\n        if not have_py3:\n     \
+          \       print(\n                '[KFP Notebook] Python3 kernel not found,\
+          \ installing...',\n                flush=True)\n            try:\n     \
+          \           subprocess.run([\n                    sys.executable, '-m',\
+          \ 'ipykernel', 'install', '--user',\n                    '--name', 'python3',\
+          \ '--display-name', 'Python 3'\n                ],\n                   \
+          \            check=True,\n                               stdout=subprocess.DEVNULL,\n\
+          \                               stderr=subprocess.DEVNULL)\n           \
+          \     print(\n                    '[KFP Notebook] Python3 kernel installed\
+          \ successfully',\n                    flush=True)\n            except subprocess.CalledProcessError\
+          \ as e:\n                raise RuntimeError(\n                    \"Failed\
+          \ to install 'python3' kernelspec for ipykernel. \"\n                  \
+          \  \"Ensure ipykernel is available in the environment or include it via\
+          \ packages_to_install. \"\n                    f\"Error: {e}\") from e\n\
+          \        else:\n            print('[KFP Notebook] Python3 kernel found',\
+          \ flush=True)\n    except ImportError as e:\n        raise RuntimeError(\n\
+          \            \"jupyter_client is not available. Ensure it's installed in\
+          \ the environment or include it via packages_to_install. \"\n          \
+          \  f\"Error: {e}\") from e\n\n    nb_path = os.path.join(__KFP_EMBEDDED_ASSET_DIR,\
+          \ __KFP_NOTEBOOK_REL_PATH)\n\n    try:\n        nb = nbformat.read(nb_path,\
+          \ as_version=4)\n    except Exception as e:\n        raise RuntimeError(\n\
+          \            f'Failed to read notebook {nb_path}. Ensure it is a valid Jupyter\
+          \ notebook. Error: {e}'\n        ) from e\n\n    try:\n        __kfp_write_parameters_cell(nb,\
+          \ kwargs)\n        print(\n            f'[KFP Notebook] Executing notebook\
+          \ with {len(nb.get(\"cells\", []))} cells',\n            flush=True)\n\n\
+          \        # Use our custom streaming client for real-time output (defined\
+          \ in the\n        # generated ephemeral source)\n        client = KFPStreamingNotebookClient(\n\
+          \            nb,\n            timeout=None,\n            allow_errors=False,\n\
+          \            store_widget_state=False,\n            kernel_name='python3')\n\
+          \        client.execute(cwd=__KFP_EMBEDDED_ASSET_DIR)\n\n        print('[KFP\
+          \ Notebook] Execution complete', flush=True)\n\n    except Exception as\
+          \ e:\n        raise RuntimeError(f'Notebook execution failed. Error: {e}')\
+          \ from e\n\n\n# Bind helper into dsl namespace so user code can call dsl.run_notebook(...)\n\
+          dsl.run_notebook = kfp_run_notebook\n\n\ndef run_train_notebook(text: str):\n\
+          \    # text is not defined in the notebook but text2 is defined\n    dsl.run_notebook(text=text)\n\
+          \n    with open(\"/tmp/kfp_nb_outputs/log.txt\", \"r\", encoding=\"utf-8\"\
+          ) as f:\n        log = f.read()\n\n    assert log == text + \" \" + \"default2\"\
+          \n\n"
+        image: python:3.9
+pipelineInfo:
+  name: nb-simple
+root:
+  dag:
+    tasks:
+      run-train-notebook:
+        cachingOptions: {}
+        componentRef:
+          name: comp-run-train-notebook
+        inputs:
+          parameters:
+            text:
+              componentInputParameter: text
+        taskInfo:
+          name: run-train-notebook
+  inputDefinitions:
+    parameters:
+      text:
+        defaultValue: hello
+        isOptional: true
+        parameterType: STRING
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.14.2

--- a/test_data/pipeline_files/valid/notebook_component_mixed.yaml
+++ b/test_data/pipeline_files/valid/notebook_component_mixed.yaml
@@ -1,0 +1,426 @@
+# PIPELINE DEFINITION
+# Name: nb-mixed
+# Inputs:
+#    text: str [Default: 'Hello   world']
+components:
+  comp-evaluate-model:
+    executorLabel: exec-evaluate-model
+    inputDefinitions:
+      artifacts:
+        model_text:
+          artifactType:
+            schemaTitle: system.Model
+            schemaVersion: 0.0.1
+    outputDefinitions:
+      artifacts:
+        metrics:
+          artifactType:
+            schemaTitle: system.Metrics
+            schemaVersion: 0.0.1
+  comp-preprocess:
+    executorLabel: exec-preprocess
+    inputDefinitions:
+      parameters:
+        text:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        dataset:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+  comp-train-model:
+    executorLabel: exec-train-model
+    inputDefinitions:
+      artifacts:
+        cleaned_text:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+    outputDefinitions:
+      artifacts:
+        model:
+          artifactType:
+            schemaTitle: system.Model
+            schemaVersion: 0.0.1
+deploymentSpec:
+  executors:
+    exec-evaluate-model:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - evaluate_model
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'nbclient>=0.10,<1'\
+          \ 'ipykernel>=6,<7' 'jupyter_client>=7,<9'  &&  python3 -m pip install --quiet\
+          \ --no-warn-script-location 'kfp==2.14.2' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\n__KFP_EMBEDDED_ARCHIVE_B64 = 'H4sIACSp1mgC/+2Vy46bMBSGWecpLG9IJEogQGAiRequXXbR3WSEHGISN2BbtukkivLuNYQkk05HlarOqJfzLQz8x+f3wRfwx/74/Sey+0jJiirnVQhOvHQNgii63rd6GEzC0EE75w1otCHKDu/8n0xSVBtW03mYJll2lwVZ6meTOEzvBg7w78OXOf1KqrymRrFC+0zu+fIVzv80jp0gCqIkTK7XE2GcJk6YBNMkmUTTpD3/8TSNHBS85fmvpSKb6uV+P4v/pRwGCOGCVpXGM3RvHxA6dG0v52YvqQ3hQqwo9s4huqNFY5jgeSEabmwH3lTVJWx3E1kRQ6x+drOqIevrKL0miSK2N1UaX+SH/u548RONkY3pkh8uohaNKuiNIa5tlbZmujNojlx3wc+uJ8/e8Te/4S/UyWoplEFCe+iLFtzW6V2DQvs12dIVU3rojk0tx9tS5vak9vauh+iOaZOL7fyzaujoNr0/ynYCDq4uhKLuDJWVIGZYUT68ztBodLxNlIpxM1zgD8KgLhEtsId6u/sF7rQFfvhuvEdmNkhI6/2jYsfnL0v7nrZy97Etn9vJZnw9dxtTvsvcESIalbNb37Zpk/xVU8thb+OhcvRsVW3bTffzfYcrwtcNWdOc8VI82Y6Y223Xrrrcm43oDVujbjExX5ZC1aRd9vhGyGvGhbLyZHCEPyQAAAAAAAAAAAAAAAAAAAAAAAAAAADwp/ANkcfbmgAoAAA='\n\
+          __KFP_NOTEBOOK_REL_PATH = 'nb_eval_metrics.ipynb'\n\nimport base64 as __kfp_b64\n\
+          import gzip as __kfp_gzip\nimport io as __kfp_io\nimport os as __kfp_os\n\
+          import sys as __kfp_sys\nimport tarfile as __kfp_tarfile\nimport tempfile\
+          \ as __kfp_tempfile\nfrom nbclient import NotebookClient\n\n# Extract embedded\
+          \ archive at import time to ensure sys.path and globals are set\nprint('[KFP]\
+          \ Extracting embedded notebook archive...', flush=True)\n__kfp_tmpdir =\
+          \ __kfp_tempfile.TemporaryDirectory()\n__KFP_EMBEDDED_ASSET_DIR = __kfp_tmpdir.name\n\
+          try:\n    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode('ascii'))\n\
+          \    with __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode='r:gz')\
+          \ as __kfp_tar:\n        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)\n\
+          \    print(f'[KFP] Notebook archive extracted to: {__KFP_EMBEDDED_ASSET_DIR}',\
+          \ flush=True)\nexcept Exception as __kfp_e:\n    raise RuntimeError(f'Failed\
+          \ to extract embedded notebook archive: {__kfp_e}')\n\n# Always prepend\
+          \ the extracted directory to sys.path for import resolution\nif __KFP_EMBEDDED_ASSET_DIR\
+          \ not in __kfp_sys.path:\n    __kfp_sys.path.insert(0, __KFP_EMBEDDED_ASSET_DIR)\n\
+          \    print(f'[KFP] Added notebook archive directory to Python path', flush=True)\n\
+          \n# Optional convenience for generic embedded file variable name\n__KFP_EMBEDDED_ASSET_FILE\
+          \ = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR, __KFP_NOTEBOOK_REL_PATH)\n\
+          \n\nclass KFPStreamingNotebookClient(NotebookClient):\n    # Streams outputs\
+          \ in real-time by emitting outputs during message processing.\n    def process_message(self,\
+          \ msg, cell, cell_index):\n        # Call the parent implementation to handle\
+          \ the message normally\n        output = super().process_message(msg, cell,\
+          \ cell_index)\n\n        # If an output was created, stream it immediately\n\
+          \        if output is not None:\n            _kfp_stream_single_output(output,\
+          \ cell_index)\n\n        return output\n\ndef __kfp_write_parameters_cell(nb,\
+          \ params):\n    \"\"\"Inject parameters following Papermill semantics.\n\
+          \n    - If a cell tagged with 'parameters' exists, insert an overriding\n\
+          \      'injected-parameters' cell immediately after it.\n    - Otherwise,\
+          \ insert the 'injected-parameters' cell at the top.\n    \"\"\"\n    import\
+          \ json\n\n    import nbformat\n\n    if not params:\n        return\n\n\
+          \    # Build the injected parameters cell\n    assignments = []\n    for\
+          \ key, value in params.items():\n        serialized = json.dumps(value)\n\
+          \        assignments.append(key + ' = json.loads(' + repr(serialized) +\
+          \ ')')\n    source = 'import json\\n' + '\\n'.join(assignments) + '\\n'\n\
+          \    cell = nbformat.v4.new_code_cell(source=source)\n    cell.metadata.setdefault('tags',\
+          \ [])\n    if 'injected-parameters' not in cell.metadata['tags']:\n    \
+          \    cell.metadata['tags'].append('injected-parameters')\n\n    # Locate\
+          \ the first 'parameters' tagged cell\n    insert_idx = 0\n    for idx, existing\
+          \ in enumerate(nb.get('cells', [])):\n        if existing.get('cell_type')\
+          \ != 'code':\n            continue\n        tags = existing.get('metadata',\
+          \ {}).get('tags', []) or []\n        if 'parameters' in tags:\n        \
+          \    insert_idx = idx + 1\n            break\n\n    nb.cells.insert(insert_idx,\
+          \ cell)\n\ndef _kfp_stream_single_output(output, cell_idx):\n    \"\"\"\
+          Stream a single notebook output immediately during execution.\n\n    Prints\
+          \ stdout/stderr and text/plain display outputs to the console so users\n\
+          \    see cell output as it happens (no need to wait until the notebook finishes).\n\
+          \    \"\"\"\n    import sys\n    output_type = output.get('output_type')\n\
+          \n    if output_type == 'stream':\n        text = output.get('text', '')\n\
+          \        if text:\n            try:\n                print(f'[nb cell {cell_idx}\
+          \ stream] ', end='', flush=False)\n            except Exception:\n     \
+          \           pass\n            print(text, end='' if text.endswith('\\n')\
+          \ else '\\n', flush=True)\n    elif output_type == 'error':\n        for\
+          \ line in output.get('traceback', []):\n            print(line, file=sys.stderr,\
+          \ flush=True)\n    else:\n        # Handle display_data and execute_result\n\
+          \        data = output.get('data', {})\n        if 'text/plain' in data:\n\
+          \            print(data['text/plain'], flush=True)\n        elif 'application/json'\
+          \ in data:\n            try:\n                import json as __kfp_json\n\
+          \                parsed = data['application/json']\n                # Some\
+          \ kernels send JSON as string; try to parse if needed\n                if\
+          \ isinstance(parsed, str):\n                    try:\n                 \
+          \       parsed = __kfp_json.loads(parsed)\n                    except Exception:\n\
+          \                        pass\n                print(__kfp_json.dumps(parsed,\
+          \ indent=2, ensure_ascii=False), flush=True)\n            except Exception:\n\
+          \                # Fallback to raw\n                print(str(data.get('application/json')),\
+          \ flush=True)\n        elif 'text/markdown' in data:\n            # Print\
+          \ markdown as-is; frontends may render, logs will show raw markdown\n  \
+          \          print(data['text/markdown'], flush=True)\n\ndef kfp_run_notebook(**kwargs):\n\
+          \    \"\"\"Execute the embedded notebook with injected parameters.\n\n \
+          \   Parameters provided via kwargs are injected into the notebook following\n\
+          \    Papermill semantics (after a parameters cell if present, otherwise\
+          \ at top).\n    Execution uses a Python kernel; nbclient and ipykernel must\
+          \ be available at\n    runtime (installed via packages_to_install for notebook\
+          \ components).\n    \"\"\"\n    import os\n    import subprocess\n    import\
+          \ sys\n\n    from nbclient import NotebookClient\n    import nbformat\n\n\
+          \    # Ensure a usable 'python3' kernel is present; install kernelspec if\
+          \ missing\n    print('[KFP Notebook] Checking for Python kernel...', flush=True)\n\
+          \    try:\n        from jupyter_client.kernelspec import KernelSpecManager\
+          \  # type: ignore\n        ksm = KernelSpecManager()\n        have_py3 =\
+          \ 'python3' in ksm.find_kernel_specs()\n        if not have_py3:\n     \
+          \       print(\n                '[KFP Notebook] Python3 kernel not found,\
+          \ installing...',\n                flush=True)\n            try:\n     \
+          \           subprocess.run([\n                    sys.executable, '-m',\
+          \ 'ipykernel', 'install', '--user',\n                    '--name', 'python3',\
+          \ '--display-name', 'Python 3'\n                ],\n                   \
+          \            check=True,\n                               stdout=subprocess.DEVNULL,\n\
+          \                               stderr=subprocess.DEVNULL)\n           \
+          \     print(\n                    '[KFP Notebook] Python3 kernel installed\
+          \ successfully',\n                    flush=True)\n            except subprocess.CalledProcessError\
+          \ as e:\n                raise RuntimeError(\n                    \"Failed\
+          \ to install 'python3' kernelspec for ipykernel. \"\n                  \
+          \  \"Ensure ipykernel is available in the environment or include it via\
+          \ packages_to_install. \"\n                    f\"Error: {e}\") from e\n\
+          \        else:\n            print('[KFP Notebook] Python3 kernel found',\
+          \ flush=True)\n    except ImportError as e:\n        raise RuntimeError(\n\
+          \            \"jupyter_client is not available. Ensure it's installed in\
+          \ the environment or include it via packages_to_install. \"\n          \
+          \  f\"Error: {e}\") from e\n\n    nb_path = os.path.join(__KFP_EMBEDDED_ASSET_DIR,\
+          \ __KFP_NOTEBOOK_REL_PATH)\n\n    try:\n        nb = nbformat.read(nb_path,\
+          \ as_version=4)\n    except Exception as e:\n        raise RuntimeError(\n\
+          \            f'Failed to read notebook {nb_path}. Ensure it is a valid Jupyter\
+          \ notebook. Error: {e}'\n        ) from e\n\n    try:\n        __kfp_write_parameters_cell(nb,\
+          \ kwargs)\n        print(\n            f'[KFP Notebook] Executing notebook\
+          \ with {len(nb.get(\"cells\", []))} cells',\n            flush=True)\n\n\
+          \        # Use our custom streaming client for real-time output (defined\
+          \ in the\n        # generated ephemeral source)\n        client = KFPStreamingNotebookClient(\n\
+          \            nb,\n            timeout=None,\n            allow_errors=False,\n\
+          \            store_widget_state=False,\n            kernel_name='python3')\n\
+          \        client.execute(cwd=__KFP_EMBEDDED_ASSET_DIR)\n\n        print('[KFP\
+          \ Notebook] Execution complete', flush=True)\n\n    except Exception as\
+          \ e:\n        raise RuntimeError(f'Notebook execution failed. Error: {e}')\
+          \ from e\n\n\n# Bind helper into dsl namespace so user code can call dsl.run_notebook(...)\n\
+          dsl.run_notebook = kfp_run_notebook\n\n\ndef evaluate_model(model_text:\
+          \ dsl.Input[dsl.Model], metrics: dsl.Output[dsl.Metrics]):\n    import json\n\
+          \n    with open(model_text.path, \"r\", encoding=\"utf-8\") as f:\n    \
+          \    model_text = f.read()\n\n    dsl.run_notebook(model_text=model_text)\n\
+          \    with open(\"/tmp/kfp_nb_outputs/metrics.json\", \"r\", encoding=\"\
+          utf-8\") as f:\n        metrics_dict = json.load(f)\n\n    assert metrics_dict\
+          \ == {\"score\": float(len(model_text))}\n\n    for metric_name, metric_value\
+          \ in metrics_dict.items():\n        metrics.log_metric(metric_name, metric_value)\n\
+          \n"
+        image: python:3.9
+    exec-preprocess:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - preprocess
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.14.2'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\n\n\ndef preprocess(text: str, dataset: dsl.Output[dsl.Dataset]):\n\
+          \    import re\n\n    cleaned_text = re.sub(r\"\\s+\", \" \", text).strip()\n\
+          \    with open(dataset.path, \"w\", encoding=\"utf-8\") as f:\n        f.write(cleaned_text)\n\
+          \n"
+        image: python:3.9
+    exec-train-model:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - train_model
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'nbclient>=0.10,<1'\
+          \ 'ipykernel>=6,<7' 'jupyter_client>=7,<9'  &&  python3 -m pip install --quiet\
+          \ --no-warn-script-location 'kfp==2.14.2' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\n__KFP_EMBEDDED_ARCHIVE_B64 = 'H4sIACSp1mgC/+2VTY/aMBCGc+ZXWLkEJBqSQAJdCanH9tZDpR7KKjKJAxaJbTmTErTiv9cJ4auwWrXartR2noMT3onnneAZcEfu6MNnWn9kNGXa+iN4B567et54cr5vdN8L/MAitfUGVCVQbeyt/5NgRgrgBZv703A2ez/zosgNwsgfh0HPQv55xDIGTbmItxzWsaKaFqXL1U4sX3f+o4mZ8bE3Dv3wfD3gT73Q8kMvCsNgHAWBmf9wGkws4r3l/BdK03X+/HMvxf9SnnqE2AnL89J+IN/MB0Ke2rWTY9gpZkJ2IlNmD48hVrOkAi5FnMhKgHlAVHl+ChcMaEqBGv2YzahAV2eXTms7jgHTpX2SH7u7/SmfrEBV0G5+PImlrHTCrhLaSc6oYGkMrAYyJ06xI51EGslZiKPNwaSzeOVX/o3CeaGkBiJLU+HwLMvSLeiGpVyXfWcEhRptMhWboe0SO0PCal5CLDfzL7pig+vtSnMB/YX9VXPgYkVAkjtJRoV50dyFGhb2TwmaXwUiFRN33c8bTR3OtilGmC/NOM2dCrJ3M2dAaEmyh+ukzZK5W1MT618emFspxXR/MPilU9J0a7/QeN/L9igvNaPmVKwqumKf0mOaU3R/04H3zuymTLO2p3xbxsks5iKTF5XYwrR/4692sJZdwiZRa22LZSZ1QZtum1wJccGF1EYOenv8o0YQBEEQBEEQBEEQBEEQBEEQBEEQBEF+APurSW0AKAAA'\n\
+          __KFP_NOTEBOOK_REL_PATH = 'nb_train_with_params.ipynb'\n\nimport base64\
+          \ as __kfp_b64\nimport gzip as __kfp_gzip\nimport io as __kfp_io\nimport\
+          \ os as __kfp_os\nimport sys as __kfp_sys\nimport tarfile as __kfp_tarfile\n\
+          import tempfile as __kfp_tempfile\nfrom nbclient import NotebookClient\n\
+          \n# Extract embedded archive at import time to ensure sys.path and globals\
+          \ are set\nprint('[KFP] Extracting embedded notebook archive...', flush=True)\n\
+          __kfp_tmpdir = __kfp_tempfile.TemporaryDirectory()\n__KFP_EMBEDDED_ASSET_DIR\
+          \ = __kfp_tmpdir.name\ntry:\n    __kfp_bytes = __kfp_b64.b64decode(__KFP_EMBEDDED_ARCHIVE_B64.encode('ascii'))\n\
+          \    with __kfp_tarfile.open(fileobj=__kfp_io.BytesIO(__kfp_bytes), mode='r:gz')\
+          \ as __kfp_tar:\n        __kfp_tar.extractall(path=__KFP_EMBEDDED_ASSET_DIR)\n\
+          \    print(f'[KFP] Notebook archive extracted to: {__KFP_EMBEDDED_ASSET_DIR}',\
+          \ flush=True)\nexcept Exception as __kfp_e:\n    raise RuntimeError(f'Failed\
+          \ to extract embedded notebook archive: {__kfp_e}')\n\n# Always prepend\
+          \ the extracted directory to sys.path for import resolution\nif __KFP_EMBEDDED_ASSET_DIR\
+          \ not in __kfp_sys.path:\n    __kfp_sys.path.insert(0, __KFP_EMBEDDED_ASSET_DIR)\n\
+          \    print(f'[KFP] Added notebook archive directory to Python path', flush=True)\n\
+          \n# Optional convenience for generic embedded file variable name\n__KFP_EMBEDDED_ASSET_FILE\
+          \ = __kfp_os.path.join(__KFP_EMBEDDED_ASSET_DIR, __KFP_NOTEBOOK_REL_PATH)\n\
+          \n\nclass KFPStreamingNotebookClient(NotebookClient):\n    # Streams outputs\
+          \ in real-time by emitting outputs during message processing.\n    def process_message(self,\
+          \ msg, cell, cell_index):\n        # Call the parent implementation to handle\
+          \ the message normally\n        output = super().process_message(msg, cell,\
+          \ cell_index)\n\n        # If an output was created, stream it immediately\n\
+          \        if output is not None:\n            _kfp_stream_single_output(output,\
+          \ cell_index)\n\n        return output\n\ndef __kfp_write_parameters_cell(nb,\
+          \ params):\n    \"\"\"Inject parameters following Papermill semantics.\n\
+          \n    - If a cell tagged with 'parameters' exists, insert an overriding\n\
+          \      'injected-parameters' cell immediately after it.\n    - Otherwise,\
+          \ insert the 'injected-parameters' cell at the top.\n    \"\"\"\n    import\
+          \ json\n\n    import nbformat\n\n    if not params:\n        return\n\n\
+          \    # Build the injected parameters cell\n    assignments = []\n    for\
+          \ key, value in params.items():\n        serialized = json.dumps(value)\n\
+          \        assignments.append(key + ' = json.loads(' + repr(serialized) +\
+          \ ')')\n    source = 'import json\\n' + '\\n'.join(assignments) + '\\n'\n\
+          \    cell = nbformat.v4.new_code_cell(source=source)\n    cell.metadata.setdefault('tags',\
+          \ [])\n    if 'injected-parameters' not in cell.metadata['tags']:\n    \
+          \    cell.metadata['tags'].append('injected-parameters')\n\n    # Locate\
+          \ the first 'parameters' tagged cell\n    insert_idx = 0\n    for idx, existing\
+          \ in enumerate(nb.get('cells', [])):\n        if existing.get('cell_type')\
+          \ != 'code':\n            continue\n        tags = existing.get('metadata',\
+          \ {}).get('tags', []) or []\n        if 'parameters' in tags:\n        \
+          \    insert_idx = idx + 1\n            break\n\n    nb.cells.insert(insert_idx,\
+          \ cell)\n\ndef _kfp_stream_single_output(output, cell_idx):\n    \"\"\"\
+          Stream a single notebook output immediately during execution.\n\n    Prints\
+          \ stdout/stderr and text/plain display outputs to the console so users\n\
+          \    see cell output as it happens (no need to wait until the notebook finishes).\n\
+          \    \"\"\"\n    import sys\n    output_type = output.get('output_type')\n\
+          \n    if output_type == 'stream':\n        text = output.get('text', '')\n\
+          \        if text:\n            try:\n                print(f'[nb cell {cell_idx}\
+          \ stream] ', end='', flush=False)\n            except Exception:\n     \
+          \           pass\n            print(text, end='' if text.endswith('\\n')\
+          \ else '\\n', flush=True)\n    elif output_type == 'error':\n        for\
+          \ line in output.get('traceback', []):\n            print(line, file=sys.stderr,\
+          \ flush=True)\n    else:\n        # Handle display_data and execute_result\n\
+          \        data = output.get('data', {})\n        if 'text/plain' in data:\n\
+          \            print(data['text/plain'], flush=True)\n        elif 'application/json'\
+          \ in data:\n            try:\n                import json as __kfp_json\n\
+          \                parsed = data['application/json']\n                # Some\
+          \ kernels send JSON as string; try to parse if needed\n                if\
+          \ isinstance(parsed, str):\n                    try:\n                 \
+          \       parsed = __kfp_json.loads(parsed)\n                    except Exception:\n\
+          \                        pass\n                print(__kfp_json.dumps(parsed,\
+          \ indent=2, ensure_ascii=False), flush=True)\n            except Exception:\n\
+          \                # Fallback to raw\n                print(str(data.get('application/json')),\
+          \ flush=True)\n        elif 'text/markdown' in data:\n            # Print\
+          \ markdown as-is; frontends may render, logs will show raw markdown\n  \
+          \          print(data['text/markdown'], flush=True)\n\ndef kfp_run_notebook(**kwargs):\n\
+          \    \"\"\"Execute the embedded notebook with injected parameters.\n\n \
+          \   Parameters provided via kwargs are injected into the notebook following\n\
+          \    Papermill semantics (after a parameters cell if present, otherwise\
+          \ at top).\n    Execution uses a Python kernel; nbclient and ipykernel must\
+          \ be available at\n    runtime (installed via packages_to_install for notebook\
+          \ components).\n    \"\"\"\n    import os\n    import subprocess\n    import\
+          \ sys\n\n    from nbclient import NotebookClient\n    import nbformat\n\n\
+          \    # Ensure a usable 'python3' kernel is present; install kernelspec if\
+          \ missing\n    print('[KFP Notebook] Checking for Python kernel...', flush=True)\n\
+          \    try:\n        from jupyter_client.kernelspec import KernelSpecManager\
+          \  # type: ignore\n        ksm = KernelSpecManager()\n        have_py3 =\
+          \ 'python3' in ksm.find_kernel_specs()\n        if not have_py3:\n     \
+          \       print(\n                '[KFP Notebook] Python3 kernel not found,\
+          \ installing...',\n                flush=True)\n            try:\n     \
+          \           subprocess.run([\n                    sys.executable, '-m',\
+          \ 'ipykernel', 'install', '--user',\n                    '--name', 'python3',\
+          \ '--display-name', 'Python 3'\n                ],\n                   \
+          \            check=True,\n                               stdout=subprocess.DEVNULL,\n\
+          \                               stderr=subprocess.DEVNULL)\n           \
+          \     print(\n                    '[KFP Notebook] Python3 kernel installed\
+          \ successfully',\n                    flush=True)\n            except subprocess.CalledProcessError\
+          \ as e:\n                raise RuntimeError(\n                    \"Failed\
+          \ to install 'python3' kernelspec for ipykernel. \"\n                  \
+          \  \"Ensure ipykernel is available in the environment or include it via\
+          \ packages_to_install. \"\n                    f\"Error: {e}\") from e\n\
+          \        else:\n            print('[KFP Notebook] Python3 kernel found',\
+          \ flush=True)\n    except ImportError as e:\n        raise RuntimeError(\n\
+          \            \"jupyter_client is not available. Ensure it's installed in\
+          \ the environment or include it via packages_to_install. \"\n          \
+          \  f\"Error: {e}\") from e\n\n    nb_path = os.path.join(__KFP_EMBEDDED_ASSET_DIR,\
+          \ __KFP_NOTEBOOK_REL_PATH)\n\n    try:\n        nb = nbformat.read(nb_path,\
+          \ as_version=4)\n    except Exception as e:\n        raise RuntimeError(\n\
+          \            f'Failed to read notebook {nb_path}. Ensure it is a valid Jupyter\
+          \ notebook. Error: {e}'\n        ) from e\n\n    try:\n        __kfp_write_parameters_cell(nb,\
+          \ kwargs)\n        print(\n            f'[KFP Notebook] Executing notebook\
+          \ with {len(nb.get(\"cells\", []))} cells',\n            flush=True)\n\n\
+          \        # Use our custom streaming client for real-time output (defined\
+          \ in the\n        # generated ephemeral source)\n        client = KFPStreamingNotebookClient(\n\
+          \            nb,\n            timeout=None,\n            allow_errors=False,\n\
+          \            store_widget_state=False,\n            kernel_name='python3')\n\
+          \        client.execute(cwd=__KFP_EMBEDDED_ASSET_DIR)\n\n        print('[KFP\
+          \ Notebook] Execution complete', flush=True)\n\n    except Exception as\
+          \ e:\n        raise RuntimeError(f'Notebook execution failed. Error: {e}')\
+          \ from e\n\n\n# Bind helper into dsl namespace so user code can call dsl.run_notebook(...)\n\
+          dsl.run_notebook = kfp_run_notebook\n\n\ndef train_model(cleaned_text: dsl.Input[dsl.Dataset],\
+          \ model: dsl.Output[dsl.Model]):\n    import shutil\n\n    with open(cleaned_text.path,\
+          \ \"r\", encoding=\"utf-8\") as f:\n        cleaned_text = f.read()\n\n\
+          \    dsl.run_notebook(cleaned_text=cleaned_text)\n\n    # Notebook writes\
+          \ its model into /tmp/kfp_nb_outputs/model.txt\n    shutil.copy(\"/tmp/kfp_nb_outputs/model.txt\"\
+          , model.path)\n\n    with open(model.path, \"r\", encoding=\"utf-8\") as\
+          \ f:\n        model_text = f.read()\n\n    assert model_text == cleaned_text.upper()\n\
+          \n"
+        image: python:3.9
+pipelineInfo:
+  name: nb-mixed
+root:
+  dag:
+    tasks:
+      evaluate-model:
+        cachingOptions: {}
+        componentRef:
+          name: comp-evaluate-model
+        dependentTasks:
+        - train-model
+        inputs:
+          artifacts:
+            model_text:
+              taskOutputArtifact:
+                outputArtifactKey: model
+                producerTask: train-model
+        taskInfo:
+          name: evaluate-model
+      preprocess:
+        cachingOptions: {}
+        componentRef:
+          name: comp-preprocess
+        inputs:
+          parameters:
+            text:
+              componentInputParameter: text
+        taskInfo:
+          name: preprocess
+      train-model:
+        cachingOptions: {}
+        componentRef:
+          name: comp-train-model
+        dependentTasks:
+        - preprocess
+        inputs:
+          artifacts:
+            cleaned_text:
+              taskOutputArtifact:
+                outputArtifactKey: dataset
+                producerTask: preprocess
+        taskInfo:
+          name: train-model
+  inputDefinitions:
+    parameters:
+      text:
+        defaultValue: Hello   world
+        isOptional: true
+        parameterType: STRING
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.14.2


### PR DESCRIPTION
**Description of your changes:**

Implements [KEP-12238: Jupyter Notebook Components](https://github.com/kubeflow/pipelines/blob/master/proposals/12238-notebook-component/README.md)

- Introduce @dsl.notebook_component for notebook-driven components
  - Embeds a .ipynb (or a dir with one .ipynb) into the component
  - Binds dsl.run_notebook(**kwargs) to execute via nbclient at runtime
  - Streams cell outputs; injects parameters (Papermill semantics)
  - Installs default runtime deps when unspecified: nbclient, ipykernel, jupyter_client
- Add embedded artifact support for lightweight components
  - Tar+gzip and base64-embed files/dirs; extract to temp dir at runtime
  - Prepend extracted dir to sys.path; expose __KFP_EMBEDDED_ASSET_DIR/FILE
  - Warn when compressed payload >1MB
- Add EmbeddedInput[...] type (runtime-only)
  - Excluded from component interface; Executor injects an Artifact to embedded asset
- Extend component_factory to support embedded_artifact_path and helper templates
  - Wire into create_component_from_func and command generation
- New DSL helpers and tests
  - Add dsl/notebook_helpers.run_notebook stub and notebook executor template
  - Tests for decorator, parameter injection, streaming, EmbeddedInput, large archive warning
  - Add sample compiled pipeline specs under test_data
- Minor: adjust FutureWarning stacklevel in component creation

Additive SDK feature; no API server changes.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
