### PR TITLE
fix(logging): reduce verbose logging for security. Fixes #12293

### DIFF
--- a/backend/src/apiserver/server/pipeline_upload_server_test.go
+++ b/backend/src/apiserver/server/pipeline_upload_server_test.go
@@ -49,23 +49,23 @@ func TestUploadPipeline(t *testing.T) {
 	tt := []struct {
 		name        string
 		spec        []byte
-		api_version string
+		apiVersion string
 	}{{
 		name:        "upload argo workflow YAML",
 		spec:        []byte("apiVersion: argoproj.io/v1alpha1\nkind: Workflow"),
-		api_version: "v1beta1",
+		apiVersion: "v1beta1",
 	}, {
 		name:        "upload argo workflow YAML",
 		spec:        []byte("apiVersion: argoproj.io/v1alpha1\nkind: Workflow"),
-		api_version: "v2beta1",
+		apiVersion: "v2beta1",
 	}, {
 		name:        "upload pipeline v2 job in proto yaml",
 		spec:        []byte(v2SpecHelloWorld),
-		api_version: "v1beta1",
+		apiVersion: "v1beta1",
 	}, {
 		name:        "upload pipeline v2 job in proto yaml",
 		spec:        []byte(v2SpecHelloWorld),
-		api_version: "v2beta1",
+		apiVersion: "v2beta1",
 	}}
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestUploadPipeline(t *testing.T) {
 			bytesBuffer, writer := setupWriter("")
 			setWriterWithBuffer("uploadfile", "hello-world.yaml", string(test.spec), writer)
 			var response *httptest.ResponseRecorder
-			switch test.api_version {
+			switch test.apiVersion {
 			case "v1beta1":
 				response = uploadPipeline("/apis/v1beta1/pipelines/upload",
 					bytes.NewReader(bytesBuffer.Bytes()), writer, server.UploadPipelineV1)
@@ -100,7 +100,7 @@ func TestUploadPipeline(t *testing.T) {
 			assert.Equal(t, "1970-01-01T00:00:01Z", parsedResponse.CreatedAt)
 
 			// Verify v1 API returns v1 object while v2 API returns v2 object.
-			switch test.api_version {
+			switch test.apiVersion {
 			case "v1beta1":
 				assert.Equal(t, "123e4567-e89b-12d3-a456-426655440000", parsedResponse.ID)
 				assert.Equal(t, "", parsedResponse.PipelineID)
@@ -235,19 +235,19 @@ func TestUploadPipelineV2_NameValidation(t *testing.T) {
 			name:    "invalid - capitalized",
 			spec:    []byte(invalidV2specCapitalized),
 			wantErr: true,
-			errMsg:  "pipeline's name must contain only lowercase alphanumeric characters or '-' and must start with alphanumeric characters",
+			errMsg:  "Failed to create a pipeline and a pipeline version",
 		},
 		{
 			name:    "invalid - dot",
 			spec:    []byte(invalidV2specDot),
 			wantErr: true,
-			errMsg:  "pipeline's name must contain only lowercase alphanumeric characters or '-' and must start with alphanumeric characters",
+			errMsg:  "Failed to create a pipeline and a pipeline version",
 		},
 		{
 			name:    "invalid - too long",
 			spec:    []byte(invalidV2specLong),
 			wantErr: true,
-			errMsg:  "pipeline's name must contain no more than 128 characters",
+			errMsg:  "Failed to create a pipeline and a pipeline version",
 		},
 	}
 	for _, test := range tt {
@@ -574,7 +574,7 @@ func TestUploadPipelineVersion_GetFromFileError(t *testing.T) {
 	response = uploadPipeline("/apis/v1beta1/pipelines/upload_version?name="+fakeVersionName+"&pipelineid="+DefaultFakeUUID,
 		bytes.NewReader(bytesBuffer.Bytes()), writer, server.UploadPipelineVersion)
 	assert.Equal(t, 400, response.Code)
-	assert.Contains(t, response.Body.String(), "error parsing pipeline spec filename")
+	assert.Contains(t, response.Body.String(), "Failed to create a pipeline version")
 }
 
 func TestUploadPipelineVersion_NameTooLong(t *testing.T) {

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -14,7 +14,12 @@
 import fetch from 'node-fetch';
 import { AWSConfigs, HttpConfigs, MinioConfigs, ProcessEnv, UIConfigs } from '../configs';
 import { Client as MinioClient } from 'minio';
-import { PreviewStream, findFileOnPodVolume, parseJSONString } from '../utils';
+import {
+  PreviewStream,
+  findFileOnPodVolume,
+  parseJSONString,
+  isAllowedResourceName,
+} from '../utils';
 import { createMinioClient, getObjectStream } from '../minio-helper';
 import * as serverInfo from '../helpers/server-info';
 import { Handler, Request, Response } from 'express';
@@ -109,6 +114,10 @@ export function getArtifactsHandler({
     }
     if (!bucket) {
       res.status(500).send('Storage bucket is missing from artifact request');
+      return;
+    }
+    if (!isAllowedResourceName(bucket)) {
+      res.status(500).send('Invalid bucket name');
       return;
     }
     if (!key) {

--- a/frontend/server/handlers/tensorboard.ts
+++ b/frontend/server/handlers/tensorboard.ts
@@ -15,7 +15,7 @@ import { Handler } from 'express';
 import * as k8sHelper from '../k8s-helper';
 import { ViewerTensorboardConfig } from '../configs';
 import { AuthorizeRequestResources, AuthorizeRequestVerb } from '../src/generated/apis/auth';
-import { parseError } from '../utils';
+import { parseError, isAllowedResourceName } from '../utils';
 import { AuthorizeFn } from '../helpers/auth';
 
 export const getTensorboardHandlers = (
@@ -34,6 +34,10 @@ export const getTensorboardHandlers = (
     }
     if (!namespace) {
       res.status(400).send('namespace argument is required');
+      return;
+    }
+    if (typeof namespace !== 'string' || !isAllowedResourceName(namespace as string)) {
+      res.status(400).send('invalid namespace');
       return;
     }
 

--- a/frontend/server/utils.ts
+++ b/frontend/server/utils.ts
@@ -300,3 +300,7 @@ function parseK8sError(error: any): ErrorDetails | undefined {
     additionalInfo: error.body,
   };
 }
+
+export function isAllowedResourceName(name: string): boolean {
+  return name.length > 0 && name.length <= 63 && /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(name);
+}


### PR DESCRIPTION
**Description of your changes:**
Sanitizes error logging in pipeline upload and K8s pod API endpoints within the frontend service. This help prevents information disclosure by returning generic error responses, while preserving debug information for troubleshooting. This also helps prevent against the ability to run scripts as shown in #12293

Fixes #12293


Testing Evidence:
## pipeline/artifacts/s3/[bucket]/kfp/[node]/[pod]/[file]

### bucket

Original:
N/A

Script:
pipeline/artifacts/s3/bucketovz9h%3cscript%3ealert(1)%3c%2fscript%3eq0bq2/bucket/kfp/node/pod/main.log?namespace=test-ns
<img width="1470" height="125" alt="Screenshot 2025-12-03 at 8 28 16 PM" src="https://github.com/user-attachments/assets/41f8d978-4c6f-40c5-a6b9-c62904105a6e" />



## pipeline/k8s/pod/events (podnamespace)

Original:
/pipeline/k8s/pod/events?podname=ml-pipeline-ts9vx-system-dag-driver-1158075769&podnamespace=kubeflow
<img width="1461" height="119" alt="Screenshot 2025-12-03 at 8 24 13 PM" src="https://github.com/user-attachments/assets/a7043b74-feb9-412b-96c6-67a8176d670d" />


Script:
pipeline/k8s/pod/events?podname=ml-pipeline-ts9vx-system-dag-driver-1158075769&podnamespace=kubeflownfjz0%3cscript%3ealert(1)%3c%2fscript%3ex5j6w
<img width="1463" height="111" alt="Screenshot 2025-12-03 at 8 24 36 PM" src="https://github.com/user-attachments/assets/5e74a015-8865-4459-8c16-871f6526929e" />



## pipeline/apps/tensorboard (namespace)

Original:
/pipeline/apps/tensorboard?logdir=/&namespace=default
<img width="1455" height="114" alt="Screenshot 2025-12-03 at 8 20 59 PM" src="https://github.com/user-attachments/assets/768cf157-d8b3-46b9-8a75-567f8fb40072" />



Script:
/pipeline/apps/tensorboard?logdir=/&namespace=defaultwpsqm%253Cscript%25s3Ealert(1)%253C/script%253Ekxsnh
<img width="1470" height="120" alt="Screenshot 2025-12-03 at 8 22 20 PM" src="https://github.com/user-attachments/assets/aeb8f3cc-1f4f-4414-8068-43309c5bbaf6" />



## pipeline/k8s/pod 

Original:
/pipeline/k8s/pod?podname=pipeline-ts9vx-system-dag-driver-1158075769&podnamespace=kubeflow
<img width="1464" height="118" alt="Screenshot 2025-12-03 at 8 23 05 PM" src="https://github.com/user-attachments/assets/24e3f750-e3f4-4eea-870e-344cf81254b4" />



### podname 

Script:
pipeline/k8s/pod?podname=pipeline-ts9vx-system-dag-driver-1158075769r8e1n%3cscript%3ealert(1)%3c%2fscript%3ez3xor&podnamespace=kubeflow
<img width="1456" height="147" alt="Screenshot 2025-12-03 at 8 23 32 PM" src="https://github.com/user-attachments/assets/3062078b-29c2-4e94-9869-7fb501b45856" />



### podnamespace
/pipeline/k8s/pod?podname=pipeline-ts9vx-system-dag-driver-1158075769&podnamespace=kubeflownfjz0%3cscript%3ealert(1)%3c%2fscript%3ex5j6w
<img width="1470" height="125" alt="Screenshot 2025-12-03 at 8 28 16 PM" src="https://github.com/user-attachments/assets/7366c2d6-5054-4128-8bad-689dcd3ae391" />


## pipeline/k8s/pod

Original:
pipeline/k8s/pod?podname=ml-pipeline-ts9vx-system-dag-driver-1158075769&podnamespace=kubeflow
<img width="1462" height="109" alt="Screenshot 2025-12-03 at 9 21 22 PM" src="https://github.com/user-attachments/assets/d5f11ec6-bd71-479d-924e-dc3da7074bdc" />

Invalid Input:
pipeline/k8s/pod?podname=%5C*&podnamespace=kubeflow
<img width="1470" height="110" alt="Screenshot 2025-12-03 at 9 22 39 PM" src="https://github.com/user-attachments/assets/1c1dd9d9-0c76-40d3-aff4-1e1241c18320" />



**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
