### PR TITLE
remove error details from pipeline upload response

### DIFF
--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -20,7 +20,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"google.golang.org/protobuf/encoding/protojson"
@@ -388,7 +387,7 @@ func (s *PipelineUploadServer) canUploadVersionedPipeline(r *http.Request, pipel
 func (s *PipelineUploadServer) writeErrorToResponse(w http.ResponseWriter, code int, err error) {
 	glog.Errorf("Failed to upload pipelines. Error: %+v", err)
 	w.WriteHeader(code)
-	errorResponse := &apiv1beta1.Error{ErrorMessage: err.Error(), ErrorDetails: fmt.Sprintf("%+v", err)}
+	errorResponse := &apiv1beta1.Error{ErrorMessage: err.Error(), ErrorDetails: ""}
 	errBytes, err := json.Marshal(errorResponse)
 	if err != nil {
 		w.Write([]byte("Error uploading pipeline"))


### PR DESCRIPTION
(will fix name if PR is taken out of draft)

**Description of your changes:**

This is a supplemental PR to #12295. The previous PR addressed making error messages less verbose but overlooked that the error details in `writeErrorToResponse` prints stack traces for errors wrapped by pkg/errors deeper in the call chain

This PR contains the correct implementation and has been validated in a live cluster

## Test Evidence:

### Before:
<img width="1230" height="449" alt="Screenshot 2025-12-03 at 11 24 08 PM" src="https://github.com/user-attachments/assets/5f13b8b1-71c6-4b78-afb3-a17dfb8b323e" />
<img width="1240" height="425" alt="Screenshot 2025-12-03 at 11 26 21 PM" src="https://github.com/user-attachments/assets/cc00bd8c-4ea9-4bf0-aeb8-97c43d1fb1b9" />

### After:
<img width="1238" height="366" alt="Screenshot 2025-12-03 at 11 17 05 PM" src="https://github.com/user-attachments/assets/d5ca8f2c-5507-4e7c-9c08-c89f3bdd4529" />
<img width="1236" height="304" alt="Screenshot 2025-12-03 at 11 16 38 PM" src="https://github.com/user-attachments/assets/adea2224-6c5f-41ab-be39-486ba18d72c2" />

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
