### PR TITLE
chore: fix import order in 15 files (baseline formatting)

### DIFF
--- a/backend/src/common/client/api_server/v2/experiment_client.go
+++ b/backend/src/common/client/api_server/v2/experiment_client.go
@@ -16,6 +16,7 @@ package api_server_v2
 
 import (
 	"fmt"
+
 	httptransport "github.com/go-openapi/runtime/client"
 
 	"github.com/go-openapi/strfmt"

--- a/backend/src/common/client/api_server/v2/recurring_run_client.go
+++ b/backend/src/common/client/api_server/v2/recurring_run_client.go
@@ -16,6 +16,7 @@ package api_server_v2
 
 import (
 	"fmt"
+
 	httptransport "github.com/go-openapi/runtime/client"
 
 	"github.com/go-openapi/runtime"

--- a/backend/src/common/client/api_server/v2/run_client.go
+++ b/backend/src/common/client/api_server/v2/run_client.go
@@ -16,6 +16,7 @@ package api_server_v2
 
 import (
 	"fmt"
+
 	httptransport "github.com/go-openapi/runtime/client"
 
 	"github.com/go-openapi/runtime"

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -203,16 +203,16 @@ func Test_bucketConfig_KeyFromURI(t *testing.T) {
 
 func Test_createS3BucketSession(t *testing.T) {
 	tt := []struct {
-		msg                string
-		ns                 string
-		sessionInfo        *SessionInfo
-		sessionSecret      *corev1.Secret
-		expectValidClient  bool
-		expectedRegion     string
-		expectedEndpoint   string
-		expectedPathStyle  bool
-		wantErr            bool
-		errorMsg           string
+		msg               string
+		ns                string
+		sessionInfo       *SessionInfo
+		sessionSecret     *corev1.Secret
+		expectValidClient bool
+		expectedRegion    string
+		expectedEndpoint  string
+		expectedPathStyle bool
+		wantErr           bool
+		errorMsg          string
 	}{
 		{
 			msg: "Bucket with session",

--- a/backend/test/compiler/compiler_visitor_test.go
+++ b/backend/test/compiler/compiler_visitor_test.go
@@ -16,8 +16,9 @@ package compiler
 
 import (
 	"fmt"
-	"google.golang.org/protobuf/types/known/structpb"
 	"path/filepath"
+
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/compiler"

--- a/backend/test/compiler/utils/workflow_utils.go
+++ b/backend/test/compiler/utils/workflow_utils.go
@@ -19,10 +19,11 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"google.golang.org/protobuf/encoding/protojson"
 	"os"
-	"sigs.k8s.io/yaml"
 	"slices"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/compiler/argocompiler"

--- a/backend/test/proto_tests/objects.go
+++ b/backend/test/proto_tests/objects.go
@@ -15,12 +15,13 @@
 package proto_tests
 
 import (
-	"google.golang.org/genproto/googleapis/rpc/status"
-	"google.golang.org/protobuf/types/known/structpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"os"
 	"path/filepath"
 	"time"
+
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	specPB "github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	pb "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"

--- a/backend/test/proto_tests/util.go
+++ b/backend/test/proto_tests/util.go
@@ -16,11 +16,12 @@ package proto_tests
 
 import (
 	"encoding/json"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/backend/test/test_utils/file_utils.go
+++ b/backend/test/test_utils/file_utils.go
@@ -16,12 +16,13 @@ package test_utils
 
 import (
 	"fmt"
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 	"os"
 	"path/filepath"
-	"sigs.k8s.io/yaml"
 	"slices"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/server"

--- a/backend/test/test_utils/pipeline_version_utils.go
+++ b/backend/test/test_utils/pipeline_version_utils.go
@@ -17,9 +17,10 @@ package test_utils
 import (
 	"fmt"
 	"os"
-	"sigs.k8s.io/yaml"
 	"sort"
 	"time"
+
+	"sigs.k8s.io/yaml"
 
 	pipeline_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_client/pipeline_service"
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_model"

--- a/backend/test/v2/api/pipeline_run_api_test.go
+++ b/backend/test/v2/api/pipeline_run_api_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/kubeflow/pipelines/backend/test/config"
 	. "github.com/kubeflow/pipelines/backend/test/constants"
 	"github.com/kubeflow/pipelines/backend/test/logger"
-	testutils "github.com/kubeflow/pipelines/backend/test/test_utils"
 	"github.com/kubeflow/pipelines/backend/test/test_utils"
 	"github.com/kubeflow/pipelines/backend/test/v2/api/matcher"
 
@@ -325,7 +324,7 @@ var _ = Describe("Verify Pipeline Run Negative Tests >", Label(NEGATIVE, API_PIP
 // ################## UTILITY METHODS ##################
 
 func configureCacheSettingAndGetPipelineFile(pipelineFilePath string, cacheDisabled bool) string {
-	pipelineSpecsFromFile := testutils.ParseFileToSpecs(pipelineFilePath, cacheDisabled, nil)
+	pipelineSpecsFromFile := test_utils.ParseFileToSpecs(pipelineFilePath, cacheDisabled, nil)
 	newPipelineFile := test_utils.CreateTempFile(pipelineSpecsFromFile.Bytes())
 	return newPipelineFile.Name()
 }

--- a/backend/test/v2/api/report_api_test.go
+++ b/backend/test/v2/api/report_api_test.go
@@ -20,13 +20,12 @@ import (
 
 	"github.com/kubeflow/pipelines/backend/test/config"
 	. "github.com/kubeflow/pipelines/backend/test/constants"
-	utils "github.com/kubeflow/pipelines/backend/test/test_utils"
 	"github.com/kubeflow/pipelines/backend/test/test_utils"
 
 	. "github.com/onsi/ginkgo/v2"
 )
 
-var projectDataDir = utils.GetTestDataDir()
+var projectDataDir = test_utils.GetTestDataDir()
 var workflowsDir = filepath.Join(projectDataDir, "compiled-workflows")
 
 // ################## TESTS ##################

--- a/backend/test/v2/integration/flags.go
+++ b/backend/test/v2/integration/flags.go
@@ -16,10 +16,11 @@ package integration
 
 import (
 	"flag"
+	"time"
+
 	"go.uber.org/zap/zapcore"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"time"
 
 	"github.com/kubeflow/pipelines/backend/test/config"
 )

--- a/backend/test/v2/integration/pipeline_version_api_test.go
+++ b/backend/test/v2/integration/pipeline_version_api_test.go
@@ -18,10 +18,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sigs.k8s.io/yaml"
 	"strings"
 	"testing"
 	"time"
+
+	"sigs.k8s.io/yaml"
 
 	params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_client/pipeline_service"
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_model"

--- a/backend/test/v2/integration/recurring_run_api_test.go
+++ b/backend/test/v2/integration/recurring_run_api_test.go
@@ -17,12 +17,13 @@ package integration
 import (
 	"context"
 	"fmt"
-	"google.golang.org/protobuf/types/known/structpb"
 	"os"
-	"sigs.k8s.io/yaml"
 	"strings"
 	"testing"
 	"time"
+
+	"google.golang.org/protobuf/types/known/structpb"
+	"sigs.k8s.io/yaml"
 
 	experiment_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/experiment_client/experiment_service"
 	params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_client/pipeline_service"


### PR DESCRIPTION
Context:
- Local pre-commit runs `golangci-lint fmt` and reorders imports in 15 legacy files on every commit.
- CI only runs `golangci-lint run --new-from-rev HEAD` and reports 0 issues, so these legacy files stayed as-is in master.

What this PR does:
- Reorders imports in the 6 files to align with the formatter expectations.
- No functional changes; formatting-only baseline to avoid unrelated diffs in future feature PRs.

Notes:
- After this baseline formatting, local pre-commit will no longer pull these files into unrelated commits.