### PR TITLE
fix(sdk): Added missing cycle detection to topological_sort in local runner

### DIFF
--- a/sdk/python/kfp/local/graph_utils.py
+++ b/sdk/python/kfp/local/graph_utils.py
@@ -60,20 +60,30 @@ def topological_sort(dependency_map: Dict[str, List[str]]) -> List[str]:
 
     Returns:
         A totally ordered stack of tasks. Tasks should be executed in the order they are popped off the right side of the stack.
+    Raises:
+        RuntimeError: If a cycle is detected in the graph.
     """
+    visited: Set[str] = set()
+    visiting: Set[str] = set()
+    result = []
 
     def dfs(node: str) -> None:
+        if node in visited:
+            return
+        if node in visiting:
+            raise RuntimeError(
+                f'Pipeline has a cycle: {node} is part of a cycle.')
+
+        visiting.add(node)
+        neighbors = sorted(dependency_map.get(node, []))
+        for neighbor in neighbors:
+            dfs(neighbor)
+
+        visiting.remove(node)
         visited.add(node)
-        for neighbor in dependency_map[node]:
-            if neighbor not in visited:
-                dfs(neighbor)
         result.append(node)
 
-    # sort lists to force deterministic result
-    dependency_map = {k: sorted(v) for k, v in dependency_map.items()}
-    visited: Set[str] = set()
-    result = []
-    for node in dependency_map:
-        if node not in visited:
-            dfs(node)
+    for node in sorted(dependency_map.keys()):
+        dfs(node)
+
     return result[::-1]

--- a/sdk/python/kfp/local/graph_utils_test.py
+++ b/sdk/python/kfp/local/graph_utils_test.py
@@ -70,6 +70,11 @@ class TestTopologicalSort(unittest.TestCase):
         expected = ['A', 'C', 'B', 'D']
         self.assertEqual(actual, expected)
 
+    def test_cycle_detection(self):
+        graph = {'A': ['B'], 'B': ['A']}
+        with self.assertRaisesRegex(RuntimeError, 'Pipeline has a cycle'):
+            graph_utils.topological_sort(graph)
+
 
 class TestTopologicalSortTasks(unittest.TestCase):
 


### PR DESCRIPTION
This PR  updates the `sdk/python/kfp/local/graph_utils.py` by incorporating the logic to detct cycles in the topological sort function. I implemented a proper Depth First Search (DFS) state tracking using a `visiting` to correctly find the back edges which if present implies a cycle in directed graphs.
Previously, the `topological_sort` function in the Local Runner would either fail silently or enter infinite recursion when encountering a cyclic graph (e.g., A -> B -> A). This caused valid but broken pipelines to hang or behave unpredictably instead of failing fast with a clear error. Now the test ensures that a `RuntimeError: Pipeline has a cycle` is raised after the cycle has been detected.
I added a regression test `test_cycle_detection` in `graph_utils_test.py` and verified it passes locally.
Fixes #12684 