### PR TITLE
fix(artifact-proxy): sets namespace. Fixes #12041

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-profile-controller/sync.py
@@ -290,6 +290,10 @@ def server_factory(frontend_image,
                                             {
                                                 "name": "ML_PIPELINE_SERVICE_PORT",
                                                 "value": "8888"
+                                            },
+                                            {
+                                                "name": "FRONTEND_SERVER_NAMESPACE",
+                                                "value": namespace,
                                             }
                                         ],
                                         "resources": {


### PR DESCRIPTION
**Description of your changes:**

When a Kubeflow pipeline specifies a "Pipeline Root," pipeline artifacts are stored in the user's `ObjectStore`. However, the web UI (`ml-pipeline-ui` in the namespace `kubeflow`) does not have access to the secret required for accessing the `ObjectStore`. To address this, artifact requests are proxied to the service `ml-pipeline-ui-artifact` in the project namespace (where the secret is located), following this flow:
(credits for the diagram to @droctothorpe from https://github.com/kubeflow/pipelines/issues/12239)

```mermaid
sequenceDiagram
    User->>UI: 
    UI->>ml-pipeline-ui: 
    ml-pipeline-ui->>ml-pipeline-ui-artifact: 
    ml-pipeline-ui-artifact->>ObjectStore: 
    ObjectStore->>ml-pipeline-ui-artifact: 
    ml-pipeline-ui-artifact->>ml-pipeline-ui: 
    ml-pipeline-ui->>UI: 
    UI->>User: 
```

**Issue:**  
When the request is proxied, the `namespace` parameter in the URL is dropped (see [code reference](https://github.com/kubeflow/pipelines/blob/126a141c1fd4d3b420ca16ef5166ac6fdf8510b1/frontend/server/handlers/artifacts.ts#L461)). As a result, the code that retrieves the `namespace` ([see here](https://github.com/kubeflow/pipelines/blob/126a141c1fd4d3b420ca16ef5166ac6fdf8510b1/frontend/server/handlers/artifacts.ts#L106-L110)) falls back to its default value, `kubeflow`. This causes the proxy to look for the `ObjectStore` secret in the `kubeflow` namespace, instead of the correct project namespace.

**Solution:**

The fix, introduced in [this PR](https://github.com/kubeflow/pipelines/pull/11059), uses the environment variable `FRONTEND_SERVER_NAMESPACE` in the deployment of `ml-pipeline-ui-artifact`. This deployment is managed by the `kubeflow-pipelines-profile-controller`, and the env var must be included in the `sync.py` script.



**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->

Fixes https://github.com/kubeflow/pipelines/issues/12041