### PR TITLE
chore : Enforcing LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,6 @@ frontend/test/package-lock.json linguist-generated
 
 # Ignore generated TS client library
 frontend/src/apis/* linguist-generated
+
+# Normalize line endings across platforms
+* text=auto eol=lf


### PR DESCRIPTION
### CRLF TO LF
- This PR adds repo-level LF line-ending normalization via .gitattributes to avoid CRLF-related diffs on Windows, where small logical changes can appear as full-file rewrites.

- This mirrors the approach already used in kubeflow/manifests and improves cross-platform contributor experience without affecting generated files or runtime behavior, as discussed in this thread :
https://cloud-native.slack.com/archives/C0742LBR5BM/p1770067104325089

