### PR TITLE
fix(ui): Enforce min of 1 on interval input spinner. Fixes #12579

### DIFF
--- a/frontend/src/components/Trigger.tsx
+++ b/frontend/src/components/Trigger.tsx
@@ -309,6 +309,7 @@ export default class Trigger extends React.Component<TriggerProps, TriggerState>
                 <Input
                   required={true}
                   type='number'
+                  inputProps={{ min: 1 }}
                   onChange={this.handleChange('intervalValue')}
                   value={intervalValue}
                   height={30}

--- a/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Trigger.test.tsx.snap
@@ -921,6 +921,11 @@ exports[`Trigger renders periodic schedule controls for initial render 1`] = `
         <Input
           error={false}
           height={30}
+          inputProps={
+            Object {
+              "min": 1,
+            }
+          }
           onChange={[Function]}
           required={true}
           type="number"


### PR DESCRIPTION
**Description of your changes:**
Changes:
Enforce min of 1 on interval input spinner

Reasoning:
Invalid values will still be able to be manually inputted, these will still be blocked. However now the down arrow will now cap out at 1

This is a 100% a nit pick but will provide some a slightly better UX

Live Cluster Testing:
Before:
<img width="445" height="78" alt="Screenshot 2025-12-22 at 8 49 01 PM" src="https://github.com/user-attachments/assets/88301b03-b0b5-4524-aaac-bad80ebe37ff" />

After:
<img width="326" height="94" alt="Screenshot 2025-12-23 at 11 31 14 AM" src="https://github.com/user-attachments/assets/a1b9e8ac-40d4-4d79-8184-eeaa721e7199" />

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
