### PR TITLE
Update ML Pipeline server address to facilitate TLS-enabled gRPC connection

### DIFF
--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -99,6 +99,7 @@ func initCerts() (*tls.Config, error) {
 		return nil, err
 	}
 	tlsCfg := &tls.Config{
+		ServerName:   common.GetMLPipelineServiceName() + "." + common.GetPodNamespace() + ".svc.cluster.local",
 		Certificates: []tls.Certificate{serverCert},
 	}
 	glog.Info("TLS cert key/pair loaded.")

--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -194,7 +194,7 @@ func getDefaultMinioSessionInfo() (objectstore.SessionInfo, error) {
 
 func GetMLPipelineServerConfig() *ServerConfig {
 	return &ServerConfig{
-		Address: common.GetMLPipelineServiceName() + "." + common.GetPodNamespace(),
+		Address: common.GetMLPipelineServiceName() + "." + common.GetPodNamespace() + ".svc.cluster.local",
 		Port:    mlPipelineGrpcServicePort,
 	}
 }

--- a/manifests/kustomize/env/cert-manager/base-tls-certs/kfp-api-cert.yaml
+++ b/manifests/kustomize/env/cert-manager/base-tls-certs/kfp-api-cert.yaml
@@ -8,12 +8,14 @@ spec:
   dnsNames:
     - ml-pipeline
     - ml-pipeline.kubeflow
+    - ml-pipeline.$(kfp-namespace).svc.cluster.local
     - ml-pipeline-scheduledworkflow
     - metadata-envoy
     - metadata-envoy-service
     - metadata-grpc-service
     - metadata-grpc-service.kubeflow
     - metadata-grpc-service.$(kfp-namespace).svc.cluster.local
+    # localhost included here because cert is used in KFP pod-to-pod TLS-enabled testing against localhost base URL
     - localhost
   ipAddresses:
     # Necessary for running TLS-enabled cluster locally.


### PR DESCRIPTION
**Description of your changes:**

This PR updates the TLS config (used only when specifically enabled) on the API server with field `ServerName` in order for the TLS-enabled gRPC connection to successfully serve requests for certs without the `localhost` dns name.  `GetMLPipelineServerConfig()` in `backend/src/v2/config/env.go` is also updated to append `".svc.cluster.local"` to the end of the configured address.

Note that `localhost` is retained on `manifests/kustomize/env/cert-manager/base-tls-certs/kfp-api-cert.yaml`, due to this manifest's use in KFP integration testing.  

Resolves #12720 

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
