### PR TITLE
chore: Apply patches for Openshift env to init-seaweedfs job

### DIFF
--- a/manifests/kustomize/env/openshift/base/kustomization.yaml
+++ b/manifests/kustomize/env/openshift/base/kustomization.yaml
@@ -109,6 +109,12 @@ patches:
       kind: Deployment
       name: mysql
       version: v1
+  - path: patches/remove-sc.json
+    target:
+      group: batch
+      kind: Job
+      name: init-seaweedfs
+      version: v1
   - path: patches/remove-sc-pod.json
     target:
       group: apps
@@ -126,4 +132,10 @@ patches:
       group: apps
       kind: Deployment
       name: seaweedfs
+      version: v1
+  - path: patches/remove-sc-pod.json
+    target:
+      group: batch
+      kind: Job
+      name: init-seaweedfs
       version: v1


### PR DESCRIPTION
**Description of your changes:**
This PR adds the init-seaweedfs Job to the list of manifests that apply OpenShift-specific patches when using the `env/openshift` environment target. Without these patches, the init job violates OpenShift SCCs, causing SeaweedFS authentication failures that prevent workflow creation.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
