### PR TITLE
fix(backend): Allow pod namespace configuration on env.go metadata-grpc service address

### DIFF
--- a/backend/metadata_writer/src/metadata_helpers.py
+++ b/backend/metadata_writer/src/metadata_helpers.py
@@ -32,9 +32,8 @@ def value_to_mlmd_value(value) -> metadata_store_pb2.Value:
 
 
 def connect_to_mlmd() -> metadata_store.MetadataStore:
-    metadata_service_host = os.environ.get("METADATA_GRPC_SERVICE_SERVICE_HOST", "metadata-grpc-service.kubeflow")
-    metadata_service_port = int(os.environ.get("METADATA_GRPC_SERVICE_SERVICE_PORT", 8080))
-    metadata_service_host = "metadata-grpc-service.kubeflow"
+    pod_namespace = os.environ.get("POD_NAMESPACE", "kubeflow")
+    metadata_service_host = "metadata-grpc-service." + pod_namespace + ".svc.cluster.local"
     metadata_service_port = 8080
 
     mlmd_connection_config = metadata_store_pb2.MetadataStoreClientConfig(

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -109,7 +109,7 @@ func IsMultiUserSharedReadMode() bool {
 }
 
 func GetPodNamespace() string {
-	return GetStringConfig(PodNamespace)
+	return GetStringConfigWithDefault(PodNamespace, DefaultPodNamespace)
 }
 
 func GetBoolFromStringWithDefault(value string, defaultValue bool) bool {

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -71,3 +71,7 @@ const (
 	TLSCertCAPath = "/kfp/certs/ca.crt"
 	CABundleDir   = "/kfp/certs"
 )
+
+const (
+	DefaultPodNamespace string = "kubeflow"
+)

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -186,7 +186,7 @@ func drive() (err error) {
 			return err
 		}
 	}
-	client, err := newMlmdClient(tlsCfg)
+	client, err := newMlmdClient(*mlmdServerAddress, *mlmdServerPort, tlsCfg)
 	if err != nil {
 		return err
 	}
@@ -346,11 +346,6 @@ func writeFile(path string, data []byte) (err error) {
 	return os.WriteFile(path, data, 0o644)
 }
 
-func newMlmdClient(tlsCfg *tls.Config) (*metadata.Client, error) {
-	mlmdConfig := metadata.DefaultConfig()
-	if *mlmdServerAddress != "" && *mlmdServerPort != "" {
-		mlmdConfig.Address = *mlmdServerAddress
-		mlmdConfig.Port = *mlmdServerPort
-	}
-	return metadata.NewClient(mlmdConfig.Address, mlmdConfig.Port, tlsCfg)
+func newMlmdClient(mlmdServerAddress string, mlmdServerPort string, tlsCfg *tls.Config) (*metadata.Client, error) {
+	return metadata.NewClient(mlmdServerAddress, mlmdServerPort, tlsCfg)
 }

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
@@ -206,6 +207,8 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 		"--http_proxy", proxy.GetConfig().GetHttpProxy(),
 		"--https_proxy", proxy.GetConfig().GetHttpsProxy(),
 		"--no_proxy", proxy.GetConfig().GetNoProxy(),
+		"--mlmd_server_address", metadata.DefaultConfig().Address,
+		"--mlmd_server_port", metadata.DefaultConfig().Port,
 	}
 	if c.cacheDisabled {
 		args = append(args, "--cache_disabled")

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
+	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -571,6 +572,8 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 		"--http_proxy", proxy.GetConfig().GetHttpProxy(),
 		"--https_proxy", proxy.GetConfig().GetHttpsProxy(),
 		"--no_proxy", proxy.GetConfig().GetNoProxy(),
+		"--mlmd_server_address", metadata.DefaultConfig().Address,
+		"--mlmd_server_port", metadata.DefaultConfig().Port,
 	}
 	if c.cacheDisabled {
 		args = append(args, "--cache_disabled")

--- a/backend/src/v2/compiler/argocompiler/importer.go
+++ b/backend/src/v2/compiler/argocompiler/importer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/v2/component"
+	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	k8score "k8s.io/api/core/v1"
 )
 
@@ -78,10 +79,8 @@ func (c *workflowCompiler) addImporterTemplate() string {
 		fmt.Sprintf("$(%s)", component.EnvPodName),
 		"--pod_uid",
 		fmt.Sprintf("$(%s)", component.EnvPodUID),
-		"--mlmd_server_address",
-		fmt.Sprintf("$(%s)", component.EnvMetadataHost),
-		"--mlmd_server_port",
-		fmt.Sprintf("$(%s)", component.EnvMetadataPort),
+		"--mlmd_server_address", metadata.DefaultConfig().Address,
+		"--mlmd_server_port", metadata.DefaultConfig().Port,
 	}
 	if c.cacheDisabled {
 		args = append(args, "--cache_disabled")

--- a/backend/src/v2/driver/container.go
+++ b/backend/src/v2/driver/container.go
@@ -231,6 +231,8 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 		opts.MLPipelineTLSEnabled,
 		opts.MLMDTLSEnabled,
 		opts.CaCertPath,
+		opts.MLMDServerAddress,
+		opts.MLMDServerPort,
 	)
 	if err != nil {
 		return execution, err

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -235,6 +235,8 @@ func initPodSpecPatch(
 	mlPipelineTLSEnabled bool,
 	metadataTLSEnabled bool,
 	caCertPath string,
+	mlmdServerAddress string,
+	mlmdServerPort string,
 ) (*k8score.PodSpec, error) {
 	executorInputJSON, err := protojson.Marshal(executorInput)
 	if err != nil {
@@ -275,10 +277,8 @@ func initPodSpecPatch(
 		fmt.Sprintf("$(%s)", component.EnvPodName),
 		"--pod_uid",
 		fmt.Sprintf("$(%s)", component.EnvPodUID),
-		"--mlmd_server_address",
-		fmt.Sprintf("$(%s)", component.EnvMetadataHost),
-		"--mlmd_server_port",
-		fmt.Sprintf("$(%s)", component.EnvMetadataPort),
+		"--mlmd_server_address", mlmdServerAddress,
+		"--mlmd_server_port", mlmdServerPort,
 		"--publish_logs", publishLogs,
 	}
 	if mlPipelineTLSEnabled {

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -280,6 +280,8 @@ func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 				false,
 				false,
 				"",
+				"metadata-grpc-service.kubeflow.svc.local",
+				"8080",
 			)
 			if tt.wantErr {
 				assert.Nil(t, podSpec)
@@ -399,6 +401,8 @@ func Test_initPodSpecPatch_resource_placeholders(t *testing.T) {
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	assert.Nil(t, err)
 	assert.Len(t, podSpec.Containers, 1)
@@ -449,6 +453,8 @@ func Test_initPodSpecPatch_legacy_resources(t *testing.T) {
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	assert.Nil(t, err)
 	assert.Len(t, podSpec.Containers, 1)
@@ -501,6 +507,8 @@ func Test_initPodSpecPatch_modelcar_input_artifact(t *testing.T) {
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	assert.Nil(t, err)
 
@@ -548,6 +556,8 @@ func Test_initPodSpecPatch_publishLogs(t *testing.T) {
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	assert.Nil(t, err)
 	cmd := podSpec.Containers[0].Command
@@ -675,6 +685,8 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 				false,
 				false,
 				"",
+				"metadata-grpc-service.kubeflow.svc.local",
+				"8080",
 			)
 			assert.Nil(t, err)
 			assert.NotEmpty(t, podSpec)
@@ -733,6 +745,8 @@ func Test_initPodSpecPatch_TaskConfig_ForwardsResourcesOnly(t *testing.T) {
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	assert.Nil(t, err)
 	assert.NotNil(t, podSpec)
@@ -797,6 +811,8 @@ func Test_initPodSpecPatch_inputTaskFinalStatus(t *testing.T) {
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	require.Nil(t, err)
 
@@ -997,6 +1013,8 @@ func Test_initPodSpecPatch_WorkspaceRequiresRunName(t *testing.T) {
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	require.NotNil(t, err)
 }
@@ -1110,7 +1128,7 @@ func TestWorkspaceMount_PassthroughVolumes_CaptureOnly(t *testing.T) {
 	taskCfg := &TaskConfig{}
 	podSpec, err := initPodSpecPatch(
 		containerSpec, componentSpec, executorInput,
-		27, "test", "run", "my-run-name", "1", "false", "false", taskCfg, false, false, "",
+		27, "test", "run", "my-run-name", "1", "false", "false", taskCfg, false, false, "", "metadata-grpc-service.kubeflow.svc.local", "8080",
 	)
 	assert.Nil(t, err)
 
@@ -1153,7 +1171,7 @@ func TestWorkspaceMount_PassthroughVolumes_ApplyAndCapture(t *testing.T) {
 	taskCfg := &TaskConfig{}
 	podSpec, err := initPodSpecPatch(
 		containerSpec, componentSpec, executorInput,
-		27, "test", "run", "my-run-name", "1", "false", "false", taskCfg, false, false, "",
+		27, "test", "run", "my-run-name", "1", "false", "false", taskCfg, false, false, "", "metatadata-grpc-service.kubeflow.svc.local", "8080",
 	)
 	assert.Nil(t, err)
 	// Should mount workspace to pod and also capture to TaskConfig
@@ -1220,6 +1238,8 @@ func Test_initPodSpecPatch_TaskConfig_Env_Passthrough_CaptureOnly(t *testing.T) 
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	assert.Nil(t, err)
 
@@ -1267,6 +1287,8 @@ func Test_initPodSpecPatch_TaskConfig_Resources_Passthrough_ApplyAndCapture(t *t
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	assert.Nil(t, err)
 	// Resources should be both on pod and in TaskConfig
@@ -1345,6 +1367,8 @@ func Test_initPodSpecPatch_TaskConfig_Affinity_NodeSelector_Tolerations_Passthro
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	assert.Nil(t, err)
 
@@ -1444,6 +1468,8 @@ func Test_initPodSpecPatch_TaskConfig_Affinity_NodeSelector_Tolerations_ApplyAnd
 		false,
 		false,
 		"",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
 	)
 	assert.Nil(t, err)
 

--- a/backend/src/v2/metadata/env.go
+++ b/backend/src/v2/metadata/env.go
@@ -1,8 +1,10 @@
 package metadata
 
+import "github.com/kubeflow/pipelines/backend/src/apiserver/common"
+
 const (
-	metadataGrpcServiceAddress = "metadata-grpc-service.kubeflow"
-	metadataGrpcServicePort    = "8080"
+	metadataGrpcServiceName = "metadata-grpc-service"
+	metadataGrpcServicePort = "8080"
 )
 
 type ServerConfig struct {
@@ -12,7 +14,7 @@ type ServerConfig struct {
 
 func DefaultConfig() *ServerConfig {
 	return &ServerConfig{
-		Address: metadataGrpcServiceAddress,
+		Address: metadataGrpcServiceName + "." + common.GetPodNamespace() + ".svc.cluster.local",
 		Port:    metadataGrpcServicePort,
 	}
 }

--- a/manifests/kustomize/env/cert-manager/base-tls-certs/kfp-api-cert.yaml
+++ b/manifests/kustomize/env/cert-manager/base-tls-certs/kfp-api-cert.yaml
@@ -13,6 +13,7 @@ spec:
     - metadata-envoy-service
     - metadata-grpc-service
     - metadata-grpc-service.kubeflow
+    - metadata-grpc-service.$(kfp-namespace).svc.cluster.local
     - localhost
   ipAddresses:
     # Necessary for running TLS-enabled cluster locally.

--- a/manifests/kustomize/env/cert-manager/base-webhook-certs/kfp-api-cert.yaml
+++ b/manifests/kustomize/env/cert-manager/base-webhook-certs/kfp-api-cert.yaml
@@ -9,6 +9,7 @@ spec:
   - ml-pipeline
   - ml-pipeline.$(kfp-namespace)
   - ml-pipeline.$(kfp-namespace).svc
+  - ml-pipeline.$(kfp-namespace).svc.cluster.local
   issuerRef:
     kind: Issuer
     name: kfp-api-webhook-selfsigned-issuer

--- a/manifests/kustomize/env/cert-manager/platform-agnostic-standalone-tls/patches/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/env/cert-manager/platform-agnostic-standalone-tls/patches/metadata-writer-deployment.yaml
@@ -8,10 +8,6 @@ spec:
       containers:
         - name: main
           env:
-            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
-              value: "metadata-grpc-service.kubeflow"
-            - name: METADATA_GRPC_SERVICE_SERVICE_PORT
-              value: "8080"
             - name: METADATA_TLS_ENABLED
               value: "true"
             - name: CA_CERT_PATH

--- a/manifests/kustomize/env/cert-manager/platform-agnostic-standalone-tls/patches/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/env/cert-manager/platform-agnostic-standalone-tls/patches/ml-pipeline-apiserver-deployment.yaml
@@ -20,8 +20,6 @@ spec:
               value: "kfp-api-tls-cert"
             - name: METADATA_TLS_ENABLED
               value: "true"
-            - name: METADATA_GRPC_SERVICE_SERVICE_HOST
-              value: "metadata-grpc-service.kubeflow"
             - name: ML_PIPELINE_SERVICE_HOST
               value: "ml-pipeline.kubeflow.svc.cluster.local"
           readinessProbe:

--- a/test_data/compiled-workflows/add_numbers.yaml
+++ b/test_data/compiled-workflows/add_numbers.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -264,6 +268,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/arguments-parameters.yaml
+++ b/test_data/compiled-workflows/arguments-parameters.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/arguments.pipeline.yaml
+++ b/test_data/compiled-workflows/arguments.pipeline.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/arguments_parameters.yaml
+++ b/test_data/compiled-workflows/arguments_parameters.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/artifact_cache.yaml
+++ b/test_data/compiled-workflows/artifact_cache.yaml
@@ -86,6 +86,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -283,6 +287,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/artifact_crust.yaml
+++ b/test_data/compiled-workflows/artifact_crust.yaml
@@ -86,6 +86,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -283,6 +287,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/artifacts_complex.yaml
+++ b/test_data/compiled-workflows/artifacts_complex.yaml
@@ -112,6 +112,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -390,6 +394,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/artifacts_simple.yaml
+++ b/test_data/compiled-workflows/artifacts_simple.yaml
@@ -97,6 +97,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -294,6 +298,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/collected_artifacts.yaml
+++ b/test_data/compiled-workflows/collected_artifacts.yaml
@@ -178,6 +178,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -375,6 +379,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/collected_parameters.yaml
+++ b/test_data/compiled-workflows/collected_parameters.yaml
@@ -113,6 +113,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -335,6 +339,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/component_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/component_with_metadata_fields.yaml
@@ -82,6 +82,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -279,6 +283,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/component_with_optional_inputs.yaml
+++ b/test_data/compiled-workflows/component_with_optional_inputs.yaml
@@ -71,6 +71,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -268,6 +272,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/component_with_pip_index_urls.yaml
+++ b/test_data/compiled-workflows/component_with_pip_index_urls.yaml
@@ -69,6 +69,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -266,6 +270,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/component_with_pip_install.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install.yaml
@@ -69,6 +69,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -266,6 +270,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
@@ -70,6 +70,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -267,6 +271,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/components_with_optional_artifacts.yaml
+++ b/test_data/compiled-workflows/components_with_optional_artifacts.yaml
@@ -83,6 +83,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -297,9 +301,9 @@ spec:
       - --pod_uid
       - $(KFP_POD_UID)
       - --mlmd_server_address
-      - $(METADATA_GRPC_SERVICE_HOST)
+      - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
-      - $(METADATA_GRPC_SERVICE_PORT)
+      - "8080"
       command:
       - launcher-v2
       env:
@@ -369,6 +373,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/concat_message.yaml
+++ b/test_data/compiled-workflows/concat_message.yaml
@@ -68,6 +68,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -265,6 +269,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
+++ b/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
@@ -89,6 +89,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -318,6 +322,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/container_component_with_no_inputs.yaml
+++ b/test_data/compiled-workflows/container_component_with_no_inputs.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/container_io.yaml
+++ b/test_data/compiled-workflows/container_io.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/container_no_input.yaml
+++ b/test_data/compiled-workflows/container_no_input.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/container_with_artifact_output.yaml
+++ b/test_data/compiled-workflows/container_with_artifact_output.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/container_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_concat_placeholder.yaml
@@ -59,6 +59,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -256,6 +260,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/container_with_if_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder.yaml
@@ -61,6 +61,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -258,6 +262,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
+++ b/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/containerized_python_component.yaml
+++ b/test_data/compiled-workflows/containerized_python_component.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/create_pod_metadata_complex.yaml
+++ b/test_data/compiled-workflows/create_pod_metadata_complex.yaml
@@ -111,6 +111,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -608,6 +612,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/cross_loop_after_topology.yaml
+++ b/test_data/compiled-workflows/cross_loop_after_topology.yaml
@@ -88,6 +88,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -317,6 +321,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/dict_input.yaml
+++ b/test_data/compiled-workflows/dict_input.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -264,6 +268,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/embedded_artifact.yaml
+++ b/test_data/compiled-workflows/embedded_artifact.yaml
@@ -108,6 +108,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -329,6 +333,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/env-var.yaml
+++ b/test_data/compiled-workflows/env-var.yaml
@@ -69,6 +69,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -266,6 +270,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/fail_v2.yaml
+++ b/test_data/compiled-workflows/fail_v2.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -264,6 +268,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/flip_coin.yaml
+++ b/test_data/compiled-workflows/flip_coin.yaml
@@ -124,6 +124,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -357,6 +361,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/hello-world.yaml
+++ b/test_data/compiled-workflows/hello-world.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/hello_world.yaml
+++ b/test_data/compiled-workflows/hello_world.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/identity.yaml
+++ b/test_data/compiled-workflows/identity.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -264,6 +268,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/if_elif_else_complex.yaml
+++ b/test_data/compiled-workflows/if_elif_else_complex.yaml
@@ -158,6 +158,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -356,6 +360,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
@@ -113,6 +113,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -376,6 +380,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
@@ -105,6 +105,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -334,6 +338,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
@@ -91,6 +91,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -322,6 +326,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/input_artifact.yaml
+++ b/test_data/compiled-workflows/input_artifact.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -264,6 +268,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/iris_pipeline_compiled.yaml
+++ b/test_data/compiled-workflows/iris_pipeline_compiled.yaml
@@ -120,6 +120,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -367,6 +371,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
@@ -122,6 +122,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -344,6 +348,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
@@ -114,6 +114,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -385,6 +389,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/log_streaming_compiled.yaml
+++ b/test_data/compiled-workflows/log_streaming_compiled.yaml
@@ -71,6 +71,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -268,6 +272,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/long-running.yaml
+++ b/test_data/compiled-workflows/long-running.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -280,6 +284,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/loop_consume_upstream.yaml
+++ b/test_data/compiled-workflows/loop_consume_upstream.yaml
@@ -115,6 +115,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -339,6 +343,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/metrics_visualization_v2.yaml
+++ b/test_data/compiled-workflows/metrics_visualization_v2.yaml
@@ -159,6 +159,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -452,6 +456,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
+++ b/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
@@ -70,6 +70,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -270,6 +274,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/mixed_parameters.yaml
+++ b/test_data/compiled-workflows/mixed_parameters.yaml
@@ -84,6 +84,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -281,6 +285,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/modelcar.yaml
+++ b/test_data/compiled-workflows/modelcar.yaml
@@ -92,6 +92,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -242,9 +246,9 @@ spec:
       - --pod_uid
       - $(KFP_POD_UID)
       - --mlmd_server_address
-      - $(METADATA_GRPC_SERVICE_HOST)
+      - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
-      - $(METADATA_GRPC_SERVICE_PORT)
+      - "8080"
       command:
       - launcher-v2
       env:
@@ -383,6 +387,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
@@ -88,6 +88,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -285,6 +289,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
@@ -87,6 +87,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -284,6 +288,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
@@ -147,6 +147,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -464,6 +468,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
@@ -98,6 +98,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -343,6 +347,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
@@ -150,6 +150,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -475,6 +479,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/nested_return.yaml
+++ b/test_data/compiled-workflows/nested_return.yaml
@@ -68,6 +68,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -265,6 +269,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/nested_with_parameters.yaml
+++ b/test_data/compiled-workflows/nested_with_parameters.yaml
@@ -100,6 +100,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -346,6 +350,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/notebook_component_mixed.yaml
+++ b/test_data/compiled-workflows/notebook_component_mixed.yaml
@@ -296,6 +296,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -543,6 +547,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/notebook_component_simple.yaml
+++ b/test_data/compiled-workflows/notebook_component_simple.yaml
@@ -165,6 +165,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -362,6 +366,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/output_metrics.yaml
+++ b/test_data/compiled-workflows/output_metrics.yaml
@@ -69,6 +69,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -266,6 +270,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/parallel_for_after_dependency.yaml
+++ b/test_data/compiled-workflows/parallel_for_after_dependency.yaml
@@ -70,6 +70,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -267,6 +271,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/parameter_cache.yaml
+++ b/test_data/compiled-workflows/parameter_cache.yaml
@@ -84,6 +84,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -281,6 +285,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/parameter_oneof.yaml
+++ b/test_data/compiled-workflows/parameter_oneof.yaml
@@ -123,6 +123,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -354,6 +358,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/parameters_complex.yaml
+++ b/test_data/compiled-workflows/parameters_complex.yaml
@@ -117,6 +117,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -314,6 +318,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/parameters_simple.yaml
+++ b/test_data/compiled-workflows/parameters_simple.yaml
@@ -88,6 +88,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -285,6 +289,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_as_exit_task.yaml
+++ b/test_data/compiled-workflows/pipeline_as_exit_task.yaml
@@ -104,6 +104,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -302,6 +306,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_in_pipeline.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline.yaml
@@ -73,6 +73,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -295,6 +299,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
@@ -82,6 +82,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -311,6 +315,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
@@ -89,6 +89,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -311,6 +315,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_producer_consumer.yaml
+++ b/test_data/compiled-workflows/pipeline_producer_consumer.yaml
@@ -120,6 +120,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -317,6 +321,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_after.yaml
+++ b/test_data/compiled-workflows/pipeline_with_after.yaml
@@ -61,6 +61,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -311,6 +315,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
@@ -89,6 +89,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -311,6 +315,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
@@ -88,6 +88,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -310,6 +314,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
@@ -60,6 +60,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -257,6 +261,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_condition.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition.yaml
@@ -86,6 +86,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -332,6 +336,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
@@ -183,6 +183,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -380,6 +384,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
@@ -58,9 +58,9 @@ spec:
       - --pod_uid
       - $(KFP_POD_UID)
       - --mlmd_server_address
-      - $(METADATA_GRPC_SERVICE_HOST)
+      - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
-      - $(METADATA_GRPC_SERVICE_PORT)
+      - "8080"
       command:
       - launcher-v2
       env:
@@ -132,6 +132,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -353,6 +357,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
@@ -145,6 +145,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -415,6 +419,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_env.yaml
@@ -73,6 +73,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -294,6 +298,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
@@ -85,6 +85,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -340,6 +344,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
+++ b/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
@@ -76,9 +76,9 @@ spec:
       - --pod_uid
       - $(KFP_POD_UID)
       - --mlmd_server_address
-      - $(METADATA_GRPC_SERVICE_HOST)
+      - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
-      - $(METADATA_GRPC_SERVICE_PORT)
+      - "8080"
       command:
       - launcher-v2
       env:
@@ -150,6 +150,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -384,6 +388,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_importer.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer.yaml
@@ -66,9 +66,9 @@ spec:
       - --pod_uid
       - $(KFP_POD_UID)
       - --mlmd_server_address
-      - $(METADATA_GRPC_SERVICE_HOST)
+      - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
-      - $(METADATA_GRPC_SERVICE_PORT)
+      - "8080"
       command:
       - launcher-v2
       env:
@@ -140,6 +140,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -350,6 +354,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
@@ -62,6 +62,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -212,9 +216,9 @@ spec:
       - --pod_uid
       - $(KFP_POD_UID)
       - --mlmd_server_address
-      - $(METADATA_GRPC_SERVICE_HOST)
+      - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
-      - $(METADATA_GRPC_SERVICE_PORT)
+      - "8080"
       command:
       - launcher-v2
       env:
@@ -329,6 +333,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
+++ b/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
@@ -85,6 +85,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -314,6 +318,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops.yaml
@@ -101,6 +101,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -458,6 +462,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
@@ -147,6 +147,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -408,6 +412,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
@@ -98,6 +98,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -320,6 +324,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
@@ -72,6 +72,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -269,6 +273,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
+++ b/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
@@ -91,6 +91,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -476,6 +480,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
@@ -88,6 +88,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -310,6 +314,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
@@ -100,6 +100,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -333,6 +337,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
@@ -78,6 +78,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -275,6 +279,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -255,6 +259,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_outputs.yaml
@@ -74,6 +74,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -296,6 +300,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
@@ -165,6 +165,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -362,6 +366,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
+++ b/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
@@ -87,6 +87,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -285,6 +289,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_placeholders.yaml
+++ b/test_data/compiled-workflows/pipeline_with_placeholders.yaml
@@ -74,6 +74,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -271,6 +275,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
@@ -189,6 +189,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -1053,6 +1057,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -298,6 +302,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_reused_component.yaml
+++ b/test_data/compiled-workflows/pipeline_with_reused_component.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -314,6 +318,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
@@ -86,6 +86,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -310,6 +314,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
@@ -74,6 +74,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -273,6 +277,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -264,6 +268,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
@@ -119,6 +119,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -414,6 +418,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_submit_request.yaml
+++ b/test_data/compiled-workflows/pipeline_with_submit_request.yaml
@@ -78,6 +78,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -299,6 +303,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
@@ -101,6 +101,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -355,6 +359,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
@@ -66,6 +66,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -295,6 +299,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -81,6 +81,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -317,6 +321,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_utils.yaml
+++ b/test_data/compiled-workflows/pipeline_with_utils.yaml
@@ -71,6 +71,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -268,6 +272,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
@@ -62,6 +62,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -284,6 +288,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume.yaml
@@ -115,6 +115,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -371,6 +375,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
@@ -115,6 +115,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -371,6 +375,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pipeline_with_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_workspace.yaml
@@ -91,6 +91,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -313,6 +317,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
+++ b/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
@@ -61,6 +61,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -258,6 +262,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/preprocess.yaml
+++ b/test_data/compiled-workflows/preprocess.yaml
@@ -89,6 +89,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -286,6 +290,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
+++ b/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
@@ -65,6 +65,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -287,6 +291,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pvc_mount.yaml
+++ b/test_data/compiled-workflows/pvc_mount.yaml
@@ -85,6 +85,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -311,6 +315,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
+++ b/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
@@ -61,9 +61,9 @@ spec:
       - --pod_uid
       - $(KFP_POD_UID)
       - --mlmd_server_address
-      - $(METADATA_GRPC_SERVICE_HOST)
+      - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
-      - $(METADATA_GRPC_SERVICE_PORT)
+      - "8080"
       command:
       - launcher-v2
       env:
@@ -135,6 +135,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -345,6 +349,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
@@ -86,6 +86,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -308,6 +312,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
@@ -87,6 +87,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -284,6 +288,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
@@ -92,6 +92,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -289,6 +293,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/ray_integration_compiled.yaml
+++ b/test_data/compiled-workflows/ray_integration_compiled.yaml
@@ -82,6 +82,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -279,6 +283,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/sequential_v1.yaml
+++ b/test_data/compiled-workflows/sequential_v1.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -279,6 +283,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/sequential_v2.yaml
+++ b/test_data/compiled-workflows/sequential_v2.yaml
@@ -62,6 +62,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -284,6 +288,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/take_nap_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_compiled.yaml
@@ -83,6 +83,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -305,6 +309,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
@@ -83,6 +83,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -305,6 +309,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/two_step_pipeline.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline.yaml
@@ -63,6 +63,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -285,6 +289,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
@@ -64,6 +64,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -286,6 +290,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/upload_download_compiled.yaml
+++ b/test_data/compiled-workflows/upload_download_compiled.yaml
@@ -122,6 +122,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -369,6 +373,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
+++ b/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
@@ -326,6 +326,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest
@@ -699,6 +703,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest


### PR DESCRIPTION
**Description of your changes:**
Update `backend/src/v2/metadata/env.go` `DefaultConfig()` to return a metadata service config containing the pod-specific namespace. This also includes a change to `backend/src/apiserver/common/config.go` `GetPodNamespace()` that sets the default pod namespace to `"kubeflow"`

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
