### PR TITLE
fix(sdk): Add support for list and dict parameter type hints

### DIFF
--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -22,6 +22,7 @@ from kfp.dsl import Input
 from kfp.dsl import Output
 from kfp.dsl import structures
 from kfp.dsl.component_decorator import component
+from kfp.dsl.types import type_utils
 from kfp.dsl.types.artifact_types import Artifact
 from kfp.dsl.types.artifact_types import Model
 from kfp.dsl.types.type_annotations import OutputPath
@@ -301,6 +302,41 @@ class TestExtractComponentInterfaceListofArtifacts(unittest.TestCase):
                         default=None,
                         is_artifact_list=True)
             })
+
+
+class TestBuiltinGenericParameterAnnotations(unittest.TestCase):
+
+    def test_builtin_list_parameter_annotations(self):
+
+        @dsl.component
+        def comp(nums: list[int]) -> list[int]:
+            return nums
+
+        spec = comp.component_spec
+        self.assertEqual(
+            type_utils.get_canonical_name_for_outer_generic(
+                spec.inputs['nums'].type), 'List')
+        self.assertFalse(spec.inputs['nums'].is_artifact_list)
+        self.assertEqual(
+            type_utils.get_canonical_name_for_outer_generic(
+                spec.outputs['Output'].type), 'List')
+        self.assertFalse(spec.outputs['Output'].is_artifact_list)
+
+    def test_builtin_dict_parameter_annotations(self):
+
+        @dsl.component
+        def comp(mapping: dict[str, int]) -> dict[str, int]:
+            return mapping
+
+        spec = comp.component_spec
+        self.assertEqual(
+            type_utils.get_canonical_name_for_outer_generic(
+                spec.inputs['mapping'].type), 'Dict')
+        self.assertFalse(spec.inputs['mapping'].is_artifact_list)
+        self.assertEqual(
+            type_utils.get_canonical_name_for_outer_generic(
+                spec.outputs['Output'].type), 'Dict')
+        self.assertFalse(spec.outputs['Output'].is_artifact_list)
 
 
 class TestArtifactStringInInputpathOutputpath(unittest.TestCase):

--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -14,7 +14,6 @@
 import inspect
 import json
 import os
-import re
 from typing import Any, Callable, Dict, List, Optional, Union
 import warnings
 
@@ -23,6 +22,7 @@ from kfp.dsl import task_final_status
 from kfp.dsl.task_config import TaskConfig
 from kfp.dsl.types import artifact_types
 from kfp.dsl.types import type_annotations
+from kfp.dsl.types import type_utils
 
 
 class Executor:
@@ -436,35 +436,18 @@ def create_artifact_instance(
     )
 
 
-def get_short_type_name(type_name: str) -> str:
-    """Extracts the short form type name.
-
-    This method is used for looking up serializer for a given type.
-
-    For example:
-      typing.List -> List
-      typing.List[int] -> List
-      typing.Dict[str, str] -> Dict
-      List -> List
-      str -> str
-
-    Args:
-      type_name: The original type name.
-
-    Returns:
-      The short form type name or the original name if pattern doesn't match.
-    """
-    match = re.match(r'(typing\.)?(?P<type>\w+)(?:\[.+\])?', type_name)
-    return match['type'] if match else type_name
-
-
 # TODO: merge with type_utils.is_parameter_type
 def is_parameter(annotation: Any) -> bool:
-    if type(annotation) == type:
-        return annotation in [str, int, float, bool, dict, list]
+    if isinstance(annotation, type):
+        if annotation in [str, int, float, bool, dict, list]:
+            return True
+        annotation_name = getattr(annotation, '__name__', '')
+        if type_utils.is_task_final_status_type(annotation_name):
+            return True
+        if type_utils.is_task_config_type(annotation_name):
+            return True
 
-    # Annotation could be, for instance `typing.Dict[str, str]`, etc.
-    return get_short_type_name(str(annotation)) in ['Dict', 'List']
+    return type_utils.is_parameter_type(str(annotation))
 
 
 def is_artifact(annotation: Any) -> bool:

--- a/sdk/python/kfp/dsl/executor_test.py
+++ b/sdk/python/kfp/dsl/executor_test.py
@@ -16,6 +16,7 @@
 import contextlib
 import json
 import os
+import sys
 import tempfile
 from typing import Callable, Dict, List, NamedTuple, Optional
 import unittest
@@ -100,6 +101,50 @@ class ExecutorTest(parameterized.TestCase):
         self.assertEqual({'parameterValues': {
             'Output': 'Hello, KFP'
         }}, output_metadata)
+
+    def test_builtin_generic_list_parameter(self):
+        if sys.version_info < (3, 9):
+            self.skipTest('Built-in generics require Python >= 3.9')
+
+        executor_input = """\
+        {
+          "inputs": {
+            "parameterValues": {
+              "num_list": [1, 2, 3]
+            }
+          },
+          "outputs": {
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func(num_list: list[int]) -> None:
+            self.assertEqual(num_list, [1, 2, 3])
+
+        self.execute_and_load_output_metadata(test_func, executor_input)
+
+    def test_builtin_generic_dict_parameter(self):
+        if sys.version_info < (3, 9):
+            self.skipTest('Built-in generics require Python >= 3.9')
+
+        executor_input = """\
+        {
+          "inputs": {
+            "parameterValues": {
+              "mapping": {"a": 1, "b": 2}
+            }
+          },
+          "outputs": {
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func(mapping: dict[str, int]) -> None:
+            self.assertEqual(mapping, {'a': 1, 'b': 2})
+
+        self.execute_and_load_output_metadata(test_func, executor_input)
 
     def test_input_artifact_custom_type(self):
         executor_input = """\


### PR DESCRIPTION
**Description of your changes:**

Resolves:
https://github.com/kubeflow/pipelines/issues/11536

I also manually tested with:

```python
from kfp import compiler, dsl

@dsl.component(
    kfp_package_path="git+https://github.com/mprahl/pipelines@fix-types#egg=kfp&subdirectory=sdk/python",
)
def list_input_component(num_list: list[int]):
    print(num_list)

@dsl.pipeline
def my_pipeline(my_list: list[int]=[1,2,3]):
    list_task = list_input_component(num_list=my_list)

if __name__ == "__main__":
    compiler.Compiler().compile(my_pipeline, package_path=__file__.replace('.py', '.yaml'))
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
