### PR TITLE
feat(sdk): Add dict parameter access for granular value extraction

### DIFF
--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -16,7 +16,8 @@
 import copy
 import json
 import typing
-from typing import Any, DefaultDict, Dict, List, Mapping, Optional, Tuple, Union
+from typing import (Any, DefaultDict, Dict, List, Mapping, Optional, Tuple,
+                    Union)
 import warnings
 
 from google.protobuf import json_format

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -189,24 +189,24 @@ def build_task_spec_for_task(
             # Build the key path by walking up the chain of DictSubvariables
             keys = []
             current = input_value
-            
+
             # Collect all keys in reverse order (from leaf to root)
             while isinstance(current, pipeline_channel.DictSubvariable):
                 keys.insert(0, current.key)
                 current = current.parent_channel
-            
+
             # Now 'current' is the root channel (the original dict parameter)
             component_input_parameter = current.full_name
             assert component_input_parameter in parent_component_inputs.parameters, \
                 f'component_input_parameter: {component_input_parameter} not found. All inputs: {parent_component_inputs}'
-            
+
             # Build the CEL expression with all keys
             # Single: parseJson(string_value)["key"]
             # Nested: parseJson(string_value)["database"]["host"]
             cel_expression = 'parseJson(string_value)'
             for key in keys:
                 cel_expression += f'["{key}"]'
-            
+
             pipeline_task_spec.inputs.parameters[
                 input_name].component_input_parameter = (
                     component_input_parameter)
@@ -1251,7 +1251,7 @@ def build_task_spec_for_group(
             while isinstance(current, pipeline_channel.DictSubvariable):
                 keys.insert(0, current.key)
                 current = current.parent_channel
-            
+
             # current is now the root channel
             channel_full_name = current.full_name
             # Build the CEL expression selector

--- a/sdk/python/kfp/dsl/pipeline_channel.py
+++ b/sdk/python/kfp/dsl/pipeline_channel.py
@@ -322,10 +322,10 @@ class DictSubvariable(PipelineParameterChannel):
         def my_pipeline(config: dict):
             # Extract individual keys
             component1(param=config['db_host'])
-            
+
             # Extract nested values
             component2(host=config['database']['host'])
-            
+
             # Pass sub-dicts
             component3(db_config=config['database'])
 

--- a/sdk/python/kfp/dsl/pipeline_channel.py
+++ b/sdk/python/kfp/dsl/pipeline_channel.py
@@ -240,6 +240,24 @@ class PipelineParameterChannel(PipelineChannel):
             task_name=task_name,
         )
 
+    def __getitem__(self, key: str) -> 'DictSubvariable':
+        """Enables dict-style access to extract values from a dict parameter.
+
+        Args:
+            key: The key to extract from the dict parameter.
+
+        Returns:
+            A DictSubvariable representing the extracted value.
+
+        Example:
+          ::
+
+            @dsl.pipeline
+            def my_pipeline(config: dict):
+                my_component(param=config['key1'])  # Extract 'key1' from config
+        """
+        return DictSubvariable(parent_channel=self, key=key)
+
 
 class PipelineArtifactChannel(PipelineChannel):
     """Represents a pipeline artifact channel.
@@ -283,6 +301,104 @@ class PipelineArtifactChannel(PipelineChannel):
             channel_type=channel_type,
             task_name=task_name,
         )
+
+
+class DictSubvariable(PipelineParameterChannel):
+    """Represents a value extracted from a dict parameter using a key.
+
+    This allows extracting individual values from a dict pipeline parameter
+    without passing the entire dict to a component. The extraction happens
+    at runtime using CEL (Common Expression Language) expressions.
+
+    Supports both single-level and nested access:
+    - Single: config['db_host'] → extracts string value
+    - Nested: config['database']['host'] → extracts nested value
+    - Sub-dict: config['database'] → extracts entire sub-dictionary
+
+    Example:
+      ::
+
+        @dsl.pipeline
+        def my_pipeline(config: dict):
+            # Extract individual keys
+            component1(param=config['db_host'])
+            
+            # Extract nested values
+            component2(host=config['database']['host'])
+            
+            # Pass sub-dicts
+            component3(db_config=config['database'])
+
+    Attributes:
+        parent_channel: The original PipelineParameterChannel (dict) that this
+            subvariable extracts from.
+        key: The dictionary key to extract.
+    """
+    SUBVAR_DELIMITER = '-subvar-'
+
+    def __init__(
+        self,
+        parent_channel: PipelineParameterChannel,
+        key: str,
+    ):
+        """Initializes a DictSubvariable instance.
+
+        Args:
+            parent_channel: The parent PipelineParameterChannel (dict type) to
+                extract from.
+            key: The dictionary key to extract. Will be used in the CEL
+                expression: parseJson(string_value)["key"]
+
+        Raises:
+            TypeError: If parent_channel is not a PipelineParameterChannel.
+        """
+        if not isinstance(parent_channel, PipelineParameterChannel):
+            raise TypeError(
+                f'parent_channel must be a PipelineParameterChannel, got {type(parent_channel)}'
+            )
+
+        self.parent_channel = parent_channel
+        self.key = key
+
+        # Create a unique name for this subvariable
+        # For nested access, chain the keys: 'config-subvar-database-subvar-host'
+        name = f'{parent_channel.name}{self.SUBVAR_DELIMITER}{key}'
+
+        # Infer the type - use a flexible type that can represent both
+        # primitives and structures. The actual type will be determined
+        # at runtime by the CEL evaluator based on the JSON structure.
+        # We use 'String' as a generic placeholder since the backend's
+        # parseJson() can return any JSON type (string, number, object, array).
+        channel_type = 'String'
+
+        super().__init__(
+            name=name,
+            channel_type=channel_type,
+            task_name=parent_channel.task_name,
+        )
+
+    def __getitem__(self, key: str) -> 'DictSubvariable':
+        """Enables nested dict access by chaining DictSubvariable objects.
+
+        This allows chained access like: config['database']['host']
+        which creates: DictSubvariable(DictSubvariable(config, 'database'), 'host')
+
+        Args:
+            key: The nested key to extract.
+
+        Returns:
+            A new DictSubvariable representing the nested access.
+
+        Example:
+          ::
+
+            config['database']['host']
+            # First call: config.__getitem__('database')
+            #   Returns: DictSubvariable(parent=config, key='database')
+            # Second call: <result>.__getitem__('host')
+            #   Returns: DictSubvariable(parent=<first>, key='host')
+        """
+        return DictSubvariable(parent_channel=self, key=key)
 
 
 class OneOfMixin(PipelineChannel):

--- a/sdk/python/kfp/dsl/pipeline_channel_test.py
+++ b/sdk/python/kfp/dsl/pipeline_channel_test.py
@@ -393,9 +393,9 @@ class DictSubvariableTest(unittest.TestCase):
             name='config',
             channel_type='Dict',
         )
-        
+
         db_host = config['db_host']
-        
+
         self.assertIsInstance(db_host, pipeline_channel.DictSubvariable)
         self.assertEqual(db_host.parent_channel, config)
         self.assertEqual(db_host.key, 'db_host')
@@ -407,32 +407,31 @@ class DictSubvariableTest(unittest.TestCase):
             name='config',
             channel_type='Dict',
         )
-        
+
         # Test 2-level nesting
         host = config['database']['host']
-        
+
         self.assertIsInstance(host, pipeline_channel.DictSubvariable)
         self.assertEqual(host.key, 'host')
-        self.assertIsInstance(host.parent_channel, pipeline_channel.DictSubvariable)
+        self.assertIsInstance(host.parent_channel,
+                              pipeline_channel.DictSubvariable)
         self.assertEqual(host.parent_channel.key, 'database')
-        
+
         # Test 3-level nesting
         username = config['database']['credentials']['username']
-        
+
         self.assertIsInstance(username, pipeline_channel.DictSubvariable)
         self.assertEqual(username.key, 'username')
-        self.assertIsInstance(username.parent_channel, pipeline_channel.DictSubvariable)
+        self.assertIsInstance(username.parent_channel,
+                              pipeline_channel.DictSubvariable)
         self.assertEqual(username.parent_channel.key, 'credentials')
 
     def test_parent_must_be_pipeline_parameter_channel(self):
         """Test that parent_channel must be a PipelineParameterChannel."""
         with self.assertRaisesRegex(
-                TypeError,
-                'parent_channel must be a PipelineParameterChannel'):
+                TypeError, 'parent_channel must be a PipelineParameterChannel'):
             pipeline_channel.DictSubvariable(
-                parent_channel='not_a_channel',
-                key='test_key'
-            )
+                parent_channel='not_a_channel', key='test_key')
 
     def test_subvar_name_in_channel_name(self):
         """Test that the subvar name is included in the channel name."""
@@ -440,9 +439,9 @@ class DictSubvariableTest(unittest.TestCase):
             name='my_config',
             channel_type='Dict',
         )
-        
+
         value = config['my_key']
-        
+
         self.assertIn('my_config', value.name)
         self.assertIn('subvar', value.name)
         self.assertIn('my_key', value.name)
@@ -453,15 +452,16 @@ class DictSubvariableTest(unittest.TestCase):
             name='config',
             channel_type='Dict',
         )
-        
+
         # Create chained access
         result = config['level1']['level2']['level3']
-        
+
         # Walk up the chain and verify structure
         self.assertEqual(result.key, 'level3')
         self.assertEqual(result.parent_channel.key, 'level2')
         self.assertEqual(result.parent_channel.parent_channel.key, 'level1')
-        self.assertEqual(result.parent_channel.parent_channel.parent_channel.name, 'config')
+        self.assertEqual(
+            result.parent_channel.parent_channel.parent_channel.name, 'config')
 
     def test_getitem_returns_new_dictsubvariable(self):
         """Test that __getitem__ returns a new DictSubvariable instance."""
@@ -469,10 +469,10 @@ class DictSubvariableTest(unittest.TestCase):
             name='config',
             channel_type='Dict',
         )
-        
+
         first = config['key1']
         second = config['key2']
-        
+
         # Different keys should create different instances
         self.assertIsNot(first, second)
         self.assertEqual(first.key, 'key1')

--- a/sdk/python/kfp/dsl/pipeline_channel_test.py
+++ b/sdk/python/kfp/dsl/pipeline_channel_test.py
@@ -430,7 +430,7 @@ class DictSubvariableTest(unittest.TestCase):
                 TypeError,
                 'parent_channel must be a PipelineParameterChannel'):
             pipeline_channel.DictSubvariable(
-                parent_channel="not_a_channel",
+                parent_channel='not_a_channel',
                 key='test_key'
             )
 

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -117,13 +117,18 @@ class PipelineTask:
 
             input_spec = component_spec.inputs[input_name]
 
-            type_utils.verify_type_compatibility(
-                given_value=argument_value,
-                expected_spec=input_spec,
-                error_message_prefix=(
-                    f'Incompatible argument passed to the input '
-                    f'{input_name!r} of component {component_spec.name!r}: '),
-            )
+            # Skip strict type checking for DictSubvariable since the actual type
+            # is determined at runtime by the CEL expression evaluator.
+            # The CEL expression parseJson(string_value)["key"] can return any JSON type
+            # (string, number, boolean, object, array) depending on the actual data.
+            if not isinstance(argument_value, pipeline_channel.DictSubvariable):
+                type_utils.verify_type_compatibility(
+                    given_value=argument_value,
+                    expected_spec=input_spec,
+                    error_message_prefix=(
+                        f'Incompatible argument passed to the input '
+                        f'{input_name!r} of component {component_spec.name!r}: '),
+                )
 
         self.component_spec = component_spec
 

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -127,7 +127,8 @@ class PipelineTask:
                     expected_spec=input_spec,
                     error_message_prefix=(
                         f'Incompatible argument passed to the input '
-                        f'{input_name!r} of component {component_spec.name!r}: '),
+                        f'{input_name!r} of component {component_spec.name!r}: '
+                    ),
                 )
 
         self.component_spec = component_spec

--- a/test_data/pipeline_files/valid/pipeline_with_dict_parameter_access.py
+++ b/test_data/pipeline_files/valid/pipeline_with_dict_parameter_access.py
@@ -1,0 +1,80 @@
+# Copyright 2025 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is# distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pipeline demonstrating dict parameter access features."""
+
+from typing import Dict
+
+from kfp import compiler
+from kfp import dsl
+
+
+@dsl.component
+def print_string(text: str):
+    print(text)
+
+
+@dsl.component
+def print_dict(config: dict):
+    print(config)
+
+
+@dsl.component
+def use_credentials(username: str, password: str):
+    print(f'User: {username}, Pass: {password}')
+
+
+@dsl.pipeline(name='pipeline-with-dict-parameter-access')
+def pipeline_with_dict_parameter_access(
+    config: Dict = {
+        'app_name': 'TestApp',
+        'database': {
+            'host': 'localhost',
+            'port': '5432',
+            'credentials': {
+                'username': 'admin',
+                'password': 'secret'
+            }
+        }
+    }
+):
+    """Pipeline demonstrating dict parameter access.
+    
+    Features demonstrated:
+    - Single-level access: config['app_name']
+    - Nested access: config['database']['host']
+    - Deep nested access: config['database']['credentials']['username']
+    - Sub-dict passing: config['database']
+    """
+    # Single-level access
+    print_string(text=config['app_name'])
+    
+    # Nested access (2 levels)
+    print_string(text=config['database']['host'])
+    print_string(text=config['database']['port'])
+    
+    # Deep nested access (3 levels)
+    use_credentials(
+        username=config['database']['credentials']['username'],
+        password=config['database']['credentials']['password'],
+    )
+    
+    # Sub-dict passing
+    print_dict(config=config['database'])
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=pipeline_with_dict_parameter_access,
+        package_path=__file__.replace('.py', '.yaml'))
+


