### PR TITLE
fix(frontend): show logs for terminated pods. Fixes #11969 

### DIFF
--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -32,11 +32,16 @@ import { errorToMessage } from 'src/lib/Utils';
 import { getTaskKeyFromNodeKey, NodeTypeNames } from 'src/lib/v2/StaticFlow';
 import {
   EXECUTION_KEY_CACHED_EXECUTION_ID,
+  getArtifactName,
   getArtifactTypeName,
   getArtifactTypes,
+  getLinkedArtifactsByExecution,
+  getStoreSessionInfoFromArtifact,
+  filterEventWithOutputArtifact,
   KfpExecutionProperties,
   LinkedArtifact,
 } from 'src/mlmd/MlmdUtils';
+import WorkflowParser from 'src/lib/WorkflowParser';
 import { NodeMlmdInfo } from 'src/pages/RunDetailsV2';
 import { ArtifactType, Execution } from 'src/third_party/mlmd';
 import ArtifactPreview from 'src/components/ArtifactPreview';
@@ -152,12 +157,12 @@ function TaskNodeDetail({
   namespace,
 }: TaskNodeDetailProps) {
   const { data: logsInfo } = useQuery<Map<string, string>, Error>(
-    [execution],
+    ['execution_logs', { executionId: execution?.getId(), namespace }],
     async () => {
       if (!execution) {
         throw new Error('No execution is found.');
       }
-      return await getLogsInfo(execution, runId);
+      return await getLogsInfo(execution, runId, namespace);
     },
     { enabled: !!execution },
   );
@@ -297,7 +302,11 @@ function getNodeVolumeMounts(
   return volumeMounts;
 }
 
-async function getLogsInfo(execution: Execution, runId?: string): Promise<Map<string, string>> {
+async function getLogsInfo(
+  execution: Execution,
+  runId?: string,
+  namespace?: string,
+): Promise<Map<string, string>> {
   const logsInfo = new Map<string, string>();
   let podName = '';
   let podNameSpace = '';
@@ -325,6 +334,34 @@ async function getLogsInfo(execution: Execution, runId?: string): Promise<Map<st
     logsDetails = await Apis.getPodLogs(runId!, podName, podNameSpace, createdAt);
     logsInfo.set(LOGS_DETAILS, logsDetails);
   } catch (err) {
+    // Primary method failed, try to get logs from executor-logs artifact in MLMD
+    console.log('Pod logs retrieval failed, attempting to fetch executor-logs artifact from MLMD');
+    try {
+      const linkedArtifacts = await getLinkedArtifactsByExecution(execution);
+      const outputArtifacts = filterEventWithOutputArtifact(linkedArtifacts);
+      const executorLogsArtifact = outputArtifacts.find(
+        artifact => getArtifactName(artifact) === 'executor-logs',
+      );
+
+      if (executorLogsArtifact) {
+        const uri = executorLogsArtifact.artifact.getUri();
+        const storagePath = WorkflowParser.parseStoragePath(uri);
+        const providerInfo = getStoreSessionInfoFromArtifact(executorLogsArtifact);
+        const artifactNamespace = namespace || podNameSpace;
+
+        logsDetails = await Apis.readFile({
+          path: storagePath,
+          providerInfo: providerInfo,
+          namespace: artifactNamespace,
+        });
+        logsInfo.set(LOGS_DETAILS, logsDetails);
+        return logsInfo;
+      }
+    } catch (artifactErr) {
+      console.error('Failed to retrieve executor-logs artifact:', artifactErr);
+    }
+
+    // Both methods failed
     let errMsg = await errorToMessage(err);
     logsBannerMessage = 'Failed to retrieve pod logs.';
     logsInfo.set(LOGS_BANNER_MESSAGE, logsBannerMessage);


### PR DESCRIPTION
Fixes #11969 

### Description

When pods are garbage collected from the Kubernetes cluster, the Logs tab in the KFP UI displays "Failed to retrieve pod logs" even for V2 runs even though executor logs are stored in object storage as `executor-logs` artifacts.     

 The existing pod logs retrieval in the frontend calls a backend endpoint with a three-tier fallback strategy:                      
  1. Fetches logs directly from the pod via K8s API → fails when pod is garbage collected                                            
  2. Uses the Argo Workflow to find the path to `main.log` in artifact storage → fails when the workflow is garbage collected          
  3. Uses static Argo configuration to query `main.log` → fails when not configured or Argo doesn't save logs to main.log  

For V2 pipelines, the KFP SDK publishes executor logs as MLMD artifacts named `executor-logs` (when using the `--publish_logs` flag). However, the existing log retrieval logic doesn't attempt to use them.  

This PR adds a fourth-tier fallback in the `RuntimeNodeDetailsV2` component that activates when the backend's three-tier strategy fails using helper functions from`frontend/src/mlmd/MlmdUtils.ts`.  

### Pictures

Before this fix, the UI shows an error when looking up logs once pods are garbage collected:

<img width="2344" height="366" alt="image" src="https://github.com/user-attachments/assets/57c1643f-c2fd-4752-9d3b-e2cf09293c29" />

After this fix, the `executor-logs` artifact is used for V2 run to display the pod logs in the UI correctly:

<img width="1960" height="838" alt="fix" src="https://github.com/user-attachments/assets/82127427-add2-4c6c-85fa-4b0a22f373f6" />

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
