### PR TITLE
chore(sdk) : Allow installation of newer python click versions Fixes #12361

### DIFF
--- a/sdk/python/kfp/cli/component.py
+++ b/sdk/python/kfp/cli/component.py
@@ -357,9 +357,13 @@ class ComponentBuilder():
             f'Built and pushed component container {self._target_image}')
 
 
-@click.group()
-def component():
+@click.group(invoke_without_command=True)
+@click.pass_context
+def component(ctx: click.Context):
     """Builds shareable, containerized components."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit(0)
 
 
 @component.command()

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -2,7 +2,7 @@
 # the following in this folder:
 # pip-compile --no-emit-index-url requirements.in
 
-click==8.1.8
+click>=8.1.8
 click-option-group==0.5.7
 docstring-parser>=0.7.3,<1
 # Pin google-api-core version for the bug fixing in 1.31.5

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -7,7 +7,7 @@ certifi==2025.10.5
     #   requests
 charset-normalizer==3.4.3
     # via requests
-click==8.1.8
+click>=8.1.8
     # via
     #   -r requirements.in
     #   click-option-group


### PR DESCRIPTION
This allows users to install newer versions of Click while maintaining compatibility with the SDK.

Fixes #12361 
