### PR TITLE
fix(backend): resolve input parameter placeholders in list/struct constants

### DIFF
--- a/backend/src/v2/driver/resolve.go
+++ b/backend/src/v2/driver/resolve.go
@@ -246,9 +246,22 @@ func resolveInputs(
 		}
 		return nil
 	}
+	handleInputParameterPlaceholders := func() error {
+		for name, value := range inputs.ParameterValues {
+			resolved, err := resolveValuePlaceholders(value, inputs.ParameterValues)
+			if err != nil {
+				return fmt.Errorf("resolving parameter placeholders in %q: %w", name, err)
+			}
+			inputs.ParameterValues[name] = resolved
+		}
+		return nil
+	}
 	// this function has many branches, so it's hard to add more postprocess steps
 	// TODO(Bobgy): consider splitting this function into several sub functions
 	defer func() {
+		if err == nil {
+			err = handleInputParameterPlaceholders()
+		}
 		if err == nil {
 			err = handleParameterExpressionSelector()
 		}
@@ -820,6 +833,61 @@ func resolvePodSpecInputRuntimeParameter(parameterValue string, executorInput *p
 		}
 	}
 	return parameterValue, nil
+}
+
+// resolveValuePlaceholders recursively walks a structpb.Value and resolves
+// any {{$.inputs.parameters['...']}} placeholders in string values using the
+// provided resolvedParams map. This handles the case where pipeline parameters
+// are embedded within list or struct constants during compilation.
+func resolveValuePlaceholders(value *structpb.Value, resolvedParams map[string]*structpb.Value) (*structpb.Value, error) {
+	if value == nil {
+		return value, nil
+	}
+	switch v := value.GetKind().(type) {
+	case *structpb.Value_StringValue:
+		s := v.StringValue
+		if isInputParameterChannel(s) {
+			paramName, err := extractInputParameterFromChannel(s)
+			if err != nil {
+				return nil, fmt.Errorf("failed to extract parameter from placeholder %q: %w", s, err)
+			}
+			resolved, ok := resolvedParams[paramName]
+			if !ok {
+				return nil, fmt.Errorf("parameter %q referenced in placeholder not found in resolved inputs", paramName)
+			}
+			return resolved, nil
+		}
+		return value, nil
+	case *structpb.Value_ListValue:
+		if v.ListValue == nil {
+			return value, nil
+		}
+		newValues := make([]*structpb.Value, len(v.ListValue.GetValues()))
+		for i, elem := range v.ListValue.GetValues() {
+			resolved, err := resolveValuePlaceholders(elem, resolvedParams)
+			if err != nil {
+				return nil, fmt.Errorf("resolving list element %d: %w", i, err)
+			}
+			newValues[i] = resolved
+		}
+		return structpb.NewListValue(&structpb.ListValue{Values: newValues}), nil
+	case *structpb.Value_StructValue:
+		if v.StructValue == nil {
+			return value, nil
+		}
+		newFields := make(map[string]*structpb.Value, len(v.StructValue.GetFields()))
+		for key, field := range v.StructValue.GetFields() {
+			resolved, err := resolveValuePlaceholders(field, resolvedParams)
+			if err != nil {
+				return nil, fmt.Errorf("resolving struct field %q: %w", key, err)
+			}
+			newFields[key] = resolved
+		}
+		return structpb.NewStructValue(&structpb.Struct{Fields: newFields}), nil
+	default:
+		// For number, bool, null - no placeholders possible.
+		return value, nil
+	}
 }
 
 // resolveK8sJsonParameter resolves a k8s JSON and unmarshal it

