### PR TITLE
fix(sdk): Set custom_path in executor output only when used

### DIFF
--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -287,8 +287,10 @@ class Executor:
                 'name': artifact.name,
                 'uri': artifact.uri,
                 'metadata': artifact.metadata,
-                'custom_path': artifact.custom_path
             }
+            if artifact.custom_path:
+                runtime_artifact['custom_path'] = artifact.custom_path
+
             artifacts_list = {'artifacts': [runtime_artifact]}
 
             self.excutor_output['artifacts'][name] = artifacts_list

--- a/sdk/python/kfp/dsl/executor_test.py
+++ b/sdk/python/kfp/dsl/executor_test.py
@@ -363,8 +363,6 @@ class ExecutorTest(parameterized.TestCase):
                                 'projects/123/locations/us-central1/metadataStores/default/artifacts/123',
                             'uri':
                                 'new-uri',
-                            'custom_path':
-                                '',
                             'metadata': {
                                 'key_1': 'value_1',
                                 'key_2': 2,
@@ -693,8 +691,6 @@ class ExecutorTest(parameterized.TestCase):
                                 'projects/123/locations/us-central1/metadataStores/default/artifacts/123',
                             'uri':
                                 'gs://some-bucket/output',
-                            'custom_path':
-                                ''
                         }]
                     }
                 },
@@ -752,8 +748,6 @@ class ExecutorTest(parameterized.TestCase):
                                 'projects/123/locations/us-central1/metadataStores/default/artifacts/123',
                             'uri':
                                 'gs://some-bucket/output',
-                            'custom_path':
-                                ''
                         }]
                     }
                 },
@@ -800,6 +794,53 @@ class ExecutorTest(parameterized.TestCase):
             self.assertIsInstance(output_artifact_one, Model)
 
         self.execute_and_load_output_metadata(test_func, executor_input)
+
+    def test_output_artifact_with_custom_path(self):
+        executor_input = """\
+        {
+          "outputs": {
+            "artifacts": {
+              "output_artifact_one": {
+                "artifacts": [
+                  {
+                    "metadata": {},
+                    "name": "projects/123/locations/us-central1/metadataStores/default/artifacts/123",
+                    "type": {
+                      "schemaTitle": "system.Dataset"
+                    },
+                    "uri": "gs://some-bucket/output_artifact_one"
+                  }
+                ]
+              }
+            },
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+        custom_path = os.path.join(self._test_dir, 'custom', 'output_artifact')
+
+        def test_func(output_artifact_one: Output[Dataset]):
+            output_artifact_one.custom_path = custom_path
+
+        output_metadata = self.execute_and_load_output_metadata(
+            test_func, executor_input)
+
+        self.assertDictEqual(
+            output_metadata, {
+                'artifacts': {
+                    'output_artifact_one': {
+                        'artifacts': [{
+                            'name':
+                                'projects/123/locations/us-central1/metadataStores/default/artifacts/123',
+                            'uri':
+                                'gs://some-bucket/output_artifact_one',
+                            'metadata': {},
+                            'custom_path':
+                                custom_path,
+                        }]
+                    }
+                }
+            })
 
     def test_named_tuple_output(self):
         executor_input = """\
@@ -867,8 +908,6 @@ class ExecutorTest(parameterized.TestCase):
                                     'projects/123/locations/us-central1/metadataStores/default/artifacts/123',
                                 'uri':
                                     'gs://some-bucket/output_dataset',
-                                'custom_path':
-                                    ''
                             }]
                         }
                     },
@@ -1107,8 +1146,6 @@ class ExecutorTest(parameterized.TestCase):
                                 '',
                             'uri':
                                 'gs://mlpipeline/v2/artifacts/my-test-pipeline-beta/b2b0cdee-b15c-48ff-b8bc-a394ae46c854/train/model',
-                            'custom_path':
-                                '',
                             'metadata': {
                                 'accuracy': 0.9
                             }
@@ -1343,8 +1380,6 @@ class ExecutorTest(parameterized.TestCase):
                                 'projects/123/locations/us-central1/metadataStores/default/artifacts/123',
                             'uri':
                                 'gs://manually_specified_bucket/foo',
-                            'custom_path':
-                                '',
                             'metadata': {
                                 'data': 123
                             }
@@ -1396,8 +1431,6 @@ class ExecutorTest(parameterized.TestCase):
                                 'projects/123/locations/us-central1/metadataStores/default/artifacts/123',
                             'uri':
                                 'gs://another_bucket/my_artifact',
-                            'custom_path':
-                                '',
                             'metadata': {
                                 'data': 123
                             }
@@ -1467,8 +1500,6 @@ class ExecutorTest(parameterized.TestCase):
                                 'projects/123/locations/us-central1/metadataStores/default/artifacts/123',
                             'uri':
                                 'gs://another_bucket/artifact',
-                            'custom_path':
-                                '',
                             'metadata': {
                                 'data': 123
                             }
@@ -1480,8 +1511,6 @@ class ExecutorTest(parameterized.TestCase):
                                 'projects/123/locations/us-central1/metadataStores/default/artifacts/321',
                             'uri':
                                 'gs://another_bucket/dataset',
-                            'custom_path':
-                                '',
                             'metadata': {}
                         }]
                     }


### PR DESCRIPTION
**Description of your changes:**

Prior to this commit, the executor output always set a custom_path field regardless of if it was set. This caused KFP API server versions prior to 2.15 to fail in the launcher with:
"output_metadata.json": proto: (line 1:237): unknown field "custom_path"

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
