### PR TITLE
chore: remove unnecessary server img patch for k8s native mode

### DIFF
--- a/manifests/kustomize/env/cert-manager/platform-agnostic-multi-user-k8s-native/patches/deployment.yaml
+++ b/manifests/kustomize/env/cert-manager/platform-agnostic-multi-user-k8s-native/patches/deployment.yaml
@@ -10,7 +10,6 @@ spec:
           ports:
           - containerPort: 8443
             name: webhook
-          image: domain.local/apiserver:local
           command:
             - "/bin/apiserver"
           args:


### PR DESCRIPTION
**Description of your changes:**

We need to use the same image for the api server in the release so this should not get changed. 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