--- a/backend/src/v2/driver/resolve_test.go
+++ b/backend/src/v2/driver/resolve_test.go
@@ -137,3 +137,190 @@ func Test_InferIndexedTaskName(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveValuePlaceholders_StringPlaceholder(t *testing.T) {
+	resolvedParams := map[string]*structpb.Value{
+		"pipelinechannel--email": structpb.NewStringValue("user@example.com"),
+	}
+
+	input := structpb.NewStringValue("{{$.inputs.parameters['pipelinechannel--email']}}")
+	result, err := resolveValuePlaceholders(input, resolvedParams)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "user@example.com", result.GetStringValue())
+}
+
+func TestResolveValuePlaceholders_ListWithPlaceholders(t *testing.T) {
+	resolvedParams := map[string]*structpb.Value{
+		"pipelinechannel--email": structpb.NewStringValue("user@example.com"),
+	}
+
+	input, _ := structpb.NewList([]interface{}{
+		"{{$.inputs.parameters['pipelinechannel--email']}}",
+	})
+	inputValue := structpb.NewListValue(input)
+
+	result, err := resolveValuePlaceholders(inputValue, resolvedParams)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(result.GetListValue().GetValues()))
+	assert.Equal(t, "user@example.com", result.GetListValue().GetValues()[0].GetStringValue())
+}
+
+func TestResolveValuePlaceholders_ListWithMixedValues(t *testing.T) {
+	resolvedParams := map[string]*structpb.Value{
+		"pipelinechannel--name": structpb.NewStringValue("Alice"),
+	}
+
+	input, _ := structpb.NewList([]interface{}{
+		"static-value",
+		"{{$.inputs.parameters['pipelinechannel--name']}}",
+		42.0,
+	})
+	inputValue := structpb.NewListValue(input)
+
+	result, err := resolveValuePlaceholders(inputValue, resolvedParams)
+
+	assert.NoError(t, err)
+	values := result.GetListValue().GetValues()
+	assert.Equal(t, 3, len(values))
+	assert.Equal(t, "static-value", values[0].GetStringValue())
+	assert.Equal(t, "Alice", values[1].GetStringValue())
+	assert.Equal(t, 42.0, values[2].GetNumberValue())
+}
+
+func TestResolveValuePlaceholders_StructWithPlaceholders(t *testing.T) {
+	resolvedParams := map[string]*structpb.Value{
+		"pipelinechannel--host": structpb.NewStringValue("db.example.com"),
+	}
+
+	input, _ := structpb.NewStruct(map[string]interface{}{
+		"host": "{{$.inputs.parameters['pipelinechannel--host']}}",
+		"port": 5432.0,
+	})
+	inputValue := structpb.NewStructValue(input)
+
+	result, err := resolveValuePlaceholders(inputValue, resolvedParams)
+
+	assert.NoError(t, err)
+	fields := result.GetStructValue().GetFields()
+	assert.Equal(t, "db.example.com", fields["host"].GetStringValue())
+	assert.Equal(t, 5432.0, fields["port"].GetNumberValue())
+}
+
+func TestResolveValuePlaceholders_NoPlaceholders(t *testing.T) {
+	resolvedParams := map[string]*structpb.Value{}
+
+	input := structpb.NewStringValue("plain-string")
+	result, err := resolveValuePlaceholders(input, resolvedParams)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "plain-string", result.GetStringValue())
+}
+
+func TestResolveValuePlaceholders_MissingParam(t *testing.T) {
+	resolvedParams := map[string]*structpb.Value{}
+
+	input := structpb.NewStringValue("{{$.inputs.parameters['pipelinechannel--missing']}}")
+	_, err := resolveValuePlaceholders(input, resolvedParams)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found in resolved inputs")
+}
+
+func TestResolveValuePlaceholders_NilValue(t *testing.T) {
+	resolvedParams := map[string]*structpb.Value{}
+
+	result, err := resolveValuePlaceholders(nil, resolvedParams)
+
+	assert.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestResolveValuePlaceholders_ListOfStructsWithPlaceholders(t *testing.T) {
+	resolvedParams := map[string]*structpb.Value{
+		"pipelinechannel--email": structpb.NewStringValue("user@example.com"),
+	}
+
+	inputValue := structpb.NewListValue(&structpb.ListValue{
+		Values: []*structpb.Value{
+			structpb.NewStructValue(&structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"email": structpb.NewStringValue("{{$.inputs.parameters['pipelinechannel--email']}}"),
+				},
+			}),
+			structpb.NewStructValue(&structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"email": structpb.NewStringValue("static@example.com"),
+				},
+			}),
+		},
+	})
+
+	result, err := resolveValuePlaceholders(inputValue, resolvedParams)
+
+	assert.NoError(t, err)
+	values := result.GetListValue().GetValues()
+	assert.Equal(t, 2, len(values))
+	assert.Equal(t, "user@example.com", values[0].GetStructValue().GetFields()["email"].GetStringValue())
+	assert.Equal(t, "static@example.com", values[1].GetStructValue().GetFields()["email"].GetStringValue())
+}
+
+func TestResolveValuePlaceholders_StructWithListPlaceholders(t *testing.T) {
+	resolvedParams := map[string]*structpb.Value{
+		"pipelinechannel--primary": structpb.NewStringValue("primary@example.com"),
+	}
+
+	inputValue := structpb.NewStructValue(&structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"recipients": structpb.NewListValue(&structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewStringValue("{{$.inputs.parameters['pipelinechannel--primary']}}"),
+					structpb.NewStringValue("backup@example.com"),
+				},
+			}),
+		},
+	})
+
+	result, err := resolveValuePlaceholders(inputValue, resolvedParams)
+
+	assert.NoError(t, err)
+	recipients := result.GetStructValue().GetFields()["recipients"].GetListValue().GetValues()
+	assert.Equal(t, 2, len(recipients))
+	assert.Equal(t, "primary@example.com", recipients[0].GetStringValue())
+	assert.Equal(t, "backup@example.com", recipients[1].GetStringValue())
+}
+
+func TestResolveValuePlaceholders_DeeplyNestedStructures(t *testing.T) {
+	resolvedParams := map[string]*structpb.Value{
+		"pipelinechannel--email": structpb.NewStringValue("deep@example.com"),
+	}
+
+	inputValue := structpb.NewStructValue(&structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"notification": structpb.NewStructValue(&structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"recipients": structpb.NewListValue(&structpb.ListValue{
+						Values: []*structpb.Value{
+							structpb.NewStructValue(&structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"email": structpb.NewStringValue("{{$.inputs.parameters['pipelinechannel--email']}}"),
+								},
+							}),
+						},
+					}),
+					"enabled": structpb.NewBoolValue(true),
+				},
+			}),
+		},
+	})
+
+	result, err := resolveValuePlaceholders(inputValue, resolvedParams)
+
+	assert.NoError(t, err)
+	notification := result.GetStructValue().GetFields()["notification"].GetStructValue().GetFields()
+	assert.Equal(t, true, notification["enabled"].GetBoolValue())
+	recipients := notification["recipients"].GetListValue().GetValues()
+	assert.Equal(t, 1, len(recipients))
+	assert.Equal(t, "deep@example.com", recipients[0].GetStructValue().GetFields()["email"].GetStringValue())
+}


### PR DESCRIPTION

Fixes #12204

**Description of your changes:**
The backend driver only resolved  `{{$.inputs.parameters[...]}}`  placeholders in string constants. When pipeline parameters were wrapped in a list (e.g `recipients=[email]`), the placeholders inside list/struct constants were left unresolved at runtime. Added recursive placeholder resolution for list and struct constant values.

### Changes made:
- Add `resolveValuePlaceholders` function and a post-processing step in `resolveInputs` in `resolve.go` to recursively resolve parameter placeholders in list/struct constants
- Add 10 tests in `resolve_test.go` for the new function

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
