### PR TITLE
fix(backend): add commonEnvs to driver for PVCs

### DIFF
--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -261,7 +261,7 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 			Command:   c.driverCommand,
 			Args:      args,
 			Resources: driverResources,
-			Env:       proxy.GetConfig().GetEnvVars(),
+			Env:       append(proxy.GetConfig().GetEnvVars(), commonEnvs...),
 		},
 	}
 	// If TLS is enabled (apiserver or metadata), add the custom CA bundle to the container driver template.

--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -104,7 +104,7 @@ func InPodNamespace() (string, error) {
 
 // InPodName gets the pod name from inside a Kubernetes Pod.
 func InPodName() (string, error) {
-	if podName, exists := os.LookupEnv("ARGO_POD_NAME"); exists && podName != "" {
+	if podName, exists := os.LookupEnv("KFP_POD_NAME"); exists && podName != "" {
 		return podName, nil
 	}
 	podName, err := os.ReadFile("/etc/hostname")

--- a/test_data/compiled-workflows/add_numbers.yaml
+++ b/test_data/compiled-workflows/add_numbers.yaml
@@ -77,6 +77,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/arguments_parameters.yaml
+++ b/test_data/compiled-workflows/arguments_parameters.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/artifact_cache.yaml
+++ b/test_data/compiled-workflows/artifact_cache.yaml
@@ -96,6 +96,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/artifact_crust.yaml
+++ b/test_data/compiled-workflows/artifact_crust.yaml
@@ -96,6 +96,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/artifacts_complex.yaml
+++ b/test_data/compiled-workflows/artifacts_complex.yaml
@@ -122,6 +122,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/artifacts_simple.yaml
+++ b/test_data/compiled-workflows/artifacts_simple.yaml
@@ -107,6 +107,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/collected_artifacts.yaml
+++ b/test_data/compiled-workflows/collected_artifacts.yaml
@@ -188,6 +188,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/collected_parameters.yaml
+++ b/test_data/compiled-workflows/collected_parameters.yaml
@@ -123,6 +123,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/component_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/component_with_metadata_fields.yaml
@@ -92,6 +92,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/component_with_optional_inputs.yaml
+++ b/test_data/compiled-workflows/component_with_optional_inputs.yaml
@@ -81,6 +81,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/component_with_pip_index_urls.yaml
+++ b/test_data/compiled-workflows/component_with_pip_index_urls.yaml
@@ -79,6 +79,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/component_with_pip_install.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install.yaml
@@ -79,6 +79,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
@@ -80,6 +80,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/components_with_optional_artifacts.yaml
+++ b/test_data/compiled-workflows/components_with_optional_artifacts.yaml
@@ -93,6 +93,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/concat_message.yaml
+++ b/test_data/compiled-workflows/concat_message.yaml
@@ -78,6 +78,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
+++ b/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
@@ -99,6 +99,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/container_component_with_no_inputs.yaml
+++ b/test_data/compiled-workflows/container_component_with_no_inputs.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/container_io.yaml
+++ b/test_data/compiled-workflows/container_io.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/container_no_input.yaml
+++ b/test_data/compiled-workflows/container_no_input.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/container_with_artifact_output.yaml
+++ b/test_data/compiled-workflows/container_with_artifact_output.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/container_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_concat_placeholder.yaml
@@ -69,6 +69,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/container_with_if_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder.yaml
@@ -71,6 +71,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
+++ b/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/containerized_python_component.yaml
+++ b/test_data/compiled-workflows/containerized_python_component.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/create_pod_metadata_complex.yaml
+++ b/test_data/compiled-workflows/create_pod_metadata_complex.yaml
@@ -121,6 +121,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/cross_loop_after_topology.yaml
+++ b/test_data/compiled-workflows/cross_loop_after_topology.yaml
@@ -98,6 +98,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/dict_input.yaml
+++ b/test_data/compiled-workflows/dict_input.yaml
@@ -77,6 +77,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/embedded_artifact.yaml
+++ b/test_data/compiled-workflows/embedded_artifact.yaml
@@ -118,6 +118,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/env-var.yaml
+++ b/test_data/compiled-workflows/env-var.yaml
@@ -79,6 +79,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/fail_v2.yaml
+++ b/test_data/compiled-workflows/fail_v2.yaml
@@ -77,6 +77,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/flip_coin.yaml
+++ b/test_data/compiled-workflows/flip_coin.yaml
@@ -134,6 +134,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/hello_world.yaml
+++ b/test_data/compiled-workflows/hello_world.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/identity.yaml
+++ b/test_data/compiled-workflows/identity.yaml
@@ -77,6 +77,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/if_elif_else_complex.yaml
+++ b/test_data/compiled-workflows/if_elif_else_complex.yaml
@@ -168,6 +168,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
@@ -123,6 +123,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
@@ -115,6 +115,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
@@ -101,6 +101,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/input_artifact.yaml
+++ b/test_data/compiled-workflows/input_artifact.yaml
@@ -77,6 +77,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/iris_pipeline_compiled.yaml
+++ b/test_data/compiled-workflows/iris_pipeline_compiled.yaml
@@ -130,6 +130,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
@@ -132,6 +132,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
@@ -124,6 +124,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/log_streaming_compiled.yaml
+++ b/test_data/compiled-workflows/log_streaming_compiled.yaml
@@ -81,6 +81,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/long-running.yaml
+++ b/test_data/compiled-workflows/long-running.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/loop_consume_upstream.yaml
+++ b/test_data/compiled-workflows/loop_consume_upstream.yaml
@@ -125,6 +125,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/metrics_visualization_v2.yaml
+++ b/test_data/compiled-workflows/metrics_visualization_v2.yaml
@@ -169,6 +169,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
+++ b/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
@@ -80,6 +80,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/mixed_parameters.yaml
+++ b/test_data/compiled-workflows/mixed_parameters.yaml
@@ -94,6 +94,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/modelcar.yaml
+++ b/test_data/compiled-workflows/modelcar.yaml
@@ -102,6 +102,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
@@ -98,6 +98,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
@@ -97,6 +97,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
@@ -157,6 +157,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
@@ -108,6 +108,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
@@ -160,6 +160,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/nested_return.yaml
+++ b/test_data/compiled-workflows/nested_return.yaml
@@ -78,6 +78,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/nested_with_parameters.yaml
+++ b/test_data/compiled-workflows/nested_with_parameters.yaml
@@ -110,6 +110,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/notebook_component_mixed.yaml
+++ b/test_data/compiled-workflows/notebook_component_mixed.yaml
@@ -306,6 +306,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/notebook_component_simple.yaml
+++ b/test_data/compiled-workflows/notebook_component_simple.yaml
@@ -175,6 +175,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/output_metrics.yaml
+++ b/test_data/compiled-workflows/output_metrics.yaml
@@ -79,6 +79,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/parallel_for_after_dependency.yaml
+++ b/test_data/compiled-workflows/parallel_for_after_dependency.yaml
@@ -80,6 +80,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/parameter_cache.yaml
+++ b/test_data/compiled-workflows/parameter_cache.yaml
@@ -94,6 +94,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/parameter_oneof.yaml
+++ b/test_data/compiled-workflows/parameter_oneof.yaml
@@ -133,6 +133,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/parameters_complex.yaml
+++ b/test_data/compiled-workflows/parameters_complex.yaml
@@ -127,6 +127,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/parameters_simple.yaml
+++ b/test_data/compiled-workflows/parameters_simple.yaml
@@ -98,6 +98,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_as_exit_task.yaml
+++ b/test_data/compiled-workflows/pipeline_as_exit_task.yaml
@@ -114,6 +114,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_in_pipeline.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline.yaml
@@ -83,6 +83,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
@@ -92,6 +92,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
@@ -99,6 +99,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_producer_consumer.yaml
+++ b/test_data/compiled-workflows/pipeline_producer_consumer.yaml
@@ -130,6 +130,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_after.yaml
+++ b/test_data/compiled-workflows/pipeline_with_after.yaml
@@ -71,6 +71,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
@@ -99,6 +99,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
@@ -98,6 +98,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
@@ -70,6 +70,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_condition.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition.yaml
@@ -96,6 +96,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
@@ -193,6 +193,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
@@ -142,6 +142,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
@@ -155,6 +155,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_env.yaml
@@ -83,6 +83,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
@@ -95,6 +95,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
+++ b/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
@@ -160,6 +160,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_importer.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer.yaml
@@ -150,6 +150,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
@@ -72,6 +72,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
@@ -224,6 +224,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
+++ b/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
@@ -95,6 +95,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops.yaml
@@ -111,6 +111,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
@@ -157,6 +157,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
@@ -108,6 +108,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
@@ -82,6 +82,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
+++ b/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
@@ -101,6 +101,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
@@ -98,6 +98,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
@@ -110,6 +110,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
@@ -88,6 +88,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_outputs.yaml
@@ -84,6 +84,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
@@ -175,6 +175,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
+++ b/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
@@ -97,6 +97,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_placeholders.yaml
+++ b/test_data/compiled-workflows/pipeline_with_placeholders.yaml
@@ -84,6 +84,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
@@ -199,6 +199,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry.yaml
@@ -77,6 +77,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_reused_component.yaml
+++ b/test_data/compiled-workflows/pipeline_with_reused_component.yaml
@@ -77,6 +77,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
@@ -96,6 +96,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
@@ -84,6 +84,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
@@ -77,6 +77,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
@@ -72,7 +72,7 @@ spec:
         kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
         sum_numbers(a: int, b: int) -\u003e int:\n    return a + b\n\n"],"image":"python:3.11","resources":{"accelerator":{"resourceCount":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}","resourceType":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"},"resourceCpuLimit":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}","resourceMemoryLimit":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}}'
     - name: components-root
-      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","cpu-limit","memory-limit","accelerator-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
+      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","cpu-limit","accelerator-limit","memory-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
   entrypoint: entrypoint
   podMetadata:
     annotations:
@@ -129,6 +129,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -359,15 +368,15 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","cpu-limit","memory-limit","accelerator-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","cpu-limit","accelerator-limit","memory-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
           - name: container
             value: '{{workflow.parameters.implementations-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task-name
             value: sum-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
-        depends: accelerator-type.Succeeded && cpu-limit.Succeeded && memory-limit.Succeeded
-          && accelerator-limit.Succeeded
+        depends: accelerator-type.Succeeded && cpu-limit.Succeeded && accelerator-limit.Succeeded
+          && memory-limit.Succeeded
         name: sum-numbers-driver
         template: system-container-driver
       - arguments:

--- a/test_data/compiled-workflows/pipeline_with_submit_request.yaml
+++ b/test_data/compiled-workflows/pipeline_with_submit_request.yaml
@@ -88,6 +88,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
@@ -111,6 +111,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
@@ -76,6 +76,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -91,6 +91,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_utils.yaml
+++ b/test_data/compiled-workflows/pipeline_with_utils.yaml
@@ -81,6 +81,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
@@ -72,6 +72,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume.yaml
@@ -125,6 +125,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
@@ -125,6 +125,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_workspace.yaml
@@ -101,6 +101,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
+++ b/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
@@ -71,6 +71,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/preprocess.yaml
+++ b/test_data/compiled-workflows/preprocess.yaml
@@ -99,6 +99,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
+++ b/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
@@ -75,6 +75,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pvc_mount.yaml
+++ b/test_data/compiled-workflows/pvc_mount.yaml
@@ -95,6 +95,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
+++ b/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
@@ -145,6 +145,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
@@ -96,6 +96,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
@@ -97,6 +97,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
@@ -102,6 +102,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/ray_integration_compiled.yaml
+++ b/test_data/compiled-workflows/ray_integration_compiled.yaml
@@ -92,6 +92,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/sequential_v1.yaml
+++ b/test_data/compiled-workflows/sequential_v1.yaml
@@ -68,6 +68,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/sequential_v2.yaml
+++ b/test_data/compiled-workflows/sequential_v2.yaml
@@ -72,6 +72,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/take_nap_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_compiled.yaml
@@ -93,6 +93,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
@@ -93,6 +93,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/two_step_pipeline.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline.yaml
@@ -73,6 +73,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
@@ -74,6 +74,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/upload_download_compiled.yaml
+++ b/test_data/compiled-workflows/upload_download_compiled.yaml
@@ -132,6 +132,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
+++ b/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
@@ -336,6 +336,15 @@ spec:
       - "8080"
       command:
       - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:


### PR DESCRIPTION
**Description of your changes:**

This PR adds `commonEnvs` to the driver container. This will now expose the `KFP_POD_NAME` and `KFP_POD_UID` env vars. This PR then updates`InPodName` to take advantage of `KFP_POD_NAME` to accurately get the full pod name without the 63 char truncation issue seen when using hostname (seen in issue #12350)

This supersedes #12351, which attempted to address this issue but was not properly tested. After deploying that change, it was discovered it did not work as expected, due to the `ARGO_POD_NAME` env var not being exposed in the main container. This PR contains the correct implementation and has been validated in a live cluster.



**Testing Evidence:**

Using the following pvc hello world file with a long pipeline name:
```python
from kfp import dsl
from kfp import kubernetes
from kfp import compiler

@dsl.component
def producer() -> str:
    with open('/data/file.txt', 'w') as file:
        file.write('Hello world')
    with open('/data/file.txt', 'r') as file:
        content = file.read()
    print(content)
    return content

@dsl.component
def consumer() -> str:
    with open('/data/file.txt', 'r') as file:
        content = file.read()
    print(content)
    return content


@dsl.pipeline
def my_pipeline_test_super_long_name_to_check_for_any_possible_errors_maybe():
    pvc1 = kubernetes.CreatePVC(
        # can also use pvc_name instead of pvc_name_suffix to use a pre-existing PVC
        pvc_name_suffix='-my-pvc',
        access_modes=['ReadWriteMany'],
        size='5Gi',
        storage_class_name='standard',
    )

    # write to the PVC
    task1 = producer()
    kubernetes.mount_pvc(
        task1,
        pvc_name=pvc1.outputs['name'],
        mount_path='/data',
    )

    # read to the PVC
    task2 = consumer()
    kubernetes.mount_pvc(
        task2,
        pvc_name=pvc1.outputs['name'],
        mount_path='/data',
    )
    task2.after(task1)

    delete_pvc1 = kubernetes.DeletePVC(
        pvc_name=pvc1.outputs['name']
    ).after(task2)

# Compile the pipeline
if __name__ == "__main__":
    compiler.Compiler().compile(pipeline_func=my_pipeline_test_super_long_name_to_check_for_any_possible_errors_maybe, package_path="kubeflow_pipeline.yaml")

```

`KFP_POD_NAME` exposed in main container
<img width="1123" height="149" alt="Screenshot 2025-11-30 at 10 11 44 PM" src="https://github.com/user-attachments/assets/6100e549-39e8-4814-8a98-a02fff72ea56" />



Passing Pipeline:
<img width="946" height="759" alt="Screenshot 2025-11-29 at 6 10 09 PM" src="https://github.com/user-attachments/assets/68b7f617-80f3-4cb6-85dc-5fa85a53a088" />


---

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
