### PR TITLE
build and publish wheel

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -89,13 +89,13 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install twine
+          pip install build twine
 
       - name: Build kfp-server-api
         run: |
           cd backend/api/v2beta1/python_http_client
           rm -rf dist
-          python setup.py --quiet sdist
+          python -m build
           twine check dist/*
 
       - name: Publish to PyPI


### PR DESCRIPTION
Build and publish a wheel, in addition to a source distribution

Also direct invocation of setup.py is deprecated.