### PR TITLE
fix(cache): include artifact URIs in cache key to prevent incorrect r…

### DIFF
--- a/api/v2alpha1/cache_key.proto
+++ b/api/v2alpha1/cache_key.proto
@@ -21,6 +21,10 @@ import "google/protobuf/struct.proto";
 import "pipeline_spec.proto";
 
 message CacheKey {
+  // Input artifact identifiers. Each string in ArtifactNameList now uses the format
+  // "name@uri" to include both the artifact name and URI, ensuring different data
+  // sources produce different cache keys. Previously only names were used, which
+  // caused incorrect cache reuse when artifacts had the same name but different URIs.
   map<string, ArtifactNameList> inputArtifactNames = 1;
   map<string, Value> inputParameters = 2 [deprecated = true];
   map<string, RuntimeArtifact> outputArtifactsSpec = 3;
@@ -36,5 +40,8 @@ message ContainerSpec {
 }
 
 message ArtifactNameList {
+  // Artifact identifiers. Format: "name@uri" when URI is present, or just "name"
+  // when URI is empty. This format ensures cache keys differ for artifacts with
+  // the same name but different data sources.
   repeated string artifactNames = 1;
 }

--- a/api/v2alpha1/cache_key.proto
+++ b/api/v2alpha1/cache_key.proto
@@ -21,10 +21,6 @@ import "google/protobuf/struct.proto";
 import "pipeline_spec.proto";
 
 message CacheKey {
-  // Input artifact identifiers. Each string in ArtifactNameList now uses the format
-  // "name@uri" to include both the artifact name and URI, ensuring different data
-  // sources produce different cache keys. Previously only names were used, which
-  // caused incorrect cache reuse when artifacts had the same name but different URIs.
   map<string, ArtifactNameList> inputArtifactNames = 1;
   map<string, Value> inputParameters = 2 [deprecated = true];
   map<string, RuntimeArtifact> outputArtifactsSpec = 3;
@@ -40,8 +36,5 @@ message ContainerSpec {
 }
 
 message ArtifactNameList {
-  // Artifact identifiers. Format: "name@uri" when URI is present, or just "name"
-  // when URI is empty. This format ensures cache keys differ for artifacts with
-  // the same name but different data sources.
   repeated string artifactNames = 1;
 }

--- a/backend/src/v2/cacheutils/cache.go
+++ b/backend/src/v2/cacheutils/cache.go
@@ -187,10 +187,8 @@ func (c *client) GenerateCacheKey(
 	for inputArtifactName, inputArtifactList := range inputs.GetArtifacts() {
 		inputArtifactNameList := cachekey.ArtifactNameList{ArtifactNames: make([]string, 0)}
 		for _, artifact := range inputArtifactList.Artifacts {
-			// CRITICAL FIX: Include both name AND URI in the cache key identifier.
-			// Previously only the name was used, which caused incorrect cache reuse
-			// when different data sources had artifacts with the same logical name.
-			// The format "name@uri" ensures different URIs produce different cache keys.
+			// Include artifact URI in the cache key to prevent incorrect cache reuse
+			// when different data sources share the same artifact name. Format: "name@uri".
 			artifactIdentifier := artifact.GetName()
 			if uri := artifact.GetUri(); uri != "" {
 				artifactIdentifier = artifact.GetName() + "@" + uri

--- a/backend/src/v2/cacheutils/cache.go
+++ b/backend/src/v2/cacheutils/cache.go
@@ -187,7 +187,15 @@ func (c *client) GenerateCacheKey(
 	for inputArtifactName, inputArtifactList := range inputs.GetArtifacts() {
 		inputArtifactNameList := cachekey.ArtifactNameList{ArtifactNames: make([]string, 0)}
 		for _, artifact := range inputArtifactList.Artifacts {
-			inputArtifactNameList.ArtifactNames = append(inputArtifactNameList.ArtifactNames, artifact.GetName())
+			// CRITICAL FIX: Include both name AND URI in the cache key identifier.
+			// Previously only the name was used, which caused incorrect cache reuse
+			// when different data sources had artifacts with the same logical name.
+			// The format "name@uri" ensures different URIs produce different cache keys.
+			artifactIdentifier := artifact.GetName()
+			if uri := artifact.GetUri(); uri != "" {
+				artifactIdentifier = artifact.GetName() + "@" + uri
+			}
+			inputArtifactNameList.ArtifactNames = append(inputArtifactNameList.ArtifactNames, artifactIdentifier)
 		}
 		cacheKey.InputArtifactNames[inputArtifactName] = &inputArtifactNameList
 	}

--- a/backend/src/v2/cacheutils/cache_test.go
+++ b/backend/src/v2/cacheutils/cache_test.go
@@ -384,7 +384,7 @@ func TestGenerateFingerPrint_ConsidersArtifactURIs(t *testing.T) {
 			"dataset": {
 				Artifacts: []*pipelinespec.RuntimeArtifact{
 					{
-						Name: "data", // Same name as above
+						Name: "data",                     // Same name as above
 						Uri:  "gs://bucket-b/dataset/v2", // Different URI
 					},
 				},


### PR DESCRIPTION
# Fix Cache Key Collisions for Input Artifacts with Different URIs

## Summary
This change fixes an issue in KFP v2 cache key generation where only input artifact **logical names** were considered.
As a result, tasks could incorrectly reuse cached outputs even when they were executed with **different input data locations (URIs)**.

## Problem
Cache keys were generated using artifact names only, ignoring the artifact URI that identifies the actual data source.
If the same pipeline was run multiple times with the same artifact name but different URIs, the cache would treat them as identical and return previously cached results.

This caused silent and incorrect cache hits when:
- Re-running pipelines with new dataset versions
- Sharing pipeline templates across teams or tenants
- Running experiments or A/B tests on different input data

## Fix
The cache key now includes the artifact URI alongside the name (`name@uri`) when generating the cache identifier.
This ensures cache hits occur only when input artifacts truly refer to the same data.

Artifacts without a URI continue to fall back to name-only behavior for backward compatibility.

## Tests
Existing cache tests were updated, and new tests were added to validate that:
- Same artifact name + different URI → different cache fingerprints
- Same name + same URI → cache hit
- Artifacts without URIs remain supported

## Behavior Change
Previously cached executions will no longer match under the new cache key format, resulting in cache misses.
This is expected and correct, as it prevents reuse of outputs computed from different inputs.

## Result
- Correct cache behavior for dataset versioning and multi-tenant usage
- No more silent reuse of outputs from different data sources
- Deterministic and trustworthy caching semantics
