### PR TITLE
feat(backend): Remediate ADA-KUBEFL-01: Server-Side Request Forgery

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -46,6 +46,10 @@ const (
 	DefaultSecurityContextRunAsNonRoot      string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_NON_ROOT"
 	BlockV1Pipelines                        string = "BLOCK_V1_PIPELINES"
 	V1NamespaceWhitelist                    string = "V1_ALLOWED_NAMESPACES"
+	PipelineURLAllowedDomains               string = "PIPELINE_URL_ALLOWED_DOMAINS"
+	PipelineURLAllowHTTP                    string = "PIPELINE_URL_ALLOW_HTTP"
+	PipelineURLTimeout                      string = "PIPELINE_URL_TIMEOUT"
+	PipelineURLValidationEnabled            string = "PIPELINE_URL_VALIDATION_ENABLED"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {

--- a/backend/src/apiserver/server/pipeline_server.go
+++ b/backend/src/apiserver/server/pipeline_server.go
@@ -16,11 +16,13 @@ package server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"path"
 	"strings"
 
+	"github.com/golang/glog"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -200,8 +202,21 @@ func (s *BasePipelineServer) createPipelineAndPipelineVersion(ctx context.Contex
 	if err != nil {
 		return nil, nil, util.NewInvalidInputError("invalid pipeline spec URL: %v", pipelineURLStr)
 	}
+
+	if err := validation.ValidatePipelineURL(pipelineURL.String()); err != nil {
+		glog.Warningf("Pipeline URL validation failed: %v", err)
+		return nil, nil, util.NewInvalidInputError("Pipeline URL validation failed")
+	}
+
 	resp, err := s.httpClient.Get(pipelineURL.String())
 	if err != nil {
+		// Unwrap redirect validation errors so they return 4xx, not 500
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			if userErr, ok := urlErr.Err.(*util.UserError); ok {
+				return nil, nil, userErr
+			}
+		}
 		return nil, nil, util.NewInternalServerError(err, "error downloading the pipeline spec from %v", pipelineURL.String())
 	} else if resp.StatusCode != http.StatusOK {
 		return nil, nil, util.NewInvalidInputError("error fetching pipeline spec from %v - request returned %v", pipelineURL.String(), resp.Status)
@@ -704,7 +719,7 @@ func NewPipelineServer(resourceManager *resource.ResourceManager, options *Pipel
 	return &PipelineServer{
 		BasePipelineServer: &BasePipelineServer{
 			resourceManager: resourceManager,
-			httpClient:      http.DefaultClient,
+			httpClient:      validation.SafePipelineHTTPClient(),
 			options:         options,
 		},
 	}
@@ -714,7 +729,7 @@ func NewPipelineServerV1(resourceManager *resource.ResourceManager, options *Pip
 	return &PipelineServerV1{
 		BasePipelineServer: &BasePipelineServer{
 			resourceManager: resourceManager,
-			httpClient:      http.DefaultClient,
+			httpClient:      validation.SafePipelineHTTPClient(),
 			options:         options,
 		},
 	}
@@ -780,12 +795,22 @@ func (s *BasePipelineServer) createPipelineVersion(ctx context.Context, pv *mode
 		return nil, util.NewInvalidInputError("Failed to create a pipeline version due to invalid pipeline spec URI. PipelineSpecURI: %v. Please specify a valid URL", pv.PipelineSpecURI)
 	}
 
+	if err := validation.ValidatePipelineURL(pipelineUrl.String()); err != nil {
+		glog.Warningf("Pipeline URL validation failed: %v", err)
+		return nil, util.NewInvalidInputError("Pipeline URL validation failed")
+	}
 	resp, err := s.httpClient.Get(pipelineUrl.String())
-	if err != nil || resp.StatusCode != http.StatusOK {
-		if err == nil {
-			return nil, util.NewInvalidInputError("Failed to fetch pipeline spec with url: %v. Request returned %v", pipelineUrl.String(), resp.Status)
+	if err != nil {
+		// Unwrap redirect validation errors so they return 4xx, not 500
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			if userErr, ok := urlErr.Err.(*util.UserError); ok {
+				return nil, userErr
+			}
 		}
 		return nil, util.NewInternalServerError(err, "Failed to create a pipeline version due error downloading the pipeline spec from %v", pipelineUrl.String())
+	} else if resp.StatusCode != http.StatusOK {
+		return nil, util.NewInvalidInputError("Failed to fetch pipeline spec with url: %v. Request returned %v", pipelineUrl.String(), resp.Status)
 	}
 	defer resp.Body.Close()
 	pipelineFileName := path.Base(pipelineUrl.String())

--- a/backend/src/apiserver/server/pipeline_server_test.go
+++ b/backend/src/apiserver/server/pipeline_server_test.go
@@ -41,6 +41,12 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
+func TestMain(m *testing.M) {
+	// Disable URL validation for tests (allows mock server URLs)
+	viper.Set(common.PipelineURLValidationEnabled, "false")
+	os.Exit(m.Run())
+}
+
 func createPipelineServerV1(resourceManager *resource.ResourceManager, httpClient *http.Client) *PipelineServerV1 {
 	return &PipelineServerV1{
 		BasePipelineServer: &BasePipelineServer{
@@ -1234,4 +1240,94 @@ func TestCanAccessPipeline_SharedPipeline_ReadAllowed_EvenWhenUnauthorized(t *te
 	// LIST on shared pipeline should still be allowed even for unauthorized user
 	err = pipelineServer.canAccessPipeline(ctx, "", &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbList})
 	assert.Nil(t, err)
+}
+
+func TestCreatePipelineV1_URLValidation_BlocksDisallowedDomain(t *testing.T) {
+	// Enable URL validation for this test (overrides TestMain's global disable)
+	viper.Set(common.PipelineURLValidationEnabled, "true")
+	defer viper.Set(common.PipelineURLValidationEnabled, "false")
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+
+	pipelineServer := createPipelineServerV1(resourceManager, http.DefaultClient)
+	_, err := pipelineServer.CreatePipelineV1(
+		context.Background(), &api.CreatePipelineRequest{
+			Pipeline: &api.Pipeline{
+				Url:  &api.Url{PipelineUrl: "https://evil.com/malicious.yaml"},
+				Name: "test-blocked-domain",
+			},
+		},
+	)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Pipeline URL validation failed")
+}
+
+func TestCreatePipelineV1_URLValidation_BlocksHTTPByDefault(t *testing.T) {
+	viper.Set(common.PipelineURLValidationEnabled, "true")
+	defer viper.Set(common.PipelineURLValidationEnabled, "false")
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+
+	pipelineServer := createPipelineServerV1(resourceManager, http.DefaultClient)
+	_, err := pipelineServer.CreatePipelineV1(
+		context.Background(), &api.CreatePipelineRequest{
+			Pipeline: &api.Pipeline{
+				Url:  &api.Url{PipelineUrl: "http://storage.googleapis.com/bucket/file.yaml"},
+				Name: "test-http-blocked",
+			},
+		},
+	)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Pipeline URL validation failed")
+}
+
+func TestCreatePipelineV1_URLValidation_BlocksFileScheme(t *testing.T) {
+	viper.Set(common.PipelineURLValidationEnabled, "true")
+	defer viper.Set(common.PipelineURLValidationEnabled, "false")
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+
+	pipelineServer := createPipelineServerV1(resourceManager, http.DefaultClient)
+	_, err := pipelineServer.CreatePipelineV1(
+		context.Background(), &api.CreatePipelineRequest{
+			Pipeline: &api.Pipeline{
+				Url:  &api.Url{PipelineUrl: "file:///etc/passwd"},
+				Name: "test-file-blocked",
+			},
+		},
+	)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Pipeline URL validation failed")
+}
+
+type errorRoundTripper struct {
+	err error
+}
+
+func (rt errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, rt.err
+}
+
+func TestCreatePipelineV1_URLValidation_MapsTransportValidationErrorToInvalidInput(t *testing.T) {
+	viper.Set(common.PipelineURLValidationEnabled, "false")
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+
+	pipelineServer := createPipelineServerV1(resourceManager, &http.Client{
+		Transport: errorRoundTripper{err: util.NewInvalidInputError("connection to blocked IP range denied")},
+	})
+	_, err := pipelineServer.CreatePipelineV1(
+		context.Background(), &api.CreatePipelineRequest{
+			Pipeline: &api.Pipeline{
+				Url:  &api.Url{PipelineUrl: "https://storage.googleapis.com/bucket/file.yaml"},
+				Name: "test-transport-validation-error",
+			},
+		},
+	)
+	assert.NotNil(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
 }

--- a/backend/src/apiserver/validation/pipeline_url.go
+++ b/backend/src/apiserver/validation/pipeline_url.go
@@ -1,0 +1,255 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+)
+
+// Default allowed domains for pipeline URLs
+var defaultAllowedDomains = []string{
+	"storage.googleapis.com",
+	"s3.amazonaws.com",
+	"github.com",
+	"raw.githubusercontent.com",
+}
+
+// Blocked CIDRs - private/loopback/link-local/metadata
+var blockedCIDRs = []string{
+	// Loopback
+	"127.0.0.0/8",
+	"::1/128",
+
+	// Private
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"fc00::/7",
+
+	// Link-local
+	"169.254.0.0/16",
+	"fe80::/10",
+
+	// Metadata
+	"169.254.169.254/32",
+	"fd00:ec2::254/128",
+
+	// Invalid
+	"0.0.0.0/8",
+	"::/128",
+}
+
+var defaultPorts = map[string]string{
+	"https": "443",
+	"http":  "80",
+}
+
+var (
+	blockedNets    []*net.IPNet
+	allowedDomains []*regexp.Regexp
+	urlConfigInit  sync.Once
+)
+
+// initURLConfig initializes blocked networks and allowed domains
+func initURLConfig() {
+	urlConfigInit.Do(func() {
+		// Parse CIDR strings into IPNet objects
+		for _, cidr := range blockedCIDRs {
+			if _, ipNet, err := net.ParseCIDR(cidr); err == nil {
+				blockedNets = append(blockedNets, ipNet)
+			} else {
+				glog.Warningf("Failed to parse blocked CIDR %q: %v", cidr, err)
+			}
+		}
+
+		// Build allowed domains: defaults + user-configured
+		allDomains := append([]string{}, defaultAllowedDomains...)
+		userDomains := common.GetStringConfigWithDefault(common.PipelineURLAllowedDomains, "")
+		if userDomains != "" {
+			for _, d := range strings.Split(userDomains, ",") {
+				if d = strings.TrimSpace(d); d != "" {
+					allDomains = append(allDomains, d)
+				}
+			}
+		}
+
+		// Compile domain patterns into regex
+		for _, domain := range allDomains {
+			pattern := "^" + strings.ReplaceAll(regexp.QuoteMeta(domain), "\\*", ".*") + "$"
+			if re, err := regexp.Compile(pattern); err == nil {
+				allowedDomains = append(allowedDomains, re)
+			} else {
+				glog.Warningf("Failed to compile domain pattern %q: %v", pattern, err)
+			}
+		}
+	})
+}
+
+// ValidatePipelineURL validates a pipeline URL is safe to fetch
+// Can be disabled via PIPELINE_URL_VALIDATION_ENABLED=false (for testing purposes only)
+func ValidatePipelineURL(urlStr string) error {
+	// Allow disabling validation
+	if !common.GetBoolConfigWithDefault(common.PipelineURLValidationEnabled, true) {
+		return nil
+	}
+
+	initURLConfig()
+
+	parsed, err := url.ParseRequestURI(urlStr)
+	if err != nil {
+		return util.NewInvalidInputError("invalid URL: %v", err)
+	}
+
+	// Validate scheme
+	allowHTTP := common.GetBoolConfigWithDefault(common.PipelineURLAllowHTTP, false)
+	if parsed.Scheme != "https" && (parsed.Scheme != "http" || !allowHTTP) {
+		return util.NewInvalidInputError("URL scheme %q not allowed, use https", parsed.Scheme)
+	}
+
+	// Validate port
+	port := parsed.Port()
+	if port != "" && port != defaultPorts[parsed.Scheme] {
+		return util.NewInvalidInputError(
+			"%s requires port %s, got %q",
+			strings.ToUpper(parsed.Scheme),
+			defaultPorts[parsed.Scheme],
+			port,
+		)
+	}
+
+	// Validate domain against allowlist
+	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if !isDomainAllowed(host) {
+		return util.NewInvalidInputError("URL domain %q not in allowlist", host)
+	}
+
+	// Resolve DNS and validate IPs are not in blocked ranges
+	if err := validateResolvedIPs(host); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isDomainAllowed(host string) bool {
+	for _, re := range allowedDomains {
+		if re.MatchString(host) {
+			return true
+		}
+	}
+	return false
+}
+
+const dnsLookupTimeout = 5 * time.Second
+
+func validateResolvedIPs(host string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), dnsLookupTimeout)
+	defer cancel()
+
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return util.NewInvalidInputError("DNS resolution failed for %q: %v", host, err)
+	}
+
+	for _, addr := range addrs {
+		if isBlockedIP(addr.IP) {
+			return util.NewInvalidInputError("URL resolves to blocked IP range: %v", addr.IP)
+		}
+	}
+	return nil
+}
+
+func isBlockedIP(ip net.IP) bool {
+	for _, ipNet := range blockedNets {
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// SafePipelineHTTPClient creates an HTTP client with timeout, redirect validation,
+// and a custom dialer that enforces IP validation at connection time to prevent
+// DNS rebinding (TOCTOU) attacks.
+const minimumHTTPTimeout = 1
+
+func SafePipelineHTTPClient() *http.Client {
+	timeoutSeconds := common.GetIntConfigWithDefault(common.PipelineURLTimeout, 30)
+	if timeoutSeconds < minimumHTTPTimeout {
+		timeoutSeconds = 30
+	}
+	timeout := time.Duration(timeoutSeconds) * time.Second
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = safeDialContext
+
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return util.NewInvalidInputError("too many redirects")
+			}
+			return ValidatePipelineURL(req.URL.String())
+		},
+	}
+}
+
+// safeDialContext resolves the host, validates all IPs against blocked ranges,
+// and connects only to a validated IP. This closes the DNS TOCTOU gap where
+// a host could resolve to a safe IP during validation but a blocked IP at
+// connection time (DNS rebinding).
+func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address %q: %v", addr, err)
+	}
+
+	initURLConfig()
+
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("DNS resolution failed for %q: %v", host, err)
+	}
+
+	for _, a := range addrs {
+		if isBlockedIP(a.IP) {
+			return nil, util.NewInvalidInputError("connection to blocked IP range denied")
+		}
+	}
+
+	// Connect using the resolved IPs directly
+	var dialer net.Dialer
+	for _, a := range addrs {
+		conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(a.IP.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to connect to any resolved address for %q", host)
+}

--- a/backend/src/apiserver/validation/pipeline_url_test.go
+++ b/backend/src/apiserver/validation/pipeline_url_test.go
@@ -1,0 +1,343 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// resetURLConfig resets the sync.Once to allow re-initialization with new config
+func resetURLConfig() {
+	urlConfigInit = sync.Once{}
+	blockedNets = nil
+	allowedDomains = nil
+}
+
+func TestValidatePipelineURL_AllowedDomains(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	// Default allowed domains should pass
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com/bucket/file.yaml"))
+	assert.NoError(t, ValidatePipelineURL("https://github.com/kubeflow/pipelines/raw/main/test.yaml"))
+	assert.NoError(t, ValidatePipelineURL("https://s3.amazonaws.com/bucket/file.yaml"))
+
+	// Disallowed domain should fail
+	err := ValidatePipelineURL("https://evil.com/malicious.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not in allowlist")
+}
+
+func TestValidatePipelineURL_BlockedDomain(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	// localhost should fail (not in allowlist)
+	err := ValidatePipelineURL("https://localhost/file.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not in allowlist")
+}
+
+func TestValidatePipelineURL_SchemeRestriction(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	// HTTP blocked by default
+	err := ValidatePipelineURL("http://storage.googleapis.com/bucket/file.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "scheme")
+
+	// HTTPS allowed
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com/bucket/file.yaml"))
+}
+
+func TestValidatePipelineURL_HTTPAllowedWhenConfigured(t *testing.T) {
+	viper.Reset()
+	viper.Set("PIPELINE_URL_ALLOW_HTTP", "true")
+	resetURLConfig()
+
+	// HTTP allowed when configured
+	assert.NoError(t, ValidatePipelineURL("http://storage.googleapis.com/bucket/file.yaml"))
+}
+
+func TestValidatePipelineURL_PortRestriction(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	// Default port (no port specified) should pass
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com/bucket/file.yaml"))
+
+	// Explicit standard port should pass
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com:443/bucket/file.yaml"))
+
+	// Non-standard port should fail
+	err := ValidatePipelineURL("https://storage.googleapis.com:8080/bucket/file.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "port")
+}
+
+func TestValidatePipelineURL_PortMustMatchScheme(t *testing.T) {
+	viper.Reset()
+	viper.Set("PIPELINE_URL_ALLOW_HTTP", "true")
+	resetURLConfig()
+
+	// HTTPS on port 80 should fail
+	err := ValidatePipelineURL("https://storage.googleapis.com:80/bucket/file.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTPS requires port 443")
+
+	// HTTP on port 443 should fail
+	err = ValidatePipelineURL("http://storage.googleapis.com:443/bucket/file.yaml")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP requires port 80")
+}
+
+func TestValidatePipelineURL_UserConfiguredDomains(t *testing.T) {
+	viper.Reset()
+	viper.Set("PIPELINE_URL_ALLOWED_DOMAINS", "example.com")
+	resetURLConfig()
+
+	// User-configured domain should pass
+	assert.NoError(t, ValidatePipelineURL("https://example.com/test.yaml"))
+
+	// Default domains should still pass
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com/bucket/file.yaml"))
+}
+
+func TestValidatePipelineURL_InvalidURL(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	err := ValidatePipelineURL("not-a-valid-url")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid URL")
+}
+
+func TestValidatePipelineURL_FileSchemeBlocked(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	err := ValidatePipelineURL("file:///etc/passwd")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "scheme")
+}
+
+func TestIsBlockedIP(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+	initURLConfig()
+
+	tests := []struct {
+		ip      string
+		blocked bool
+		desc    string
+	}{
+		// Loopback
+		{"127.0.0.1", true, "IPv4 loopback"},
+		{"127.255.255.255", true, "IPv4 loopback range end"},
+		{"::1", true, "IPv6 loopback"},
+
+		// Private IPv4
+		{"10.0.0.1", true, "Private Class A"},
+		{"10.255.255.255", true, "Private Class A end"},
+		{"172.16.0.1", true, "Private Class B start"},
+		{"172.31.255.255", true, "Private Class B end"},
+		{"192.168.1.1", true, "Private Class C"},
+		{"192.168.255.255", true, "Private Class C end"},
+
+		// Link-local / metadata
+		{"169.254.0.1", true, "Link-local"},
+		{"169.254.169.254", true, "Cloud metadata endpoint"},
+
+		// Public IPs (should NOT be blocked)
+		{"8.8.8.8", false, "Google DNS"},
+		{"1.1.1.1", false, "Cloudflare DNS"},
+		{"142.250.80.46", false, "Google public"},
+		{"151.101.1.140", false, "GitHub"},
+	}
+
+	for _, tt := range tests {
+		ip := net.ParseIP(tt.ip)
+		assert.NotNil(t, ip, "Failed to parse IP: %s", tt.ip)
+		assert.Equal(t, tt.blocked, isBlockedIP(ip), "%s: IP %s should be blocked=%v", tt.desc, tt.ip, tt.blocked)
+	}
+}
+
+func TestIsBlockedIP_IPv6Metadata(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+	initURLConfig()
+
+	ip := net.ParseIP("fd00:ec2::254")
+	assert.NotNil(t, ip)
+	assert.True(t, isBlockedIP(ip), "AWS EC2 IPv6 metadata endpoint should be blocked")
+}
+
+func TestValidatePipelineURL_HostnameNormalization(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	// Trailing dot (FQDN) should be normalized and pass
+	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com./bucket/file.yaml"))
+
+	// Mixed case should be normalized and pass
+	assert.NoError(t, ValidatePipelineURL("https://Storage.GoogleAPIs.COM/bucket/file.yaml"))
+}
+
+func TestSafePipelineHTTPClient_RedirectValidation(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+
+	// Simulate a redirect to a disallowed domain
+	redirectRequest := &http.Request{
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "evil.com",
+			Path:   "/malicious.yaml",
+		},
+	}
+	via := []*http.Request{{}} // one prior redirect
+	err := client.CheckRedirect(redirectRequest, via)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not in allowlist")
+
+	// Simulate a redirect to an allowed domain
+	allowedRequest := &http.Request{
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "storage.googleapis.com",
+			Path:   "/bucket/redirected.yaml",
+		},
+	}
+	err = client.CheckRedirect(allowedRequest, via)
+	assert.NoError(t, err)
+}
+
+func TestSafePipelineHTTPClient_TooManyRedirects(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+
+	redirectRequest := &http.Request{
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "storage.googleapis.com",
+			Path:   "/file.yaml",
+		},
+	}
+	// 10 prior redirects should trigger "too many redirects"
+	via := make([]*http.Request, 10)
+	err := client.CheckRedirect(redirectRequest, via)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too many redirects")
+}
+
+func TestSafePipelineHTTPClient_ZeroTimeoutDefaultsTo30(t *testing.T) {
+	viper.Reset()
+	viper.Set("PIPELINE_URL_TIMEOUT", "0")
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+	assert.Equal(t, 30*time.Second, client.Timeout, "Zero timeout should default to 30 seconds")
+}
+
+func TestSafePipelineHTTPClient_HasTimeout(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+	assert.NotNil(t, client)
+	assert.True(t, client.Timeout > 0, "Client should have a timeout configured")
+}
+
+func TestSafePipelineHTTPClient_CustomTimeout(t *testing.T) {
+	viper.Reset()
+	viper.Set("PIPELINE_URL_TIMEOUT", "60")
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+	assert.NotNil(t, client)
+	// 60 seconds = 60,000,000,000 nanoseconds
+	assert.Equal(t, int64(60_000_000_000), int64(client.Timeout))
+}
+
+func TestSafePipelineHTTPClient_HasCustomTransport(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+	assert.NotNil(t, client.Transport, "Client should have a custom transport to prevent DNS rebinding")
+	_, ok := client.Transport.(*http.Transport)
+	assert.True(t, ok, "Transport should be *http.Transport with custom DialContext")
+}
+
+func TestSafeDialContext_BlocksPrivateIPs(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+	initURLConfig()
+
+	ctx := context.Background()
+	// 127.0.0.1 is in the loopback blocked range
+	_, err := safeDialContext(ctx, "tcp", "127.0.0.1:443")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "blocked IP")
+}
+
+func TestSafeDialContext_BlocksMetadataIP(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+	initURLConfig()
+
+	ctx := context.Background()
+	// 169.254.169.254 is the cloud metadata endpoint
+	_, err := safeDialContext(ctx, "tcp", "169.254.169.254:80")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "blocked IP")
+}
+
+func TestSafeDialContext_InvalidAddress(t *testing.T) {
+	viper.Reset()
+	resetURLConfig()
+	initURLConfig()
+
+	ctx := context.Background()
+	_, err := safeDialContext(ctx, "tcp", "no-port")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid address")
+}
+
+func TestSafePipelineHTTPClient_DisablesProxyFromEnvironment(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://squid.squid.svc.cluster.local:3128")
+	t.Setenv("HTTP_PROXY", "http://squid.squid.svc.cluster.local:3128")
+	viper.Reset()
+	resetURLConfig()
+
+	client := SafePipelineHTTPClient()
+	transport, ok := client.Transport.(*http.Transport)
+	assert.True(t, ok)
+	assert.Nil(t, transport.Proxy)
+}


