### PR TITLE
feat: Support driver pod labels and annotations configuration at API server startup

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -62,6 +62,35 @@ Run
 docker build . -f backend/Dockerfile.conformance -t <tag>
 ```
 
+## API Server Configuration
+
+### Driver Pod Labels and Annotations
+
+The API server supports configuring custom labels and annotations for driver pods through the configuration file or the Kubernetes ConfigMap. This is useful for integration with service mesh (Istio), monitoring systems, or other infrastructure requirements.
+
+**Configuration via config.json:**
+```json
+{
+  "DRIVER_POD_LABELS": {
+    "sidecar.istio.io/inject": "true",
+    "app": "ml-pipeline-driver"
+  },
+  "DRIVER_POD_ANNOTATIONS": {
+    "proxy.istio.io/config": "{\"holdApplicationUntilProxyStarts\":true}"
+  }
+}
+```
+
+**Configuration via Kubernetes ConfigMap (`pipeline-install-config`):**
+```yaml
+DRIVER_POD_LABELS: '{"sidecar.istio.io/inject":"true"}'
+DRIVER_POD_ANNOTATIONS: '{"proxy.istio.io/config":"{\"holdApplicationUntilProxyStarts\":true}"}'
+```
+
+When configured via the ConfigMap, every value must be a JSON string. Write `"true"` rather than the bare boolean `true`, and never `null`. The configuration is validated at API server startup: malformed JSON, any value that is not a JSON string, and label keys, label values, or annotation keys that Kubernetes would reject all cause startup to fail with a descriptive error rather than being silently ignored. Annotation values are free form, so a value such as an inline JSON document is accepted.
+
+Note: Labels and annotations with the prefix `pipelines.kubeflow.org/` are reserved and will be filtered out to prevent overriding system metadata. Changes to driver pod configuration require an API server restart.
+
 ## API Server Development
 
 ### Run the KFP Backend Locally With a Kind Cluster

--- a/backend/src/apiserver/common/driver_config.go
+++ b/backend/src/apiserver/common/driver_config.go
@@ -1,0 +1,253 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package common provides shared utilities and configuration for the KFP API server.
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/spf13/viper"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	// Config keys. Viper derives the environment variable name from the key, so these
+	// are also the names the API server Deployment must use when it wires the values
+	// in from the pipeline-install-config ConfigMap.
+	DriverPodLabels      = "DRIVER_POD_LABELS"
+	DriverPodAnnotations = "DRIVER_POD_ANNOTATIONS"
+
+	// Reserved label prefix that will be filtered out to prevent
+	// overriding system labels that control workflow behavior
+	ReservedLabelPrefix = "pipelines.kubeflow.org/"
+)
+
+// DriverPodConfig holds the labels and annotations applied to driver pods.
+type DriverPodConfig struct {
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+var (
+	// cachedDriverPodConfig holds the driver pod configuration loaded at startup.
+	// It is swapped atomically by InitDriverPodConfig so readers never observe a
+	// partly updated state. A nil pointer means the config has not been loaded yet.
+	cachedDriverPodConfig *DriverPodConfig
+	// driverConfigMutex protects the cached config from concurrent access.
+	driverConfigMutex sync.RWMutex
+)
+
+// InitDriverPodConfig loads, validates, and caches driver pod configuration at API
+// server startup. This should be called once after Viper configuration is loaded.
+// It returns an error when the configuration is present but cannot be parsed, so the
+// API server fails fast instead of starting with a silently empty configuration.
+func InitDriverPodConfig() error {
+	// Build and validate the new config before taking the lock for the swap.
+	cfg, err := newDriverPodConfig()
+	if err != nil {
+		return err
+	}
+
+	driverConfigMutex.Lock()
+	defer driverConfigMutex.Unlock()
+
+	if cachedDriverPodConfig != nil {
+		glog.Info("Re-initializing driver pod configuration")
+	}
+	cachedDriverPodConfig = cfg
+
+	glog.Infof("Driver pod configuration initialized: %d labels, %d annotations",
+		len(cfg.Labels), len(cfg.Annotations))
+	if len(cfg.Labels) > 0 {
+		glog.V(1).Infof("Driver pod labels: %v", cfg.Labels)
+	}
+	if len(cfg.Annotations) > 0 {
+		glog.V(1).Infof("Driver pod annotations: %v", cfg.Annotations)
+	}
+	return nil
+}
+
+// newDriverPodConfig reads the driver pod labels and annotations from Viper,
+// validates them, and returns a fully populated config or an error. Keeping
+// construction separate from the cache swap guarantees the update is applied
+// completely or not at all.
+func newDriverPodConfig() (*DriverPodConfig, error) {
+	if err := validateMapConfig(DriverPodLabels); err != nil {
+		return nil, err
+	}
+	if err := validateMapConfig(DriverPodAnnotations); err != nil {
+		return nil, err
+	}
+
+	labels := filterReservedEntries(GetMapConfig(DriverPodLabels))
+	if err := validateLabels(labels); err != nil {
+		return nil, err
+	}
+
+	annotations := filterReservedEntries(GetMapConfig(DriverPodAnnotations))
+	if err := validateAnnotationKeys(annotations); err != nil {
+		return nil, err
+	}
+
+	return &DriverPodConfig{
+		Labels:      labels,
+		Annotations: annotations,
+	}, nil
+}
+
+// validateLabels rejects label keys or values that Kubernetes would not accept, so a
+// bad entry fails at API server startup rather than later when the driver pod is
+// created and the pod is rejected by the API.
+func validateLabels(labels map[string]string) error {
+	for k, v := range labels {
+		if errs := validation.IsQualifiedName(k); len(errs) > 0 {
+			return fmt.Errorf("%s has an invalid label key %q: %s", DriverPodLabels, k, strings.Join(errs, "; "))
+		}
+		if errs := validation.IsValidLabelValue(v); len(errs) > 0 {
+			return fmt.Errorf("%s has an invalid label value %q for key %q: %s", DriverPodLabels, v, k, strings.Join(errs, "; "))
+		}
+	}
+	return nil
+}
+
+// validateAnnotationKeys rejects annotation keys that Kubernetes would not accept.
+// Annotation values are free form, so only the keys are checked.
+func validateAnnotationKeys(annotations map[string]string) error {
+	for k := range annotations {
+		if errs := validation.IsQualifiedName(k); len(errs) > 0 {
+			return fmt.Errorf("%s has an invalid annotation key %q: %s", DriverPodAnnotations, k, strings.Join(errs, "; "))
+		}
+	}
+	return nil
+}
+
+// validateMapConfig rejects a ConfigMap value that Viper would not turn into the map the
+// operator meant. On the ConfigMap string path viper.GetStringMapString swallows problems
+// in two different ways, and neither produces an error: a boolean or a number makes it
+// drop the whole map, while a JSON null is quietly coerced to an empty string. Both leave
+// the operator with a configuration that looks accepted but silently does not do what
+// they asked for, so the raw value is probed here and every entry must be a JSON string.
+func validateMapConfig(name string) error {
+	if !viper.IsSet(name) {
+		return nil
+	}
+
+	// A native map (config.json) reports an empty string here, and a blank or whitespace
+	// only value means no configuration. Neither needs probing.
+	raw := strings.TrimSpace(viper.GetString(name))
+	if raw == "" {
+		return nil
+	}
+
+	var probe map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &probe); err != nil {
+		return fmt.Errorf("%s could not be parsed as a JSON object: %w (raw value: %q)", name, err, raw)
+	}
+	for k, v := range probe {
+		if _, ok := v.(string); !ok {
+			return fmt.Errorf("%s has a value that is not a JSON string for key %q; every value must be quoted, for example \"true\" rather than true or null (raw value: %q)", name, k, raw)
+		}
+	}
+	return nil
+}
+
+// GetDriverPodConfig returns a copy of the cached driver pod configuration, or nil when
+// no labels or annotations are configured. The returned value is safe to mutate.
+//
+// Both maps are copied under a single read lock. Calling the two getters in turn would
+// take the lock twice, which would let a concurrent InitDriverPodConfig slip in between
+// and hand back labels from one version of the config and annotations from another. That
+// would defeat the point of swapping the cache as one atomic snapshot.
+func GetDriverPodConfig() *DriverPodConfig {
+	driverConfigMutex.RLock()
+	defer driverConfigMutex.RUnlock()
+
+	if cachedDriverPodConfig == nil {
+		return nil
+	}
+
+	labels := copyMap(cachedDriverPodConfig.Labels)
+	annotations := copyMap(cachedDriverPodConfig.Annotations)
+	if len(labels) == 0 && len(annotations) == 0 {
+		return nil
+	}
+	return &DriverPodConfig{
+		Labels:      labels,
+		Annotations: annotations,
+	}
+}
+
+// GetDriverPodLabels returns a copy of cached driver pod labels from configuration.
+// Labels with pipelines.kubeflow.org/ prefix are filtered out during initialization.
+// Returns nil if InitDriverPodConfig has not been called or no labels are configured.
+func GetDriverPodLabels() map[string]string {
+	driverConfigMutex.RLock()
+	defer driverConfigMutex.RUnlock()
+
+	if cachedDriverPodConfig == nil {
+		return nil
+	}
+	return copyMap(cachedDriverPodConfig.Labels)
+}
+
+// GetDriverPodAnnotations returns a copy of cached driver pod annotations from configuration.
+// Returns nil if InitDriverPodConfig has not been called or no annotations are configured.
+func GetDriverPodAnnotations() map[string]string {
+	driverConfigMutex.RLock()
+	defer driverConfigMutex.RUnlock()
+
+	if cachedDriverPodConfig == nil {
+		return nil
+	}
+	return copyMap(cachedDriverPodConfig.Annotations)
+}
+
+// copyMap returns a shallow copy of the given map, or nil if the input is nil.
+func copyMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	cp := make(map[string]string, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return cp
+}
+
+// filterReservedEntries removes entries whose key starts with the reserved prefix.
+// Used for both labels and annotations to prevent overriding metadata managed by the system.
+// Returns nil if the input is nil or the result is empty after filtering.
+func filterReservedEntries(entries map[string]string) map[string]string {
+	if entries == nil {
+		return nil
+	}
+
+	filtered := make(map[string]string, len(entries))
+	for k, v := range entries {
+		if strings.HasPrefix(k, ReservedLabelPrefix) {
+			glog.Warningf("Ignoring reserved key %s (prefix %s is reserved)", k, ReservedLabelPrefix)
+			continue
+		}
+		filtered[k] = v
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}

--- a/backend/src/apiserver/common/driver_config_test.go
+++ b/backend/src/apiserver/common/driver_config_test.go
@@ -1,0 +1,600 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Do not add t.Parallel() to these tests, because they share global Viper and package level state.
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetDriverConfig resets the driver config state for testing
+func resetDriverConfig() {
+	driverConfigMutex.Lock()
+	defer driverConfigMutex.Unlock()
+	cachedDriverPodConfig = nil
+}
+
+func TestInitDriverPodConfig(t *testing.T) {
+	tests := []struct {
+		name                string
+		labels              map[string]string
+		annotations         map[string]string
+		expectedLabels      map[string]string
+		expectedAnnotations map[string]string
+	}{
+		{
+			name:                "empty config",
+			labels:              nil,
+			annotations:         nil,
+			expectedLabels:      nil,
+			expectedAnnotations: nil,
+		},
+		{
+			name: "valid config with filtering",
+			labels: map[string]string{
+				"sidecar.istio.io/inject":       "true",
+				"pipelines.kubeflow.org/system": "reserved",
+				"app":                           "test",
+			},
+			annotations: map[string]string{
+				"proxy.istio.io/config": "{\"holdApplicationUntilProxyStarts\":true}",
+			},
+			expectedLabels: map[string]string{
+				"sidecar.istio.io/inject": "true",
+				"app":                     "test",
+			},
+			expectedAnnotations: map[string]string{
+				"proxy.istio.io/config": "{\"holdApplicationUntilProxyStarts\":true}",
+			},
+		},
+		{
+			name: "filters reserved annotations too",
+			labels: map[string]string{
+				"app": "test",
+			},
+			annotations: map[string]string{
+				"custom":                              "value",
+				"pipelines.kubeflow.org/v2_component": "true",
+			},
+			expectedLabels: map[string]string{
+				"app": "test",
+			},
+			expectedAnnotations: map[string]string{
+				"custom": "value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper and driver config state
+			viper.Reset()
+			resetDriverConfig()
+
+			if tt.labels != nil {
+				viper.Set(DriverPodLabels, tt.labels)
+			}
+			if tt.annotations != nil {
+				viper.Set(DriverPodAnnotations, tt.annotations)
+			}
+
+			// Initialize driver config
+			require.NoError(t, InitDriverPodConfig())
+
+			// Verify labels
+			labels := GetDriverPodLabels()
+			assert.Equal(t, tt.expectedLabels, labels)
+
+			// Verify annotations
+			annotations := GetDriverPodAnnotations()
+			assert.Equal(t, tt.expectedAnnotations, annotations)
+		})
+	}
+}
+
+func TestGetDriverPodLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "empty config",
+			config:   nil,
+			expected: nil,
+		},
+		{
+			name: "valid labels",
+			config: map[string]string{
+				"sidecar.istio.io/inject": "true",
+				"app":                     "test",
+			},
+			expected: map[string]string{
+				"sidecar.istio.io/inject": "true",
+				"app":                     "test",
+			},
+		},
+		{
+			name: "filters reserved labels",
+			config: map[string]string{
+				"sidecar.istio.io/inject":       "true",
+				"pipelines.kubeflow.org/system": "reserved",
+				"app":                           "test",
+			},
+			expected: map[string]string{
+				"sidecar.istio.io/inject": "true",
+				"app":                     "test",
+			},
+		},
+		{
+			name: "all reserved labels returns nil",
+			config: map[string]string{
+				"pipelines.kubeflow.org/system": "reserved",
+				"pipelines.kubeflow.org/task":   "reserved",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper and driver config state
+			viper.Reset()
+			resetDriverConfig()
+
+			if tt.config != nil {
+				viper.Set(DriverPodLabels, tt.config)
+			}
+
+			// Initialize driver config to load from Viper
+			require.NoError(t, InitDriverPodConfig())
+
+			result := GetDriverPodLabels()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetDriverPodAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "empty config",
+			config:   nil,
+			expected: nil,
+		},
+		{
+			name: "valid annotations",
+			config: map[string]string{
+				"proxy.istio.io/config": "{\"holdApplicationUntilProxyStarts\":true}",
+				"custom":                "annotation",
+			},
+			expected: map[string]string{
+				"proxy.istio.io/config": "{\"holdApplicationUntilProxyStarts\":true}",
+				"custom":                "annotation",
+			},
+		},
+		{
+			name: "filters reserved annotation prefix",
+			config: map[string]string{
+				"proxy.istio.io/config":               "value",
+				"pipelines.kubeflow.org/v2_component": "true",
+			},
+			expected: map[string]string{
+				"proxy.istio.io/config": "value",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset viper and driver config state
+			viper.Reset()
+			resetDriverConfig()
+
+			if tt.config != nil {
+				viper.Set(DriverPodAnnotations, tt.config)
+			}
+
+			// Initialize driver config to load from Viper
+			require.NoError(t, InitDriverPodConfig())
+
+			result := GetDriverPodAnnotations()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestInitDriverPodConfigFromJSONString(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	// ConfigMap values arrive as JSON strings, not Go maps.
+	// Viper's GetStringMapString must parse them correctly.
+	viper.Set(DriverPodLabels, `{"sidecar.istio.io/inject":"true","app":"driver"}`)
+	viper.Set(DriverPodAnnotations, `{"proxy.istio.io/config":"hold"}`)
+
+	require.NoError(t, InitDriverPodConfig())
+
+	labels := GetDriverPodLabels()
+	assert.Equal(t, map[string]string{
+		"sidecar.istio.io/inject": "true",
+		"app":                     "driver",
+	}, labels)
+
+	annotations := GetDriverPodAnnotations()
+	assert.Equal(t, map[string]string{
+		"proxy.istio.io/config": "hold",
+	}, annotations)
+}
+
+// TestInitDriverPodConfig_NonStringJSONValues verifies that a ConfigMap value whose
+// JSON contains a value that is not a string (for example a boolean) fails startup
+// instead of being silently swallowed as an empty map by viper.GetStringMapString.
+func TestInitDriverPodConfig_NonStringJSONValues(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	// Boolean instead of string, the most realistic ConfigMap typo.
+	viper.Set(DriverPodLabels, `{"sidecar.istio.io/inject":true}`)
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "a value that is not a string should fail startup when set via ConfigMap")
+	assert.Contains(t, err.Error(), DriverPodLabels)
+}
+
+// TestInitDriverPodConfig_NullJSONValue guards a case that is easy to miss. Viper does not
+// drop a JSON null the way it drops a boolean or a number. It quietly turns null into an
+// empty string, so without an explicit check the operator would get a label with an empty
+// value and no warning at all. Someone writing null for the Istio injection flag would
+// believe injection was enabled while the driver pod carried an empty value instead.
+func TestInitDriverPodConfig_NullJSONValue(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodLabels, `{"sidecar.istio.io/inject":null}`)
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "a JSON null should fail startup rather than become an empty label value")
+	assert.Contains(t, err.Error(), DriverPodLabels)
+	assert.Contains(t, err.Error(), "sidecar.istio.io/inject")
+}
+
+// TestInitDriverPodConfig_NullMixedWithValidValue covers the same problem when the null
+// sits alongside a perfectly good entry, which is where it is easiest to overlook.
+func TestInitDriverPodConfig_NullMixedWithValidValue(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodLabels, `{"team":"ml","sidecar.istio.io/inject":null}`)
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "a JSON null mixed with a valid value should still fail startup")
+	assert.Contains(t, err.Error(), "sidecar.istio.io/inject")
+}
+
+// TestInitDriverPodConfig_MalformedJSON verifies that a syntactically invalid JSON
+// string in the ConfigMap fails startup with a clear error.
+func TestInitDriverPodConfig_MalformedJSON(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodAnnotations, "{bad json}")
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "malformed JSON should fail at startup")
+	assert.Contains(t, err.Error(), DriverPodAnnotations)
+}
+
+// TestInitDriverPodConfig_EmptyJSONObjectIsValid guards the edge case that a valid but
+// empty JSON object ("{}") is a legitimate configuration that does nothing, not a parse failure.
+func TestInitDriverPodConfig_EmptyJSONObjectIsValid(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodLabels, "{}")
+	viper.Set(DriverPodAnnotations, "{}")
+
+	require.NoError(t, InitDriverPodConfig())
+	assert.Nil(t, GetDriverPodLabels())
+	assert.Nil(t, GetDriverPodAnnotations())
+}
+
+// TestInitDriverPodConfig_BlankValuesAreValid guards the manifest default, where the
+// ConfigMap ships DriverPodLabels and DriverPodAnnotations as empty strings. A blank or
+// whitespace value must initialize cleanly with no configuration and never fail startup.
+func TestInitDriverPodConfig_BlankValuesAreValid(t *testing.T) {
+	for _, raw := range []string{"", "   "} {
+		viper.Reset()
+		resetDriverConfig()
+		viper.Set(DriverPodLabels, raw)
+		viper.Set(DriverPodAnnotations, raw)
+
+		require.NoError(t, InitDriverPodConfig(), "blank value %q should not fail startup", raw)
+		assert.Nil(t, GetDriverPodConfig(), "blank value %q should yield no configuration", raw)
+	}
+}
+
+// TestInitDriverPodConfig_FromEnvVarWiring locks the contract between the API server
+// Deployment and Viper. The Deployment wires the pipeline-install-config keys into the
+// container as the environment variables DRIVERPODLABELS and DRIVERPODANNOTATIONS,
+// which are the uppercased forms of the Viper keys below. Without that wiring the
+// ConfigMap values never reach the API server. If the Viper keys are ever renamed, the
+// Deployment must be updated to match, and this test is what will catch it.
+func TestInitDriverPodConfig_FromEnvVarWiring(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+	t.Cleanup(func() {
+		viper.Reset()
+		resetDriverConfig()
+	})
+
+	// Same Viper setup as initConfig() in main.go.
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+	viper.AllowEmptyEnv(true)
+
+	t.Setenv(strings.ToUpper(DriverPodLabels), `{"sidecar.istio.io/inject":"true"}`)
+	t.Setenv(strings.ToUpper(DriverPodAnnotations), `{"proxy.istio.io/config":"hold"}`)
+
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Equal(t, map[string]string{"sidecar.istio.io/inject": "true"}, GetDriverPodLabels())
+	assert.Equal(t, map[string]string{"proxy.istio.io/config": "hold"}, GetDriverPodAnnotations())
+}
+
+// TestInitDriverPodConfig_EmptyEnvVarIsValid guards the default install. Every manifest
+// ships DriverPodLabels and DriverPodAnnotations as empty strings, and the Deployment
+// passes them to the container as empty environment variables. Viper runs with
+// AllowEmptyEnv, so an empty variable still counts as set. Startup must succeed with no
+// configuration, otherwise every default install would fail to start.
+func TestInitDriverPodConfig_EmptyEnvVarIsValid(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+	t.Cleanup(func() {
+		viper.Reset()
+		resetDriverConfig()
+	})
+
+	// Same Viper setup as initConfig() in main.go.
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+	viper.AllowEmptyEnv(true)
+
+	t.Setenv(strings.ToUpper(DriverPodLabels), "")
+	t.Setenv(strings.ToUpper(DriverPodAnnotations), "")
+
+	require.NoError(t, InitDriverPodConfig(), "the shipped empty default must not fail startup")
+	assert.Nil(t, GetDriverPodConfig(), "empty defaults should yield no configuration")
+}
+
+// TestInitDriverPodConfig_InvalidLabelKey verifies that a label key Kubernetes would
+// reject fails at startup instead of when the driver pod is created.
+func TestInitDriverPodConfig_InvalidLabelKey(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodLabels, map[string]string{"not a valid key!": "x"})
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "an invalid label key should fail startup")
+	assert.Contains(t, err.Error(), "invalid label key")
+}
+
+// TestInitDriverPodConfig_InvalidLabelValue verifies that a label value Kubernetes
+// would reject fails at startup.
+func TestInitDriverPodConfig_InvalidLabelValue(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodLabels, map[string]string{"app": "spaces are not allowed"})
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "an invalid label value should fail startup")
+	assert.Contains(t, err.Error(), "invalid label value")
+}
+
+// TestInitDriverPodConfig_InvalidAnnotationKey verifies that an annotation key
+// Kubernetes would reject fails at startup.
+func TestInitDriverPodConfig_InvalidAnnotationKey(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodAnnotations, map[string]string{"bad key!": "value"})
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "an invalid annotation key should fail startup")
+	assert.Contains(t, err.Error(), "invalid annotation key")
+}
+
+// TestInitDriverPodConfig_IstioMetadataAccepted guards the primary use case. Annotation
+// values are free form and often carry JSON, so validation must check annotation keys
+// only and must never reject a value like the Istio proxy config below.
+func TestInitDriverPodConfig_IstioMetadataAccepted(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodLabels, map[string]string{"sidecar.istio.io/inject": "true"})
+	viper.Set(DriverPodAnnotations, map[string]string{
+		"proxy.istio.io/config": `{"holdApplicationUntilProxyStarts":true}`,
+	})
+
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"])
+	assert.Equal(t, `{"holdApplicationUntilProxyStarts":true}`, GetDriverPodAnnotations()["proxy.istio.io/config"])
+}
+
+func TestGetDriverPodLabelsNotInitialized(t *testing.T) {
+	resetDriverConfig()
+
+	labels := GetDriverPodLabels()
+	assert.Nil(t, labels, "should return nil when not initialized")
+
+	annotations := GetDriverPodAnnotations()
+	assert.Nil(t, annotations, "should return nil when not initialized")
+
+	config := GetDriverPodConfig()
+	assert.Nil(t, config, "should return nil when not initialized")
+}
+
+func TestGetDriverPodConfig(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodLabels, map[string]string{"app": "driver"})
+	viper.Set(DriverPodAnnotations, map[string]string{"note": "value"})
+	require.NoError(t, InitDriverPodConfig())
+
+	config := GetDriverPodConfig()
+	require.NotNil(t, config)
+	assert.Equal(t, map[string]string{"app": "driver"}, config.Labels)
+	assert.Equal(t, map[string]string{"note": "value"}, config.Annotations)
+}
+
+func TestGetDriverPodConfigNilWhenAllEmpty(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	// Only reserved keys are configured, so everything is filtered out.
+	viper.Set(DriverPodLabels, map[string]string{"pipelines.kubeflow.org/system": "reserved"})
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Nil(t, GetDriverPodConfig(), "should return nil when no labels or annotations remain after filtering")
+}
+
+func TestCopyMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "nil returns nil",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty returns empty",
+			input:    map[string]string{},
+			expected: map[string]string{},
+		},
+		{
+			name:     "copies entries",
+			input:    map[string]string{"a": "1", "b": "2"},
+			expected: map[string]string{"a": "1", "b": "2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := copyMap(tt.input)
+			assert.Equal(t, tt.expected, result)
+			// Verify it is a true copy (not the same reference) for input that is not nil
+			if tt.input != nil {
+				tt.input["mutated"] = "yes"
+				assert.NotContains(t, result, "mutated")
+			}
+		})
+	}
+}
+
+func TestGetDriverPodLabelsReturnsCopy(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodLabels, map[string]string{
+		"app": "test",
+	})
+	require.NoError(t, InitDriverPodConfig())
+
+	copy1 := GetDriverPodLabels()
+	copy2 := GetDriverPodLabels()
+
+	// Mutating one copy should not affect the other
+	copy1["app"] = "mutated"
+	assert.Equal(t, "test", copy2["app"], "returned maps should be independent copies")
+}
+
+func TestFilterReservedEntries(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "empty input returns nil",
+			input:    map[string]string{},
+			expected: nil,
+		},
+		{
+			name: "no reserved labels",
+			input: map[string]string{
+				"app": "test",
+				"env": "prod",
+			},
+			expected: map[string]string{
+				"app": "test",
+				"env": "prod",
+			},
+		},
+		{
+			name: "mixed labels",
+			input: map[string]string{
+				"app":                           "test",
+				"pipelines.kubeflow.org/system": "reserved",
+				"env":                           "prod",
+			},
+			expected: map[string]string{
+				"app": "test",
+				"env": "prod",
+			},
+		},
+		{
+			name: "all reserved returns nil",
+			input: map[string]string{
+				"pipelines.kubeflow.org/system": "reserved",
+				"pipelines.kubeflow.org/task":   "reserved",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterReservedEntries(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -651,6 +651,14 @@ func initConfig() error {
 	})
 
 	proxy.InitializeConfigWithEnv()
+
+	// Initialize driver pod configuration after Viper config is loaded.
+	// This loads and caches the configuration to catch errors at startup.
+	// Note: driver pod config is intentionally NOT reloaded on config file change;
+	// an API server restart is required for changes to take effect.
+	if err := common.InitDriverPodConfig(); err != nil {
+		return fmt.Errorf("driver pod config: %w", err)
+	}
 	return nil
 }
 

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	scheduledworkflow "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
@@ -148,6 +149,9 @@ func (t *V2Spec) ScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.Sche
 			DefaultRunAsGroup:    t.templateOptions.DefaultRunAsGroup,
 			DefaultRunAsNonRoot:  t.templateOptions.DefaultRunAsNonRoot,
 			DefaultHostUsers:     t.templateOptions.DefaultHostUsers,
+			// Read the admin configured driver pod metadata here, at the API server layer,
+			// so the compiler itself stays free of any dependency on API server state.
+			DriverPodConfig: common.GetDriverPodConfig(),
 		}
 		obj, err = argocompiler.Compile(job, kubernetesSpec, opts)
 	}
@@ -391,6 +395,9 @@ func (t *V2Spec) RunWorkflow(modelRun *model.Run, options RunWorkflowOptions) (u
 			DefaultRunAsGroup:    t.templateOptions.DefaultRunAsGroup,
 			DefaultRunAsNonRoot:  t.templateOptions.DefaultRunAsNonRoot,
 			DefaultHostUsers:     t.templateOptions.DefaultHostUsers,
+			// Read the admin configured driver pod metadata here, at the API server layer,
+			// so the compiler itself stays free of any dependency on API server state.
+			DriverPodConfig: common.GetDriverPodConfig(),
 		}
 		obj, err = argocompiler.Compile(job, kubernetesSpec, opts)
 	}

--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -62,6 +62,11 @@ type Options struct {
 	// in a dedicated Linux user namespace: UID 0 inside the pod maps to an
 	// unprivileged host UID, so root processes in the container are not root on the host.
 	DefaultHostUsers *bool
+	// Optional: administrator-configured labels and annotations for driver pods.
+	// Nil means not set (feature disabled). The API server reads this from its own
+	// configuration and passes it in, so callers that compile outside the API server,
+	// such as the standalone compiler, simply leave it nil and get no extra metadata.
+	DriverPodConfig *common.DriverPodConfig
 }
 
 const (
@@ -219,6 +224,7 @@ func Compile(jobArg *pipelinespec.PipelineJob, kubernetesSpecArg *pipelinespec.S
 		c.defaultRunAsGroup = opts.DefaultRunAsGroup
 		c.defaultRunAsNonRoot = opts.DefaultRunAsNonRoot
 		c.defaultHostUsers = opts.DefaultHostUsers
+		c.driverPodConfig = opts.DriverPodConfig
 		if opts.DriverImage != "" {
 			c.driverImage = opts.DriverImage
 		}
@@ -325,6 +331,36 @@ type workflowCompiler struct {
 	defaultRunAsGroup    *int64
 	defaultRunAsNonRoot  *bool
 	defaultHostUsers     *bool
+	driverPodConfig      *common.DriverPodConfig
+}
+
+// applyDriverPodConfig applies driver pod labels and annotations to a workflow
+// template's metadata. Existing keys are kept, since admin configuration has lower
+// priority than metadata that the system already set.
+func applyDriverPodConfig(d *common.DriverPodConfig, tmpl *wfapi.Template) {
+	if d == nil || tmpl == nil {
+		return
+	}
+	if len(d.Labels) > 0 {
+		if tmpl.Metadata.Labels == nil {
+			tmpl.Metadata.Labels = make(map[string]string, len(d.Labels))
+		}
+		for k, v := range d.Labels {
+			if _, exists := tmpl.Metadata.Labels[k]; !exists {
+				tmpl.Metadata.Labels[k] = v
+			}
+		}
+	}
+	if len(d.Annotations) > 0 {
+		if tmpl.Metadata.Annotations == nil {
+			tmpl.Metadata.Annotations = make(map[string]string, len(d.Annotations))
+		}
+		for k, v := range d.Annotations {
+			if _, exists := tmpl.Metadata.Annotations[k]; !exists {
+				tmpl.Metadata.Annotations[k] = v
+			}
+		}
+	}
 }
 
 func (c *workflowCompiler) Resolver(name string, component *pipelinespec.ComponentSpec, resolver *pipelinespec.PipelineDeploymentConfig_ResolverSpec) error {

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -281,6 +281,9 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 	}
 	setRuntimeRole(template, util.ExecutionRuntimeRoleDriver)
 	applySecurityContextToTemplate(template)
+
+	applyDriverPodConfig(c.driverPodConfig, template)
+
 	// If TLS is enabled (apiserver or metadata), add the custom CA bundle to the container driver template.
 	if setCABundle {
 		ConfigureCustomCABundle(template)

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -647,6 +647,9 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 	}
 	setRuntimeRole(template, util.ExecutionRuntimeRoleDriver)
 	applySecurityContextToTemplate(template)
+
+	applyDriverPodConfig(c.driverPodConfig, template)
+
 	// If TLS is enabled (apiserver or metadata), add the custom CA bundle to the DAG driver template.
 	if setCABundle {
 		ConfigureCustomCABundle(template)

--- a/backend/src/v2/compiler/argocompiler/driver_pod_config_test.go
+++ b/backend/src/v2/compiler/argocompiler/driver_pod_config_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocompiler
+
+import (
+	"testing"
+
+	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyDriverPodConfig_NilConfig(t *testing.T) {
+	tmpl := &wfapi.Template{}
+	var d *common.DriverPodConfig
+	// Should not panic
+	applyDriverPodConfig(d, tmpl)
+}
+
+func TestApplyDriverPodConfig_NilTemplate(t *testing.T) {
+	d := &common.DriverPodConfig{
+		Labels: map[string]string{"app": "test"},
+	}
+	// Should not panic
+	applyDriverPodConfig(d, nil)
+}
+
+func TestApplyDriverPodConfig_AddsLabelsAndAnnotations(t *testing.T) {
+	d := &common.DriverPodConfig{
+		Labels:      map[string]string{"app": "driver", "team": "ml"},
+		Annotations: map[string]string{"proxy.istio.io/config": "value"},
+	}
+	tmpl := &wfapi.Template{}
+	applyDriverPodConfig(d, tmpl)
+
+	assert.Equal(t, "driver", tmpl.Metadata.Labels["app"])
+	assert.Equal(t, "ml", tmpl.Metadata.Labels["team"])
+	assert.Equal(t, "value", tmpl.Metadata.Annotations["proxy.istio.io/config"])
+}
+
+func TestApplyDriverPodConfig_DoesNotOverwriteExistingLabels(t *testing.T) {
+	d := &common.DriverPodConfig{
+		Labels:      map[string]string{"system-label": "admin-value", "new-label": "admin"},
+		Annotations: map[string]string{"system-annotation": "admin-value", "new-annotation": "admin"},
+	}
+	tmpl := &wfapi.Template{
+		Metadata: wfapi.Metadata{
+			Labels:      map[string]string{"system-label": "system-value"},
+			Annotations: map[string]string{"system-annotation": "system-value"},
+		},
+	}
+	applyDriverPodConfig(d, tmpl)
+
+	// Existing system labels must NOT be overwritten by admin config
+	assert.Equal(t, "system-value", tmpl.Metadata.Labels["system-label"])
+	assert.Equal(t, "system-value", tmpl.Metadata.Annotations["system-annotation"])
+	// New labels from admin config should be added
+	assert.Equal(t, "admin", tmpl.Metadata.Labels["new-label"])
+	assert.Equal(t, "admin", tmpl.Metadata.Annotations["new-annotation"])
+}
+
+func TestApplyDriverPodConfig_OnlyLabelsNoAnnotations(t *testing.T) {
+	d := &common.DriverPodConfig{
+		Labels: map[string]string{"app": "test"},
+	}
+	tmpl := &wfapi.Template{}
+	applyDriverPodConfig(d, tmpl)
+
+	assert.Equal(t, "test", tmpl.Metadata.Labels["app"])
+	assert.Nil(t, tmpl.Metadata.Annotations)
+}
+
+func TestApplyDriverPodConfig_OnlyAnnotationsNoLabels(t *testing.T) {
+	d := &common.DriverPodConfig{
+		Annotations: map[string]string{"note": "value"},
+	}
+	tmpl := &wfapi.Template{}
+	applyDriverPodConfig(d, tmpl)
+
+	assert.Nil(t, tmpl.Metadata.Labels)
+	assert.Equal(t, "value", tmpl.Metadata.Annotations["note"])
+}
+
+// TestContainerDriverTemplate_IncludesDriverPodConfig verifies the full compilation
+// path: a compiler configured with driver pod labels/annotations produces a container
+// driver template whose metadata carries them. This guards the integration point in
+// addContainerDriverTemplate, which unit tests of applyDriverPodConfig cannot.
+func TestContainerDriverTemplate_IncludesDriverPodConfig(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+	c := &workflowCompiler{
+		templates: make(map[string]*wfapi.Template),
+		wf: &wfapi.Workflow{
+			Spec: wfapi.WorkflowSpec{
+				Templates: []wfapi.Template{},
+			},
+		},
+		spec: &pipelinespec.PipelineSpec{
+			PipelineInfo: &pipelinespec.PipelineInfo{Name: "test-pipeline"},
+		},
+		job: &pipelinespec.PipelineJob{},
+		driverPodConfig: &common.DriverPodConfig{
+			Labels:      map[string]string{"sidecar.istio.io/inject": "true"},
+			Annotations: map[string]string{"proxy.istio.io/config": "hold"},
+		},
+	}
+
+	name := c.addContainerDriverTemplate()
+	tmpl, exists := c.templates[name]
+	require.True(t, exists, "system-container-driver template should exist")
+	require.NotNil(t, tmpl)
+	assert.Equal(t, "true", tmpl.Metadata.Labels["sidecar.istio.io/inject"])
+	assert.Equal(t, "hold", tmpl.Metadata.Annotations["proxy.istio.io/config"])
+}
+
+// TestDAGDriverTemplate_IncludesDriverPodConfig mirrors the container driver check for
+// the DAG driver template, guarding the integration point in addDAGDriverTemplate.
+func TestDAGDriverTemplate_IncludesDriverPodConfig(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+	c := &workflowCompiler{
+		templates: make(map[string]*wfapi.Template),
+		wf: &wfapi.Workflow{
+			Spec: wfapi.WorkflowSpec{
+				Templates: []wfapi.Template{},
+			},
+		},
+		spec: &pipelinespec.PipelineSpec{
+			PipelineInfo: &pipelinespec.PipelineInfo{Name: "test-pipeline"},
+		},
+		job: &pipelinespec.PipelineJob{},
+		driverPodConfig: &common.DriverPodConfig{
+			Labels:      map[string]string{"sidecar.istio.io/inject": "true"},
+			Annotations: map[string]string{"proxy.istio.io/config": "hold"},
+		},
+	}
+
+	name := c.addDAGDriverTemplate()
+	tmpl, exists := c.templates[name]
+	require.True(t, exists, "system-dag-driver template should exist")
+	require.NotNil(t, tmpl)
+	assert.Equal(t, "true", tmpl.Metadata.Labels["sidecar.istio.io/inject"])
+	assert.Equal(t, "hold", tmpl.Metadata.Annotations["proxy.istio.io/config"])
+}

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -130,3 +130,10 @@ data:
   ## USERID_PREFIX is stripped from the header value before it is used as the user id.
   USERID_HEADER: "kubeflow-userid"
   USERID_PREFIX: ""
+  ## Custom labels and annotations for driver pods (JSON format).
+  ## Useful for enabling Istio sidecar injection or other infrastructure integration.
+  ## Every value must be a JSON string, for example "true" rather than true.
+  ## Keys with the prefix "pipelines.kubeflow.org/" are reserved and will be filtered out.
+  ## Example: '{"sidecar.istio.io/inject":"true"}'
+  DRIVER_POD_LABELS: ""
+  DRIVER_POD_ANNOTATIONS: ""

--- a/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
@@ -125,3 +125,10 @@ data:
   ## USERID_PREFIX is stripped from the header value before it is used as the user id.
   USERID_HEADER: "kubeflow-userid"
   USERID_PREFIX: ""
+  ## Custom labels and annotations for driver pods (JSON format).
+  ## Useful for enabling Istio sidecar injection or other infrastructure integration.
+  ## Every value must be a JSON string, for example "true" rather than true.
+  ## Keys with the prefix "pipelines.kubeflow.org/" are reserved and will be filtered out.
+  ## Example: '{"sidecar.istio.io/inject":"true"}'
+  DRIVER_POD_LABELS: ""
+  DRIVER_POD_ANNOTATIONS: ""

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -257,6 +257,21 @@ spec:
                   name: pipeline-install-config
                   key: V1_ALLOWED_NAMESPACES
                   optional: true
+            # Driver pod labels and annotations. Viper reads these config keys from the
+            # environment, so the variable names must match the keys defined in
+            # backend/src/apiserver/common/driver_config.go.
+            - name: DRIVER_POD_LABELS
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: DRIVER_POD_LABELS
+                  optional: true
+            - name: DRIVER_POD_ANNOTATIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: DRIVER_POD_ANNOTATIONS
+                  optional: true
           image: ghcr.io/kubeflow/kfp-api-server:dummy
           imagePullPolicy: IfNotPresent
           name: ml-pipeline-api-server

--- a/manifests/kustomize/base/postgresql/pipeline/ml-pipeline-apiserver-deployment-patch.yaml
+++ b/manifests/kustomize/base/postgresql/pipeline/ml-pipeline-apiserver-deployment-patch.yaml
@@ -65,6 +65,20 @@ spec:
               name: pipeline-install-config
               key: V1_ALLOWED_NAMESPACES
               optional: true
+        # Driver pod labels and annotations. This patch replaces the container env list,
+        # so these must be repeated here to reach the API server on PostgreSQL installs.
+        - name: DRIVER_POD_LABELS
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: DRIVER_POD_LABELS
+              optional: true
+        - name: DRIVER_POD_ANNOTATIONS
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: DRIVER_POD_ANNOTATIONS
+              optional: true
         # PostgreSQL Config
         - name: DBCONFIG_POSTGRESQLCONFIG_USER
           valueFrom:


### PR DESCRIPTION
## Summary

This PR implements admin-level configuration for driver pod labels and annotations, addressing issue #12015. Configuration is loaded once at API server startup and cached for performance.

### Key Changes

- **Startup-time configuration loading**: Driver pod config (labels and annotations) is initialized once when the API server starts via `common.InitDriverPodConfig()` in backend/src/apiserver/main.go
- **Thread-safe caching**: Uses `sync.RWMutex` for safe concurrent access to cached configuration
- **Reserved prefix filtering**: Automatically filters out labels and annotations with the `pipelines.kubeflow.org/` prefix to prevent overriding system-managed metadata
- **JSON configuration format**: Supports JSON format for configuration (as per reviewer feedback)
- **Comprehensive testing**: Unit tests covering all configuration scenarios including JSON string input from ConfigMap

### All Reviewer Requirements Addressed (7/7)

✅ **Removed .gitignore changes** - Only relevant backend and manifest changes included  
✅ **Using Viper configuration** - Integrated with existing Viper config system  
✅ **JSON format only** - Removed YAML support, JSON format only  
✅ **Kubernetes-compatible format** - Standard Kubernetes label/annotation format  
✅ **Startup-time loading with caching** - Config loaded once at startup, cached for performance  
✅ **Documentation in backend/README.md** - Concise documentation added  
✅ **Removed unimplemented options** - Removed environment variable and serviceaccount options

### Testing

Local tests passed:
- ✅ All driver config unit tests (backend/src/apiserver/common/driver_config_test.go)
- ✅ All argocompiler unit tests  
- ✅ go mod tidy
- ✅ go vet
- ✅ gofmt

### Configuration Example

```json
{
  "DriverPodLabels": {
    "custom-label": "value",
    "team": "ml-platform"
  },
  "DriverPodAnnotations": {
    "sidecar.istio.io/inject": "true",
    "custom-annotation": "value"
  }
}
```

Resolves: #12015

---

**Note**: This PR supersedes #12306 which was closed due to commit history issues. All code changes and reviewer feedback remain fully addressed in this clean PR.