### PR TITLE
fix(manifests): remove unused kustomize vars causing build warnings

### DIFF
--- a/manifests/kustomize/base/installs/generic/kustomization.yaml
+++ b/manifests/kustomize/base/installs/generic/kustomization.yaml
@@ -9,34 +9,6 @@ resources:
 - mysql-secret.yaml
 vars:
 - fieldref:
-    fieldPath: metadata.namespace
-  name: kfp-namespace
-  objref:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: ml-pipeline
-- fieldref:
-    fieldPath: data.appName
-  name: kfp-app-name
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
-- fieldref:
-    fieldPath: data.appVersion
-  name: kfp-app-version
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
-- fieldref:
-    fieldPath: data.bucketName
-  name: kfp-artifact-bucket-name
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
-- fieldref:
     fieldPath: data.defaultPipelineRoot
   name: kfp-default-pipeline-root
   objref:

--- a/manifests/kustomize/base/installs/generic/postgres/kustomization.yaml
+++ b/manifests/kustomize/base/installs/generic/postgres/kustomization.yaml
@@ -9,34 +9,6 @@ resources:
 - postgres-secret-extended.yaml
 vars:
 - fieldref:
-    fieldPath: metadata.namespace
-  name: kfp-namespace
-  objref:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: ml-pipeline
-- fieldref:
-    fieldPath: data.appName
-  name: kfp-app-name
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
-- fieldref:
-    fieldPath: data.appVersion
-  name: kfp-app-version
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
-- fieldref:
-    fieldPath: data.bucketName
-  name: kfp-artifact-bucket-name
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
-- fieldref:
     fieldPath: data.defaultPipelineRoot
   name: kfp-default-pipeline-root
   objref:


### PR DESCRIPTION
## Walkthrough - Fix Kustomize Warnings
I have removed the unused variables from the Kustomize manifests to resolve the "well-defined vars that were never replaced" warnings.

### Changes
generic
[MODIFY]  `kustomization.yaml`
Removed the following unused vars:

```
kfp-namespace
kfp-app-name
kfp-app-version
kfp-artifact-bucket-name
```
Kept `kfp-default-pipeline-root` as it is used in 
`base/pipeline/kfp-launcher-configmap.yaml`
.

[MODIFY]  postgres/kustomization.yaml
Removed the same unused `vars`.

### Verification Results
Automated Tests
Ran `kustomize build .` in `manifests/kustomize/base/installs/generic` and `manifests/kustomize/base/installs/generic/postgres`.

- Result: The "well-defined vars that were never replaced" warnings are gone.
- Note: A warning `# Warning: 'vars' is deprecated. Please use 'replacements' instead.` remains, which is expected since we are still using one legacy var `kfp-default-pipeline-root`.

Manual Verification
Verified that `kfp-launcher` ConfigMap is generated with` defaultPipelineRoot: "" (empty string)`, confirming that the variable `$(kfp-default-pipeline-root)` was correctly substituted.

```
apiVersion: v1
data:
  defaultPipelineRoot: ""
kind: ConfigMap
metadata:
  name: kfp-launcher
  namespace: kubeflow
```

Fixes : #12615 