### PR TITLE
feat(manifests): Add init containers for startup ordering

### DIFF
--- a/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         - sh
         - -c
         - |
-          timeout=600
+          timeout=300
           elapsed=0
           until nc -z "${MYSQL_HOST}" "${MYSQL_PORT}"; do
             if [ $elapsed -ge $timeout ]; then
@@ -45,7 +45,6 @@ spec:
             sleep 5
             elapsed=$((elapsed + 5))
           done
-          sleep 10
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
@@ -45,6 +45,7 @@ spec:
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          sleep 10
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
@@ -20,7 +20,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: wait-for-mysql
-        image: ghcr.io/containerd/busybox:1.36
+        image: alpine:3.23
         env:
         - name: MYSQL_HOST
           valueFrom:

--- a/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
@@ -38,13 +38,17 @@ spec:
         - |
           timeout=300
           elapsed=0
-          until nc -z "${MYSQL_HOST}" "${MYSQL_PORT}"; do
+          echo "Waiting for ${MYSQL_HOST}:${MYSQL_PORT}..."
+          until nc -z -w 3 "${MYSQL_HOST}" "${MYSQL_PORT}"; do
             if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timed out after ${elapsed}s waiting for ${MYSQL_HOST}:${MYSQL_PORT}"
               exit 1
             fi
+            echo "${MYSQL_HOST}:${MYSQL_PORT} not ready (${elapsed}s elapsed), retrying..."
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          echo "${MYSQL_HOST}:${MYSQL_PORT} is ready after ${elapsed}s"
           sleep 10
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
@@ -20,7 +20,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: wait-for-mysql
-        image: curlimages/curl:8.5.0
+        image: ghcr.io/containerd/busybox:1.36
         env:
         - name: MYSQL_HOST
           valueFrom:
@@ -36,10 +36,30 @@ spec:
         - sh
         - -c
         - |
+          timeout=600
+          elapsed=0
           until nc -z "${MYSQL_HOST}" "${MYSQL_PORT}"; do
+            if [ $elapsed -ge $timeout ]; then
+              exit 1
+            fi
             sleep 5
+            elapsed=$((elapsed + 5))
           done
           sleep 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65534
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
 
       containers:
       - name: container

--- a/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
@@ -18,6 +18,29 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-mysql
+        image: curlimages/curl:8.5.0
+        env:
+        - name: MYSQL_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: dbHost
+        - name: MYSQL_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: dbPort
+        command:
+        - sh
+        - -c
+        - |
+          until nc -z "${MYSQL_HOST}" "${MYSQL_PORT}"; do
+            sleep 5
+          done
+          sleep 10
+
       containers:
       - name: container
         # ! Sync to the same MLMD version:

--- a/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
@@ -28,13 +28,17 @@ spec:
         - |
           timeout=300
           elapsed=0
-          until nc -z metadata-grpc-service 8080; do
+          echo "Waiting for metadata-grpc-service:8080..."
+          until nc -z -w 3 metadata-grpc-service 8080; do
             if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timed out after ${elapsed}s waiting for metadata-grpc-service:8080"
               exit 1
             fi
+            echo "metadata-grpc-service:8080 not ready (${elapsed}s elapsed), retrying..."
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          echo "metadata-grpc-service:8080 is ready after ${elapsed}s"
           sleep 10
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
@@ -35,6 +35,7 @@ spec:
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          sleep 10
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - sh
         - -c
         - |
-          timeout=600
+          timeout=300
           elapsed=0
           until nc -z metadata-grpc-service 8080; do
             if [ $elapsed -ge $timeout ]; then
@@ -35,7 +35,6 @@ spec:
             sleep 5
             elapsed=$((elapsed + 5))
           done
-          sleep 10
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     
       initContainers:
       - name: wait-for-metadata-grpc
-        image: ghcr.io/containerd/busybox:1.36
+        image: alpine:3.23
         command:
         - sh
         - -c

--- a/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
@@ -19,6 +19,18 @@ spec:
         seccompProfile:
           type: RuntimeDefault
     
+      initContainers:
+      - name: wait-for-metadata-grpc
+        image: curlimages/curl:8.5.0
+        command:
+        - sh
+        - -c
+        - |
+          until nc -z metadata-grpc-service 8080; do
+            sleep 5
+          done
+          sleep 10
+
       containers:
       - name: main
         image: ghcr.io/kubeflow/kfp-metadata-writer:dummy

--- a/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
@@ -21,15 +21,35 @@ spec:
     
       initContainers:
       - name: wait-for-metadata-grpc
-        image: curlimages/curl:8.5.0
+        image: ghcr.io/containerd/busybox:1.36
         command:
         - sh
         - -c
         - |
+          timeout=600
+          elapsed=0
           until nc -z metadata-grpc-service 8080; do
+            if [ $elapsed -ge $timeout ]; then
+              exit 1
+            fi
             sleep 5
+            elapsed=$((elapsed + 5))
           done
           sleep 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65534
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
 
       containers:
       - name: main

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - sh
         - -c
         - |
