### PR TITLE
test: add unit tests for k8s-helper kubernetes API functions

### DIFF
--- a/frontend/server/k8s-helper.test.ts
+++ b/frontend/server/k8s-helper.test.ts
@@ -11,7 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { TEST_ONLY as K8S_TEST_EXPORT } from './k8s-helper';
+import {
+  TEST_ONLY as K8S_TEST_EXPORT,
+  getPodLogs,
+  getPod,
+  getConfigMap,
+  listPodEvents,
+  getArgoWorkflow,
+  getK8sSecret,
+} from './k8s-helper';
 
 describe('k8s-helper', () => {
   describe('parseTensorboardLogDir', () => {
@@ -161,6 +169,316 @@ describe('k8s-helper', () => {
       const logdir = 'volume://artifact/other';
       expect(() => K8S_TEST_EXPORT.parseTensorboardLogDir(logdir, podTemplateSpec)).toThrowError(
         'Cannot find file "volume://artifact/other" in pod "unknown": volume "artifact" not mounted or volume "artifact" with subPath (which is prefix of other) not mounted',
+      );
+    });
+  });
+
+  describe('getPodLogs', () => {
+    let readNamespacedPodLogSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      readNamespacedPodLogSpy = jest.spyOn(K8S_TEST_EXPORT.k8sV1Client, 'readNamespacedPodLog');
+    });
+
+    afterEach(() => {
+      readNamespacedPodLogSpy.mockRestore();
+    });
+
+    it('returns pod logs when successful', async () => {
+      const mockLogs = 'container log output';
+      readNamespacedPodLogSpy.mockResolvedValue({ body: mockLogs });
+
+      const logs = await getPodLogs('test-pod', 'test-namespace', 'main');
+
+      expect(readNamespacedPodLogSpy).toHaveBeenCalledWith('test-pod', 'test-namespace', 'main');
+      expect(logs).toBe(mockLogs);
+    });
+
+    it('uses default container name "main" when not specified', async () => {
+      readNamespacedPodLogSpy.mockResolvedValue({ body: 'logs' });
+
+      await getPodLogs('test-pod', 'test-namespace');
+
+      expect(readNamespacedPodLogSpy).toHaveBeenCalledWith('test-pod', 'test-namespace', 'main');
+    });
+
+    it('returns empty string when response body is undefined', async () => {
+      readNamespacedPodLogSpy.mockResolvedValue({});
+
+      const logs = await getPodLogs('test-pod', 'test-namespace');
+
+      expect(logs).toBe('');
+    });
+
+    it('throws error when API call fails', async () => {
+      const errorBody = { message: 'Pod not found', code: 404 };
+      readNamespacedPodLogSpy.mockRejectedValue({ body: errorBody });
+
+      await expect(getPodLogs('nonexistent-pod', 'test-namespace')).rejects.toThrow(
+        JSON.stringify(errorBody),
+      );
+    });
+  });
+
+  describe('getPod', () => {
+    let readNamespacedPodSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      readNamespacedPodSpy = jest.spyOn(K8S_TEST_EXPORT.k8sV1Client, 'readNamespacedPod');
+    });
+
+    afterEach(() => {
+      readNamespacedPodSpy.mockRestore();
+    });
+
+    it('returns pod when found', async () => {
+      const mockPod = {
+        metadata: { name: 'test-pod', namespace: 'test-namespace' },
+        spec: { containers: [] },
+        status: { phase: 'Running' },
+      };
+      readNamespacedPodSpy.mockResolvedValue({ body: mockPod });
+
+      const [pod, error] = await getPod('test-pod', 'test-namespace');
+
+      expect(readNamespacedPodSpy).toHaveBeenCalledWith('test-pod', 'test-namespace');
+      expect(pod).toEqual(mockPod);
+      expect(error).toBeUndefined();
+    });
+
+    it('returns error when pod not found', async () => {
+      readNamespacedPodSpy.mockRejectedValue({ body: { message: 'not found' } });
+
+      const [pod, error] = await getPod('nonexistent-pod', 'test-namespace');
+
+      expect(pod).toBeUndefined();
+      expect(error).toEqual({
+        message: 'Could not get pod nonexistent-pod in namespace test-namespace',
+      });
+    });
+
+    it('returns invalid resource name error for invalid pod name', async () => {
+      readNamespacedPodSpy.mockRejectedValue({ body: { message: 'invalid' } });
+
+      const [pod, error] = await getPod('../invalid-name', 'test-namespace');
+
+      expect(pod).toBeUndefined();
+      expect(error).toEqual({ message: 'Invalid resource name' });
+    });
+
+    it('returns invalid resource name error for invalid namespace', async () => {
+      readNamespacedPodSpy.mockRejectedValue({ body: { message: 'invalid' } });
+
+      const [pod, error] = await getPod('test-pod', '../invalid-namespace');
+
+      expect(pod).toBeUndefined();
+      expect(error).toEqual({ message: 'Invalid resource name' });
+    });
+  });
+
+  describe('getConfigMap', () => {
+    let readNamespacedConfigMapSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      readNamespacedConfigMapSpy = jest.spyOn(
+        K8S_TEST_EXPORT.k8sV1Client,
+        'readNamespacedConfigMap',
+      );
+    });
+
+    afterEach(() => {
+      readNamespacedConfigMapSpy.mockRestore();
+    });
+
+    it('returns configmap when found', async () => {
+      const mockConfigMap = {
+        metadata: { name: 'test-config', namespace: 'test-namespace' },
+        data: { key1: 'value1', key2: 'value2' },
+      };
+      readNamespacedConfigMapSpy.mockResolvedValue({ body: mockConfigMap });
+
+      const [configMap, error] = await getConfigMap('test-config', 'test-namespace');
+
+      expect(readNamespacedConfigMapSpy).toHaveBeenCalledWith('test-config', 'test-namespace');
+      expect(configMap).toEqual(mockConfigMap);
+      expect(error).toBeUndefined();
+    });
+
+    it('returns error when configmap not found', async () => {
+      readNamespacedConfigMapSpy.mockRejectedValue({ body: { message: 'not found' } });
+
+      const [configMap, error] = await getConfigMap('nonexistent', 'test-namespace');
+
+      expect(configMap).toBeUndefined();
+      expect(error).toEqual({
+        message: 'Could not get configMap nonexistent in namespace test-namespace',
+      });
+    });
+
+    it('returns invalid resource name error for invalid configmap name', async () => {
+      readNamespacedConfigMapSpy.mockRejectedValue({ body: { message: 'invalid' } });
+
+      const [configMap, error] = await getConfigMap('../invalid', 'test-namespace');
+
+      expect(configMap).toBeUndefined();
+      expect(error).toEqual({ message: 'Invalid resource name' });
+    });
+
+    it('returns invalid resource name error for invalid namespace', async () => {
+      readNamespacedConfigMapSpy.mockRejectedValue({ body: { message: 'invalid' } });
+
+      const [configMap, error] = await getConfigMap('test-config', '../invalid');
+
+      expect(configMap).toBeUndefined();
+      expect(error).toEqual({ message: 'Invalid resource name' });
+    });
+  });
+
+  describe('listPodEvents', () => {
+    let listNamespacedEventSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      listNamespacedEventSpy = jest.spyOn(K8S_TEST_EXPORT.k8sV1Client, 'listNamespacedEvent');
+    });
+
+    afterEach(() => {
+      listNamespacedEventSpy.mockRestore();
+    });
+
+    it('returns events when successful', async () => {
+      const mockEvents = {
+        items: [
+          { message: 'Created container', reason: 'Created' },
+          { message: 'Started container', reason: 'Started' },
+        ],
+      };
+      listNamespacedEventSpy.mockResolvedValue({ body: mockEvents });
+
+      const [events, error] = await listPodEvents('test-pod', 'test-namespace');
+
+      expect(listNamespacedEventSpy).toHaveBeenCalledWith(
+        'test-namespace',
+        undefined,
+        undefined,
+        undefined,
+        'involvedObject.namespace=test-namespace,involvedObject.name=test-pod,involvedObject.kind=Pod',
+      );
+      expect(events).toEqual(mockEvents);
+      expect(error).toBeUndefined();
+    });
+
+    it('returns error when API call fails', async () => {
+      listNamespacedEventSpy.mockRejectedValue({ body: { message: 'forbidden' } });
+
+      const [events, error] = await listPodEvents('test-pod', 'test-namespace');
+
+      expect(events).toBeUndefined();
+      expect(error).toEqual({
+        message: 'Error when listing pod events for pod test-pod in namespace test-namespace',
+      });
+    });
+
+    it('returns invalid resource name error for invalid pod name', async () => {
+      listNamespacedEventSpy.mockRejectedValue({ body: { message: 'invalid' } });
+
+      const [events, error] = await listPodEvents('../invalid', 'test-namespace');
+
+      expect(events).toBeUndefined();
+      expect(error).toEqual({ message: 'Invalid resource name' });
+    });
+
+    it('returns invalid resource name error for invalid namespace', async () => {
+      listNamespacedEventSpy.mockRejectedValue({ body: { message: 'invalid' } });
+
+      const [events, error] = await listPodEvents('test-pod', '../invalid');
+
+      expect(events).toBeUndefined();
+      expect(error).toEqual({ message: 'Invalid resource name' });
+    });
+  });
+
+  describe('getArgoWorkflow', () => {
+    // Note: getArgoWorkflow requires serverNamespace which is read from
+    // /var/run/secrets/kubernetes.io/serviceaccount/namespace at module load time.
+    // In a non-cluster environment, this file doesn't exist so serverNamespace is undefined.
+    // These tests verify the namespace validation behavior and error handling.
+
+    it('throws error when serverNamespace is not available', async () => {
+      // This test verifies behavior when running outside a kubernetes cluster
+      await expect(getArgoWorkflow('test-workflow')).rejects.toThrow(
+        'Cannot get namespace from /var/run/secrets/kubernetes.io/serviceaccount/namespace',
+      );
+    });
+
+    // Additional tests for getArgoWorkflow would require running inside a k8s cluster
+    // or mocking the module initialization. The following behaviors are tested via
+    // integration tests (integration-tests/tensorboard.test.ts):
+    // - Returns workflow when found with 200 status
+    // - Throws error when status code is 400 or higher
+    // - Throws error when status code is null
+  });
+
+  describe('getK8sSecret', () => {
+    let readNamespacedSecretSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      readNamespacedSecretSpy = jest.spyOn(K8S_TEST_EXPORT.k8sV1Client, 'readNamespacedSecret');
+    });
+
+    afterEach(() => {
+      readNamespacedSecretSpy.mockRestore();
+    });
+
+    it('returns decoded secret value when found', async () => {
+      const secretValue = 'my-secret-value';
+      const base64Value = Buffer.from(secretValue).toString('base64');
+      readNamespacedSecretSpy.mockResolvedValue({
+        body: {
+          data: { 'secret-key': base64Value },
+        },
+      });
+
+      const result = await getK8sSecret('test-secret', 'secret-key', 'test-namespace');
+
+      expect(readNamespacedSecretSpy).toHaveBeenCalledWith('test-secret', 'test-namespace');
+      expect(result).toBe(secretValue);
+    });
+
+    it('returns empty string when secret key does not exist', async () => {
+      readNamespacedSecretSpy.mockResolvedValue({
+        body: {
+          data: { 'other-key': 'c29tZXRoaW5n' },
+        },
+      });
+
+      const result = await getK8sSecret('test-secret', 'nonexistent-key', 'test-namespace');
+
+      expect(result).toBe('');
+    });
+
+    it('returns empty string when data is undefined', async () => {
+      readNamespacedSecretSpy.mockResolvedValue({
+        body: {},
+      });
+
+      const result = await getK8sSecret('test-secret', 'secret-key', 'test-namespace');
+
+      expect(result).toBe('');
+    });
+
+    it('throws error when API call fails', async () => {
+      readNamespacedSecretSpy.mockRejectedValue(new Error('API error'));
+
+      await expect(getK8sSecret('test-secret', 'secret-key', 'test-namespace')).rejects.toThrow(
+        'API error',
+      );
+    });
+
+    it('throws error when no namespace is provided and serverNamespace is unavailable', async () => {
+      // This test verifies behavior when running outside a kubernetes cluster
+      // and no providedNamespace is given
+      await expect(getK8sSecret('test-secret', 'secret-key')).rejects.toThrow(
+        'Cannot get namespace from /var/run/secrets/kubernetes.io/serviceaccount/namespace',
       );
     });
   });


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for kubernetes client functions in `k8s-helper.ts` to improve test coverage ahead of the planned `@kubernetes/client-node` upgrade from 0.16.3 to 1.4.0.

### Tests added for:
- `getPodLogs`: success, default container, empty response, API errors
- `getPod`: success, not found, invalid resource name validation
- `getConfigMap`: success, not found, invalid resource name validation  
- `listPodEvents`: success, API errors, invalid resource name validation
- `getArgoWorkflow`: namespace validation
- `getK8sSecret`: base64 decoding, missing keys, empty data, API errors, namespace validation

### Coverage improvement for k8s-helper.ts:
| Metric | Before | After |
|--------|--------|-------|
| Statements | 72.66% | 90.64% |
| Branches | 54.23% | 84.74% |
| Functions | 68.42% | 100% |
| Lines | 71.54% | 90.24% |

## Test plan
- [x] All 33 k8s-helper tests pass
- [x] All 153 server tests pass
- [x] Tests follow existing project patterns (jest.spyOn on TEST_ONLY exports)