### PR TITLE
move temp CA bundle and cert env var logic ahead of downloadArtifacts()

### DIFF
--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -503,21 +503,6 @@ func execute(
 	publishLogs string,
 	customCAPath string,
 ) (*pipelinespec.ExecutorOutput, error) {
-	if err := downloadArtifacts(ctx, executorInput, bucket, bucketConfig, namespace, k8sClient); err != nil {
-		return nil, err
-	}
-
-	if err := prepareOutputFolders(executorInput); err != nil {
-		return nil, err
-	}
-
-	var writer io.Writer
-	if publishLogs == "true" {
-		writer = getLogWriter(executorInput.Outputs.GetArtifacts())
-	} else {
-		writer = os.Stdout
-	}
-
 	// If a custom CA path is input, append to system CA and save to a temp file for executor access.
 	if customCAPath != "" {
 		var caBundleTmpPath string
@@ -539,6 +524,20 @@ func execute(
 			glog.Errorf("Error setting SSL_CERT_FILE environment variable, %s", err.Error())
 		}
 
+	}
+	if err := downloadArtifacts(ctx, executorInput, bucket, bucketConfig, namespace, k8sClient); err != nil {
+		return nil, err
+	}
+
+	if err := prepareOutputFolders(executorInput); err != nil {
+		return nil, err
+	}
+
+	var writer io.Writer
+	if publishLogs == "true" {
+		writer = getLogWriter(executorInput.Outputs.GetArtifacts())
+	} else {
+		writer = os.Stdout
 	}
 
 	// Prepare command that will execute end user code.


### PR DESCRIPTION
**Description of your changes:**
Move code block that checks for custom CA Cert, executes `compileTempCABundleWithCustomCA` and adds cert env variables, so that this step executes before `downloadArtifacts()` executes. This is necessary for the case in which the object store serves over TLS, in order for `downloadArtifacts()` to execute successfully. 

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
