### PR TITLE
fix(CI): ensure SeaweedFS S3 auth is set up before tests 

### DIFF
--- a/.github/resources/scripts/deploy-kfp.sh
+++ b/.github/resources/scripts/deploy-kfp.sh
@@ -32,6 +32,7 @@ MULTI_USER=false
 STORAGE_BACKEND="seaweedfs"
 AWF_VERSION=""
 POD_TO_POD_TLS_ENABLED=false
+SEAWEEDFS_INIT_TIMEOUT=300s
 
 # Loop over script arguments passed. This uses a single switch-case
 # block with default value in case we want to make alternative deployments
@@ -201,6 +202,17 @@ if [[ $EXIT_CODE -ne 0 ]]
 then
   echo "Deploy unsuccessful. Not all pods running."
   exit 1
+fi
+
+# Ensure SeaweedFS S3 auth is configured before proceeding
+if [ "${STORAGE_BACKEND}" == "seaweedfs" ]; then
+  wait_for_seaweedfs_init kubeflow "${SEAWEEDFS_INIT_TIMEOUT}" || EXIT_CODE=$?
+  if [[ $EXIT_CODE -ne 0 ]]
+  then
+    echo "SeaweedFS init job did not complete successfully."
+    exit 1
+  fi
+  echo "SeaweedFS init job completed successfully."
 fi
 
 # Verify pipeline integration for multi-user mode

--- a/.github/resources/scripts/helper-functions.sh
+++ b/.github/resources/scripts/helper-functions.sh
@@ -61,6 +61,17 @@ wait_for_pods () {
     python "${C_DIR}"/kfp-readiness/wait_for_pods.py
 }
 
+wait_for_seaweedfs_init () {
+    # Wait for SeaweedFS init job to complete to ensure S3 auth is configured
+    local namespace="$1"
+    local timeout="$2"
+    if kubectl -n "$namespace" get job init-seaweedfs > /dev/null 2>&1; then
+        if ! kubectl -n "$namespace" wait --for=condition=complete --timeout="$timeout" job/init-seaweedfs; then
+            return 1
+        fi
+    fi
+}
+
 deploy_with_retries () {
     if [[ $# -ne 4 ]]
     then


### PR DESCRIPTION
**Description of your changes:**
Resolves https://github.com/kubeflow/pipelines/issues/12259

SDK Execution and Kubernetes tests intermittently failed with the following error-
msg="Pod failed: Error (exit code 64): failed to put file: Signed request requires setting up SeaweedFS S3 authentication" 
This PR ensures SeaweedFS S3 authentication is configured before the tests run.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