-          timeout=600
+          timeout=300
           elapsed=0
           until nc -z "${MYSQL_HOST}" "${MYSQL_PORT}"; do
             if [ $elapsed -ge $timeout ]; then
@@ -46,7 +46,6 @@ spec:
             sleep 5
             elapsed=$((elapsed + 5))
           done
-          sleep 10
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -46,6 +46,7 @@ spec:
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          sleep 10
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
@@ -66,7 +67,7 @@ spec:
         - sh
         - -c
         - |
-          timeout=600
+          timeout=300
           elapsed=0
           until nc -z metadata-grpc-service 8080; do
             if [ $elapsed -ge $timeout ]; then

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -19,6 +19,38 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-mysql
+        image: curlimages/curl:8.5.0
+        env:
+        - name: MYSQL_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: dbHost
+        - name: MYSQL_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: dbPort
+        command:
+        - sh
+        - -c
+        - |
+          until nc -z "${MYSQL_HOST}" "${MYSQL_PORT}"; do
+            sleep 5
+          done
+          sleep 10
+      - name: wait-for-metadata-grpc
+        image: curlimages/curl:8.5.0
+        command:
+        - sh
+        - -c
+        - |
+          until nc -z metadata-grpc-service 8080; do
+            sleep 5
+          done
+          sleep 10
       containers:
         - env:
             # Whether or not to publish component logs to the object store.

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -21,7 +21,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: wait-for-mysql
-        image: curlimages/curl:8.5.0
+        image: ghcr.io/containerd/busybox:1.36
         env:
         - name: MYSQL_HOST
           valueFrom:
@@ -37,20 +37,60 @@ spec:
         - sh
         - -c
         - |
+          timeout=600
+          elapsed=0
           until nc -z "${MYSQL_HOST}" "${MYSQL_PORT}"; do
+            if [ $elapsed -ge $timeout ]; then
+              exit 1
+            fi
             sleep 5
+            elapsed=$((elapsed + 5))
           done
           sleep 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65534
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
       - name: wait-for-metadata-grpc
-        image: curlimages/curl:8.5.0
+        image: ghcr.io/containerd/busybox:1.36
         command:
         - sh
         - -c
         - |
+          timeout=600
+          elapsed=0
           until nc -z metadata-grpc-service 8080; do
+            if [ $elapsed -ge $timeout ]; then
+              exit 1
+            fi
             sleep 5
+            elapsed=$((elapsed + 5))
           done
           sleep 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65534
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
       containers:
         - env:
             # Whether or not to publish component logs to the object store.

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -21,7 +21,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: wait-for-mysql
-        image: ghcr.io/containerd/busybox:1.36
+        image: alpine:3.23
         env:
         - name: MYSQL_HOST
           valueFrom:
@@ -66,7 +66,7 @@ spec:
             cpu: 100m
             memory: 64Mi
       - name: wait-for-metadata-grpc
-        image: ghcr.io/containerd/busybox:1.36
+        image: alpine:3.23
         command:
         - sh
         - -c

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -39,13 +39,17 @@ spec:
         - |
           timeout=300
           elapsed=0
-          until nc -z "${MYSQL_HOST}" "${MYSQL_PORT}"; do
+          echo "Waiting for ${MYSQL_HOST}:${MYSQL_PORT}..."
+          until nc -z -w 3 "${MYSQL_HOST}" "${MYSQL_PORT}"; do
             if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timed out after ${elapsed}s waiting for ${MYSQL_HOST}:${MYSQL_PORT}"
               exit 1
             fi
+            echo "${MYSQL_HOST}:${MYSQL_PORT} not ready (${elapsed}s elapsed), retrying..."
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          echo "${MYSQL_HOST}:${MYSQL_PORT} is ready after ${elapsed}s"
           sleep 10
         securityContext:
           allowPrivilegeEscalation: false
@@ -69,13 +73,17 @@ spec:
         - |
           timeout=300
           elapsed=0
-          until nc -z metadata-grpc-service 8080; do
+          echo "Waiting for metadata-grpc-service:8080..."
+          until nc -z -w 3 metadata-grpc-service 8080; do
             if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timed out after ${elapsed}s waiting for metadata-grpc-service:8080"
               exit 1
             fi
+            echo "metadata-grpc-service:8080 not ready (${elapsed}s elapsed), retrying..."
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          echo "metadata-grpc-service:8080 is ready after ${elapsed}s"
           sleep 10
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -21,7 +21,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: wait-for-ml-pipeline
-        image: ghcr.io/containerd/busybox:1.36
+        image: alpine:3.23
         command:
         - sh
         - -c

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - sh
         - -c
         - |
-          timeout=600
+          timeout=300
           elapsed=0
           until wget -q -O /dev/null http://ml-pipeline:8888/apis/v1beta1/healthz; do
             if [ $elapsed -ge $timeout ]; then

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -28,13 +28,17 @@ spec:
         - |
           timeout=300
           elapsed=0
-          until nc -z ml-pipeline 8888; do
+          echo "Waiting for ml-pipeline:8888..."
+          until nc -z -w 3 ml-pipeline 8888; do
             if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timed out after ${elapsed}s waiting for ml-pipeline:8888"
               exit 1
             fi
