### PR TITLE
fix(ci): add retry logic to metadata-envoy Dockerfile for apt mirror

### DIFF
--- a/third_party/metadata_envoy/Dockerfile
+++ b/third_party/metadata_envoy/Dockerfile
@@ -14,8 +14,10 @@
 
 FROM envoyproxy/envoy:v1.37.0
 
-RUN apt-get update -y && \
-  apt-get install --no-install-recommends -y -q gettext openssl
+RUN (apt-get update -y || (sleep 10 && apt-get update -y) || (sleep 30 && apt-get update -y)) && \
+  apt-get install --no-install-recommends -y -q gettext openssl && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 
 # Copy license files.


### PR DESCRIPTION
## Summary
- Add retry logic for `apt-get update` to handle transient mirror sync issues
- Clean apt cache before and after installation to reduce image size
- Improves CI build reliability for metadata-envoy Docker image