### PR TITLE
feat(sdk): add support for Literal input parameters in compiler

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -19,7 +19,7 @@ import re
 import subprocess
 import tempfile
 import textwrap
-from typing import Any, Dict, List, NamedTuple, Optional
+from typing import Any, Dict, List, Literal, NamedTuple, Optional
 import unittest
 
 from absl.testing import parameterized
@@ -186,6 +186,53 @@ def print_artifact(a: Input[Artifact]):
 
 
 class TestCompilePipeline(parameterized.TestCase):
+
+    def test_compile_pipeline_with_literal_input_valid(self):
+
+        @dsl.component
+        def literal_component(literal_param: Literal['a', 'b']):
+            print_op(message=literal_param)
+
+        @dsl.pipeline(name='test-literal-pipeline')
+        def literal_pipeline():
+            literal_component(literal_param='a')
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_file = os.path.join(tmpdir, 'result.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=literal_pipeline,
+                package_path=target_file,
+            )
+            self.assertTrue(os.path.exists(target_file))
+            with open(target_file) as f:
+                data = yaml.safe_load(f)
+            param = data['components']['comp-literal-component'][
+                'inputDefinitions']['parameters']['literal_param']
+            self.assertIn('literals', param)
+            self.assertEqual(param['literals'], ['a', 'b'])
+
+    def test_compile_pipeline_with_literal_input_mixed_types_invalid(self):
+        # Mixed-type Literal should be rejected at component definition time
+        with self.assertRaises(TypeError):
+
+            @dsl.component
+            def literal_component_with_mixed_types(literal_param: Literal[1, 2,
+                                                                          'a']):
+                print_op(message=literal_param)
+
+    def test_compile_pipeline_with_literal_input_invalid_value(self):
+        # Compilation should fail when a constant argument is not in the allowed Literal set
+        @dsl.component
+        def literal_component(literal_param: Literal['a', 'b']):
+            print_op(message=literal_param)
+
+        # The validation happens when the pipeline is defined (not during compile)
+        # because the invalid value is detected when calling the component
+        with self.assertRaises(type_utils.InconsistentTypeException):
+
+            @dsl.pipeline(name='test-literal-pipeline-invalid')
+            def literal_pipeline():
+                literal_component(literal_param='c')
 
     def test_can_use_dsl_attribute_on_kfp(self):
 

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -234,6 +234,19 @@ class TestCompilePipeline(parameterized.TestCase):
             def literal_pipeline():
                 literal_component(literal_param='c')
 
+    def test_compile_pipeline_with_disjoint_literal_channel_raises(self):
+        # Fix 3: pipeline input Literal['c'] wired into component Literal['a','b'] must raise
+
+        @dsl.component(base_image='python:3.11')
+        def consume(x: Literal['a', 'b']):
+            pass
+
+        with self.assertRaises(type_utils.InconsistentTypeException):
+
+            @dsl.pipeline(name='test-disjoint-literal-pipeline')
+            def p(x: Literal['c']):
+                consume(x=x)
+
     def test_can_use_dsl_attribute_on_kfp(self):
 
         @kfp.dsl.pipeline
@@ -470,7 +483,7 @@ class TestCompilePipeline(parameterized.TestCase):
 
         @dsl.pipeline(description='Prefer me.')
         def my_pipeline():
