### PR TITLE
Fix the reconciliation bug:

### DIFF
--- a/backend/src/apiserver/model/resource_reference.go
+++ b/backend/src/apiserver/model/resource_reference.go
@@ -181,6 +181,10 @@ type FilterContext struct {
 	*ReferenceKey
 }
 
+func EmptyFilterContext() *FilterContext {
+	return &FilterContext{}
+}
+
 // Checks whether the resource-reference relationship combination is valid.
 func ValidateResourceReferenceRelationship(resType ResourceType, refType ResourceType, relType Relationship) bool {
 	check, err := validResourceReferenceRelationship[ResourceReferenceRelationshipTriplet{

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -628,9 +628,7 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 
 // ReconcileSwfCrs reconciles the ScheduledWorkflow CRs based on existing jobs.
 func (r *ResourceManager) ReconcileSwfCrs(ctx context.Context) error {
-	filterContext := &model.FilterContext{
-		ReferenceKey: &model.ReferenceKey{Type: model.NamespaceResourceType, ID: common.GetPodNamespace()},
-	}
+	filterContext := model.EmptyFilterContext()
 
 	opts := list.EmptyOptions()
 


### PR DESCRIPTION
**Description of your changes:**

Fix the reconciliation bug

Previously, the reconciliation code filtered jobs by pod.namespace. At the time, this might have made sense, as reconciliation could occur within the users' namespaces.

However, in the current implementation, reconciliation happens inside the API server, where the pod.namespace is always kubeflow. As a result, recurring runs were effectively not updated and continued to operate with the driver/launcher versions they were originally created with. In single-user mode, filtering by namespace seems entirely unnecessary.

Consider moving the reconciliation logic to a separate service in the future. Currently, the API server could be deployed with a replicaset size >1, which may result in reconciliation being executed multiple times unnecessarily.

сс: @HumairAK @droctothorpe @juliusvonkohout 
