### PR TITLE
Fix pipeline parameter propagation for PVC mounts inside conditionals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,11 @@ logs/
 
 # Project-local tools
 bin/
+# Local developer virtualenv (custom name)
+k/
+
+# Local repro / debug scripts
+repro_pvc_conditional.py
+
+# Local scratch directory (not repo kubernetes code)
+kubernetes/


### PR DESCRIPTION
Fixes #12617
### What this PR does
Fixes an issue where pipeline parameters used by k8s.mount_pvc were not
propagated into conditional (dsl.If) DAGs.

### Problem
Pipeline parameters referenced only through task.platform_config were not
included when building conditional DAG inputs. As a result, pvc_name worked
outside dsl.If but failed inside it.

### Solution
The compiler now collects pipeline channels referenced in platform_config
and propagates them into conditional DAG inputs.

### Tests
- Added a compiler test that verifies pvc_name is available when mount_pvc
  is used inside a dsl.If block.
