### PR TITLE
feat(backend): add ARM64/linux multi-arch support for container images

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -44,6 +44,11 @@ on:
         default: false
         description: 'Whether to push image to CR or not'
         required: false
+      platforms:
+        type: string
+        default: 'linux/amd64'
+        description: 'Target platforms for multi-arch builds'
+        required: false
   workflow_dispatch:
     inputs:
       src_branch:
@@ -96,6 +101,11 @@ on:
         default: false
         description: 'Whether to push image to CR or not'
         required: true
+      platforms:
+        type: string
+        default: 'linux/amd64'
+        description: 'Target platforms for multi-arch builds'
+        required: false
 env:
   SOURCE_BRANCH: ${{ inputs.src_branch }}
   TARGET_IMAGE_TAG: ${{ inputs.target_tag }}
@@ -178,7 +188,7 @@ jobs:
         with:
           context: ${{ inputs.image_context }}
           file: ${{ inputs.docker_file }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ inputs.platforms }}
           push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -121,9 +121,11 @@ jobs:
         with:
           ref: ${{env.SOURCE_BRANCH}}
 
-      - name: Get checked-out commit SHA
-        id: get_commit
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3
@@ -168,6 +170,7 @@ jobs:
       # Build the image. If the build succeeds, it pushes the image to GitHub
       # Packages. It uses the context parameter to define the build's context
       # as the set of files located in the specified path.
+      # Multi-platform builds for amd64 and arm64 support.
       - name: Build and push Image
         id: push
         uses: docker/build-push-action@v6
