### PR TITLE
fix(sdk): add type inference for CLI run parameters. Fixes #11607

### DIFF
--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -126,7 +126,15 @@ def create(ctx: click.Context, experiment_name: str, run_name: str,
             err=True)
         sys.exit(1)
 
-    arg_dict = dict(arg.split('=', maxsplit=1) for arg in args)
+    arg_dict = {}
+    for arg in args:
+        if '=' not in arg:
+            click.echo(
+                f"Invalid argument format: '{arg}'. Expected 'key=value'.",
+                err=True)
+            sys.exit(1)
+        k, v = arg.split('=', maxsplit=1)
+        arg_dict[k] = parsing.parse_parameter_value(v)
 
     experiment = client_obj.create_experiment(experiment_name)
     run = client_obj.run_pipeline(

--- a/sdk/python/kfp/cli/utils/parsing.py
+++ b/sdk/python/kfp/cli/utils/parsing.py
@@ -11,9 +11,47 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import json
 import re
-from typing import Callable
+from typing import Any, Callable
+
+
+def parse_parameter_value(value: str) -> Any:
+    """Parse a CLI string value into the appropriate Python type.
+
+    Attempts JSON parsing for complex types (lists, dicts, quoted strings),
+    then tries numeric and boolean conversion, falling back to string.
+
+    Args:
+        value: The string value from CLI argument.
+
+    Returns:
+        The parsed value with inferred type (int, float, bool, list, dict,
+        or str).
+    """
+    try:
+        parsed = json.loads(value)
+        if isinstance(parsed, (list, dict, int, float, bool, str, type(None))):
+            return parsed
+    except (json.JSONDecodeError, ValueError):
+        pass  # Not valid JSON, try other conversions
+
+    if value.lower() == 'true':
+        return True
+    if value.lower() == 'false':
+        return False
+
+    try:
+        return int(value)
+    except ValueError:
+        pass  # Not an integer, try float
+
+    try:
+        return float(value)
+    except ValueError:
+        pass  # Not a number, return as string
+
+    return value
 
 
 def get_param_descr(fn: Callable, param_name: str) -> str:

--- a/sdk/python/kfp/cli/utils/parsing_test.py
+++ b/sdk/python/kfp/cli/utils/parsing_test.py
@@ -132,5 +132,86 @@ class TestGetParamDescr(unittest.TestCase):
         )
 
 
+class TestParseParameterValue(unittest.TestCase):
+    """Tests for parse_parameter_value function."""
+
+    def test_integer_positive(self):
+        self.assertEqual(parsing.parse_parameter_value('123'), 123)
+
+    def test_integer_negative(self):
+        self.assertEqual(parsing.parse_parameter_value('-456'), -456)
+
+    def test_integer_zero(self):
+        self.assertEqual(parsing.parse_parameter_value('0'), 0)
+
+    def test_float_positive(self):
+        self.assertEqual(parsing.parse_parameter_value('12.5'), 12.5)
+
+    def test_float_negative(self):
+        self.assertEqual(parsing.parse_parameter_value('-3.14'), -3.14)
+
+    def test_float_scientific(self):
+        self.assertEqual(parsing.parse_parameter_value('1e10'), 1e10)
+
+    def test_boolean_true_lowercase(self):
+        self.assertEqual(parsing.parse_parameter_value('true'), True)
+
+    def test_boolean_false_lowercase(self):
+        self.assertEqual(parsing.parse_parameter_value('false'), False)
+
+    def test_boolean_true_capitalized(self):
+        self.assertEqual(parsing.parse_parameter_value('True'), True)
+
+    def test_boolean_false_capitalized(self):
+        self.assertEqual(parsing.parse_parameter_value('False'), False)
+
+    def test_list_integers(self):
+        self.assertEqual(parsing.parse_parameter_value('[1, 2, 3]'), [1, 2, 3])
+
+    def test_list_strings(self):
+        self.assertEqual(
+            parsing.parse_parameter_value('["a", "b", "c"]'), ['a', 'b', 'c'])
+
+    def test_list_empty(self):
+        self.assertEqual(parsing.parse_parameter_value('[]'), [])
+
+    def test_dict_simple(self):
+        self.assertEqual(
+            parsing.parse_parameter_value('{"key": "value"}'), {'key': 'value'})
+
+    def test_dict_nested(self):
+        self.assertEqual(
+            parsing.parse_parameter_value('{"a": {"b": 1}}'), {'a': {
+                'b': 1
+            }})
+
+    def test_dict_empty(self):
+        self.assertEqual(parsing.parse_parameter_value('{}'), {})
+
+    def test_null_value(self):
+        self.assertIsNone(parsing.parse_parameter_value('null'))
+
+    def test_string_simple(self):
+        self.assertEqual(parsing.parse_parameter_value('hello'), 'hello')
+
+    def test_string_with_spaces(self):
+        self.assertEqual(
+            parsing.parse_parameter_value('hello world'), 'hello world')
+
+    def test_json_quoted_string_preserves_value(self):
+        self.assertEqual(parsing.parse_parameter_value('"007"'), '007')
+        self.assertEqual(parsing.parse_parameter_value('"hello"'), 'hello')
+
+    def test_string_that_looks_like_number(self):
+        self.assertEqual(parsing.parse_parameter_value('007'), 7)
+        self.assertEqual(
+            parsing.parse_parameter_value('+1-555-1234'), '+1-555-1234')
+
+    def test_string_preserves_value(self):
+        self.assertEqual(
+            parsing.parse_parameter_value('some-pipeline-name'),
+            'some-pipeline-name')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of your changes:**
Added type inference for CLI `kfp run create` parameters. Previously, all parameter values passed via `'key=value'` arguments were treated as strings, causing errors when the pipeline expected typed values.


#### Changes:
- Add `parse_parameter_value()` function to `sdk/python/kfp/cli/utils/parsing.py`
- Update `run.py` to use type inference when parsing CLI arguments
- Add 21 unit tests for the new function

#### Type Inference Order
1. JSON parsing (lists, dicts, null)
2. Boolean (true/false, case-insensitive)
3. Integer
4. Float
5. String (fallback)

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