### PR DESCRIPTION
# Add Dict Parameter Access Feature for Pipeline Parameters

## Summary

This PR adds support for extracting individual values from dictionary pipeline parameters using Pythonic syntax, eliminating the need to pass entire dictionaries to components that only need specific values.

## Motivation

Previously, when a pipeline had a dictionary parameter, the entire dictionary had to be passed to every component, even if the component only needed a single value or subset. This led to:
- Unnecessary data exposure to components
- Reduced code clarity
- Potential security concerns with passing sensitive data unnecessarily

## Changes

### 1. New `DictSubvariable` Class (`sdk/python/kfp/dsl/pipeline_channel.py`)
- Introduced `DictSubvariable` class to represent values extracted from dict parameters
- Added `__getitem__` method to `PipelineParameterChannel` to enable dict-style access
- Supports both single-level and nested dict access
- Supports passing sub-dictionaries to components

### 2. Compiler Support (`sdk/python/kfp/compiler/pipeline_spec_builder.py`)
- Extended compiler to recognize `DictSubvariable` instances
- Generates appropriate CEL (Common Expression Language) `parameter_expression_selector` expressions
- Supports nested access by building chained CEL expressions
- Works in both task and group contexts

### 3. Type Checking (`sdk/python/kfp/dsl/pipeline_task.py`)
- Modified type compatibility checking to skip strict validation for `DictSubvariable`
- Actual types are resolved at runtime by the CEL evaluator

