### PR TITLE
fix(test): respect TLSEnabled flag in integration tests

### DIFF
--- a/backend/test/v2/integration/cache_test.go
+++ b/backend/test/v2/integration/cache_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"testing"
 	"time"
@@ -69,9 +70,13 @@ func (s *CacheTestSuite) SetupTest() {
 	var newRunClient func() (*apiServer.RunClient, error)
 	var newRecurringRunClient func() (*apiServer.RecurringRunClient, error)
 
-	tlsCfg, err := test.GetTLSConfig(*config.CaCertPath)
-	if err != nil {
-		glog.Exitf("Failed to get TLS config. Error: %s", err.Error())
+	var tlsCfg *tls.Config
+	var err error
+	if *config.TLSEnabled {
+		tlsCfg, err = test.GetTLSConfig(*config.CaCertPath)
+		if err != nil {
+			glog.Exitf("Failed to get TLS config. Error: %s", err.Error())
+		}
 	}
 
 	if *isKubeflowMode {

--- a/backend/test/v2/integration/healthz_api_test.go
+++ b/backend/test/v2/integration/healthz_api_test.go
@@ -15,6 +15,7 @@
 package integration
 
 import (
+	"crypto/tls"
 	"os"
 	"testing"
 
@@ -49,9 +50,12 @@ func (s *HealthzApiTest) SetupTest() {
 	s.namespace = *config.Namespace
 	clientConfig := test.GetClientConfig(*config.Namespace)
 	var err error
-	tlsCfg, err := test.GetTLSConfig(*config.CaCertPath)
-	if err != nil {
-		glog.Exitf("Failed to get TLS config. Error: %s", err.Error())
+	var tlsCfg *tls.Config
+	if *config.TLSEnabled {
+		tlsCfg, err = test.GetTLSConfig(*config.CaCertPath)
+		if err != nil {
+			glog.Exitf("Failed to get TLS config. Error: %s", err.Error())
+		}
 	}
 	s.healthzClient, err = api_server.NewHealthzClient(clientConfig, false, tlsCfg)
 	if err != nil {


### PR DESCRIPTION
## Problem

Two integration test files were ignoring the `-tlsEnabled` flag and unconditionally creating TLS configurations:
- `backend/test/v2/integration/healthz_api_test.go`
- `backend/test/v2/integration/cache_test.go`

This caused the following issues:
1. Tests always attempted HTTPS connections even when `-tlsEnabled=false` was set
2. When testing against HTTP-only API servers, tests failed with: `"http: server gave HTTP response to HTTPS client"`
3. Inconsistent behavior compared to other test files

## Root Cause

Both files called `test.GetTLSConfig(*config.CaCertPath)` unconditionally, which:
- Returns a non-nil `*tls.Config` object even when `caCertPath` is empty
- The non-nil config forces `NewHTTPRuntime()` to use HTTPS (see `util.go:85`)
- Ignores user intent expressed via `-tlsEnabled=false`