### PR TITLE
Recurring Runs Queue Throughput Optimization

### DIFF
--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -44,4 +44,4 @@ COPY --from=builder /bin/controller /bin/controller
 ENV NAMESPACE=""
 ENV LOG_LEVEL=info
 
-CMD ["/bin/sh", "-c", "/bin/controller --logtostderr=true --namespace=${NAMESPACE} --logLevel=${LOG_LEVEL} --clientQPS=${CLIENT_QPC:-5} --clientBurst=${CLIENT_BURST:-10} --metricsPort=${METRICS_PORT:-9090}"]
+CMD ["/bin/sh", "-c", "/bin/controller --logtostderr=true --namespace=${NAMESPACE} --logLevel=${LOG_LEVEL} --clientQPS=${CLIENT_QPS:-5} --clientBurst=${CLIENT_BURST:-10} --recurringRunResyncIntervalSeconds=${RESYNC_INTERVAL_SECONDS:-30} --metricsPort=${METRICS_PORT:-9090}"]

--- a/backend/src/crd/controller/scheduledworkflow/README.md
+++ b/backend/src/crd/controller/scheduledworkflow/README.md
@@ -1,0 +1,27 @@
+## Controller Flags
+
+The controller supports the following command-line flags:
+
+| Flag                                  | Description | Default |
+|---------------------------------------|-------------|---------|
+| `--logtostderr`                       | Log output to stderr instead of files. | `true` |
+| `--logLevel`                          | Defines the log level for the application. | `""` |
+| `--clientQPS`                         | Maximum queries per second to the Kubernetes API server. | `5` |
+| `--clientBurst`                       | Maximum burst for throttle from this client. | `10` |
+| `--recurringRunResyncIntervalSeconds` | Full resync interval in seconds for recurring run reconciliations. | `30` |
+| `--metricsPort`                       | The port for the metrics endpoint. | `9090` |
+
+## Prometheus Metrics
+
+The controller exposes the following Prometheus metrics:
+
+| Metric | Type | Description | Labels |
+|--------|------|-------------|--------|
+| `process_scheduled_workflow_duration_seconds` | Histogram | Duration of scheduled workflow handling in seconds. | `status` |
+| `scheduled_workflow_duration_operation_seconds` | Histogram | Duration of scheduled workflow handling by operation. | `operation`, `status` |
+| `scheduled_workflow_queue_size` | Gauge | Current number of workflows in the queue. | - |
+| `scheduled_workflow_throughput_total` | Counter | Total number of workflows processed (throughput). | - |
+
+### Example Usage
+
+These metrics are automatically registered with Prometheus using `promauto`. You can scrape them at the port specified by `--metricsPort` (default `9090`):

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -25,8 +25,10 @@ spec:
         env:
           - name: METRICS_PORT
             value: "9090"
-          - name: CLIENT_QPC
+          - name: CLIENT_QPS
             value: "10"
+          - name: "RESYNC_INTERVAL_SECONDS"
+            value: "30"
           - name: CLIENT_BURST
             value: "20"
           - name: LOG_LEVEL
@@ -40,6 +42,9 @@ spec:
               configMapKeyRef:
                 name: pipeline-install-config
                 key: cronScheduleTimezone
+        ports:
+          - name: http
+            containerPort: 9090
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true


### PR DESCRIPTION
**Description of your changes:**

Optimized the execution of recurring runs.
Previously, in the ScheduledWorkflow controller, every event-driven/full reconciliation unconditionally updated the corresponding ScheduledWorkflow. 
- Each update triggered another reconciliation of the same resource, which led to workqueue flooding when thousands of ScheduledWorkflows were present in the cluster.
- Additionally, mass updates of ScheduledWorkflows became a bottleneck due to excessive Kubernetes API server requests: update calls had 0.2–0.5s p95 latency under load. This bottleneck was further amplified by client-side QPS/Burst limits.

The fix [introduces](https://github.com/kubeflow/pipelines/pull/12610/files#diff-d773c400e6cc4d6bab184a77e5bc9a5801030a787a2c5704c4e6400f4a4355b3R657) a pre-update state comparison and skips no-op updates to the Kubernetes API, eliminating redundant writes.

According to the informer configuration, a full resync still runs every 30 seconds. During this resync, all ScheduledWorkflows are iterated to check whether it is time to trigger a new run.
This change does not alter or remove that behavior. Instead, it just eliminates unnecessary updates reconciliation, so the periodic full resync remains the single place where time-based scheduling logic is applied.

Additionally
-  added metrics to scheduledworkflow controller 
- made QPS/burst configurable parameters for the controller.

@juliusvonkohout 
