### PR TITLE
Cleanup kind workflows and Harden release downloads(incl. artifact paging)

### DIFF
--- a/.github/actions/create-cluster/action.yml
+++ b/.github/actions/create-cluster/action.yml
@@ -13,6 +13,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Free up disk space on runner
+      shell: bash
+      run: ./.github/resources/scripts/free-disk-space.sh
+
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1.12.0
       id: cluster-create

--- a/.github/resources/scripts/collect-logs.sh
+++ b/.github/resources/scripts/collect-logs.sh
@@ -23,9 +23,10 @@ fi
 
 function check_namespace {
     if ! kubectl get namespace "$1" &>/dev/null; then
-        echo "Namespace '$1' does not exist."
-        exit 1
+        echo "Namespace '$1' does not exist. Skipping log collection."
+        return 1
     fi
+    return 0
 }
 
 function display_pod_info {
@@ -61,5 +62,8 @@ function display_pod_info {
     echo "Pod information stored in $OUTPUT_FILE"
 }
 
-check_namespace "$NS"
-display_pod_info "$NS"
+if check_namespace "$NS"; then
+    display_pod_info "$NS"
+else
+    exit 0
+fi

--- a/.github/workflows/e2e-test-frontend.yml
+++ b/.github/workflows/e2e-test-frontend.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Free up disk space
-        run: ./.github/resources/scripts/free-disk-space.sh
-
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -73,11 +70,7 @@ jobs:
       - name: Collect failed logs
         if: ${{ steps.deploy.outcome != 'success' || steps.forward-frontend-port.outcome != 'success' || steps.tests.outcome != 'success' }}
         run: |
-          if kubectl get namespace kubeflow >/dev/null 2>&1; then
-            ./.github/resources/scripts/collect-logs.sh --ns kubeflow --output /tmp/tmp_pod_log.txt
-          else
-            echo "kubeflow namespace not found; skipping log collection."
-          fi
+          ./.github/resources/scripts/collect-logs.sh --ns kubeflow --output /tmp/tmp_pod_log.txt
           exit 1
 
       - name: Collect test results

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Free up disk space
-        run: ./.github/resources/scripts/free-disk-space.sh
-
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -88,11 +85,7 @@ jobs:
       - name: Collect failed logs
         if: ${{ steps.forward-mysql-port.outcome != 'success' || steps.integration-tests.outcome != 'success' || steps.initialization-tests.outcome != 'success' }}
         run: |
-          if kubectl get namespace kubeflow >/dev/null 2>&1; then
-            ./.github/resources/scripts/collect-logs.sh --ns kubeflow --output /tmp/tmp_pod_log.txt
-          else
-            echo "kubeflow namespace not found; skipping log collection."
-          fi
+          ./.github/resources/scripts/collect-logs.sh --ns kubeflow --output /tmp/tmp_pod_log.txt
           exit 1
 
       - name: Collect test results

--- a/.github/workflows/kfp-webhooks.yml
+++ b/.github/workflows/kfp-webhooks.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Free up disk space
-        run: ./.github/resources/scripts/free-disk-space.sh
-
       - name: Create KFP cluster
         id: create-kfp-cluster
         uses: ./.github/actions/create-cluster
@@ -59,11 +56,7 @@ jobs:
       - name: Collect failed logs
         if: ${{ steps.create-kfp-cluster.outcome != 'success' || steps.deploy.outcome != 'success' || steps.tests.outcome != 'success' }}
         run: |
-          if kubectl get namespace kubeflow >/dev/null 2>&1; then
-            ./.github/resources/scripts/collect-logs.sh --ns kubeflow --output /tmp/tmp_pod_log.txt
-          else
-            echo "kubeflow namespace not found; skipping log collection."
-          fi
+          ./.github/resources/scripts/collect-logs.sh --ns kubeflow --output /tmp/tmp_pod_log.txt
           exit 1
 
       - name: Collect test results


### PR DESCRIPTION
### Description of your changes:

- add a shared cleanup step to integration-tests-v1, kfp-webhooks, and e2e-test-frontend so we free disk and skip log collection when the kubeflow namespace never comes up; this unblocks the disk-exhaustion regressions seen in kubeflow/pipelines#12442

- harden .github/actions/check-artifact-exists so GitHub’s 403 pagination limit is treated as “artifact not found” rather than crashing the job

- fix our Docker builds (backend/Dockerfile, test/release/Dockerfile.release) to fetch Argo CLI and git-cliff with Accept: application/octet-stream and then extract, avoiding HTML responses that were breaking the unpack step