### PR TITLE
feat(components): add support for persistent resources in `HyperparameterTuningJobRunOp` component. Fixes #12436

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py
@@ -16,7 +16,7 @@ from typing import List
 
 from google_cloud_pipeline_components import _image
 from google_cloud_pipeline_components import _placeholders
-from kfp.dsl import ConcatPlaceholder
+from google_cloud_pipeline_components import utils
 from kfp.dsl import container_component
 from kfp.dsl import ContainerSpec
 from kfp.dsl import OutputPath
@@ -96,48 +96,27 @@ def hyperparameter_tuning_job(
           '--type',
           'HyperparameterTuningJob',
           '--payload',
-          ConcatPlaceholder([
-              '{',
-              '"display_name": "',
-              display_name,
-              '"',
-              ', "study_spec": {',
-              '"metrics": ',
-              study_spec_metrics,
-              ', "parameters": ',
-              study_spec_parameters,
-              ', "algorithm": "',
-              study_spec_algorithm,
-              '"',
-              ', "measurement_selection_type": "',
-              study_spec_measurement_selection_type,
-              '"',
-              '}',
-              ', "max_trial_count": ',
-              max_trial_count,
-              ', "parallel_trial_count": ',
-              parallel_trial_count,
-              ', "max_failed_trial_count": ',
-              max_failed_trial_count,
-              ', "trial_job_spec": {',
-              '"worker_pool_specs": ',
-              worker_pool_specs,
-              ', "service_account": "',
-              service_account,
-              '"',
-              ', "network": "',
-              network,
-              '"',
-              ', "base_output_directory": {',
-              '"output_uri_prefix": "',
-              base_output_directory,
-              '"}',
-              '}',
-              ', "encryption_spec": {"kms_key_name":"',
-              encryption_spec_key_name,
-              '"}',
-              '}',
-          ]),
+          utils.container_component_dumps({
+              'display_name': display_name,
+              'study_spec': {
+                  'metrics': study_spec_metrics,
+                  'parameters': study_spec_parameters,
+                  'algorithm': study_spec_algorithm,
+                  'measurement_selection_type': study_spec_measurement_selection_type,
+              },
+              'max_trial_count': max_trial_count,
+              'parallel_trial_count': parallel_trial_count,
+              'max_failed_trial_count': max_failed_trial_count,
+              'trial_job_spec': {
+                  'worker_pool_specs': worker_pool_specs,
+                  'service_account': service_account,
+                  'network': network,
+                  'base_output_directory': {
+                      'output_uri_prefix': base_output_directory
+                  },
+              },
+              'encryption_spec': {'kms_key_name': encryption_spec_key_name},
+          }),
           '--project',
           project,
           '--location',

--- a/components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py
+++ b/components/google-cloud/google_cloud_pipeline_components/v1/hyperparameter_tuning_job/component.py
@@ -39,6 +39,7 @@ def hyperparameter_tuning_job(
     encryption_spec_key_name: str = '',
     service_account: str = '',
     network: str = '',
+    persistent_resource_id: str = _placeholders.PERSISTENT_RESOURCE_ID_PLACEHOLDER,
     project: str = _placeholders.PROJECT_ID_PLACEHOLDER,
 ):
   # fmt: off
@@ -79,6 +80,7 @@ def hyperparameter_tuning_job(
       service_account: Specifies the service account for workload run-as account. Users submitting jobs must have act-as permission on this run-as account.
       network: The full name of the Compute Engine network to which the job should be peered. For example, `projects/12345/global/networks/myVPC`. Private services access must already be configured for the network. If left unspecified, the job is not peered with any network.
       project: Project to run the HyperparameterTuningJob in. Defaults to the project in which the PipelineJob is run.
+      persistent_resource_id: The id of the PersistentResource in the same Project and Location which to run. The default value is a placeholder that will be resolved to the PipelineJob [RuntimeConfig](https://cloud.google.com/vertex-ai/docs/reference/rest/v1/projects.locations.pipelineJobs#PipelineJob.RuntimeConfig)'s persistent resource id at runtime. However, if the PipelineJob doesn't set Persistent Resource as the job level runtime, the placedholder will be resolved to an empty string and the custom job will be run on demand. If this is specified, the job will be run on existing machines held by the PersistentResource instead of on-demand short-live machines. The network and CMEK configs on the job should be consistent with those on the PersistentResource, otherwise, the job will be rejected.
 
   Returns:
       gcp_resources: Serialized JSON of `gcp_resources` [proto](https://github.com/kubeflow/pipelines/tree/master/components/google-cloud/google_cloud_pipeline_components/proto) which contains the GCP resource ID of the Hyperparameter Tuning job.
@@ -114,6 +116,7 @@ def hyperparameter_tuning_job(
                   'base_output_directory': {
                       'output_uri_prefix': base_output_directory
                   },
+                  'persistent_resource_id': persistent_resource_id,
               },
               'encryption_spec': {'kms_key_name': encryption_spec_key_name},
           }),


### PR DESCRIPTION
**Description of your changes:**

I added support for persistent resources to the `HyperparameterTuningJobRunOp` component.
This enables running Vertex AI hyperparameter tuning jobs on [persistent resources](https://docs.cloud.google.com/vertex-ai/docs/training/persistent-resource-train), which is expected to provide stable job execution.

Since the `CustomTrainingJobOp` component already had [support for persistent resources added](https://github.com/kubeflow/pipelines/blob/f20abd4091dd779f97a5149bc0a0b7ace859284e/components/google-cloud/google_cloud_pipeline_components/preview/custom_job/component.py#L40), I used it as a reference.

Resolves https://github.com/kubeflow/pipelines/issues/12436

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
