### PR TITLE
test: fixing http client creation and renaming e2e pipeline name prefix

### DIFF
--- a/backend/src/common/client/api_server/util.go
+++ b/backend/src/common/client/api_server/util.go
@@ -88,9 +88,6 @@ func NewHTTPRuntime(clientConfig clientcmd.ClientConfig, debug bool, tlsCfg *tls
 				TLSClientConfig: tlsCfg,
 			}
 			httpClient = &http.Client{Transport: tr}
-		} else {
-			scheme = []string{"http"}
-			httpClient = &http.Client{}
 		}
 		runtimeClient = httptransport.NewWithClient(host, "", scheme, httpClient)
 		if debug {

--- a/backend/test/end2end/pipeline_e2e_test.go
+++ b/backend/test/end2end/pipeline_e2e_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Upload and Verify Pipeline Run >", Label(FullRegression), func
 		logger.Log("Test Context: %p", testContext)
 		randomName = strconv.FormatInt(time.Now().UnixNano(), 10)
 		testContext.Pipeline.UploadParams = upload_params.NewUploadPipelineParams()
-		testContext.Pipeline.PipelineGeneratedName = "e2e_test-" + randomName
+		testContext.Pipeline.PipelineGeneratedName = "e2e-test-" + randomName
 		testContext.Pipeline.CreatedPipelines = make([]*pipeline_upload_model.V2beta1Pipeline, 0)
 		testContext.PipelineRun.CreatedRunIds = make([]string, 0)
 		testContext.Pipeline.ExpectedPipeline = new(pipeline_upload_model.V2beta1Pipeline)


### PR DESCRIPTION
- Removing else statement from http client creation method which was causing all other conditional http clients to be overridden
- Renaming e2e test pipeline name prefix to accommodate k8s native api naming convention

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).