### PR TITLE
fix(backend): support custom S3 endpoints with environment credentials. Fixes #12525

### DIFF
--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -289,6 +289,51 @@ func Test_createS3BucketSession(t *testing.T) {
 			wantErr:           true,
 			errorMsg:          "could not find specified keys",
 		},
+		{
+			msg: "Bucket with fromEnv and custom endpoint",
+			ns:  "testnamespace",
+			sessionInfo: &SessionInfo{
+				Provider: "s3",
+				Params: map[string]string{
+					"region":         "us-west-2",
+					"endpoint":       "minio-service.kubeflow:9000",
+					"disableSSL":     "true",
+					"fromEnv":        "true",
+					"forcePathStyle": "true",
+				},
+			},
+			sessionSecret:     nil,
+			expectValidClient: true,
+			expectedRegion:    "us-west-2",
+			expectedEndpoint:  "minio-service.kubeflow:9000",
+			expectedPathStyle: true,
+		},
+		{
+			msg: "Bucket with fromEnv and only region",
+			ns:  "testnamespace",
+			sessionInfo: &SessionInfo{
+				Provider: "s3",
+				Params: map[string]string{
+					"region":  "eu-central-1",
+					"fromEnv": "true",
+				},
+			},
+			sessionSecret:     nil,
+			expectValidClient: true,
+			expectedRegion:    "eu-central-1",
+		},
+		{
+			msg: "Bucket with fromEnv but no endpoint or region",
+			ns:  "testnamespace",
+			sessionInfo: &SessionInfo{
+				Provider: "s3",
+				Params: map[string]string{
+					"fromEnv": "true",
+				},
+			},
+			sessionSecret:     nil,
+			expectValidClient: false,
+		},
 	}
 	for _, test := range tt {
 		t.Run(test.msg, func(t *testing.T) {


### PR DESCRIPTION
Fixes #12525

**Description of your changes:**
Fixed DNS resolution failures when importing S3 artifacts using `dsl.importer` with environment credentials (`fromEnv: true`) and custom endpoints.

- Fixed `createS3BucketSession` to configure endpoint/region even when using environment credentials
- Updated `ImportSpecToMLMDArtifact` to preserve full session info from ConfigMap instead of hardcoding `fromEnv: true`
- Added test cases for `fromEnv` scenarios with custom endpoints

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
