### PR TITLE
fix(manifests): remove unused kustomize vars causing warnings

### DIFF
--- a/manifests/kustomize/base/installs/generic/kustomization.yaml
+++ b/manifests/kustomize/base/installs/generic/kustomization.yaml
@@ -1,47 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 namespace: kubeflow
+
 resources:
 - ../../pipeline
 - ../../cache
 - ../../cache-deployer
 - pipeline-install-config.yaml
 - mysql-secret.yaml
-vars:
-- fieldref:
-    fieldPath: metadata.namespace
-  name: kfp-namespace
-  objref:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: ml-pipeline
-- fieldref:
-    fieldPath: data.appName
-  name: kfp-app-name
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
-- fieldref:
-    fieldPath: data.appVersion
-  name: kfp-app-version
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
-- fieldref:
-    fieldPath: data.bucketName
-  name: kfp-artifact-bucket-name
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
-- fieldref:
-    fieldPath: data.defaultPipelineRoot
-  name: kfp-default-pipeline-root
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
+
 configurations:
 - params.yaml


### PR DESCRIPTION
Fixes #12615

### What this PR does
- Removes deprecated and unused `vars` from kustomize generic install
- Eliminates warnings for unsubstituted vars

### Why this is needed
- `vars` is deprecated in kustomize
- These vars were defined but never replaced
- CI already validates configuration via `params.yaml`

### Testing
- Ran `kustomize build` locally
- Verified no warnings are emitted