### PR DESCRIPTION
**Description of your changes:**

## Background

Fixes SSRF vulnerability (ADA-KUBEFL-01) in CreatePipelineV1/V2 APIs where user-provided URLs are fetched without destination validation

```
Recommended remediation
Restrict where the backend will fetch from and validate the final destination:
• Replace arbitrary URLs with file uploads or server-generated pre-signed URLs for controlled object storage.
• If URLs must remain, enforce an allow-list of trusted domains; block private/loopback/link-local/metadata IP ranges
after DNS resolution and on every redirect; restrict schemes/ports (prefer https:// on standard ports); and use tight
timeouts.
```

To avoid disruption of any current users who rely on URLs for pipeline upload functionality, the following remediations have been completed:

- [X] Domain allow-list
- [X] Block private/loopback/link-local/metadata IP ranges
- [X] DNS resolution before request
- [X] Validation on every redirect
- [X] Restrict schemes
- [X] Restrict ports
- [X] Request timeout


## Logic:

### Validate Pipeline URL:
1. Scheme check 
   - https required by default
   - user controlled http allowance
2.  Port check
    - https restricted to port 443
    - http restricted to port 80 
3.  DNS allow-list check
    - validate DNS against a preset list of common DNS 
        - github
        - aws s3
        - google cloud storage
    - user controlled additional allowed DNS
