### PR TITLE
fix(ci): port-forward minio-service instead of pod

### DIFF
--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -73,7 +73,8 @@ runs:
       run: |
         NAMESPACE="${{ inputs.default_namespace }}"
         pkill -f "kubectl port-forward.*minio" || true
-        ./.github/resources/scripts/forward-port.sh -q "$NAMESPACE" "minio" 9000 9000
+        kubectl port-forward -n "$NAMESPACE" service/minio-service 9000:9000 > /dev/null 2>&1 &
+        sleep 5
       continue-on-error: true
 
     - name: Run Tests


### PR DESCRIPTION

- **Problem**: Port-forward script searched for pods with `app=minio` label, which fails when using seaweedfs backend (pods have `app=seaweedfs` label)
- **Solution**: Port-forward directly to `service/minio-service`, which works with both minio and seaweedfs backends
- **Impact**: E2E tests can now access archived workflow logs regardless of storage backend
