### PR TITLE
chore(backend): add TLS certificate rotation documentation and helper scripts. Fixes #12328

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -389,7 +389,7 @@ kubectl -n <namespace> get deploy -o name \
   | grep -C3 "name: <secret-name>" || true
 ```
 
-### Certified rotation procedure
+### Certificate rotation procedure
 
 #### 1. Prepare/obtain new cert and key
 Generate or obtain new cert files: `server.crt` and `server.key` (PEM encoded).

--- a/backend/README.md
+++ b/backend/README.md
@@ -353,7 +353,7 @@ kind delete clusters dev-pipelines-api
 
 ### Context
 
-When pod-to-pod TLS is enabled, backend components (ml-pipeline-apiserver, metadata-envoy-deployment, metadata-grpc-deployment, ml-pipeline-persistenceagent, ml-pipeline-scheduledworkflow, and ml-pipeline-ui) use the TLS certificate stored in the Kubernetes TLS Secret `kfp-api-tls-cert`. These certificates expire and must be rotated periodically.
+When pod-to-pod TLS is enabled, backend components (`ml-pipeline-apiserver`, `metadata-envoy-deployment`, `metadata-grpc-deployment`, `ml-pipeline-persistenceagent`, `ml-pipeline-scheduledworkflow`, and `ml-pipeline-ui`) use the TLS certificate stored in the Kubernetes TLS Secret `kfp-api-tls-cert`. These certificates expire and must be rotated periodically.
 
 
 Important operational behaviour: updating a Kubernetes Secret does not cause running pods to read the updated secret automatically. Pods mount Secrets as files or reference them via environment variables at container start time. To pick up rotated certificates, you must restart the pods that read those secrets (a rolling restart of the affected deployments).
@@ -374,7 +374,7 @@ Which secrets and components are impacted:
 * `ml-pipeline-ui`
 
 > **Note**
-> The `pipelines-cache` / cache deployment generally does **not** require the CA cert for inbound TLS from pipeline components; confirm whether your deployment references the TLS secret before restarting it.
+> The `cache-server` deployment generally does **not** require the CA cert for inbound TLS from pipeline components; confirm whether your deployment references the TLS secret before restarting it.
 
 
 > **Note**
@@ -443,6 +443,16 @@ kubectl describe secret <secret-name> -n <namespace>
 ```
 
 Optional: connect to the API server over TLS (from inside cluster or via port-forward) to confirm certificate in use.
+
+Example (port-forward the API server service and test TLS locally):
+
+```bash
+kubectl -n <namespace> port-forward svc/ml-pipeline 8443:443
+```
+Confirm the certificate presented by the server
+```bash
+openssl s_client -connect localhost:8443 -servername ml-pipeline 2>/dev/null | openssl x509 -noout -subject -issuer -dates
+```
 
 ## Best practices & notes
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -362,15 +362,14 @@ This section documents a recommended, minimal process for safely renewing TLS ce
 
 ### Which secrets and components are impacted
 
-TLS certificates are commonly stored in a Kubernetes TLS Secret (for example: `kfp-pod-tls`) in the KFP namespace (commonly `kubeflow`).
+TLS certificates are stored in the Kubernetes TLS Secret `kfp-api-tls-cert` in the KFP namespace (commonly `kubeflow`).
 
 Which secrets and components are impacted:
 
 * `ml-pipeline-apiserver`
-* `ml-pipeline-persistenceagent`
-* `metadata-writer`
 * `metadata-envoy-deployment`
 * `metadata-grpc-deployment`
+* `ml-pipeline-persistenceagent`
 * `ml-pipeline-scheduledworkflow`
 * `ml-pipeline-ui`
 
@@ -391,7 +390,7 @@ kubectl -n <namespace> get deploy -o name \
   | grep -C3 "name: <secret-name>" || true
 ```
 
-### Recommended rotation procedure (example)
+### Recommended rotation procedure
 
 #### Prepare/obtain new cert and key
 Generate or obtain new cert files: `server.crt` and `server.key` (PEM encoded).
@@ -410,7 +409,7 @@ Replace <namespace> and <secret-name> with your cluster's values:
 Example:
 
    ```bash
-   kubectl create secret tls kfp-pod-tls \
+   kubectl create secret tls kfp-api-tls-cert \
       --cert=server.crt \
       --key=server.key \
       --dry-run=client -o yaml | kubectl apply -f -

