### PR TITLE
fix(ci): use localhost for Docker push to local registry in deploy action

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -63,10 +63,12 @@ runs:
         APPS=("apiserver" "driver" "launcher" "scheduledworkflow" "persistenceagent" "frontend" "metadata-writer" "viewer-crd-controller" "visualization-server" "cache-deployer" "cache-server" "metadata-envoy"  )
         for app in "${APPS[@]}"; do
           docker image load -i ${{ inputs.image_path }}/$app/$app.tar
-          docker push ${{ inputs.image_registry }}/$app:${{ inputs.image_tag }}
+          docker tag ${{ inputs.image_registry }}/$app:${{ inputs.image_tag }} localhost:5000/$app:${{ inputs.image_tag }}
+          docker push localhost:5000/$app:${{ inputs.image_tag }}
           rm ${{ inputs.image_path }}/$app/$app.tar
           docker image rm ${{ inputs.image_registry }}/$app:${{ inputs.image_tag }}
-        done  
+          docker image rm localhost:5000/$app:${{ inputs.image_tag }}
+        done
 
     - name: Configure Args
       shell: bash


### PR DESCRIPTION
## Summary
- Fix Docker image push failure in CI deploy action by re-tagging images to `localhost:5000` before pushing, instead of using the `kind-registry` hostname

## Problem
Docker's insecure registry HTTP exemption only applies to the **literal string `localhost`** — not to other hostnames that resolve to `127.0.0.1`. When the deploy action pushes to `kind-registry:5000`, Docker requires HTTPS and the push fails.

> *"Docker considers a private registry either secure or insecure. A registry is considered secure if it uses TLS (HTTPS). By default, Docker only allows communication with secure registries. The exception is localhost: registries at localhost (including localhost:5000) are automatically allowed to use HTTP without any additional configuration."*

The key point is that this exemption is based on **string matching**, not DNS resolution. Even though `kind-registry` resolves to `127.0.0.1` via `/etc/hosts`, Docker sees the hostname `kind-registry` and requires HTTPS.

## Solution
- Re-tag each image from `<image_registry>/<app>` to `localhost:5000/<app>` before `docker push`
- Push using `localhost:5000` so Docker allows plain HTTP
- Clean up the re-tagged image after push

## References
- [dockerd - Insecure registries](https://docs.docker.com/reference/cli/dockerd/#insecure-registries)
- [CNCF Distribution - Test an insecure registry](https://distribution.github.io/distribution/about/insecure/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)