### PR TITLE
fix(sdk): support bare OutputPath/InputPath class annotations

### DIFF
--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -272,6 +272,12 @@ def get_name_to_specs(
         annotation = type_annotations.maybe_strip_optional_from_annotation(
             func_param.annotation)
 
+        # Normalize bare InputPath/OutputPath classes to instances with default type.
+        if annotation is type_annotations.InputPath:
+            annotation = type_annotations.InputPath()
+        elif annotation is type_annotations.OutputPath:
+            annotation = type_annotations.OutputPath()
+
         # no annotation
         if annotation == inspect._empty:
             raise TypeError(f'Missing type annotation for argument: {name}')

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -373,6 +373,28 @@ class TestArtifactStringInInputpathOutputpath(unittest.TestCase):
                          'system.Dataset@0.0.1')
         self.assertFalse(comp.component_spec.inputs['i'].is_artifact_list)
 
+    def test_bare_class_without_parentheses(self):
+        """Bare InputPath/OutputPath classes (without parentheses) should
+        default to system.Artifact@0.0.1, same as InputPath()/OutputPath() with
+        no args.
+
+        Regression test for github.com/kubeflow/pipelines/issues/12071.
+        """
+
+        @dsl.component
+        def comp(
+            i: dsl.InputPath,
+            o: dsl.OutputPath,
+        ):
+            ...
+
+        self.assertEqual(comp.component_spec.outputs['o'].type,
+                         'system.Artifact@0.0.1')
+        self.assertFalse(comp.component_spec.outputs['o'].is_artifact_list)
+        self.assertEqual(comp.component_spec.inputs['i'].type,
+                         'system.Artifact@0.0.1')
+        self.assertFalse(comp.component_spec.inputs['i'].is_artifact_list)
+
 
 class TestOutputListsOfArtifactsTemporarilyBlocked(unittest.TestCase):
 


### PR DESCRIPTION


Fixes #12071

**Description of your changes:**
Using `dsl.OutputPath` or `dsl.InputPath` as bare classes (without parentheses) in component function signatures raises `TypeError`. Normalized them to instances with the default type in `get_name_to_specs()`, so `dsl.OutputPath` behaves identically to `dsl.OutputPath()`

### Changes
- Add bare `InputPath/OutputPath` class-to-instance normalization in `get_name_to_specs()`
- Add `test_bare_class_without_parentheses` regression test

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
