### PR TITLE
Revert complete pre-commit refactor.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,20 +12,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref || github.ref_name }}
-      - uses: actions/setup-python@v3
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
-        with:
-          version: v2.3
-          args: --new --new-from-merge-base=origin/${{ github.base_ref || github.ref_name }}
     #- uses: pre-commit/action@v3.0.1
     #  # This is set to only run the golangci-lint pre-commit hooks
     #  # Remove in a later PR to run all hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
       - id: golangci-lint
         name: golangci-lint
         description: Fast linters runner for Go.
-        entry: golangci-lint run --new-from-rev HEAD --fix --whole-files
+        entry: golangci-lint run --new-from-rev HEAD --fix
         types: [go]
         language: golang
         require_serial: true


### PR DESCRIPTION
**Description of your changes:**
Revert changes made to `.github/workflows/pre-commit.yml`  added in #12302 . Because the entire codebase has not been linted yet, this precommit was failing PRs that touched files with unlinted code. #12319  attempted to fix these failures by removing `--whole-files` flag, but the overall check was still executing.

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