-            """Don't prefer me"""
+            """Don't prefer me."""
             VALID_PRODUCER_COMPONENT_SAMPLE(input_param='input')
 
         self.assertEqual(my_pipeline.pipeline_spec.pipeline_info.description,
@@ -492,7 +505,8 @@ class TestCompilePipeline(parameterized.TestCase):
         def my_pipeline():
             """Docstring-specified description.
 
-            More information about this pipeline."""
+            More information about this pipeline.
+            """
             VALID_PRODUCER_COMPONENT_SAMPLE(input_param='input')
 
         self.assertEqual(
@@ -2887,6 +2901,7 @@ class TestYamlComments(unittest.TestCase):
                 sample_input1: bool = True,
                 sample_input2: str = 'string') -> str:
             """docstring short description.
+
             docstring long description. docstring long description.
             """
             op1 = my_comp(string=sample_input2, model=sample_input1)
@@ -2913,10 +2928,9 @@ class TestYamlComments(unittest.TestCase):
         def pipeline_with_multiline_definition(
                 sample_input1: bool = True,
                 sample_input2: str = 'string') -> str:
-            """
-            docstring long description.
-            docstring long description.
-            docstring long description.
+            """docstring long description.
+
+            docstring long description. docstring long description.
             """
             op1 = my_comp(string=sample_input2, model=sample_input1)
             result = op1.output
@@ -2945,8 +2959,8 @@ class TestYamlComments(unittest.TestCase):
         def my_pipeline(sample_input1: bool = True,
                         sample_input2: str = 'string') -> str:
             """docstring short description.
-            docstring long description.
-            docstring long description.
+
+            docstring long description. docstring long description.
             """
             op1 = my_comp(string=sample_input2, model=sample_input1)
             result = op1.output
@@ -4512,7 +4526,8 @@ class TestPlatformConfig(unittest.TestCase):
 
     def test_compile_fails_when_workspace_placeholder_used_without_workspace_config(
             self):
-        """Tests that compilation fails if placeholder is used and no workspace configured."""
+        """Tests that compilation fails if placeholder is used and no workspace
+        configured."""
 
         @dsl.component
         def uses_workspace(workspace_path: str) -> str:
@@ -4540,7 +4555,8 @@ class TestPlatformConfig(unittest.TestCase):
 
     def test_compile_fails_when_workspace_placeholder_used_in_nested_groups_without_workspace_config(
             self):
-        """Tests that compilation fails if placeholder is used within nested groups and no workspace configured."""
+        """Tests that compilation fails if placeholder is used within nested
+        groups and no workspace configured."""
 
         import os
         import tempfile
@@ -4580,7 +4596,8 @@ class TestPlatformConfig(unittest.TestCase):
 
     def test_compile_fails_when_importer_download_to_workspace_without_workspace_config(
             self):
-        """Tests that compilation fails if importer uses download_to_workspace without workspace config."""
+        """Tests that compilation fails if importer uses download_to_workspace
+        without workspace config."""
 
         import os
         import tempfile
@@ -4609,7 +4626,8 @@ class TestPlatformConfig(unittest.TestCase):
 
     def test_compile_succeeds_when_importer_download_to_workspace_with_workspace_config(
             self):
-        """Tests that compilation succeeds with both download_to_workspace and workspace config."""
+        """Tests that compilation succeeds with both download_to_workspace and
+        workspace config."""
 
         import os
         import tempfile
@@ -4635,7 +4653,8 @@ class TestPlatformConfig(unittest.TestCase):
             self.assertTrue(os.path.exists(output_yaml))
 
     def test_pipeline_with_ttl_seconds_after_finished(self):
-        """ttl_seconds_after_finished → resource_ttl_on_completion (SecondsAfterCompletion)."""
+        """ttl_seconds_after_finished → resource_ttl_on_completion
+        (SecondsAfterCompletion)."""
 
         @dsl.pipeline(
             pipeline_config=dsl.PipelineConfig(ttl_seconds_after_finished=300))
@@ -4654,7 +4673,8 @@ class TestPlatformConfig(unittest.TestCase):
         self.assertEqual(loaded_pipeline.platform_spec, expected)
 
     def test_pipeline_with_ttl_seconds_after_success(self):
-        """ttl_seconds_after_success → resource_ttl_on_success (SecondsAfterSuccess)."""
+        """ttl_seconds_after_success → resource_ttl_on_success
+        (SecondsAfterSuccess)."""
 
         @dsl.pipeline(
             pipeline_config=dsl.PipelineConfig(ttl_seconds_after_success=600))
@@ -4672,7 +4692,8 @@ class TestPlatformConfig(unittest.TestCase):
         self.assertEqual(loaded_pipeline.platform_spec, expected)
 
     def test_pipeline_with_ttl_seconds_after_failure(self):
-        """ttl_seconds_after_failure → resource_ttl_on_failure (SecondsAfterFailure)."""
+        """ttl_seconds_after_failure → resource_ttl_on_failure
+        (SecondsAfterFailure)."""
 
         @dsl.pipeline(
             pipeline_config=dsl.PipelineConfig(ttl_seconds_after_failure=120))
@@ -4716,9 +4737,10 @@ class TestPlatformConfig(unittest.TestCase):
     def test_pipeline_with_ttl_zero(self):
         """TTL of 0 is accepted but treated as "not set" and not serialized.
 
-        A value of 0 is indistinguishable from the proto3 int32 default, so the
-        serializer skips it.  The resulting platform spec contains no
-        pipelineConfig entry at all, identical to not setting a TTL.
+        A value of 0 is indistinguishable from the proto3 int32 default,
+        so the serializer skips it.  The resulting platform spec
+        contains no pipelineConfig entry at all, identical to not
+        setting a TTL.
         """
 
         @dsl.pipeline(
@@ -4804,7 +4826,8 @@ class TestPlatformConfig(unittest.TestCase):
         self.assertEqual(loaded_pipeline.platform_spec, expected)
 
     def test_pipeline_with_active_deadline_none_omits_field(self):
-        """active_deadline_seconds=None (default) produces no platform spec entry."""
+        """active_deadline_seconds=None (default) produces no platform spec
+        entry."""
 
         @dsl.pipeline(
             pipeline_config=dsl.PipelineConfig(active_deadline_seconds=None))
@@ -5074,7 +5097,7 @@ class ExtractInputOutputDescription(unittest.TestCase):
             string: str,
             in_artifact: Input[Artifact],
         ) -> Outputs:
-            """Pipeline description. Returns
+            """Pipeline description. Returns.
 
             Args:
                 string: Return Pipeline input string. Returns
@@ -5537,7 +5560,9 @@ class TestDslOneOf(unittest.TestCase):
     # To help narrow the tests further (we already test lots of aspects in the following cases), we choose focus on the dsl.OneOf behavior, not the conditional logic if If/Elif/Else. This is more verbose, but more maintainable and the behavior under test is clearer.
 
     def test_if_else_returned(self):
-        """Uses If and Else branches, parameters passed to dsl.OneOf, dsl.OneOf returned from a pipeline, and different output keys on dsl.OneOf channels."""
+        """Uses If and Else branches, parameters passed to dsl.OneOf, dsl.OneOf
+        returned from a pipeline, and different output keys on dsl.OneOf
+        channels."""
 
         @dsl.pipeline
         def roll_die_pipeline() -> str:
@@ -5598,7 +5623,9 @@ class TestDslOneOf(unittest.TestCase):
         )
 
     def test_if_elif_else_returned(self):
-        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf, dsl.OneOf returned from a pipeline, and different output keys on dsl.OneOf channels."""
+        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf,
+        dsl.OneOf returned from a pipeline, and different output keys on
+        dsl.OneOf channels."""
 
         @dsl.pipeline
         def roll_die_pipeline() -> str:
@@ -5673,7 +5700,9 @@ class TestDslOneOf(unittest.TestCase):
         )
 
     def test_if_elif_else_consumed(self):
-        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf, dsl.OneOf passed to a consumer task, and different output keys on dsl.OneOf channels."""
+        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf,
+        dsl.OneOf passed to a consumer task, and different output keys on
+        dsl.OneOf channels."""
 
         @dsl.pipeline
         def roll_die_pipeline():
