### PR TITLE
fix(compiler): Support None/null values in pipeline parameters (#12240)

### DIFF
--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -63,8 +63,11 @@ def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
     Raises:
         ValueError if the given value is not one of the parameter types.
     """
+    # None check must come first to handle null values from YAML
+    if value is None:
+        return struct_pb2.Value(null_value=struct_pb2.NULL_VALUE)
     # bool check must be above (int, float) check because bool is a subclass of int so isinstance(True, int) == True
-    if isinstance(value, bool):
+    elif isinstance(value, bool):
         return struct_pb2.Value(bool_value=value)
     elif isinstance(value, str):
         return struct_pb2.Value(string_value=value)
@@ -81,7 +84,7 @@ def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
                 values=[to_protobuf_value(v) for v in value]))
     else:
         raise ValueError('Value must be one of the following types: '
-                         'str, int, float, bool, dict, and list. Got: '
+                         'str, int, float, bool, dict, list, and None. Got: '
                          f'"{value}" of type "{type(value)}".')
 
 

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -37,7 +37,7 @@ from kfp.dsl.types import artifact_types
 from kfp.dsl.types import type_annotations
 
 DEFAULT_ARTIFACT_SCHEMA_VERSION = '0.0.1'
-PARAMETER_TYPES = Union[str, int, float, bool, dict, list]
+PARAMETER_TYPES = Union[str, int, float, bool, dict, list, None]
 
 # ComponentSpec I/O types to DSL ontology artifact classes mapping.
 ARTIFACT_CLASSES_MAPPING = {


### PR DESCRIPTION
This PR fixes a compilation failure that occurred when pipeline parameters contained `None` values, which commonly arise from YAML `null` values.

**The Problem:**
When users loaded pipeline configurations from YAML files containing `null` values, the compiler would fail with either a `TypeError: bad argument type for built-in operation` or `ValueError: Value must be one of the following types...`. This happened because the `to_protobuf_value()` function didn't handle Python's `None` type, even though:
- Google Protocol Buffers natively support null values via `struct_pb2.NULL_VALUE`
- YAML's `null` is a standard scalar value that converts to Python's `None`
- Users frequently use `null` for optional or unset parameters

**The Solution:**
This PR adds proper `None` handling by:
1. Adding `None` to the `PARAMETER_TYPES` type hint to accurately reflect supported types
2. Checking for `None` values first in `to_protobuf_value()` and converting them to `struct_pb2.Value(null_value=struct_pb2.NULL_VALUE)`
3. Updating error messages to reflect that `None` is now a valid type
4. Adding 13 comprehensive unit tests covering None at all nesting levels

**What Now Works:**
```python
# YAML with null values now compiles successfully
config = yaml.safe_load("""
  text_param: "hello"
  optional_param: null
  nested:
    key: null
  list_param: [1, null, 3]
""")
```
**Related Issue:**
Fixes #12240 
