### PR TITLE
fix: include requirements files in python sdist

### DIFF
--- a/kubernetes_platform/python/MANIFEST.in
+++ b/kubernetes_platform/python/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include requirements-dev.txt


### PR DESCRIPTION
**Description of your changes:**

The source distribution produced does not include all of the files
needed to rebuild the wheel. This change adds a MANIFEST.in file to
cause the requirements.txt and requirements-dev.txt files to be included
so when the setup.py tries to read them they are present.


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->