--- a/backend/README.md
+++ b/backend/README.md
@@ -391,6 +391,29 @@ kubectl -n <namespace> get deploy -o name \
 
 ### Certificate rotation procedure
 
+> **Tip: helper scripts**
+> This repo also includes two optional helper scripts to simplify identifying impacted components and performing a rotation:
+>
+> - `scripts/find-tls-refs.sh`: lists pods/deployments in a namespace that reference a given TLS Secret.
+> - `scripts/rotate-tls.sh`: updates the TLS Secret and performs a rolling restart of all deployments that reference it.
+>
+> Examples:
+>
+> ```bash
+> # List deployments referencing the TLS Secret
+> ./scripts/find-tls-refs.sh <namespace> <secret-name>
+>
+> # Rotate certs and restart impacted deployments
+> ./scripts/rotate-tls.sh <namespace> <secret-name> <cert-file> <key-file>
+> ```
+>
+> For the default cert-manager setup:
+>
+> ```bash
+> ./scripts/find-tls-refs.sh kubeflow kfp-api-tls-cert
+> ./scripts/rotate-tls.sh kubeflow kfp-api-tls-cert server.crt server.key
+> ```
+
 #### 1. Prepare/obtain new cert and key
 Generate or obtain new cert files: `server.crt` and `server.key` (PEM encoded).
 
@@ -407,7 +430,7 @@ kubectl create secret tls <secret-name> \
 
 Example:
 
- ```bash
+```bash
  kubectl create secret tls kfp-api-tls-cert \
     --cert=server.crt \
     --key=server.key \

--- a/scripts/find-tls-refs.sh
+++ b/scripts/find-tls-refs.sh
@@ -3,7 +3,7 @@
 # Defaults: namespace=kubeflow, secret=kfp-pod-tls
 
 NS="${1:-kubeflow}"
-SECRET="${2:-kfp-pod-tls}"
+SECRET="${2:-kfp-api-tls-cert}"
 
 set -euo pipefail
 

--- a/scripts/find-tls-refs.sh
+++ b/scripts/find-tls-refs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/find-tls-refs.sh <namespace> <secret-name>
+# Defaults: namespace=kubeflow, secret=kfp-pod-tls
+
+NS="${1:-kubeflow}"
+SECRET="${2:-kfp-pod-tls}"
+
+set -euo pipefail
+
+echo "Looking in cluster namespace: ${NS} for secret: ${SECRET}"
+echo
+
+echo "Pods that reference the secret via volumes or env:"
+kubectl get pods -n "${NS}" -o json | jq -r --arg SECRET "${SECRET}" '
+  .items[] |
+  select(
+    (.spec.volumes[]? | select(.secret and .secret.secretName == $SECRET)) or
+    (.spec.containers[]?.env[]? | select(.valueFrom and .valueFrom.secretKeyRef and .valueFrom.secretKeyRef.name == $SECRET))
+  ) | .metadata.name
+' || true
+
+echo
+echo "Deployments referencing the secret:"
+kubectl get deploy -n "${NS}" -o json | jq -r --arg SECRET "${SECRET}" '
+  .items[] |
+  select(
+    (.spec.template.spec.volumes[]? | select(.secret and .secret.secretName == $SECRET)) or
+    (.spec.template.spec.containers[]?.env[]? | select(.valueFrom and .valueFrom.secretKeyRef and .valueFrom.secretKeyRef.name == $SECRET))
+  ) | .metadata.name
+' || true

