### PR TITLE
feat(#12169): Show retry attempts for pipeline tasks in UI

### DIFF
--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -242,9 +242,17 @@ function getTaskDetailsFields(
 
       const createdAt = new Date(execution.getCreateTimeSinceEpoch()).toString();
       details.push(['Created At', createdAt]);
-      
-      const retryCount = execution?.getCustomPropertiesMap().get('retry_count')?.getStringValue() || '0';
-      const maxRetries = execution?.getCustomPropertiesMap().get('max_retries')?.getStringValue() || '∞';
+
+      const retryCount =
+        execution
+          ?.getCustomPropertiesMap()
+          .get('retry_count')
+          ?.getStringValue() || '0';
+      const maxRetries =
+        execution
+          ?.getCustomPropertiesMap()
+          .get('max_retries')
+          ?.getStringValue() || '∞';
       details.push(['Retry Attempts', `${retryCount}/${maxRetries}`]);
 
       const lastUpdatedTime = execution.getLastUpdateTimeSinceEpoch();


### PR DESCRIPTION
**Description of your changes:**

Added "Retry Attempts" field to Task Details table in `RuntimeNodeDetailsV2.tsx`.

Displays `retry_count/max_retries` from execution custom properties for pipeline tasks with `.set_retry()`. 

Addresses core #12169 request: makes retry information visible in Run Details UI.

**Before:** Only final attempt shown  
**After:** `Retry Attempts: 2/3` in Task Details table[1]

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://[github](https://github.com/kubeflow/pipelines/issues/12169).com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

/area frontend

Closes #12169