### PR TITLE
fix(sdk): skip NaN values in log_metric(). Fixes #12227

### DIFF
--- a/sdk/python/kfp/dsl/types/artifact_types.py
+++ b/sdk/python/kfp/dsl/types/artifact_types.py
@@ -14,6 +14,7 @@
 """Classes and utilities for using and creating artifacts in components."""
 
 import enum
+import math
 import os
 from typing import Dict, List, Optional, Type
 import warnings
@@ -121,8 +122,8 @@ def convert_local_path_to_remote_path(path: str) -> str:
         return RemotePrefix.S3.value + path[len(_S3_LOCAL_MOUNT_PREFIX):]
     elif path.startswith(_OCI_LOCAL_MOUNT_PREFIX):
         remote_path = path[len(_OCI_LOCAL_MOUNT_PREFIX):].replace('_', '/')
-        if remote_path.endswith("/models"):
-            remote_path = remote_path[:-len("/models")]
+        if remote_path.endswith('/models'):
+            remote_path = remote_path[:-len('/models')]
 
         return RemotePrefix.OCI.value + remote_path
 
@@ -148,10 +149,10 @@ class Model(Artifact):
 
     @property
     def path(self) -> str:
-        if self.uri.startswith("oci://"):
+        if self.uri.startswith('oci://'):
             # Modelcar container images are expected to have the model files stored in /models
             # https://github.com/kserve/kserve/blob/v0.14.1/pkg/webhook/admission/pod/storage_initializer_injector.go#L732
-            return self._get_path() + "/models"
+            return self._get_path() + '/models'
 
         return self._get_path()
 
@@ -191,6 +192,10 @@ class Metrics(Artifact):
           metric: The metric key.
           value: The metric value.
         """
+        if math.isnan(value):
+            warnings.warn(f'Metric "{metric}" is NaN and will be skipped.', stacklevel=2)
+            return
+
         self.metadata[metric] = value
 
 


### PR DESCRIPTION

**Description of your changes:**

log_metric() previously failed when a metric value was NaN, causing component errors.  

This change adds a check to skip NaN values and issue a warning instead:

```python
if math.isnan(value):
    warnings.warn(f'Metric "{metric}" is NaN and will be skipped.', stacklevel=2)
    return
```
Fixes #12227 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
