### PR TITLE
fix(sdk): Added missing `path` property setter to `kfp.dsl.types.artifact_types.Model` class. Fixes  #11728

### DIFF
--- a/sdk/python/kfp/dsl/types/artifact_types.py
+++ b/sdk/python/kfp/dsl/types/artifact_types.py
@@ -187,6 +187,10 @@ class Model(Artifact):
 
         return self._get_path()
 
+    @path.setter
+    def path(self, path: str) -> None:
+        self._set_path(path)
+
     @framework.setter
     def framework(self, framework: str) -> None:
         self._set_framework(framework)


### PR DESCRIPTION
**Description of your changes:**

Added missing `path` property setter to `kfp.dsl.types.artifact_types.Model` class.

New `path` property setter in `Model` class calls `self._set_path(...)` method defined in parent `Artifact` class.

**Root cause**
The bug fixed in this PR probably originated when getter for `path` property was overriden in `Model` class to handle Modelcar (`oci://`) paths in commit  cc1c435f1e06aad3e9b83e57768512a63460b15b. The setter was ommited by mistake.

**Related issues**
Fixes #11728

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
