### PR TITLE
Add optional `just` command runner for developer convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,23 @@ Check out our AI Powered repo documentation on [DeepWiki](https://deepwiki.com/k
 
 Before you start contributing to Kubeflow Pipelines, read the guidelines in [How to Contribute](./CONTRIBUTING.md). To learn how to build and deploy Kubeflow Pipelines from source code, read the [developer guide](./developer_guide.md).
 
+### Optional `just` command runner
+
+For local developer convenience, this repository includes an optional [just](https://github.com/casey/just) command runner at the repo root. It provides short aliases for existing `make` targets and does not replace any CI or release workflows.
+
+To use it, install `just` and run, for example:
+
+```bash
+just           # list available recipes
+just backend-test
+just backend-images
+```
+
+Notes:
+
+* All `just` recipes are thin wrappers around existing `make` targets (for example, `make -C backend/src/v2 test`).
+* There is intentionally no generic `just build` or `just test` recipe; heavy or Docker-building flows are exposed only via explicitly named recipes such as `backend-images`.
+
 ## Kubeflow Pipelines Community
 
 ### Community Meeting

--- a/justfile
+++ b/justfile
@@ -1,0 +1,75 @@
+# Optional developer convenience commands for Kubeflow Pipelines
+#
+# These recipes are simple wrappers around existing Make targets.
+# They are entirely optional and are not used by CI.
+
+# Use a POSIX shell for consistency across platforms
+set shell := ["sh", "-cu"]
+
+# Default: show available recipes
+default:
+    @echo "Available recipes (run 'just <name>'):" \
+    && just --list
+
+# ---- High-level commands ----
+
+# NOTE:
+# - There is intentionally no generic `build` or `test` recipe.
+# - The backend `all` target builds multiple Docker images and must not be
+#   wired to a generic `just build`.
+
+# Explicitly build all backend container images (backend/Makefile: all -> image_all)
+backend-images:
+    make -C backend all
+
+# Backend Go unit tests for the v2 engine (backend/src/v2/Makefile: test)
+backend-test:
+    make -C backend/src/v2 test
+
+# ---- Backend helpers ----
+
+# Create a local standalone Kind cluster with KFP deployed
+kind-standalone:
+    make -C backend kind-cluster-agnostic
+
+# Create a local Kind cluster for API server development
+kind-dev:
+    make -C backend dev-kind-cluster
+
+# Backend lint and format (backend/Makefile)
+backend-lint:
+    make -C backend lint
+
+backend-format:
+    make -C backend format
+
+backend-lint-format:
+    make -C backend lint-and-format
+
+# Backend integration webhook tests
+backend-webhook-test:
+    make -C backend/test/integration test-webhook
+
+# ---- SDK / API / platform helpers ----
+
+# Build API v2alpha1 Go and Python artifacts (api/Makefile: all)
+api-protos:
+    make -C api all
+
+# Build Kubernetes platform Go and Python artifacts (kubernetes_platform/Makefile: all)
+kubernetes-platform-protos:
+    make -C kubernetes_platform all
+
+# Build SDK Python distribution artifacts (sdk/Makefile: python)
+sdk-build:
+    make -C sdk python
+
+# ---- Repo-wide tooling ----
+
+# Install Ginkgo test runner into ./bin (root Makefile)
+ginkgo:
+    make ginkgo
+
+# Check that generated files are up to date (root Makefile)
+check-diff:
+    make check-diff


### PR DESCRIPTION
Fixes  #12630

### What this PR does - 
- Adds a root-level `justfile` as an **optional** developer convenience
- Wraps existing Makefile targets using `make` / `make -C`
- Does **not** modify or remove any Makefiles
- Does **not** affect CI or existing workflows

### Notes
- No generic `build` or `test` recipe is provided intentionally
- Heavy Docker/Kind workflows are exposed only via explicitly named recipes
- All recipes were verified locally using `just -n`