@@ -5750,7 +5779,9 @@ class TestDslOneOf(unittest.TestCase):
         )
 
     def test_if_else_consumed_and_returned(self):
-        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf, and dsl.OneOf passed to a consumer task and returned from the pipeline."""
+        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf,
+        and dsl.OneOf passed to a consumer task and returned from the
+        pipeline."""
 
         @dsl.pipeline
         def flip_coin_pipeline() -> str:
@@ -5823,7 +5854,8 @@ class TestDslOneOf(unittest.TestCase):
         )
 
     def test_if_else_consumed_and_returned_artifacts(self):
-        """Uses If, Elif, and Else branches, artifacts passed to dsl.OneOf, and dsl.OneOf passed to a consumer task and returned from the pipeline."""
+        """Uses If, Elif, and Else branches, artifacts passed to dsl.OneOf, and
+        dsl.OneOf passed to a consumer task and returned from the pipeline."""
 
         @dsl.pipeline
         def flip_coin_pipeline() -> Artifact:
@@ -5990,7 +6022,8 @@ class TestDslOneOf(unittest.TestCase):
                                      print_task_2.outputs['a'])
 
     def test_deeply_nested_consumed(self):
-        """Uses If, Elif, Else, and OneOf deeply nested within multiple dub-DAGs."""
+        """Uses If, Elif, Else, and OneOf deeply nested within multiple dub-
+        DAGs."""
 
         @dsl.pipeline
         def flip_coin_pipeline(execute_pipeline: bool):
@@ -6089,7 +6122,8 @@ class TestDslOneOf(unittest.TestCase):
                                  print_task_2.outputs['a'])
 
     def test_oneof_in_condition(self):
-        """Tests that dsl.OneOf's channel can be consumed in a downstream group nested one level"""
+        """Tests that dsl.OneOf's channel can be consumed in a downstream group
+        nested one level."""
 
         @dsl.pipeline
         def roll_die_pipeline(repeat_on: str = 'Got heads!'):
@@ -6142,7 +6176,8 @@ class TestDslOneOf(unittest.TestCase):
         )
 
     def test_consumed_in_nested_groups(self):
-        """Tests that dsl.OneOf's channel can be consumed in a downstream group nested multiple levels"""
+        """Tests that dsl.OneOf's channel can be consumed in a downstream group
+        nested multiple levels."""
 
         @dsl.pipeline
         def roll_die_pipeline(

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -2930,7 +2930,8 @@ class TestYamlComments(unittest.TestCase):
                 sample_input2: str = 'string') -> str:
             """docstring long description.
 
-            docstring long description. docstring long description.
+            docstring long description.
+            docstring long description.
             """
             op1 = my_comp(string=sample_input2, model=sample_input1)
             result = op1.output
@@ -2960,7 +2961,8 @@ class TestYamlComments(unittest.TestCase):
                         sample_input2: str = 'string') -> str:
             """docstring short description.
 
-            docstring long description. docstring long description.
+            docstring long description.
+            docstring long description.
             """
             op1 = my_comp(string=sample_input2, model=sample_input1)
             result = op1.output

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -483,7 +483,7 @@ class TestCompilePipeline(parameterized.TestCase):
 
         @dsl.pipeline(description='Prefer me.')
         def my_pipeline():
