### PR TITLE
fix(backend): add formatting to make parameter macros such as [[CurrentTime]] forward compatible from v1 to v2

### DIFF
--- a/backend/src/apiserver/server/run_server.go
+++ b/backend/src/apiserver/server/run_server.go
@@ -460,7 +460,6 @@ func (s *RunServerV1) ReportRunMetricsV1(ctx context.Context, request *apiv1beta
 	return &apiv1beta1.ReportRunMetricsResponse{Results: apiResults}, nil
 }
 
-
 // Terminates a run.
 // Applies common logic on v1beta1 and v2beta1 API.
 func (s *BaseRunServer) terminateRun(ctx context.Context, runId string) error {
@@ -604,7 +603,6 @@ func (s *RunServer) DeleteRun(ctx context.Context, request *apiv2beta1.DeleteRun
 	}
 	return &emptypb.Empty{}, nil
 }
-
 
 // Terminates a run.
 // Supports v2beta1 behavior.

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -1479,7 +1479,6 @@ func TestCanAccessRun_Unauthenticated(t *testing.T) {
 	)
 }
 
-
 func TestRetryRun(t *testing.T) {
 	clients, manager, experiment := initWithExperiment(t)
 	defer clients.Close()

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -325,7 +325,7 @@ func (t *V2Spec) RunWorkflow(modelRun *model.Run, options RunWorkflowOptions) (u
 
 	if job.RuntimeConfig != nil && len(job.RuntimeConfig.GetParameterValues()) > 0 {
 		scheduledEpoch := int64(-1) // disabled by default
-		
+
 		if modelRun.ScheduledAtInSec > 0 {
 			scheduledEpoch = modelRun.ScheduledAtInSec
 		}


### PR DESCRIPTION
**Description of your changes:**

Addresses the issue #12494 and also #3855

Minimal code change that fixes the formatting issue that macros such as [[CurrentTime]] were facing in kfpv2, by adding forwards compatibility from v1 to v2, the PR will add that formatting logic which was present in v1 to the `RunWorkflow` method of `V2Spec` that processes the runtime parameters before validation, wrote it right before the compilation logic.

Supports 4 macros [[RunUUID]], [[CurrentTime]], [[ScheduledTime]] and [[Index]] for kfpv2

Extracts the string values from structpb.Value, formats them using the `util.NewSWFParameterFormatter()` (instead of `util.NewRunParameterFormatter()` to support all macros including [[ScheduledTime]] and [[Index]]), converts back to structpb.Value with `structpb.NewStringValue()`. This is done in the `RunWorkflow()` function and `ScheduledWorkflow()` function.

Parameters are stored unformatted and will be formatted later by the scheduled workflow controller when individual runs are created, which extracts string values from the stored parameters, formats them using `util.NewSWFParameterFormatter()` with run-specific values, and converts reusing existing ParameterFormatter logic.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 