### PR TITLE
fix(backend): Fix pod name truncation issue in PVC creation. Fixes #12350

### DIFF
--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -94,6 +94,9 @@ func InPodNamespace() (string, error) {
 
 // InPodName gets the pod name from inside a Kubernetes Pod.
 func InPodName() (string, error) {
+	if podName, exists := os.LookupEnv("ARGO_POD_NAME"); exists && podName != "" {
+		return podName, nil
+	}
 	podName, err := os.ReadFile("/etc/hostname")
 	if err != nil {
 		return "", fmt.Errorf("failed to get pod name in Pod: %w", err)


### PR DESCRIPTION
**Description of your changes:**

Use `ARGO_POD_NAME` environment variable instead of reading hostname to obtain the pod name, falling back to hostname if `ARGO_POD_NAME` is not set or empty. `ARGO_POD_NAME` should contain the complete pod name and avoids the 63-character truncation issue that causes PVC creation failures as described in issue #12350

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
