### PR TITLE
ci: checking artifacts

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -57,7 +57,7 @@ runs:
       run: ./.github/resources/squid/deploy-squid.sh
 
     - name: Download Docker Images
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v6
       with:
         path: "images_${{ github.sha }}"
 

--- a/.github/workflows/image-builds-with-cache.yml
+++ b/.github/workflows/image-builds-with-cache.yml
@@ -68,25 +68,17 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # Check if the image tarball already exists or not, if yes, then skip building the image
-      - name: Attempt to download the artifact
-        uses: actions/download-artifact@v4
+      - name: Check if artifact exists
+        uses: nsingla/github-actions/github-artifacts@main
         with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: ${{ env.ARTIFACTS_PATH }}
-        continue-on-error: true
-        id: artifact-download
-
-      # If the image tarball was successfully downloaded, then clean it up as the download should
-      # happen when image tarballs are actually required for deployment (most likely in a new workflow/job)
-      - name: Delete the artifact downloaded artifact
-        if: ${{ steps.artifact-download.outcome == 'success' }}
-        run: |
-          rm -rf ${{ env.ARTIFACTS_PATH }}/${{ env.ARTIFACT_NAME }}
-        shell: bash
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          operation: 'check'
+          artifact-name: ${{ env.ARTIFACT_NAME }}
+        id: artifact-check
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        if: ${{ steps.artifact-download.outcome == 'failure' }}
+        if: ${{ steps.artifact-check.outputs.artifact-exists == 'false' }}
         id: setup-buildx
 
       - name: Build and save Docker image


### PR DESCRIPTION
 ### Changes Made

  1. Replaced the artifact download step (image-builds-with-cache.yml:71-77):
    - Removed actions/download-artifact@v4 which actually downloaded artifacts
    - Added nsingla/github-actions/github-artifacts@main with operation 'check' to only verify if artifacts exist
  2. Updated the Docker Buildx step condition (image-builds-with-cache.yml:82):
    - Changed from steps.artifact-download.outcome == 'failure'
    - To steps.artifact-check.outputs.artifact-exists == 'false'
    - Now it runs when the artifact does NOT exist (when we need to build)
  3. Removed the artifact cleanup step (previously lines 79-85):
    - Since we're no longer downloading artifacts, we don't need to clean them up
    - The action only checks for existence, doesn't actually download anything

 ### Benefits of This Change

  - More efficient: No longer downloads artifacts unnecessarily just to check if they exist
  - Cleaner workflow: Removes the download-then-delete pattern
  - Better logic: Uses a proper boolean check (artifact-exists == 'false') instead of relying on step outcomes
  - Reduced network usage: Only queries artifact metadata instead of downloading full files


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
