### PR TITLE
Configure service name env variables on API server

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -36,6 +36,8 @@ const (
 	CaBundleSecretName                      string = "CABUNDLE_SECRET_NAME"
 	RequireNamespaceForPipelines            string = "REQUIRE_NAMESPACE_FOR_PIPELINES"
 	CompiledPipelineSpecPatch               string = "COMPILED_PIPELINE_SPEC_PATCH"
+	MLPipelineServiceName                   string = "ML_PIPELINE_SERVICE_NAME"
+	MetadataServiceName                     string = "METADATA_SERVICE_NAME"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {
@@ -110,6 +112,14 @@ func IsMultiUserSharedReadMode() bool {
 
 func GetPodNamespace() string {
 	return GetStringConfigWithDefault(PodNamespace, DefaultPodNamespace)
+}
+
+func GetMLPipelineServiceName() string {
+	return GetStringConfigWithDefault(MLPipelineServiceName, DefaultMLPipelineServiceName)
+}
+
+func GetMetadataServiceName() string {
+	return GetStringConfigWithDefault(MetadataServiceName, DefaultMetadataServiceName)
 }
 
 func GetBoolFromStringWithDefault(value string, defaultValue bool) bool {

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -75,3 +75,8 @@ const (
 const (
 	DefaultPodNamespace string = "kubeflow"
 )
+
+const (
+	DefaultMLPipelineServiceName string = "ml-pipeline"
+	DefaultMetadataServiceName   string = "metadata-grpc-service"
+)

--- a/backend/src/v2/cacheutils/cache.go
+++ b/backend/src/v2/cacheutils/cache.go
@@ -26,7 +26,6 @@ const (
 	MaxClientGRPCMessageSize = 100 * 1024 * 1024
 	// The endpoint uses Kubernetes service DNS name with namespace:
 	// https://kubernetes.io/docs/concepts/services-networking/service/#dns
-	defaultKfpApiEndpoint = "ml-pipeline.kubeflow:8887"
 )
 
 type Client interface {
@@ -77,7 +76,7 @@ type client struct {
 var _ Client = &client{}
 
 // NewClient creates a Client.
-func NewClient(cacheDisabled bool, tlsCfg *tls.Config) (Client, error) {
+func NewClient(mlPipelineServerAddress string, mlPipelineServerPort string, cacheDisabled bool, tlsCfg *tls.Config) (Client, error) {
 	if cacheDisabled {
 		return &disabledCacheClient{}, nil
 	}
@@ -86,9 +85,10 @@ func NewClient(cacheDisabled bool, tlsCfg *tls.Config) (Client, error) {
 	if tlsCfg != nil {
 		creds = credentials.NewTLS(tlsCfg)
 	}
-	glog.Infof("Connecting to cache endpoint %s", defaultKfpApiEndpoint)
+	cacheEndPoint := mlPipelineServerAddress + ":" + mlPipelineServerPort
+	glog.Infof("Connecting to cache endpoint %s", cacheEndPoint)
 	conn, err := grpc.NewClient(
-		defaultKfpApiEndpoint,
+		cacheEndPoint,
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxClientGRPCMessageSize)),
 		grpc.WithTransportCredentials(creds),
 	)

--- a/backend/src/v2/cacheutils/cache_test.go
+++ b/backend/src/v2/cacheutils/cache_test.go
@@ -218,7 +218,7 @@ func TestGenerateCacheKey(t *testing.T) {
 			wantErr: false,
 		},
 	}
-	cacheClient, err := NewClient(false, &tls.Config{})
+	cacheClient, err := NewClient("ml-pipeline.kubeflow", "8887", false, &tls.Config{})
 	require.NoError(t, err)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -339,7 +339,7 @@ func TestGenerateFingerPrint(t *testing.T) {
 			fingerPrint: "3d9a2a778fa3174c6cfc6e639c507c265b5f21ef6e5b1dd70b236462cc6da464",
 		},
 	}
-	cacheClient, err := NewClient(false, &tls.Config{})
+	cacheClient, err := NewClient("ml-pipeline.kubeflow", "8887", false, &tls.Config{})
 	require.NoError(t, err)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -409,7 +409,7 @@ func TestGenerateFingerPrint_ConsidersPVCNames(t *testing.T) {
 		},
 	}
 
-	cacheClient, err := NewClient(false, &tls.Config{})
+	cacheClient, err := NewClient("ml-pipeline.kubeflow", "8887", false, &tls.Config{})
 	require.NoError(t, err)
 
 	baseFP, err := cacheClient.GenerateFingerPrint(base)

--- a/backend/src/v2/client_manager/client_manager.go
+++ b/backend/src/v2/client_manager/client_manager.go
@@ -29,11 +29,13 @@ type ClientManager struct {
 }
 
 type Options struct {
-	MLMDServerAddress string
-	MLMDServerPort    string
-	CacheDisabled     bool
-	CaCertPath        string
-	MLMDTLSEnabled    bool
+	MLPipelineServerAddress string
+	MLPipelineServerPort    string
+	MLMDServerAddress       string
+	MLMDServerPort          string
+	CacheDisabled           bool
+	CaCertPath              string
+	MLMDTLSEnabled          bool
 }
 
 // NewClientManager creates and Init a new instance of ClientManager.
@@ -76,7 +78,7 @@ func (cm *ClientManager) init(opts *Options) error {
 	if err != nil {
 		return err
 	}
-	cacheClient, err := initCacheClient(opts.CacheDisabled, tlsCfg)
+	cacheClient, err := initCacheClient(opts.MLPipelineServerAddress, opts.MLPipelineServerPort, opts.CacheDisabled, tlsCfg)
 	if err != nil {
 		return err
 	}
@@ -102,6 +104,6 @@ func initMetadataClient(address string, port string, tlsCfg *tls.Config) (metada
 	return metadata.NewClient(address, port, tlsCfg)
 }
 
-func initCacheClient(cacheDisabled bool, tlsCfg *tls.Config) (cacheutils.Client, error) {
-	return cacheutils.NewClient(cacheDisabled, tlsCfg)
+func initCacheClient(mlPipelineServerAddress string, mlPipelineServerPort string, cacheDisabled bool, tlsCfg *tls.Config) (cacheutils.Client, error) {
+	return cacheutils.NewClient(mlPipelineServerAddress, mlPipelineServerPort, cacheDisabled, tlsCfg)
 }

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -69,8 +69,10 @@ var (
 	k8sExecConfigJson = flag.String("kubernetes_config", "{}", "kubernetes executor config")
 
 	// config
-	mlmdServerAddress = flag.String("mlmd_server_address", "", "MLMD server address")
-	mlmdServerPort    = flag.String("mlmd_server_port", "", "MLMD server port")
+	mlPipelineServerAddress = flag.String("ml_pipeline_server_address", "ml-pipeline", "The name of the ML pipeline API server address.")
+	mlPipelineServerPort    = flag.String("ml_pipeline_server_port", "8887", "The port of the ML pipeline API server.")
+	mlmdServerAddress       = flag.String("mlmd_server_address", "", "MLMD server address")
+	mlmdServerPort          = flag.String("mlmd_server_port", "", "MLMD server port")
 
 	// output paths
 	executionIDPath    = flag.String("execution_id_path", "", "Exeucution ID output path")
@@ -190,7 +192,7 @@ func drive() (err error) {
 	if err != nil {
 		return err
 	}
-	cacheClient, err := cacheutils.NewClient(*cacheDisabledFlag, tlsCfg)
+	cacheClient, err := cacheutils.NewClient(*mlPipelineServerAddress, *mlPipelineServerPort, *cacheDisabledFlag, tlsCfg)
 	if err != nil {
 		return err
 	}

--- a/backend/src/v2/cmd/launcher-v2/main.go
+++ b/backend/src/v2/cmd/launcher-v2/main.go
@@ -28,26 +28,28 @@ import (
 
 // TODO: use https://github.com/spf13/cobra as a framework to create more complex CLI tools with subcommands.
 var (
-	copy                 = flag.String("copy", "", "copy this binary to specified destination path")
-	pipelineName         = flag.String("pipeline_name", "", "pipeline context name")
-	runID                = flag.String("run_id", "", "pipeline run uid")
-	parentDagID          = flag.Int64("parent_dag_id", 0, "parent DAG execution ID")
-	executorType         = flag.String("executor_type", "container", "The type of the ExecutorSpec")
-	executionID          = flag.Int64("execution_id", 0, "Execution ID of this task.")
-	executorInputJSON    = flag.String("executor_input", "", "The JSON-encoded ExecutorInput.")
-	componentSpecJSON    = flag.String("component_spec", "", "The JSON-encoded ComponentSpec.")
-	importerSpecJSON     = flag.String("importer_spec", "", "The JSON-encoded ImporterSpec.")
-	taskSpecJSON         = flag.String("task_spec", "", "The JSON-encoded TaskSpec.")
-	podName              = flag.String("pod_name", "", "Kubernetes Pod name.")
-	podUID               = flag.String("pod_uid", "", "Kubernetes Pod UID.")
-	mlmdServerAddress    = flag.String("mlmd_server_address", "", "The MLMD gRPC server address.")
-	mlmdServerPort       = flag.String("mlmd_server_port", "8080", "The MLMD gRPC server port.")
-	logLevel             = flag.String("log_level", "1", "The verbosity level to log.")
-	publishLogs          = flag.String("publish_logs", "true", "Whether to publish component logs to the object store")
-	cacheDisabledFlag    = flag.Bool("cache_disabled", false, "Disable cache globally.")
-	caCertPath           = flag.String("ca_cert_path", "", "The path to the CA certificate to trust on connections to the ML pipeline API server and metadata server.")
-	mlPipelineTLSEnabled = flag.Bool("ml_pipeline_tls_enabled", false, "Set to true if mlpipeline API server serves over TLS.")
-	metadataTLSEnabled   = flag.Bool("metadata_tls_enabled", false, "Set to true if MLMD serves over TLS.")
+	copy                    = flag.String("copy", "", "copy this binary to specified destination path")
+	pipelineName            = flag.String("pipeline_name", "", "pipeline context name")
+	runID                   = flag.String("run_id", "", "pipeline run uid")
+	parentDagID             = flag.Int64("parent_dag_id", 0, "parent DAG execution ID")
+	executorType            = flag.String("executor_type", "container", "The type of the ExecutorSpec")
+	executionID             = flag.Int64("execution_id", 0, "Execution ID of this task.")
+	executorInputJSON       = flag.String("executor_input", "", "The JSON-encoded ExecutorInput.")
+	componentSpecJSON       = flag.String("component_spec", "", "The JSON-encoded ComponentSpec.")
+	importerSpecJSON        = flag.String("importer_spec", "", "The JSON-encoded ImporterSpec.")
+	taskSpecJSON            = flag.String("task_spec", "", "The JSON-encoded TaskSpec.")
+	podName                 = flag.String("pod_name", "", "Kubernetes Pod name.")
+	podUID                  = flag.String("pod_uid", "", "Kubernetes Pod UID.")
+	mlPipelineServerAddress = flag.String("ml_pipeline_server_address", "ml-pipeline.kubeflow", "The name of the ML pipeline API server address.")
+	mlPipelineServerPort    = flag.String("ml_pipeline_server_port", "8887", "The port of the ML pipeline API server.")
+	mlmdServerAddress       = flag.String("mlmd_server_address", "", "The MLMD gRPC server address.")
+	mlmdServerPort          = flag.String("mlmd_server_port", "8080", "The MLMD gRPC server port.")
+	logLevel                = flag.String("log_level", "1", "The verbosity level to log.")
+	publishLogs             = flag.String("publish_logs", "true", "Whether to publish component logs to the object store")
+	cacheDisabledFlag       = flag.Bool("cache_disabled", false, "Disable cache globally.")
+	caCertPath              = flag.String("ca_cert_path", "", "The path to the CA certificate to trust on connections to the ML pipeline API server and metadata server.")
+	mlPipelineTLSEnabled    = flag.Bool("ml_pipeline_tls_enabled", false, "Set to true if mlpipeline API server serves over TLS.")
+	metadataTLSEnabled      = flag.Bool("metadata_tls_enabled", false, "Set to true if MLMD serves over TLS.")
 )
 
 func main() {
@@ -79,18 +81,20 @@ func run() error {
 	}
 
 	launcherV2Opts := &component.LauncherV2Options{
-		Namespace:            namespace,
-		PodName:              *podName,
-		PodUID:               *podUID,
-		MLMDServerAddress:    *mlmdServerAddress,
-		MLMDServerPort:       *mlmdServerPort,
-		PipelineName:         *pipelineName,
-		RunID:                *runID,
-		PublishLogs:          *publishLogs,
-		CacheDisabled:        *cacheDisabledFlag,
-		MLPipelineTLSEnabled: *mlPipelineTLSEnabled,
-		MLMDTLSEnabled:       *metadataTLSEnabled,
-		CaCertPath:           *caCertPath,
+		Namespace:               namespace,
+		PodName:                 *podName,
+		PodUID:                  *podUID,
+		MLPipelineServerAddress: *mlPipelineServerAddress,
+		MLPipelineServerPort:    *mlPipelineServerPort,
+		MLMDServerAddress:       *mlmdServerAddress,
+		MLMDServerPort:          *mlmdServerPort,
+		PipelineName:            *pipelineName,
+		RunID:                   *runID,
+		PublishLogs:             *publishLogs,
+		CacheDisabled:           *cacheDisabledFlag,
+		MLPipelineTLSEnabled:    *mlPipelineTLSEnabled,
+		MLMDTLSEnabled:          *metadataTLSEnabled,
+		CaCertPath:              *caCertPath,
 	}
 
 	switch *executorType {
@@ -110,11 +114,13 @@ func run() error {
 		return nil
 	case "container":
 		clientOptions := &client_manager.Options{
-			MLMDServerAddress: launcherV2Opts.MLMDServerAddress,
-			MLMDServerPort:    launcherV2Opts.MLMDServerPort,
-			CacheDisabled:     launcherV2Opts.CacheDisabled,
-			MLMDTLSEnabled:    launcherV2Opts.MLMDTLSEnabled,
-			CaCertPath:        launcherV2Opts.CaCertPath,
+			MLPipelineServerAddress: launcherV2Opts.MLPipelineServerAddress,
+			MLPipelineServerPort:    launcherV2Opts.MLPipelineServerPort,
+			MLMDServerAddress:       launcherV2Opts.MLMDServerAddress,
+			MLMDServerPort:          launcherV2Opts.MLMDServerPort,
+			CacheDisabled:           launcherV2Opts.CacheDisabled,
+			MLMDTLSEnabled:          launcherV2Opts.MLMDTLSEnabled,
+			CaCertPath:              launcherV2Opts.CaCertPath,
 		}
 		clientManager, err := client_manager.NewClientManager(clientOptions)
 		if err != nil {

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kubeflow/pipelines/backend/src/v2/config"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -207,8 +208,10 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 		"--http_proxy", proxy.GetConfig().GetHttpProxy(),
 		"--https_proxy", proxy.GetConfig().GetHttpsProxy(),
 		"--no_proxy", proxy.GetConfig().GetNoProxy(),
-		"--mlmd_server_address", metadata.DefaultConfig().Address,
-		"--mlmd_server_port", metadata.DefaultConfig().Port,
+		"--ml_pipeline_server_address", config.GetMLPipelineServerConfig().Address,
+		"--ml_pipeline_server_port", config.GetMLPipelineServerConfig().Port,
+		"--mlmd_server_address", metadata.GetMetadataConfig().Address,
+		"--mlmd_server_port", metadata.GetMetadataConfig().Port,
 	}
 	if c.cacheDisabled {
 		args = append(args, "--cache_disabled")

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
+	"github.com/kubeflow/pipelines/backend/src/v2/config"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 
 	wfapi "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
@@ -572,8 +573,10 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 		"--http_proxy", proxy.GetConfig().GetHttpProxy(),
 		"--https_proxy", proxy.GetConfig().GetHttpsProxy(),
 		"--no_proxy", proxy.GetConfig().GetNoProxy(),
-		"--mlmd_server_address", metadata.DefaultConfig().Address,
-		"--mlmd_server_port", metadata.DefaultConfig().Port,
+		"--ml_pipeline_server_address", config.GetMLPipelineServerConfig().Address,
+		"--ml_pipeline_server_port", config.GetMLPipelineServerConfig().Port,
+		"--mlmd_server_address", metadata.GetMetadataConfig().Address,
+		"--mlmd_server_port", metadata.GetMetadataConfig().Port,
 	}
 	if c.cacheDisabled {
 		args = append(args, "--cache_disabled")

--- a/backend/src/v2/compiler/argocompiler/importer.go
+++ b/backend/src/v2/compiler/argocompiler/importer.go
@@ -79,8 +79,8 @@ func (c *workflowCompiler) addImporterTemplate() string {
 		fmt.Sprintf("$(%s)", component.EnvPodName),
 		"--pod_uid",
 		fmt.Sprintf("$(%s)", component.EnvPodUID),
-		"--mlmd_server_address", metadata.DefaultConfig().Address,
-		"--mlmd_server_port", metadata.DefaultConfig().Port,
+		"--mlmd_server_address", metadata.GetMetadataConfig().Address,
+		"--mlmd_server_port", metadata.GetMetadataConfig().Port,
 	}
 	if c.cacheDisabled {
 		args = append(args, "--cache_disabled")

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -48,6 +48,8 @@ type LauncherV2Options struct {
 	Namespace,
 	PodName,
 	PodUID,
+	MLPipelineServerAddress,
+	MLPipelineServerPort,
 	MLMDServerAddress,
 	MLMDServerPort,
 	PipelineName,

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -320,7 +320,7 @@ func Test_get_log_Writer(t *testing.T) {
 func Test_NewLauncherV2(t *testing.T) {
 	var testCmdArgs = []string{"sh", "-c", "echo \"hello world\""}
 
-	disabledCacheClient, _ := cacheutils.NewClient(true, &tls.Config{})
+	disabledCacheClient, _ := cacheutils.NewClient("ml-pipeline.kubeflow", "8887", true, &tls.Config{})
 	var testLauncherV2Deps = client_manager.NewFakeClientManager(
 		fake.NewSimpleClientset(),
 		metadata.NewFakeClient(),

--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	"sigs.k8s.io/yaml"
 
@@ -43,6 +44,10 @@ const (
 	minioArtifactAccessKeyKey = "accesskey"
 )
 
+const (
+	mlPipelineGrpcServicePort = "8887"
+)
+
 type BucketProviders struct {
 	Minio *MinioProviderConfig `json:"minio"`
 	S3    *S3ProviderConfig    `json:"s3"`
@@ -56,6 +61,11 @@ type SessionInfoProvider interface {
 // Config is the KFP runtime configuration.
 type Config struct {
 	data map[string]string
+}
+
+type ServerConfig struct {
+	Address string
+	Port    string
 }
 
 // FromConfigMap loads config from a kfp-launcher Kubernetes config map.
@@ -180,4 +190,11 @@ func getDefaultMinioSessionInfo() (objectstore.SessionInfo, error) {
 		},
 	}
 	return sess, nil
+}
+
+func GetMLPipelineServerConfig() *ServerConfig {
+	return &ServerConfig{
+		Address: common.GetMLPipelineServiceName() + "." + common.GetPodNamespace(),
+		Port:    mlPipelineGrpcServicePort,
+	}
 }

--- a/backend/src/v2/metadata/env.go
+++ b/backend/src/v2/metadata/env.go
@@ -3,7 +3,6 @@ package metadata
 import "github.com/kubeflow/pipelines/backend/src/apiserver/common"
 
 const (
-	metadataGrpcServiceName = "metadata-grpc-service"
 	metadataGrpcServicePort = "8080"
 )
 
@@ -12,9 +11,9 @@ type ServerConfig struct {
 	Port    string
 }
 
-func DefaultConfig() *ServerConfig {
+func GetMetadataConfig() *ServerConfig {
 	return &ServerConfig{
-		Address: metadataGrpcServiceName + "." + common.GetPodNamespace() + ".svc.cluster.local",
+		Address: common.GetMetadataServiceName() + "." + common.GetPodNamespace() + ".svc.cluster.local",
 		Port:    metadataGrpcServicePort,
 	}
 }

--- a/backend/test/v2/integration/cache_test.go
+++ b/backend/test/v2/integration/cache_test.go
@@ -47,7 +47,7 @@ func TestCache(t *testing.T) {
 
 func (s *CacheTestSuite) SetupSuite() {
 	var err error
-	s.mlmdClient, err = testutils.NewTestMlmdClient("127.0.0.1", metadata.DefaultConfig().Port, *config.TLSEnabled, *config.CaCertPath)
+	s.mlmdClient, err = testutils.NewTestMlmdClient("127.0.0.1", metadata.GetMetadataConfig().Port, *config.TLSEnabled, *config.CaCertPath)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), s.mlmdClient)
 }

--- a/test_data/compiled-workflows/add_numbers.yaml
+++ b/test_data/compiled-workflows/add_numbers.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -268,6 +272,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/arguments_parameters.yaml
+++ b/test_data/compiled-workflows/arguments_parameters.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -259,6 +263,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/artifact_cache.yaml
+++ b/test_data/compiled-workflows/artifact_cache.yaml
@@ -86,6 +86,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -287,6 +291,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/artifact_crust.yaml
+++ b/test_data/compiled-workflows/artifact_crust.yaml
@@ -86,6 +86,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -287,6 +291,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/artifacts_complex.yaml
+++ b/test_data/compiled-workflows/artifacts_complex.yaml
@@ -112,6 +112,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -394,6 +398,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/artifacts_simple.yaml
+++ b/test_data/compiled-workflows/artifacts_simple.yaml
@@ -97,6 +97,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -298,6 +302,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/collected_artifacts.yaml
+++ b/test_data/compiled-workflows/collected_artifacts.yaml
@@ -178,6 +178,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -379,6 +383,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/collected_parameters.yaml
+++ b/test_data/compiled-workflows/collected_parameters.yaml
@@ -113,6 +113,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -339,6 +343,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/component_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/component_with_metadata_fields.yaml
@@ -82,6 +82,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -283,6 +287,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/component_with_optional_inputs.yaml
+++ b/test_data/compiled-workflows/component_with_optional_inputs.yaml
@@ -71,6 +71,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -272,6 +276,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/component_with_pip_index_urls.yaml
+++ b/test_data/compiled-workflows/component_with_pip_index_urls.yaml
@@ -69,6 +69,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -270,6 +274,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/component_with_pip_install.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install.yaml
@@ -69,6 +69,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -270,6 +274,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
@@ -70,6 +70,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -271,6 +275,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/components_with_optional_artifacts.yaml
+++ b/test_data/compiled-workflows/components_with_optional_artifacts.yaml
@@ -83,6 +83,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -373,6 +377,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/concat_message.yaml
+++ b/test_data/compiled-workflows/concat_message.yaml
@@ -68,6 +68,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -269,6 +273,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
+++ b/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
@@ -89,6 +89,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -322,6 +326,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/container_component_with_no_inputs.yaml
+++ b/test_data/compiled-workflows/container_component_with_no_inputs.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -259,6 +263,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/container_io.yaml
+++ b/test_data/compiled-workflows/container_io.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -259,6 +263,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/container_no_input.yaml
+++ b/test_data/compiled-workflows/container_no_input.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -259,6 +263,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/container_with_artifact_output.yaml
+++ b/test_data/compiled-workflows/container_with_artifact_output.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -259,6 +263,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/container_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_concat_placeholder.yaml
@@ -59,6 +59,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -260,6 +264,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/container_with_if_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder.yaml
@@ -61,6 +61,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -262,6 +266,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
+++ b/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -259,6 +263,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/containerized_python_component.yaml
+++ b/test_data/compiled-workflows/containerized_python_component.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -259,6 +263,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/create_pod_metadata_complex.yaml
+++ b/test_data/compiled-workflows/create_pod_metadata_complex.yaml
@@ -111,6 +111,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -612,6 +616,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/cross_loop_after_topology.yaml
+++ b/test_data/compiled-workflows/cross_loop_after_topology.yaml
@@ -88,6 +88,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -321,6 +325,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/dict_input.yaml
+++ b/test_data/compiled-workflows/dict_input.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -268,6 +272,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/embedded_artifact.yaml
+++ b/test_data/compiled-workflows/embedded_artifact.yaml
@@ -108,6 +108,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -333,6 +337,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/env-var.yaml
+++ b/test_data/compiled-workflows/env-var.yaml
@@ -69,6 +69,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -270,6 +274,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/fail_v2.yaml
+++ b/test_data/compiled-workflows/fail_v2.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -268,6 +272,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/flip_coin.yaml
+++ b/test_data/compiled-workflows/flip_coin.yaml
@@ -124,6 +124,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -361,6 +365,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/hello_world.yaml
+++ b/test_data/compiled-workflows/hello_world.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -259,6 +263,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/identity.yaml
+++ b/test_data/compiled-workflows/identity.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -268,6 +272,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/if_elif_else_complex.yaml
+++ b/test_data/compiled-workflows/if_elif_else_complex.yaml
@@ -158,6 +158,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -360,6 +364,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
@@ -113,6 +113,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -380,6 +384,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
@@ -105,6 +105,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -338,6 +342,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
@@ -91,6 +91,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -326,6 +330,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/input_artifact.yaml
+++ b/test_data/compiled-workflows/input_artifact.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -268,6 +272,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/iris_pipeline_compiled.yaml
+++ b/test_data/compiled-workflows/iris_pipeline_compiled.yaml
@@ -120,6 +120,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -371,6 +375,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
@@ -122,6 +122,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -348,6 +352,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
@@ -114,6 +114,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -389,6 +393,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/log_streaming_compiled.yaml
+++ b/test_data/compiled-workflows/log_streaming_compiled.yaml
@@ -71,6 +71,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -272,6 +276,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/long-running.yaml
+++ b/test_data/compiled-workflows/long-running.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -284,6 +288,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/loop_consume_upstream.yaml
+++ b/test_data/compiled-workflows/loop_consume_upstream.yaml
@@ -115,6 +115,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -343,6 +347,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/metrics_visualization_v2.yaml
+++ b/test_data/compiled-workflows/metrics_visualization_v2.yaml
@@ -159,6 +159,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -456,6 +460,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
+++ b/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
@@ -70,6 +70,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -274,6 +278,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/mixed_parameters.yaml
+++ b/test_data/compiled-workflows/mixed_parameters.yaml
@@ -84,6 +84,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -285,6 +289,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/modelcar.yaml
+++ b/test_data/compiled-workflows/modelcar.yaml
@@ -92,6 +92,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -387,6 +391,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
@@ -88,6 +88,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -289,6 +293,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
@@ -87,6 +87,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -288,6 +292,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
@@ -147,6 +147,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -468,6 +472,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
@@ -98,6 +98,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -347,6 +351,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
@@ -150,6 +150,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -479,6 +483,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/nested_return.yaml
+++ b/test_data/compiled-workflows/nested_return.yaml
@@ -68,6 +68,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -269,6 +273,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/nested_with_parameters.yaml
+++ b/test_data/compiled-workflows/nested_with_parameters.yaml
@@ -100,6 +100,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -350,6 +354,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/notebook_component_mixed.yaml
+++ b/test_data/compiled-workflows/notebook_component_mixed.yaml
@@ -296,6 +296,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -547,6 +551,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/notebook_component_simple.yaml
+++ b/test_data/compiled-workflows/notebook_component_simple.yaml
@@ -165,6 +165,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -366,6 +370,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/output_metrics.yaml
+++ b/test_data/compiled-workflows/output_metrics.yaml
@@ -69,6 +69,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -270,6 +274,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/parallel_for_after_dependency.yaml
+++ b/test_data/compiled-workflows/parallel_for_after_dependency.yaml
@@ -70,6 +70,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -271,6 +275,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/parameter_cache.yaml
+++ b/test_data/compiled-workflows/parameter_cache.yaml
@@ -84,6 +84,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -285,6 +289,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/parameter_oneof.yaml
+++ b/test_data/compiled-workflows/parameter_oneof.yaml
@@ -123,6 +123,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -358,6 +362,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/parameters_complex.yaml
+++ b/test_data/compiled-workflows/parameters_complex.yaml
@@ -117,6 +117,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -318,6 +322,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/parameters_simple.yaml
+++ b/test_data/compiled-workflows/parameters_simple.yaml
@@ -88,6 +88,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -289,6 +293,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_as_exit_task.yaml
+++ b/test_data/compiled-workflows/pipeline_as_exit_task.yaml
@@ -104,6 +104,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -306,6 +310,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_in_pipeline.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline.yaml
@@ -73,6 +73,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -299,6 +303,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
@@ -82,6 +82,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -315,6 +319,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
@@ -89,6 +89,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -315,6 +319,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_producer_consumer.yaml
+++ b/test_data/compiled-workflows/pipeline_producer_consumer.yaml
@@ -120,6 +120,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -321,6 +325,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_after.yaml
+++ b/test_data/compiled-workflows/pipeline_with_after.yaml
@@ -61,6 +61,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -315,6 +319,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
@@ -89,6 +89,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -315,6 +319,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
@@ -88,6 +88,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -314,6 +318,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
@@ -60,6 +60,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -261,6 +265,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_condition.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition.yaml
@@ -86,6 +86,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -336,6 +340,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
@@ -183,6 +183,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -384,6 +388,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
@@ -132,6 +132,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -357,6 +361,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
@@ -145,6 +145,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -419,6 +423,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_env.yaml
@@ -73,6 +73,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -298,6 +302,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
@@ -85,6 +85,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -344,6 +348,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
+++ b/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
@@ -150,6 +150,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -388,6 +392,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_importer.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer.yaml
@@ -140,6 +140,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -354,6 +358,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
@@ -62,6 +62,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -333,6 +337,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
+++ b/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
@@ -85,6 +85,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -318,6 +322,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops.yaml
@@ -101,6 +101,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -462,6 +466,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
@@ -147,6 +147,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -412,6 +416,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
@@ -98,6 +98,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -324,6 +328,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
@@ -72,6 +72,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -273,6 +277,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
+++ b/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
@@ -91,6 +91,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -480,6 +484,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
@@ -88,6 +88,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -314,6 +318,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
@@ -100,6 +100,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -337,6 +341,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
@@ -78,6 +78,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -279,6 +283,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -259,6 +263,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_outputs.yaml
@@ -74,6 +74,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -300,6 +304,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
@@ -165,6 +165,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -366,6 +370,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
+++ b/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
@@ -87,6 +87,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -289,6 +293,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_placeholders.yaml
+++ b/test_data/compiled-workflows/pipeline_with_placeholders.yaml
@@ -74,6 +74,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -275,6 +279,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
@@ -189,6 +189,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -1057,6 +1061,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -302,6 +306,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_reused_component.yaml
+++ b/test_data/compiled-workflows/pipeline_with_reused_component.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -318,6 +322,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
@@ -86,6 +86,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -314,6 +318,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
@@ -74,6 +74,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -277,6 +281,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
@@ -67,6 +67,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -268,6 +272,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
@@ -72,7 +72,7 @@ spec:
         kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
         sum_numbers(a: int, b: int) -\u003e int:\n    return a + b\n\n"],"image":"python:3.11","resources":{"accelerator":{"resourceCount":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}","resourceType":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"},"resourceCpuLimit":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}","resourceMemoryLimit":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}}'
     - name: components-root
-      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","accelerator-limit","cpu-limit","memory-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
+      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","cpu-limit","memory-limit","accelerator-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
   entrypoint: entrypoint
   podMetadata:
     annotations:
@@ -119,6 +119,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -355,15 +359,15 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","accelerator-limit","cpu-limit","memory-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","cpu-limit","memory-limit","accelerator-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
           - name: container
             value: '{{workflow.parameters.implementations-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task-name
             value: sum-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
-        depends: accelerator-type.Succeeded && accelerator-limit.Succeeded && cpu-limit.Succeeded
-          && memory-limit.Succeeded
+        depends: accelerator-type.Succeeded && cpu-limit.Succeeded && memory-limit.Succeeded
+          && accelerator-limit.Succeeded
         name: sum-numbers-driver
         template: system-container-driver
       - arguments:
@@ -418,6 +422,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_submit_request.yaml
+++ b/test_data/compiled-workflows/pipeline_with_submit_request.yaml
@@ -78,6 +78,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -303,6 +307,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
@@ -101,6 +101,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -359,6 +363,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
@@ -66,6 +66,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -299,6 +303,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -81,6 +81,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -321,6 +325,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_utils.yaml
+++ b/test_data/compiled-workflows/pipeline_with_utils.yaml
@@ -71,6 +71,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -272,6 +276,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
@@ -62,6 +62,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -288,6 +292,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume.yaml
@@ -115,6 +115,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -375,6 +379,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
@@ -115,6 +115,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -375,6 +379,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pipeline_with_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_workspace.yaml
@@ -91,6 +91,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -317,6 +321,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
+++ b/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
@@ -61,6 +61,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -262,6 +266,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/preprocess.yaml
+++ b/test_data/compiled-workflows/preprocess.yaml
@@ -89,6 +89,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -290,6 +294,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
+++ b/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
@@ -65,6 +65,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -291,6 +295,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pvc_mount.yaml
+++ b/test_data/compiled-workflows/pvc_mount.yaml
@@ -85,6 +85,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -315,6 +319,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
+++ b/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
@@ -135,6 +135,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -349,6 +353,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
@@ -86,6 +86,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -312,6 +316,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
@@ -87,6 +87,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -288,6 +292,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
@@ -92,6 +92,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -293,6 +297,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/ray_integration_compiled.yaml
+++ b/test_data/compiled-workflows/ray_integration_compiled.yaml
@@ -82,6 +82,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -283,6 +287,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/sequential_v1.yaml
+++ b/test_data/compiled-workflows/sequential_v1.yaml
@@ -58,6 +58,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -283,6 +287,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/sequential_v2.yaml
+++ b/test_data/compiled-workflows/sequential_v2.yaml
@@ -62,6 +62,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -288,6 +292,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/take_nap_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_compiled.yaml
@@ -83,6 +83,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -309,6 +313,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
@@ -83,6 +83,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -309,6 +313,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/two_step_pipeline.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline.yaml
@@ -63,6 +63,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -289,6 +293,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
@@ -64,6 +64,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -290,6 +294,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/upload_download_compiled.yaml
+++ b/test_data/compiled-workflows/upload_download_compiled.yaml
@@ -122,6 +122,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -373,6 +377,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port

--- a/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
+++ b/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
@@ -326,6 +326,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
@@ -703,6 +707,10 @@ spec:
       - ""
       - --no_proxy
       - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow
+      - --ml_pipeline_server_port
+      - "8887"
       - --mlmd_server_address
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port


### PR DESCRIPTION
**Description of your changes:**
Allow user to set `ML_PIPELINE_SERVICE_NAME` and `METADATA_SERVICE_NAME` env variables to specify service addresses. Defaults stay the same, so there is no change to existing behavior.

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