@@ -175,13 +178,10 @@ jobs:
         with:
           context: ${{ inputs.image_context }}
           file: ${{ inputs.docker_file }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            COMMIT_SHA=${{ steps.get_commit.outputs.sha }}
-            COMMIT_HASH=${{ steps.get_commit.outputs.sha }}
-            TAG_NAME=${{ inputs.target_tag }}
 
       # This step generates an artifact attestation for the image,
       # which is an unforgeable statement about where and how it was built.

--- a/.github/workflows/image-builds-master.yml
+++ b/.github/workflows/image-builds-master.yml
@@ -12,42 +12,55 @@ jobs:
           - image: kfp-api-server
             dockerfile: backend/Dockerfile
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-frontend
             dockerfile: frontend/Dockerfile
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-persistence-agent
             dockerfile: backend/Dockerfile.persistenceagent
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-scheduled-workflow-controller
             dockerfile: backend/Dockerfile.scheduledworkflow
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-viewer-crd-controller
             dockerfile: backend/Dockerfile.viewercontroller
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-visualization-server
             dockerfile: backend/Dockerfile.visualization
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-launcher
             dockerfile: backend/Dockerfile.launcher
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-driver
             dockerfile: backend/Dockerfile.driver
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-cache-deployer
             dockerfile: backend/src/cache/deployer/Dockerfile
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-cache-server
             dockerfile: backend/Dockerfile.cacheserver
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-metadata-writer
             dockerfile: backend/metadata_writer/Dockerfile
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-metadata-envoy
             dockerfile: third_party/metadata_envoy/Dockerfile
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-inverse-proxy-agent
             dockerfile: proxy/Dockerfile
             context: ./proxy
+            platforms: 'linux/amd64'  # base image is amd64-only
     uses: ./.github/workflows/build-and-push.yml
     with:
       src_branch: master
@@ -58,4 +71,5 @@ jobs:
       app_to_build: ${{ matrix.image }}
       image_context: ${{ matrix.context }}
       docker_file: ${{ matrix.dockerfile }}
+      platforms: ${{ matrix.platforms }}
       push: true

--- a/.github/workflows/image-builds-release.yml
+++ b/.github/workflows/image-builds-release.yml
@@ -41,42 +41,55 @@ jobs:
           - image: kfp-api-server
             dockerfile: backend/Dockerfile
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-frontend
             dockerfile: frontend/Dockerfile
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-persistence-agent
             dockerfile: backend/Dockerfile.persistenceagent
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-scheduled-workflow-controller
             dockerfile: backend/Dockerfile.scheduledworkflow
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-viewer-crd-controller
             dockerfile: backend/Dockerfile.viewercontroller
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-visualization-server
             dockerfile: backend/Dockerfile.visualization
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-launcher
             dockerfile: backend/Dockerfile.launcher
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-driver
             dockerfile: backend/Dockerfile.driver
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-cache-deployer
             dockerfile: backend/src/cache/deployer/Dockerfile
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-cache-server
             dockerfile: backend/Dockerfile.cacheserver
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-metadata-writer
             dockerfile: backend/metadata_writer/Dockerfile
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-metadata-envoy
             dockerfile: third_party/metadata_envoy/Dockerfile
             context: .
+            platforms: 'linux/amd64,linux/arm64'
           - image: kfp-inverse-proxy-agent
             dockerfile: proxy/Dockerfile
             context: ./proxy
+            platforms: 'linux/amd64'  # base image is amd64-only
     uses: ./.github/workflows/build-and-push.yml
     with:
       src_branch: ${{ inputs.src_branch }}
@@ -87,4 +100,5 @@ jobs:
       app_to_build: ${{ matrix.image }}
       image_context: ${{ matrix.context }}
       docker_file: ${{ matrix.dockerfile }}
+      platforms: ${{ matrix.platforms }}
       push: ${{ !inputs.dry_run }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,9 +28,15 @@ COPY . .
 RUN GO111MODULE=on go build -o /bin/apiserver backend/src/apiserver/*.go
 
 # 2. Compile preloaded pipeline samples
-FROM python:3.11 AS compiler
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev jq
-RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
+FROM python:3.11-slim AS compiler
+# Install only required packages (jq for JSON parsing)
+# Note: Java is not needed - pipeline samples are compiled with Python
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y -q \
+    curl \
+    jq && \
+    rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3
 COPY backend/requirements.txt .
 RUN python3 -m pip install -r requirements.txt --no-cache-dir
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -16,6 +16,10 @@ CONTAINER_ENGINE ?= $(shell \
 
 # IMG_REGISTRY can be used to automatically prepend registry details. e.g. "quay.io/kubeflow/"
 IMG_REGISTRY ?=
+# PLATFORM can be set to build for different architectures.
+# For multi-arch builds, use: PLATFORM=linux/amd64,linux/arm64
+# Default is linux/amd64 for backwards compatibility.
+PLATFORM ?= linux/amd64
 IMG_TAG_APISERVER         ?= apiserver
 IMG_TAG_PERSISTENCEAGENT  ?= persistence-agent
 IMG_TAG_CACHESERVER       ?= cache-server
@@ -40,25 +44,25 @@ image_all: image_apiserver image_persistence_agent image_cache image_swf image_v
 
 .PHONY: image_apiserver
 image_apiserver:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform linux/amd64 -t ${IMG_REGISTRY}${IMG_TAG_APISERVER} -f backend/Dockerfile .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform $(PLATFORM) -t ${IMG_REGISTRY}${IMG_TAG_APISERVER} -f backend/Dockerfile .
 .PHONY: image_persistence_agent
 image_persistence_agent:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform linux/amd64 -t ${IMG_REGISTRY}${IMG_TAG_PERSISTENCEAGENT} -f backend/Dockerfile.persistenceagent .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform $(PLATFORM) -t ${IMG_REGISTRY}${IMG_TAG_PERSISTENCEAGENT} -f backend/Dockerfile.persistenceagent .
 .PHONY: image_cache
 image_cache:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform linux/amd64 -t ${IMG_REGISTRY}${IMG_TAG_CACHESERVER} -f backend/Dockerfile.cacheserver .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform $(PLATFORM) -t ${IMG_REGISTRY}${IMG_TAG_CACHESERVER} -f backend/Dockerfile.cacheserver .
 .PHONY: image_swf
 image_swf:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform linux/amd64 -t ${IMG_REGISTRY}${IMG_TAG_SCHEDULEDWORKFLOW} -f backend/Dockerfile.scheduledworkflow .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform $(PLATFORM) -t ${IMG_REGISTRY}${IMG_TAG_SCHEDULEDWORKFLOW} -f backend/Dockerfile.scheduledworkflow .
 .PHONY: image_viewer
 image_viewer:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform linux/amd64 -t ${IMG_REGISTRY}${IMG_TAG_VIEWERCONTROLLER} -f backend/Dockerfile.viewercontroller .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform $(PLATFORM) -t ${IMG_REGISTRY}${IMG_TAG_VIEWERCONTROLLER} -f backend/Dockerfile.viewercontroller .
 .PHONY: image_visualization
 image_visualization:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform linux/amd64 -t ${IMG_REGISTRY}${IMG_TAG_VISUALIZATION} -f backend/Dockerfile.visualization .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform $(PLATFORM) -t ${IMG_REGISTRY}${IMG_TAG_VISUALIZATION} -f backend/Dockerfile.visualization .
 .PHONY: image_driver
 image_driver:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform linux/amd64 -t ${IMG_REGISTRY}${IMG_TAG_DRIVER} -f backend/Dockerfile.driver .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform $(PLATFORM) -t ${IMG_REGISTRY}${IMG_TAG_DRIVER} -f backend/Dockerfile.driver .
 .PHONY: image_driver_debug
 image_driver_debug:
 	cd $(MOD_ROOT) && sed -e '/RUN .*go mod download/a\
@@ -68,10 +72,10 @@ image_driver_debug:
 	COPY --from=builder /go/bin/dlv /bin/dlv\
 	EXPOSE 2345' \
 	backend/Dockerfile.driver > backend/Dockerfile.driver-debug
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform linux/amd64 --build-arg GCFLAGS="all=-N -l" -t ${IMG_REGISTRY}${IMG_TAG_DRIVER}:debug -f backend/Dockerfile.driver-debug .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform $(PLATFORM) --build-arg GCFLAGS="all=-N -l" -t ${IMG_REGISTRY}${IMG_TAG_DRIVER}:debug -f backend/Dockerfile.driver-debug .
 .PHONY: image_launcher
 image_launcher:
-	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform linux/amd64 -t ${IMG_REGISTRY}${IMG_TAG_LAUNCHER} -f backend/Dockerfile.launcher .
+	cd $(MOD_ROOT) && ${CONTAINER_ENGINE} build --platform $(PLATFORM) -t ${IMG_REGISTRY}${IMG_TAG_LAUNCHER} -f backend/Dockerfile.launcher .
 
 .PHONY: install-cert-manager
 install-cert-manager:

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -41,8 +41,12 @@ ENV PROTOC_GEN_GO_GRPC=v1.5.1
 ENV PROTOBUF_GO=v1.36.6
 
 # Install protoc.
+# Use TARGETARCH for multi-architecture support
+ARG TARGETARCH
 RUN apt-get update -y && apt-get install -y jq sed unzip
-RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+# Map TARGETARCH to protoc naming convention (amd64 -> x86_64, arm64 -> aarch_64)
+RUN PROTOC_ARCH=$(case ${TARGETARCH} in amd64) echo "x86_64";; arm64) echo "aarch_64";; *) echo "x86_64";; esac) && \
+    curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip
 RUN unzip -o protoc.zip -d /tmp/protoc && \
     mv /tmp/protoc/bin/protoc /usr/bin/protoc && \
     chmod +x /usr/bin/protoc
@@ -67,8 +71,9 @@ RUN mkdir -p /protoc-gen-openapiv2 && \
     cp -r /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway/v2@${GRPC_GATEWAY_VERSION}/protoc-gen-openapiv2/options /protoc-gen-openapiv2/options
 
 # Download go-swagger binary.
-RUN curl -LO "https://github.com/go-swagger/go-swagger/releases/download/${GO_SWAGGER_VERSION}/swagger_linux_amd64"
-RUN chmod +x swagger_linux_amd64 && mv swagger_linux_amd64 /usr/bin/swagger
+# Use TARGETARCH for multi-architecture support
+RUN curl -LO "https://github.com/go-swagger/go-swagger/releases/download/${GO_SWAGGER_VERSION}/swagger_linux_${TARGETARCH}"
+RUN chmod +x swagger_linux_${TARGETARCH} && mv swagger_linux_${TARGETARCH} /usr/bin/swagger
 
 # Need protobuf source code for -I in protoc command.
 # Install protoc-gen-go.

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -30,7 +30,9 @@ RUN /usr/local/gcloud/google-cloud-sdk/install.sh
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 # Install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+# Use TARGETARCH for multi-architecture support (amd64, arm64)
+ARG TARGETARCH
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl
 RUN chmod +x ./kubectl
 RUN mv kubectl /usr/local/bin/
 

--- a/test/release/Dockerfile.release
+++ b/test/release/Dockerfile.release
@@ -39,7 +39,9 @@ RUN apt-get update \
 
 # install yq==3
 # Released in https://github.com/mikefarah/yq/releases/tag/3.4.1
-RUN curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 && \
+# Use TARGETARCH for multi-architecture support
+ARG TARGETARCH
+RUN curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_${TARGETARCH} && \
     chmod +x /usr/local/bin/yq
 
 # Make all files accessible to non-root users.
@@ -49,6 +51,8 @@ RUN chmod -R 777 $NVM_DIR && \
 # Configure npm cache location
 RUN npm config set cache /tmp/.npm --global
 
-RUN curl -L -H "Accept: application/octet-stream" \
-        https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz \
+# Map TARGETARCH to git-cliff naming convention (amd64 -> x86_64, arm64 -> aarch64)
+RUN GIT_CLIFF_ARCH=$(case ${TARGETARCH} in amd64) echo "x86_64";; arm64) echo "aarch64";; *) echo "x86_64";; esac) && \
+    curl -L -H "Accept: application/octet-stream" \
+        https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-${GIT_CLIFF_ARCH}-unknown-linux-gnu.tar.gz \
     | tar -xz --strip-components=1 -C /usr/local/bin git-cliff-${GIT_CLIFF_VERSION}/git-cliff


### PR DESCRIPTION


This PR adds ARM64/linux multi-architecture support for Kubeflow Pipelines container images.

### Changes:
- **CI Workflow** (`.github/workflows/build-and-push.yml`): Added QEMU and Docker Buildx setup for multi-platform builds (`linux/amd64,linux/arm64`)
- **Backend Dockerfile** (`backend/Dockerfile`): Switched to `python:3.11-slim`, removed unused Java dependency, added `TARGETARCH` for Argo CLI download
- **Makefile** (`backend/Makefile`): Added configurable `PLATFORM` variable (default: `linux/amd64` for backwards compatibility)
- **API Generator** (`backend/api/Dockerfile`): Added `TARGETARCH` for protoc and swagger binary downloads
- **Proxy** (`proxy/Dockerfile`): Added `TARGETARCH` for kubectl download
- **Release Dockerfile** (`test/release/Dockerfile.release`): Added `TARGETARCH` for yq and git-cliff downloads

### Testing:
- Successfully built `apiserver` image for `linux/arm64`
- Successfully built `kfp-driver` image for `linux/arm64`

### Note:
The proxy base image (`gcr.io/inverting-proxy/agent`) is externally maintained and may not have ARM64 support. A comment has been added to document this limitation.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. 