### PR TITLE
chore: Apply patches for Openshift env to seaweedfs deployment

### DIFF
--- a/manifests/kustomize/env/openshift/base/kustomization.yaml
+++ b/manifests/kustomize/env/openshift/base/kustomization.yaml
@@ -65,6 +65,12 @@ patches:
     target:
       group: apps
       kind: Deployment
+      name: seaweedfs
+      version: v1
+  - path: patches/remove-sc.json
+    target:
+      group: apps
+      kind: Deployment
       name: ml-pipeline
       version: v1
   - path: patches/remove-sc.json
@@ -114,4 +120,10 @@ patches:
       group: apps
       kind: Deployment
       name: minio
+      version: v1
+  - path: patches/remove-sc-pod.json
+    target:
+      group: apps
+      kind: Deployment
+      name: seaweedfs
       version: v1


### PR DESCRIPTION
**Description of your changes:**
With platform-agnostic env now deploying seasweedfs instead of minio, add it's deployment to the list of manifests to apply openshift-specific patches to when using the `env/openshift` environment target.

Without this, seaweedfs Deployments will not be able to create pods

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