4.  DNS resolution
5. IP check
   - validate against a preset non-configurable blacklist of CIDR ranges
       - private
       - loopback
       - link-local
       - metadata
       - invalid 


### SafePipelineHTTPClient:
- Implement timeouts
   - defaults to 30 seconds
   - user controlled override
- Restrict redirects
   - maximum of 10
   - validate pipeline url on every redirect

### General:
- Prevent XSS attacks by returning generic error messages, but log full error report 

### User-configurable options:

* `PIPELINE_URL_ALLOWED_DOMAINS`: extend the default domain allow-list
* `PIPELINE_URL_ALLOW_HTTP`: allow HTTP URLs (default false)
* `PIPELINE_URL_TIMEOUT`: configure request timeout in seconds (default 30)
* `PIPELINE_URL_VALIDATION_ENABLED`: toggle pipeline url validation - for testing purposes (default true)

## Live Cluster Testing Evidence 

### Before:
<img width="1470" height="747" alt="Screenshot 2026-02-04 at 10 42 49 PM" src="https://github.com/user-attachments/assets/60e93d4f-c030-40dd-b0a1-e990bd168b3c" />
<img width="1470" height="744" alt="Screenshot 2026-02-04 at 10 48 56 PM" src="https://github.com/user-attachments/assets/95ebe15d-b9f7-4279-913a-9faddea5de8d" />
<img width="1470" height="593" alt="Screenshot 2026-02-04 at 10 43 58 PM" src="https://github.com/user-attachments/assets/3acec5d3-c0a8-43d9-a0ef-e28d44bccaf3" />


### After
<img width="1470" height="759" alt="Screenshot 2026-02-04 at 11 16 55 PM" src="https://github.com/user-attachments/assets/cc5ad91b-1a2c-4106-ba7d-620723fc4d36" />
<img width="1470" height="735" alt="Screenshot 2026-02-04 at 11 16 47 PM" src="https://github.com/user-attachments/assets/593a8e8f-19bf-410c-86cb-a3e5fedf0d06" />
<img width="1470" height="573" alt="Screenshot 2026-02-04 at 11 17 10 PM" src="https://github.com/user-attachments/assets/2337cb98-12ee-48b2-9948-666865d27b76" />
(no additional URL fetch from latest test)


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
