### PR TITLE
fix(frontend): require podnamespace for pod logs when authz is enabled

### DIFF
--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -495,6 +495,13 @@ describe('UIServer apis', () => {
         .get('/k8s/pod/logs?podname=test-pod&podnamespace=test-ns')
         .expect(403, 'Access denied to namespace');
     });
+
+    it('asks for podnamespace if not provided when authorization is enabled', async () => {
+      const authRequest = requests(app.app);
+      await authRequest
+        .get('/k8s/pod/logs?podname=test-pod')
+        .expect(422, 'podnamespace argument is required');
+    });
   });
 
   describe('/apis/v1beta1/', () => {

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -202,7 +202,13 @@ function createUIServer(options: UIConfigs) {
     registerHandler(
       app.get,
       '/k8s/pod/logs',
-      getPodLogsHandler(options.argo, options.artifacts, options.pod.logContainerName, authorizeFn),
+      getPodLogsHandler(
+        options.argo,
+        options.artifacts,
+        options.pod.logContainerName,
+        authorizeFn,
+        options.auth.enabled,
+      ),
     );
   }
 
@@ -228,7 +234,13 @@ function createUIServer(options: UIConfigs) {
     registerHandler(
       app.get,
       '/k8s/pod/logs',
-      getPodLogsHandler(options.argo, options.artifacts, options.pod.logContainerName, authorizeFn),
+      getPodLogsHandler(
+        options.argo,
+        options.artifacts,
+        options.pod.logContainerName,
+        authorizeFn,
+        options.auth.enabled,
+      ),
     );
   }
 


### PR DESCRIPTION
## What
- Require `podnamespace` for `GET /k8s/pod/logs` when authorization is enabled.
- Keep existing behavior unchanged when authorization is disabled.
- Add regression test coverage for the auth-enabled + missing-namespace case.

## Why
This is a follow-up closure for a residual gap after #12528.

#12528 added namespace authorization checks for pod endpoints, but `/k8s/pod/logs` still allowed requests without `podnamespace`, which could bypass the namespace auth gate via fallback namespace behavior.

## Scope Add Note (Follow-up to #12528)
This PR is intentionally scoped as a security hardening follow-up to close the remaining logs-path gap from #12528.

## Changes
- `frontend/server/handlers/pod-logs.ts`
  - Added `authEnabled` parameter to `getPodLogsHandler`.
  - Added early validation: when auth is enabled and `podnamespace` is missing, return `422` (`podnamespace argument is required`).
- `frontend/server/app.ts`
  - Pass `options.auth.enabled` into `getPodLogsHandler` registrations.
- `frontend/server/app.test.ts`
  - Added regression test: `asks for podnamespace if not provided when authorization is enabled`.

## Verification
- Ran: `cd frontend/server && npm test -- app.test.ts`
- Result: `32 passed / 32 total`

## Checklist
- [x] Signed off commits (DCO)
