### PR TITLE
chore(ci): use author_association to avoid API rate limits in approve workflow

### DIFF
--- a/.github/workflows/gh-workflow-approve.yml
+++ b/.github/workflows/gh-workflow-approve.yml
@@ -23,25 +23,25 @@ jobs:
     steps:
       - name: Check if author is a Kubeflow GitHub member
         id: membership-check
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const username = context.payload.pull_request.user.login;
-            const org = context.repo.owner;
-            try {
-              const res = await github.rest.orgs.checkMembershipForUser({
-                org,
-                username
-              });
-              core.setOutput("is_member", true);
-            } catch (error) {
-              if (error.status === 404) {
-                // User is not a member
-                core.setOutput("is_member", false);
-              } else {
-                throw error;
-              }
-            }
+        env:
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "::group::PR Information"
+          echo "PR Number: #$PR_NUMBER"
+          echo "PR Author: $PR_AUTHOR"
+          echo "Author Association: $AUTHOR_ASSOCIATION"
+          echo "::endgroup::"
+          
+          # MEMBER = org member, OWNER = org owner, COLLABORATOR = invited collaborator
+          if [[ "$AUTHOR_ASSOCIATION" == "MEMBER" || "$AUTHOR_ASSOCIATION" == "OWNER" || "$AUTHOR_ASSOCIATION" == "COLLABORATOR" ]]; then
+            echo "::notice::Author '$PR_AUTHOR' is a trusted contributor (association: $AUTHOR_ASSOCIATION). Auto-approving workflow runs."
+            echo "is_member=true" >> $GITHUB_OUTPUT
+          else
+            echo "::notice::Author '$PR_AUTHOR' is not a trusted contributor (association: $AUTHOR_ASSOCIATION). Checking for 'ok-to-test' label."
+            echo "is_member=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Approve Pending Workflow Runs
         if: steps.membership-check.outputs.is_member == 'true' || contains(github.event.pull_request.labels.*.name, 'ok-to-test')


### PR DESCRIPTION
**Description of your changes:**

- Replace `github.rest.orgs.checkMembershipForUser()` API call with `author_association` from webhook payload
- Eliminates the API call that causes rate limit failures
- The `author_association` field is already included in the PR webhook payload. No API call needed.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
