### PR TITLE
Fix: cache image tarballs for PR builds

### DIFF
--- a/.github/workflows/image-builds-with-cache.yml
+++ b/.github/workflows/image-builds-with-cache.yml
@@ -86,14 +86,14 @@ jobs:
         id: date
         run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
-      # Check if the image was already built for this SHA using cache
-      - name: Check if already built
+      # Restore cached image tarball for this SHA (PRs only)
+      - name: Restore image tarball cache
         id: cache-check
         if: ${{ github.ref_name != github.event.repository.default_branch }}
         uses: actions/cache@v5
         with:
-          path: .build-marker-${{ matrix.image }}
-          key: image-built-${{ matrix.image }}-${{ github.sha }}-${{ steps.date.outputs.date }}
+          path: ${{ env.ARTIFACTS_PATH }}/${{ env.ARTIFACT_NAME }}.tar
+          key: image-tar-${{ matrix.image }}-${{ github.sha }}-${{ steps.date.outputs.date }}
           lookup-only: true
 
       - name: Set up Docker Buildx
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: ${{ steps.save-image.outcome == 'success' || steps.rebuild.outcome == 'success' }}
+        if: ${{ steps.save-image.outcome == 'success' || steps.rebuild.outcome == 'success' || steps.cache-check.outputs.cache-hit == 'true' }}
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.ARTIFACTS_PATH }}/${{ env.ARTIFACT_NAME }}.tar
@@ -133,13 +133,9 @@ jobs:
         # Continue the workflow even if the upload failed, because upload can fail if other jobs were able to upload artifact first before the current one
         continue-on-error: true
 
-      - name: Create build marker
-        if: ${{ steps.save-image.outcome == 'success' || steps.rebuild.outcome == 'success' }}
-        run: echo "built" > .build-marker-${{ matrix.image }}
-
-      - name: Save build marker to cache
+      - name: Save image tarball to cache
         if: ${{ steps.save-image.outcome == 'success' || steps.rebuild.outcome == 'success' }}
         uses: actions/cache/save@v5
         with:
-          path: .build-marker-${{ matrix.image }}
-          key: image-built-${{ matrix.image }}-${{ github.sha }}-${{ steps.date.outputs.date }}
+          path: ${{ env.ARTIFACTS_PATH }}/${{ env.ARTIFACT_NAME }}.tar
+          key: image-tar-${{ matrix.image }}-${{ github.sha }}-${{ steps.date.outputs.date }}


### PR DESCRIPTION
### Summary

- Cache/restore image tarballs on PR runs so cache hits still produce artifacts.
- Keep deploy strict while preventing missing image tarball failures.

### Why this change is necessary

- Current master uses a build‑marker cache on PRs: when it hits, the build is skipped.
- The image tarball is created only during the build step, so on a cache hit no tarball exists.
- Deploy now requires every tarball (e.g., metadata-writer) and fails with:
     `open .../metadata-writer/metadata-writer.tar: no such file or directory`
- This is a reliability gap: cache hits can cause missing artifacts even when the image “exists” logically.

### Fix approach

- Cache the actual tarball instead of a marker.
- On cache hit, restore the tarball and still upload it as an artifact.
- This preserves CI speed while guaranteeing artifacts for deploy.