### PR TITLE
chore: remove --whole-files flag from precommit check

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,7 +25,7 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.3
-          args: --new --whole-files --new-from-merge-base=origin/${{ github.base_ref || github.ref_name }}
+          args: --new --new-from-merge-base=origin/${{ github.base_ref || github.ref_name }}
     #- uses: pre-commit/action@v3.0.1
     #  # This is set to only run the golangci-lint pre-commit hooks
     #  # Remove in a later PR to run all hooks


### PR DESCRIPTION
**Description of your changes:**
Remove --whole-files flag from precommit check. Because the entire codebase has not been linted yet, this precommit was failing PRs that touched files with unlinted code.

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