-            """Don't prefer me."""
+            """Don't prefer me"""
             VALID_PRODUCER_COMPONENT_SAMPLE(input_param='input')
 
         self.assertEqual(my_pipeline.pipeline_spec.pipeline_info.description,
@@ -505,8 +505,7 @@ class TestCompilePipeline(parameterized.TestCase):
         def my_pipeline():
             """Docstring-specified description.
 
-            More information about this pipeline.
-            """
+            More information about this pipeline."""
             VALID_PRODUCER_COMPONENT_SAMPLE(input_param='input')
 
         self.assertEqual(
@@ -2901,7 +2900,6 @@ class TestYamlComments(unittest.TestCase):
                 sample_input1: bool = True,
                 sample_input2: str = 'string') -> str:
             """docstring short description.
-
             docstring long description. docstring long description.
             """
             op1 = my_comp(string=sample_input2, model=sample_input1)
@@ -2928,8 +2926,8 @@ class TestYamlComments(unittest.TestCase):
         def pipeline_with_multiline_definition(
                 sample_input1: bool = True,
                 sample_input2: str = 'string') -> str:
-            """docstring long description.
-
+            """
+            docstring long description.
             docstring long description.
             docstring long description.
             """
@@ -2960,7 +2958,6 @@ class TestYamlComments(unittest.TestCase):
         def my_pipeline(sample_input1: bool = True,
                         sample_input2: str = 'string') -> str:
             """docstring short description.
-
             docstring long description.
             docstring long description.
             """
@@ -4528,8 +4525,7 @@ class TestPlatformConfig(unittest.TestCase):
 
     def test_compile_fails_when_workspace_placeholder_used_without_workspace_config(
             self):
-        """Tests that compilation fails if placeholder is used and no workspace
-        configured."""
+        """Tests that compilation fails if placeholder is used and no workspace configured."""
 
         @dsl.component
         def uses_workspace(workspace_path: str) -> str:
@@ -4557,8 +4553,7 @@ class TestPlatformConfig(unittest.TestCase):
 
     def test_compile_fails_when_workspace_placeholder_used_in_nested_groups_without_workspace_config(
             self):
-        """Tests that compilation fails if placeholder is used within nested
-        groups and no workspace configured."""
+        """Tests that compilation fails if placeholder is used within nested groups and no workspace configured."""
 
         import os
         import tempfile
@@ -4598,8 +4593,7 @@ class TestPlatformConfig(unittest.TestCase):
 
     def test_compile_fails_when_importer_download_to_workspace_without_workspace_config(
             self):
-        """Tests that compilation fails if importer uses download_to_workspace
-        without workspace config."""
+        """Tests that compilation fails if importer uses download_to_workspace without workspace config."""
 
         import os
         import tempfile
@@ -4628,8 +4622,7 @@ class TestPlatformConfig(unittest.TestCase):
 
     def test_compile_succeeds_when_importer_download_to_workspace_with_workspace_config(
             self):
-        """Tests that compilation succeeds with both download_to_workspace and
-        workspace config."""
+        """Tests that compilation succeeds with both download_to_workspace and workspace config."""
 
         import os
         import tempfile
@@ -4655,8 +4648,7 @@ class TestPlatformConfig(unittest.TestCase):
             self.assertTrue(os.path.exists(output_yaml))
 
     def test_pipeline_with_ttl_seconds_after_finished(self):
-        """ttl_seconds_after_finished → resource_ttl_on_completion
-        (SecondsAfterCompletion)."""
+        """ttl_seconds_after_finished → resource_ttl_on_completion (SecondsAfterCompletion)."""
 
         @dsl.pipeline(
             pipeline_config=dsl.PipelineConfig(ttl_seconds_after_finished=300))
@@ -4675,8 +4667,7 @@ class TestPlatformConfig(unittest.TestCase):
         self.assertEqual(loaded_pipeline.platform_spec, expected)
 
     def test_pipeline_with_ttl_seconds_after_success(self):
-        """ttl_seconds_after_success → resource_ttl_on_success
-        (SecondsAfterSuccess)."""
+        """ttl_seconds_after_success → resource_ttl_on_success (SecondsAfterSuccess)."""
 
         @dsl.pipeline(
             pipeline_config=dsl.PipelineConfig(ttl_seconds_after_success=600))
@@ -4694,8 +4685,7 @@ class TestPlatformConfig(unittest.TestCase):
         self.assertEqual(loaded_pipeline.platform_spec, expected)
 
     def test_pipeline_with_ttl_seconds_after_failure(self):
-        """ttl_seconds_after_failure → resource_ttl_on_failure
-        (SecondsAfterFailure)."""
+        """ttl_seconds_after_failure → resource_ttl_on_failure (SecondsAfterFailure)."""
 
         @dsl.pipeline(
             pipeline_config=dsl.PipelineConfig(ttl_seconds_after_failure=120))
@@ -4739,10 +4729,9 @@ class TestPlatformConfig(unittest.TestCase):
     def test_pipeline_with_ttl_zero(self):
         """TTL of 0 is accepted but treated as "not set" and not serialized.
 
-        A value of 0 is indistinguishable from the proto3 int32 default,
-        so the serializer skips it.  The resulting platform spec
-        contains no pipelineConfig entry at all, identical to not
-        setting a TTL.
+        A value of 0 is indistinguishable from the proto3 int32 default, so the
+        serializer skips it.  The resulting platform spec contains no
+        pipelineConfig entry at all, identical to not setting a TTL.
         """
 
         @dsl.pipeline(
@@ -4828,8 +4817,7 @@ class TestPlatformConfig(unittest.TestCase):
         self.assertEqual(loaded_pipeline.platform_spec, expected)
 
     def test_pipeline_with_active_deadline_none_omits_field(self):
-        """active_deadline_seconds=None (default) produces no platform spec
-        entry."""
+        """active_deadline_seconds=None (default) produces no platform spec entry."""
 
         @dsl.pipeline(
             pipeline_config=dsl.PipelineConfig(active_deadline_seconds=None))
@@ -5099,7 +5087,7 @@ class ExtractInputOutputDescription(unittest.TestCase):
             string: str,
             in_artifact: Input[Artifact],
         ) -> Outputs:
-            """Pipeline description. Returns.
+            """Pipeline description. Returns
 
             Args:
                 string: Return Pipeline input string. Returns
@@ -5562,9 +5550,7 @@ class TestDslOneOf(unittest.TestCase):
     # To help narrow the tests further (we already test lots of aspects in the following cases), we choose focus on the dsl.OneOf behavior, not the conditional logic if If/Elif/Else. This is more verbose, but more maintainable and the behavior under test is clearer.
 
     def test_if_else_returned(self):
-        """Uses If and Else branches, parameters passed to dsl.OneOf, dsl.OneOf
-        returned from a pipeline, and different output keys on dsl.OneOf
-        channels."""
+        """Uses If and Else branches, parameters passed to dsl.OneOf, dsl.OneOf returned from a pipeline, and different output keys on dsl.OneOf channels."""
 
         @dsl.pipeline
         def roll_die_pipeline() -> str:
@@ -5625,9 +5611,7 @@ class TestDslOneOf(unittest.TestCase):
         )
 
     def test_if_elif_else_returned(self):
-        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf,
-        dsl.OneOf returned from a pipeline, and different output keys on
-        dsl.OneOf channels."""
+        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf, dsl.OneOf returned from a pipeline, and different output keys on dsl.OneOf channels."""
 
         @dsl.pipeline
         def roll_die_pipeline() -> str:
@@ -5702,9 +5686,7 @@ class TestDslOneOf(unittest.TestCase):
         )
 
     def test_if_elif_else_consumed(self):
-        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf,
-        dsl.OneOf passed to a consumer task, and different output keys on
-        dsl.OneOf channels."""
+        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf, dsl.OneOf passed to a consumer task, and different output keys on dsl.OneOf channels."""
 
         @dsl.pipeline
         def roll_die_pipeline():
@@ -5781,9 +5763,7 @@ class TestDslOneOf(unittest.TestCase):
         )
 
     def test_if_else_consumed_and_returned(self):