+            echo "ml-pipeline:8888 not ready (${elapsed}s elapsed), retrying..."
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          echo "ml-pipeline:8888 is ready after ${elapsed}s"
           sleep 10
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -28,13 +28,14 @@ spec:
         - |
           timeout=300
           elapsed=0
-          until wget -q -O /dev/null http://ml-pipeline:8888/apis/v1beta1/healthz; do
+          until nc -z ml-pipeline 8888; do
             if [ $elapsed -ge $timeout ]; then
               exit 1
             fi
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          sleep 10
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -19,6 +19,17 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-ml-pipeline
+        image: curlimages/curl:8.5.0
+        command:
+        - sh
+        - -c
+        - |
+          until nc -z ml-pipeline 8888; do
+            sleep 5
+          done
+          sleep 10
       containers:
       - env:
           - name: NAMESPACE

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -21,15 +21,34 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: wait-for-ml-pipeline
-        image: curlimages/curl:8.5.0
+        image: ghcr.io/containerd/busybox:1.36
         command:
         - sh
         - -c
         - |
-          until nc -z ml-pipeline 8888; do
+          timeout=600
+          elapsed=0
+          until wget -q -O /dev/null http://ml-pipeline:8888/apis/v1beta1/healthz; do
+            if [ $elapsed -ge $timeout ]; then
+              exit 1
+            fi
             sleep 5
+            elapsed=$((elapsed + 5))
           done
-          sleep 10
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65534
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
       containers:
       - env:
           - name: NAMESPACE

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -21,7 +21,7 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: wait-for-ml-pipeline
-        image: ghcr.io/containerd/busybox:1.36
+        image: alpine:3.23
         command:
         - sh
         - -c

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         - sh
         - -c
         - |
-          timeout=600
+          timeout=300
           elapsed=0
           until wget -q -O /dev/null http://ml-pipeline:8888/apis/v1beta1/healthz; do
             if [ $elapsed -ge $timeout ]; then

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -28,13 +28,17 @@ spec:
         - |
           timeout=300
           elapsed=0
-          until nc -z ml-pipeline 8888; do
+          echo "Waiting for ml-pipeline:8888..."
+          until nc -z -w 3 ml-pipeline 8888; do
             if [ $elapsed -ge $timeout ]; then
+              echo "ERROR: Timed out after ${elapsed}s waiting for ml-pipeline:8888"
               exit 1
             fi
+            echo "ml-pipeline:8888 not ready (${elapsed}s elapsed), retrying..."
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          echo "ml-pipeline:8888 is ready after ${elapsed}s"
           sleep 10
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -28,13 +28,14 @@ spec:
         - |
           timeout=300
           elapsed=0
-          until wget -q -O /dev/null http://ml-pipeline:8888/apis/v1beta1/healthz; do
+          until nc -z ml-pipeline 8888; do
             if [ $elapsed -ge $timeout ]; then
               exit 1
             fi
             sleep 5
             elapsed=$((elapsed + 5))
           done
+          sleep 10
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -19,6 +19,16 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+      - name: wait-for-ml-pipeline
+        image: curlimages/curl:8.5.0
+        command:
+        - sh
+        - -c
+        - |
+          until nc -z ml-pipeline 8888; do
+            sleep 5
+          done
       containers:
       - image: ghcr.io/kubeflow/kfp-scheduled-workflow-controller:dummy
         imagePullPolicy: IfNotPresent

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -21,14 +21,34 @@ spec:
           type: RuntimeDefault
       initContainers:
       - name: wait-for-ml-pipeline
-        image: curlimages/curl:8.5.0
+        image: ghcr.io/containerd/busybox:1.36
         command:
         - sh
         - -c
         - |
-          until nc -z ml-pipeline 8888; do
+          timeout=600
+          elapsed=0
+          until wget -q -O /dev/null http://ml-pipeline:8888/apis/v1beta1/healthz; do
+            if [ $elapsed -ge $timeout ]; then
+              exit 1
+            fi
             sleep 5
+            elapsed=$((elapsed + 5))
           done
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 65534
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
       containers:
       - image: ghcr.io/kubeflow/kfp-scheduled-workflow-controller:dummy
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**Description of your changes:**
Adds init containers to critical deployments to wait for their dependencies before starting. This prevents CrashLoopBackOff during fresh installations on local Kubernetes clusters.
**Changes:**
- `metadata-grpc-deployment`: waits for MySQL to be ready
- `metadata-writer-deployment`: waits for metadata-grpc-service
- `ml-pipeline-apiserver-deployment`: waits for MySQL and metadata-grpc
- `ml-pipeline-persistenceagent-deployment`: waits for ml-pipeline
- `ml-pipeline-scheduledworkflow-deployment`: waits for ml-pipeline
**Testing:**
Tested on Kind cluster (v1.31.0) with fresh installation. Before this change, pods had 6-9 restarts. After this change, all pods start with 0 restarts.
Fixes #12702
