### PR TITLE
Fix: pip upgrade in backend API Dockerfile

### DIFF
--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -77,7 +77,7 @@ RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRP
 
 # Needed for buildling python packages requiring protoc
 RUN apt-get update && apt-get install -y python3-pip
-RUN apt-get -y upgrade python3-pip && pip3 install --upgrade setuptools wheel --break-system-packages
+RUN python3 -m pip install --no-cache-dir --break-system-packages --upgrade --ignore-installed pip setuptools wheel
 
 # WORKAROUND: https://github.com/docker-library/golang/issues/225#issuecomment-403170792
 ENV XDG_CACHE_HOME=/tmp/.cache


### PR DESCRIPTION
### Summary

Fix backend API Dockerfile so the image build no longer fails when upgrading wheel. PIP now runs with --ignore-installed, layering new pip/setuptools/wheel versions without trying to uninstall the Debian-provided packages that lack RECORD metadata, which was triggering the CI failure.
