### PR TITLE
fix(ci): Fix step order in SDK client tests workflow

### DIFF
--- a/.github/workflows/kfp-sdk-client-tests.yml
+++ b/.github/workflows/kfp-sdk-client-tests.yml
@@ -77,6 +77,13 @@ jobs:
           pip install --upgrade pip
           pip install build==${{ env.PYTHON_BUILD_PKG_VERSION }}
 
+      - name: Install Test dependencies
+        run: |
+          pip install -r sdk/python/requirements.txt
+          pip install -r sdk/python/requirements-dev.txt
+          pip install pytest
+          pip install pytest-cov
+
       - name: Build & install kfp-server-api dist
         id: install-kfp-server-api
         shell: bash
@@ -85,13 +92,6 @@ jobs:
           rm -rf dist/
           python -m build .
           pip install dist/*.whl
-
-      - name: Install Test dependencies
-        run: |
-          pip install -r sdk/python/requirements.txt
-          pip install -r sdk/python/requirements-dev.txt
-          pip install pytest
-          pip install pytest-cov
 
       - name: Run tests
         id: tests


### PR DESCRIPTION
**Description of your changes:**

I've been running into issues with getting #12574 to pass the CI checks

Upon further investigation I found the workflow test was building and installing the local kfp-server-api wheel (2.15.2) before installing requirements.txt, which pins kfp-server-api==2.15.0. This caused pip to downgrade the local build back to the PyPI version:

```
Installing collected packages: kfp-server-api
    Attempting uninstall: kfp-server-api
      Found existing installation: kfp-server-api 2.15.2
      Uninstalling kfp-server-api-2.15.2:
        Successfully uninstalled kfp-server-api-2.15.2
    Successfully installed kfp-server-api-2.15.0
```

This breaks tests for PRs that add new models to the API client, since the downgraded PyPI version doesn't contain them:
```
  ModuleNotFoundError: No module named 'kfp_server_api.models.v2beta1_delete_propagation_policy'
```
Swapping the order ensures the local wheel is installed after requirements, so it upgrades over the pinned version and includes any new models from the PR

**Testing Evidence:**

I also made this exact same change in #12574 ([here](https://github.com/kubeflow/pipelines/pull/12574/files#diff-b2202c84203adabdd8b50a0df71367f8bd5a6a3685ae301af83cf84bdb63aadeR80-R86)), as soon as this change was made the PR is now passing all checks

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
