### PR TITLE
test(backend): add internal unit tests for api_util validation

### DIFF
--- a/backend/src/apiserver/server/api_util_internal_test.go
+++ b/backend/src/apiserver/server/api_util_internal_test.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	apiv1beta1 "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// TestValidateRuntimeConfigV1 increases coverage for api_util.go:380
+func TestValidateRuntimeConfigV1(t *testing.T) {
+	// 1. Create a "Huge" string that exceeds the limit (util.MaxParameterBytes)
+	// MaxParameterBytes is usually around 64KB or similar. We add 100 bytes to ensure overflow.
+	hugeString := make([]byte, util.MaxParameterBytes+100)
+	for i := range hugeString {
+		hugeString[i] = 'a'
+	}
+
+	tests := []struct {
+		name      string
+		config    *apiv1beta1.PipelineSpec_RuntimeConfig
+		wantErr   bool
+		errSubstr string // Substring we expect in the error message
+	}{
+		{
+			name: "Valid small parameters",
+			config: &apiv1beta1.PipelineSpec_RuntimeConfig{
+				Parameters: map[string]*structpb.Value{
+					"param1": {Kind: &structpb.Value_StringValue{StringValue: "small-value"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "Nil parameters",
+			config: &apiv1beta1.PipelineSpec_RuntimeConfig{},
+			wantErr: false,
+		},
+		{
+			name: "Parameters exceed max size",
+			config: &apiv1beta1.PipelineSpec_RuntimeConfig{
+				Parameters: map[string]*structpb.Value{
+					// This giant value should trigger the size limit check
+					"huge_param": {Kind: &structpb.Value_StringValue{StringValue: string(hugeString)}},
+				},
+			},
+			wantErr:   true,
+			errSubstr: "The input parameter length exceed maximum size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRuntimeConfigV1(tt.config)
+			
+			// Check if error presence matches expectation
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateRuntimeConfigV1() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			
+			// Check if error message matches expectation
+			if tt.wantErr && err != nil {
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got %q", tt.errSubstr, err.Error())
+				}
+			}
+		})
+	}
+}
+
+// TestValidatePipelineManifest increases coverage for api_util.go:416
+func TestValidatePipelineManifest(t *testing.T) {
+	tests := []struct {
+		name             string
+		pipelineManifest string
+		wantErr          bool
+	}{
+		{
+			name:             "Empty manifest",
+			pipelineManifest: "",
+			wantErr:          false,
+		},
+		{
+			name:             "Valid YAML",
+			pipelineManifest: "apiVersion: argoproj.io/v1alpha1\nkind: Workflow",
+			wantErr:          false,
+		},
+		{
+			name:             "Invalid YAML",
+			// A colon without a value or key structure is invalid YAML
+			pipelineManifest: ": : : invalid yaml : : :",
+			wantErr:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePipelineManifest(tt.pipelineManifest)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validatePipelineManifest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds missing unit tests for `validateRuntimeConfigV1` and `validatePipelineManifest` in `backend/src/apiserver/server/api_util.go`.

Prior to this change, these critical validation functions had low test coverage:
- `validateRuntimeConfigV1`: ~28% coverage
- `validatePipelineManifest`: ~40% coverage

I added a new internal test file `api_util_internal_test.go` with table-driven tests to cover edge cases (e.g., invalid YAML, parameter size limits).

**Verification:**
I ran the tests locally using `go test -v .` and verified the coverage increase:
- `validateRuntimeConfigV1`: Increased to ~85.7%
- `validatePipelineManifest`: Increased to 100%

### Which issue(s) this PR fixes
Fixes #12651

### Special notes for the reviewer
I created a new `_internal_test.go` file as per the contribution guidelines to test these private validation functions.