### PR TITLE
Fix: Seaweedfs admin credentials not loaded after restart

### DIFF
--- a/manifests/kustomize/third-party/seaweedfs/base/seaweedfs/seaweedfs-deployment.yaml
+++ b/manifests/kustomize/third-party/seaweedfs/base/seaweedfs/seaweedfs-deployment.yaml
@@ -24,17 +24,9 @@ spec:
           type: RuntimeDefault
       containers:
       - name: seaweedfs
-        env:
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: mlpipeline-minio-artifact
-              key: accesskey
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: mlpipeline-minio-artifact
-              key: secretkey
+        envFrom:
+        - secretRef:
+            name: mlpipeline-minio-artifact
         image: "chrislusf/seaweedfs:4.00"
         args:
         - "server"
@@ -43,6 +35,24 @@ spec:
         - "-iam"
         - "-filer"
         - "-master.volumePreallocate=false"
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/sh
+              - -ec
+              - |
+                # wait until seaweedfs master is ready
+                for i in $(seq 1 120); do
+                  if wget -q --spider http://127.0.0.1:8333/status; then
+                    break
+                  fi
+                  sleep 2
+                done
+                # create bucket if not exists (ignore error if exists)
+                echo "s3.bucket.create --name mlpipeline" | /usr/bin/weed shell || true
+                # configure admin user using keys from secret
+                echo "s3.configure -user kubeflow-admin -access_key $accesskey -secret_key $secretkey -actions Admin -apply" | /usr/bin/weed shell
         ports:
         - containerPort: 8333
         - containerPort: 8111


### PR DESCRIPTION
This reverts commit 17c7d751b468095f7914b40b27cd7eaf546052a0.

**Description of your changes:**

After creating new users and restarting the pod, the admin credentials from env will not longer work. Reverting this as discussed here https://github.com/kubeflow/pipelines/pull/12406#issuecomment-3548479531

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