### 4. Tests
- Added comprehensive unit tests in `pipeline_channel_test.py`
- Added integration test pipeline in `test_data/pipeline_files/valid/pipeline_with_dict_parameter_access.py`

## Usage Examples

### Single-Level Access
```python
@dsl.pipeline
def my_pipeline(config: dict):
    # Extract a single value
    component1(db_host=config['db_host'])
```

### Nested Access
```python
@dsl.pipeline
def my_pipeline(config: dict):
    # Access nested values
    component2(host=config['database']['host'])
    component3(username=config['database']['credentials']['username'])
```

### Sub-Dictionary Passing
```python
@dsl.pipeline
def my_pipeline(config: dict):
    # Pass an entire sub-dictionary
    component4(db_config=config['database'])
```

## Technical Details

### Compile-Time vs Runtime
- **Compile-time**: The SDK creates `DictSubvariable` objects and the compiler generates CEL expressions
- **Runtime**: The backend driver evaluates CEL expressions to extract values from the actual JSON data

### CEL Expression Generation
- Single: `parseJson(string_value)["key"]`
- Nested: `parseJson(string_value)["database"]["host"]`
- Backend already supports these expressions (no backend changes required)

## Benefits

1. **Improved Security**: Components only receive the data they need
2. **Better Code Clarity**: Clear intent about what data each component uses
3. **Reduced Coupling**: Components don't depend on entire config structures
4. **Type Safety**: Type checking happens at runtime based on actual values
5. **Backward Compatible**: Existing code continues to work unchanged

## Testing

Run unit tests:
```bash
pytest -v sdk/python/kfp/dsl/pipeline_channel_test.py::DictSubvariableTest
```

Run integration test:
```bash
python test_data/pipeline_files/valid/pipeline_with_dict_parameter_access.py
```

## Checklist
- [x] Added unit tests
- [x] Added integration test
- [x] Code follows project formatting standards (isort)
- [x] All tests pass
- [x] No breaking changes
- [x] Documentation (docstrings) added

## Related Issues

Closes #12418

## Additional Notes

This feature leverages existing backend CEL expression evaluation capabilities, so no server-side changes are required. All changes are SDK-side and applied at compile time.

