### PR TITLE
chore(sdk): allow installing click > 8.1.8

### DIFF
--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -7,7 +7,7 @@ certifi==2025.10.5
     #   requests
 charset-normalizer==3.4.3
     # via requests
-click==8.1.8
+click>=8.1.8
     # via
     #   -r requirements.in
     #   click-option-group


### PR DESCRIPTION
Relaxed the click package version in `requirements.txt` from `click==8.1.8` to `click>=8.1.8`.
This allows users to install newer versions of click while maintaining compatibility with the SDK.

Note: Running CLI tests on Python 3.13 may still show failures due to protobuf / generated pipeline_spec differences. Maintainers are expected to handle those separately.

fixes #12361 