-        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf,
-        and dsl.OneOf passed to a consumer task and returned from the
-        pipeline."""
+        """Uses If, Elif, and Else branches, parameters passed to dsl.OneOf, and dsl.OneOf passed to a consumer task and returned from the pipeline."""
 
         @dsl.pipeline
         def flip_coin_pipeline() -> str:
@@ -5856,8 +5836,7 @@ class TestDslOneOf(unittest.TestCase):
         )
 
     def test_if_else_consumed_and_returned_artifacts(self):
-        """Uses If, Elif, and Else branches, artifacts passed to dsl.OneOf, and
-        dsl.OneOf passed to a consumer task and returned from the pipeline."""
+        """Uses If, Elif, and Else branches, artifacts passed to dsl.OneOf, and dsl.OneOf passed to a consumer task and returned from the pipeline."""
 
         @dsl.pipeline
         def flip_coin_pipeline() -> Artifact:
@@ -6024,8 +6003,7 @@ class TestDslOneOf(unittest.TestCase):
                                      print_task_2.outputs['a'])
 
     def test_deeply_nested_consumed(self):
-        """Uses If, Elif, Else, and OneOf deeply nested within multiple dub-
-        DAGs."""
+        """Uses If, Elif, Else, and OneOf deeply nested within multiple dub-DAGs."""
 
         @dsl.pipeline
         def flip_coin_pipeline(execute_pipeline: bool):
@@ -6124,8 +6102,7 @@ class TestDslOneOf(unittest.TestCase):
                                  print_task_2.outputs['a'])
 
     def test_oneof_in_condition(self):
-        """Tests that dsl.OneOf's channel can be consumed in a downstream group
-        nested one level."""
+        """Tests that dsl.OneOf's channel can be consumed in a downstream group nested one level"""
 
         @dsl.pipeline
         def roll_die_pipeline(repeat_on: str = 'Got heads!'):
@@ -6178,8 +6155,7 @@ class TestDslOneOf(unittest.TestCase):
         )
 
     def test_consumed_in_nested_groups(self):
