### PR TITLE
fix(sdk): Added check to prevent crash when logging NaN values 

### DIFF
--- a/sdk/python/kfp/dsl/types/artifact_types.py
+++ b/sdk/python/kfp/dsl/types/artifact_types.py
@@ -14,6 +14,7 @@
 """Classes and utilities for using and creating artifacts in components."""
 
 import enum
+import math
 import os
 from typing import Dict, List, Optional, Type
 import warnings
@@ -227,6 +228,11 @@ class Metrics(Artifact):
           metric: The metric key.
           value: The metric value.
         """
+        if math.isnan(value) or math.isinf(value):
+            raise ValueError(
+                f'Invalid metric value for "{metric}": {value}. '
+                'Metrics must be finite numbers (no NaN or Inf) to be JSON compliant.'
+            )
         self.metadata[metric] = value
 
 

--- a/sdk/python/kfp/dsl/types/artifact_types_test.py
+++ b/sdk/python/kfp/dsl/types/artifact_types_test.py
@@ -58,6 +58,18 @@ class ArtifactsTest(unittest.TestCase):
             expected_json = json.load(json_file)
             self.assertEqual(expected_json, metrics.metadata)
 
+    def test_log_metric_validates_finite_numbers(self):
+        metrics = dsl.Metrics()
+        with self.assertRaisesRegex(ValueError, r'Invalid metric value'):
+            metrics.log_metric('accuracy', float('nan'))
+        with self.assertRaisesRegex(ValueError, r'Invalid metric value'):
+            metrics.log_metric('loss', float('inf'))
+        with self.assertRaisesRegex(ValueError, r'Invalid metric value'):
+            metrics.log_metric('loss', float('-inf'))
+
+        metrics.log_metric('valid_score', 0.95)
+        self.assertEqual(metrics.metadata['valid_score'], 0.95)
+
 
 @contextlib.contextmanager
 def set_temporary_task_root(task_root: str):


### PR DESCRIPTION
This PR fixes a crash in the KFP executor caused by logging `NaN` or `Infinity` values in metrics.
Earlier, `log_metric()` accepted `float('nan')` or `float('inf')`. However, standard JSON (and the underlying Protobuf serialization used by the backend) does not support these values. As a result, the pipeline would crash with a `SerializationError` when trying to save the output metadata.

**Changes:**
- Added a guard clause in `kfp.dsl.types.artifact_types.Metrics.log_metric` to raise a `ValueError` immediately if the value is not finite.
- Added a unit test `test_log_metric_validates_finite_numbers` to `artifact_types_test.py` to ensure this behavior is preserved.

Fixes #12227

