### PR TITLE
fix(ci): retry auto workflow approval

### DIFF
--- a/.github/workflows/ok-to-test-ci.yml
+++ b/.github/workflows/ok-to-test-ci.yml
@@ -44,7 +44,7 @@ jobs:
             runs=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
               -H "Accept: application/vnd.github.v3+json" \
               "https://api.github.com/repos/${{ github.repository }}/actions/runs?head_sha=$PR_SHA" | \
-              jq -r '.workflow_runs[] // [] | select(.status == "pending" or .status == "waiting") | .id')
+              jq -r '(.workflow_runs // [])[] | select(.status == "pending" or .status == "waiting") | .id')
 
             if [[ -n "$runs" ]]; then
               echo "Found pending runs on attempt $attempt"


### PR DESCRIPTION
**Description of your changes:**
Adds retry logic to the ok-to-test-ci.yml workflow to handle race conditions when approving pending workflow runs.

**Problem**
When a fork PR with the ok-to-test label is synchronized (e.g., rebased), the approval workflow runs immediately but the triggered CI workflows may not yet be in "pending" status. The previous 5-second sleep was insufficient, causing the workflow to exit with "No workflow runs found requiring approval" even though runs were about to need approval.

**Solution**
Replace the single 5-second sleep with a retry loop:

6 attempts with 10-second intervals (60 seconds max wait)
Breaks early once pending runs are found
Provides clearer logging of retry attempts

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
