### PR TITLE
fix(components): Replace deprecated method_whitelist with allowed_methods in urllib3 Retry. Fixes kubeflow#12134

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/container/v1/dataproc/utils/dataproc_util.py
+++ b/components/google-cloud/google_cloud_pipeline_components/container/v1/dataproc/utils/dataproc_util.py
@@ -77,7 +77,7 @@ class DataprocBatchRemoteRunner:
         total=_CONNECTION_ERROR_RETRY_LIMIT,
         status_forcelist=[429, 503],
         backoff_factor=_CONNECTION_RETRY_BACKOFF_FACTOR,
-        method_whitelist=['GET', 'POST'],
+        allowed_methods=['GET', 'POST'],
     )
     adapter = HTTPAdapter(max_retries=retry)
     session = requests.Session()


### PR DESCRIPTION
**Description of your changes:**

- Replace deprecated 'method_whitelist' parameter with 'allowed_methods' in dataproc_util.py
- This fixes compatibility with urllib3 2.x where method_whitelist was deprecated
- Maintains the same functionality while using the modern API
- Resolves the breaking issue for users running PySpark jobs on Dataproc

The change ensures compatibility with urllib3 2.4.0+ which is used in the base image gcr.io/ml-pipeline/google-cloud-pipeline-components:2.20.1.

PR copied from #12158 by @akintunero. I don't know why his PR has been closed. We need this issue fixed, thanks everyone for your support

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

