### PR TITLE
fix(testing) retention for image-builds-with-cache artifacts

### DIFF
--- a/.github/workflows/image-builds-with-cache.yml
+++ b/.github/workflows/image-builds-with-cache.yml
@@ -82,6 +82,10 @@ jobs:
             echo "registry=${{ env.REGISTRY }}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
       # Check if the image was already built for this SHA using cache
       - name: Check if already built
         id: cache-check
@@ -89,7 +93,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .build-marker-${{ matrix.image }}
-          key: image-built-${{ matrix.image }}-${{ github.sha }}
+          key: image-built-${{ matrix.image }}-${{ github.sha }}-${{ steps.date.outputs.date }}
           lookup-only: true
 
       - name: Set up Docker Buildx
@@ -138,4 +142,4 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: .build-marker-${{ matrix.image }}
-          key: image-built-${{ matrix.image }}-${{ github.sha }}
+          key: image-built-${{ matrix.image }}-${{ github.sha }}-${{ steps.date.outputs.date }}


### PR DESCRIPTION
**Description of your changes:**
Add the current date to the cache key used in `.github/workflows/image-builds-with-cache.yml`. This forces the cache key to change daily, so that old image markers disappear after midnight, syncing cache expiration with single-day artifact retention.This change should fix the CI bug in which image artifacts fail to be located.

This PR is a follow-up to the cache lookups added in #12712. 
Resolves #12734 

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
- [] Make sure the changes work with DSPO. Run the tests in DSPO with DSPA images pointing to this PR's images
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
