### PR TITLE
fix(ci): switch from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/welcome-new-contributors.yaml
+++ b/.github/workflows/welcome-new-contributors.yaml
@@ -1,7 +1,7 @@
 name: Welcome new contributors
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened]
   issues:
     types: [opened]


### PR DESCRIPTION
**Description of your changes:**
https://github.com/kubeflow/pipelines/blob/master/.github/workflows/welcome-new-contributors.yaml runs on every PR, even if the contributor has opened / merged PRs in the past. Here's an example: https://github.com/kubeflow/pipelines/pull/12756#issuecomment-3832785540; Jeff has multiple merged PRs to the repo. Looking at the first interaction [docs](https://github.com/actions/first-interaction/tree/v3/), it looks like the event should be `pull_request`, not `pull_request_target`, so this PR updates the event to adhere to the docs.


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
