### PR TITLE
fix(compiler): apply retryPolicy per item for tasks in dsl.ParallelFor

### DIFF
--- a/backend/src/v2/compiler/argocompiler/retry_test.go
+++ b/backend/src/v2/compiler/argocompiler/retry_test.go
@@ -1,0 +1,144 @@
+// Copyright 2021-2023 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocompiler_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
+	"github.com/kubeflow/pipelines/backend/src/v2/compiler/argocompiler"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+	"sigs.k8s.io/yaml"
+)
+
+func TestRetryInParallelFor(t *testing.T) {
+	// Initialize proxy config to avoid panic
+	proxy.InitializeConfigWithEmptyForTests()
+
+	// Read the yaml file
+	yamlBytes, err := os.ReadFile("testdata/parallel_for_retry.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read testdata/parallel_for_retry.yaml: %v", err)
+	}
+
+	// Unmarshal to a generic map first to get the PipelineSpec part
+	var genericMap map[string]interface{}
+	err = yaml.Unmarshal(yamlBytes, &genericMap)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal yaml: %v", err)
+	}
+
+	// Assuming the file content is directly mapped to PipelineSpec, but usually keys match json fields
+	jsonBytes, err := yaml.YAMLToJSON(yamlBytes)
+	if err != nil {
+		t.Fatalf("Failed to convert yaml to json: %v", err)
+	}
+
+	spec := &pipelinespec.PipelineSpec{}
+	err = protojson.Unmarshal(jsonBytes, spec)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal pipeline spec: %v", err)
+	}
+
+	// Construct PipelineJob
+	job := &pipelinespec.PipelineJob{
+		PipelineSpec: &structpb.Struct{}, // We need to put spec into this struct?
+		// Wait, PipelineJob definition
+	}
+	// The Compile function expects PipelineJob.
+	// But PipelineJob has "pipeline_spec" as a Map (Struct).
+	// We need to convert spec back to Struct.
+
+	specStruct := &structpb.Struct{}
+	specJson, _ := protojson.Marshal(spec)
+	err = protojson.Unmarshal(specJson, specStruct)
+	if err != nil {
+		t.Fatalf("Failed to convert spec to struct: %v", err)
+	}
+	
+	job = &pipelinespec.PipelineJob{
+		PipelineSpec: specStruct,
+	}
+
+	options := &argocompiler.Options{
+		// No PipelineName
+	}
+
+	// Compile
+	wf, err := argocompiler.Compile(job, nil, options)
+	if err != nil {
+		t.Fatalf("Failed to compile: %v", err)
+	}
+
+	// Check if retry strategy is present on the implementation template
+	foundImplWithRetry := false
+	for _, tmpl := range wf.Spec.Templates {
+		if tmpl.RetryStrategy != nil {
+			if tmpl.RetryStrategy.Limit != nil && tmpl.RetryStrategy.Limit.StrVal == "{{inputs.parameters.retry-max-count}}" {
+				foundImplWithRetry = true
+				break
+			}
+		}
+	}
+	if !foundImplWithRetry {
+		t.Errorf("Generic retry implementation template not found")
+	}
+
+	// Check if the loop body DAG passes the correct retry count
+	foundArg := false
+	// The loop component name is comp-for-loop-1
+	for _, tmpl := range wf.Spec.Templates {
+		if tmpl.Name == "comp-for-loop-1" {
+			if tmpl.DAG == nil {
+				continue
+			}
+			for _, task := range tmpl.DAG.Tasks {
+				if task.Name == "random-failure-op" {
+					for _, p := range task.Arguments.Parameters {
+						if p.Name == "retry-max-count" && p.Value != nil && *p.Value == "20" {
+							foundArg = true
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Print the workflow yaml for manual inspection
+	wfBytes, _ := yaml.Marshal(wf)
+	t.Logf("Workflow YAML:\n%s", string(wfBytes))
+
+	if !foundArg {
+		t.Errorf("Argument retry-max-count=20 not found in comp-for-loop-1 DAG")
+	}
+
+	// Check if retry strategy is present on the iteration template (structural fix for Argo issue)
+	foundIterationRetry := false
+	for _, tmpl := range wf.Spec.Templates {
+		// Look for the iteration template (e.g. comp-for-loop-1-iteration)
+		if strings.HasSuffix(tmpl.Name, "-iteration") {
+			if tmpl.RetryStrategy != nil && tmpl.RetryStrategy.Limit != nil && tmpl.RetryStrategy.Limit.StrVal == "20" {
+				foundIterationRetry = true
+			}
+		}
+	}
+	if !foundIterationRetry {
+		t.Errorf("Retry strategy not found on iteration template (expected limit 20)")
+	}
+}

--- a/backend/src/v2/compiler/argocompiler/testdata/parallel_for_retry.yaml
+++ b/backend/src/v2/compiler/argocompiler/testdata/parallel_for_retry.yaml
@@ -1,0 +1,118 @@
+# PIPELINE DEFINITION
+# Name: parallel-retry-demo
+# Inputs:
+#    exit_codes: str [Default: '0,1,2,3']
+#    workers: list [Default: ['A', 'B', 'C', 'D', 'E']]
+components:
+  comp-for-loop-1:
+    dag:
+      tasks:
+        random-failure-op:
+          cachingOptions: {}
+          componentRef:
+            name: comp-random-failure-op
+          inputs:
+            parameters:
+              exit_codes:
+                componentInputParameter: pipelinechannel--exit_codes
+              worker_id:
+                componentInputParameter: pipelinechannel--workers-loop-item
+          retryPolicy:
+            backoffDuration: 0s
+            backoffFactor: 2.0
+            backoffMaxDuration: 3600s
+            maxRetryCount: 20
+          taskInfo:
+            name: random-failure-op
+    inputDefinitions:
+      parameters:
+        pipelinechannel--exit_codes:
+          parameterType: STRING
+        pipelinechannel--workers:
+          parameterType: LIST
+        pipelinechannel--workers-loop-item:
+          parameterType: STRING
+  comp-random-failure-op:
+    executorLabel: exec-random-failure-op
+    inputDefinitions:
+      parameters:
+        exit_codes:
+          description: Comma-separated list of integer exit codes, e.g. "0,1,2".
+          parameterType: STRING
+        worker_id:
+          description: Label to identify the parallel worker in logs.
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-random-failure-op:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - random_failure_op
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef random_failure_op(exit_codes: str, worker_id: str):\n    \"\"\
+          \"Randomly exits with one of the provided exit codes.\n\n    Args:\n   \
+          \     exit_codes: Comma-separated list of integer exit codes, e.g. \"0,1,2\"\
+          .\n        worker_id: Label to identify the parallel worker in logs.\n \
+          \   \"\"\"\n    import random\n    import sys\n    import time\n\n    code\
+          \ = int(random.choice(exit_codes.split(\",\")))\n    print(f\"[{worker_id}]\
+          \ picked exit code: {code}\")\n    time.sleep(1.0)\n    sys.exit(code)\n\
+          \n"
+        image: python:3.11
+pipelineInfo:
+  name: parallel-retry-demo
+root:
+  dag:
+    tasks:
+      for-loop-1:
+        componentRef:
+          name: comp-for-loop-1
+        inputs:
+          parameters:
+            pipelinechannel--exit_codes:
+              componentInputParameter: exit_codes
+            pipelinechannel--workers:
+              componentInputParameter: workers
+        parameterIterator:
+          itemInput: pipelinechannel--workers-loop-item
+          items:
+            inputParameter: pipelinechannel--workers
+        taskInfo:
+          name: for-loop-1
+  inputDefinitions:
+    parameters:
+      exit_codes:
+        defaultValue: 0,1,2,3
+        isOptional: true
+        parameterType: STRING
+      workers:
+        defaultValue:
+        - A
+        - B
+        - C
+        - D
+        - E
+        isOptional: true
+        parameterType: LIST
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.15.2


### PR DESCRIPTION
### What this PR does

Fixes an issue where `Task.set_retry()` is ignored for tasks inside `dsl.ParallelFor`.

When a component with a retryPolicy is used inside `ParallelFor`, the compiler currently attaches the retryStrategy at a level that Argo does not retry per iteration item. As a result, a failing item is not retried and the branch fails immediately.

This PR lifts the retryPolicy from the single task in the loop body and applies it to the iteration template, enabling retries to be executed independently per item.

### Why this is needed

- Standalone tasks correctly respect `set_retry()`, but tasks inside `dsl.ParallelFor` do not
- This behavior is inconsistent and surprising for users
- Argo retries are applied per template execution, so the retryStrategy must live on the iteration template to enable per-item retries

### Scope of change

- Affects only `dsl.ParallelFor`
- Applies only when the loop body contains exactly one task with a retryPolicy
- No changes to SDK, DSL surface, or runtime behavior
- Preserves existing semantics for non-ParallelFor components and multi-task DAGs

### How it works

- Detects a retryPolicy on the single task inside a ParallelFor loop body
- Lifts the retryPolicy to the iteration template generated by the Argo compiler
- This allows Argo to retry each iteration item independently

### Testing

- Added a compiler unit test that verifies retryStrategy is correctly applied to the iteration template for ParallelFor tasks

### Related issue

Fixes #12389 