### PR TITLE
feat(SDK+Proto): Revert semaphore/mutex fields in preparation for simplified design

### DIFF
--- a/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
+++ b/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
@@ -2746,16 +2746,12 @@ func (x *KubernetesWorkspaceConfig) GetPvcSpecPatch() *structpb.Struct {
 // Spec for pipeline-level config options. See PipelineConfig DSL class.
 type PipelineConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Name of the semaphore key to control pipeline concurrency
-	SemaphoreKey string `protobuf:"bytes,1,opt,name=semaphore_key,json=semaphoreKey,proto3" json:"semaphore_key,omitempty"`
-	// Name of the mutex to ensure mutual exclusion
-	MutexName string `protobuf:"bytes,2,opt,name=mutex_name,json=mutexName,proto3" json:"mutex_name,omitempty"`
 	// Time to live configuration after the pipeline run is completed for
 	// ephemeral resources created by the pipeline run.
-	ResourceTtl int32 `protobuf:"varint,3,opt,name=resource_ttl,json=resourceTtl,proto3" json:"resource_ttl,omitempty"`
+	ResourceTtl int32 `protobuf:"varint,1,opt,name=resource_ttl,json=resourceTtl,proto3" json:"resource_ttl,omitempty"`
 	// Configuration for a shared storage workspace that persists for the duration of the pipeline run.
 	// The workspace can be configured with size and Kubernetes-specific settings to override default PVC configurations.
-	Workspace     *WorkspaceConfig `protobuf:"bytes,4,opt,name=workspace,proto3,oneof" json:"workspace,omitempty"`
+	Workspace     *WorkspaceConfig `protobuf:"bytes,2,opt,name=workspace,proto3,oneof" json:"workspace,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2788,20 +2784,6 @@ func (x *PipelineConfig) ProtoReflect() protoreflect.Message {
 // Deprecated: Use PipelineConfig.ProtoReflect.Descriptor instead.
 func (*PipelineConfig) Descriptor() ([]byte, []int) {
 	return file_pipeline_spec_proto_rawDescGZIP(), []int{34}
-}
-
-func (x *PipelineConfig) GetSemaphoreKey() string {
-	if x != nil {
-		return x.SemaphoreKey
-	}
-	return ""
-}
-
-func (x *PipelineConfig) GetMutexName() string {
-	if x != nil {
-		return x.MutexName
-	}
-	return ""
 }
 
 func (x *PipelineConfig) GetResourceTtl() int32 {
@@ -6105,13 +6087,10 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\v_kubernetes\"r\n" +
 	"\x19KubernetesWorkspaceConfig\x12B\n" +
 	"\x0epvc_spec_patch\x18\x01 \x01(\v2\x17.google.protobuf.StructH\x00R\fpvcSpecPatch\x88\x01\x01B\x11\n" +
-	"\x0f_pvc_spec_patch\"\xc7\x01\n" +
-	"\x0ePipelineConfig\x12#\n" +
-	"\rsemaphore_key\x18\x01 \x01(\tR\fsemaphoreKey\x12\x1d\n" +
-	"\n" +
-	"mutex_name\x18\x02 \x01(\tR\tmutexName\x12!\n" +
-	"\fresource_ttl\x18\x03 \x01(\x05R\vresourceTtl\x12@\n" +
-	"\tworkspace\x18\x04 \x01(\v2\x1d.ml_pipelines.WorkspaceConfigH\x00R\tworkspace\x88\x01\x01B\f\n" +
+	"\x0f_pvc_spec_patch\"\x83\x01\n" +
+	"\x0ePipelineConfig\x12!\n" +
+	"\fresource_ttl\x18\x01 \x01(\x05R\vresourceTtl\x12@\n" +
+	"\tworkspace\x18\x02 \x01(\v2\x1d.ml_pipelines.WorkspaceConfigH\x00R\tworkspace\x88\x01\x01B\f\n" +
 	"\n" +
 	"_workspaceB<Z:github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespecb\x06proto3"
 

--- a/api/v2alpha1/pipeline_spec.proto
+++ b/api/v2alpha1/pipeline_spec.proto
@@ -1163,17 +1163,11 @@ message KubernetesWorkspaceConfig {
 
 // Spec for pipeline-level config options. See PipelineConfig DSL class.
 message PipelineConfig {
-  // Name of the semaphore key to control pipeline concurrency
-  string semaphore_key = 1;
-
-  // Name of the mutex to ensure mutual exclusion
-  string mutex_name = 2;
-
   // Time to live configuration after the pipeline run is completed for
   // ephemeral resources created by the pipeline run.
-  int32 resource_ttl = 3;
+  int32 resource_ttl = 1;
 
   // Configuration for a shared storage workspace that persists for the duration of the pipeline run.
   // The workspace can be configured with size and Kubernetes-specific settings to override default PVC configurations.
-  optional WorkspaceConfig workspace = 4;
+  optional WorkspaceConfig workspace = 2;
 }

--- a/backend/test/proto_tests/objects.go
+++ b/backend/test/proto_tests/objects.go
@@ -306,9 +306,7 @@ var platformSpec = &specPB.PlatformSpec{
 				},
 			},
 			PipelineConfig: &specPB.PipelineConfig{
-				SemaphoreKey: "test-key",
-				MutexName:    "test-mutex",
-				ResourceTtl:  24,
+				ResourceTtl: 24,
 			},
 		},
 	},

--- a/backend/test/proto_tests/testdata/generated-1791485/platform_spec.json
+++ b/backend/test/proto_tests/testdata/generated-1791485/platform_spec.json
@@ -1,23 +1,21 @@
 {
-  "platforms":  {
-    "kubernetes":  {
-      "deployment_spec":  {
-        "executors":  {
-          "root-executor":  {
-            "container":  {
-              "image":  "test-image"
+  "platforms": {
+    "kubernetes": {
+      "deployment_spec": {
+        "executors": {
+          "root-executor": {
+            "container": {
+              "image": "test-image"
             }
           }
         }
       },
-      "platform":  "kubernetes",
-      "config":  {
-        "project":  "test-project"
+      "platform": "kubernetes",
+      "config": {
+        "project": "test-project"
       },
-      "pipelineConfig":  {
-        "semaphore_key":  "test-key",
-        "mutex_name":  "test-mutex",
-        "resource_ttl":  24
+      "pipelineConfig": {
+        "resource_ttl": 24
       }
     }
   }

--- a/backend/test/proto_tests/testdata/generated-1791485/platform_spec.pb
+++ b/backend/test/proto_tests/testdata/generated-1791485/platform_spec.pb
@@ -1,7 +1,7 @@
 
-
+x
 
-kubernetes€
+kubernetesj
 ;
 9
 root-executor(
@@ -12,6 +12,4 @@ kubernetes€
 test-image
 kubernetes
 
-projecttest-project"
-test-key
-test-mutex
+projecttest-project"

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -4336,67 +4336,6 @@ class TestPlatformConfig(unittest.TestCase):
                     pipeline_func=my_pipeline, package_path=output_yaml)
 
 
-class TestPipelineSemaphoreMutex(unittest.TestCase):
-
-    def test_pipeline_with_semaphore(self):
-        """Test that pipeline config correctly sets the semaphore key."""
-        config = PipelineConfig()
-        config.semaphore_key = 'semaphore'
-
-        @dsl.pipeline(pipeline_config=config)
-        def my_pipeline():
-            task = comp()
-
-        with tempfile.TemporaryDirectory() as tempdir:
-            output_yaml = os.path.join(tempdir, 'pipeline.yaml')
-            compiler.Compiler().compile(
-                pipeline_func=my_pipeline, package_path=output_yaml)
-
-            with open(output_yaml, 'r') as f:
-                pipeline_docs = list(yaml.safe_load_all(f))
-
-        platform_spec = None
-        for doc in pipeline_docs:
-            if 'platforms' in doc:
-                platform_spec = doc
-                break
-
-        self.assertIsNotNone(platform_spec,
-                             'No platforms section found in compiled output')
-        kubernetes_spec = platform_spec['platforms']['kubernetes'][
-            'pipelineConfig']
-        self.assertEqual(kubernetes_spec['semaphoreKey'], 'semaphore')
-
-    def test_pipeline_with_mutex(self):
-        """Test that pipeline config correctly sets the mutex name."""
-        config = PipelineConfig()
-        config.mutex_name = 'mutex'
-
-        @dsl.pipeline(pipeline_config=config)
-        def my_pipeline():
-            task = comp()
-
-        with tempfile.TemporaryDirectory() as tempdir:
-            output_yaml = os.path.join(tempdir, 'pipeline.yaml')
-            compiler.Compiler().compile(
-                pipeline_func=my_pipeline, package_path=output_yaml)
-
-            with open(output_yaml, 'r') as f:
-                pipeline_docs = list(yaml.safe_load_all(f))
-
-        platform_spec = None
-        for doc in pipeline_docs:
-            if 'platforms' in doc:
-                platform_spec = doc
-                break
-
-        self.assertIsNotNone(platform_spec,
-                             'No platforms section found in compiled output')
-        kubernetes_spec = platform_spec['platforms']['kubernetes'][
-            'pipelineConfig']
-        self.assertEqual(kubernetes_spec['mutexName'], 'mutex')
-
-
 class ExtractInputOutputDescription(unittest.TestCase):
 
     def test_no_descriptions(self):

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -2242,20 +2242,14 @@ def _write_kubernetes_manifest_to_file(
 
 def _merge_pipeline_config(pipelineConfig: pipeline_config.PipelineConfig,
                            platformSpec: pipeline_spec_pb2.PlatformSpec):
-    config_dict = {}
-
     workspace = pipelineConfig.workspace
-    if workspace is not None:
-        config_dict['workspace'] = workspace.get_workspace()
+    if workspace is None:
+        return platformSpec
 
-    if pipelineConfig.semaphore_key is not None:
-        config_dict['semaphoreKey'] = pipelineConfig.semaphore_key
-    if pipelineConfig.mutex_name is not None:
-        config_dict['mutexName'] = pipelineConfig.mutex_name
-
-    if config_dict:
-        json_format.ParseDict({'pipelineConfig': config_dict},
-                              platformSpec.platforms['kubernetes'])
+    json_format.ParseDict(
+        {'pipelineConfig': {
+            'workspace': workspace.get_workspace(),
+        }}, platformSpec.platforms['kubernetes'])
 
     return platformSpec
 

--- a/sdk/python/kfp/dsl/pipeline_config.py
+++ b/sdk/python/kfp/dsl/pipeline_config.py
@@ -96,57 +96,5 @@ class WorkspaceConfig:
 class PipelineConfig:
     """PipelineConfig contains pipeline-level config options."""
 
-    def __init__(self,
-                 workspace: Optional[WorkspaceConfig] = None,
-                 semaphore_key: Optional[str] = None,
-                 mutex_name: Optional[str] = None):
+    def __init__(self, workspace: Optional[WorkspaceConfig] = None):
         self.workspace = workspace
-        self._semaphore_key = semaphore_key
-        self._mutex_name = mutex_name
-
-    @property
-    def semaphore_key(self) -> Optional[str]:
-        """Get the semaphore key for controlling pipeline concurrency.
-
-        Returns:
-            Optional[str]: The semaphore key, or None if not set.
-        """
-        return self._semaphore_key
-
-    @semaphore_key.setter
-    def semaphore_key(self, value: str):
-        """Set the semaphore key to control pipeline concurrency.
-
-        Pipelines with the same semaphore key will be limited to a configured maximum
-        number of concurrent executions. This allows you to control resource usage by
-        ensuring that only a specific number of pipelines can run simultaneously.
-
-        Note: A pipeline can use both semaphores and mutexes together. The pipeline
-        will wait until all required locks are available before starting.
-
-        Args:
-            value (str): The semaphore key name for controlling concurrent executions.
-        """
-        self._semaphore_key = (value and value.strip()) or None
-
-    @property
-    def mutex_name(self) -> Optional[str]:
-        """Get the mutex name for exclusive pipeline execution.
-
-        Returns:
-            Optional[str]: The mutex name, or None if not set.
-        """
-        return self._mutex_name
-
-    @mutex_name.setter
-    def mutex_name(self, value: str):
-        """Set the name of the mutex to ensure mutual exclusion.
-
-        Pipelines with the same mutex name will only run one at a time. This ensures
-        exclusive access to shared resources and prevents conflicts when multiple
-        pipelines would otherwise compete for the same resources.
-
-        Args:
-            value (str): Name of the mutex for exclusive pipeline execution.
-        """
-        self._mutex_name = (value and value.strip()) or None


### PR DESCRIPTION
**Description of your changes:**

This PR reverts the semaphore and mutex functionality introduced in PRs #11340 and #11384 to prepare for a simplified design approach that provides better user experience.

## Reverted Changes

- **feat(api): Add SemaphoreKey and MutexName fields to proto** (commit `28e5ba9d3`)
- **feat(sdk): Add SemaphoreKey and MutexName fields to DSL** (commit `e997d426`)

## Background

After team discussion (referenced in [this PR comment](https://github.com/kubeflow/pipelines/pull/11370#issuecomment-3353175709)), we determined that the original approach requiring users to manually manage `semaphore_key` and `mutex_name` fields was too complex and required excessive Kubernetes knowledge.

### Original approach issues:
- Users needed to understand Kubernetes semaphores/mutexes
- Required manual ConfigMap key management  
- Complex partially-managed ConfigMap state
- Poor user experience for simple "limit concurrent runs" use case

## New Simplified Design (Future PR)

The replacement design will introduce a single `pipeline_run_parallelism` integer field that:

- Takes a simple integer value (e.g., `pipeline_run_parallelism=3`) 
- Automatically generates semaphore keys as `<pipeline_name>/<pipeline_version>`
- Eliminates need for Kubernetes knowledge
- Provides intuitive "max concurrent runs" semantics

## Impact

- Removes `semaphore_key` and `mutex_name` fields from `PipelineConfig` proto and SDK
- Existing YAML pipelines using these fields will have them ignored (no errors)
- No gRPC API impact (fields were only used for YAML/JSON parsing)

## Testing

- Protobuf regenerated and validated
- All semaphore/mutex tests removed cleanly  
- Existing workspace functionality preserved
- No breaking changes to core pipeline compilation

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