--- a/scripts/rotate-tls.sh
+++ b/scripts/rotate-tls.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Usage: ./scripts/rotate-tls.sh <namespace> <secret-name> <cert-file> <key-file>
+# Defaults: namespace=kubeflow, secret=kfp-pod-tls, cert=server.crt, key=server.key
+
+NS="${1:-kubeflow}"
+SECRET="${2:-kfp-pod-tls}"
+CERT="${3:-server.crt}"
+KEY="${4:-server.key}"
+
+set -euo pipefail
+
+if [[ ! -f "${CERT}" || ! -f "${KEY}" ]]; then
+  echo "Cert or key file missing. Provide paths to cert and key."
+  echo "Usage: $0 <namespace> <secret-name> <cert-file> <key-file>"
+  exit 1
+fi
+
+echo "Applying TLS secret ${SECRET} in namespace ${NS} (dry-run -> apply)..."
+kubectl create secret tls "${SECRET}" --cert="${CERT}" --key="${KEY}" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "Secret applied. Now finding deployments that reference ${SECRET} ..."
+readarray -t DEPS < <(kubectl get deploy -n "${NS}" -o json | jq -r --arg SECRET "${SECRET}" '
+  .items[] |
+  select(
+    (.spec.template.spec.volumes[]? | select(.secret and .secret.secretName == $SECRET)) or
+    (.spec.template.spec.containers[]?.env[]? | select(.valueFrom and .valueFrom.secretKeyRef and .valueFrom.secretKeyRef.name == $SECRET))
+  ) | .metadata.name
+')
+
+if [[ "${#DEPS[@]}" -eq 0 ]]; then
+  echo "No deployments found referencing secret ${SECRET} in namespace ${NS}."
+  echo "You may need to restart specific deployments manually."
+  exit 0
+fi
+
+echo "Found deployments:"
+for d in "${DEPS[@]}"; do
+  echo "  - ${d}"
+done
+
+echo
+for d in "${DEPS[@]}"; do
+  echo "Rolling restart: ${d}"
+  kubectl rollout restart "deploy/${d}" -n "${NS}"
+  echo "Waiting for rollout of ${d}..."
+  kubectl rollout status "deploy/${d}" -n "${NS}"
+done
+
+echo "All rollouts triggered. Verify with: kubectl get pods -n ${NS}"

--- a/scripts/rotate-tls.sh
+++ b/scripts/rotate-tls.sh
@@ -3,7 +3,7 @@
 # Defaults: namespace=kubeflow, secret=kfp-pod-tls, cert=server.crt, key=server.key
 
 NS="${1:-kubeflow}"
-SECRET="${2:-kfp-pod-tls}"
+SECRET="${2:-kfp-api-tls-cert}"
 CERT="${3:-server.crt}"
 KEY="${4:-server.key}"
 


### PR DESCRIPTION
chore(backend): add TLS certificate rotation documentation and helper scripts. Fixes #12328

**Description of your changes:**

This PR adds missing documentation for TLS certificate rotation required when using the pod-to-pod TLS feature introduced in PR #12082. When TLS secrets are renewed, backend services (API server, persistence agent, metadata writer, cache server, etc.) do not automatically reload updated certificate data. A rolling restart is required. This behavior was previously undocumented.

The updates included in this PR:

1. **Documentation update (`backend/README.md`):**
   - Added a new section **“TLS Certificate Rotation (Pod-to-Pod TLS)”**.
   - Explained why certificate rotation is needed, how secrets interact with backend components, and why pods must be restarted.
   - Added a complete, copy-paste-ready rotation procedure:
     - Generate/obtain new TLS certs (`server.crt` / `server.key`)
     - Update the TLS secret using `kubectl create secret tls ... | kubectl apply -f -`
     - Restart affected deployments with `kubectl rollout restart`
     - Verify rollouts and confirm certificate is active.
   - Added best practices, troubleshooting notes, common errors, and automation guidance (cert-manager + checksum annotations).
   - Added cluster discovery commands to help users identify the exact secret and deployments referencing it.

2. **Helper scripts added (optional but helpful for operators):**
   - `scripts/find-tls-refs.sh`  
     Identifies which pods/deployments reference the TLS secret (via volumes or env secretKeyRef).  
     Helps operators know exactly which deployments must be restarted.
   - `scripts/rotate-tls.sh`  
     Applies new TLS cert/key to the Kubernetes Secret and automatically restarts all deployments referencing the secret, waiting for rollout completion.

3. **General improvements:**
   - Normalized README formatting.
   - Ensured all examples are reproducible and use correct fenced code blocks.
   - Provided safer and clearer operational guidance for cluster administrators.

These changes directly address the missing operational documentation noted in issue #12328 and align with the maintainers’ suggestion to include example commands.

---

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) follows the title convention.  
      [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
    * `chore: set up changelog generation tools`
    * `test: fix CI failure. Part of #1234`
-->

---

**Links**
- Related feature PR (TLS implementation): #12082  
- Documentation issue: #12328
