### PR TITLE
feat(metadata-writer): Configure gRPC max_receive_message_length via environment variable

### DIFF
--- a/backend/metadata_writer/src/metadata_helpers.py
+++ b/backend/metadata_writer/src/metadata_helpers.py
@@ -41,6 +41,16 @@ def connect_to_mlmd() -> metadata_store.MetadataStore:
         port=metadata_service_port,
     )
 
+    # Configure gRPC channel options
+    max_receive_message_length = os.environ.get("METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH")
+    if max_receive_message_length:
+        try:
+            max_length = int(max_receive_message_length)
+            mlmd_connection_config.channel_arguments.max_receive_message_length = max_length
+            print('Configured gRPC max_receive_message_length to {} bytes'.format(max_length))
+        except ValueError:
+            print('Warning: Invalid METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH value: {}. Using default.'.format(max_receive_message_length), file=sys.stderr)
+
     tls_enabled = os.environ.get("METADATA_TLS_ENABLED", "false").lower() in ("1", "true", "yes")
 
     if tls_enabled:


### PR DESCRIPTION
add METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH config
Configure gRPC max_receive_message_length via environment variable

**Description of your changes:**


  This PR fixes a critical issue where metadata_writer fails to start due to gRPC message size limitations when dealing with large MLMD responses.

###  Problem:
  The metadata_writer service was failing to start with "send message over 4MB" errors because the default gRPC
  max_receive_message_length limit (4MB) was insufficient for large metadata operations.

###  Solution:
  - Added METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH environment variable support in metadata_helpers.py
  - Uses MLMD's channel_arguments.max_receive_message_length field to configure larger message size limits
  - Includes input validation with helpful warnings for invalid configurations
  - Enables dynamic configuration without code modification

###  Impact:
  Resolves startup failures in environments with large pipeline artifacts or extensive metadata by allowing users to increase the
  gRPC message size limit via environment configuration.

###  Usage:
  Set METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH=104857600 (100MB or desired size) to accommodate large metadata responses.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
