### PR TITLE
fix(ci): pass build-args to Docker builds to fix unknown ref in tutorial links

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -121,6 +121,10 @@ jobs:
         with:
           ref: ${{env.SOURCE_BRANCH}}
 
+      - name: Get checked-out commit SHA
+        id: get_commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -174,6 +178,10 @@ jobs:
           push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            COMMIT_SHA=${{ steps.get_commit.outputs.sha }}
+            COMMIT_HASH=${{ steps.get_commit.outputs.sha }}
+            TAG_NAME=${{ inputs.target_tag }}
 
       # This step generates an artifact attestation for the image,
       # which is an unforgeable statement about where and how it was built.


### PR DESCRIPTION
## Summary

- Adds `COMMIT_SHA`, `COMMIT_HASH`, and `TAG_NAME` as `build-args` in the `build-and-push.yml` GitHub Actions workflow
- The backend Dockerfile uses `COMMIT_SHA` (default `unknown`) in a `sed` command to pin tutorial source code links to the correct git commit. Without this build arg, links resolve to `tree/unknown/`, producing GitHub 404s
- The frontend Dockerfile uses `COMMIT_HASH` to write version metadata. Without it, the UI sidebar shows `Version: unknown`
- `TAG_NAME` is used by both Dockerfiles for version display (e.g., `2.14.3`)

Fixes #12376

## Test plan

- [ ] Verify the `build-and-push.yml` workflow passes `build-args` to `docker/build-push-action`
- [ ] Build the backend Docker image locally with `--build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg TAG_NAME=test` and confirm `sample_config.json` inside the image has valid GitHub URLs (not `tree/unknown/`)
- [ ] Build the frontend Docker image locally with `--build-arg COMMIT_HASH=$(git rev-parse HEAD) --build-arg TAG_NAME=test` and confirm `COMMIT_HASH` and `TAG_NAME` files in `server/dist/` contain the correct values
- [ ] After deploying with fixed images, verify tutorial "source code" links in the Pipelines UI navigate to valid GitHub pages
- [ ] Verify the SideNav version display shows the correct tag instead of `unknown`