### PR TITLE
ci: add pr number to the cache key

### DIFF
--- a/.github/workflows/image-builds-with-cache.yml
+++ b/.github/workflows/image-builds-with-cache.yml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: .build-marker-${{ matrix.image }}
-          key: image-built-${{ matrix.image }}-${{ github.sha }}-${{ steps.date.outputs.date }}
+          key: image-built-${{ matrix.image }}-${{ github.sha }}-${{ github.event.pull_request.number || github.ref_name }}-${{ steps.date.outputs.date }}
           lookup-only: true
 
       - name: Set up Docker Buildx
@@ -142,4 +142,4 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: .build-marker-${{ matrix.image }}
-          key: image-built-${{ matrix.image }}-${{ github.sha }}-${{ steps.date.outputs.date }}
+          key: image-built-${{ matrix.image }}-${{ github.sha }}-${{ github.event.pull_request.number || github.ref_name }}-${{ steps.date.outputs.date }}


### PR DESCRIPTION
**Description of your changes:**
Adding pr number to the cache key, hopefully this resolves the issue with cross pr contamination when master is merged in prs and commits are not squashed, then the sha of the last commit is the master sha, or when different prs are not rebased correctly and the sha matches. For e.g. this failure:
https://github.com/kubeflow/pipelines/actions/runs/21638591850/job/62376928389?pr=12442

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
