### PR TITLE
chore(test): use make commands in `gcpc-modules-tests.yml`

### DIFF
--- a/.github/workflows/gcpc-modules-tests.yml
+++ b/.github/workflows/gcpc-modules-tests.yml
@@ -53,14 +53,9 @@ jobs:
           python -m build .
           pip install dist/*.whl
 
-      - name: Install python sdk
-        run: pip install sdk/python
-
-      - name: Install google-cloud component
-        run: pip install components/google-cloud
-
-      - name: Install Pytest
-        run: pip install "$(grep 'pytest==' sdk/python/requirements-dev.txt)"
+      - name: Install GCPC test dependencies
+        run: make install-gcpc-test-deps
 
       - name: Run test
-        run: pytest ./test/gcpc-tests/run_all_gcpc_modules.py
+        run: make test-gcpc-modules
+

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,15 @@ ginkgo:
 	mkdir -p $(BIN_DIR)
 	GOBIN=$(BIN_DIR) go install github.com/onsi/ginkgo/v2/ginkgo@latest
 	@echo "Ginkgo installed to $(BIN_DIR)/ginkgo"
+
+# GCPC Module Tests
+.PHONY: test-gcpc-modules
+test-gcpc-modules:
+	pytest ./test/gcpc-tests/run_all_gcpc_modules.py
+
+# Install GCPC test dependencies (kfp SDK, google-cloud components, pytest)
+.PHONY: install-gcpc-test-deps
+install-gcpc-test-deps:
+	pip install sdk/python
+	pip install components/google-cloud
+	pip install "$$(grep 'pytest==' sdk/python/requirements-dev.txt)"


### PR DESCRIPTION
**Description of your changes:**
- Added two new targets:
   - `install-gcpc-test-deps`: Installs python SDK, google-cloud components, and pytest
  - `test-gcpc-modules`: Runs the actual pytest execution
-  Refactored `.github/workflows/gcpc-modules-tests.yml` to use these make commands instead of inline shell scripts


Fixes: #11689 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
