### PR TITLE
chore(manifests): remove "localhost" from kfp-api-cert

### DIFF
--- a/manifests/kustomize/env/cert-manager/base-tls-certs/kfp-api-cert.yaml
+++ b/manifests/kustomize/env/cert-manager/base-tls-certs/kfp-api-cert.yaml
@@ -14,7 +14,6 @@ spec:
     - metadata-grpc-service
     - metadata-grpc-service.kubeflow
     - metadata-grpc-service.$(kfp-namespace).svc.cluster.local
-    - localhost
   ipAddresses:
     # Necessary for running TLS-enabled cluster locally.
     - 127.0.0.1


### PR DESCRIPTION
Fixes #12720

Removed "localhost" from kfp-api-cert dnsNames list to avoid insecure/non-standard certificate SAN configuration.
