### PR TITLE
chore: add GitHub welcome workflow for new contributors

### DIFF
--- a/.github/workflows/welcome-new-contributors.yaml
+++ b/.github/workflows/welcome-new-contributors.yaml
@@ -25,12 +25,11 @@ jobs:
             Thanks for opening your first issue! We're happy to have you as part of our community 🚀
 
             **Next steps:**
-            - Our team will review your issue soon! cc @kubeflow/wg-pipeline-leads
             - Check out the [Contributing Guide](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md) for repo-specific guidelines and the [Kubeflow Contributor Guide](https://www.kubeflow.org/docs/about/contributing/) for general community standards
             - Join our [#kubeflow-pipelines](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) Slack channel
             - Attend the [Kubeflow Pipelines WG](http://bit.ly/kfp-meeting-notes) meetings
 
-            Feel free to ask questions in the comments. Thanks again for contributing! 🙏
+            Feel free to ask questions in the comments.
 
           pr_message: |
             🎉 **Welcome to the Kubeflow Pipelines repo!** 🎉
@@ -38,9 +37,8 @@ jobs:
             Thanks for opening your first PR! We're excited to have you onboard 🚀
 
             **Next steps:**
-            - Our team will review your PR soon! cc @kubeflow/wg-pipeline-leads
             - Check out the [Contributing Guide](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md) for repo-specific guidelines and the [Kubeflow Contributor Guide](https://www.kubeflow.org/docs/about/contributing/) for general community standards
             - Join our [#kubeflow-pipelines](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) Slack channel
             - Attend the [Kubeflow Pipelines WG](http://bit.ly/kfp-meeting-notes) meetings
 
-            Feel free to ask questions in the comments. Thanks again for contributing! 🙏
+            Feel free to ask questions in the comments.


### PR DESCRIPTION
## What this PR does

This PR adds a GitHub Actions–based welcome workflow to the Kubeflow Pipelines repository. 

The workflow automatically welcomes first-time contributors when they open an issue or a pull request and provides helpful guidance and links to get started.

## Why this is needed

- Improves onboarding experience for new contributors
- Encourages participation and smooth contribution workflow
- Provides links to the Contributing Guide and community Slack channels

## Workflow details

- Trigger: First-time `pull_request` and `issue` events
- Messages are tailored for PRs and issues separately
- Uses the [actions/first-interaction](https://github.com/actions/first-interaction) GitHub Action

## Additional notes

- This workflow is inspired by the existing workflow in [kubeflow/sdk](https://github.com/kubeflow/sdk/blob/main/.github/workflows/welcome-new-contributors.yaml)
- Once merged, new contributors will see a friendly welcome message automatically.

fixes #12526 
