### PR TITLE
fix(cli): remove unused namespace in `run.py`

### DIFF
--- a/sdk/python/kfp/cli/run.py
+++ b/sdk/python/kfp/cli/run.py
@@ -112,7 +112,6 @@ def create(ctx: click.Context, experiment_name: str, run_name: str,
            timeout: int, version: str, args: List[str]):
     """Submit a pipeline run."""
     client_obj: client.Client = ctx.obj['client']
-    namespace = ctx.obj['namespace']
     output_format = ctx.obj['output']
     if not run_name:
         run_name = experiment_name
@@ -165,7 +164,6 @@ def create(ctx: click.Context, experiment_name: str, run_name: str,
 def get(ctx: click.Context, watch: bool, detail: bool, run_id: str):
     """Get information about a pipeline run."""
     client_obj: client.Client = ctx.obj['client']
-    namespace = ctx.obj['namespace']
     output_format = ctx.obj['output']
     if detail:
         output_format = 'json'


### PR DESCRIPTION
**Description of your changes:**
Removed unused `namespace` variable from `create()` and `get()` in `run.py` which was dead code. The namespace is already passed to the Client constructor in `cli.py`.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