-        """Tests that dsl.OneOf's channel can be consumed in a downstream group
-        nested multiple levels."""
+        """Tests that dsl.OneOf's channel can be consumed in a downstream group nested multiple levels"""
 
         @dsl.pipeline
         def roll_die_pipeline(

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -417,6 +417,11 @@ def _build_component_spec_from_component_spec_structure(
             if input_spec.description:
                 component_spec.input_definitions.parameters[
                     input_name].description = input_spec.description
+            if input_spec.literals:
+                for literal_value in input_spec.literals:
+                    component_spec.input_definitions.parameters[
+                        input_name].literals.append(
+                            to_protobuf_value(literal_value))
 
         else:
             component_spec.input_definitions.artifacts[

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -311,10 +311,9 @@ def get_name_to_specs(
 
         # parameter type
         else:
-            type_string = type_utils._annotation_to_type_struct(annotation)
             name_to_input_specs[maybe_make_unique(
                 name, list(name_to_input_specs))] = make_input_spec(
-                    type_string, func_param)
+                    annotation, func_param)
 
     ### handle return annotations ###
     return_ann = signature.return_annotation
@@ -343,7 +342,11 @@ def get_name_to_specs(
             if not type_annotations.is_list_of_artifacts(
                     annotation) and not type_annotations.is_artifact_class(
                         annotation):
-                annotation = type_utils._annotation_to_type_struct(annotation)
+                result = type_utils._annotation_to_type_struct(annotation)
+                if isinstance(result, tuple):
+                    annotation, _ = result
+                else:
+                    annotation = result
             name_to_output_specs[maybe_make_unique(
                 name,
                 list(name_to_output_specs))] = make_output_spec(annotation)
@@ -355,8 +358,12 @@ def get_name_to_specs(
             ' 0.1.32. Please use typing.NamedTuple to declare multiple'
             ' outputs.', DeprecationWarning)
         for output_name, output_type_annotation in return_ann.items():
-            output_type = type_utils._annotation_to_type_struct(
+            result = type_utils._annotation_to_type_struct(
                 output_type_annotation)
+            if isinstance(result, tuple):
+                output_type, _ = result
+            else:
+                output_type = result
             name_to_output_specs[maybe_make_unique(
                 output_name, list(name_to_output_specs))] = output_type
     # is the simple single return case (can be `-> <param>` or `-> Artifact`)
@@ -385,17 +392,30 @@ def make_input_output_spec_args(annotation: Any) -> Dict[str, Any]:
     if is_artifact_list:
         annotation = type_annotations.get_inner_type(annotation)
 
+    literals = None
+
     if type_annotations.issubclass_of_artifact(annotation):
         typ = type_utils.create_bundled_artifact_type(annotation.schema_title,
                                                       annotation.schema_version)
     else:
-        typ = type_utils._annotation_to_type_struct(annotation)
-    return {'type': typ, 'is_artifact_list': is_artifact_list}
+        result = type_utils._annotation_to_type_struct(annotation)
+        # _annotation_to_type_struct returns (type_struct, literals) for Literal types
+        # and just type_struct for other types
+        if isinstance(result, tuple):
+            typ, literals = result
+        else:
+            typ = result
+    return {
+        'type': typ,
+        'is_artifact_list': is_artifact_list,
+        'literals': literals,
+    }
 
 
 def make_output_spec(annotation: Any) -> structures.OutputSpec:
     annotation = canonicalize_annotation(annotation)
     args = make_input_output_spec_args(annotation)
+    args.pop('literals', None)
     return structures.OutputSpec(**args)
 
 

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -435,6 +435,12 @@ def make_input_spec(annotation: Any,
     default = None if inspect_param.default == inspect.Parameter.empty or type_annotations.issubclass_of_artifact(
         annotation) else inspect_param.default
 
+    literals = input_output_spec_args.get('literals')
+    if literals is not None and default is not None and default not in literals:
+        raise ValueError(
+            f'Default value {default!r} is not one of the allowed Literal values {literals!r}.'
+        )
+
     optional = (
         inspect_param.default is not inspect.Parameter.empty or
         type_utils.is_task_final_status_type(
@@ -881,8 +887,15 @@ def make_input_for_parameterized_container_component_function(
             # Treat as STRUCT for IR and use reserved input name at runtime.
             placeholder._ir_type = 'STRUCT'
         else:
+            # Normalize annotation: for Literal types, _annotation_to_type_struct
+            # returns (type_struct, literals); unwrap to get the plain type string.
+            result = type_utils._annotation_to_type_struct(annotation)
+            if isinstance(result, tuple):
+                type_struct, _ = result
+            else:
+                type_struct = result
             placeholder._ir_type = type_utils.get_parameter_type_name(
-                annotation)
+                type_struct)
         return placeholder
 
 

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -14,6 +14,12 @@
 
 import re
 from typing import List
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 import unittest
 
 from kfp import dsl
@@ -409,6 +415,34 @@ class TestPythonEOLWarning(unittest.TestCase):
             @dsl.component
             def foo():
                 pass
+
+
+class TestLiteralParameterFixes(unittest.TestCase):
+
+    def test_literal_default_valid(self):
+        # Fix 1: valid default should not raise
+        @dsl.component(base_image='python:3.11')
+        def comp(x: Literal['a', 'b'] = 'a'):
+            pass
+
+        self.assertEqual(comp.component_spec.inputs['x'].default, 'a')
+        self.assertEqual(comp.component_spec.inputs['x'].literals, ['a', 'b'])
+
+    def test_literal_default_invalid_raises(self):
+        # Fix 1: default outside allowed set must raise at definition time
+        with self.assertRaises(ValueError):
+
+            @dsl.component(base_image='python:3.11')
+            def comp(x: Literal['a', 'b'] = 'c'):
+                pass
+
+    def test_container_component_with_literal_input(self):
+        # Fix 4: container_component with Literal input must not raise
+        @dsl.container_component
+        def cc(x: Literal['a', 'b']):
+            return dsl.ContainerSpec(image='alpine', command=['echo', x])
+
+        self.assertEqual(cc.component_spec.inputs['x'].literals, ['a', 'b'])
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/dsl/graph_component.py
+++ b/sdk/python/kfp/dsl/graph_component.py
@@ -57,6 +57,7 @@ class GraphComponent(base_component.BaseComponent):
                     name=arg_name,
                     channel_type=input_spec.type,
                     is_artifact_list=input_spec.is_artifact_list,
+                    literals=getattr(input_spec, 'literals', None),
                 ))
 
         with pipeline_context.Pipeline(

--- a/sdk/python/kfp/dsl/pipeline_channel.py
+++ b/sdk/python/kfp/dsl/pipeline_channel.py
@@ -211,6 +211,7 @@ class PipelineParameterChannel(PipelineChannel):
         channel_type: Union[str, Dict],
         task_name: Optional[str] = None,
         value: Optional[type_utils.PARAMETER_TYPES] = None,
+        literals: Optional[list] = None,
     ):
         """Initializes a PipelineArtifactChannel instance.
 
@@ -220,6 +221,7 @@ class PipelineParameterChannel(PipelineChannel):
           task_name: Optional; The name of the task that produces the pipeline
             channel.
           value: Optional; The actual value of the pipeline channel.
+          literals: Optional; Allowed Literal values for the channel.
 
         Raises:
           ValueError: If name or task_name contains invalid characters.
@@ -233,6 +235,7 @@ class PipelineParameterChannel(PipelineChannel):
             raise TypeError(f'{channel_type} is not a parameter type.')
 
         self.value = value
+        self.literals = literals
 
         super(PipelineParameterChannel, self).__init__(
             name=name,
@@ -513,6 +516,7 @@ def create_pipeline_channel(
     task_name: Optional[str] = None,
     value: Optional[type_utils.PARAMETER_TYPES] = None,
     is_artifact_list: bool = False,
+    literals: Optional[list] = None,
 ) -> PipelineChannel:
     """Creates a PipelineChannel object.
 
@@ -522,6 +526,7 @@ def create_pipeline_channel(
             PipelineParameterChannel or PipelineArtifactChannel
         task_name: Optional; the task that produced the channel.
         value: Optional; the realized value for a channel.
+        literals: Optional; allowed Literal values for the channel.
 
     Returns:
         A PipelineParameterChannel or PipelineArtifactChannel object.
@@ -532,6 +537,7 @@ def create_pipeline_channel(
             channel_type=channel_type,
             task_name=task_name,
             value=value,
+            literals=literals,
         )
     else:
         return PipelineArtifactChannel(

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -45,12 +45,19 @@ class InputSpec:
         type: The type of the input.
         default (optional): the default value for the input.
         optional: Wether the input is optional. An input is optional when it has an explicit default value.
+        literals (optional): list of allowed input values.
         is_artifact_list: True if `type` represents a list of the artifact type. Only applies when `type` is an artifact.
         description: Input description.
     """
     type: Union[str, dict]
     default: Optional[Any] = None
     optional: bool = False
+    literals: Optional[Union[
+        List[str],
+        List[int],
+        List[float],
+        List[bool],
+    ]] = None
     # This special flag for lists of artifacts allows type to be used the same way for list of artifacts and single artifacts. This is aligned with how IR represents lists of artifacts (same as for single artifacts), as well as simplifies downstream type handling/checking operations in the SDK since we don't need to parse the string `type` to determine if single artifact or list.
     is_artifact_list: bool = False
     description: Optional[str] = None
@@ -84,8 +91,12 @@ class InputSpec:
             # without isOptional=True
             optional = ir_component_inputs_dict.get(
                 'isOptional', 'defaultValue' in ir_component_inputs_dict)
+            literals = ir_component_inputs_dict.get('literals')
             return InputSpec(
-                type=type_, default=default_value, optional=optional)
+                type=type_,
+                default=default_value,
+                optional=optional,
+                literals=literals)
 
         else:
             type_ = ir_component_inputs_dict['artifactType']['schemaTitle']

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -374,7 +374,25 @@ def verify_type_compatibility(
         if literals is not None:
             # avoid circular import
             from kfp.dsl import pipeline_channel
-            if not isinstance(given_value, pipeline_channel.PipelineChannel):
+            if isinstance(given_value, pipeline_channel.PipelineChannel):
+                # Validate channel-to-channel: if the source channel also has
+                # literals, check that the source set is a subset of the expected.
+                channel_literals = getattr(given_value, 'literals', None)
+                if channel_literals is not None:
+                    incompatible = [
+                        v for v in channel_literals if v not in literals
+                    ]
+                    if incompatible:
+                        error_text = (
+                            error_message_prefix +
+                            f'Source Literal values {channel_literals!r} are not all in the allowed Literal values {literals!r}'
+                        )
+                        if raise_on_error:
+                            raise InconsistentTypeException(error_text)
+                        else:
+                            warnings.warn(InconsistentTypeWarning(error_text))
+                            types_are_compatible = False
+            else:
                 if given_value not in literals:
                     error_text = (
                         error_message_prefix +
@@ -384,6 +402,7 @@ def verify_type_compatibility(
                         raise InconsistentTypeException(error_text)
                     else:
                         warnings.warn(InconsistentTypeWarning(error_text))
+                        types_are_compatible = False
 
     return types_are_compatible
 

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -1008,5 +1008,102 @@ class TestGetCanonicalNameForOuterGeneric(parameterized.TestCase):
             type_utils.get_canonical_name_for_outer_generic(type_name))
 
 
+class TestLiteralTypeCompatibility(unittest.TestCase):
+
+    def test_literal_constant_valid(self):
+        spec = structures.InputSpec('String', literals=['a', 'b'])
+        self.assertTrue(
+            type_utils.verify_type_compatibility(
+                given_value='a',
+                expected_spec=spec,
+                error_message_prefix='',
+            ))
+
+    def test_literal_constant_invalid_raises(self):
+        spec = structures.InputSpec('String', literals=['a', 'b'])
+        with self.assertRaises(type_utils.InconsistentTypeException):
+            type_utils.verify_type_compatibility(
+                given_value='c',
+                expected_spec=spec,
+                error_message_prefix='',
+            )
+
+    def test_literal_constant_invalid_warn_only_returns_false(self):
+        # Fix 2: warn-only mode must return False, not True, on mismatch
+        spec = structures.InputSpec('String', literals=['a', 'b'])
+        import warnings
+        with warnings.catch_warnings(record=True):
+            result = type_utils.verify_type_compatibility(
+                given_value='c',
+                expected_spec=spec,
+                error_message_prefix='',
+                raise_on_error=False,
+            )
+        self.assertFalse(result)
+
+    def test_literal_channel_disjoint_sets_raises(self):
+        # Fix 3: pipeline channel with Literal['c'] into component Literal['a','b'] must raise
+        channel = pipeline_channel.PipelineParameterChannel(
+            name='x',
+            channel_type='String',
+            literals=['c'],
+        )
+        spec = structures.InputSpec('String', literals=['a', 'b'])
+        with self.assertRaises(type_utils.InconsistentTypeException):
+            type_utils.verify_type_compatibility(
+                given_value=channel,
+                expected_spec=spec,
+                error_message_prefix='',
+            )
+
+    def test_literal_channel_subset_valid(self):
+        # Fix 3: channel literals that are a subset of expected literals are valid
+        channel = pipeline_channel.PipelineParameterChannel(
+            name='x',
+            channel_type='String',
+            literals=['a'],
+        )
+        spec = structures.InputSpec('String', literals=['a', 'b'])
+        self.assertTrue(
+            type_utils.verify_type_compatibility(
+                given_value=channel,
+                expected_spec=spec,
+                error_message_prefix='',
+            ))
+
+    def test_literal_channel_no_literals_allowed(self):
+        # Channel without literals into a Literal-constrained spec is allowed
+        # (source Literal is unknown, so we can't reject it at compile time)
+        channel = pipeline_channel.PipelineParameterChannel(
+            name='x',
+            channel_type='String',
+        )
+        spec = structures.InputSpec('String', literals=['a', 'b'])
+        self.assertTrue(
+            type_utils.verify_type_compatibility(
+                given_value=channel,
+                expected_spec=spec,
+                error_message_prefix='',
+            ))
+
+    def test_literal_channel_disjoint_warn_only_returns_false(self):
+        # Fix 2+3: warn-only channel disjoint must return False
+        channel = pipeline_channel.PipelineParameterChannel(
+            name='x',
+            channel_type='String',
+            literals=['c'],
+        )
+        spec = structures.InputSpec('String', literals=['a', 'b'])
+        import warnings
+        with warnings.catch_warnings(record=True):
+            result = type_utils.verify_type_compatibility(
+                given_value=channel,
+                expected_spec=spec,
+                error_message_prefix='',
+                raise_on_error=False,
+            )
+        self.assertFalse(result)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/test/compilation/pipeline_compilation_test.py
+++ b/sdk/python/test/compilation/pipeline_compilation_test.py
@@ -210,6 +210,8 @@ from test_data.sdk_compiled_pipelines.valid.pipeline_with_importer import \
     my_pipeline as importer_pipeline
 from test_data.sdk_compiled_pipelines.valid.pipeline_with_importer_and_gcpc_types import \
     my_pipeline as pipeline_with_importer_and_gcpc_types
+from test_data.sdk_compiled_pipelines.valid.pipeline_with_literal_inputs import \
+    literal_pipeline
 from test_data.sdk_compiled_pipelines.valid.pipeline_with_loops_and_conditions import \
     my_pipeline as loops_and_conditions_pipeline
 from test_data.sdk_compiled_pipelines.valid.pipeline_with_metadata_fields import \
@@ -1126,6 +1128,13 @@ class TestPipelineCompilation:
                 pipeline_func_args=None,
                 compiled_file_name='placeholder_none_input_value.yaml',
                 expected_compiled_file_path=f'{_VALID_PIPELINE_FILES}/essential/placeholder_with_if_placeholder_none_input_value.yaml'
+            ),
+            TestData(
+                pipeline_name='literal-pipeline',
+                pipeline_func=literal_pipeline,
+                pipeline_func_args=None,
+                compiled_file_name='pipeline_with_literal_inputs.yaml',
+                expected_compiled_file_path=f'{_VALID_PIPELINE_FILES}/pipeline_with_literal_inputs.yaml'
             ),
         ],
         ids=str)

--- a/test_data/compiled-workflows/pipeline_with_literal_inputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_literal_inputs.yaml
@@ -1,0 +1,405 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: literal-pipeline-
+spec:
+  arguments:
+    parameters:
+    - name: components-cfb3af4f0325a031d788f28088a0c7e83e480be9a685f4caa2579417d16fc9a4
+      value: '{"executorLabel":"exec-literal-component","inputDefinitions":{"parameters":{"literal_param":{"literals":["a","b"],"parameterType":"STRING"}}}}'
+    - name: implementations-cfb3af4f0325a031d788f28088a0c7e83e480be9a685f4caa2579417d16fc9a4
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","literal_component"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.15.2'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        literal_component(literal_param: Literal[''a'', ''b'']):\n    print(literal_param)\n\n"],"image":"python:3.11"}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"literal-component":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-literal-component"},"inputs":{"parameters":{"literal_param":{"runtimeValue":{"constant":"a"}}}},"taskInfo":{"name":"literal-component"}}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - literal-pipeline
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      command:
+      - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: task-name
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata: {}
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+        name: executor
+        template: system-container-impl
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+    metadata: {}
+    name: system-container-executor
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher:latest
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+    metadata: {}
+    name: system-container-impl
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-cfb3af4f0325a031d788f28088a0c7e83e480be9a685f4caa2579417d16fc9a4}}'
+          - name: task
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-literal-component"},"inputs":{"parameters":{"literal_param":{"runtimeValue":{"constant":"a"}}}},"taskInfo":{"name":"literal-component"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-cfb3af4f0325a031d788f28088a0c7e83e480be9a685f4caa2579417d16fc9a4}}'
+          - name: task-name
+            value: literal-component
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: literal-component-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.literal-component-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.literal-component-driver.outputs.parameters.cached-decision}}'
+        depends: literal-component-driver.Succeeded
+        name: literal-component
+        template: system-container-executor
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - literal-pipeline
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: ""
+        name: task-name
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata: {}
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/test_data/compiled-workflows/pipeline_with_literal_inputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_literal_inputs.yaml
@@ -117,7 +117,9 @@ spec:
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: driver
     name: system-container-driver
     outputs:
       parameters:
@@ -224,7 +226,9 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: launcher
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -356,7 +360,9 @@ spec:
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: driver
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_literal_inputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_literal_inputs.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -294,6 +296,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/sdk_compiled_pipelines/valid/pipeline_with_literal_inputs.py
+++ b/test_data/sdk_compiled_pipelines/valid/pipeline_with_literal_inputs.py
@@ -1,0 +1,26 @@
+"""Pipeline used to validate successful compilation of Literal input parameters.
+
+This test ensures that pipelines using typing.Literal inputs compile correctly
+and produce stable IR output.
+"""
+
+from typing import Literal
+from kfp import dsl
+
+
+@dsl.component
+def literal_component(literal_param: Literal['a', 'b']):
+    print(literal_param)
+
+
+@dsl.pipeline(name='literal-pipeline')
+def literal_pipeline():
+    literal_component(literal_param='a')
+
+
+if __name__ == '__main__':
+    from kfp import compiler
+    compiler.Compiler().compile(
+        pipeline_func=literal_pipeline,
+        package_path=__file__.replace('.py', '.yaml'),
+    )

--- a/test_data/sdk_compiled_pipelines/valid/pipeline_with_literal_inputs.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/pipeline_with_literal_inputs.yaml
@@ -1,0 +1,62 @@
+# PIPELINE DEFINITION
+# Name: literal-pipeline
+components:
+  comp-literal-component:
+    executorLabel: exec-literal-component
+    inputDefinitions:
+      parameters:
+        literal_param:
+          literals:
+          - a
+          - b
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-literal-component:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - literal_component
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef literal_component(literal_param: Literal['a', 'b']):\n    print(literal_param)\n\
+          \n"
+        image: python:3.11
+pipelineInfo:
+  name: literal-pipeline
+root:
+  dag:
+    tasks:
+      literal-component:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-literal-component
+        inputs:
+          parameters:
+            literal_param:
+              runtimeValue:
+                constant: a
+        taskInfo:
+          name: literal-component
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.15.2


### PR DESCRIPTION
### What this PR does
Adds SDK compiler support for `typing.Literal` input parameters, enabling validation of allowed constant values and enforcing single-type Literal definitions.

### Key changes
- Extend `InputSpec` with `literals` field
- Parse `typing.Literal` annotations into `(type, literals)` during compilation
- Reject mixed-type Literal definitions at component definition time
- Validate constant inputs against allowed Literal values during type compatibility checks
- Add compiler unit tests covering valid and invalid Literal usage

### Scope
- SDK compiler only
- No runtime or backend changes

### Related
- Part of KEP-11385

Fixes #12601 