### PR TITLE
docs(agent): Add code-tree knowledge graph for AI-assisted development and PR reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,44 +1,114 @@
 # Copilot Instructions
 
+Tier 1 PR reviewer for the Kubeflow Pipelines monorepo. Maintainer time is limited; your vigilance helps ensure project continuity against high-volume LLM-generated PRs.
+
 ## Review style
 
-- The volume of PRs has increased significantly as a result of LLMs. Your job is to help maintain the codebase by being a tier 1 reviewer for incoming PRs. Maintainer time is limited. Your vigilance will help ensure the continuity of the project.
-- Explain the "why" behind recommendations using bullet points.
-- Don't get bogged down in small details that will be caught by the hooks listed in `.pre-commit-config.yaml` anyway.
-- Make sure that functions have clear docstrings and are well-documented.
-- Make sure that type hints are used consistently for Python code.
-- Make sure that logic is clear and easy to follow.
-- Make sure that functions are reasonably sized and properly decomposed.
-- Make sure complex logic is broken down into smaller functions.
-- Make sure complex logic has sufficient comments, within reason, to explain the why behind the logic.
-- Make sure that variable names are descriptive and meaningful.
-- Make sure that new logic is covered by unit tests.
-- Make sure that large changes have adequate large tests, not just small tests.
-- Make sure that the PR description is clear.
-- Identify design flaws, uneccessary redundancy, and security issues introduced by the PR.
-- Provide an estimate about whether or not the PR is LLM-generated. Include a confidence level for the estimate. Do this as an HTML comment in the "PR Overview" section.
-- Once a PR has met all of these criterias, comment on the PR with "🤖 LGTM 🤖" to notify maintainers that it's time for human review.
-- Adhere to the following software engineering principles:
+- Explain the "why" behind recommendations.
+- Skip details caught by `.pre-commit-config.yaml` hooks.
+- Verify: clear docstrings, type hints, descriptive names, proper decomposition, sufficient comments.
+- Verify: new logic has tests proportional to change size; PR description explains the "why".
+- Identify design flaws, redundancy, and security issues.
+- Estimate LLM-generation likelihood with confidence level as an HTML comment in "PR Overview".
+- Comment "All Copilot criteria are met." when all criteria are met.
 
-FUNDAMENTAL SOFTWARE ENGINEERING PRINCIPLES
+## Review strategy
 
---- CORE DESIGN PRINCIPLES (SOLID) ---
-S - Single Responsibility Principle (SRP): A class or module should have one, and only one, reason to change.
-O - Open/Closed Principle (OCP): Software entities should be open for extension, but closed for modification.
-L - Liskov Substitution Principle (LSP): Subtypes must be substitutable for their base types without altering program correctness.
-I - Interface Segregation Principle (ISP): Clients should not be forced to depend on methods they do not use; prefer small, specific interfaces.
-D - Dependency Inversion Principle (DIP): Depend upon abstractions (interfaces), not concretes (classes).
+This file is the canonical source for PR review procedure details. Keep `AGENTS.md` aligned as
+high-level guardrails and avoid duplicating fine-grained workflow logic in multiple places.
 
---- ESSENTIAL DEVELOPMENT PRINCIPLES ---
-DRY (Don't Repeat Yourself): Every piece of knowledge must have a single, unambiguous representation within a system.
-KISS (Keep It Simple, Stupid): Avoid unnecessary complexity; simple code is easier to maintain and debug.
-YAGNI (You Aren't Gonna Need It): Do not add functionality until it is deemed necessary.
-Composition Over Inheritance: Prefer achieving polymorphic behavior and code reuse by composing objects rather than inheriting from a base class.
-Law of Demeter (Principle of Least Knowledge): A module should only talk to its immediate neighbors, not to strangers.
+For each batch: load review guide → read diffs → run code-tree queries → post comments → compress or drop context → unload guide.
 
---- SOFTWARE ARCHITECTURE & QUALITY PRINCIPLES ---
-Separation of Concerns: Divide code into distinct sections, each addressing a separate concern or functionality.
-Encapsulation: Hide the internal state and behavior of an object, exposing only necessary functionality.
-High Cohesion: Elements within a module should belong together, focusing on a single, well-defined task.
-Low Coupling: Minimize dependencies between modules to reduce the impact of changes.
-Boy Scout Rule: Always leave the code cleaner than you found it.
+### Small-batch file review
+
+Review files in batches of 3-5, in this order:
+
+1. **Proto/API** -- `.proto` files and generated code diffs
+2. **Backend Go** -- `backend/` changes (error handling, interface compliance)
+3. **SDK Python** -- `sdk/python/` changes (type annotations, docstrings)
+4. **Kubernetes Platform** -- `kubernetes_platform/` changes (proto, Go, Python reviewed together as a self-contained module)
+5. **Tests and goldens** -- test files against the code they test
+6. **Manifests and CI** -- `manifests/` and `.github/` changes
+
+### Context pruning between batches
+
+Skip for PRs with ≤5 changed files.
+
+Decide whether to compress or drop based on downstream consumers:
+
+| Completed batch | Downstream consumers |
+|-----------------|----------------------|
+| Proto/API | Backend Go, SDK Python, Kubernetes Platform |
+| Backend Go | Tests |
+| SDK Python | Tests |
+| Kubernetes Platform | Backend Go, Tests |
+| Tests | _(none)_ |
+| Manifests/CI | _(none)_ |
+
+- **Has consumers:** collapse diffs into a ≤10-line summary -- new/changed public APIs, error contracts, invariants, and issues found (file:line, severity). Drop all line-level detail.
+- **No consumers:** drop batch context entirely after posting review comments. Do not compress.
+
+If a later batch uncovers a dependency on dropped context, use code-tree queries (next section) to retrieve only the specific symbol -- never reload the full batch.
+
+### Code-tree impact analysis
+
+After reading changed files, regenerate the knowledge graph and run queries before writing comments:
+
+```bash
+# Regenerate graph to capture PR changes
+python3 tools/code-tree/code_tree.py --repo-root . --incremental -q
+
+python3 tools/code-tree/query_graph.py --rdeps <changed-file>      # blast radius
+python3 tools/code-tree/query_graph.py --impact <changed-file> --depth 5  # transitive
+python3 tools/code-tree/query_graph.py --test-impact <changed-file> # affected tests
+python3 tools/code-tree/query_graph.py --callers <function-name>    # all call sites
+python3 tools/code-tree/query_graph.py --hierarchy <class-name>     # inheritance
+```
+
+Use results to flag untested blast radius, missing caller updates, and cardinality assumption breaks.
+
+### Backend endpoint/query reference
+
+Whenever a new backend API endpoint and/or SQL/query logic is added or edited, use
+[PR #12999](https://github.com/kubeflow/pipelines/pull/12999) comments and test coverage level as a
+reference for review depth:
+
+- Check endpoint behavior consistency across create/upload/get/list/update flows and call out intentional differences.
+- Require positive + negative tests for each new or edited endpoint, including validation/error paths.
+- For `pipeline_store.go` changes, verify filter/query-building correctness and safe parameterization.
+- For `pipeline_store_kubernetes.go` changes, evaluate cache correctness vs performance tradeoffs and ensure race-sensitive tests cover update/delete then immediate read paths.
+
+### Security scan
+
+Run the [security-code-reviewer](https://github.com/anthropics/claude-code-action/blob/main/.claude/agents/security-code-reviewer.md) as a separate, independent pass on every PR. It does not require the knowledge graph or saved context from other review batches. It scans for:
+
+- **OWASP Top 10** -- injection, broken auth, sensitive data exposure, XXE, broken access control, security misconfiguration, XSS, insecure deserialization, known-vulnerable components, insufficient logging
+- **Input validation** -- unsanitized user input, path traversal, missing type/format/range checks
+- **Auth/authz** -- session management, privilege escalation, IDOR, RBAC gaps
+
+Findings are reported by severity (Critical > High > Medium > Low > Informational) with CWE references.
+
+## Review guide files
+
+| File | Load when |
+|------|-----------|
+| [architecture-context.md](review-guides/architecture-context.md) | PR crosses subsystems, modifies controllers, changes class hierarchies, or needs backward compat analysis |
+| [impact-analysis.md](review-guides/impact-analysis.md) | Assessing blast radius, proto changes, XXL PRs, cardinality changes |
+| [language-checklists.md](review-guides/language-checklists.md) | Any code review (pick the relevant language section) |
+| [security-review.md](review-guides/security-review.md) | PRs touching manifests, RBAC, security contexts, Dockerfiles, credentials |
+| [security-code-reviewer.md](https://github.com/anthropics/claude-code-action/blob/main/.claude/agents/security-code-reviewer.md) | Independent security scan on every PR -- OWASP Top 10, input validation, auth/authz |
+| [test-quality.md](review-guides/test-quality.md) | PRs that add/modify tests, or should include tests |
+
+## Quick checklist
+
+1. PR description explains the "why"
+2. Generated files not hand-edited
+3. Hub file changes get extra scrutiny
+4. Cross-boundary changes justified
+5. Tests proportional to change size
+6. Security addressed for manifest/RBAC/auth changes
+7. Proto changes: all language targets regenerated, test files added
+8. Code-tree impact analysis run on changed files
+9. Backward compatibility verified for API/proto/data-format changes
+10. Every new Go `err` variable checked or returned; every validation path tested
+11. For backend API/storage PRs that add/edit endpoints or SQL/query logic, use `#12999` comments and test coverage depth as a review reference

--- a/.github/review-guides/architecture-context.md
+++ b/.github/review-guides/architecture-context.md
@@ -1,0 +1,87 @@
+# Architecture Context for Reviews
+
+Load when reviewing PRs that touch multiple subsystems, modify controllers, or change class hierarchies.
+
+**See also:** [impact-analysis.md](impact-analysis.md), [language-checklists.md](language-checklists.md)
+
+---
+
+## High-level architecture
+
+```
+SDK (Python) -> compile -> IR YAML (PipelineSpec proto)
+  -> API Server (Go) -> compile -> Argo Workflow YAML
+    -> Driver (Go init container) -> resolve inputs, check cache
+      -> Launcher (Go) -> download artifacts -> invoke user container
+        -> Executor (Python) -> component function -> output artifacts
+          -> Launcher -> upload artifacts -> record in MLMD
+```
+
+## Key subsystem boundaries
+
+| Subsystem | Language | Root path |
+|-----------|----------|-----------|
+| SDK DSL/Compiler/Client/Local | Python | `sdk/python/kfp/` |
+| API Server | Go | `backend/src/apiserver/` |
+| Backend Compiler | Go | `backend/src/v2/compiler/argocompiler/` |
+| Driver | Go | `backend/src/v2/driver/` |
+| Launcher | Go | `backend/src/v2/component/` |
+| Cache Server | Go | `backend/src/cache/` |
+| Object Store | Go | `backend/src/v2/objectstore/` |
+| MLMD Client | Go | `backend/src/v2/metadata/` |
+| CRD Controllers | Go | `backend/src/crd/controller/` |
+| K8s Platform | Python+Proto | `kubernetes_platform/` |
+| Pipeline Spec | Proto | `api/v2alpha1/` |
+| Frontend | TypeScript | `frontend/` |
+
+## Critical dependency directions
+
+Flag violations of these dependency rules:
+
+```
+# Allowed direction (arrow = "may depend on"). Reverse is forbidden.
+sdk/python/kfp/compiler  -> sdk/python/kfp/dsl       (compiler may use dsl, NOT the reverse)
+sdk/python/kfp/client    -> sdk/python/kfp/dsl       (client may use dsl, NOT the reverse)
+
+# Forbidden imports
+backend/src/v2/*         must NOT import backend/src/apiserver/
+backend/src/crd/controller/* may only import backend/src/crd/pkg, NOT apiserver/
+```
+
+Full dependency map: see [code-tree.md](../../docs/agents/code-tree.md#key-module-dependencies).
+
+## Controller patterns
+
+- **No synchronous API callbacks**: Controllers must not call back to the API server. Pass data via CRD spec/annotations/labels.
+- **Idempotent reconciliation**: Each loop iteration must be safe to retry.
+- **Informer-based reads**: Read from caches, not direct API calls.
+- **New gRPC dependencies**: Require architectural justification.
+
+## Cross-language struct alignment
+
+When Go structs mirror Python dataclasses or Proto messages (e.g., `TaskKubernetesConfig`):
+
+- Add cross-reference comments in both languages
+- Proto is the source of truth
+- Flag changes to one side without corresponding changes to the other
+
+## Backward compatibility
+
+For API/proto/data-format changes:
+
+- What happens when an old backend receives new SDK output? New fields must have safe defaults.
+- What happens when a new backend reads old persisted data? Migration path must be explicit.
+- Key format changes (maps, ConfigMaps, databases) must handle old-format keys during transition.
+- Cached executions may be invalidated -- document the upgrade path.
+
+## Cardinality changes
+
+When a value changes from single to list (or vice versa):
+
+1. Use `--callers` and `--rdeps` to find all consumers
+2. Check for `[0]` indexing, `.length == 1` assumptions, nil checks
+3. Verify downstream systems (MLMD, cache keys, Argo specs)
+
+## Inheritance hierarchies
+
+Changes to base classes affect all subclasses. Verify LSP compliance. Key hierarchies in [sdk-guide.md](../../docs/agents/sdk-guide.md#artifact-types) and [code-tree.md](../../docs/agents/code-tree.md#key-inheritance-hierarchies).

--- a/.github/review-guides/impact-analysis.md
+++ b/.github/review-guides/impact-analysis.md
@@ -1,0 +1,54 @@
+# Impact Analysis for Reviews
+
+Load when assessing blast radius, proto changes, or reviewing XXL PRs.
+
+**See also:** [architecture-context.md](architecture-context.md) (backward compat, cardinality), [test-quality.md](test-quality.md) (coverage adequacy)
+
+---
+
+## PR size and scope
+
+- Flag PRs > 500 additions crossing 3+ subsystems as "needs decomposition discussion"
+- XXL PRs (>1000 additions): each component needs dedicated tests, not just E2E
+- Suggest splitting when a single PR includes: proto + backend + SDK + E2E + CI + manifests
+
+## Hub files
+
+Changes to these files need extra scrutiny. Full table with 9 entries in [code-tree.md](../../docs/agents/code-tree.md#hub-files-most-connected).
+
+| File | Imported by |
+|------|-------------|
+| `backend/src/common/util/time.go` | 369 files |
+| `backend/src/common/util/json.go` | 319 files |
+| `backend/src/apiserver/common/utils.go` | 171 files |
+| `backend/src/common/util/consts.go` | 155 files |
+
+## Cross-boundary changes
+
+Flag without clear justification:
+- SDK changes that also modify backend code (unless end-to-end proto support)
+- Backend changes modifying frontend API clients (should use code generation)
+- Proto changes without test pipeline files
+- Import violations (see [architecture-context.md](architecture-context.md#critical-dependency-directions))
+
+## Cross-file consistency
+
+When the same pattern is applied to many files (security contexts to 20+ manifests, RBAC to multiple roles):
+- Spot-check at least 3 files for consistency
+- Suggest automation (script or Kustomize patch) for 10+ files
+
+## Proto change checklist
+
+1. Backward compatible (no removed/renumbered fields)
+2. ALL language targets regenerated (Go `.pb.go` + Python `_pb2.py` + frontend if applicable in diff)
+3. Test pipelines in `test_data/sdk_compiled_pipelines/valid/`
+4. Compiled workflow goldens updated in `test_data/compiled-workflows/`
+5. `kubernetes_platform` protos regenerated if `pipeline_spec.proto` changed
+6. SDK `pipeline_spec_builder.py` handles new user-facing fields
+7. Backend compiler `argocompiler/argo.go` handles fields affecting compilation
+8. Version skew analyzed (see [architecture-context.md](architecture-context.md#backward-compatibility))
+9. Generated code formatting-only diffs noted in PR description
+
+## Generated files
+
+Never hand-edit. Key files listed in [protobuf-build.md](../../docs/agents/protobuf-build.md#never-edit-directly-generated-files). Reject PRs modifying generated files without regenerating from sources.

--- a/.github/review-guides/language-checklists.md
+++ b/.github/review-guides/language-checklists.md
@@ -1,0 +1,59 @@
+# Language-Specific Review Checklists
+
+Load when reviewing code changes. Pick the relevant language section.
+
+---
+
+## Python (SDK, kfp-kubernetes)
+
+- Type hints on all function signatures
+- Docstrings on all public APIs/properties (feed Sphinx docs); include usage examples for new DSL options
+- No SDK-only imports in executor/runtime paths (guarded by `_KFP_RUNTIME`)
+- YAPF, isort (`--profile google`), pycln, docformatter compliance
+- Return type annotations must cover ALL runtime types (e.g., `Optional[Union[str, Dict]]` not just `Optional[str]`)
+- Cross-language structs: add `# Must stay aligned with Go struct in ...` comments
+- Protobuf field presence: use `msg.HasField('field')`, not `msg.field is None`
+- `Iterable[str]` params: guard against bare `str` input (iterates as individual chars)
+- No bare `Exception` catches, mutable defaults, or missing `__init__.py` exports
+
+## Go (backend)
+
+### Error handling and control flow
+- Every `err :=` must be checked or returned. Swallowed errors cause silent failures.
+- Wrap errors: `fmt.Errorf("context: %w", err)` or `util.Wrap()`
+- `return` inside loops: verify it should be `continue`, not premature exit
+- Loops assigning to a variable: verify intermediate values aren't discarded
+- No variable shadowing of function arguments
+- No unnecessary `else` after `return`
+- Re-read existing comments in modified functions -- they may be stale after refactoring
+
+### Concurrency
+- No nested goroutines (`go func() { go func() { ... } }()`)
+- Reuse K8s clients from struct fields, not `kubernetes.NewForConfig()` per call
+- Fire-and-forget goroutines: require `context.WithTimeout` + error logging
+- Functions always returning `nil` after launching goroutine: flag (caller can't handle errors)
+
+### Code quality
+- `golangci-lint run` passes
+- Context propagation (`context.Context` as first parameter)
+- Resource cleanup (`defer` close for readers/connections)
+- Ginkgo conventions for integration/E2E tests
+- Extract repeated `fmt.Sprintf` patterns (3+ times) into named functions
+- No deprecated protobuf fields in new code or tests
+- Descriptive variable names, especially in security-critical code (`securityContext` not `sc`)
+- camelCase for locals (`parentDAGID` not `parent_dag_id`)
+
+## TypeScript (frontend)
+
+- Prettier, ESLint, TypeScript strict mode, React peer compatibility
+- Vitest tests for new components
+- No direct modification of generated API clients
+- No inline styles (use Tailwind/Material-UI), no direct DOM manipulation
+
+## Protocol Buffers
+
+- Field numbers never reused; deprecated fields marked `[deprecated = true]`
+- New fields additive (backward compatible); use `optional` for presence detection
+- API comments precise: "will" not "may" when behavior is deterministic
+- "At most one" semantics enforced at compile/validation time
+- Full proto change checklist in [impact-analysis.md](impact-analysis.md#proto-change-checklist)

--- a/.github/review-guides/security-review.md
+++ b/.github/review-guides/security-review.md
@@ -1,0 +1,46 @@
+# Security Review Guide
+
+Load when reviewing PRs touching manifests, RBAC, security contexts, Dockerfiles, or credentials.
+
+---
+
+## Principles
+
+- **Enforcement > defaults**: `runAsNonRoot: true` means nothing without Pod Security Admission enforcing it
+- **Never configurable**: `allowPrivilegeEscalation`, `privileged` must be hardcoded `false` -- no env var overrides
+- **System containers**: driver, launcher, API server must ALWAYS run non-root. User workloads may have documented exceptions.
+- **Reject "helpful flexibility"**: Don't expose dangerous K8s APIs 1:1. Expose only the safe subset; hardcode secure defaults.
+- **Defense in depth**: Backend must enforce policy independently of SDK. SDK is convenience; server is enforcement.
+- **Threat model required**: PRs adding security-configurable fields should answer: "What could a malicious pipeline author do?"
+- **Verify third-party assumptions**: "Argo runs as root" must be fact-checked against official docs.
+- **Dockerfile USER**: All KFP Dockerfiles specify non-root USER (UID 65532) matching manifest `runAsUser`.
+
+## Container SecurityContext checklist
+
+**NEVER user-configurable:** `privileged`, `add_capabilities`, `allowPrivilegeEscalation`
+**ALWAYS hardcoded:** `drop: ["ALL"]`, `seccompProfile: RuntimeDefault`
+**MAY be user-configurable:** `runAsUser` (warn on UID 0), `runAsGroup`, `readOnlyRootFilesystem`
+
+- Proto schema is the security boundary -- remove dangerous fields from proto, don't just hide in SDK
+- Use `reserved` numbers for removed fields: `reserved 3, 4, 5; // forbidden by policy`
+- Container-level `securityContext` must not conflict with pod-level `PodSecurityContext`
+- Admin-set contexts take precedence over user-specified values
+- Tests must not normalize violations (no golden files with `privileged: true`)
+
+## RBAC manifest review
+
+- `resourceNames` restrictions on `update`/`patch`/`delete` where possible
+- `create` can't be scoped by `resourceNames` -- document why needed, validate in code
+- Standalone role and multi-user cluster role updated in sync
+- ClusterRoleBindings use Kustomize variables (`$(kfp-cluster-scoped-namespace)`)
+- New ClusterRoles follow `ml-pipeline-*` naming; added to `kustomization.yaml`
+
+## General
+
+- No hardcoded credentials; credential chains for object store access
+- Multi-user RBAC checks on new API endpoints
+- Parameterized SQL queries only (squirrel builder)
+- Input validation on pipeline spec sizes and uploads
+- ConfigMap keys must match `[-._a-zA-Z0-9]+`; validate inputs used as keys
+- ConfigMap/Secret cleanup on resource deletion (no orphans)
+- CI workflows: no secrets in logs, `set -euo pipefail` in scripts, pinned action versions

--- a/.github/review-guides/test-quality.md
+++ b/.github/review-guides/test-quality.md
@@ -1,0 +1,69 @@
+# Test Quality Review Guide
+
+Load when reviewing PRs that add/modify tests, or should include tests.
+
+---
+
+## Coverage requirements
+
+- Every new public function: happy path + edge cases + error paths
+- New store/SQL methods: unit tests with mock database, edge cases (empty, not-found)
+- New API endpoints: integration tests in `backend/test/v2/api/`
+- Compilation changes: golden files in `test_data/compiled-workflows/`
+- Pipeline execution changes: E2E tests in `backend/test/end2end/`
+- New algorithmic code (BFS, tree walks): dedicated unit tests -- E2E alone is insufficient
+
+## Proportional coverage
+
+| Change size | Expected |
+|-------------|----------|
+| Bug fix (< 50 lines) | Unit test reproducing bug + fix |
+| Small feature (50-200) | Unit tests + integration if API-facing |
+| Medium feature (200-500) | Unit + integration + golden files |
+| Large feature (500+) | Unit + integration + E2E + goldens + negative tests |
+
+## Validation symmetry
+
+- Validation at N layers (API server, driver, SDK) requires tests at ALL N layers
+- Error messages across layers must use consistent terminology
+
+## Test organization
+
+- Utilities go in shared packages (`backend/test/testutil/`, `e2e_utils/`), not individual test files
+- New tests go in existing test files following project conventions, not new files unless introducing a new module
+- Test helpers in `_test.go` or test utility packages, not production code
+
+## Assertions and matchers
+
+- Assertion failure messages must match what the assertion actually checks
+- Use specific assertions (`Equal(y)`) over generic (`NotTo(BeNil())`) when value is known
+- If matchers are relaxed (e.g., skipping `SecurityContext`), add compensating test elsewhere
+
+## Test naming
+
+- Follow pattern: `"valid input - <type> <feature>"` / `"invalid input - <type> <feature>"`
+- Group related cases together; use descriptive parameter names
+
+## Fixture integrity
+
+- Never modify shared fixtures for new features -- create new ones
+- Golden files must reflect ALL changes the code produces, not a subset
+- Tests must not normalize violations (no `"Valid - Privileged"` for forbidden features)
+- Sleep durations: 5s max (not 20s+); no hardcoded paths or env-specific values
+
+## Resource management
+
+- `defer response.Body.Close()` after HTTP calls
+- `defer f.Close()` after file opens
+- Tests order-independent and parallel-safe (no name collisions)
+- Clean up resources in `AfterEach`, not via namespace deletion
+
+## Proto change test coverage
+
+Three-file sync required. Full process in [testing-ci.md](../../docs/agents/testing-ci.md#proto-changes-require-test-coverage).
+
+## CI workflow quality
+
+- Top-level comment explaining purpose
+- Matrix job names include all parameters: `name: Tests - K8s=${{ matrix.k8s_version }}`
+- New `go.mod` dependencies: justified, maintained, license-compatible

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ bin/
 frontend/scripts/ui-smoke-test/node_modules/
 .npm-cache/
 .npm/
+
+# Generated code-tree knowledge graph artifacts (rebuilt on session start)
+docs/code-tree/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,663 +1,75 @@
 # Agent Guide: Kubeflow Pipelines (KFP) Monorepo
 
-## Purpose
-
-- **Who this is for**: AI agents and developers working inside this repo.
-- **What you get**: The minimum set of facts, files, and commands to navigate, modify, and run KFP locally.
-
-### Document metadata
-
-- Last updated: 2026-03-21
-- Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 17)
-
-### Maintenance (agents and contributors)
-
-- If you change commands, file paths, Make targets, environment variables, or workflows in this repo, update this guide in the relevant sections (Local development, Local testing, Local execution, Regenerate protobufs, Frontend development, CI/CD).
-- When you add or change generated files, update the "🚫 NEVER EDIT DIRECTLY (Generated files)" section with sources and regeneration commands.
-- When you change CI matrices (Kubernetes versions, pipeline stores, proxy/cache toggles, Argo versions) or add/remove workflows, update the CI/CD section.
-- If you come across new common errors or fixes, extend "Common error patterns and quick fixes".
-- Always bump the "Last updated" date above when you make substantive changes.
-
-### Code reuse policy (agents and contributors)
-
-- Always reuse existing functions, helpers, and utilities before writing new code. Search the codebase for existing implementations that accomplish the same goal.
-- Do not duplicate logic that already exists elsewhere in the repo. If a function, method, or pattern is already implemented, import and call it rather than reimplementing it.
-- When adding new functionality, check related packages and modules for shared code that can be leveraged.
-- If existing code needs slight modifications to be reusable, prefer refactoring the existing code to be more general over duplicating it with changes.
-- Use descriptive variable and function names. Avoid abbreviations or single-letter names — prefer full, meaningful names that clearly convey purpose (e.g., `executionID` over `execID`, `fingerPrint` over `fp`).
-
-### Testing policy (agents and contributors)
-
-- Every new non-trivial function, method, or exported API must have accompanying unit tests before merging. Trivial helpers and glue code may be excluded when testing adds no meaningful value.
-- All existing tests must pass locally before pushing changes. Run the relevant test suites listed in the [Local testing](#local-testing) and [Quick reference](#quick-reference) sections (Go backend, Python SDK, `kfp-kubernetes`, and frontend).
-- When modifying existing functions, verify that existing tests still pass and add new test cases if the behavior changes.
-- Do not submit changes that break existing tests. If a test failure is pre-existing and unrelated to your changes, note it explicitly in the PR description.
-
-### Commit policy (agents and contributors)
-
-- Always sign off on commits with `git commit -s` (adds a `Signed-off-by:` trailer).
-- Never include AI agents (e.g. Claude Code, Copilot, or similar tools) as co-authors on commits. The human author is responsible for the work.
-
-## Baseline architecture
-
-- Start with inspecting the architectural diagram found here `images/kfp-cluster-wide-architecture.drawio.xml` (rendered format can be found here: `images/kfp-cluster-wide-architecture.png`).
-
-## End-to-end flow (SDK → API Server → Driver → Launcher → Executor → completion)
-
-- **SDK**:
-  - Compiles Python DSL to the pipeline spec (IR YAML). See `sdk/python/kfp/compiler/pipeline_spec_builder.py`.
-  - The pipeline spec schema is defined via Protobufs under `api/`.
-  - Can execute pipelines locally via Subprocess or Docker runner modes.
-- **API Server**:
-  - On run creation, compiles the pipeline spec to Argo Workflows `Workflow` objects.
-  - Uploads and runs pipelines remotely on a Kubernetes cluster.
-- **Driver**:
-  - Resolves input parameters.
-  - Computes the pod spec patch based on component resource requests/limits.
-  - All other Kubernetes configuration originates from the platform spec implemented by `kubernetes_platform`.
-- **Launcher**:
-  - Not used by Subprocess/Docker runners.
-  - Downloads input artifacts, uploads outputs, invokes the Python executor, handles executor results.
-- **Python executor**:
-  - Entrypoint: `sdk/python/kfp/dsl/executor_main.py`.
-  - Never involved during the pipeline compilation stage.
-  - During task runtime, `kfp` is installed with `--no-deps` and `_KFP_RUNTIME=true` disables most SDK imports.
-  - API Server mode: the Go launcher (copied via `init` container) executes the executor inside the user container
-    defined by the component `base_image` (there is a default).
-  - Subprocess/Docker runners: the launcher is skipped; executor runs directly.
-
-## Packages and naming
-
-- All Python packages are installed under the `kfp` namespace.
-- KFP Python packages:
-  - **kfp**: Primary SDK (DSL, client, local execution).
-  - **kfp-pipeline-spec**: Protobuf-defined API contract used by SDK and backend.
-  - **kfp-kubernetes**: Kubernetes Python extension layer for `kfp` located at `kubernetes_platform/python` for
-    Kubernetes-specific settings and platform spec.
-- The `kfp-kubernetes` package imports generated Python code from `kfp-pipeline-spec` and renames imports via
-  `kubernetes_platform/python/generate_proto.py` to resolve inconsistencies.
-
-## Local development setup
-
-- Always use a `.venv` virtual environment.
-
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -U pip setuptools wheel
-
-make -C api python-dev
-make -C kubernetes_platform python-dev
-
-pip install -e api/v2alpha1/python --config-settings editable_mode=strict
-pip install -e sdk/python --config-settings editable_mode=strict
-pip install -e kubernetes_platform/python --config-settings editable_mode=strict
-```
-
-### Required CLI tools
-
-- Ginkgo CLI for running Go-based test suites.
-
-Install locally into `./bin`:
-
-```bash
-make ginkgo
-export PATH="$PWD/bin:$PATH"  # ensure the ginkgo binary is on PATH
-```
-
-Or install directly with `go install` into a project-local `./bin`:
-
-```bash
-GOBIN=$PWD/bin go install github.com/onsi/ginkgo/v2/ginkgo@latest
-export PATH="$PWD/bin:$PATH"
-```
-
-## Local cluster deployment
-
-KFP provides Make targets for setting up local Kind clusters for development and testing:
-
-### Standalone mode deployment
-
-For deploying the latest master branch in standalone mode (single-user, no authentication):
-
-```bash
-make -C backend kind-cluster-agnostic
-```
-
-This target:
-
-- Creates a Kind cluster named `dev-pipelines-api`
-- Deploys KFP in standalone mode using `manifests/kustomize/env/platform-agnostic`
-- Sets up MySQL database and metadata services
-- Switches kubectl context to the `kubeflow` namespace
-
-### Development mode deployment
-
-For local API server development with additional debugging capabilities:
-
-```bash
-make -C backend dev-kind-cluster
-```
-
-This target:
-
-- Creates a Kind cluster with webhook proxy support
-- Installs cert-manager for certificate management
-- Deploys KFP using `manifests/kustomize/env/dev-kind`
-- Includes webhook proxy for advanced debugging scenarios
-
-### Deployment modes
-
-KFP supports two main deployment modes:
-
-**Standalone Mode:**
-
-- Single-user deployment without authentication
-- Simpler setup, ideal for development and testing
-- Uses manifests from `manifests/kustomize/env/platform-agnostic` or
-  `manifests/kustomize/env/cert-manager/platform-agnostic-k8s-native`
-- All users have full access to all pipelines and experiments
-
-**Multi-user Mode:**
-
-- Multi-tenant deployment with authentication and authorization
-- Requires integration with identity providers (e.g., Dex, OIDC)
-- Uses manifests from `manifests/kustomize/env/cert-manager/platform-agnostic-multi-user` or
-  `manifests/kustomize/env/cert-manager/platform-agnostic-multi-user-k8s-native`
-- Includes user isolation, namespace-based access control, and Istio integration
-- Suitable for production environments with multiple users/teams
-
-## Local testing
-
-- Python (SDK):
-
-```bash
-pip install -r sdk/python/requirements-dev.txt
-pytest -v sdk/python/kfp
-```
-
-- Python (`kfp-kubernetes`):
-
-```bash
-pytest -v kubernetes_platform/python/test
-```
-
-- Go (backend) unit tests only, excluding integration/API/Compiler/E2E tests:
-
-```bash
-go test -v $(go list ./backend/... | \
-  grep -v backend/test/v2/api | \
-  grep -v backend/test/integration | \
-  grep -v backend/test/v2/integration | \
-  grep -v backend/test/initialization | \
-  grep -v backend/test/v2/initialization | \
-  grep -v backend/test/compiler | \
-  grep -v backend/test/end2end)
-```
-
-Notes:
-
-- API Server tests under `backend/test/v2/api` are integration tests run with Ginkgo; they require a running cluster and are not part of unit tests.
-- Compiler tests live under `backend/test/compiler` and E2E tests under `backend/test/end2end`; both are Ginkgo-based and excluded from unit presubmits.
-
-### Backend Ginkgo test suites
-
-- Compiler tests:
-
-```bash
-# Run compiler tests
-ginkgo -v ./backend/test/compiler
-
-# Update compiled workflow goldens when intended
-ginkgo -v ./backend/test/compiler -- -updateCompiledFiles=true
-
-# Auto-create missing goldens (default true); disable with:
-ginkgo -v ./backend/test/compiler -- -createGoldenFiles=false
-```
-
-- v2 API integration tests (label-filterable):
-
-```bash
-# All API tests
-ginkgo -v ./backend/test/v2/api
-
-# Example: run only Smoke-labeled tests with ginkgo
-ginkgo -v --label-filter="Smoke" ./backend/test/v2/api
-```
-
-- End-to-end tests:
-
-```bash
-ginkgo -v ./backend/test/end2end -- -namespace=kubeflow -isDebugMode=true
-```
-
-Test data is centralized under:
-
-- `test_data/pipeline_files/valid/` (inputs) with a `valid/critical/` subset for smoke lanes
-- `test_data/compiled-workflows/` (expected compiled Argo Workflows)
-
-## Local execution
-
-- **Subprocess Runner** (no Docker required):
-
-```python
-from kfp import local
-local.init(runner=local.SubprocessRunner())
-
-# Run components directly
-task = my_component(param="value")
-print(task.output)
-```
-
-- **Docker Runner** (requires Docker):
-
-```python
-from kfp import local
-local.init(runner=local.DockerRunner())
-
-# Runs components in containers
-task = my_component(param="value")
-```
-
-- **Pipeline execution**:
-
-```python
-# Pipelines can be executed like regular functions
-run = my_pipeline(input_param="test")
-
-# If the pipeline has a single output:
-print(run.output)
-
-# Or, for named outputs:
-print(run.outputs['<output_name>'])
-```
-
-Note: Local execution outputs are stored in `./local_outputs` by default.
-
-Notes:
-
-- SubprocessRunner supports only Lightweight Python Components (executes the KFP Python executor directly).
-- Use DockerRunner for Container Components or when task images require containerized execution.
-
-## Regenerate protobufs after schema changes
-
-- Pipeline spec Protobufs live under `api/`.
-- Run both Python and Go generations:
-
-```bash
-make -C api python && make -C api golang
-```
-
-- Note for Linux with SELinux: protoc-related steps may fail under enforcing mode.
-
-  - Temporarily disable before generation: `sudo setenforce 0`
-  - Re-enable after: `sudo setenforce 1`
-
-- `api/v2alpha1/python/kfp/pipeline_spec/pipeline_spec_pb2.py` is NOT committed. Any workflow or script installing
-  `kfp/api` from source must generate this file beforehand.
-
-### 🚫 NEVER EDIT DIRECTLY (Generated files)
-
-The following files are generated; edit their sources and regenerate:
-
-- `api/v2alpha1/python/kfp/pipeline_spec/pipeline_spec_pb2.py`
-  - Source: `api/v2alpha1/pipeline_spec.proto`
-  - Generate: `make -C api python` (or `make -C api python-dev` for editable local dev)
-- `kubernetes_platform/python/kfp/kubernetes/kubernetes_executor_config_pb2.py`
-  - Source: `kubernetes_platform/proto/kubernetes_executor_config.proto`
-  - Generate: `make -C kubernetes_platform python` (or `make -C kubernetes_platform python-dev`)
-- Frontend API clients under `frontend/src/apis` and `frontend/src/apisv2beta1`
-  - Sources: Swagger specs under `backend/api/**/swagger/*.json`
-  - Generate: `cd frontend && npm run apis` / `npm run apis:v2beta1` / `npm run apis:all` (uses pinned Docker image `openapitools/openapi-generator-cli:v7.19.0`)
-- Frontend MLMD proto outputs under `frontend/src/third_party/mlmd/generated`
-  - Sources: `third_party/ml-metadata/*.proto`
-  - Generate: `cd frontend && npm run build:protos`
-
-## Key paths and files
-
-- Architecture diagram: `images/kfp-cluster-wide-architecture.png`
-- SDK compiler: `sdk/python/kfp/compiler/pipeline_spec_builder.py`
-- DSL core: `sdk/python/kfp/dsl/` (e.g., `component_factory.py`, `pipeline_task.py`, `pipeline_context.py`)
-- Executor entrypoint: `sdk/python/kfp/dsl/executor_main.py`
-- Platform integration (Python): `kubernetes_platform/python/kfp/`
-- Platform spec proto: `kubernetes_platform/proto/`
-- API definitions (Protobufs): `api/`
-- Backend (API server, driver, launcher, etc.): `backend/` (see `backend/README.md` for build, test, and local development setup)
-- Backend test suites: `backend/test/compiler`, `backend/test/v2/api`, `backend/test/end2end`
-- Frontend: `frontend/` (React TypeScript, see `frontend/CONTRIBUTING.md`)
-- Manifests (Kustomize bases/overlays for deployments): `manifests/`
-- CI manifests and overlays used by workflows: `.github/resources/manifests/{kubernetes-native,multiuser,standalone}`
-- Test data (inputs/goldens): `test_data/pipeline_files/valid/`, `test_data/compiled-workflows/`
-
-## Documentation
-
-- SDK reference docs are auto-generated with Sphinx using autodoc from Python docstrings. Keep SDK docstrings
-  user-facing and accurate, as they appear in published documentation.
-
-## Frontend development
-
-The KFP frontend is a React TypeScript application that provides the web UI for Kubeflow Pipelines.
-
-### Prerequisites
-
-- Node.js version specified in `frontend/.nvmrc`
-- Docker (required for frontend API client generation via OpenAPI Generator container)
-- Use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) for Node version management:
-
-  ```bash
-  # With fnm (faster)
-  fnm install "$(cat frontend/.nvmrc)" && fnm use "$(cat frontend/.nvmrc)"
-  # With nvm
-  nvm install "$(cat frontend/.nvmrc)" && nvm use "$(cat frontend/.nvmrc)"
-  ```
-
-### Setup and installation
-
-```bash
-cd frontend
-npm ci  # Install exact dependencies from package-lock.json
-```
-
-### Development workflows
-
-#### Local development with mock API
-
-Quick start for UI development without backend dependencies:
-
-```bash
-npm run mock:api    # Start mock backend server on port 3001
-npm start           # Start Vite dev server on port 3000 (hot reload)
-```
-
-#### Local development with real cluster
-
-For full integration testing against a real KFP deployment:
-
-1. **Single-user mode**:
-
+Operational playbook for AI agents working in this repo. For onboarding (what/why/how), see [CLAUDE.md](CLAUDE.md).
+
+- Last updated: 2026-03-24
+- Scope: KFP master branch (v2 engine)
+
+## Reference files
+
+| File | Load when |
+|------|-----------|
+| [architecture.md](docs/agents/architecture.md) | Understanding E2E flow, caching, MLMD, object storage, or cross-subsystem changes |
+| [sdk-guide.md](docs/agents/sdk-guide.md) | Working on `sdk/python/`, `kubernetes_platform/python/`, Python components |
+| [backend-guide.md](docs/agents/backend-guide.md) | Working on `backend/`, Go code, API server, local dev setup |
+| [protobuf-build.md](docs/agents/protobuf-build.md) | Modifying `.proto` files, regenerating code |
+| [frontend-guide.md](docs/agents/frontend-guide.md) | Working on `frontend/`, UI components |
+| [testing-ci.md](docs/agents/testing-ci.md) | Running tests, adding coverage, CI changes |
+| [code-tree.md](docs/agents/code-tree.md) | Codebase exploration, impact analysis, PR reviews |
+| [security-code-reviewer.md](https://github.com/anthropics/claude-code-action/blob/main/.claude/agents/security-code-reviewer.md) | Security scan — OWASP Top 10, input validation, auth/authz |
+
+PR review checklists: see [.github/copilot-instructions.md](.github/copilot-instructions.md) and files under `.github/review-guides/`.
+
+## Task routing
+
+| Task type | Load | Then |
+|-----------|------|------|
+| Bug fix or feature in `backend/` | [backend-guide.md](docs/agents/backend-guide.md) | Run code-tree `--rdeps` on changed files before editing |
+| Bug fix or feature in `sdk/python/` or `kubernetes_platform/` | [sdk-guide.md](docs/agents/sdk-guide.md) | Check compilation flow if touching compiler/DSL |
+| Bug fix or feature in `frontend/` | [frontend-guide.md](docs/agents/frontend-guide.md) | Match Node version to `.nvmrc` first |
+| Proto schema change | [protobuf-build.md](docs/agents/protobuf-build.md) | Regenerate ALL targets (Go + Python + frontend) |
+| Understanding E2E flow, caching, MLMD, object storage | [architecture.md](docs/agents/architecture.md) | Start with architecture diagram |
+| Writing or running tests, CI changes | [testing-ci.md](docs/agents/testing-ci.md) | Match test type to correct suite |
+| Codebase exploration, impact analysis, dependency tracing | [code-tree.md](docs/agents/code-tree.md) | Use `query_graph.py` before reading source |
+| PR review | [.github/copilot-instructions.md](.github/copilot-instructions.md) + [code-tree.md](docs/agents/code-tree.md) | Run code-tree `--rdeps` on changed files first |
+| Security scan | [security-code-reviewer.md](https://github.com/anthropics/claude-code-action/blob/main/.claude/agents/security-code-reviewer.md) | Run independently |
+| Cross-subsystem change | [architecture.md](docs/agents/architecture.md) + relevant subsystem guide | Verify dependency direction rules |
+
+## PR review workflow
+
+When reviewing a PR, follow this order. Detailed batch strategy is in `.github/copilot-instructions.md`.
+
+1. **Code-tree first** (before reading any diffs):
    ```bash
-   # Deploy KFP standalone (see Local cluster deployment section)
-   make -C backend kind-cluster-agnostic
-
-   # Scale down cluster UI
-   kubectl -n kubeflow scale --replicas=0 deployment/ml-pipeline-ui
-
-   # Start local development
-   npm run start:proxy-and-server  # Proxy to cluster + hot reload
+   python3 tools/code-tree/code_tree.py --repo-root . --incremental -q
+   python3 tools/code-tree/query_graph.py --rdeps <changed-file>
+   python3 tools/code-tree/query_graph.py --test-impact <changed-file>
+   python3 tools/code-tree/query_graph.py --callers <changed-function>
    ```
+   Run for every changed file. Identifies untested blast radius, missing caller updates, affected tests.
 
-2. **Multi-user mode**:
+2. **Read diffs in batches**: Proto/API → Backend Go → SDK Python → Tests → Manifests/CI.
 
-   ```bash
-   export VITE_NAMESPACE=kubeflow-user-example-com
-   npm run build
-   # Install mod-header Chrome extension for auth headers
-   npm run start:proxy-and-server
-   ```
+3. **Write comments**: Combine code-tree findings with diff analysis. Flag untested callers, missing test coverage, blast radius.
 
-### Key technologies and architecture
+4. **Backend endpoint/query checks** (for API/storage PRs): Use [PR #12999](https://github.com/kubeflow/pipelines/pull/12999) as reference for endpoint completeness, test coverage, SQL/query construction, and cache correctness.
 
-- **React 17** with TypeScript
-- **Material-UI v3** for components
-- **React Router v5** for navigation
-- **Dagre** for graph layout visualization
-- **D3** for data visualization
-- **Vitest + Testing Library** for UI testing
-- **Jest** for frontend server tests (UI tests migrated off Jest/Enzyme)
-- **Prettier + ESLint** for code formatting/linting
-- **Storybook** for component development
-- **Tailwind CSS** for utility-first styling
+## Validation checklist
 
-### React effect discipline
+Before completing any task, verify what applies:
 
-When writing or reviewing React code in `frontend/src`:
+- [ ] Changed files pass relevant tests (SDK: pytest, Backend: go test, Frontend: npm test)
+- [ ] Changed files pass relevant linters
+- [ ] No generated files hand-edited
+- [ ] Proto changes: all language targets regenerated, test pipeline added in `test_data/sdk_compiled_pipelines/valid/`
+- [ ] New Go `err` variables checked or returned
+- [ ] New Python functions have type hints and docstrings
+- [ ] `kfp` runtime path tested: no SDK-only imports in task-executed code
+- [ ] Cross-boundary changes: dependency direction rules respected
 
-- Treat every `useEffect` as an escape hatch for external synchronization.
-  Valid cases include browser APIs, timers, subscriptions, storage, imperative DOM APIs,
-  or coordinating with async systems that exist outside React render.
-- Do not use `useEffect` for derived UI state.
-  If state can be computed from props, query results, or existing state, derive it during render
-  or with a memoized pure helper.
-- Do not put user-action behavior in an effect.
-  Navigation, snackbars, dialog open/close behavior, and mutation success/failure handling should
-  live in event handlers or mutation callbacks.
-- Avoid effect chains where one effect sets state that triggers another.
-  If a page needs several coupled state transitions, prefer a reducer or a single explicit update path.
-- Preserve user-controlled state across refreshes and refetches.
-  Query refreshes must not silently reset selected runs, selected artifacts, typed names, or toggles
-  unless that reset is an explicit product requirement.
-- Treat `eslint-disable react-hooks/exhaustive-deps` as a code smell.
-  Only keep it when the invariant is documented in code and covered by a targeted test.
-- During reviews, classify each new or changed effect as one of:
-  `external sync`, `derived state`, `event-driven`, `state reset`, or `effect chain`.
-  Anything except `external sync` requires explicit justification in the diff or review notes.
+## Maintenance
 
-### Essential commands (frontend)
-
-- `npm start` - Start Vite dev server with hot reload (port 3000)
-- `npm run start:proxy-and-server` - Full development with cluster proxy
-- `npm run mock:api` - Start mock backend API server (port 3001)
-- `npm run build` - Production build
-- `npm run test` - Run Vitest UI tests (same as `test:ui`, with `LC_ALL` set)
-- `npm run test:ui` - Run Vitest UI tests
-- `npm run test:ui:coverage` - Run Vitest UI tests with coverage
-- `npm run test:ui:coverage:loop` - Run Vitest UI coverage with a capped worker count (stability loop)
-- `npm run test -u` - Update Vitest snapshots
-- `npm run lint` - Run ESLint
-- `npm run typecheck` - Run TypeScript typecheck (`tsc --noEmit`)
-- `npm run typecheck:mock-backend` - Typecheck mock-backend against generated API types
-- `npm run check:react-peers` - Enforce lockfile React peer compatibility for current target (React 17 today)
-- `npm run check:react-peers:18` - Preview lockfile React peer compatibility against React 18
-- `npm run check:react-peers:19` - Preview lockfile React peer compatibility against React 19
-- `npm run format` - Format code with Prettier
-- `npm run format:check` - Fast pre-push check for frontend formatting; for a small TS/TSX diff, `npx prettier --check <changed files>` is the quickest equivalent
-- `npm run storybook` - Start Storybook on port 6006
-
-### Code generation
-
-The frontend includes several generated code components:
-
-- **API clients**: Generated from backend Swagger specs
-
-  ```bash
-  npm run apis:all    # Generate all frontend + server API clients
-  npm run apis        # Generate v1 API clients
-  npm run apis:v2beta1 # Generate v2beta1 API clients
-  ```
-
-  Note: These commands use Docker image `openapitools/openapi-generator-cli:v7.19.0`.
-  Ensure Docker is running.
-
-- **Protocol Buffers**: Generated from proto definitions
-
-  ```bash
-  npm run build:protos              # MLMD protos
-  npm run build:pipeline-spec       # Pipeline spec protos
-  npm run build:platform-spec:kubernetes-platform # K8s platform spec
-  ```
-
-### Testing
-
-- **UI tests**: `npm run test:ui` or `npm test` (Vitest + Testing Library)
-- **Server tests**: `npm run test:server:coverage` (Jest)
-- **Coverage**: `npm run test:ui:coverage` (Vitest) + `npm run test:coverage` (Vitest UI + Jest server)
-- **Stability loop**: `npm run test:ui:coverage:loop` (Vitest coverage with capped workers)
-- **CI pipeline**: `npm run test:ci` (format check + lint + typecheck + lockfile React peer check + Vitest UI coverage + Jest coverage)
-- **Snapshot tests**: Auto-update with `npm test -u` or `npm run test:ui -- -u` (Vitest)
-- **Frontend integration tests**: See `test/frontend-integration-test/README.md` for the containerized local flow. Supported debug env vars include `DEBUG=1`, `HEADLESS=false`, and `WDIO_SPECS=./tensorboard-example.spec.js`; headful runs expose Selenium's noVNC desktop on port `7900`.
-
-### Effect-focused frontend verification
-
-When changing an effect-heavy frontend component, add or run the smallest relevant regression test:
-
-- mutation success runs exactly once even if related async work resolves later
-- refresh/refetch does not overwrite user selection or form edits unless intended
-- error banners and dialogs clear after a successful retry or recovery path
-- mount-time logic does not emit parent callbacks unless the component contract explicitly requires it
-
-## CI/CD (GitHub Actions)
-
-- Workflows: `.github/workflows/` (build, test, lint, release)
-- Composite actions: `.github/actions/` (e.g., `kfp-k8s`, `create-cluster`, `deploy`, `test-and-report`)
-- Typical checks: Go unit tests (backend), Python SDK tests, frontend tests/lint, image builds.
-- Frontend workflow (`frontend.yml`) verifies generated API clients are up to date by running `npm run apis:all` and failing on diff.
-
-### Test matrices and variants (Kubernetes, stores, proxy, cache)
-
-- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.29.2` and `v1.31.0`.
-  - Examples: `e2e-test.yml`, `sdk-execution.yml`, `upgrade-test.yml`, `kfp-kubernetes-execution-tests.yml`, `kfp-webhooks.yml`, `api-server-tests.yml`, `compiler-tests.yml`, `legacy-v2-api-integration-tests.yml`, `integration-tests-v1.yml`, and frontend integration in `e2e-test-frontend.yml`.
-- Pipeline store variants (v2 engine): tests run with `database` and `kubernetes` stores, and a dedicated job compiles pipelines to Kubernetes-native manifests.
-  - Example: `e2e-test.yml` job "API integration tests v2 - K8s with ${pipeline_store}" and "compile pipelines with Kubernetes".
-- Argo Workflows version matrix for compatibility (where relevant): e.g., `e2e-test.yml` includes an Argo job (e.g., `v3.5.14`).
-- Proxy / cache toggles: dedicated jobs run with HTTP proxy enabled and with execution cache disabled to validate those modes.
-- Artifacts: failing logs and test outputs are uploaded as workflow artifacts for debugging.
-
-### CI cluster setup and helpers
-
-- Kind-based clusters are provisioned via the `kfp-cluster` composite action, parameterized by `k8s_version`, `pipeline_store`, `proxy`, `cache_enabled`, and optional `argo_version`.
-- The `create-cluster` and `deploy` actions are used by newer suites; `kfp-k8s` installs SDK components from source inside jobs that execute Python-based tests.
-- The `protobuf` composite action prepares `protoc` and related dependencies when compiling Python protobufs.
-- The `create-cluster` action caches Kind node images by Kubernetes version to reduce Docker Hub pulls.
-- Python workflows use `actions/cache@v5` for pip cache to reduce repeated dependency installs.
-
-### Code style and formatting
-
-- **Prettier** config in `.prettierrc.yaml`:
-  - Single quotes, trailing commas, 100 char line width
-  - Format: `npm run format`
-  - Check: `npm run format:check`
-- **ESLint** extends `react-app` with custom rules in `.eslintrc.yaml`
-- **Auto-format on save**: Configure your IDE with the Prettier extension
-
-Notes:
-
-- Legacy `kfp-samples.yml` and `periodic.yml` workflows were removed.
-
-### Workflow path verification
-
-To verify all GitHub workflow path references are valid:
-
-1. **Iterate through all workflow files** in `.github/workflows/` (both `.yml` and `.yaml` files)
-2. **Parse each YAML file** and extract path references from:
-   - `working-directory` fields
-   - `dockerfile` and `context` fields in Docker build steps
-   - `script` or command paths (look for `./` prefixes)
-   - Any string values that appear to be file/directory paths
-   - Action references (e.g., `./.github/actions/...`)
-3. **Clean extracted paths** by removing `./` prefixes and variable expansions
-4. **Verify each extracted path exists** in the project filesystem
-5. **Report missing paths** and which workflows reference them
-
-This verification ensures workflow integrity and prevents CI failures due to missing files or incorrect path references.
-
-### Feature flags
-
-KFP frontend supports feature flags for development:
-
-- Configure in `src/features.ts`
-- Access via `http://localhost:3000/#/frontend_features`
-- Manage locally: `localStorage.setItem('flags', "")`
-
-### Common development tasks
-
-- **Add new API**: Update swagger specs, run `npm run apis:all`
-- **Update proto definitions**: Modify protos, run respective build commands
-- **Add new component**: Create in `atoms/` or `components/`, add tests and stories
-- **Debug server**: Use `npm run start:proxy-and-server-inspect`
-- **Bundle analysis**: `npm run analyze-bundle`
-
-### Troubleshooting
-
-- **Port conflicts**: Frontend uses 3000 (React), 3001 (Node server), 3002 (API proxy)
-- **Node version issues**: Ensure you're using the version in `.nvmrc`
-- **API generation failures**: Ensure Docker is running and `docker` CLI is available in PATH
-- **Proto generation**: Requires `protoc` and `protoc-gen-grpc-web` in PATH
-- **Mock backend**: Limited API support; use real cluster for full testing
-
-## Lint and formatting checks
-
-- Go lint (CI uses `golangci-lint`):
-
-```bash
-golangci-lint run
-```
-
-- Python SDK import/order and unused import cleanups:
-
-```bash
-pip install -r sdk/python/requirements-dev.txt
-pycln --check sdk/python
-isort --check --profile google sdk/python
-```
-
-- Python SDK formatting (YAPF + string fixer):
-
-```bash
-pip install yapf pre_commit_hooks
-python3 -m pre_commit_hooks.string_fixer $(find sdk/python/kfp/**/*.py -type f)
-yapf --recursive --diff sdk/python/
-```
-
-- Python SDK docstring formatting:
-
-```bash
-pip install docformatter
-docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
-```
-
-## Common agent workflows
-
-- **Modify pipeline spec schema**:
-  1. Edit Protobufs under `api/`
-  2. Regenerate: `make -C api python && make -C api golang`
-  3. Update SDK/backend usages as needed
-- **Adjust Kubernetes behavior for tasks**:
-  - Resource requests/limits: set on component specs; the Driver converts these into pod spec patches.
-  - All other Kubernetes config: handled via `kubernetes_platform` platform spec.
-
-## Quick reference
-
-### Essential commands
-
-- Compile pipeline: `kfp dsl compile --py pipeline.py --output pipeline.yaml`
-- Generate protos: `make -C api python && make -C api golang`
-- Deploy local cluster (standalone): `make -C backend kind-cluster-agnostic`
-- Deploy local cluster (development) and run the API server in the IDE: `make -C backend dev-kind-cluster`
-- Run SDK tests: `pytest -v sdk/python/kfp`
-- Run backend unit tests: `go test -v $(go list ./backend/... | grep -v backend/test/)`
-- Run compiler tests: `ginkgo -v ./backend/test/compiler`
-- Run API tests: `ginkgo -v --label-filter="Smoke" ./backend/test/v2/api`
-- Run E2E tests: `ginkgo -v ./backend/test/end2end -- -namespace=kubeflow`
-- Check formatting:
-  `yapf --recursive --diff sdk/python/ && pycln --check sdk/python && isort --check --profile google sdk/python`
-- Frontend dev server: `cd frontend && npm start`
-- Frontend with cluster: `cd frontend && npm run start:proxy-and-server`
-- Frontend tests: `cd frontend && npm run test:ui` (Vitest) or `npm test` (same as `test:ui`)
-- Frontend React peer gate: `cd frontend && npm run check:react-peers` (or `check:react-peers:18` / `check:react-peers:19`)
-- Frontend formatting: `cd frontend && npm run format`
-- Generate frontend APIs: `cd frontend && npm run apis:all`
-
-### Key environment variables
-
-- `_KFP_RUNTIME=true`: Disables SDK imports during task execution
-- `VITE_NAMESPACE=...`: Sets the target namespace for the frontend in multi-user mode
-- `LOCAL_API_SERVER=true`: Enables local API server testing mode when running integration tests on a Kind cluster
-
-## Troubleshooting and pitfalls
-
-- `_KFP_RUNTIME=true` during executor runtime disables much of the SDK; avoid importing SDK-only modules from task code.
-- `kfp` is installed into task containers with `--no-deps`; ensure runtime dependencies are present in `base_image`.
-- SELinux enforcing can break proto generation; toggle with `setenforce` as noted above.
-- Do not assume `pipeline_spec_pb2.py` exists in the repo; it must be generated.
-- Frontend API generation requires Docker (`openapitools/openapi-generator-cli:v7.19.0`).
-- Frontend proto generation requires `protoc` and `protoc-gen-grpc-web` binaries.
-- Node version must match `.nvmrc`; use nvm/fnm to manage versions.
-- Frontend port conflicts: 3000 (Vite), 3001 (Node server), 3002 (API proxy), 6006 (Storybook).
-
-### Common error patterns and quick fixes
-
-- Protobuf generation fails with "protoc: command not found": use the Make targets that run this in a container.
-- Protobuf generation fails under SELinux enforcing: temporarily disable with `sudo setenforce 0`; re-enable after.
-- API client generation fails with Docker errors (for example permission denied to Docker socket): ensure Docker is running and your user can access the Docker daemon.
-- Frontend fails to start due to Node version mismatch: `nvm use $(cat frontend/.nvmrc)` or `fnm use`.
-- Runtime component imports SDK-only modules: `_KFP_RUNTIME=true` disables many SDK imports; avoid importing SDK-only modules in task code.
+- Update the relevant file under `docs/agents/` when changing commands, paths, Make targets, env vars, or workflows.
+- Update [protobuf-build.md](docs/agents/protobuf-build.md) when changing generated files.
+- Update [testing-ci.md](docs/agents/testing-ci.md) when changing CI matrices or workflows.
+- Extend troubleshooting in the relevant guide for new common errors. Bump the date above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# Kubeflow Pipelines
+
+ML pipeline orchestration platform. Users define pipelines in Python (SDK), compile to YAML, and submit to a Kubernetes-based backend that schedules, caches, and tracks runs via MLMD.
+
+## Tech stack
+
+- **Backend**: Go (API server, persistence, scheduling) — `backend/`
+- **SDK**: Python (DSL, compiler, client) — `sdk/python/`
+- **Frontend**: React 18, MUI v5 — `frontend/`
+- **Protos**: gRPC/protobuf API definitions — `api/`, `kubernetes_platform/`
+
+## Key directories
+
+| Directory | Purpose |
+|-----------|---------|
+| `backend/src/apiserver/` | Go API server (REST + gRPC) |
+| `sdk/python/kfp/` | Python SDK: compiler, components, client |
+| `frontend/src/` | React UI |
+| `api/v2alpha1/` | Proto definitions for pipeline IR |
+| `kubernetes_platform/` | K8s-specific platform proto + Python package |
+| `test_data/` | Golden test files and sample pipelines |
+| `tools/code-tree/` | Codebase analysis tool for impact/dependency tracing |
+
+## Essential commands
+
+| Task | Command |
+|------|---------|
+| Compile pipeline | `kfp dsl compile --py pipeline.py --output pipeline.yaml` |
+| SDK tests | `pytest -v sdk/python/kfp` |
+| K8s platform tests | `pytest -v kubernetes_platform/python/test` |
+| Backend unit tests | `go test -v $(go list ./backend/... \| grep -v backend/test)` |
+| Compiler tests | `ginkgo -v ./backend/test/compiler` |
+| Frontend dev | `cd frontend && npm ci && npm start` |
+| Frontend tests | `cd frontend && npm run test:ci` |
+| Generate protos | `make -C api python && make -C api golang` |
+| Generate backend API | `make -C backend/api generate` |
+| Python lint | `yapf --recursive --diff sdk/python/ && pycln --check sdk/python && isort --check --profile google sdk/python` |
+| Go lint | `golangci-lint run` |
+| Ginkgo install | `make ginkgo && export PATH="$PWD/bin:$PATH"` |
+
+## Commit policy
+
+- Sign off all commits: `git commit -s`
+- Do not include AI agents as co-authors
+
+## Agent workflows
+
+See @AGENTS.md for task routing, PR review workflow, reference docs, and validation checklist.

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,0 +1,157 @@
+# KFP Architecture
+
+How Kubeflow Pipelines components interact end-to-end, from SDK compilation through execution and artifact storage.
+
+**See also:** [sdk-guide.md](sdk-guide.md) (SDK classes/compilation detail), [backend-guide.md](backend-guide.md) (Go component detail), [protobuf-build.md](protobuf-build.md) (proto schema)
+
+---
+
+## Baseline architecture
+
+Start with the architectural diagram: `images/kfp-cluster-wide-architecture.drawio.xml` (rendered: `images/kfp-cluster-wide-architecture.png`).
+
+## End-to-end flow (SDK -> API Server -> Driver -> Launcher -> Executor -> completion)
+
+### SDK (Python)
+
+The SDK compiles Python DSL to the pipeline spec (IR YAML) and optionally submits it to a remote cluster or runs locally. See [sdk-guide.md](sdk-guide.md#sdk-compilation-flow) for the full compilation flow.
+
+### API Server (Go)
+
+- Entry point: `backend/src/apiserver/main.go`
+- gRPC server on port 8887 with TLS support; HTTP proxy on port 8888 via grpc-gateway.
+- Registers gRPC services for both v1beta1 and v2beta1 APIs.
+- On run creation, compiles the pipeline spec to Argo Workflows `Workflow` objects via `argocompiler.Compile()`.
+- Uploads and runs pipelines remotely on a Kubernetes cluster.
+- Uses `ResourceManager` (`backend/src/apiserver/resource/resource_manager.go`) to orchestrate pipeline/run/experiment CRUD operations.
+- Uses `ClientManager` (`backend/src/apiserver/client_manager/client_manager.go`) to initialize DB, object store, and execution clients.
+- Configuration via `viper` with nested env vars (e.g., `OBJECTSTORECONFIG_ACCESSKEY`).
+
+### Backend Compiler (Go)
+
+- Entry point: `backend/src/v2/cmd/compiler/main.go`
+- Core logic: `backend/src/v2/compiler/argocompiler/argo.go` -> `Compile()` function
+- Visitor pattern: `backend/src/v2/compiler/visitor.go` -> `Accept()` traverses the PipelineSpec DAG
+- Converts KFP PipelineSpec IR -> Argo Workflow YAML manifest
+- Configurable via `Options`: LauncherImage, DriverImage, PipelineRoot, CacheDisabled, security context defaults
+
+### Driver (Go)
+
+- Entry point: `backend/src/v2/cmd/driver/main.go`
+- Runs as an init container before each task execution.
+- Three driver types:
+  - **ROOT_DAG** (`backend/src/v2/driver/dag.go:41`): Initializes the top-level pipeline execution, creates pipeline context in MLMD.
+  - **DAG** (`backend/src/v2/driver/dag.go`): Executes sub-DAG nodes, manages iteration logic for ParallelFor.
+  - **CONTAINER** (`backend/src/v2/driver/container.go:46`): Resolves inputs, computes pod spec patch, checks cache, writes ExecutorInput.
+- Outputs written to Argo parameters: `ExecutionID`, `PodSpecPatch`, `CachedDecision`, `Condition`.
+- All other Kubernetes configuration originates from the platform spec implemented by `kubernetes_platform`.
+
+### Launcher (Go)
+
+- Entry point: `backend/src/v2/cmd/launcher-v2/main.go`
+- Core logic: `backend/src/v2/component/launcher_v2.go`
+- Not used by Subprocess/Docker runners.
+- Downloads input artifacts from object store, invokes the user container (or importer), uploads output artifacts, records results in MLMD.
+- Two executor types: `container` (user workload) and `importer` (external data import).
+
+### Python Executor
+
+- Entrypoint: `sdk/python/kfp/dsl/executor_main.py`.
+- Never involved during the pipeline compilation stage.
+- During task runtime, `kfp` is installed with `--no-deps` and `_KFP_RUNTIME=true` disables most SDK imports.
+- API Server mode: the Go launcher (copied via `init` container) executes the executor inside the user container
+  defined by the component `base_image` (there is a default).
+- Subprocess/Docker runners: the launcher is skipped; executor runs directly.
+
+### Execution flows
+
+**Remote execution (API Server mode):**
+
+```
+Client.create_run()
+  -> API Server: ResourceManager.CreateRun()
+    -> argocompiler.Compile(PipelineSpec) -> Argo Workflow YAML
+      -> ExecClient.Submit() -> Argo Controller
+        -> ROOT_DAG Driver pod -> creates pipeline context in MLMD
+          -> DAG/CONTAINER Driver pods -> resolve inputs, check cache
+            -> Launcher pod -> download artifacts -> invoke user container
+              -> executor_main.py -> Executor.execute() -> component function
+                -> Launcher -> upload outputs -> publish to MLMD
+```
+
+**Local execution (SubprocessRunner):**
+
+```
+pipeline_func()
+  -> run_local_pipeline() (local/pipeline_orchestrator.py)
+    -> SubprocessTaskHandler.run() (local/subprocess_task_handler.py)
+      -> executor_main.py -> component function -> outputs to local_outputs/
+```
+
+## Object storage
+
+KFP uses a multi-provider object storage layer for pipeline specs and artifacts.
+
+### API Server object store
+
+- Interface: `backend/src/apiserver/storage/object_store.go` -- `ObjectStore` interface with `AddFile`, `GetFile`, `DeleteFile`, etc.
+- MinIO client: `backend/src/apiserver/client/minio.go` -- creates minio-go client with credential chain (static, env, IAM).
+- Initialization: `backend/src/apiserver/client_manager/client_manager.go` -- builds config from env vars, creates S3 client via AWS SDK v2, supports IRSA.
+
+### V2 artifact object store
+
+- Config: `backend/src/v2/objectstore/config.go` -- scheme (gs://, s3://, minio://), bucket, prefix, credentials from K8s secrets.
+- Operations: `backend/src/v2/objectstore/object_store.go`:
+  - `OpenBucket()`: Opens bucket via gocloud.dev blob API (S3/MinIO via AWS SDK v2, GCS via gcsblob).
+  - `UploadBlob()`: Recursively uploads files/directories.
+  - `DownloadBlob()`: Streams downloads with prefix listing.
+
+## Execution caching
+
+- Cache server: `backend/src/cache/main.go` -- Kubernetes mutating admission webhook on `/mutate`.
+- Cache utilities: `backend/src/v2/cacheutils/cache.go`:
+  - `GenerateCacheKey()` + `GenerateFingerPrint()`: Computes cache key from inputs/outputs/container spec.
+  - `GetExecutionCache()`: Queries by fingerprint, pipelineName, namespace; returns most recent match.
+  - `CreateExecutionCache()`: Records new cache entry after execution.
+- Cache storage: MySQL-backed via `backend/src/cache/storage/`.
+- Flow: Driver(CONTAINER) generates fingerprint -> queries cache -> if hit, uses cached execution; if miss, executes and records.
+
+## Metadata tracking (MLMD)
+
+- Client: `backend/src/v2/metadata/client.go` -- gRPC client to ML Metadata service.
+- Key operations: `GetPipeline()`, `CreateExecution()`, `PublishExecution()`, `RecordArtifact()`, `GetExecutionsInDAG()`.
+- Execution types: `system.ContainerExecution`, `system.DAGExecution`, `system.ImporterExecution`.
+- Connection: gRPC with retry logic, TLS support, max message size 100MB.
+
+## CRD controllers
+
+The repo contains CRD controllers under `backend/src/crd/controller/`:
+
+- **ScheduledWorkflow controller** (`backend/src/crd/controller/scheduledworkflow/`): Manages recurring runs, triggers workflow creation on schedule.
+- **Viewer controller** (`backend/src/crd/controller/viewer/`): Manages viewer CRDs for TensorBoard and other visualizations.
+
+### Controller design rules
+
+- Controllers should **not** make synchronous gRPC/HTTP calls back to the API server during reconciliation. This creates circular dependencies and fragile failure modes.
+- Pass data to controllers via CRD spec fields, annotations, or labels -- not runtime API lookups.
+- Controllers should read state from informer caches, not direct API calls.
+- New controller dependencies (gRPC clients, additional K8s clients) require architectural justification.
+
+### Dependency direction
+
+```
+API Server -> CRD controllers (creates CRD objects)
+CRD controllers -> CRD types only (backend/src/crd/pkg)
+CRD controllers should NOT import from backend/src/apiserver/
+```
+
+## Packages and naming
+
+- All Python packages are installed under the `kfp` namespace.
+- KFP Python packages:
+  - **kfp**: Primary SDK (DSL, client, local execution).
+  - **kfp-pipeline-spec**: Protobuf-defined API contract used by SDK and backend.
+  - **kfp-kubernetes**: Kubernetes Python extension layer for `kfp` located at `kubernetes_platform/python` for
+    Kubernetes-specific settings and platform spec.
+- The `kfp-kubernetes` package imports generated Python code from `kfp-pipeline-spec` and renames imports via
+  `kubernetes_platform/python/generate_proto.py` to resolve inconsistencies.

--- a/docs/agents/backend-guide.md
+++ b/docs/agents/backend-guide.md
@@ -1,0 +1,185 @@
+# KFP Backend Guide (Go)
+
+Backend component details, key Go files, local development setup, cluster deployment, and common agent workflows for working on `backend/`.
+
+**See also:** [architecture.md](architecture.md) (E2E flow, object storage, caching, MLMD), [protobuf-build.md](protobuf-build.md) (backend API proto generation), [testing-ci.md](testing-ci.md) (Go tests, Ginkgo suites)
+
+---
+
+## Key backend files
+
+| Component | File | Key symbols |
+|-----------|------|-------------|
+| API Server | `backend/src/apiserver/main.go` | `main()`, RPC/HTTP server init |
+| Resource Manager | `backend/src/apiserver/resource/resource_manager.go` | `ResourceManager` struct |
+| Client Manager | `backend/src/apiserver/client_manager/client_manager.go` | `ClientManager` -- DB, object store, exec clients |
+| Pipeline Upload | `backend/src/apiserver/server/pipeline_upload_server.go` | HTTP multipart upload handler |
+| Run Server | `backend/src/apiserver/server/run_server.go` | gRPC CreateRun, GetRun, TerminateRun |
+| Argo Compiler | `backend/src/v2/compiler/argocompiler/argo.go` | `Compile()` -- PipelineSpec -> Argo Workflow |
+| Visitor | `backend/src/v2/compiler/visitor.go` | `Accept()` -- DAG traversal |
+| Container Driver | `backend/src/v2/driver/container.go` | `Container()` -- input resolution, cache check |
+| DAG Driver | `backend/src/v2/driver/dag.go` | `DAG()`, `ROOT_DAG` -- execution context setup |
+| Launcher V2 | `backend/src/v2/component/launcher_v2.go` | Artifact download/upload, executor invocation |
+| MLMD Client | `backend/src/v2/metadata/client.go` | gRPC client for ML Metadata |
+| Cache Utils | `backend/src/v2/cacheutils/cache.go` | Fingerprint generation, cache lookup |
+| Cache Server | `backend/src/cache/main.go` | Mutating webhook for caching |
+| Object Store | `backend/src/v2/objectstore/object_store.go` | `OpenBucket()`, `UploadBlob()`, `DownloadBlob()` |
+| Object Store Config | `backend/src/v2/objectstore/config.go` | Scheme/bucket/prefix/credentials |
+| MinIO Client | `backend/src/apiserver/client/minio.go` | MinIO/S3 client with credential chain |
+| Store Interfaces | `backend/src/apiserver/storage/` | `PipelineStoreInterface`, `RunStoreInterface`, etc. |
+| Webhook | `backend/src/apiserver/webhook/` | PipelineVersion validation webhook |
+
+## Other key paths
+
+- Architecture diagram: `images/kfp-cluster-wide-architecture.png`
+- Platform integration (Python): `kubernetes_platform/python/kfp/`
+- Platform spec proto: `kubernetes_platform/proto/`
+- API definitions (Protobufs): `api/`
+- Backend test suites: `backend/test/compiler`, `backend/test/v2/api`, `backend/test/end2end`
+- Frontend: `frontend/` (React TypeScript, see `frontend/CONTRIBUTING.md`)
+- Manifests (Kustomize bases/overlays for deployments): `manifests/`
+- CI manifests and overlays used by workflows: `.github/resources/manifests/{kubernetes-native,multiuser,standalone}`
+- Test data (inputs/goldens): `test_data/sdk_compiled_pipelines/valid/`, `test_data/compiled-workflows/`
+
+## Local development setup
+
+Always use a `.venv` virtual environment.
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -U pip setuptools wheel
+
+make -C api python-dev
+make -C kubernetes_platform python-dev
+
+pip install -e api/v2alpha1/python --config-settings editable_mode=strict
+pip install -e sdk/python --config-settings editable_mode=strict
+pip install -e kubernetes_platform/python --config-settings editable_mode=strict
+```
+
+### Required CLI tools
+
+Ginkgo CLI for running Go-based test suites.
+
+Install locally into `./bin`:
+
+```bash
+make ginkgo
+export PATH="$PWD/bin:$PATH"  # ensure the ginkgo binary is on PATH
+```
+
+Or install directly with `go install` into a project-local `./bin`:
+
+```bash
+GOBIN=$PWD/bin go install github.com/onsi/ginkgo/v2/ginkgo@latest
+export PATH="$PWD/bin:$PATH"
+```
+
+## Local cluster deployment
+
+KFP provides Make targets for setting up local Kind clusters for development and testing.
+
+### Standalone mode deployment
+
+For deploying the latest master branch in standalone mode (single-user, no authentication):
+
+```bash
+make -C backend kind-cluster-agnostic
+```
+
+This target:
+
+- Creates a Kind cluster named `dev-pipelines-api`
+- Deploys KFP in standalone mode using `manifests/kustomize/env/platform-agnostic`
+- Sets up MySQL database and metadata services
+- Switches kubectl context to the `kubeflow` namespace
+
+### Development mode deployment
+
+For local API server development with additional debugging capabilities:
+
+```bash
+make -C backend dev-kind-cluster
+```
+
+This target:
+
+- Creates a Kind cluster with webhook proxy support
+- Installs cert-manager for certificate management
+- Deploys KFP using `manifests/kustomize/env/dev-kind`
+- Includes webhook proxy for advanced debugging scenarios
+
+### Deployment modes
+
+KFP supports two main deployment modes:
+
+**Standalone Mode:**
+
+- Single-user deployment without authentication
+- Simpler setup, ideal for development and testing
+- Uses manifests from `manifests/kustomize/env/platform-agnostic` or
+  `manifests/kustomize/env/cert-manager/platform-agnostic-k8s-native`
+- All users have full access to all pipelines and experiments
+
+**Multi-user Mode:**
+
+- Multi-tenant deployment with authentication and authorization
+- Requires integration with identity providers (e.g., Dex, OIDC)
+- Uses manifests from `manifests/kustomize/env/cert-manager/platform-agnostic-multi-user` or
+  `manifests/kustomize/env/cert-manager/platform-agnostic-multi-user-k8s-native`
+- Includes user isolation, namespace-based access control, and Istio integration
+- Suitable for production environments with multiple users/teams
+
+## Go coding standards
+
+Follow [language-checklists.md](../../.github/review-guides/language-checklists.md#go-backend) for error handling, concurrency, and code quality rules. Key patterns: error wrapping with `%w`, no nested goroutines, reuse K8s clients, cross-reference comments for Go/Python struct alignment.
+
+For RBAC and manifest guidelines, see [security-review.md](../../.github/review-guides/security-review.md#rbac-manifest-review).
+
+## Common agent workflows
+
+### Modify pipeline spec schema
+
+1. Edit Protobufs under `api/`
+2. Regenerate: `make -C api python && make -C api golang`
+3. Update SDK/backend usages as needed
+
+### Adjust Kubernetes behavior for tasks
+
+- Resource requests/limits: set on component specs; the Driver converts these into pod spec patches.
+- All other Kubernetes config: handled via `kubernetes_platform` platform spec.
+
+### Add a new backend API endpoint
+
+1. Edit proto files under `backend/api/v2beta1/`
+2. Regenerate: `make -C backend/api generate`
+3. Implement the gRPC service method in `backend/src/apiserver/server/`
+4. Add ResourceManager method in `backend/src/apiserver/resource/`
+5. Add storage interface method if persistence is needed
+
+### Backend endpoint and query review reference
+
+Whenever a new backend API endpoint and/or SQL/query logic is added or edited, use the
+[PR #12999](https://github.com/kubeflow/pipelines/pull/12999) review comments and test coverage level
+as a reference for review depth and expected test quality.
+
+For endpoint additions/changes, verify:
+
+1. **API completeness across entry points**: if behavior exists in gRPC/REST create flows, ensure upload and related flows are intentionally aligned (or explicitly documented as different).
+2. **Request/response parity**: thread fields through proto -> server -> resource manager -> store -> client models; no partial plumbing.
+3. **Validation coverage**: every new validation path has negative tests (bad input, malformed query params, invalid limits).
+4. **Integration coverage**: add/update tests for create/get/list/update/delete paths and endpoint-specific behavior.
+
+For `pipeline_store.go` and `pipeline_store_kubernetes.go` changes, verify:
+
+1. **Query semantics are preserved**: filtering (including tags predicates), pagination, and sorting remain correct under combined predicates.
+2. **SQL/query building safety**: dynamic filters stay parameterized and constrained; avoid brittle string concatenation.
+3. **Read/write path split is deliberate**: mutating paths should avoid stale/cache-shared objects; read-heavy paths should avoid unnecessary API-server load regressions.
+4. **Race-sensitive behavior is tested**: update/delete followed by immediate get/list should be covered to catch cache-latency and consistency issues.
+
+### Modify object storage behavior
+
+- API server storage: `backend/src/apiserver/storage/object_store.go` (interface), `backend/src/apiserver/client/minio.go` (MinIO/S3 client)
+- V2 artifact storage: `backend/src/v2/objectstore/` (OpenBucket/UploadBlob/DownloadBlob)
+- Config: `backend/src/v2/objectstore/config.go` (scheme/bucket/prefix/credentials)

--- a/docs/agents/code-tree.md
+++ b/docs/agents/code-tree.md
@@ -1,0 +1,184 @@
+# KFP Code-Tree Knowledge Graph
+
+Pre-built knowledge graph artifacts, query commands, codebase statistics, entry points, hub files, module dependencies, inheritance hierarchies, and workflows for development and PR reviews.
+
+**See also:** [architecture.md](architecture.md) (system architecture), [backend-guide.md](backend-guide.md) (backend files), [sdk-guide.md](sdk-guide.md) (SDK files)
+
+---
+
+## Development workflow
+
+Follow this workflow for any code change. Regenerate the graph first, use queries to scope your change, then verify impact after.
+
+### Before writing code
+
+1. **Regenerate graph**: `python3 tools/code-tree/code_tree.py --repo-root . --incremental -q`
+2. **Locate**: `python3 tools/code-tree/query_graph.py --symbol <name>` or `--search <keyword>`
+3. **Scope**: `--rdeps <file>` to understand blast radius before changing anything
+4. **Read**: Load the relevant guide from [AGENTS.md](../../AGENTS.md), then read the target files
+
+### While writing code
+
+5. **Guard generated files**: Never hand-edit files listed in [protobuf-build.md](protobuf-build.md). Edit sources and regenerate.
+6. **Guard hub files**: Extra care when touching high-fanout files (see hub files below). Run `--impact <file> --depth 5` first.
+7. **Match patterns**: Follow existing code style. Go: error wrapping with `%w`, no nested goroutines. Python: type hints, docstrings, YAPF formatting.
+8. **Cross-boundary changes**: Verify dependency direction rules (see key module dependencies below).
+
+### After writing code
+
+9. **Run relevant tests**: See essential commands in [AGENTS.md](../../AGENTS.md)
+10. **Run impact check**: `python3 tools/code-tree/query_graph.py --test-impact <changed-file>`
+11. **Lint**: Run the appropriate formatter/linter for the language you changed
+
+---
+
+## Available artifacts
+
+| File | Contents | Use case |
+|------|----------|----------|
+| `docs/code-tree/summary.md` | Architecture overview, hub files, key types, inheritance, module deps | **Start here** for any exploration |
+| `docs/code-tree/graph.json` | Full knowledge graph (nodes + edges) | Programmatic queries with `jq` |
+| `docs/code-tree/tags.json` | Flat symbol index (symbols with file:line locations) | Quick symbol lookup |
+| `docs/code-tree/modules.json` | Directory-level dependency map | Module impact analysis |
+
+## Querying the graph
+
+Use the query tool at `tools/code-tree/query_graph.py`:
+
+```bash
+# Find where a symbol is defined
+python3 tools/code-tree/query_graph.py --symbol Pipeline
+
+# Trace what a file depends on
+python3 tools/code-tree/query_graph.py --deps sdk/python/kfp/compiler/compiler.py
+
+# Find what imports a file (reverse deps / blast radius)
+python3 tools/code-tree/query_graph.py --rdeps sdk/python/kfp/dsl/pipeline_context.py
+
+# Show inheritance hierarchy for a class
+python3 tools/code-tree/query_graph.py --hierarchy Artifact
+
+# Search symbols by keyword
+python3 tools/code-tree/query_graph.py --search "compiler"
+
+# Get module overview (files, deps, symbols)
+python3 tools/code-tree/query_graph.py --module sdk/python/kfp/compiler
+
+# Find entry points (main functions, unimported files)
+python3 tools/code-tree/query_graph.py --entry-points
+
+# Extract code chunks from a file for context
+python3 tools/code-tree/query_graph.py --chunks sdk/python/kfp/compiler/compiler.py
+
+# Who calls this function/method?
+python3 tools/code-tree/query_graph.py --callers Compile
+
+# What does this function call?
+python3 tools/code-tree/query_graph.py --callees Container
+
+# Find call paths between two symbols
+python3 tools/code-tree/query_graph.py --call-chain CreateRun Compile
+
+# Change impact analysis (transitive)
+python3 tools/code-tree/query_graph.py --impact backend/src/v2/driver/container.go
+python3 tools/code-tree/query_graph.py --impact Artifact --depth 8
+
+# Which tests are affected by a change?
+python3 tools/code-tree/query_graph.py --test-impact sdk/python/kfp/dsl/pipeline_task.py
+
+# What tests cover a file?
+python3 tools/code-tree/query_graph.py --test-coverage sdk/python/kfp/compiler/compiler.py
+
+# Graph statistics
+python3 tools/code-tree/query_graph.py --stats
+```
+
+Add `--json` to any query for machine-readable output.
+Use `--depth N` to control impact/call-chain traversal depth (default: 5).
+
+## Codebase statistics
+
+Run `python3 tools/code-tree/query_graph.py --stats` for current numbers. Approximate as of 2026-03:
+
+- **~2,750 files** across 7 languages: Python, Go, TypeScript, Bash, Protobuf, JavaScript, SQL
+- **~22,000 symbols**: methods, functions, classes, structs, interfaces, constants, enums
+- **~88,000 edges**: imports, contains, calls, tests, inherits
+- **~47%** source file test coverage
+
+## Entry points
+
+| Entry point | Purpose |
+|-------------|---------|
+| `backend/src/apiserver/main.go` | API server (gRPC:8887 + HTTP:8888) |
+| `backend/src/v2/cmd/driver/main.go` | V2 driver (ROOT_DAG/DAG/CONTAINER) |
+| `backend/src/v2/cmd/compiler/main.go` | Backend compiler (PipelineSpec -> Argo Workflow) |
+| `backend/src/v2/cmd/launcher-v2/main.go` | V2 launcher (artifact download/upload + executor invocation) |
+| `backend/src/cache/main.go` | Cache server (mutating webhook) |
+| `backend/src/agent/persistence/main.go` | Persistence agent |
+| `backend/src/crd/controller/scheduledworkflow/main.go` | Scheduled workflow controller |
+| `backend/src/crd/controller/viewer/main.go` | Viewer controller |
+| `sdk/python/kfp/dsl/executor_main.py` | Python executor entrypoint |
+
+## Hub files (most connected)
+
+These files are imported by the most other files. Changes to them have the widest blast radius:
+
+| File | Imported by |
+|------|-------------|
+| `backend/src/common/util/time.go` | 369 files |
+| `backend/src/common/util/json.go` | 319 files |
+| `backend/api/v1beta1/python_http_client/kfp_server_api/rest.py` | 186 files |
+| `backend/api/v2beta1/python_http_client/kfp_server_api/rest.py` | 186 files |
+| `backend/src/apiserver/common/utils.go` | 171 files |
+| `backend/src/common/util/uuid.go` | 163 files |
+| `backend/src/common/util/string.go` | 159 files |
+| `backend/src/common/util/consts.go` | 155 files |
+| `backend/src/common/util/error.go` | 155 files |
+
+## Key module dependencies
+
+```
+sdk/python/kfp/compiler       -> sdk/python/kfp/dsl
+sdk/python/kfp/client          -> sdk/python/kfp/dsl
+backend/src/apiserver/*         -> backend/src/common/util
+backend/src/apiserver/template  -> backend/src/v2/compiler/argocompiler
+backend/src/apiserver/resource  -> backend/src/apiserver/storage, backend/src/apiserver/template
+backend/src/cache/*             -> backend/src/apiserver/archive, backend/src/common/util
+backend/src/v2/component        -> backend/src/v2/metadata, backend/src/v2/objectstore
+backend/src/v2/driver            -> backend/src/v2/cacheutils, backend/src/v2/metadata, backend/src/v2/objectstore
+backend/src/v2/compiler/argocompiler -> api/v2alpha1/go/pipelinespec, backend/src/v2/compiler
+backend/src/v2/cmd/driver       -> backend/src/v2/driver, backend/src/v2/metadata, backend/src/v2/cacheutils
+backend/src/v2/cmd/launcher-v2  -> backend/src/v2/component, backend/src/v2/client_manager
+```
+
+## Key inheritance hierarchies
+
+```
+Artifact (sdk/python/kfp/dsl/types/artifact_types.py)
+  |- ClassificationMetrics, Dataset, HTML, Markdown, Metrics, Model, SlicedClassificationMetrics
+
+ModelBase (sdk/python)
+  |- BinaryPredicate
+  |    |- EqualsPredicate, GreaterThanPredicate, LessThenPredicate, ...
+  |- ComponentSpec, ContainerSpec, CachingStrategySpec, ...
+
+BaseAPI (backend/api/*/python_http_client)
+  |- ExperimentServiceApi, PipelineServiceApi, RunServiceApi, RecurringRunServiceApi, ...
+
+OpenApiException
+  |- ApiException, ApiKeyError, ApiTypeError, ApiValueError
+```
+
+## Regenerating the graph
+
+Always regenerate before first use in a session:
+
+```bash
+# Incremental (fast -- only reparses changed files)
+python3 tools/code-tree/code_tree.py --repo-root . --incremental -q
+
+# Full rebuild (after major changes)
+python3 tools/code-tree/code_tree.py --repo-root .
+```
+
+For a structured PR review workflow using these queries, see [copilot-instructions.md](../../.github/copilot-instructions.md#code-tree-impact-analysis).

--- a/docs/agents/frontend-guide.md
+++ b/docs/agents/frontend-guide.md
@@ -1,0 +1,195 @@
+# KFP Frontend Guide
+
+Prerequisites, setup, development workflows, technologies, commands, code generation, testing, feature flags, and troubleshooting for working on `frontend/`.
+
+**See also:** [protobuf-build.md](protobuf-build.md) (frontend proto generation), [testing-ci.md](testing-ci.md) (CI pipeline, formatting checks)
+
+---
+
+## Prerequisites
+
+- Node.js version specified in `frontend/.nvmrc` (currently v24.14.0)
+- Java 8+ (required for `java -jar swagger-codegen-cli.jar` when generating API clients)
+- Use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) for Node version management:
+
+  ```bash
+  # With fnm (faster)
+  fnm install 24.14.0 && fnm use 24.14.0
+  # With nvm
+  nvm install 24.14.0 && nvm use 24.14.0
+  ```
+
+## Setup and installation
+
+```bash
+cd frontend
+npm ci  # Install exact dependencies from package-lock.json
+```
+
+## Development workflows
+
+### Local development with mock API
+
+Quick start for UI development without backend dependencies:
+
+```bash
+npm run mock:api    # Start mock backend server on port 3001
+npm start           # Start Vite dev server on port 3000 (hot reload)
+```
+
+### Local development with real cluster
+
+For full integration testing against a real KFP deployment:
+
+1. **Single-user mode**:
+
+   ```bash
+   # Deploy KFP standalone (see backend-guide.md Local cluster deployment)
+   make -C backend kind-cluster-agnostic
+
+   # Scale down cluster UI
+   kubectl -n kubeflow scale --replicas=0 deployment/ml-pipeline-ui
+
+   # Start local development
+   npm run start:proxy-and-server  # Proxy to cluster + hot reload
+   ```
+
+2. **Multi-user mode**:
+
+   ```bash
+   export VITE_NAMESPACE=kubeflow-user-example-com
+   npm run build
+   # Install mod-header Chrome extension for auth headers
+   npm run start:proxy-and-server
+   ```
+
+## Key technologies and architecture
+
+- **React 18** with TypeScript
+- **MUI v5** (`@mui/material`) for components
+- **React Router v5** for navigation
+- **Dagre** for graph layout visualization
+- **D3** for data visualization
+- **Vitest + Testing Library** for UI testing
+- **Jest** for frontend server tests (UI tests migrated off Jest/Enzyme)
+- **Prettier + ESLint** for code formatting/linting
+- **Storybook** for component development
+- **Tailwind CSS** for utility-first styling
+
+### React effect discipline
+
+When writing or reviewing React code in `frontend/src`:
+
+- Treat every `useEffect` as an escape hatch for external synchronization.
+  Valid cases include browser APIs, timers, subscriptions, storage, imperative DOM APIs,
+  or coordinating with async systems that exist outside React render.
+- Do not use `useEffect` for derived UI state.
+  If state can be computed from props, query results, or existing state, derive it during render
+  or with a memoized pure helper.
+- Do not put user-action behavior in an effect.
+  Navigation, snackbars, dialog open/close behavior, and mutation success/failure handling should
+  live in event handlers or mutation callbacks.
+- Avoid effect chains where one effect sets state that triggers another.
+  If a page needs several coupled state transitions, prefer a reducer or a single explicit update path.
+- Preserve user-controlled state across refreshes and refetches.
+  Query refreshes must not silently reset selected runs, selected artifacts, typed names, or toggles
+  unless that reset is an explicit product requirement.
+- Treat `eslint-disable react-hooks/exhaustive-deps` as a code smell.
+  Only keep it when the invariant is documented in code and covered by a targeted test.
+- During reviews, classify each new or changed effect as one of:
+  `external sync`, `derived state`, `event-driven`, `state reset`, or `effect chain`.
+  Anything except `external sync` requires explicit justification in the diff or review notes.
+
+## Essential commands
+
+- `npm start` - Start Vite dev server with hot reload (port 3000)
+- `npm run start:proxy-and-server` - Full development with cluster proxy
+- `npm run mock:api` - Start mock backend API server (port 3001)
+- `npm run build` - Production build
+- `npm run test` - Run Vitest UI tests (same as `test:ui`, with `LC_ALL` set)
+- `npm run test:ui` - Run Vitest UI tests
+- `npm run test:ui:coverage` - Run Vitest UI tests with coverage
+- `npm run test:ui:coverage:loop` - Run Vitest UI coverage with a capped worker count (stability loop)
+- `npm run test -u` - Update Vitest snapshots
+- `npm run lint` - Run ESLint
+- `npm run typecheck` - Run TypeScript typecheck (`tsc --noEmit`)
+- `npm run check:react-peers` - Enforce lockfile React peer compatibility for current target (React 18 today)
+- `npm run check:react-peers:18` - Preview lockfile React peer compatibility against React 18
+- `npm run check:react-peers:19` - Preview lockfile React peer compatibility against React 19
+- `npm run format:check` - Fast pre-push check for frontend formatting; for a small TS/TSX diff, `npx prettier --check <changed files>` is the quickest equivalent
+- `npm run format` - Format code with Prettier
+- `npm run storybook` - Start Storybook on port 6006
+
+## Code generation
+
+The frontend includes several generated code components:
+
+- **API clients**: Generated from backend Swagger specs
+
+  ```bash
+  npm run apis        # Generate v1 API clients
+  npm run apis:v2beta1 # Generate v2beta1 API clients
+  ```
+
+  Note: Ensure `swagger-codegen-cli.jar` is available to `java -jar` when running from `frontend/`
+  (e.g., place the JAR in `frontend/` or reference a full path).
+
+- **Protocol Buffers**: Generated from proto definitions
+
+  ```bash
+  npm run build:protos              # MLMD protos
+  npm run build:pipeline-spec       # Pipeline spec protos
+  npm run build:platform-spec:kubernetes-platform # K8s platform spec
+  ```
+### Effect-focused frontend verification
+
+When changing an effect-heavy frontend component, add or run the smallest relevant regression test:
+
+- mutation success runs exactly once even if related async work resolves later
+- refresh/refetch does not overwrite user selection or form edits unless intended
+- error banners and dialogs clear after a successful retry or recovery path
+- mount-time logic does not emit parent callbacks unless the component contract explicitly requires it
+
+## Testing
+
+- **UI tests**: `npm run test:ui` or `npm test` (Vitest + Testing Library)
+- **Server tests**: `npm run test:server:coverage` (Jest)
+- **Coverage**: `npm run test:ui:coverage` (Vitest) + `npm run test:coverage` (Vitest UI + Jest server)
+- **Stability loop**: `npm run test:ui:coverage:loop` (Vitest coverage with capped workers)
+- **CI pipeline**: `npm run test:ci` (format check + lint + typecheck + lockfile React peer check + Vitest UI coverage + Jest coverage)
+- **Snapshot tests**: Auto-update with `npm test -u` or `npm run test:ui -- -u` (Vitest)
+- **Integration tests**: See `test/frontend-integration-test/README.md` for the containerized local flow. Supported debug env vars include `DEBUG=1`, `HEADLESS=false`, and `WDIO_SPECS=./tensorboard-example.spec.js`; headful runs expose Selenium's noVNC desktop on port `7900`.
+
+
+## Feature flags
+
+KFP frontend supports feature flags for development:
+
+- Configure in `src/features.ts`
+- Access via `http://localhost:3000/#/frontend_features`
+- Manage locally: `localStorage.setItem('flags', "")`
+
+## Common development tasks
+
+- **Add new API**: Update swagger specs, run `npm run apis`
+- **Update proto definitions**: Modify protos, run respective build commands
+- **Add new component**: Create in `atoms/` or `components/`, add tests and stories
+- **Debug server**: Use `npm run start:proxy-and-server-inspect`
+- **Bundle analysis**: `npm run analyze-bundle`
+
+## Code style and formatting
+
+- **Prettier** config in `.prettierrc.yaml`:
+  - Single quotes, trailing commas, 100 char line width
+  - Format: `npm run format`
+  - Check: `npm run format:check`
+- **ESLint** extends `react-app` with custom rules in `.eslintrc.yaml`
+- **Auto-format on save**: Configure your IDE with the Prettier extension
+
+## Troubleshooting
+
+- **Port conflicts**: Frontend uses 3000 (React), 3001 (Node server), 3002 (API proxy)
+- **Node version issues**: Ensure you're using the version in `.nvmrc`
+- **API generation failures**: Check that swagger-codegen-cli.jar is in PATH
+- **Proto generation**: Requires `protoc` and `protoc-gen-grpc-web` in PATH
+- **Mock backend**: Limited API support; use real cluster for full testing

--- a/docs/agents/protobuf-build.md
+++ b/docs/agents/protobuf-build.md
@@ -1,0 +1,124 @@
+# KFP Protobuf Build System
+
+Proto sources, generation pipeline (Go, Python, JavaScript/TypeScript), IR YAML mapping, and generated files inventory.
+
+**See also:** [testing-ci.md](testing-ci.md) (proto change test coverage requirements), [backend-guide.md](backend-guide.md) (backend API workflows), [sdk-guide.md](sdk-guide.md) (SDK proto usage)
+
+---
+
+## Proto sources
+
+| Proto file | Package | Key messages |
+|-----------|---------|-------------|
+| `api/v2alpha1/pipeline_spec.proto` | `ml_pipelines` | `PipelineJob`, `PipelineSpec`, `ComponentSpec`, `DagSpec`, `PipelineTaskSpec`, `ParameterType`, `ArtifactTypeSchema`, `PipelineDeploymentConfig` |
+| `api/v2alpha1/cache_key.proto` | `ml_pipelines` | `CacheKey`, `ContainerSpec`, `ArtifactNameList` |
+| `kubernetes_platform/proto/kubernetes_executor_config.proto` | `kfp_kubernetes` | `KubernetesExecutorConfig`, `SecretAsVolume`, `PvcMount`, `NodeSelector`, `Toleration` |
+| `backend/api/v2beta1/*.proto` | `kubeflow.pipelines.backend.api.v2beta1` | `Pipeline`, `Run`, `Experiment`, `RecurringRun` (gRPC services) |
+| `backend/api/v1beta1/*.proto` | `kubeflow.pipelines.backend.api.v1beta1` | Legacy API services |
+
+## Generation pipeline
+
+### Pipeline spec protos (api/)
+
+```bash
+# Both Go and Python
+make -C api python && make -C api golang
+
+# Dev mode (editable install, no Docker)
+make -C api python-dev
+```
+
+- Go: `protoc --go_out` generates `api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go`
+- Python: `protoc --python_out` generates `api/v2alpha1/python/kfp/pipeline_spec/pipeline_spec_pb2.py`
+- Uses pre-built Docker image: `ghcr.io/kubeflow/kfp-api-generator:master`
+- Dependencies fetched at build time: googleapis (specific commit), protobuf v26.0
+
+### Kubernetes platform protos
+
+```bash
+make -C kubernetes_platform python && make -C kubernetes_platform golang
+
+# Dev mode
+make -C kubernetes_platform python-dev
+```
+
+- Post-processing: `kubernetes_platform/python/generate_proto.py` rewrites `import pipeline_spec_pb2` -> `from kfp.pipeline_spec import pipeline_spec_pb2` to fix cross-package imports.
+
+### Backend API protos (multi-phase)
+
+```bash
+make -C backend/api generate
+```
+
+Generator script (`backend/api/hack/generator.sh`) runs 6 phases:
+1. `protoc --go_out --go-grpc_out` -> `*.pb.go` + `*_grpc.pb.go`
+2. `protoc --grpc-gateway_out` -> `*.pb.gw.go` (REST gateway)
+3. `protoc --openapiv2_out` -> `*.swagger.json` (OpenAPI specs)
+4. `jq` merge -> `kfp_api_single_file.swagger.json`
+5. `swagger generate client` -> Go HTTP clients per service
+6. `sed` post-processing for type marshaling fixes
+
+Dockerfile (`backend/api/Dockerfile`) bundles: protoc v31.1, protoc-gen-go v1.36.6, protoc-gen-go-grpc v1.5.1, grpc-gateway v2.27.1, go-swagger v0.32.3.
+
+### Frontend protos
+
+```bash
+cd frontend
+npm run build:protos              # MLMD protos (grpc-web)
+npm run build:pipeline-spec       # Pipeline spec
+npm run build:platform-spec:kubernetes-platform  # K8s platform spec
+npm run apis                      # v1 Swagger API clients (requires swagger-codegen-cli.jar)
+npm run apis:v2beta1              # v2beta1 Swagger API clients
+```
+
+## Pipeline spec -> compiled IR YAML mapping
+
+```
+PipelineSpec proto
++-- pipeline_info -> name, display_name, description
++-- components (map<string, ComponentSpec>)
+|   +-- ComponentSpec
+|       +-- input_definitions (parameters + artifacts)
+|       +-- output_definitions
+|       +-- dag -> DagSpec (tasks map) OR
+|       +-- executor_label -> reference to deployment_spec executor
++-- root -> root ComponentSpec reference
++-- deployment_spec -> PipelineDeploymentConfig (container specs)
++-- schema_version -> "2.0.0"
++-- sdk_version -> kfp SDK version
+```
+
+## NEVER EDIT DIRECTLY (Generated files)
+
+The following files are generated; edit their sources and regenerate:
+
+- `api/v2alpha1/python/kfp/pipeline_spec/pipeline_spec_pb2.py`
+  - Source: `api/v2alpha1/pipeline_spec.proto`
+  - Generate: `make -C api python` (or `make -C api python-dev` for editable local dev)
+- `api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go`
+  - Source: `api/v2alpha1/pipeline_spec.proto`
+  - Generate: `make -C api golang`
+- `api/v2alpha1/go/cachekey/cache_key.pb.go`
+  - Source: `api/v2alpha1/cache_key.proto`
+  - Generate: `make -C api golang`
+- `kubernetes_platform/python/kfp/kubernetes/kubernetes_executor_config_pb2.py`
+  - Source: `kubernetes_platform/proto/kubernetes_executor_config.proto`
+  - Generate: `make -C kubernetes_platform python` (or `make -C kubernetes_platform python-dev`)
+- `kubernetes_platform/go/kubernetesplatform/kubernetes_executor_config.pb.go`
+  - Source: `kubernetes_platform/proto/kubernetes_executor_config.proto`
+  - Generate: `make -C kubernetes_platform golang`
+- `backend/api/v2beta1/go_client/*.pb.go`, `*.pb.gw.go`, `*_grpc.pb.go`
+  - Sources: `backend/api/v2beta1/*.proto`
+  - Generate: `make -C backend/api generate`
+- `backend/api/v2beta1/go_http_client/**/*.go`
+  - Sources: `backend/api/v2beta1/swagger/*.swagger.json`
+  - Generate: `make -C backend/api generate`
+- `backend/api/v2beta1/swagger/*.swagger.json`
+  - Sources: `backend/api/v2beta1/*.proto`
+  - Generate: `make -C backend/api generate`
+- Frontend API clients under `frontend/src/apis` and `frontend/src/apisv2beta1`
+  - Sources: Swagger specs under `backend/api/**/swagger/*.json`
+  - Generate: `cd frontend && npm run apis` / `npm run apis:v2beta1` (includes postprocess for TS 4.9 delete fix)
+- Frontend MLMD proto outputs under `frontend/src/third_party/mlmd/generated`
+  - Sources: `third_party/ml-metadata/*.proto`
+  - Generate: `cd frontend && npm run build:protos`

--- a/docs/agents/sdk-guide.md
+++ b/docs/agents/sdk-guide.md
@@ -1,0 +1,111 @@
+# KFP SDK Guide (Python)
+
+SDK classes, compilation flow, executor, client, local execution, and artifact types for working on `sdk/python/` and `kubernetes_platform/python/`.
+
+**See also:** [architecture.md](architecture.md) (E2E flow), [protobuf-build.md](protobuf-build.md) (proto generation for `kfp-pipeline-spec`), [testing-ci.md](testing-ci.md) (SDK tests)
+
+---
+
+## SDK compilation flow
+
+```
+@dsl.pipeline decorator
+  -> Pipeline context manager (pipeline_context.py) registers tasks
+    -> Component factory (component_factory.py) creates ComponentSpec
+      -> PipelineTask (pipeline_task.py) instantiates with PipelineChannels
+        -> Compiler (compiler.py) traverses task graph
+          -> pipeline_spec_builder.py builds PipelineSpec proto messages
+            -> Serialized to IR YAML via protobuf JSON format
+```
+
+## Key classes and their roles
+
+| Class | File | Purpose |
+|-------|------|---------|
+| `Pipeline` | `sdk/python/kfp/dsl/pipeline_context.py` | Context manager; registers tasks during pipeline definition |
+| `PipelineTask` | `sdk/python/kfp/dsl/pipeline_task.py` | Represents an instantiated component; manages inputs/outputs/config |
+| `PipelineChannel` | `sdk/python/kfp/dsl/pipeline_channel.py` | Abstract base for data flow between tasks (parameters and artifacts) |
+| `ComponentSpec` | `sdk/python/kfp/dsl/structures.py` | Full component specification with inputs/outputs/implementation |
+| `Compiler` | `sdk/python/kfp/compiler/compiler.py` | Entry point; calls `pipeline_spec_builder` to produce IR YAML |
+| `Executor` | `sdk/python/kfp/dsl/executor.py` | Handles runtime artifact/parameter mapping and function invocation |
+| `TasksGroup` | `sdk/python/kfp/dsl/tasks_group.py` | Base for control flow: `ParallelFor`, `Condition`, `ExitHandler` |
+| `Client` | `sdk/python/kfp/client/client.py` | KFP API client for remote pipeline upload and run management |
+
+## Key SDK files
+
+| Component | File | Key symbols |
+|-----------|------|-------------|
+| Pipeline decorator | `sdk/python/kfp/dsl/pipeline_context.py` | `@pipeline`, `Pipeline` class |
+| Component decorator | `sdk/python/kfp/dsl/component_decorator.py` | `@component` |
+| Pipeline Task | `sdk/python/kfp/dsl/pipeline_task.py` | `PipelineTask` |
+| Pipeline Channel | `sdk/python/kfp/dsl/pipeline_channel.py` | `PipelineChannel`, `PipelineParameterChannel`, `PipelineArtifactChannel` |
+| Component Factory | `sdk/python/kfp/dsl/component_factory.py` | `create_component_from_func()`, `ComponentInfo` |
+| Structures | `sdk/python/kfp/dsl/structures.py` | `InputSpec`, `OutputSpec`, `ComponentSpec`, `ContainerSpec` |
+| Tasks Groups | `sdk/python/kfp/dsl/tasks_group.py` | `ParallelFor`, `Condition`, `ExitHandler` |
+| For Loop | `sdk/python/kfp/dsl/for_loop.py` | `LoopParameterArgument`, `Collected` |
+| Compiler | `sdk/python/kfp/compiler/compiler.py` | `Compiler.compile()` |
+| Pipeline Spec Builder | `sdk/python/kfp/compiler/pipeline_spec_builder.py` | `build_task_spec_for_task()`, `to_protobuf_value()` |
+| Compiler Utils | `sdk/python/kfp/compiler/compiler_utils.py` | `get_all_groups()`, `get_inputs_for_all_groups()` |
+| Executor | `sdk/python/kfp/dsl/executor.py` | `Executor` class |
+| Executor Main | `sdk/python/kfp/dsl/executor_main.py` | `executor_main()` entry point |
+| Artifact Types | `sdk/python/kfp/dsl/types/artifact_types.py` | `Artifact`, `Model`, `Dataset`, `Metrics` |
+| Client | `sdk/python/kfp/client/client.py` | `Client` class |
+| Local Pipeline | `sdk/python/kfp/local/pipeline_orchestrator.py` | `run_local_pipeline()` |
+| Subprocess Handler | `sdk/python/kfp/local/subprocess_task_handler.py` | `SubprocessTaskHandler` |
+| Docker Handler | `sdk/python/kfp/local/docker_task_handler.py` | `DockerTaskHandler` |
+
+## Local execution
+
+### Subprocess Runner (no Docker required)
+
+```python
+from kfp import local
+local.init(runner=local.SubprocessRunner())
+
+# Run components directly
+task = my_component(param="value")
+print(task.output)
+```
+
+### Docker Runner (requires Docker)
+
+```python
+from kfp import local
+local.init(runner=local.DockerRunner())
+
+# Runs components in containers
+task = my_component(param="value")
+```
+
+### Pipeline execution
+
+```python
+# Pipelines can be executed like regular functions
+run = my_pipeline(input_param="test")
+
+# If the pipeline has a single output:
+print(run.output)
+
+# Or, for named outputs:
+print(run.outputs['<output_name>'])
+```
+
+Note: Local execution outputs are stored in `./local_outputs` by default.
+
+Notes:
+
+- SubprocessRunner supports only Lightweight Python Components (executes the KFP Python executor directly).
+- Use DockerRunner for Container Components or when task images require containerized execution.
+
+## Artifact types
+
+Inheritance hierarchy:
+
+```
+Artifact (sdk/python/kfp/dsl/types/artifact_types.py)
+  |- ClassificationMetrics, Dataset, HTML, Markdown, Metrics, Model, SlicedClassificationMetrics
+```
+
+## Documentation
+
+SDK reference docs are auto-generated with Sphinx using autodoc from Python docstrings. Keep SDK docstrings user-facing and accurate, as they appear in published documentation.

--- a/docs/agents/testing-ci.md
+++ b/docs/agents/testing-ci.md
@@ -1,0 +1,246 @@
+# KFP Testing and CI/CD
+
+Local testing commands, Ginkgo suites, test data iteration mechanics, proto change test coverage requirements, CI/CD matrices, cluster setup, and linting/code style.
+
+**See also:** [protobuf-build.md](protobuf-build.md) (proto generation commands), [backend-guide.md](backend-guide.md) (local dev setup, cluster deployment), [sdk-guide.md](sdk-guide.md) (SDK details)
+
+---
+
+## Local testing
+
+### Python (SDK)
+
+```bash
+pip install -r sdk/python/requirements-dev.txt
+pytest -v sdk/python/kfp
+```
+
+### Python (kfp-kubernetes)
+
+```bash
+pytest -v kubernetes_platform/python/test
+```
+
+### Go (backend) unit tests
+
+Excludes integration/API/Compiler/E2E tests:
+
+```bash
+go test -v $(go list ./backend/... | \
+  grep -v backend/test/v2/api | \
+  grep -v backend/test/integration | \
+  grep -v backend/test/v2/integration | \
+  grep -v backend/test/initialization | \
+  grep -v backend/test/v2/initialization | \
+  grep -v backend/test/compiler | \
+  grep -v backend/test/end2end)
+```
+
+Notes:
+
+- API Server tests under `backend/test/v2/api` are integration tests run with Ginkgo; they require a running cluster and are not part of unit tests.
+- Compiler tests live under `backend/test/compiler` and E2E tests under `backend/test/end2end`; both are Ginkgo-based and excluded from unit presubmits.
+
+## Backend Ginkgo test suites
+
+### Compiler tests
+
+```bash
+# Run compiler tests
+ginkgo -v ./backend/test/compiler
+
+# Update compiled workflow goldens when intended
+ginkgo -v ./backend/test/compiler -- -updateCompiledFiles=true
+
+# Auto-create missing goldens (default true); disable with:
+ginkgo -v ./backend/test/compiler -- -createGoldenFiles=false
+```
+
+### v2 API integration tests (label-filterable)
+
+```bash
+# All API tests
+ginkgo -v ./backend/test/v2/api
+
+# Example: run only Smoke-labeled tests with ginkgo
+ginkgo -v --label-filter="Smoke" ./backend/test/v2/api
+```
+
+### End-to-end tests
+
+```bash
+ginkgo -v ./backend/test/end2end -- -namespace=kubeflow -isDebugMode=true
+```
+
+### Test data locations
+
+- `test_data/sdk_compiled_pipelines/valid/` (inputs) with a `valid/critical/` subset for smoke lanes
+- `test_data/compiled-workflows/` (expected compiled Argo Workflows)
+
+## Test data iteration mechanics
+
+Each test suite discovers and iterates over test files differently:
+
+### Compiler tests
+
+- **Discovery function**: `GetListOfAllFilesInDir()` (recursive)
+- **Input directory**: `test_data/sdk_compiled_pipelines/valid/`
+- **Process**: Compiles each `.yaml` pipeline spec -> compares against `test_data/compiled-workflows/{name}.yaml`
+- **File filters**: Discovery functions exclude `.py`, `Dockerfile`, `.md`, `.ipynb` -- only `.yaml` and `.zip` are tested
+
+### E2E tests
+
+- **Discovery function**: `GetListOfFilesInADir()` (non-recursive)
+- **Directories and labels**:
+  - `valid/critical/` -> `Label: E2eCritical`
+  - `valid/essential/` -> `Label: E2eEssential`
+  - `valid/failing/` -> `Label: E2eFailed`
+  - `valid/integration/` -> `Label: Integration`
+
+### Smoke/Sanity tests
+
+- Hardcoded subset of files from `essential/` and `critical/`
+
+### API tests
+
+- **Upload tests**: `GetListOfAllFilesInDir()` (recursive) on `valid/`
+- **Negative tests**: `GetListOfFilesInADir()` on `invalid/`
+
+### SDK Python tests
+
+- Explicit test functions referencing specific `.py` files and comparing to `.yaml` goldens
+
+### Skip logic
+
+- Files with `_GH-{issue}` in name are auto-skipped
+
+## Proto changes require test coverage
+
+When any `.proto` file is modified (especially `api/v2alpha1/pipeline_spec.proto` or `kubernetes_platform/proto/kubernetes_executor_config.proto`), you **must** add or update test files that exercise the changed or new proto fields. The test system uses a three-file pipeline that must stay in sync:
+
+```
+1. Python pipeline source  (.py)  ->  test_data/sdk_compiled_pipelines/valid/{critical,essential}/
+2. Compiled pipeline spec  (.yaml) ->  test_data/sdk_compiled_pipelines/valid/{critical,essential}/
+3. Compiled Argo Workflow  (.yaml) ->  test_data/compiled-workflows/
+```
+
+### Step-by-step process
+
+1. **Write a Python pipeline** that uses the new or changed proto field. Place it in:
+   - `test_data/sdk_compiled_pipelines/valid/critical/` -- for features that are functionally important (e.g., new pipeline features, artifact handling, parameter types, pod metadata, caching behavior)
+   - `test_data/sdk_compiled_pipelines/valid/essential/` -- for foundational features that validate core KFP functionality (e.g., basic component composition, pip installs, pipeline nesting, conditionals, loops)
+
+2. **Compile the Python pipeline** to a KFP pipeline spec YAML. Place the output `.yaml` in the same directory as the `.py` file:
+   ```bash
+   kfp dsl compile --py test_data/sdk_compiled_pipelines/valid/critical/my_pipeline.py \
+                    --output test_data/sdk_compiled_pipelines/valid/critical/my_pipeline.yaml
+   ```
+
+3. **Generate the Argo Workflow golden file** by running the compiler tests with the update flag:
+   ```bash
+   ginkgo -v ./backend/test/compiler -- -updateCompiledFiles=true
+   ```
+   This writes the compiled Argo Workflow YAML to `test_data/compiled-workflows/my_pipeline.yaml`.
+
+4. **Verify all three files are consistent** by running the compiler tests without the update flag:
+   ```bash
+   ginkgo -v ./backend/test/compiler
+   ```
+
+### How the test framework uses these files
+
+| Test suite | Input directory | What it does |
+|------------|----------------|--------------|
+| Compiler tests (`backend/test/compiler`) | `test_data/sdk_compiled_pipelines/valid/**/*.yaml` -> `test_data/compiled-workflows/*.yaml` | Compiles every pipeline spec to an Argo Workflow and compares against the golden YAML |
+| E2E essential (`Label(E2eEssential)`) | `test_data/sdk_compiled_pipelines/valid/essential/` | Uploads and runs every pipeline in `essential/` on a live cluster |
+| E2E critical (`Label(E2eCritical)`) | `test_data/sdk_compiled_pipelines/valid/critical/` | Uploads and runs every pipeline in `critical/` on a live cluster |
+| Smoke tests (`Label(Smoke)`) | Hand-picked files from `essential/` and `critical/` | Runs a small subset for fast validation |
+
+### Naming conventions
+
+- The `.py` and `.yaml` files in `critical/` or `essential/` share the same base name: `my_pipeline.py` <-> `my_pipeline.yaml`
+- The Argo Workflow golden in `compiled-workflows/` also uses the same base name: `my_pipeline.yaml`
+- Exception: some files use `_compiled` suffix (e.g., `iris_pipeline.py` -> `iris_pipeline_compiled.yaml`)
+
+### When NOT to add test files
+
+- Pure documentation or comment changes in `.proto` files that don't alter the wire format
+- Changes to deprecated v1beta1 protos (unless explicitly maintaining v1 compatibility)
+
+## CI/CD (GitHub Actions)
+
+- Workflows: `.github/workflows/` (build, test, lint, release)
+- Composite actions: `.github/actions/` (e.g., `kfp-k8s`, `create-cluster`, `deploy`, `test-and-report`)
+- Typical checks: Go unit tests (backend), Python SDK tests, frontend tests/lint, image builds.
+
+### Test matrices and variants
+
+- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.29.2` and `v1.31.0`.
+  - Examples: `e2e-test.yml`, `sdk-execution.yml`, `upgrade-test.yml`, `kfp-kubernetes-execution-tests.yml`, `kfp-webhooks.yml`, `api-server-tests.yml`, `compiler-tests.yml`, `legacy-v2-api-integration-tests.yml`, `integration-tests-v1.yml`, and frontend integration in `e2e-test-frontend.yml`.
+- Pipeline store variants (v2 engine): tests run with `database` and `kubernetes` stores, and a dedicated job compiles pipelines to Kubernetes-native manifests.
+  - Example: `e2e-test.yml` job "API integration tests v2 - K8s with ${pipeline_store}" and "compile pipelines with Kubernetes".
+- Argo Workflows version matrix for compatibility (where relevant): e.g., `e2e-test.yml` includes an Argo job (e.g., `v3.5.14`).
+- Proxy / cache toggles: dedicated jobs run with HTTP proxy enabled and with execution cache disabled to validate those modes.
+- Artifacts: failing logs and test outputs are uploaded as workflow artifacts for debugging.
+
+### CI cluster setup and helpers
+
+- Kind-based clusters are provisioned via the `kfp-cluster` composite action, parameterized by `k8s_version`, `pipeline_store`, `proxy`, `cache_enabled`, and optional `argo_version`.
+- The `create-cluster` and `deploy` actions are used by newer suites; `kfp-k8s` installs SDK components from source inside jobs that execute Python-based tests.
+- The `protobuf` composite action prepares `protoc` and related dependencies when compiling Python protobufs.
+- The `create-cluster` action caches Kind node images by Kubernetes version to reduce Docker Hub pulls.
+- Python workflows use `actions/cache@v5` for pip cache to reduce repeated dependency installs.
+
+### Workflow path verification
+
+To verify all GitHub workflow path references are valid:
+
+1. **Iterate through all workflow files** in `.github/workflows/` (both `.yml` and `.yaml` files)
+2. **Parse each YAML file** and extract path references from:
+   - `working-directory` fields
+   - `dockerfile` and `context` fields in Docker build steps
+   - `script` or command paths (look for `./` prefixes)
+   - Any string values that appear to be file/directory paths
+   - Action references (e.g., `./.github/actions/...`)
+3. **Clean extracted paths** by removing `./` prefixes and variable expansions
+4. **Verify each extracted path exists** in the project filesystem
+5. **Report missing paths** and which workflows reference them
+
+## Test quality guidelines
+
+For comprehensive test quality, naming conventions, fixture isolation, and proportional coverage rules, see [test-quality.md](../../.github/review-guides/test-quality.md).
+
+## Lint and formatting checks
+
+### Go lint
+
+```bash
+golangci-lint run
+```
+
+### Python SDK
+
+```bash
+pip install -r sdk/python/requirements-dev.txt
+pycln --check sdk/python
+isort --check --profile google sdk/python
+```
+
+### Python SDK formatting (YAPF + string fixer)
+
+```bash
+pip install yapf pre_commit_hooks
+python3 -m pre_commit_hooks.string_fixer $(find sdk/python/kfp/**/*.py -type f)
+yapf --recursive --diff sdk/python/
+```
+
+### Python SDK docstring formatting
+
+```bash
+pip install docformatter
+docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
+```
+
+Notes:
+
+- Legacy `kfp-samples.yml` and `periodic.yml` workflows were removed.

--- a/tools/code-tree/code_tree.py
+++ b/tools/code-tree/code_tree.py
@@ -1,0 +1,2300 @@
+#!/usr/bin/env python3
+"""code_tree.py - Build a knowledge graph of a codebase with call graph and test mapping.
+
+Hybrid Parser + Knowledge Graph + Chunked Context approach:
+1. Parse: Extract symbols, calls, and references from every file
+2. Index: Link symbols into a knowledge graph with dependency edges
+3. Map: Connect tests to source code, detect module boundaries
+4. Output: Generate structured artifacts for AI agent consumption
+
+Edge types: contains, imports, inherits, calls, tests, type_of
+
+Usage:
+    python code_tree.py [--repo-root .] [--output-dir docs/code-tree]
+    python code_tree.py --help
+
+Zero external dependencies required. Optional: tree-sitter for enhanced parsing.
+"""
+
+import argparse
+import ast as python_ast
+import fnmatch
+import hashlib
+import json
+import logging
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+# ── Constants ─────────────────────────────────────────────────────
+
+LANG_EXTENSIONS = {
+    ".py": "python", ".pyw": "python",
+    ".go": "go",
+    ".js": "javascript", ".jsx": "javascript", ".mjs": "javascript", ".cjs": "javascript",
+    ".ts": "typescript", ".tsx": "typescript", ".mts": "typescript",
+    ".java": "java",
+    ".rs": "rust",
+    ".rb": "ruby",
+    ".cpp": "cpp", ".cc": "cpp", ".cxx": "cpp", ".hpp": "cpp",
+    ".c": "c", ".h": "c",
+    ".cs": "csharp",
+    ".php": "php",
+    ".swift": "swift",
+    ".kt": "kotlin", ".kts": "kotlin",
+    ".scala": "scala",
+    ".proto": "protobuf",
+    ".sql": "sql",
+    ".sh": "bash", ".bash": "bash",
+    ".lua": "lua",
+    ".dart": "dart",
+    ".ex": "elixir", ".exs": "elixir",
+    ".hs": "haskell",
+    ".zig": "zig",
+    ".r": "r", ".R": "r",
+    ".vue": "vue", ".svelte": "svelte",
+}
+
+DEFAULT_EXCLUDES = [
+    ".git", "node_modules", "__pycache__", ".venv", "venv", "vendor",
+    "dist", "build", ".tox", ".mypy_cache", ".pytest_cache", "eggs",
+    ".egg-info", ".idea", ".vscode", ".code-tree", "generated",
+    ".next", ".nuxt", "coverage", ".cache", ".terraform",
+    ".claude",
+]
+
+BINARY_EXTENSIONS = {
+    ".pyc", ".pyo", ".so", ".o", ".a", ".dylib", ".class", ".jar",
+    ".exe", ".dll", ".bin", ".dat", ".db", ".sqlite", ".sqlite3",
+    ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".ico", ".svg",
+    ".mp3", ".mp4", ".wav", ".avi", ".mov", ".mkv",
+    ".zip", ".tar", ".gz", ".bz2", ".xz", ".rar", ".7z",
+    ".woff", ".woff2", ".ttf", ".eot", ".otf",
+    ".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx",
+}
+
+TEST_MARKERS = {"test_", "_test.", ".test.", ".spec.", "tests/", "__tests__/", "test/"}
+
+BUILD_FILES = {
+    "go.mod", "go.sum",
+    "package.json",
+    "pyproject.toml", "setup.py", "setup.cfg",
+    "pom.xml", "build.gradle", "build.gradle.kts",
+    "Cargo.toml",
+    "Gemfile",
+    "composer.json",
+    "pubspec.yaml",
+    "mix.exs",
+}
+
+MAX_FILE_SIZE = 1_048_576  # 1 MB
+
+# Python builtins to exclude from call graph (module-level frozenset for O(1) lookup)
+_PYTHON_BUILTINS = frozenset({
+    "print", "len", "range", "enumerate", "zip", "map", "filter",
+    "sorted", "reversed", "list", "dict", "set", "tuple", "str",
+    "int", "float", "bool", "bytes", "type", "isinstance", "issubclass",
+    "hasattr", "getattr", "setattr", "delattr", "property",
+    "staticmethod", "classmethod", "super", "open", "repr",
+    "iter", "next", "any", "all", "min", "max", "sum", "abs",
+    "round", "id", "hash", "input", "format", "vars", "dir",
+    "callable", "chr", "ord", "hex", "oct", "bin",
+    "ValueError", "TypeError", "KeyError", "IndexError",
+    "AttributeError", "RuntimeError", "NotImplementedError",
+    "StopIteration", "Exception", "OSError", "IOError",
+    "FileNotFoundError", "PermissionError", "ImportError",
+})
+
+# Keywords to skip in regex call extraction (module-level frozenset)
+_REGEX_CALL_KEYWORDS = frozenset({
+    "if", "for", "while", "switch", "return", "new", "delete", "throw", "catch",
+})
+
+
+# ── Data Classes ──────────────────────────────────────────────────
+
+@dataclass
+class Symbol:
+    id: str
+    type: str  # file, class, function, method, interface, struct, enum, constant, variable
+    name: str
+    file: str
+    language: str
+    line_start: int
+    line_end: int
+    scope: Optional[str] = None
+    params: list[str] = field(default_factory=list)
+    bases: list[str] = field(default_factory=list)
+    decorators: list[str] = field(default_factory=list)
+    docstring: Optional[str] = None
+    exported: bool = True
+    signature: Optional[str] = None
+    is_test: bool = False
+
+
+@dataclass
+class Edge:
+    source: str
+    target: str
+    type: str  # contains, imports, inherits, calls, tests, type_of
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class CallRef:
+    """Raw call reference extracted from a function body, before resolution."""
+    caller_id: str      # Symbol ID of the calling function/method
+    raw_name: str        # Unresolved callee name (e.g. "foo", "self.bar", "pkg.func")
+    line: int            # Line number of the call
+    file: str            # File containing the call
+
+
+@dataclass
+class ModuleBoundary:
+    """A detected build module / package boundary."""
+    root_dir: str        # Directory containing the build file
+    build_file: str      # Name of the build file (e.g. "package.json")
+    name: Optional[str] = None  # Module name if detectable
+    language: Optional[str] = None
+
+
+# ── File Discovery ────────────────────────────────────────────────
+
+def should_exclude(path: str, excludes: list[str]) -> bool:
+    parts = Path(path).parts
+    for exc in excludes:
+        if any(fnmatch.fnmatch(p, exc) for p in parts):
+            return True
+        if fnmatch.fnmatch(path, exc):
+            return True
+    return False
+
+
+def is_binary(file_path: str) -> bool:
+    ext = Path(file_path).suffix.lower()
+    if ext in BINARY_EXTENSIONS:
+        return True
+    try:
+        with open(file_path, "rb") as f:
+            chunk = f.read(8192)
+            return b"\x00" in chunk
+    except (OSError, IOError):
+        return True
+
+
+def is_test_file(rel_path: str) -> bool:
+    """Determine if a file is a test file based on naming conventions."""
+    lower_rel = rel_path.lower()
+    return any(m in lower_rel for m in TEST_MARKERS)
+
+
+def file_hash(file_path: str) -> str:
+    """Compute SHA-256 hash of a file for change detection."""
+    h = hashlib.sha256()
+    try:
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+    except OSError:
+        return ""
+    return h.hexdigest()
+
+
+def discover_all(
+    root: str,
+    excludes: list[str],
+    include_tests: bool = True,
+    max_file_size: int = MAX_FILE_SIZE,
+) -> tuple[list[tuple[str, str, str, bool]], list[ModuleBoundary]]:
+    """Discover source files and build files in a single os.walk() pass.
+
+    Returns (files, module_boundaries) where files is a list of
+    (abs_path, rel_path, language, is_test) tuples.
+    """
+    files = []
+    boundaries = []
+    root = os.path.abspath(root)
+    exclude_set = set(excludes)
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            d for d in dirnames
+            if d not in exclude_set
+        ]
+
+        for fname in filenames:
+            abs_path = os.path.join(dirpath, fname)
+
+            # Check for build files
+            if fname in BUILD_FILES:
+                rel_dir = os.path.relpath(dirpath, root)
+                if rel_dir == ".":
+                    rel_dir = ""
+                boundary = ModuleBoundary(root_dir=rel_dir, build_file=fname)
+                try:
+                    _enrich_module_boundary(abs_path, boundary)
+                except (OSError, json.JSONDecodeError, UnicodeDecodeError) as e:
+                    logging.debug("Failed to enrich module boundary from %s: %s", abs_path, e)
+                boundaries.append(boundary)
+
+            # Check for source files
+            ext = Path(fname).suffix.lower()
+            lang = LANG_EXTENSIONS.get(ext)
+            if not lang:
+                continue
+
+            rel_path = os.path.relpath(abs_path, root)
+            if should_exclude(rel_path, excludes):
+                continue
+
+            test = is_test_file(rel_path)
+            if not include_tests and test:
+                continue
+
+            try:
+                size = os.path.getsize(abs_path)
+                if size > max_file_size or size == 0:
+                    continue
+            except OSError:
+                continue
+
+            if is_binary(abs_path):
+                continue
+
+            files.append((abs_path, rel_path, lang, test))
+
+    return sorted(files, key=lambda x: x[1]), boundaries
+
+
+def _enrich_module_boundary(abs_path: str, boundary: ModuleBoundary):
+    """Extract module name and language from a build file."""
+    fname = boundary.build_file
+
+    if fname == "go.mod":
+        boundary.language = "go"
+        with open(abs_path, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("module "):
+                    boundary.name = line.split()[1].strip()
+                    break
+
+    elif fname == "package.json":
+        boundary.language = "javascript"
+        with open(abs_path, "r", encoding="utf-8") as f:
+            try:
+                data = json.load(f)
+                boundary.name = data.get("name", "")
+            except json.JSONDecodeError:
+                pass
+
+    elif fname in ("pyproject.toml", "setup.cfg"):
+        boundary.language = "python"
+        with open(abs_path, "r", encoding="utf-8") as f:
+            m = _TOML_NAME_RE.search(f.read())
+            if m:
+                boundary.name = m.group(1)
+
+    elif fname == "Cargo.toml":
+        boundary.language = "rust"
+        with open(abs_path, "r", encoding="utf-8") as f:
+            m = _TOML_NAME_RE.search(f.read())
+            if m:
+                boundary.name = m.group(1)
+
+    elif fname in ("pom.xml",):
+        boundary.language = "java"
+        with open(abs_path, "r", encoding="utf-8") as f:
+            content = f.read()
+            m = re.search(r'<artifactId>([^<]+)</artifactId>', content)
+            if m:
+                boundary.name = m.group(1)
+
+    elif fname in ("build.gradle", "build.gradle.kts"):
+        boundary.language = "java"
+
+
+def read_file(path: str) -> Optional[str]:
+    for encoding in ("utf-8", "latin-1"):
+        try:
+            with open(path, "r", encoding=encoding) as f:
+                return f.read()
+        except (UnicodeDecodeError, OSError):
+            continue
+    return None
+
+
+# ── Python Parser (ast module) ────────────────────────────────────
+
+def parse_python(
+    content: str, rel_path: str, is_test: bool,
+) -> tuple[list[Symbol], list[Edge], list[CallRef]]:
+    """Parse Python using the ast module with call graph extraction."""
+    symbols = []
+    edges = []
+    call_refs = []
+    file_id = f"file:{rel_path}"
+
+    try:
+        tree = python_ast.parse(content, filename=rel_path)
+    except SyntaxError:
+        return symbols, edges, call_refs
+
+    # Extract imports
+    for node in python_ast.walk(tree):
+        if isinstance(node, python_ast.Import):
+            for alias in node.names:
+                edges.append(Edge(file_id, f"module:{alias.name}", "imports"))
+        elif isinstance(node, python_ast.ImportFrom):
+            if node.module:
+                level = node.level or 0
+                module_ref = node.module
+                if level > 0:
+                    # Relative import: compute target module
+                    parts = Path(rel_path).parts
+                    if len(parts) > level:
+                        base = ".".join(parts[:len(parts) - level])
+                        module_ref = f"{base}.{node.module}" if node.module else base
+                edges.append(Edge(file_id, f"module:{module_ref}", "imports"))
+                for alias in (node.names or []):
+                    if alias.name != "*":
+                        edges.append(Edge(
+                            file_id,
+                            f"symbol:{module_ref}.{alias.name}",
+                            "imports",
+                            {"from_import": True},
+                        ))
+
+    # Walk top-level nodes for symbols
+    _walk_python_body(
+        tree, rel_path, file_id, None, symbols, edges, call_refs, is_test,
+    )
+
+    return symbols, edges, call_refs
+
+
+def _walk_python_body(
+    node, rel_path: str, parent_id: str, scope: Optional[str],
+    symbols: list, edges: list, call_refs: list, is_test: bool,
+):
+    """Recursively walk Python AST nodes to extract symbols and calls."""
+    for child in python_ast.iter_child_nodes(node):
+        if isinstance(child, python_ast.ClassDef):
+            _extract_python_class(
+                child, rel_path, parent_id, scope, symbols, edges, call_refs, is_test,
+            )
+        elif isinstance(child, (python_ast.FunctionDef, python_ast.AsyncFunctionDef)):
+            _extract_python_function(
+                child, rel_path, parent_id, scope, symbols, edges, call_refs, is_test,
+            )
+        elif isinstance(child, python_ast.Assign):
+            # Module-level constants (UPPER_CASE)
+            if scope is None:  # Only at module level
+                for target in child.targets:
+                    if isinstance(target, python_ast.Name) and target.id.isupper():
+                        sym_id = f"constant:{rel_path}:{target.id}"
+                        symbols.append(Symbol(
+                            id=sym_id, type="constant", name=target.id,
+                            file=rel_path, language="python",
+                            line_start=child.lineno,
+                            line_end=child.end_lineno or child.lineno,
+                            exported=not target.id.startswith("_"),
+                            is_test=is_test,
+                        ))
+                        edges.append(Edge(parent_id, sym_id, "contains"))
+
+
+def _extract_python_class(
+    node: python_ast.ClassDef, rel_path: str, parent_id: str,
+    outer_scope: Optional[str],
+    symbols: list, edges: list, call_refs: list, is_test: bool,
+):
+    """Extract a Python class, including nested classes and methods."""
+    qualified = f"{outer_scope}.{node.name}" if outer_scope else node.name
+    sym_id = f"class:{rel_path}:{qualified}"
+
+    bases = []
+    for base in node.bases:
+        try:
+            bases.append(python_ast.unparse(base))
+        except (ValueError, TypeError):
+            if isinstance(base, python_ast.Name):
+                bases.append(base.id)
+
+    decorators = []
+    for dec in node.decorator_list:
+        try:
+            decorators.append(python_ast.unparse(dec))
+        except (ValueError, TypeError):
+            pass
+
+    docstring = python_ast.get_docstring(node)
+    symbols.append(Symbol(
+        id=sym_id, type="class", name=node.name,
+        file=rel_path, language="python",
+        line_start=node.lineno,
+        line_end=node.end_lineno or node.lineno,
+        scope=outer_scope,
+        bases=bases, decorators=decorators,
+        docstring=docstring[:200] if docstring else None,
+        exported=not node.name.startswith("_"),
+        is_test=is_test,
+    ))
+    edges.append(Edge(parent_id, sym_id, "contains"))
+
+    for base_name in bases:
+        edges.append(Edge(sym_id, f"class:?:{base_name}", "inherits", {"unresolved": True}))
+
+    # Recurse into class body — handles nested classes, methods, inner functions
+    _walk_python_body(
+        node, rel_path, sym_id, qualified, symbols, edges, call_refs, is_test,
+    )
+
+
+def _extract_python_function(
+    node, rel_path: str, parent_id: str, scope: Optional[str],
+    symbols: list, edges: list, call_refs: list, is_test: bool,
+):
+    """Extract a Python function/method with call graph analysis."""
+    qualified = f"{scope}.{node.name}" if scope else node.name
+
+    # Determine if this is a method (parent is a class)
+    is_method = scope is not None and parent_id.startswith("class:")
+    sym_type = "method" if is_method else "function"
+
+    sym_id = f"{sym_type}:{rel_path}:{qualified}"
+
+    params = [a.arg for a in node.args.args if a.arg != "self"]
+    docstring = python_ast.get_docstring(node)
+    decorators = []
+    for dec in node.decorator_list:
+        try:
+            decorators.append(python_ast.unparse(dec))
+        except (ValueError, TypeError):
+            pass
+
+    # Build signature
+    sig_parts = []
+    for a in node.args.args:
+        part = a.arg
+        if a.annotation:
+            try:
+                part += f": {python_ast.unparse(a.annotation)}"
+            except (ValueError, TypeError):
+                pass
+        sig_parts.append(part)
+    signature = f"({', '.join(sig_parts)})"
+    if hasattr(node, 'returns') and node.returns:
+        try:
+            signature += f" -> {python_ast.unparse(node.returns)}"
+        except (ValueError, TypeError):
+            pass
+
+    symbols.append(Symbol(
+        id=sym_id, type=sym_type, name=node.name,
+        file=rel_path, language="python",
+        line_start=node.lineno,
+        line_end=node.end_lineno or node.lineno,
+        scope=scope, params=params, decorators=decorators,
+        docstring=docstring[:200] if docstring else None,
+        exported=not node.name.startswith("_"),
+        signature=signature,
+        is_test=is_test or node.name.startswith("test_"),
+    ))
+    edges.append(Edge(parent_id, sym_id, "contains"))
+
+    # Extract calls from function body
+    _extract_python_calls(node, sym_id, rel_path, call_refs)
+
+    # Recurse into nested functions/classes inside this function
+    for child in python_ast.iter_child_nodes(node):
+        if isinstance(child, python_ast.ClassDef):
+            _extract_python_class(
+                child, rel_path, sym_id, qualified, symbols, edges, call_refs, is_test,
+            )
+        elif isinstance(child, (python_ast.FunctionDef, python_ast.AsyncFunctionDef)):
+            # Nested function (closure)
+            _extract_python_function(
+                child, rel_path, sym_id, qualified, symbols, edges, call_refs, is_test,
+            )
+
+
+def _extract_python_calls(
+    func_node, caller_id: str, rel_path: str,
+    call_refs: list,
+):
+    """Walk a Python function body to extract call references.
+
+    Uses a manual stack instead of ast.walk() to skip nested
+    FunctionDef/AsyncFunctionDef/ClassDef nodes (those are handled
+    separately and would cause double-counting).
+    """
+    stack = list(python_ast.iter_child_nodes(func_node))
+    while stack:
+        node = stack.pop()
+
+        # Skip nested function/class definitions — they have their own caller_id
+        if isinstance(node, (python_ast.FunctionDef, python_ast.AsyncFunctionDef, python_ast.ClassDef)):
+            continue
+
+        if isinstance(node, python_ast.Call):
+            raw_name = None
+            line = getattr(node, 'lineno', 0)
+
+            if isinstance(node.func, python_ast.Name):
+                raw_name = node.func.id
+            elif isinstance(node.func, python_ast.Attribute):
+                try:
+                    raw_name = python_ast.unparse(node.func)
+                except (ValueError, TypeError):
+                    raw_name = node.func.attr
+
+            if raw_name and raw_name not in _PYTHON_BUILTINS:
+                call_refs.append(CallRef(
+                    caller_id=caller_id,
+                    raw_name=raw_name,
+                    line=line,
+                    file=rel_path,
+                ))
+
+        # Continue walking children
+        stack.extend(python_ast.iter_child_nodes(node))
+
+
+# ── Regex Parsers ─────────────────────────────────────────────────
+
+def _compile_patterns(raw_patterns):
+    """Pre-compile a list of (regex_str, sym_type, groups) into (compiled_re, sym_type, groups)."""
+    return [(re.compile(pat), sym_type, groups) for pat, sym_type, groups in raw_patterns]
+
+GO_PATTERNS = _compile_patterns([
+    (r"^package\s+(\w+)", "package", {"name": 1}),
+    (r'^func\s+(\w+)\s*\(([^)]*)\)', "function", {"name": 1, "params": 2}),
+    (r'^func\s+\(\w+\s+\*?(\w+)\)\s+(\w+)\s*\(([^)]*)\)', "method", {"scope": 1, "name": 2, "params": 3}),
+    (r'^type\s+(\w+)\s+struct\s*\{', "struct", {"name": 1}),
+    (r'^type\s+(\w+)\s+interface\s*\{', "interface", {"name": 1}),
+    (r'^\s*"([^"]+)"', "_import", {"name": 1}),
+])
+
+GO_IMPORT_BLOCK = re.compile(r'^import\s*\(\s*\n(.*?)\n\s*\)', re.MULTILINE | re.DOTALL)
+GO_IMPORT_SINGLE = re.compile(r'^import\s+"([^"]+)"', re.MULTILINE)
+
+JS_PATTERNS = _compile_patterns([
+    (r"^(?:export\s+)?class\s+(\w+)(?:\s+extends\s+(\w+))?", "class", {"name": 1, "bases": 2}),
+    (r"^(?:export\s+)?(?:async\s+)?function\s+(\w+)\s*\(([^)]*)\)", "function", {"name": 1, "params": 2}),
+    (r"^(?:export\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s+)?(?:\([^)]*\)|[^=])\s*=>", "function", {"name": 1}),
+    (r'^import\s+.*?\s+from\s+[\'"]([^\'"]+)[\'"]', "_import", {"name": 1}),
+    (r'^import\s+[\'"]([^\'"]+)[\'"]', "_import", {"name": 1}),
+    (r"require\(\s*['\"]([^'\"]+)['\"]\s*\)", "_import", {"name": 1}),
+    (r"^(?:export\s+)?interface\s+(\w+)", "interface", {"name": 1}),
+    (r"^(?:export\s+)?type\s+(\w+)\s*=", "interface", {"name": 1}),
+    (r"^(?:export\s+)?enum\s+(\w+)", "enum", {"name": 1}),
+])
+
+JAVA_PATTERNS = _compile_patterns([
+    (r"^package\s+([\w.]+);", "package", {"name": 1}),
+    (r"^import\s+([\w.]+);", "_import", {"name": 1}),
+    (r"(?:public|private|protected)?\s*(?:abstract\s+)?(?:static\s+)?class\s+(\w+)(?:\s+extends\s+(\w+))?", "class", {"name": 1, "bases": 2}),
+    (r"(?:public|private|protected)?\s*interface\s+(\w+)", "interface", {"name": 1}),
+    (r"(?:public|private|protected)?\s*enum\s+(\w+)", "enum", {"name": 1}),
+    (r"(?:public|private|protected)\s+(?:static\s+)?(?:abstract\s+)?(?:synchronized\s+)?(?:final\s+)?\w+(?:<[^>]+>)?\s+(\w+)\s*\(([^)]*)\)", "method", {"name": 1, "params": 2}),
+])
+
+RUST_PATTERNS = _compile_patterns([
+    (r"^pub\s+fn\s+(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)", "function", {"name": 1, "params": 2}),
+    (r"^fn\s+(\w+)\s*(?:<[^>]*>)?\s*\(([^)]*)\)", "function", {"name": 1, "params": 2}),
+    (r"^pub\s+struct\s+(\w+)", "struct", {"name": 1}),
+    (r"^struct\s+(\w+)", "struct", {"name": 1}),
+    (r"^pub\s+enum\s+(\w+)", "enum", {"name": 1}),
+    (r"^enum\s+(\w+)", "enum", {"name": 1}),
+    (r"^pub\s+trait\s+(\w+)", "interface", {"name": 1}),
+    (r"^trait\s+(\w+)", "interface", {"name": 1}),
+    (r"^impl(?:<[^>]*>)?\s+(\w+)", "struct", {"name": 1}),
+    (r'^use\s+([\w:]+)', "_import", {"name": 1}),
+    (r'^mod\s+(\w+);', "_import", {"name": 1}),
+])
+
+PROTO_PATTERNS = _compile_patterns([
+    (r'^message\s+(\w+)\s*\{', "class", {"name": 1}),
+    (r'^service\s+(\w+)\s*\{', "interface", {"name": 1}),
+    (r'^\s*rpc\s+(\w+)\s*\((\w+)\)\s*returns\s*\((\w+)\)', "method", {"name": 1, "params": 2}),
+    (r'^enum\s+(\w+)\s*\{', "enum", {"name": 1}),
+    (r'^import\s+"([^"]+)"', "_import", {"name": 1}),
+])
+
+CSHARP_PATTERNS = _compile_patterns([
+    (r"(?:public|private|protected|internal)?\s*(?:abstract\s+)?(?:static\s+)?class\s+(\w+)(?:\s*:\s*(\w+))?", "class", {"name": 1, "bases": 2}),
+    (r"(?:public|private|protected|internal)?\s*interface\s+(\w+)", "interface", {"name": 1}),
+    (r"(?:public|private|protected|internal)?\s*enum\s+(\w+)", "enum", {"name": 1}),
+    (r"(?:public|private|protected|internal)\s+(?:static\s+)?(?:async\s+)?(?:virtual\s+)?(?:override\s+)?\w+(?:<[^>]+>)?\s+(\w+)\s*\(([^)]*)\)", "method", {"name": 1, "params": 2}),
+    (r'^using\s+([\w.]+);', "_import", {"name": 1}),
+])
+
+LANG_PATTERNS = {
+    "go": GO_PATTERNS,
+    "javascript": JS_PATTERNS,
+    "typescript": JS_PATTERNS,
+    "java": JAVA_PATTERNS,
+    "rust": RUST_PATTERNS,
+    "protobuf": PROTO_PATTERNS,
+    "csharp": CSHARP_PATTERNS,
+}
+
+# Regex pattern for extracting function calls from source code
+CALL_PATTERN = re.compile(r'\b([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\(')
+
+# Shared TOML name extraction pattern (used for pyproject.toml and Cargo.toml)
+_TOML_NAME_RE = re.compile(r'name\s*=\s*"([^"]+)"')
+
+
+def _extract_go_import_edges(content: str, file_id: str) -> list[Edge]:
+    """Extract Go import edges from content (shared by regex and tree-sitter paths)."""
+    edges = []
+    for m in GO_IMPORT_BLOCK.finditer(content):
+        block = m.group(1)
+        for line in block.strip().split("\n"):
+            line = line.strip().strip('"')
+            if line and not line.startswith("//"):
+                parts = line.split()
+                imp = parts[-1].strip('"') if parts else line
+                edges.append(Edge(file_id, f"module:{imp}", "imports"))
+    for m in GO_IMPORT_SINGLE.finditer(content):
+        edges.append(Edge(file_id, f"module:{m.group(1)}", "imports"))
+    return edges
+
+
+def parse_with_regex(
+    content: str, rel_path: str, language: str, is_test: bool,
+) -> tuple[list[Symbol], list[Edge], list[CallRef]]:
+    """Parse a source file using regex patterns with call extraction."""
+    symbols = []
+    edges = []
+    call_refs = []
+    file_id = f"file:{rel_path}"
+    patterns = LANG_PATTERNS.get(language, [])
+    if not patterns:
+        return symbols, edges, call_refs
+
+    lines = content.split("\n")
+
+    # Handle Go import blocks
+    if language == "go":
+        edges.extend(_extract_go_import_edges(content, file_id))
+
+    current_class = None
+    brace_depth = 0
+    symbol_ranges = []  # Track (line_start, sym_id, sym_type) for call extraction
+
+    for lineno, line in enumerate(lines, 1):
+        stripped = line.rstrip()
+
+        brace_depth += stripped.count("{") - stripped.count("}")
+        if brace_depth <= 0:
+            current_class = None
+
+        for compiled_re, sym_type, groups in patterns:
+            m = compiled_re.search(stripped)
+            if not m:
+                continue
+
+            name = m.group(groups["name"]) if "name" in groups else None
+            if not name:
+                continue
+
+            if sym_type == "_import":
+                if language != "go":
+                    edges.append(Edge(file_id, f"module:{name}", "imports"))
+                continue
+
+            if sym_type == "package":
+                continue
+
+            params_str = m.group(groups["params"]) if "params" in groups and groups["params"] <= len(m.groups()) else None
+            params = [p.strip().split()[-1].split(":")[0] for p in params_str.split(",") if p.strip()] if params_str else []
+
+            bases_match = m.group(groups["bases"]) if "bases" in groups and groups["bases"] <= len(m.groups()) and m.group(groups["bases"]) else None
+            bases = [bases_match] if bases_match else []
+
+            scope_match = m.group(groups["scope"]) if "scope" in groups and groups["scope"] <= len(m.groups()) and m.group(groups["scope"]) else None
+            scope = scope_match or (current_class if sym_type == "method" else None)
+
+            # Determine end line (use len(lines) + 1 so the last line is reachable)
+            end_line = lineno
+            for j in range(lineno, min(lineno + 500, len(lines) + 1)):
+                if j > lineno and j <= len(lines) and lines[j - 1].strip() and not lines[j - 1].startswith((" ", "\t")) and brace_depth <= 1:
+                    end_line = j - 1
+                    break
+            else:
+                end_line = min(lineno + 50, len(lines))
+
+            if scope:
+                sym_id = f"{sym_type}:{rel_path}:{scope}.{name}"
+            else:
+                sym_id = f"{sym_type}:{rel_path}:{name}"
+
+            exported = not name.startswith("_")
+            if language == "go":
+                exported = name[0].isupper() if name else True
+
+            symbols.append(Symbol(
+                id=sym_id, type=sym_type, name=name,
+                file=rel_path, language=language,
+                line_start=lineno, line_end=end_line,
+                scope=scope, params=params, bases=bases,
+                exported=exported,
+                is_test=is_test,
+            ))
+
+            if sym_type in ("class", "struct", "interface", "enum"):
+                edges.append(Edge(file_id, sym_id, "contains"))
+                current_class = name
+                for b in bases:
+                    edges.append(Edge(sym_id, f"class:?:{b}", "inherits", {"unresolved": True}))
+            elif sym_type == "method" and scope:
+                parent_id = f"class:{rel_path}:{scope}"
+                edges.append(Edge(parent_id, sym_id, "contains"))
+            elif sym_type == "function":
+                edges.append(Edge(file_id, sym_id, "contains"))
+
+            symbol_ranges.append((lineno, end_line, sym_id))
+            break
+
+    # Extract calls from function/method bodies using regex
+    _extract_regex_calls(lines, symbol_ranges, rel_path, call_refs)
+
+    return symbols, edges, call_refs
+
+
+def _extract_regex_calls(
+    lines: list[str], symbol_ranges: list, rel_path: str, call_refs: list,
+):
+    """Extract function calls from source code using regex (fallback)."""
+    for start, end, sym_id in symbol_ranges:
+        if not (sym_id.startswith("function:") or sym_id.startswith("method:")):
+            continue
+
+        for lineno in range(start, min(end + 1, len(lines) + 1)):
+            line = lines[lineno - 1] if lineno <= len(lines) else ""
+            # Skip comments and strings (rough heuristic)
+            stripped = line.strip()
+            if stripped.startswith("//") or stripped.startswith("#") or stripped.startswith("*"):
+                continue
+
+            for m in CALL_PATTERN.finditer(line):
+                raw_name = m.group(1)
+                if raw_name in _REGEX_CALL_KEYWORDS:
+                    continue
+                call_refs.append(CallRef(
+                    caller_id=sym_id,
+                    raw_name=raw_name,
+                    line=lineno,
+                    file=rel_path,
+                ))
+
+
+def _extract_regex_imports(
+    content: str, rel_path: str, language: str,
+) -> list[Edge]:
+    """Extract only import edges using regex — lightweight fallback for tree-sitter."""
+    edges = []
+    file_id = f"file:{rel_path}"
+    patterns = LANG_PATTERNS.get(language, [])
+
+    # Handle Go import blocks
+    if language == "go":
+        return _extract_go_import_edges(content, file_id)
+
+    # For other languages, scan only import patterns
+    for line in content.split("\n"):
+        stripped = line.rstrip()
+        for compiled_re, sym_type, groups in patterns:
+            if sym_type != "_import":
+                continue
+            m = compiled_re.search(stripped)
+            if m:
+                name = m.group(groups["name"]) if "name" in groups else None
+                if name:
+                    edges.append(Edge(file_id, f"module:{name}", "imports"))
+
+    return edges
+
+
+# ── Tree-sitter Integration ──────────────────────────────────────
+
+def try_load_tree_sitter() -> dict:
+    """Try to load tree-sitter with available language grammars."""
+    available = {}
+
+    try:
+        from tree_sitter import Language, Parser
+    except ImportError:
+        return available
+
+    grammar_packages = {
+        "python": "tree_sitter_python",
+        "go": "tree_sitter_go",
+        "javascript": "tree_sitter_javascript",
+        "typescript": "tree_sitter_typescript",
+        "java": "tree_sitter_java",
+        "rust": "tree_sitter_rust",
+        "ruby": "tree_sitter_ruby",
+        "c": "tree_sitter_c",
+        "cpp": "tree_sitter_cpp",
+    }
+
+    for lang, pkg in grammar_packages.items():
+        try:
+            mod = __import__(pkg)
+            language_func = getattr(mod, "language", None)
+            if language_func:
+                lang_obj = Language(language_func())
+                parser = Parser(lang_obj)
+                available[lang] = (parser, lang_obj)
+        except (ImportError, AttributeError, OSError) as e:
+            logging.debug("tree-sitter grammar %s unavailable: %s", pkg, e)
+
+    if not available:
+        try:
+            from tree_sitter_languages import get_parser, get_language
+            for lang in ["python", "go", "javascript", "typescript", "java", "rust", "ruby", "c", "cpp"]:
+                try:
+                    available[lang] = (get_parser(lang), get_language(lang))
+                except (ImportError, AttributeError, OSError) as e:
+                    logging.debug("tree-sitter-languages %s unavailable: %s", lang, e)
+        except ImportError:
+            pass
+
+    return available
+
+
+# Node types that represent symbol declarations per language
+TS_SYMBOL_TYPES = {
+    "python": {
+        "class_definition": "class",
+        "function_definition": "function",
+    },
+    "go": {
+        "function_declaration": "function",
+        "method_declaration": "method",
+        "type_declaration": None,  # need sub-check for struct vs interface
+    },
+    "javascript": {
+        "class_declaration": "class",
+        "function_declaration": "function",
+        "arrow_function": "function",
+        "method_definition": "method",
+        "interface_declaration": "interface",
+    },
+    "typescript": {
+        "class_declaration": "class",
+        "function_declaration": "function",
+        "arrow_function": "function",
+        "method_definition": "method",
+        "interface_declaration": "interface",
+        "type_alias_declaration": "interface",
+        "enum_declaration": "enum",
+    },
+    "java": {
+        "class_declaration": "class",
+        "interface_declaration": "interface",
+        "enum_declaration": "enum",
+        "method_declaration": "method",
+        "constructor_declaration": "method",
+    },
+    "rust": {
+        "function_item": "function",
+        "struct_item": "struct",
+        "enum_item": "enum",
+        "trait_item": "interface",
+        "impl_item": None,  # scope provider, not a symbol itself
+    },
+}
+
+# Node types that represent function calls per language
+TS_CALL_TYPES = {
+    "python": ["call"],
+    "go": ["call_expression"],
+    "javascript": ["call_expression", "new_expression"],
+    "typescript": ["call_expression", "new_expression"],
+    "java": ["method_invocation", "object_creation_expression"],
+    "rust": ["call_expression", "macro_invocation"],
+}
+
+def parse_with_tree_sitter(
+    content: str, rel_path: str, language: str, parser, lang_obj, is_test: bool,
+) -> tuple[list[Symbol], list[Edge], list[CallRef]]:
+    """Parse a file using tree-sitter with full call graph extraction."""
+    symbols = []
+    edges = []
+    call_refs = []
+    file_id = f"file:{rel_path}"
+
+    content_bytes = content.encode("utf-8")
+    try:
+        tree = parser.parse(content_bytes)
+    except (ValueError, TypeError, RuntimeError) as e:
+        logging.debug("tree-sitter parse failed for %s: %s", rel_path, e)
+        return symbols, edges, call_refs
+    symbol_types = TS_SYMBOL_TYPES.get(language, {})
+    call_types = set(TS_CALL_TYPES.get(language, []))
+
+    def get_node_text(node):
+        return content_bytes[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
+
+    def find_name(node):
+        """Extract the name identifier from a declaration node."""
+        # Try field name first
+        name_node = node.child_by_field_name("name")
+        if name_node:
+            return get_node_text(name_node)
+
+        # Try first identifier child
+        for child in node.children:
+            if child.type in ("identifier", "name", "type_identifier", "property_identifier"):
+                return get_node_text(child)
+        return None
+
+    def find_params(node):
+        """Extract parameter names from a function/method declaration."""
+        params = []
+        param_node = node.child_by_field_name("parameters") or node.child_by_field_name("formal_parameters")
+        if not param_node:
+            for child in node.children:
+                if child.type in ("parameters", "formal_parameters", "parameter_list"):
+                    param_node = child
+                    break
+
+        if param_node:
+            for child in param_node.children:
+                if child.type in ("identifier", "name"):
+                    text = get_node_text(child)
+                    if text != "self" and text != "cls":
+                        params.append(text)
+                elif child.type in ("parameter", "formal_parameter", "typed_parameter",
+                                     "default_parameter", "typed_default_parameter"):
+                    name_n = child.child_by_field_name("name")
+                    if not name_n:
+                        for sub in child.children:
+                            if sub.type == "identifier":
+                                name_n = sub
+                                break
+                    if name_n:
+                        text = get_node_text(name_n)
+                        if text != "self" and text != "cls":
+                            params.append(text)
+        return params
+
+    def find_bases(node, language):
+        """Extract base classes/interfaces from a class declaration."""
+        bases = []
+        # Python: argument_list in class_definition
+        superclass_node = node.child_by_field_name("superclasses")
+        if superclass_node:
+            for child in superclass_node.children:
+                if child.type in ("identifier", "attribute"):
+                    bases.append(get_node_text(child))
+            return bases
+
+        # Java/JS/TS: superclass field
+        for field_name in ("superclass", "super_class"):
+            sc = node.child_by_field_name(field_name)
+            if sc:
+                bases.append(get_node_text(sc))
+
+        # Look for extends/implements clauses
+        for child in node.children:
+            if child.type in ("superclass", "class_heritage"):
+                for sub in child.children:
+                    if sub.type in ("identifier", "type_identifier"):
+                        bases.append(get_node_text(sub))
+        return bases
+
+    def extract_calls_from_body(body_node, caller_id):
+        """Walk a function body to extract call references."""
+        if body_node is None:
+            return
+
+        stack = [body_node]
+        while stack:
+            node = stack.pop()
+
+            if node.type in call_types:
+                func_node = node.child_by_field_name("function")
+                if not func_node:
+                    # Try first child for some languages
+                    if node.children:
+                        func_node = node.children[0]
+
+                if func_node:
+                    raw_name = get_node_text(func_node)
+                    # Clean up the name
+                    raw_name = raw_name.strip()
+                    if raw_name and len(raw_name) < 200:  # sanity limit
+                        call_refs.append(CallRef(
+                            caller_id=caller_id,
+                            raw_name=raw_name,
+                            line=node.start_point[0] + 1,
+                            file=rel_path,
+                        ))
+
+            # Don't recurse into nested function/class declarations for calls
+            if node.type not in symbol_types and node != body_node:
+                for child in node.children:
+                    stack.append(child)
+            elif node == body_node:
+                for child in node.children:
+                    stack.append(child)
+
+    def visit(node, scope=None, parent_id=None):
+        """Recursively visit tree-sitter AST nodes."""
+        if parent_id is None:
+            parent_id = file_id
+
+        node_type = node.type
+
+        # Handle scope-only nodes (e.g., impl_item in Rust) that provide
+        # scope context for their children but are not symbols themselves
+        if node_type in symbol_types and symbol_types[node_type] is None:
+            impl_name = find_name(node)
+            if impl_name:
+                for child in node.children:
+                    visit(child, scope=impl_name, parent_id=parent_id)
+            else:
+                for child in node.children:
+                    visit(child, scope=scope, parent_id=parent_id)
+            return
+
+        sym_type = symbol_types.get(node_type)
+
+        if sym_type is not None:
+            name = find_name(node)
+            if name:
+                qualified = f"{scope}.{name}" if scope else name
+
+                # Determine actual sym_type for special cases
+                actual_type = sym_type
+                if language == "go" and node_type == "type_declaration":
+                    # Check if struct or interface
+                    for child in node.children:
+                        if child.type == "type_spec":
+                            for sub in child.children:
+                                if sub.type == "struct_type":
+                                    actual_type = "struct"
+                                elif sub.type == "interface_type":
+                                    actual_type = "interface"
+                            name_node = child.child_by_field_name("name")
+                            if name_node:
+                                name = get_node_text(name_node)
+                                qualified = f"{scope}.{name}" if scope else name
+
+                # Determine if method
+                if actual_type == "function" and scope and parent_id.startswith("class:"):
+                    actual_type = "method"
+
+                sym_id = f"{actual_type}:{rel_path}:{qualified}"
+
+                exported = not name.startswith("_")
+                if language == "go":
+                    exported = name[0].isupper() if name else True
+
+                params = find_params(node)
+                bases = find_bases(node, language) if actual_type in ("class", "struct") else []
+
+                symbols.append(Symbol(
+                    id=sym_id, type=actual_type, name=name,
+                    file=rel_path, language=language,
+                    line_start=node.start_point[0] + 1,
+                    line_end=node.end_point[0] + 1,
+                    scope=scope, params=params, bases=bases,
+                    exported=exported,
+                    is_test=is_test,
+                ))
+
+                # Create containment edges
+                if actual_type in ("class", "struct", "interface", "enum"):
+                    edges.append(Edge(parent_id, sym_id, "contains"))
+                    for b in bases:
+                        edges.append(Edge(sym_id, f"class:?:{b}", "inherits", {"unresolved": True}))
+                    # Recurse into class body with scope
+                    for child in node.children:
+                        visit(child, scope=name, parent_id=sym_id)
+                    return
+                elif actual_type == "method" and scope:
+                    scope_id = f"class:{rel_path}:{scope}"
+                    edges.append(Edge(scope_id, sym_id, "contains"))
+                else:
+                    edges.append(Edge(parent_id, sym_id, "contains"))
+
+                # Extract calls from function/method body
+                body_node = node.child_by_field_name("body") or node.child_by_field_name("block")
+                if body_node is None:
+                    # Some languages use the last block child
+                    for child in reversed(node.children):
+                        if child.type in ("block", "statement_block", "compound_statement"):
+                            body_node = child
+                            break
+                extract_calls_from_body(body_node, sym_id)
+                return  # Don't recurse into function body for more symbols (nested handled above)
+
+        # Not a symbol node; recurse
+        for child in node.children:
+            visit(child, scope, parent_id)
+
+    visit(tree.root_node)
+
+    # Extract imports using regex (more reliable for multi-language consistency)
+    edges.extend(_extract_regex_imports(content, rel_path, language))
+
+    return symbols, edges, call_refs
+
+
+# ── Parser Dispatcher ─────────────────────────────────────────────
+
+def parse_file(
+    abs_path: str, rel_path: str, language: str,
+    ts_parsers: dict, is_test: bool,
+) -> tuple[list[Symbol], list[Edge], list[CallRef], int]:
+    """Parse a single file, choosing the best available parser.
+
+    Returns (symbols, edges, call_refs, line_count).
+    """
+    content = read_file(abs_path)
+    if content is None:
+        return [], [], [], 0
+
+    line_count = content.count("\n") + (1 if content and not content.endswith("\n") else 0)
+
+    # Python: always use ast module (most accurate)
+    if language == "python":
+        symbols, edges, calls = parse_python(content, rel_path, is_test)
+        return symbols, edges, calls, line_count
+
+    # Tree-sitter if available
+    if language in ts_parsers:
+        parser, lang_obj = ts_parsers[language]
+        symbols, edges, calls = parse_with_tree_sitter(
+            content, rel_path, language, parser, lang_obj, is_test,
+        )
+        if symbols or edges:
+            return symbols, edges, calls, line_count
+
+    # Fallback: regex
+    symbols, edges, calls = parse_with_regex(content, rel_path, language, is_test)
+    return symbols, edges, calls, line_count
+
+
+# ── Call Resolution ───────────────────────────────────────────────
+
+def resolve_calls(
+    call_refs: list[CallRef],
+    symbols: list[Symbol],
+    edges: list[Edge],
+    file_map: dict,
+) -> list[Edge]:
+    """Resolve raw call references to known symbols, creating calls edges."""
+    call_edges = []
+
+    # Build lookup indexes
+    # name -> list of symbol IDs
+    name_to_symbols = defaultdict(list)
+    for sym in symbols:
+        name_to_symbols[sym.name].append(sym)
+        if sym.scope:
+            name_to_symbols[f"{sym.scope}.{sym.name}"].append(sym)
+
+    # file -> {imported_name -> module_path}
+    file_imports = defaultdict(dict)
+    for edge in edges:
+        if edge.type == "imports" and edge.source.startswith("file:"):
+            src_file = edge.source[5:]
+            if edge.target.startswith("symbol:"):
+                # from X import Y -> local name Y maps to symbol
+                symbol_path = edge.target[7:]
+                parts = symbol_path.rsplit(".", 1)
+                if len(parts) == 2:
+                    local_name = parts[1]
+                    file_imports[src_file][local_name] = symbol_path
+            elif edge.target.startswith("module:"):
+                mod_name = edge.target[7:]
+                # import X -> local name X
+                local_name = mod_name.rsplit(".", 1)[-1]
+                file_imports[src_file][local_name] = mod_name
+
+    # file -> list of symbols defined in that file
+    file_symbols = defaultdict(list)
+    for sym in symbols:
+        file_symbols[sym.file].append(sym)
+
+    # Build a set of all symbol IDs for O(1) existence checks
+    symbol_ids = {s.id for s in symbols}
+
+    # Deduplicate calls: (caller_id, resolved_target_id) pairs
+    seen_calls = set()
+
+    for ref in call_refs:
+        raw = ref.raw_name
+        caller_id = ref.caller_id
+
+        resolved = None
+
+        # 1. self.method() -> look up method in the same class
+        if raw.startswith("self.") or raw.startswith("this."):
+            method_name = raw.split(".", 1)[1]
+            # Find the class scope from caller_id
+            # caller_id format: method:file:Class.method_name
+            parts = caller_id.split(":")
+            if len(parts) >= 3:
+                scope_parts = parts[2].rsplit(".", 1)
+                if len(scope_parts) == 2:
+                    class_name = scope_parts[0]
+                    target_id = f"method:{ref.file}:{class_name}.{method_name}"
+                    if target_id in symbol_ids:
+                        resolved = target_id
+
+        # 2. Direct name -> look up in same file, then imports
+        if not resolved and "." not in raw:
+            # Same file first
+            for sym in file_symbols.get(ref.file, []):
+                if sym.name == raw and sym.id != caller_id:
+                    resolved = sym.id
+                    break
+
+            # Check imports
+            if not resolved:
+                imported_path = file_imports.get(ref.file, {}).get(raw)
+                if imported_path:
+                    # Find the actual symbol
+                    parts = imported_path.rsplit(".", 1)
+                    if len(parts) == 2:
+                        sym_name = parts[1]
+                        for sym in name_to_symbols.get(sym_name, []):
+                            resolved = sym.id
+                            break
+
+        # 3. Qualified name: module.func or Class.method
+        if not resolved and "." in raw:
+            parts = raw.split(".")
+            # Try as imported_module.symbol
+            if len(parts) == 2:
+                obj, attr = parts
+                # Check if obj is an imported module
+                imported_path = file_imports.get(ref.file, {}).get(obj)
+                if imported_path:
+                    for sym in name_to_symbols.get(attr, []):
+                        resolved = sym.id
+                        break
+
+                # Check if obj is a class in the same file -> static method or class ref
+                if not resolved:
+                    for sym in file_symbols.get(ref.file, []):
+                        if sym.name == obj and sym.type in ("class", "struct"):
+                            target_id = f"method:{ref.file}:{obj}.{attr}"
+                            if target_id in symbol_ids:
+                                resolved = target_id
+                                break
+
+        # 4. Last resort: match by name across all symbols
+        if not resolved:
+            simple_name = raw.split(".")[-1]
+            candidates = name_to_symbols.get(simple_name, [])
+            if len(candidates) == 1 and candidates[0].id != caller_id:
+                resolved = candidates[0].id
+
+        if resolved:
+            key = (caller_id, resolved)
+            if key not in seen_calls and caller_id != resolved:
+                seen_calls.add(key)
+                call_edges.append(Edge(
+                    caller_id, resolved, "calls",
+                    {"line": ref.line},
+                ))
+
+    return call_edges
+
+
+# ── Test-to-Code Mapping ─────────────────────────────────────────
+
+def detect_test_relationships(
+    symbols: list[Symbol],
+    edges: list[Edge],
+    files: list[tuple[str, str, str, bool]],
+    file_map: dict,
+) -> list[Edge]:
+    """Map test files/functions to the source code they test."""
+    test_edges = []
+    seen = set()
+
+    test_files = [(abs_p, rel_p, lang) for abs_p, rel_p, lang, is_test in files if is_test]
+    source_files = {rel_p for _, rel_p, _, is_test in files if not is_test}
+
+    # Build indexes (bare name and qualified scope.name for method-level matching)
+    symbol_by_name = defaultdict(list)
+    for sym in symbols:
+        if not sym.is_test:
+            symbol_by_name[sym.name].append(sym)
+            if sym.scope:
+                symbol_by_name[f"{sym.scope}.{sym.name}"].append(sym)
+
+    # Strategy 1: Path mirroring
+    for _, test_rel, lang in test_files:
+        source_match = _match_test_to_source_path(test_rel, source_files)
+        if source_match:
+            key = (f"file:{test_rel}", f"file:{source_match}")
+            if key not in seen:
+                seen.add(key)
+                test_edges.append(Edge(
+                    f"file:{test_rel}", f"file:{source_match}", "tests",
+                    {"strategy": "path_mirror"},
+                ))
+
+    # Strategy 2: Import-based (test imports source module)
+    file_import_targets = defaultdict(set)
+    for edge in edges:
+        if edge.type == "imports" and edge.source.startswith("file:") and edge.target.startswith("file:"):
+            src = edge.source[5:]
+            tgt = edge.target[5:]
+            if is_test_file(src) and tgt in source_files:
+                file_import_targets[src].add(tgt)
+
+    for test_file, source_targets in file_import_targets.items():
+        for source_target in source_targets:
+            key = (f"file:{test_file}", f"file:{source_target}")
+            if key not in seen:
+                seen.add(key)
+                test_edges.append(Edge(
+                    f"file:{test_file}", f"file:{source_target}", "tests",
+                    {"strategy": "import"},
+                ))
+
+    # Strategy 3: Name matching (test_foo -> foo, TestUserModel -> UserModel)
+    for sym in symbols:
+        if not sym.is_test:
+            continue
+        if sym.type not in ("function", "method", "class"):
+            continue
+
+        targets = _match_test_symbol_to_source(sym, symbol_by_name)
+        for target_sym in targets:
+            key = (sym.id, target_sym.id)
+            if key not in seen:
+                seen.add(key)
+                test_edges.append(Edge(
+                    sym.id, target_sym.id, "tests",
+                    {"strategy": "name_match"},
+                ))
+
+    return test_edges
+
+
+def _match_test_to_source_path(test_path: str, source_files: set) -> Optional[str]:
+    """Match a test file to its source file by path conventions."""
+    test_p = Path(test_path)
+    stem = test_p.stem
+    parent = str(test_p.parent)
+    suffix = test_p.suffix
+
+    # Strip test prefixes/suffixes from filename
+    source_stem = stem
+    for prefix in ("test_", "test"):
+        if source_stem.startswith(prefix):
+            source_stem = source_stem[len(prefix):]
+            break
+    for suffix_str in ("_test", "_spec", ".test", ".spec"):
+        if source_stem.endswith(suffix_str):
+            source_stem = source_stem[:-len(suffix_str)]
+            break
+
+    if source_stem == stem:
+        return None  # No transformation happened
+
+    # Try same directory
+    candidate = str(test_p.with_name(source_stem + suffix))
+    if candidate in source_files:
+        return candidate
+
+    # Try stripping test directory prefixes
+    parent_parts = Path(parent).parts
+    for test_dir in ("tests", "test", "__tests__", "spec"):
+        if test_dir in parent_parts:
+            idx = parent_parts.index(test_dir)
+            # Replace test dir with src/lib or just remove it
+            for src_dir in ("src", "lib", "pkg", "internal", ""):
+                if src_dir:
+                    new_parts = parent_parts[:idx] + (src_dir,) + parent_parts[idx + 1:]
+                else:
+                    new_parts = parent_parts[:idx] + parent_parts[idx + 1:]
+                candidate = str(Path(*new_parts) / (source_stem + suffix)) if new_parts else source_stem + suffix
+                if candidate in source_files:
+                    return candidate
+
+    # Try searching source_files for matching stem
+    for sf in source_files:
+        if Path(sf).stem == source_stem:
+            return sf
+
+    return None
+
+
+def _match_test_symbol_to_source(
+    test_sym: Symbol, symbol_by_name: dict,
+) -> list[Symbol]:
+    """Match a test function/class to the source symbol it tests."""
+    name = test_sym.name
+    matches = []
+
+    # test_foo -> foo
+    if name.startswith("test_"):
+        target_name = name[5:]
+        if target_name in symbol_by_name:
+            matches.extend(symbol_by_name[target_name])
+
+    # TestFoo -> Foo  (test classes)
+    if name.startswith("Test") and len(name) > 4 and name[4].isupper():
+        target_name = name[4:]
+        if target_name in symbol_by_name:
+            matches.extend(symbol_by_name[target_name])
+
+    # test_ClassName_method -> ClassName.method
+    if name.startswith("test_") and "_" in name[5:]:
+        parts = name[5:].split("_", 1)
+        if len(parts) == 2:
+            class_name, method_hint = parts
+            qualified = f"{class_name}.{method_hint}"
+            if qualified in symbol_by_name:
+                matches.extend(symbol_by_name[qualified])
+
+    return matches
+
+
+# ── Graph Builder ─────────────────────────────────────────────────
+
+def resolve_imports(
+    symbols: list[Symbol], edges: list[Edge], file_map: dict[str, str],
+    module_boundaries: list[ModuleBoundary],
+) -> list[Edge]:
+    """Resolve import edges to actual files where possible."""
+    resolved = []
+
+    # Build lookup maps
+    module_to_files = defaultdict(list)
+    for rel_path, lang in file_map.items():
+        parts = Path(rel_path).with_suffix("").parts
+        module_name = ".".join(parts)
+        module_to_files[module_name].append(rel_path)
+
+        for i in range(len(parts)):
+            partial = ".".join(parts[i:])
+            module_to_files[partial].append(rel_path)
+
+    # Also index by __init__.py aware paths
+    for rel_path, lang in file_map.items():
+        if Path(rel_path).stem == "__init__":
+            # Package directory maps to its __init__.py
+            pkg_parts = Path(rel_path).parent.parts
+            if pkg_parts:
+                pkg_name = ".".join(pkg_parts)
+                module_to_files[pkg_name].append(rel_path)
+
+    # Map Go import paths
+    go_pkg_map = defaultdict(list)
+    for rel_path, lang in file_map.items():
+        if lang == "go":
+            pkg_dir = str(Path(rel_path).parent)
+            go_pkg_map[pkg_dir].append(rel_path)
+
+    # Use module boundaries for better Go module resolution
+    go_module_prefix = ""
+    for boundary in module_boundaries:
+        if boundary.language == "go" and boundary.name:
+            go_module_prefix = boundary.name
+            break
+
+    # Build (file, name) -> symbol index for O(1) symbol lookup in import resolution
+    file_name_to_symbol = {}
+    for sym in symbols:
+        file_name_to_symbol[(sym.file, sym.name)] = sym
+
+    for edge in edges:
+        if edge.type != "imports":
+            resolved.append(edge)
+            continue
+
+        target = edge.target
+        if target.startswith("module:"):
+            module_name = target[7:]
+
+            # Resolve relative imports (./foo, ../bar, or Python relative like pkg.sub)
+            # against the importing file's directory
+            if module_name.startswith("."):
+                src_file = edge.source[5:] if edge.source.startswith("file:") else ""
+                if src_file:
+                    src_lang = file_map.get(src_file, "")
+                    src_dir = str(Path(src_file).parent)
+                    rel_target = os.path.normpath(os.path.join(src_dir, module_name))
+                    found = False
+                    # Build candidate extensions based on language
+                    if src_lang in ("javascript", "typescript"):
+                        exts = ("", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".mts")
+                        index_names = ("index.ts", "index.tsx", "index.js", "index.jsx")
+                    elif src_lang == "python":
+                        exts = ("", ".py")
+                        index_names = ("__init__.py",)
+                    else:
+                        exts = ("",)
+                        index_names = ()
+                    for ext in exts:
+                        candidate = rel_target + ext
+                        if candidate in file_map:
+                            resolved.append(Edge(edge.source, f"file:{candidate}", "imports", edge.metadata))
+                            found = True
+                            break
+                    if not found:
+                        for index_name in index_names:
+                            candidate = os.path.join(rel_target, index_name)
+                            if candidate in file_map:
+                                resolved.append(Edge(edge.source, f"file:{candidate}", "imports", edge.metadata))
+                                found = True
+                                break
+                    if not found:
+                        resolved.append(edge)  # Keep unresolved
+                    continue
+
+            # Try direct file mapping
+            candidates = module_to_files.get(module_name, [])
+            if candidates:
+                for c in candidates:
+                    resolved.append(Edge(edge.source, f"file:{c}", "imports", edge.metadata))
+                continue
+
+            # Try Go package mapping with module prefix stripping
+            if go_module_prefix and module_name.startswith(go_module_prefix):
+                local_path = module_name[len(go_module_prefix):].lstrip("/")
+                if local_path in go_pkg_map:
+                    for f in go_pkg_map[local_path]:
+                        resolved.append(Edge(edge.source, f"file:{f}", "imports", edge.metadata))
+                    continue
+
+            # Try Go package mapping by suffix
+            for pkg_path, pkg_files in go_pkg_map.items():
+                if module_name.endswith(pkg_path.replace("/", ".")):
+                    for f in pkg_files:
+                        resolved.append(Edge(edge.source, f"file:{f}", "imports", edge.metadata))
+                    break
+            else:
+                resolved.append(edge)  # Keep unresolved external
+
+        elif target.startswith("symbol:"):
+            symbol_path = target[7:]
+            parts = symbol_path.rsplit(".", 1)
+            if len(parts) == 2:
+                module_part, sym_name = parts
+                candidates = module_to_files.get(module_part, [])
+                if candidates:
+                    for c in candidates:
+                        sym = file_name_to_symbol.get((c, sym_name))
+                        if sym:
+                            resolved.append(Edge(edge.source, sym.id, "imports", edge.metadata))
+                        else:
+                            resolved.append(Edge(edge.source, f"file:{c}", "imports", edge.metadata))
+                    continue
+            resolved.append(edge)
+        else:
+            resolved.append(edge)
+
+    # Build class/struct/interface name -> symbols for O(1) inheritance resolution
+    # Use defaultdict(list) to handle multiple classes with the same name across files
+    class_by_name: dict[str, list[Symbol]] = defaultdict(list)
+    for sym in symbols:
+        if sym.type in ("class", "struct", "interface"):
+            class_by_name[sym.name].append(sym)
+
+    # Resolve inheritance edges
+    final = []
+    for edge in resolved:
+        if edge.type == "inherits" and edge.metadata.get("unresolved"):
+            base_name = edge.target.split(":")[-1]
+            candidates = class_by_name.get(base_name, [])
+            if len(candidates) == 1:
+                final.append(Edge(edge.source, candidates[0].id, "inherits"))
+            elif candidates:
+                # Disambiguate: prefer class in the same file as the source symbol
+                source_file = edge.source.split(":")[1] if ":" in edge.source else ""
+                match = next((c for c in candidates if c.file == source_file), candidates[0])
+                final.append(Edge(edge.source, match.id, "inherits"))
+            else:
+                final.append(edge)
+        else:
+            final.append(edge)
+
+    return final
+
+
+def compute_directory_stats(
+    files: list[tuple[str, str, str, bool]], symbols: list[Symbol],
+) -> dict:
+    """Compute statistics per directory."""
+    dir_stats = defaultdict(lambda: {
+        "files": 0, "test_files": 0, "languages": set(),
+        "symbols": 0, "classes": 0, "functions": 0,
+    })
+
+    for _, rel_path, lang, is_test in files:
+        d = str(Path(rel_path).parent) or "."
+        dir_stats[d]["files"] += 1
+        if is_test:
+            dir_stats[d]["test_files"] += 1
+        dir_stats[d]["languages"].add(lang)
+
+    for sym in symbols:
+        d = str(Path(sym.file).parent) or "."
+        dir_stats[d]["symbols"] += 1
+        if sym.type in ("class", "struct", "interface"):
+            dir_stats[d]["classes"] += 1
+        elif sym.type in ("function", "method"):
+            dir_stats[d]["functions"] += 1
+
+    for d in dir_stats:
+        dir_stats[d]["languages"] = sorted(dir_stats[d]["languages"])
+
+    return dict(dir_stats)
+
+
+# ── Output Generators ─────────────────────────────────────────────
+
+def _serialize_boundaries(boundaries: list[ModuleBoundary]) -> list[dict]:
+    """Serialize module boundaries to dicts (shared by graph and modules output)."""
+    result = []
+    for mb in boundaries:
+        entry = {"root_dir": mb.root_dir, "build_file": mb.build_file}
+        if mb.name:
+            entry["name"] = mb.name
+        if mb.language:
+            entry["language"] = mb.language
+        result.append(entry)
+    return result
+
+def compute_graph_stats(
+    symbols: list[Symbol], edges: list[Edge],
+    files: list[tuple[str, str, str, bool]],
+) -> dict:
+    """Compute stats shared by graph.json and summary.md (single pass)."""
+    lang_counts = Counter(lang for _, _, lang, _ in files)
+    type_counts = Counter(sym.type for sym in symbols)
+    edge_type_counts = Counter(edge.type for edge in edges)
+    test_count = sum(1 for _, _, _, t in files if t)
+    return {
+        "lang_counts": lang_counts,
+        "type_counts": type_counts,
+        "edge_type_counts": edge_type_counts,
+        "test_count": test_count,
+    }
+
+
+def generate_graph_json(
+    symbols: list[Symbol], edges: list[Edge],
+    files: list[tuple[str, str, str, bool]], repo_root: str,
+    file_hashes: dict, module_boundaries: list[ModuleBoundary],
+    line_counts: Optional[dict] = None,
+    stats: Optional[dict] = None,
+) -> dict:
+    """Generate the full knowledge graph as a JSON-serializable dict."""
+    if stats is None:
+        stats = compute_graph_stats(symbols, edges, files)
+
+    lang_counts = stats["lang_counts"]
+    type_counts = stats["type_counts"]
+    edge_type_counts = stats["edge_type_counts"]
+
+    if line_counts is None:
+        line_counts = {}
+
+    # Build file nodes
+    nodes = []
+    for abs_path, rel_path, lang, is_test in files:
+        line_count = line_counts.get(rel_path, 0)
+
+        node = {
+            "id": f"file:{rel_path}",
+            "type": "file",
+            "name": Path(rel_path).name,
+            "path": rel_path,
+            "language": lang,
+            "line_count": line_count,
+        }
+        if is_test:
+            node["is_test"] = True
+        nodes.append(node)
+
+    # Add symbol nodes
+    for sym in symbols:
+        node = asdict(sym)
+        node = {k: v for k, v in node.items() if v is not None and v != [] and v is not False}
+        if "exported" not in node:
+            node["exported"] = False
+        if sym.is_test:
+            node["is_test"] = True
+        nodes.append(node)
+
+    # Serialize edges
+    edge_list = [asdict(e) for e in edges]
+    for e in edge_list:
+        if not e.get("metadata"):
+            del e["metadata"]
+
+    return {
+        "metadata": {
+            "repo_root": repo_root,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "languages": dict(sorted(lang_counts.items(), key=lambda x: -x[1])),
+            "total_files": len(files),
+            "total_symbols": len(symbols),
+            "symbol_types": dict(sorted(type_counts.items(), key=lambda x: -x[1])),
+            "edge_types": dict(sorted(edge_type_counts.items(), key=lambda x: -x[1])),
+            "file_hashes": file_hashes,
+            "module_boundaries": _serialize_boundaries(module_boundaries),
+        },
+        "nodes": nodes,
+        "edges": edge_list,
+    }
+
+
+def generate_tags_json(symbols: list[Symbol]) -> list[dict]:
+    """Generate a flat symbol index for quick lookup."""
+    tags = []
+    for sym in symbols:
+        tag = {
+            "name": sym.name,
+            "type": sym.type,
+            "file": sym.file,
+            "line": sym.line_start,
+            "end_line": sym.line_end,
+            "language": sym.language,
+        }
+        if sym.scope:
+            tag["scope"] = sym.scope
+        if sym.params:
+            tag["params"] = sym.params
+        if sym.bases:
+            tag["bases"] = sym.bases
+        if sym.docstring:
+            tag["doc"] = sym.docstring
+        if sym.signature:
+            tag["signature"] = sym.signature
+        if not sym.exported:
+            tag["private"] = True
+        if sym.is_test:
+            tag["is_test"] = True
+        tags.append(tag)
+    return sorted(tags, key=lambda t: (t["file"], t["line"]))
+
+
+def generate_modules_json(
+    edges: list[Edge], files: list[tuple[str, str, str, bool]],
+    module_boundaries: list[ModuleBoundary],
+) -> dict:
+    """Generate module-level dependency map with build module awareness."""
+    # Group files by directory
+    dir_files = defaultdict(list)
+    for _, rel_path, lang, _ in files:
+        d = str(Path(rel_path).parent) or "."
+        dir_files[d].append(rel_path)
+
+    file_to_dir = {}
+    for _, rel_path, _, _ in files:
+        file_to_dir[rel_path] = str(Path(rel_path).parent) or "."
+
+    # Module dependency edges
+    module_deps = defaultdict(set)
+    for edge in edges:
+        if edge.type != "imports":
+            continue
+        src_file = edge.source.replace("file:", "") if edge.source.startswith("file:") else None
+        tgt_file = edge.target.replace("file:", "") if edge.target.startswith("file:") else None
+
+        if src_file and tgt_file and src_file in file_to_dir and tgt_file in file_to_dir:
+            src_dir = file_to_dir[src_file]
+            tgt_dir = file_to_dir[tgt_file]
+            if src_dir != tgt_dir:
+                module_deps[src_dir].add(tgt_dir)
+
+    # Test relationships per module
+    module_tests = defaultdict(set)
+    for edge in edges:
+        if edge.type == "tests":
+            src = edge.source.replace("file:", "") if edge.source.startswith("file:") else None
+            tgt = edge.target.replace("file:", "") if edge.target.startswith("file:") else None
+            if src and tgt and src in file_to_dir and tgt in file_to_dir:
+                test_dir = file_to_dir[src]
+                source_dir = file_to_dir[tgt]
+                module_tests[source_dir].add(test_dir)
+
+    # Build module map
+    module_map = {}
+    for d, f in sorted(dir_files.items()):
+        entry = {
+            "files": sorted(f),
+            "depends_on": sorted(module_deps.get(d, set())),
+        }
+        tests = module_tests.get(d, set())
+        if tests:
+            entry["tested_by"] = sorted(tests)
+        module_map[d] = entry
+
+    return {
+        "modules": module_map,
+        "build_modules": _serialize_boundaries(module_boundaries),
+    }
+
+
+def generate_summary_md(
+    symbols: list[Symbol], edges: list[Edge],
+    files: list[tuple[str, str, str, bool]], dir_stats: dict,
+    repo_root: str, ts_available: bool,
+    stats: Optional[dict] = None,
+    module_deps: Optional[dict] = None,
+) -> str:
+    """Generate a human/AI-readable codebase summary."""
+    if stats is None:
+        stats = compute_graph_stats(symbols, edges, files)
+
+    lang_counts = stats["lang_counts"]
+    type_counts = stats["type_counts"]
+    edge_type_counts = stats["edge_type_counts"]
+    test_count = stats["test_count"]
+
+    # Single pass over edges for hub files, hub symbols, inheritance, and test coverage
+    import_counts = Counter()
+    call_counts = Counter()
+    inheritance = defaultdict(list)
+    tested_files = set()
+    test_map = defaultdict(set)
+
+    for edge in edges:
+        if edge.type == "imports" and edge.target.startswith("file:"):
+            import_counts[edge.target[5:]] += 1
+        elif edge.type == "calls":
+            call_counts[edge.target] += 1
+        elif edge.type == "inherits" and not edge.metadata.get("unresolved"):
+            child_name = edge.source.split(":")[-1]
+            parent_name = edge.target.split(":")[-1]
+            inheritance[parent_name].append(child_name)
+        elif edge.type == "tests" and edge.target.startswith("file:"):
+            tested_files.add(edge.target[5:])
+            test_name = edge.source[5:] if edge.source.startswith("file:") else edge.source
+            test_map[edge.target[5:]].add(test_name)
+
+    hub_files = import_counts.most_common(15)
+    hub_symbols = call_counts.most_common(15)
+
+    lines = []
+    lines.append("# Codebase Knowledge Graph\n")
+    lines.append(f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}")
+    lines.append(f"Parser: {'Tree-sitter + AST' if ts_available else 'AST + Regex'}\n")
+
+    # Statistics
+    lines.append("## Statistics\n")
+    lines.append(f"- **{len(files)}** files ({test_count} test files) across **{len(lang_counts)}** languages")
+    lines.append(f"- **{len(symbols)}** symbols extracted")
+    for st, count in sorted(type_counts.items(), key=lambda x: -x[1]):
+        plural = st if st.endswith("s") else f"{st}es" if st.endswith("ss") else f"{st}s"
+        lines.append(f"  - {count} {plural if count != 1 else st}")
+    lines.append(f"- **{len(edges)}** edges:")
+    for et, count in sorted(edge_type_counts.items(), key=lambda x: -x[1]):
+        lines.append(f"  - {count} {et}")
+    if tested_files:
+        source_count = sum(1 for _, _, _, t in files if not t)
+        lines.append(f"- **{len(tested_files)}/{source_count}** source files have test coverage")
+    lines.append("")
+
+    # Languages
+    lines.append("## Languages\n")
+    lines.append("| Language | Files |")
+    lines.append("|----------|-------|")
+    for lang, count in sorted(lang_counts.items(), key=lambda x: -x[1]):
+        lines.append(f"| {lang} | {count} |")
+    lines.append("")
+
+    # Directory structure
+    lines.append("## Directory Structure\n")
+    lines.append("```")
+    for d in sorted(dir_stats.keys()):
+        dir_info = dir_stats[d]
+        indent = "  " * d.count("/")
+        dir_name = Path(d).name or "."
+        lang_str = ", ".join(dir_info["languages"])
+        test_str = f", {dir_info['test_files']} tests" if dir_info.get("test_files") else ""
+        lines.append(f"{indent}{dir_name}/ ({dir_info['files']} files{test_str}, {lang_str})")
+    lines.append("```\n")
+
+    # Hub files
+    if hub_files:
+        lines.append("## Hub Files (most imported)\n")
+        lines.append("| File | Imported by |")
+        lines.append("|------|-------------|")
+        for f, count in hub_files:
+            lines.append(f"| `{f}` | {count} files |")
+        lines.append("")
+
+    # Most-called symbols
+    if hub_symbols:
+        lines.append("## Most-Called Symbols\n")
+        lines.append("| Symbol | Called by |")
+        lines.append("|--------|----------|")
+        for sym_id, count in hub_symbols:
+            parts = sym_id.split(":", 2)
+            display = parts[-1] if len(parts) >= 3 else sym_id
+            lines.append(f"| `{display}` | {count} callers |")
+        lines.append("")
+
+    # Key classes
+    classes = [s for s in symbols if s.type in ("class", "struct", "interface") and s.exported and not s.is_test]
+    if classes:
+        lines.append("## Key Types\n")
+        lines.append("| Type | Kind | File | Line | Bases |")
+        lines.append("|------|------|------|------|-------|")
+        for cls in sorted(classes, key=lambda c: c.name)[:50]:
+            bases_str = ", ".join(cls.bases) if cls.bases else "-"
+            lines.append(f"| `{cls.name}` | {cls.type} | `{cls.file}` | {cls.line_start} | {bases_str} |")
+        if len(classes) > 50:
+            lines.append(f"\n*... and {len(classes) - 50} more types (see tags.json)*\n")
+        lines.append("")
+
+    # Inheritance trees
+    roots = [name for name in inheritance if not any(name in children for children in inheritance.values())]
+    if roots:
+        lines.append("## Inheritance Hierarchy\n")
+        lines.append("```")
+
+        def print_tree(name, indent=0, visited=None):
+            if visited is None:
+                visited = set()
+            if name in visited:
+                return
+            visited.add(name)
+            prefix = "  " * indent + ("|- " if indent > 0 else "")
+            lines.append(f"{prefix}{name}")
+            for child in sorted(inheritance.get(name, [])):
+                print_tree(child, indent + 1, visited)
+
+        for root in sorted(roots)[:10]:
+            print_tree(root)
+        lines.append("```\n")
+
+    # Key functions
+    exported_funcs = [s for s in symbols if s.type == "function" and s.exported and not s.is_test]
+    if exported_funcs:
+        lines.append("## Key Functions\n")
+        lines.append("| Function | File | Line | Params |")
+        lines.append("|----------|------|------|--------|")
+        for func in sorted(exported_funcs, key=lambda f: f.name)[:50]:
+            params_str = ", ".join(func.params[:5]) if func.params else "-"
+            if len(func.params) > 5:
+                params_str += ", ..."
+            lines.append(f"| `{func.name}` | `{func.file}` | {func.line_start} | {params_str} |")
+        if len(exported_funcs) > 50:
+            lines.append(f"\n*... and {len(exported_funcs) - 50} more functions (see tags.json)*\n")
+        lines.append("")
+
+    # Module dependencies (use pre-computed or compute from modules_json)
+    if module_deps is not None:
+        dir_deps = module_deps
+    else:
+        file_set = {rel for _, rel, _, _ in files}
+        dir_deps = defaultdict(set)
+        for edge in edges:
+            if edge.type == "imports":
+                src = edge.source.replace("file:", "")
+                tgt = edge.target.replace("file:", "")
+                if src in file_set and tgt in file_set:
+                    sd = str(Path(src).parent) or "."
+                    td = str(Path(tgt).parent) or "."
+                    if sd != td:
+                        dir_deps[sd].add(td)
+
+    if dir_deps:
+        lines.append("## Module Dependencies\n")
+        lines.append("```")
+        for src_dir in sorted(dir_deps.keys()):
+            deps = sorted(dir_deps[src_dir])
+            lines.append(f"{src_dir} -> {', '.join(deps)}")
+        lines.append("```\n")
+
+    # Test coverage (test_map already built in single-pass above)
+    if tested_files:
+        lines.append("## Test Coverage Map\n")
+        lines.append("| Source File | Tested By |")
+        lines.append("|------------|-----------|")
+        for src_file in sorted(test_map.keys())[:30]:
+            testers = sorted(test_map[src_file])
+            testers_str = ", ".join(f"`{t}`" for t in testers[:3])
+            if len(testers) > 3:
+                testers_str += f" +{len(testers) - 3} more"
+            lines.append(f"| `{src_file}` | {testers_str} |")
+        if len(test_map) > 30:
+            lines.append(f"\n*... and {len(test_map) - 30} more tested files*\n")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _edge_file(node_id: str) -> str:
+    """Extract the file path from a node ID for incremental merge filtering."""
+    if node_id.startswith("file:"):
+        return node_id[5:]
+    # Symbol IDs have format "type:file:name" — extract file part
+    parts = node_id.split(":", 2)
+    if len(parts) >= 3:
+        return parts[1]
+    return ""
+
+
+# ── Main ──────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build a knowledge graph of a codebase with call graph and test mapping",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--repo-root", default=".",
+        help="Repository root directory (default: current directory)",
+    )
+    parser.add_argument(
+        "--output-dir", default=None,
+        help="Output directory (default: <repo-root>/docs/code-tree)",
+    )
+    parser.add_argument(
+        "--exclude", action="append", default=[],
+        help="Additional glob patterns to exclude (repeatable)",
+    )
+    parser.add_argument(
+        "--max-file-size", type=int, default=MAX_FILE_SIZE,
+        help=f"Skip files larger than this in bytes (default: {MAX_FILE_SIZE})",
+    )
+    parser.add_argument(
+        "--exclude-tests", action="store_true",
+        help="Exclude test files from analysis (tests are included by default)",
+    )
+    parser.add_argument(
+        "--no-tree-sitter", action="store_true",
+        help="Disable tree-sitter even if available",
+    )
+    parser.add_argument(
+        "--no-call-graph", action="store_true",
+        help="Skip call graph extraction (faster but less detailed)",
+    )
+    parser.add_argument(
+        "--incremental", action="store_true",
+        help="Only reparse files that changed since last run",
+    )
+    parser.add_argument(
+        "--quiet", "-q", action="store_true",
+        help="Suppress progress output",
+    )
+
+    args = parser.parse_args()
+    repo_root = os.path.abspath(args.repo_root)
+    output_dir = args.output_dir or os.path.join(repo_root, "docs", "code-tree")
+    excludes = DEFAULT_EXCLUDES + args.exclude
+    include_tests = not args.exclude_tests
+
+    def log(msg):
+        if not args.quiet:
+            print(msg, file=sys.stderr)
+
+    log(f"Scanning: {repo_root}")
+
+    # Load previous graph for incremental mode
+    prev_hashes = {}
+    prev_graph = None
+    if args.incremental:
+        prev_graph_path = os.path.join(output_dir, "graph.json")
+        if os.path.exists(prev_graph_path):
+            try:
+                with open(prev_graph_path, "r", encoding="utf-8") as f:
+                    prev_graph = json.load(f)
+                prev_hashes = prev_graph.get("metadata", {}).get("file_hashes", {})
+                log(f"Loaded previous graph with {len(prev_hashes)} file hashes")
+            except (json.JSONDecodeError, OSError):
+                prev_graph = None
+
+    # Load tree-sitter
+    ts_parsers = {}
+    if not args.no_tree_sitter:
+        ts_parsers = try_load_tree_sitter()
+        if ts_parsers:
+            log(f"Tree-sitter available for: {', '.join(sorted(ts_parsers.keys()))}")
+        else:
+            log("Tree-sitter not available, using AST/regex parsers")
+
+    # Discover files and build boundaries in a single pass
+    files, module_boundaries = discover_all(repo_root, excludes, include_tests, args.max_file_size)
+    test_file_count = sum(1 for _, _, _, t in files if t)
+    source_file_count = len(files) - test_file_count
+    log(f"Found {len(files)} files ({source_file_count} source, {test_file_count} test)")
+
+    if not files:
+        log("No files found. Check --repo-root and --exclude options.")
+        sys.exit(1)
+
+    if module_boundaries:
+        log(f"Found {len(module_boundaries)} build module(s): {', '.join(mb.name or mb.build_file for mb in module_boundaries)}")
+
+    # Compute file hashes and determine what needs parsing
+    current_hashes = {}
+    files_to_parse = []
+    for abs_path, rel_path, lang, is_test in files:
+        h = file_hash(abs_path)
+        current_hashes[rel_path] = h
+        if args.incremental and prev_hashes.get(rel_path) == h:
+            continue  # File unchanged
+        files_to_parse.append((abs_path, rel_path, lang, is_test))
+
+    if args.incremental:
+        log(f"Incremental: {len(files_to_parse)}/{len(files)} files need parsing")
+
+    # Build file_map from ALL files (needed by resolve_imports even in incremental mode)
+    file_map = {rel_path: lang for _, rel_path, lang, _ in files}
+
+    # Parse files
+    all_symbols = []
+    all_edges = []
+    all_call_refs = []
+    line_counts = {}
+
+    # In incremental mode, load symbols/edges for unchanged files from previous graph
+    changed_files = {rel for _, rel, _, _ in files_to_parse} if files_to_parse else set()
+    if args.incremental and prev_graph is not None and changed_files:
+        prev_nodes = prev_graph.get("nodes", [])
+        prev_edges = prev_graph.get("edges", [])
+
+        for node in prev_nodes:
+            node_file = node.get("file") or node.get("path", "")
+            if node_file and node_file not in changed_files:
+                if node.get("type") == "file":
+                    line_counts[node.get("path", "")] = node.get("line_count", 0)
+                else:
+                    all_symbols.append(Symbol(
+                        id=node["id"], type=node["type"], name=node["name"],
+                        file=node.get("file", ""), language=node.get("language", ""),
+                        line_start=node.get("line_start", 0),
+                        line_end=node.get("line_end", 0),
+                        scope=node.get("scope"),
+                        params=node.get("params", []),
+                        bases=node.get("bases", []),
+                        decorators=node.get("decorators", []),
+                        docstring=node.get("docstring"),
+                        exported=node.get("exported", True),
+                        signature=node.get("signature"),
+                        is_test=node.get("is_test", False),
+                    ))
+
+        for edge_data in prev_edges:
+            src_file = _edge_file(edge_data.get("source", ""))
+            # Keep edges whose source is from an unchanged file (changed files
+            # will be reparsed and their outgoing edges re-emitted fresh)
+            if src_file not in changed_files:
+                all_edges.append(Edge(
+                    source=edge_data["source"], target=edge_data["target"],
+                    type=edge_data["type"],
+                    metadata=edge_data.get("metadata", {}),
+                ))
+
+        log(f"Loaded {len(all_symbols)} symbols, {len(all_edges)} edges from previous graph (unchanged files)")
+
+    parse_target = files_to_parse if files_to_parse else files
+    parse_count = len(parse_target)
+
+    for i, (abs_path, rel_path, lang, is_test) in enumerate(parse_target):
+        if not args.quiet and (i + 1) % 100 == 0:
+            log(f"  Parsed {i + 1}/{parse_count} files...")
+
+        symbols, file_edges, call_refs, lc = parse_file(abs_path, rel_path, lang, ts_parsers, is_test)
+        line_counts[rel_path] = lc
+        all_symbols.extend(symbols)
+        all_edges.extend(file_edges)
+        if not args.no_call_graph:
+            all_call_refs.extend(call_refs)
+
+    log(f"Extracted {len(all_symbols)} symbols, {len(all_edges)} edges, {len(all_call_refs)} call references")
+
+    # Resolve calls before import normalization — resolve_calls() needs the
+    # raw module:/symbol: import edges to rebuild alias mappings.  Once
+    # resolve_imports() rewrites those targets to file: paths the alias
+    # information is lost.
+    if not args.no_call_graph and all_call_refs:
+        call_edges = resolve_calls(all_call_refs, all_symbols, all_edges, file_map)
+        all_edges.extend(call_edges)
+        log(f"Resolved {len(call_edges)} call edges from {len(all_call_refs)} references")
+
+    # Resolve imports (rewrites module:/symbol: targets to file: paths)
+    all_edges = resolve_imports(all_symbols, all_edges, file_map, module_boundaries)
+    log(f"Resolved imports: {len(all_edges)} edges after resolution")
+
+    # Detect test-to-code relationships
+    if include_tests:
+        test_edges = detect_test_relationships(all_symbols, all_edges, files, file_map)
+        all_edges.extend(test_edges)
+        log(f"Mapped {len(test_edges)} test relationships")
+
+    # Compute directory stats
+    dir_stats = compute_directory_stats(files, all_symbols)
+
+    # Generate outputs
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Compute stats once and share across generators
+    graph_stats = compute_graph_stats(all_symbols, all_edges, files)
+
+    # graph.json
+    graph = generate_graph_json(
+        all_symbols, all_edges, files, repo_root, current_hashes, module_boundaries,
+        line_counts=line_counts, stats=graph_stats,
+    )
+    graph_path = os.path.join(output_dir, "graph.json")
+    with open(graph_path, "w", encoding="utf-8") as f:
+        json.dump(graph, f, indent=2, default=str)
+    log(f"Wrote {graph_path}")
+
+    # tags.json
+    tags = generate_tags_json(all_symbols)
+    tags_path = os.path.join(output_dir, "tags.json")
+    with open(tags_path, "w", encoding="utf-8") as f:
+        json.dump(tags, f, indent=2)
+    log(f"Wrote {tags_path}")
+
+    # modules.json
+    modules = generate_modules_json(all_edges, files, module_boundaries)
+    modules_path = os.path.join(output_dir, "modules.json")
+    with open(modules_path, "w", encoding="utf-8") as f:
+        json.dump(modules, f, indent=2)
+    log(f"Wrote {modules_path}")
+
+    # summary.md (reuse stats)
+    summary = generate_summary_md(
+        all_symbols, all_edges, files, dir_stats,
+        repo_root, bool(ts_parsers), stats=graph_stats,
+    )
+    summary_path = os.path.join(output_dir, "summary.md")
+    with open(summary_path, "w", encoding="utf-8") as f:
+        f.write(summary)
+    log(f"Wrote {summary_path}")
+
+    # Print summary (reuse stats instead of re-counting)
+    log(f"\nDone. Output in: {output_dir}")
+    log(f"  graph.json   - Full knowledge graph ({len(graph['nodes'])} nodes, {len(graph['edges'])} edges)")
+    log(f"  tags.json    - Symbol index ({len(tags)} tags)")
+    log(f"  modules.json - Module dependencies ({len(modules['modules'])} modules)")
+    log(f"  summary.md   - Codebase overview")
+    log(f"\n  Edge breakdown:")
+    for et, count in sorted(graph_stats["edge_type_counts"].items(), key=lambda x: -x[1]):
+        log(f"    {et}: {count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/code-tree/query_graph.py
+++ b/tools/code-tree/query_graph.py
@@ -1,0 +1,1043 @@
+#!/usr/bin/env python3
+"""query_graph.py - Query the code-tree knowledge graph with impact analysis.
+
+Traverses the knowledge graph to find relevant code, trace call chains,
+analyze change impact, and map test coverage.
+
+Usage:
+    python query_graph.py --symbol ClassName          # Find symbol definition
+    python query_graph.py --deps path/to/file.py      # File dependencies
+    python query_graph.py --rdeps path/to/file.py     # Reverse dependencies
+    python query_graph.py --hierarchy ClassName        # Inheritance tree
+    python query_graph.py --search "keyword"           # Search symbols
+    python query_graph.py --module src/api             # Module overview
+    python query_graph.py --entry-points               # Find entry points
+    python query_graph.py --chunks path/to/file.py     # Extract code chunks
+    python query_graph.py --callers func_name          # Who calls this?
+    python query_graph.py --callees func_name          # What does this call?
+    python query_graph.py --impact path/to/file.py     # Change impact analysis
+    python query_graph.py --test-impact path/to/file.py  # Which tests are affected?
+
+All queries output file:line references suitable for AI agent context.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import Optional
+
+
+def load_graph(graph_dir: str) -> dict:
+    graph_path = os.path.join(graph_dir, "graph.json")
+    if not os.path.exists(graph_path):
+        print(f"Error: graph.json not found in {graph_dir}", file=sys.stderr)
+        print("Run code_tree.py first to generate the knowledge graph.", file=sys.stderr)
+        sys.exit(1)
+    with open(graph_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_tags(graph_dir: str) -> list[dict]:
+    tags_path = os.path.join(graph_dir, "tags.json")
+    if not os.path.exists(tags_path):
+        return []
+    with open(tags_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_modules(graph_dir: str) -> dict:
+    modules_path = os.path.join(graph_dir, "modules.json")
+    if not os.path.exists(modules_path):
+        return {"modules": {}}
+    with open(modules_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+class GraphQuery:
+    """Query interface for the code-tree knowledge graph with impact analysis."""
+
+    def __init__(self, graph_dir: str, repo_root: str):
+        self.graph = load_graph(graph_dir)
+        self.tags = load_tags(graph_dir)
+        self.modules = load_modules(graph_dir)
+        self.repo_root = repo_root
+
+        # Build indexes
+        self.nodes_by_id = {}
+        self.nodes_by_name = defaultdict(list)
+        self.nodes_by_file = defaultdict(list)
+        self.nodes_by_type = defaultdict(list)
+
+        for node in self.graph.get("nodes", []):
+            nid = node.get("id", "")
+            self.nodes_by_id[nid] = node
+            name = node.get("name", "")
+            self.nodes_by_name[name].append(node)
+            file_path = node.get("file") or node.get("path", "")
+            if file_path:
+                self.nodes_by_file[file_path].append(node)
+            self.nodes_by_type[node.get("type", "")].append(node)
+
+        # Build adjacency lists
+        self.outgoing = defaultdict(list)  # source -> [(target, edge)]
+        self.incoming = defaultdict(list)  # target -> [(source, edge)]
+
+        # Also index by edge type for fast filtering
+        self.outgoing_by_type = defaultdict(lambda: defaultdict(list))
+        self.incoming_by_type = defaultdict(lambda: defaultdict(list))
+
+        for edge in self.graph.get("edges", []):
+            src = edge.get("source", "")
+            tgt = edge.get("target", "")
+            etype = edge.get("type", "")
+            self.outgoing[src].append((tgt, edge))
+            self.incoming[tgt].append((src, edge))
+            self.outgoing_by_type[etype][src].append((tgt, edge))
+            self.incoming_by_type[etype][tgt].append((src, edge))
+
+    # ── Symbol Lookup ─────────────────────────────────────────────
+
+    def find_symbol(self, name: str) -> list[dict]:
+        """Find all symbols matching a name (exact or partial)."""
+        results = []
+
+        if name in self.nodes_by_name:
+            results.extend(self.nodes_by_name[name])
+
+        if not results:
+            name_lower = name.lower()
+            for n, nodes in self.nodes_by_name.items():
+                if name_lower in n.lower():
+                    results.extend(nodes)
+
+        return results
+
+    # ── Dependency Queries ────────────────────────────────────────
+
+    def get_dependencies(self, file_path: str) -> dict:
+        """Get all files/symbols that a given file depends on."""
+        file_id = f"file:{file_path}"
+        deps = {"imports": [], "inherits": [], "calls": []}
+
+        for target, edge in self.outgoing.get(file_id, []):
+            if edge["type"] == "imports" and target.startswith("file:"):
+                deps["imports"].append(target[5:])
+
+        # Check symbols in this file
+        for node in self.nodes_by_file.get(file_path, []):
+            nid = node.get("id", "")
+            for target, edge in self.outgoing.get(nid, []):
+                if edge["type"] == "inherits":
+                    target_node = self.nodes_by_id.get(target, {})
+                    if target_node:
+                        deps["inherits"].append({
+                            "from": node.get("name"),
+                            "to": target_node.get("name"),
+                            "file": target_node.get("file"),
+                        })
+                elif edge["type"] == "calls":
+                    target_node = self.nodes_by_id.get(target, {})
+                    if target_node and target_node.get("file") != file_path:
+                        deps["calls"].append({
+                            "caller": node.get("name"),
+                            "callee": target_node.get("name"),
+                            "file": target_node.get("file"),
+                        })
+
+        return deps
+
+    def get_reverse_dependencies(self, file_path: str) -> list[str]:
+        """Get all files that import a given file."""
+        file_id = f"file:{file_path}"
+        rdeps = set()
+
+        for source, edge in self.incoming.get(file_id, []):
+            if edge["type"] == "imports" and source.startswith("file:"):
+                rdeps.add(source[5:])
+
+        for node in self.nodes_by_file.get(file_path, []):
+            nid = node.get("id", "")
+            for source, edge in self.incoming.get(nid, []):
+                if edge["type"] == "imports" and source.startswith("file:"):
+                    rdeps.add(source[5:])
+
+        return sorted(rdeps)
+
+    # ── Call Graph Queries ────────────────────────────────────────
+
+    def get_callers(self, symbol_name: str) -> list[dict]:
+        """Find all functions/methods that call a given symbol."""
+        # Find the target symbol(s)
+        targets = [
+            n for n in self.nodes_by_name.get(symbol_name, [])
+            if n.get("type") in ("function", "method", "class")
+        ]
+
+        results = []
+        seen = set()
+
+        for target in targets:
+            tid = target.get("id", "")
+            for source_id, edge in self.incoming_by_type["calls"].get(tid, []):
+                if source_id in seen:
+                    continue
+                seen.add(source_id)
+                source_node = self.nodes_by_id.get(source_id, {})
+                results.append({
+                    "caller": source_node.get("name", "?"),
+                    "type": source_node.get("type", "?"),
+                    "file": source_node.get("file", "?"),
+                    "line": source_node.get("line_start", "?"),
+                    "call_line": edge.get("metadata", {}).get("line", "?"),
+                })
+
+        return sorted(results, key=lambda x: (str(x.get("file", "")), x.get("line", 0)))
+
+    def get_callees(self, symbol_name: str) -> list[dict]:
+        """Find all functions/methods called by a given symbol."""
+        sources = [
+            n for n in self.nodes_by_name.get(symbol_name, [])
+            if n.get("type") in ("function", "method")
+        ]
+
+        results = []
+        seen = set()
+
+        for source in sources:
+            sid = source.get("id", "")
+            for target_id, edge in self.outgoing_by_type["calls"].get(sid, []):
+                if target_id in seen:
+                    continue
+                seen.add(target_id)
+                target_node = self.nodes_by_id.get(target_id, {})
+                results.append({
+                    "callee": target_node.get("name", "?"),
+                    "type": target_node.get("type", "?"),
+                    "file": target_node.get("file", "?"),
+                    "line": target_node.get("line_start", "?"),
+                    "call_line": edge.get("metadata", {}).get("line", "?"),
+                })
+
+        return sorted(results, key=lambda x: (str(x.get("file", "")), x.get("line", 0)))
+
+    def get_call_chain(self, from_name: str, to_name: str, max_depth: int = 8) -> list[list[str]]:
+        """Find call paths from one symbol to another (BFS shortest paths)."""
+        # Find source and target IDs
+        from_ids = {
+            n["id"] for n in self.nodes_by_name.get(from_name, [])
+            if n.get("type") in ("function", "method")
+        }
+        to_ids = {
+            n["id"] for n in self.nodes_by_name.get(to_name, [])
+            if n.get("type") in ("function", "method", "class")
+        }
+
+        if not from_ids or not to_ids:
+            return []
+
+        # BFS from each source
+        paths = []
+        for start in from_ids:
+            queue = deque([(start, [start])])
+            visited = {start}
+
+            while queue and len(paths) < 5:
+                current, path = queue.popleft()
+                if len(path) > max_depth:
+                    continue
+
+                for target_id, edge in self.outgoing_by_type["calls"].get(current, []):
+                    if target_id in to_ids:
+                        paths.append(path + [target_id])
+                        continue
+                    if target_id not in visited:
+                        visited.add(target_id)
+                        queue.append((target_id, path + [target_id]))
+
+        return paths
+
+    # ── Hierarchy ─────────────────────────────────────────────────
+
+    def get_hierarchy(self, class_name: str) -> dict:
+        """Get the inheritance hierarchy for a class."""
+        candidates = [
+            n for n in self.nodes_by_name.get(class_name, [])
+            if n.get("type") in ("class", "struct", "interface")
+        ]
+
+        if not candidates:
+            return {"error": f"Class '{class_name}' not found"}
+
+        result = {"ancestors": [], "descendants": []}
+
+        for cls in candidates:
+            cls_id = cls.get("id", "")
+            visited = set()
+
+            def find_ancestors(node_id, depth=0):
+                if node_id in visited or depth > 10:
+                    return
+                visited.add(node_id)
+                for target, edge in self.outgoing.get(node_id, []):
+                    if edge["type"] == "inherits":
+                        target_node = self.nodes_by_id.get(target, {"name": target.split(":")[-1]})
+                        result["ancestors"].append({
+                            "name": target_node.get("name", "?"),
+                            "file": target_node.get("file", "?"),
+                            "depth": depth + 1,
+                        })
+                        find_ancestors(target, depth + 1)
+
+            find_ancestors(cls_id)
+            visited.clear()
+
+            def find_descendants(node_id, depth=0):
+                if node_id in visited or depth > 10:
+                    return
+                visited.add(node_id)
+                for source, edge in self.incoming.get(node_id, []):
+                    if edge["type"] == "inherits":
+                        source_node = self.nodes_by_id.get(source, {"name": source.split(":")[-1]})
+                        result["descendants"].append({
+                            "name": source_node.get("name", "?"),
+                            "file": source_node.get("file", "?"),
+                            "depth": depth + 1,
+                        })
+                        find_descendants(source, depth + 1)
+
+            find_descendants(cls_id)
+
+        return result
+
+    # ── Search ────────────────────────────────────────────────────
+
+    def search(self, keyword: str) -> list[dict]:
+        """Search symbols by keyword (name, docstring, file path)."""
+        keyword_lower = keyword.lower()
+        results = []
+
+        for tag in self.tags:
+            score = 0
+            name = tag.get("name", "")
+            doc = tag.get("doc", "")
+            file_path = tag.get("file", "")
+
+            if keyword_lower == name.lower():
+                score = 100
+            elif keyword_lower in name.lower():
+                score = 50
+            elif keyword_lower in file_path.lower():
+                score = 20
+            elif doc and keyword_lower in doc.lower():
+                score = 10
+
+            if score > 0:
+                results.append({**tag, "_score": score})
+
+        results.sort(key=lambda x: (-x["_score"], x.get("file", ""), x.get("line", 0)))
+        return results[:30]
+
+    # ── Module Queries ────────────────────────────────────────────
+
+    def get_module(self, module_path: str) -> dict:
+        """Get overview of a module (directory)."""
+        module_data = self.modules.get("modules", {}).get(module_path, {})
+
+        module_symbols = []
+        for tag in self.tags:
+            if tag.get("file", "").startswith(module_path):
+                module_symbols.append(tag)
+
+        return {
+            "path": module_path,
+            "files": module_data.get("files", []),
+            "depends_on": module_data.get("depends_on", []),
+            "tested_by": module_data.get("tested_by", []),
+            "symbols": module_symbols,
+        }
+
+    def find_entry_points(self) -> list[dict]:
+        """Find likely entry points (files with no internal importers)."""
+        all_files = {
+            n.get("path") for n in self.nodes_by_type.get("file", []) if n.get("path")
+        }
+
+        # Use the imports index instead of scanning all edges
+        imported_files = set()
+        for file_id, edges_list in self.incoming_by_type["imports"].items():
+            if file_id.startswith("file:"):
+                imported_files.add(file_id[5:])
+
+        entry_candidates = all_files - imported_files
+
+        main_patterns = [
+            "main.py", "main.go", "index.js", "index.ts", "app.py",
+            "server.go", "__main__.py", "cli.py", "cmd/",
+        ]
+
+        # Build a file-to-tags index for efficient lookup
+        tags_by_file = defaultdict(list)
+        for t in self.tags:
+            f = t.get("file")
+            if f:
+                tags_by_file[f].append(t)
+
+        results = []
+
+        for f in sorted(entry_candidates):
+            priority = 0
+            for pat in main_patterns:
+                if pat in f:
+                    priority = 10
+                    break
+
+            file_symbols = tags_by_file.get(f, [])
+            has_main = any(t.get("name") == "main" for t in file_symbols)
+            if has_main:
+                priority = 20
+
+            results.append({
+                "file": f,
+                "priority": priority,
+                "symbols": len(file_symbols),
+            })
+
+        results.sort(key=lambda x: (-x["priority"], x["file"]))
+        return results[:20]
+
+    # ── Chunk Extraction ──────────────────────────────────────────
+
+    def extract_chunks(self, file_path: str) -> list[dict]:
+        """Extract clean code chunks from a file using symbol boundaries."""
+        abs_path = os.path.join(self.repo_root, file_path)
+        if not os.path.exists(abs_path):
+            return [{"error": f"File not found: {file_path}"}]
+
+        try:
+            with open(abs_path, "r", encoding="utf-8", errors="ignore") as f:
+                lines = f.readlines()
+        except OSError:
+            return [{"error": f"Cannot read: {file_path}"}]
+
+        file_symbols = sorted(
+            [t for t in self.tags if t.get("file") == file_path],
+            key=lambda t: t.get("line", 0),
+        )
+
+        if not file_symbols:
+            return [{
+                "file": file_path,
+                "line_start": 1,
+                "line_end": len(lines),
+                "type": "file",
+                "name": Path(file_path).name,
+                "content": "".join(lines[:200]),
+            }]
+
+        chunks = []
+        for sym in file_symbols:
+            line_start = sym.get("line", 1)
+            line_end = sym.get("end_line", line_start + 50)
+
+            # Use actual end_line from tags if available
+            line_end = min(line_end, len(lines))
+
+            chunk_lines = lines[line_start - 1 : line_end]
+            chunks.append({
+                "file": file_path,
+                "line_start": line_start,
+                "line_end": line_end,
+                "type": sym.get("type", "unknown"),
+                "name": sym.get("name", "?"),
+                "scope": sym.get("scope"),
+                "content": "".join(chunk_lines),
+            })
+
+        return chunks
+
+    # ── Impact Analysis ───────────────────────────────────────────
+
+    def _compute_impact_bfs(self, target: str, max_depth: int = 5) -> tuple[dict, set]:
+        """Core BFS for impact analysis. Returns (affected_map, start_ids).
+
+        affected_map: node_id -> {"depth": N, "via": edge_type}
+        start_ids: set of origin node IDs
+        """
+        start_ids = set()
+
+        # Try as file path
+        file_id = f"file:{target}"
+        if file_id in self.nodes_by_id:
+            start_ids.add(file_id)
+            for node in self.nodes_by_file.get(target, []):
+                start_ids.add(node.get("id", ""))
+        else:
+            # Try as symbol name
+            for node in self.nodes_by_name.get(target, []):
+                start_ids.add(node.get("id", ""))
+                if node.get("file"):
+                    start_ids.add(f"file:{node['file']}")
+
+        if not start_ids:
+            return {}, start_ids
+
+        # BFS through reverse dependency edges (imports, calls, inherits)
+        affected = {}
+        queue = deque()
+
+        for sid in start_ids:
+            affected[sid] = {"depth": 0, "via": "origin"}
+            queue.append((sid, 0))
+
+        while queue:
+            current_id, depth = queue.popleft()
+            if depth >= max_depth:
+                continue
+
+            for source_id, edge in self.incoming.get(current_id, []):
+                etype = edge.get("type", "")
+                if etype not in ("imports", "calls", "inherits"):
+                    continue
+
+                if source_id not in affected or affected[source_id]["depth"] > depth + 1:
+                    affected[source_id] = {"depth": depth + 1, "via": etype}
+                    queue.append((source_id, depth + 1))
+
+        return affected, start_ids
+
+    def _build_impact_report(self, target: str, affected: dict, max_depth: int) -> dict:
+        """Build a structured impact report from pre-computed BFS results.
+
+        Organizes the affected map into files and symbols ranked by distance.
+        """
+        affected_files = set()
+        affected_symbols = []
+
+        for node_id, info in affected.items():
+            if info["depth"] == 0:
+                continue  # Skip the origin nodes
+
+            node = self.nodes_by_id.get(node_id, {})
+            if node.get("type") == "file":
+                affected_files.add(node.get("path", ""))
+            elif node.get("type") in ("function", "method", "class", "struct", "interface"):
+                affected_symbols.append({
+                    "name": node.get("name", "?"),
+                    "type": node.get("type", "?"),
+                    "file": node.get("file", "?"),
+                    "line": node.get("line_start", "?"),
+                    "depth": info["depth"],
+                    "via": info["via"],
+                })
+
+                # Track the file too
+                if node.get("file"):
+                    affected_files.add(node["file"])
+
+        # Sort by depth then name
+        affected_symbols.sort(key=lambda x: (x["depth"], str(x.get("file", "")), x.get("name", "")))
+
+        return {
+            "target": target,
+            "affected_files": sorted(affected_files),
+            "affected_symbols": affected_symbols,
+            "total_affected_files": len(affected_files),
+            "total_affected_symbols": len(affected_symbols),
+            "max_depth_reached": max_depth,
+        }
+
+    def get_impact(self, target: str, max_depth: int = 5) -> dict:
+        """Compute transitive impact of changing a file or symbol.
+
+        Given a file path or symbol name, finds everything that depends on it
+        transitively through imports, calls, and inheritance edges.
+
+        Returns a structured impact report with affected items ranked by distance.
+        """
+        affected, start_ids = self._compute_impact_bfs(target, max_depth)
+
+        if not start_ids:
+            return {"error": f"No file or symbol found matching '{target}'"}
+
+        return self._build_impact_report(target, affected, max_depth)
+
+    def get_test_impact(self, target: str, max_depth: int = 5) -> dict:
+        """Find all tests affected by a change to a file or symbol.
+
+        Combines impact analysis with test mapping to determine which tests
+        need to be re-run or reviewed when code changes.
+        """
+        affected, start_ids = self._compute_impact_bfs(target, max_depth)
+
+        if not start_ids:
+            return {"error": f"No file or symbol found matching '{target}'"}
+
+        # Reuse BFS result to build impact summary (avoids duplicate BFS)
+        impact = self._build_impact_report(target, affected, max_depth)
+
+        # All affected node IDs are already in the affected map
+        affected_ids = set(affected.keys())
+
+        # Use the tests index for O(1) lookup per affected node
+        affected_tests = []
+        seen_tests = set()
+
+        for node_id in affected_ids:
+            for test_source, edge in self.incoming_by_type["tests"].get(node_id, []):
+                if test_source in seen_tests:
+                    continue
+                seen_tests.add(test_source)
+                test_node = self.nodes_by_id.get(test_source, {})
+
+                test_file = test_node.get("file") or test_node.get("path", "")
+                if test_source.startswith("file:"):
+                    test_file = test_source[5:]
+
+                affected_tests.append({
+                    "test": test_file or test_source,
+                    "test_name": test_node.get("name", "?"),
+                    "test_type": test_node.get("type", "file"),
+                    "tests_target": node_id.split(":")[-1] if ":" in node_id else node_id,
+                    "strategy": edge.get("metadata", {}).get("strategy", "?"),
+                })
+
+        # Deduplicate by test file
+        test_files = sorted(set(t["test"] for t in affected_tests))
+
+        return {
+            "target": target,
+            "affected_test_files": test_files,
+            "affected_tests": affected_tests,
+            "total_test_files": len(test_files),
+            "total_tests": len(affected_tests),
+            "impact_summary": {
+                "directly_affected_files": len(impact.get("affected_files", [])),
+                "directly_affected_symbols": len(impact.get("affected_symbols", [])),
+            },
+        }
+
+    def get_test_coverage(self, file_path: str) -> dict:
+        """Show which tests cover a given file."""
+        file_id = f"file:{file_path}"
+        tests = []
+        seen = set()
+
+        # Direct test edges to this file
+        for source_id, edge in self.incoming_by_type["tests"].get(file_id, []):
+            if source_id not in seen:
+                seen.add(source_id)
+                node = self.nodes_by_id.get(source_id, {})
+                tests.append({
+                    "test": node.get("path") or node.get("file", source_id),
+                    "name": node.get("name", "?"),
+                    "type": node.get("type", "?"),
+                    "strategy": edge.get("metadata", {}).get("strategy", "?"),
+                })
+
+        # Tests targeting symbols in this file
+        for node in self.nodes_by_file.get(file_path, []):
+            nid = node.get("id", "")
+            for source_id, edge in self.incoming_by_type["tests"].get(nid, []):
+                if source_id not in seen:
+                    seen.add(source_id)
+                    source_node = self.nodes_by_id.get(source_id, {})
+                    tests.append({
+                        "test": source_node.get("file", source_id),
+                        "name": source_node.get("name", "?"),
+                        "type": source_node.get("type", "?"),
+                        "targets": node.get("name", "?"),
+                        "strategy": edge.get("metadata", {}).get("strategy", "?"),
+                    })
+
+        return {
+            "file": file_path,
+            "tests": tests,
+            "total": len(tests),
+        }
+
+
+# ── Output Formatters ─────────────────────────────────────────────
+
+def format_symbol_result(node: dict) -> str:
+    parts = []
+    sym_type = node.get("type", "?")
+    name = node.get("name", "?")
+    file_path = node.get("file") or node.get("path", "?")
+    line = node.get("line_start") or node.get("line", "?")
+
+    header = f"{sym_type}: {name}"
+    if node.get("scope"):
+        header = f"{sym_type}: {node['scope']}.{name}"
+    parts.append(header)
+    parts.append(f"  Location: {file_path}:{line}")
+
+    if node.get("signature"):
+        parts.append(f"  Signature: {name}{node['signature']}")
+    elif node.get("params"):
+        parts.append(f"  Params: {', '.join(node['params'])}")
+    if node.get("bases"):
+        parts.append(f"  Bases: {', '.join(node['bases'])}")
+    if node.get("decorators"):
+        parts.append(f"  Decorators: {', '.join(node['decorators'])}")
+    if node.get("docstring") or node.get("doc"):
+        doc = node.get("docstring") or node.get("doc", "")
+        parts.append(f"  Doc: {doc[:120]}")
+    if node.get("is_test"):
+        parts.append(f"  [TEST]")
+
+    return "\n".join(parts)
+
+
+def format_deps(deps: dict) -> str:
+    lines = []
+    if deps.get("imports"):
+        lines.append("Imports:")
+        for imp in sorted(deps["imports"]):
+            lines.append(f"  -> {imp}")
+    if deps.get("inherits"):
+        lines.append("Inherits:")
+        for inh in deps["inherits"]:
+            lines.append(f"  {inh['from']} extends {inh['to']} ({inh.get('file', '?')})")
+    if deps.get("calls"):
+        lines.append("Calls (cross-file):")
+        for call in deps["calls"][:20]:
+            lines.append(f"  {call['caller']} -> {call['callee']} ({call.get('file', '?')})")
+        if len(deps.get("calls", [])) > 20:
+            lines.append(f"  ... and {len(deps['calls']) - 20} more")
+    if not lines:
+        lines.append("No internal dependencies found.")
+    return "\n".join(lines)
+
+
+def format_hierarchy(hierarchy: dict) -> str:
+    if "error" in hierarchy:
+        return hierarchy["error"]
+
+    lines = []
+    if hierarchy.get("ancestors"):
+        lines.append("Ancestors (inherits from):")
+        for a in hierarchy["ancestors"]:
+            indent = "  " * a["depth"]
+            lines.append(f"{indent}<- {a['name']} ({a['file']})")
+    if hierarchy.get("descendants"):
+        lines.append("Descendants (inherited by):")
+        for d in hierarchy["descendants"]:
+            indent = "  " * d["depth"]
+            lines.append(f"{indent}-> {d['name']} ({d['file']})")
+    if not lines:
+        lines.append("No inheritance relationships found.")
+    return "\n".join(lines)
+
+
+def format_chunks(chunks: list[dict]) -> str:
+    lines = []
+    for chunk in chunks:
+        if "error" in chunk:
+            lines.append(chunk["error"])
+            continue
+        header = f"--- {chunk['type']}: {chunk['name']} ({chunk['file']}:{chunk['line_start']}-{chunk['line_end']}) ---"
+        lines.append(header)
+        lines.append(chunk["content"])
+        lines.append("")
+    return "\n".join(lines)
+
+
+def format_impact(impact: dict) -> str:
+    if "error" in impact:
+        return impact["error"]
+
+    lines = []
+    lines.append(f"Impact analysis for: {impact['target']}")
+    lines.append(f"  Affected files: {impact['total_affected_files']}")
+    lines.append(f"  Affected symbols: {impact['total_affected_symbols']}")
+    lines.append("")
+
+    if impact.get("affected_files"):
+        lines.append("Affected files:")
+        for f in impact["affected_files"]:
+            lines.append(f"  * {f}")
+        lines.append("")
+
+    if impact.get("affected_symbols"):
+        # Group by depth
+        by_depth = defaultdict(list)
+        for sym in impact["affected_symbols"]:
+            by_depth[sym["depth"]].append(sym)
+
+        for depth in sorted(by_depth.keys()):
+            label = "Direct" if depth == 1 else f"Depth {depth}"
+            lines.append(f"{label} dependencies:")
+            for sym in by_depth[depth]:
+                lines.append(f"  {sym['type']:10s} {sym['name']:30s} {sym['file']}:{sym['line']}  (via {sym['via']})")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_test_impact(test_impact: dict) -> str:
+    if "error" in test_impact:
+        return test_impact["error"]
+
+    lines = []
+    lines.append(f"Test impact for: {test_impact['target']}")
+    lines.append(f"  Test files to re-run: {test_impact['total_test_files']}")
+    lines.append(f"  Total test mappings: {test_impact['total_tests']}")
+    lines.append(f"  Impact scope: {test_impact['impact_summary']['directly_affected_files']} files, "
+                 f"{test_impact['impact_summary']['directly_affected_symbols']} symbols")
+    lines.append("")
+
+    if test_impact.get("affected_test_files"):
+        lines.append("Test files to re-run:")
+        for f in test_impact["affected_test_files"]:
+            lines.append(f"  * {f}")
+        lines.append("")
+
+    if test_impact.get("affected_tests"):
+        lines.append("Test details:")
+        for t in test_impact["affected_tests"]:
+            lines.append(f"  {t['test_name']:30s} tests {t['tests_target']:20s} ({t['strategy']})")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── Main ──────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Query the code-tree knowledge graph with impact analysis",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--graph-dir", default=None,
+        help="Directory containing graph.json (default: <repo-root>/docs/code-tree)",
+    )
+    parser.add_argument(
+        "--repo-root", default=".",
+        help="Repository root directory (default: current directory)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--symbol", "-s", help="Find a symbol by name")
+    group.add_argument("--deps", "-d", help="Show dependencies of a file")
+    group.add_argument("--rdeps", "-r", help="Show reverse dependencies of a file")
+    group.add_argument("--hierarchy", "-H", help="Show inheritance hierarchy for a class")
+    group.add_argument("--search", "-S", help="Search symbols by keyword")
+    group.add_argument("--module", "-m", help="Show module (directory) overview")
+    group.add_argument("--entry-points", "-e", action="store_true", help="Find entry points")
+    group.add_argument("--chunks", "-c", help="Extract code chunks from a file")
+    group.add_argument("--callers", help="Find all callers of a symbol")
+    group.add_argument("--callees", help="Find all functions called by a symbol")
+    group.add_argument("--call-chain", nargs=2, metavar=("FROM", "TO"),
+                       help="Find call paths between two symbols")
+    group.add_argument("--impact", "-I", help="Compute change impact for a file or symbol")
+    group.add_argument("--test-impact", "-T", help="Find tests affected by changes to a file or symbol")
+    group.add_argument("--test-coverage", help="Show test coverage for a file")
+    group.add_argument("--stats", action="store_true", help="Show graph statistics")
+
+    parser.add_argument("--depth", type=int, default=5,
+                       help="Max depth for impact/call-chain analysis (default: 5)")
+
+    args = parser.parse_args()
+    repo_root = os.path.abspath(args.repo_root)
+    graph_dir = args.graph_dir or os.path.join(repo_root, "docs", "code-tree")
+
+    gq = GraphQuery(graph_dir, repo_root)
+
+    if args.symbol:
+        results = gq.find_symbol(args.symbol)
+        if args.json:
+            print(json.dumps(results, indent=2, default=str))
+        elif results:
+            for r in results:
+                print(format_symbol_result(r))
+                print()
+        else:
+            print(f"No symbols matching '{args.symbol}' found.")
+
+    elif args.deps:
+        deps = gq.get_dependencies(args.deps)
+        if args.json:
+            print(json.dumps(deps, indent=2))
+        else:
+            print(f"Dependencies of {args.deps}:\n")
+            print(format_deps(deps))
+
+    elif args.rdeps:
+        rdeps = gq.get_reverse_dependencies(args.rdeps)
+        if args.json:
+            print(json.dumps(rdeps, indent=2))
+        else:
+            print(f"Files that import {args.rdeps}:\n")
+            for r in rdeps:
+                print(f"  <- {r}")
+            if not rdeps:
+                print("  No internal importers found.")
+
+    elif args.hierarchy:
+        hierarchy = gq.get_hierarchy(args.hierarchy)
+        if args.json:
+            print(json.dumps(hierarchy, indent=2))
+        else:
+            print(f"Inheritance hierarchy for {args.hierarchy}:\n")
+            print(format_hierarchy(hierarchy))
+
+    elif args.search:
+        results = gq.search(args.search)
+        if args.json:
+            print(json.dumps(results, indent=2))
+        else:
+            print(f"Search results for '{args.search}':\n")
+            for r in results:
+                test_marker = " [T]" if r.get("is_test") else ""
+                print(f"  {r['type']:10s} {r['name']:30s} {r['file']}:{r['line']}{test_marker}")
+            if not results:
+                print("  No matches found.")
+
+    elif args.module:
+        module_data = gq.get_module(args.module)
+        if args.json:
+            print(json.dumps(module_data, indent=2))
+        else:
+            print(f"Module: {args.module}\n")
+            print(f"Files ({len(module_data['files'])}):")
+            for f in module_data["files"]:
+                print(f"  {f}")
+            print(f"\nDepends on ({len(module_data['depends_on'])}):")
+            for d in module_data["depends_on"]:
+                print(f"  -> {d}")
+            if module_data.get("tested_by"):
+                print(f"\nTested by ({len(module_data['tested_by'])}):")
+                for t in module_data["tested_by"]:
+                    print(f"  <- {t}")
+            print(f"\nSymbols ({len(module_data['symbols'])}):")
+            for s in module_data["symbols"][:30]:
+                test_marker = " [T]" if s.get("is_test") else ""
+                print(f"  {s['type']:10s} {s['name']:30s} :{s['line']}{test_marker}")
+            if len(module_data["symbols"]) > 30:
+                print(f"  ... and {len(module_data['symbols']) - 30} more")
+
+    elif args.entry_points:
+        entries = gq.find_entry_points()
+        if args.json:
+            print(json.dumps(entries, indent=2))
+        else:
+            print("Entry points (files not imported by others):\n")
+            for e in entries:
+                marker = " *" if e["priority"] >= 10 else ""
+                print(f"  {e['file']}{marker} ({e['symbols']} symbols)")
+
+    elif args.chunks:
+        chunks = gq.extract_chunks(args.chunks)
+        if args.json:
+            print(json.dumps(chunks, indent=2))
+        else:
+            print(format_chunks(chunks))
+
+    elif args.callers:
+        callers = gq.get_callers(args.callers)
+        if args.json:
+            print(json.dumps(callers, indent=2))
+        else:
+            print(f"Callers of '{args.callers}':\n")
+            if callers:
+                for c in callers:
+                    print(f"  {c['type']:10s} {c['caller']:30s} {c['file']}:{c['line']}  (calls at :{c['call_line']})")
+            else:
+                print("  No callers found.")
+
+    elif args.callees:
+        callees = gq.get_callees(args.callees)
+        if args.json:
+            print(json.dumps(callees, indent=2))
+        else:
+            print(f"Functions called by '{args.callees}':\n")
+            if callees:
+                for c in callees:
+                    print(f"  -> {c['type']:10s} {c['callee']:30s} {c['file']}:{c['line']}")
+            else:
+                print("  No callees found.")
+
+    elif args.call_chain:
+        from_name, to_name = args.call_chain
+        chains = gq.get_call_chain(from_name, to_name, args.depth)
+        if args.json:
+            # Convert node IDs to readable names
+            readable_chains = []
+            for chain in chains:
+                readable = []
+                for node_id in chain:
+                    node = gq.nodes_by_id.get(node_id, {})
+                    readable.append({
+                        "name": node.get("name", node_id),
+                        "type": node.get("type", "?"),
+                        "file": node.get("file", "?"),
+                    })
+                readable_chains.append(readable)
+            print(json.dumps(readable_chains, indent=2))
+        else:
+            print(f"Call chains from '{from_name}' to '{to_name}':\n")
+            if chains:
+                for i, chain in enumerate(chains):
+                    names = []
+                    for node_id in chain:
+                        node = gq.nodes_by_id.get(node_id, {})
+                        names.append(node.get("name", node_id.split(":")[-1]))
+                    print(f"  Chain {i + 1}: {' -> '.join(names)}")
+            else:
+                print("  No call chains found.")
+
+    elif args.impact:
+        impact = gq.get_impact(args.impact, args.depth)
+        if args.json:
+            print(json.dumps(impact, indent=2))
+        else:
+            print(format_impact(impact))
+
+    elif args.test_impact:
+        test_impact = gq.get_test_impact(args.test_impact)
+        if args.json:
+            print(json.dumps(test_impact, indent=2))
+        else:
+            print(format_test_impact(test_impact))
+
+    elif args.test_coverage:
+        coverage = gq.get_test_coverage(args.test_coverage)
+        if args.json:
+            print(json.dumps(coverage, indent=2))
+        else:
+            print(f"Test coverage for {args.test_coverage}:\n")
+            if coverage["tests"]:
+                for t in coverage["tests"]:
+                    target_str = f" -> {t['targets']}" if t.get("targets") else ""
+                    print(f"  {t['name']:30s} ({t['type']}) in {t['test']}{target_str}")
+            else:
+                print("  No tests found for this file.")
+
+    elif args.stats:
+        meta = gq.graph.get("metadata", {})
+        if args.json:
+            # Don't include file_hashes in stats output (too verbose)
+            stats_meta = {k: v for k, v in meta.items() if k != "file_hashes"}
+            print(json.dumps(stats_meta, indent=2))
+        else:
+            print("Knowledge Graph Statistics:\n")
+            print(f"  Files:        {meta.get('total_files', '?')}")
+            print(f"  Symbols:      {meta.get('total_symbols', '?')}")
+            print(f"  Languages:    {meta.get('languages', {})}")
+            print(f"  Symbol types: {meta.get('symbol_types', {})}")
+            print(f"  Edge types:   {meta.get('edge_types', {})}")
+            print(f"  Generated:    {meta.get('generated_at', '?')}")
+            if meta.get("module_boundaries"):
+                print(f"\n  Build modules:")
+                for mb in meta["module_boundaries"]:
+                    name = mb.get("name", mb.get("build_file", "?"))
+                    print(f"    {name} ({mb.get('build_file', '?')}) in {mb.get('root_dir', '.')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/code-tree/test_code_tree.py
+++ b/tools/code-tree/test_code_tree.py
@@ -1,0 +1,1209 @@
+#!/usr/bin/env python3
+"""Unit tests for code_tree.py — covers parsing, call resolution, import
+resolution, test mapping, incremental mode, and output generation."""
+
+import textwrap
+import unittest
+from collections import defaultdict
+
+from code_tree import (
+    CallRef,
+    Edge,
+    ModuleBoundary,
+    Symbol,
+    _edge_file,
+    _extract_go_import_edges,
+    _extract_regex_imports,
+    _match_test_symbol_to_source,
+    _match_test_to_source_path,
+    compute_directory_stats,
+    compute_graph_stats,
+    detect_test_relationships,
+    generate_tags_json,
+    is_test_file,
+    parse_python,
+    parse_with_regex,
+    resolve_calls,
+    resolve_imports,
+    should_exclude,
+)
+
+
+class TestRelativeImportResolution(unittest.TestCase):
+    """Fix 1: Relative JS/TS and Python imports must resolve to local files."""
+
+    def test_js_relative_import_sibling(self):
+        """import from './utils' resolves to src/utils.ts."""
+        symbols = []
+        edges = [
+            Edge("file:src/app.ts", "module:./utils", "imports"),
+        ]
+        file_map = {"src/app.ts": "typescript", "src/utils.ts": "typescript"}
+        result = resolve_imports(symbols, edges, file_map, [])
+        resolved_targets = [e.target for e in result if e.type == "imports"]
+        self.assertIn("file:src/utils.ts", resolved_targets)
+        self.assertNotIn("module:./utils", [e.target for e in result])
+
+    def test_js_relative_import_parent_dir(self):
+        """import from '../providers/utils' resolves correctly."""
+        symbols = []
+        edges = [
+            Edge("file:src/components/app.tsx", "module:../providers/utils", "imports"),
+        ]
+        file_map = {
+            "src/components/app.tsx": "typescript",
+            "src/providers/utils.ts": "typescript",
+        }
+        result = resolve_imports(symbols, edges, file_map, [])
+        resolved_targets = [e.target for e in result if e.type == "imports"]
+        self.assertIn("file:src/providers/utils.ts", resolved_targets)
+
+    def test_js_relative_import_index_file(self):
+        """import from './components' resolves to components/index.ts."""
+        symbols = []
+        edges = [
+            Edge("file:src/app.ts", "module:./components", "imports"),
+        ]
+        file_map = {
+            "src/app.ts": "typescript",
+            "src/components/index.ts": "typescript",
+        }
+        result = resolve_imports(symbols, edges, file_map, [])
+        resolved_targets = [e.target for e in result if e.type == "imports"]
+        self.assertIn("file:src/components/index.ts", resolved_targets)
+
+    def test_js_relative_import_jsx_extension(self):
+        """import from './Button' resolves to Button.jsx."""
+        symbols = []
+        edges = [
+            Edge("file:src/app.js", "module:./Button", "imports"),
+        ]
+        file_map = {"src/app.js": "javascript", "src/Button.jsx": "javascript"}
+        result = resolve_imports(symbols, edges, file_map, [])
+        resolved_targets = [e.target for e in result if e.type == "imports"]
+        self.assertIn("file:src/Button.jsx", resolved_targets)
+
+    def test_python_relative_import(self):
+        """Python relative import ./foo resolves to foo.py in same dir."""
+        symbols = []
+        edges = [
+            Edge("file:pkg/bar.py", "module:./foo", "imports"),
+        ]
+        file_map = {"pkg/bar.py": "python", "pkg/foo.py": "python"}
+        result = resolve_imports(symbols, edges, file_map, [])
+        resolved_targets = [e.target for e in result if e.type == "imports"]
+        self.assertIn("file:pkg/foo.py", resolved_targets)
+
+    def test_python_relative_import_init(self):
+        """Python relative import ./sub resolves to sub/__init__.py."""
+        symbols = []
+        edges = [
+            Edge("file:pkg/bar.py", "module:./sub", "imports"),
+        ]
+        file_map = {"pkg/bar.py": "python", "pkg/sub/__init__.py": "python"}
+        result = resolve_imports(symbols, edges, file_map, [])
+        resolved_targets = [e.target for e in result if e.type == "imports"]
+        self.assertIn("file:pkg/sub/__init__.py", resolved_targets)
+
+    def test_unresolvable_relative_import_kept(self):
+        """Relative import with no matching file stays as unresolved edge."""
+        symbols = []
+        edges = [
+            Edge("file:src/app.ts", "module:./nonexistent", "imports"),
+        ]
+        file_map = {"src/app.ts": "typescript"}
+        result = resolve_imports(symbols, edges, file_map, [])
+        unresolved = [e for e in result if e.target == "module:./nonexistent"]
+        self.assertEqual(len(unresolved), 1)
+
+    def test_non_relative_import_unchanged(self):
+        """Absolute module imports still go through the existing path."""
+        symbols = []
+        edges = [
+            Edge("file:src/app.ts", "module:react", "imports"),
+        ]
+        file_map = {"src/app.ts": "typescript"}
+        result = resolve_imports(symbols, edges, file_map, [])
+        # 'react' is external, should remain as-is
+        kept = [e for e in result if e.target == "module:react"]
+        self.assertEqual(len(kept), 1)
+
+
+class TestQualifiedTestMatching(unittest.TestCase):
+    """Fix 2: test_Class_method must match Class.method via symbol_by_name."""
+
+    def _make_symbols(self):
+        """Create source and test symbols for method-level matching."""
+        source_method = Symbol(
+            id="method:src/a.py:MyClass.process",
+            type="method", name="process",
+            file="src/a.py", language="python",
+            line_start=10, line_end=20,
+            scope="MyClass", exported=True, is_test=False,
+        )
+        source_class = Symbol(
+            id="class:src/a.py:MyClass",
+            type="class", name="MyClass",
+            file="src/a.py", language="python",
+            line_start=5, line_end=25,
+            exported=True, is_test=False,
+        )
+        test_func = Symbol(
+            id="function:tests/test_a.py:test_MyClass_process",
+            type="function", name="test_MyClass_process",
+            file="tests/test_a.py", language="python",
+            line_start=1, line_end=5,
+            exported=True, is_test=True,
+        )
+        return source_class, source_method, test_func
+
+    def test_qualified_name_in_index(self):
+        """symbol_by_name must contain 'MyClass.process' key."""
+        source_class, source_method, test_func = self._make_symbols()
+        all_symbols = [source_class, source_method, test_func]
+        files = [
+            ("/abs/src/a.py", "src/a.py", "python", False),
+            ("/abs/tests/test_a.py", "tests/test_a.py", "python", True),
+        ]
+        file_map = {"src/a.py": "python", "tests/test_a.py": "python"}
+
+        test_edges = detect_test_relationships(all_symbols, [], files, file_map)
+        # Should have a symbol-level tests edge from test_func to source_method
+        symbol_test_edges = [
+            e for e in test_edges
+            if e.source == test_func.id and e.target == source_method.id
+        ]
+        self.assertEqual(len(symbol_test_edges), 1,
+                         "test_MyClass_process should create a tests edge to MyClass.process")
+
+    def test_bare_name_still_works(self):
+        """test_foo should still match function foo (bare name matching)."""
+        source_func = Symbol(
+            id="function:src/a.py:foo",
+            type="function", name="foo",
+            file="src/a.py", language="python",
+            line_start=1, line_end=5,
+            exported=True, is_test=False,
+        )
+        test_func = Symbol(
+            id="function:tests/test_a.py:test_foo",
+            type="function", name="test_foo",
+            file="tests/test_a.py", language="python",
+            line_start=1, line_end=5,
+            exported=True, is_test=True,
+        )
+        # Build the index the same way detect_test_relationships does
+        symbol_by_name = defaultdict(list)
+        for sym in [source_func, test_func]:
+            if not sym.is_test:
+                symbol_by_name[sym.name].append(sym)
+                if sym.scope:
+                    symbol_by_name[f"{sym.scope}.{sym.name}"].append(sym)
+
+        matches = _match_test_symbol_to_source(test_func, symbol_by_name)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].id, source_func.id)
+
+    def test_test_class_prefix_still_works(self):
+        """TestFoo should match class Foo."""
+        source_class = Symbol(
+            id="class:src/a.py:Foo",
+            type="class", name="Foo",
+            file="src/a.py", language="python",
+            line_start=1, line_end=10,
+            exported=True, is_test=False,
+        )
+        test_class = Symbol(
+            id="class:tests/test_a.py:TestFoo",
+            type="class", name="TestFoo",
+            file="tests/test_a.py", language="python",
+            line_start=1, line_end=10,
+            exported=True, is_test=True,
+        )
+        symbol_by_name = defaultdict(list)
+        for sym in [source_class]:
+            symbol_by_name[sym.name].append(sym)
+
+        matches = _match_test_symbol_to_source(test_class, symbol_by_name)
+        self.assertEqual(len(matches), 1)
+        self.assertEqual(matches[0].id, source_class.id)
+
+
+class TestIncrementalEdgePreservation(unittest.TestCase):
+    """Fix 3: Incremental mode must keep edges from unchanged files
+    even when they point at changed files."""
+
+    def _simulate_incremental_merge(self, prev_edges, changed_files):
+        """Simulate the incremental edge merge logic from main().
+
+        This mirrors the fixed logic: keep edges whose source is from
+        an unchanged file.
+        """
+        from code_tree import _edge_file
+
+        kept = []
+        for edge_data in prev_edges:
+            src_file = _edge_file(edge_data.get("source", ""))
+            if src_file not in changed_files:
+                kept.append(Edge(
+                    source=edge_data["source"],
+                    target=edge_data["target"],
+                    type=edge_data["type"],
+                    metadata=edge_data.get("metadata", {}),
+                ))
+        return kept
+
+    def test_unchanged_to_changed_edge_preserved(self):
+        """b.py (unchanged) imports a.py (changed) — edge must survive."""
+        prev_edges = [
+            {"source": "file:b.py", "target": "file:a.py", "type": "imports"},
+        ]
+        changed_files = {"a.py"}
+
+        kept = self._simulate_incremental_merge(prev_edges, changed_files)
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(kept[0].source, "file:b.py")
+        self.assertEqual(kept[0].target, "file:a.py")
+
+    def test_changed_to_unchanged_edge_dropped(self):
+        """a.py (changed) imports b.py (unchanged) — edge dropped (reparsed)."""
+        prev_edges = [
+            {"source": "file:a.py", "target": "file:b.py", "type": "imports"},
+        ]
+        changed_files = {"a.py"}
+
+        kept = self._simulate_incremental_merge(prev_edges, changed_files)
+        self.assertEqual(len(kept), 0,
+                         "Edges from changed files should be dropped (they get re-emitted by reparsing)")
+
+    def test_unchanged_to_unchanged_edge_preserved(self):
+        """b.py (unchanged) imports c.py (unchanged) — edge must survive."""
+        prev_edges = [
+            {"source": "file:b.py", "target": "file:c.py", "type": "imports"},
+        ]
+        changed_files = {"a.py"}
+
+        kept = self._simulate_incremental_merge(prev_edges, changed_files)
+        self.assertEqual(len(kept), 1)
+
+    def test_symbol_edge_unchanged_source(self):
+        """Symbol-level call from unchanged file to changed file is preserved."""
+        prev_edges = [
+            {
+                "source": "function:b.py:bar",
+                "target": "function:a.py:foo",
+                "type": "calls",
+                "metadata": {"line": 8},
+            },
+        ]
+        changed_files = {"a.py"}
+
+        kept = self._simulate_incremental_merge(prev_edges, changed_files)
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(kept[0].type, "calls")
+
+    def test_mixed_edges_correct_filtering(self):
+        """Multiple edges with mixed changed/unchanged sources."""
+        prev_edges = [
+            {"source": "file:b.py", "target": "file:a.py", "type": "imports"},      # keep (source unchanged)
+            {"source": "file:a.py", "target": "file:b.py", "type": "imports"},      # drop (source changed)
+            {"source": "file:c.py", "target": "file:a.py", "type": "imports"},      # keep (source unchanged)
+            {"source": "function:a.py:foo", "target": "function:b.py:bar", "type": "calls"},  # drop
+            {"source": "function:b.py:bar", "target": "function:a.py:foo", "type": "calls"},  # keep
+        ]
+        changed_files = {"a.py"}
+
+        kept = self._simulate_incremental_merge(prev_edges, changed_files)
+        self.assertEqual(len(kept), 3)
+        sources = [e.source for e in kept]
+        self.assertTrue(all("a.py" not in s.split(":")[1] for s in sources if ":" in s),
+                        "No kept edge should have a changed-file source")
+
+
+class TestShouldExclude(unittest.TestCase):
+    """Tests for should_exclude path filtering."""
+
+    def test_exact_dir_match(self):
+        self.assertTrue(should_exclude("node_modules/foo.js", ["node_modules"]))
+
+    def test_nested_excluded_dir(self):
+        self.assertTrue(should_exclude("src/vendor/lib.go", ["vendor"]))
+
+    def test_non_excluded_path(self):
+        self.assertFalse(should_exclude("src/main.py", ["node_modules", ".git"]))
+
+    def test_glob_pattern(self):
+        self.assertTrue(should_exclude("build/output.js", ["build"]))
+
+    def test_deep_path_not_matching(self):
+        self.assertFalse(should_exclude("src/app/components/Button.tsx", ["node_modules"]))
+
+
+class TestIsTestFile(unittest.TestCase):
+    """Tests for is_test_file detection."""
+
+    def test_test_prefix(self):
+        self.assertTrue(is_test_file("test_foo.py"))
+
+    def test_test_suffix(self):
+        self.assertTrue(is_test_file("foo_test.go"))
+
+    def test_spec_suffix(self):
+        self.assertTrue(is_test_file("Button.spec.tsx"))
+
+    def test_tests_directory(self):
+        self.assertTrue(is_test_file("tests/test_utils.py"))
+
+    def test_underscore_tests_dir(self):
+        self.assertTrue(is_test_file("__tests__/Button.test.js"))
+
+    def test_not_test(self):
+        self.assertFalse(is_test_file("src/utils.py"))
+
+    def test_not_test_similar_name(self):
+        self.assertFalse(is_test_file("src/testing_utils.py"))
+
+
+class TestEdgeFile(unittest.TestCase):
+    """Tests for _edge_file helper."""
+
+    def test_file_prefix(self):
+        self.assertEqual(_edge_file("file:src/a.py"), "src/a.py")
+
+    def test_symbol_id(self):
+        self.assertEqual(_edge_file("function:src/a.py:foo"), "src/a.py")
+
+    def test_method_with_scope(self):
+        self.assertEqual(_edge_file("method:src/b.py:MyClass.bar"), "src/b.py")
+
+    def test_empty_string(self):
+        self.assertEqual(_edge_file(""), "")
+
+    def test_no_colon(self):
+        self.assertEqual(_edge_file("bare"), "")
+
+
+class TestParsePython(unittest.TestCase):
+    """Tests for Python AST parsing."""
+
+    def test_function_extraction(self):
+        code = textwrap.dedent("""\
+            def hello(name: str) -> str:
+                return f"Hello {name}"
+        """)
+        symbols, edges, calls = parse_python(code, "app.py", False)
+        func_syms = [s for s in symbols if s.type == "function"]
+        self.assertEqual(len(func_syms), 1)
+        self.assertEqual(func_syms[0].name, "hello")
+        self.assertEqual(func_syms[0].params, ["name"])
+        self.assertIn("-> str", func_syms[0].signature)
+
+    def test_class_with_methods(self):
+        code = textwrap.dedent("""\
+            class Calculator:
+                \"\"\"A simple calculator.\"\"\"
+                def add(self, a, b):
+                    return a + b
+
+                def subtract(self, a, b):
+                    return a - b
+        """)
+        symbols, edges, calls = parse_python(code, "calc.py", False)
+        class_syms = [s for s in symbols if s.type == "class"]
+        method_syms = [s for s in symbols if s.type == "method"]
+        self.assertEqual(len(class_syms), 1)
+        self.assertEqual(class_syms[0].name, "Calculator")
+        self.assertEqual(class_syms[0].docstring, "A simple calculator.")
+        self.assertEqual(len(method_syms), 2)
+        method_names = {m.name for m in method_syms}
+        self.assertEqual(method_names, {"add", "subtract"})
+        # self should be excluded from params
+        for m in method_syms:
+            self.assertNotIn("self", m.params)
+
+    def test_class_inheritance(self):
+        code = textwrap.dedent("""\
+            class Child(Parent):
+                pass
+        """)
+        symbols, edges, calls = parse_python(code, "child.py", False)
+        inherits = [e for e in edges if e.type == "inherits"]
+        self.assertEqual(len(inherits), 1)
+        self.assertIn("Parent", inherits[0].target)
+
+    def test_import_edges(self):
+        code = textwrap.dedent("""\
+            import os
+            from pathlib import Path
+            from . import utils
+        """)
+        symbols, edges, calls = parse_python(code, "pkg/main.py", False)
+        import_edges = [e for e in edges if e.type == "imports"]
+        targets = {e.target for e in import_edges}
+        self.assertIn("module:os", targets)
+        self.assertIn("symbol:pathlib.Path", targets)
+
+    def test_call_extraction(self):
+        code = textwrap.dedent("""\
+            def process():
+                result = compute(data)
+                result.save()
+        """)
+        symbols, edges, calls = parse_python(code, "app.py", False)
+        call_names = {c.raw_name for c in calls}
+        self.assertIn("compute", call_names)
+        self.assertIn("result.save", call_names)
+
+    def test_builtin_calls_excluded(self):
+        code = textwrap.dedent("""\
+            def process():
+                x = len(data)
+                print(x)
+                items = list(range(10))
+        """)
+        symbols, edges, calls = parse_python(code, "app.py", False)
+        call_names = {c.raw_name for c in calls}
+        self.assertNotIn("len", call_names)
+        self.assertNotIn("print", call_names)
+        self.assertNotIn("list", call_names)
+        self.assertNotIn("range", call_names)
+
+    def test_nested_function_calls_separate(self):
+        """Nested functions should have their own caller_id."""
+        code = textwrap.dedent("""\
+            def outer():
+                do_outer()
+                def inner():
+                    do_inner()
+        """)
+        symbols, edges, calls = parse_python(code, "app.py", False)
+        outer_calls = [c for c in calls if "outer" in c.caller_id and "inner" not in c.caller_id]
+        inner_calls = [c for c in calls if "inner" in c.caller_id]
+        self.assertTrue(any(c.raw_name == "do_outer" for c in outer_calls))
+        self.assertTrue(any(c.raw_name == "do_inner" for c in inner_calls))
+
+    def test_constant_extraction(self):
+        code = textwrap.dedent("""\
+            MAX_SIZE = 1024
+            _PRIVATE = "hidden"
+            regular_var = 42
+        """)
+        symbols, edges, calls = parse_python(code, "config.py", False)
+        constants = [s for s in symbols if s.type == "constant"]
+        names = {c.name for c in constants}
+        self.assertIn("MAX_SIZE", names)
+        self.assertIn("_PRIVATE", names)
+        self.assertNotIn("regular_var", names)
+
+    def test_decorated_function(self):
+        code = textwrap.dedent("""\
+            @staticmethod
+            def create():
+                pass
+        """)
+        symbols, edges, calls = parse_python(code, "app.py", False)
+        func = [s for s in symbols if s.type == "function"][0]
+        self.assertIn("staticmethod", func.decorators)
+
+    def test_test_function_flagged(self):
+        code = textwrap.dedent("""\
+            def test_something():
+                assert True
+        """)
+        symbols, edges, calls = parse_python(code, "test_app.py", True)
+        func = [s for s in symbols if s.type == "function"][0]
+        self.assertTrue(func.is_test)
+
+    def test_syntax_error_returns_empty(self):
+        code = "def broken(:\n    pass"
+        symbols, edges, calls = parse_python(code, "bad.py", False)
+        self.assertEqual(len(symbols), 0)
+
+    def test_async_function(self):
+        code = textwrap.dedent("""\
+            async def fetch(url):
+                return await get(url)
+        """)
+        symbols, edges, calls = parse_python(code, "api.py", False)
+        func_syms = [s for s in symbols if s.type == "function"]
+        self.assertEqual(len(func_syms), 1)
+        self.assertEqual(func_syms[0].name, "fetch")
+
+
+class TestParseWithRegex(unittest.TestCase):
+    """Tests for regex-based parsing (Go, JS, Java)."""
+
+    def test_go_function(self):
+        code = "func HandleRequest(w http.ResponseWriter, r *http.Request) {\n}\n"
+        symbols, edges, calls = parse_with_regex(code, "handler.go", "go", False)
+        func_syms = [s for s in symbols if s.type == "function"]
+        self.assertEqual(len(func_syms), 1)
+        self.assertEqual(func_syms[0].name, "HandleRequest")
+        self.assertTrue(func_syms[0].exported)
+
+    def test_go_unexported(self):
+        code = "func handleInternal(ctx context.Context) {\n}\n"
+        symbols, edges, calls = parse_with_regex(code, "handler.go", "go", False)
+        func_syms = [s for s in symbols if s.type == "function"]
+        self.assertEqual(len(func_syms), 1)
+        self.assertFalse(func_syms[0].exported)
+
+    def test_go_method(self):
+        code = "func (s *Server) Start(port int) error {\n}\n"
+        symbols, edges, calls = parse_with_regex(code, "server.go", "go", False)
+        method_syms = [s for s in symbols if s.type == "method"]
+        self.assertEqual(len(method_syms), 1)
+        self.assertEqual(method_syms[0].name, "Start")
+        self.assertEqual(method_syms[0].scope, "Server")
+
+    def test_go_struct(self):
+        code = "type Config struct {\n\tPort int\n}\n"
+        symbols, edges, calls = parse_with_regex(code, "config.go", "go", False)
+        struct_syms = [s for s in symbols if s.type == "struct"]
+        self.assertEqual(len(struct_syms), 1)
+        self.assertEqual(struct_syms[0].name, "Config")
+
+    def test_go_interface(self):
+        code = "type Handler interface {\n\tHandle(ctx context.Context) error\n}\n"
+        symbols, edges, calls = parse_with_regex(code, "handler.go", "go", False)
+        iface_syms = [s for s in symbols if s.type == "interface"]
+        self.assertEqual(len(iface_syms), 1)
+        self.assertEqual(iface_syms[0].name, "Handler")
+
+    def test_js_class_with_extends(self):
+        code = "export class Button extends Component {\n}\n"
+        symbols, edges, calls = parse_with_regex(code, "Button.jsx", "javascript", False)
+        class_syms = [s for s in symbols if s.type == "class"]
+        self.assertEqual(len(class_syms), 1)
+        self.assertEqual(class_syms[0].name, "Button")
+        self.assertEqual(class_syms[0].bases, ["Component"])
+
+    def test_js_arrow_function(self):
+        code = "export const fetchData = async (url) => {\n}\n"
+        symbols, edges, calls = parse_with_regex(code, "api.js", "javascript", False)
+        func_syms = [s for s in symbols if s.type == "function"]
+        self.assertEqual(len(func_syms), 1)
+        self.assertEqual(func_syms[0].name, "fetchData")
+
+    def test_js_import_edge(self):
+        code = "import { useState } from 'react'\n"
+        symbols, edges, calls = parse_with_regex(code, "app.jsx", "javascript", False)
+        import_edges = [e for e in edges if e.type == "imports"]
+        self.assertTrue(any(e.target == "module:react" for e in import_edges))
+
+    def test_ts_interface(self):
+        code = "export interface UserProps {\n  name: string;\n}\n"
+        symbols, edges, calls = parse_with_regex(code, "types.ts", "typescript", False)
+        iface_syms = [s for s in symbols if s.type == "interface"]
+        self.assertEqual(len(iface_syms), 1)
+        self.assertEqual(iface_syms[0].name, "UserProps")
+
+    def test_ts_enum(self):
+        code = "export enum Status {\n  Active,\n  Inactive\n}\n"
+        symbols, edges, calls = parse_with_regex(code, "types.ts", "typescript", False)
+        enum_syms = [s for s in symbols if s.type == "enum"]
+        self.assertEqual(len(enum_syms), 1)
+        self.assertEqual(enum_syms[0].name, "Status")
+
+    def test_java_class(self):
+        code = "public class UserService extends BaseService {\n}\n"
+        symbols, edges, calls = parse_with_regex(code, "UserService.java", "java", False)
+        class_syms = [s for s in symbols if s.type == "class"]
+        self.assertEqual(len(class_syms), 1)
+        self.assertEqual(class_syms[0].name, "UserService")
+        self.assertEqual(class_syms[0].bases, ["BaseService"])
+
+    def test_unsupported_language_returns_empty(self):
+        symbols, edges, calls = parse_with_regex("some code", "file.lua", "lua", False)
+        self.assertEqual(len(symbols), 0)
+        self.assertEqual(len(edges), 0)
+
+
+class TestExtractGoImportEdges(unittest.TestCase):
+    """Tests for Go import block and single-line extraction."""
+
+    def test_import_block(self):
+        code = textwrap.dedent("""\
+            import (
+                "fmt"
+                "net/http"
+            )
+        """)
+        edges = _extract_go_import_edges(code, "file:main.go")
+        targets = {e.target for e in edges}
+        self.assertIn("module:fmt", targets)
+        self.assertIn("module:net/http", targets)
+
+    def test_single_import(self):
+        code = 'import "os"\n'
+        edges = _extract_go_import_edges(code, "file:main.go")
+        self.assertTrue(any(e.target == "module:os" for e in edges))
+
+    def test_aliased_import(self):
+        code = textwrap.dedent("""\
+            import (
+                pb "google.golang.org/protobuf"
+            )
+        """)
+        edges = _extract_go_import_edges(code, "file:main.go")
+        self.assertTrue(any("protobuf" in e.target for e in edges))
+
+
+class TestExtractRegexImports(unittest.TestCase):
+    """Tests for _extract_regex_imports fallback."""
+
+    def test_js_imports(self):
+        code = "import { foo } from 'bar'\nimport 'side-effect'\n"
+        edges = _extract_regex_imports(code, "app.js", "javascript")
+        targets = {e.target for e in edges}
+        self.assertIn("module:bar", targets)
+        self.assertIn("module:side-effect", targets)
+
+    def test_python_no_regex_imports(self):
+        """Python imports are handled by ast, not regex. No patterns defined."""
+        code = "import os\nfrom pathlib import Path\n"
+        edges = _extract_regex_imports(code, "app.py", "python")
+        self.assertEqual(len(edges), 0)
+
+    def test_go_delegates_to_go_handler(self):
+        code = 'import "fmt"\n'
+        edges = _extract_regex_imports(code, "main.go", "go")
+        self.assertTrue(any(e.target == "module:fmt" for e in edges))
+
+
+class TestResolveCalls(unittest.TestCase):
+    """Tests for call graph resolution."""
+
+    def _make_symbols_and_edges(self):
+        sym_foo = Symbol(
+            id="function:a.py:foo", type="function", name="foo",
+            file="a.py", language="python", line_start=1, line_end=5,
+        )
+        sym_bar = Symbol(
+            id="function:b.py:bar", type="function", name="bar",
+            file="b.py", language="python", line_start=1, line_end=10,
+        )
+        sym_cls = Symbol(
+            id="class:a.py:MyClass", type="class", name="MyClass",
+            file="a.py", language="python", line_start=10, line_end=30,
+        )
+        sym_method = Symbol(
+            id="method:a.py:MyClass.process", type="method", name="process",
+            file="a.py", language="python", line_start=15, line_end=25,
+            scope="MyClass",
+        )
+        symbols = [sym_foo, sym_bar, sym_cls, sym_method]
+        edges = [
+            Edge("file:b.py", "file:a.py", "imports"),
+            Edge("file:b.py", "symbol:a.foo", "imports", {"from_import": True}),
+        ]
+        return symbols, edges
+
+    def test_direct_name_same_file(self):
+        symbols, edges = self._make_symbols_and_edges()
+        refs = [CallRef("function:a.py:foo", "process", 3, "a.py")]
+        # process is a method in a.py, foo calls it by name
+        call_edges = resolve_calls(refs, symbols, edges, {"a.py": "python"})
+        # Should resolve "process" to method:a.py:MyClass.process
+        targets = {e.target for e in call_edges}
+        self.assertIn("method:a.py:MyClass.process", targets)
+
+    def test_self_method_call_falls_back_to_name(self):
+        """self.foo where foo isn't a method of MyClass falls back to name match."""
+        symbols, edges = self._make_symbols_and_edges()
+        refs = [CallRef("method:a.py:MyClass.process", "self.foo", 20, "a.py")]
+        call_edges = resolve_calls(refs, symbols, edges, {"a.py": "python"})
+        # foo is unique globally so last-resort name match resolves it
+        self.assertEqual(len(call_edges), 1)
+        self.assertEqual(call_edges[0].target, "function:a.py:foo")
+
+    def test_imported_name_resolution(self):
+        symbols, edges = self._make_symbols_and_edges()
+        refs = [CallRef("function:b.py:bar", "foo", 5, "b.py")]
+        call_edges = resolve_calls(refs, symbols, edges, {"b.py": "python"})
+        targets = {e.target for e in call_edges}
+        self.assertIn("function:a.py:foo", targets)
+
+    def test_no_self_call(self):
+        """A function should not resolve a call to itself."""
+        symbols, edges = self._make_symbols_and_edges()
+        refs = [CallRef("function:a.py:foo", "foo", 3, "a.py")]
+        call_edges = resolve_calls(refs, symbols, edges, {"a.py": "python"})
+        for e in call_edges:
+            self.assertNotEqual(e.source, e.target)
+
+    def test_deduplication(self):
+        """Multiple calls to the same target from same caller produce one edge."""
+        symbols, edges = self._make_symbols_and_edges()
+        refs = [
+            CallRef("function:b.py:bar", "foo", 5, "b.py"),
+            CallRef("function:b.py:bar", "foo", 7, "b.py"),
+        ]
+        call_edges = resolve_calls(refs, symbols, edges, {"b.py": "python"})
+        targets = [e.target for e in call_edges if e.source == "function:b.py:bar"]
+        self.assertEqual(len(targets), 1)
+
+    def test_qualified_class_method(self):
+        """MyClass.process should resolve via class lookup in same file."""
+        symbols, edges = self._make_symbols_and_edges()
+        refs = [CallRef("function:a.py:foo", "MyClass.process", 3, "a.py")]
+        call_edges = resolve_calls(refs, symbols, edges, {"a.py": "python"})
+        targets = {e.target for e in call_edges}
+        self.assertIn("method:a.py:MyClass.process", targets)
+
+
+class TestMatchTestToSourcePath(unittest.TestCase):
+    """Tests for test-to-source file path matching."""
+
+    def test_test_prefix(self):
+        source_files = {"src/utils.py"}
+        result = _match_test_to_source_path("tests/test_utils.py", source_files)
+        self.assertEqual(result, "src/utils.py")
+
+    def test_test_suffix(self):
+        source_files = {"handler.go"}
+        result = _match_test_to_source_path("handler_test.go", source_files)
+        self.assertEqual(result, "handler.go")
+
+    def test_spec_suffix(self):
+        source_files = {"src/Button.tsx"}
+        result = _match_test_to_source_path("src/Button.spec.tsx", source_files)
+        self.assertEqual(result, "src/Button.tsx")
+
+    def test_same_directory(self):
+        source_files = {"pkg/server.go"}
+        result = _match_test_to_source_path("pkg/server_test.go", source_files)
+        self.assertEqual(result, "pkg/server.go")
+
+    def test_no_match(self):
+        source_files = {"src/other.py"}
+        result = _match_test_to_source_path("tests/test_utils.py", source_files)
+        self.assertIsNone(result)
+
+    def test_no_transformation(self):
+        """File without test prefix/suffix returns None."""
+        source_files = {"src/utils.py"}
+        result = _match_test_to_source_path("src/utils.py", source_files)
+        self.assertIsNone(result)
+
+
+class TestResolveImportsNonRelative(unittest.TestCase):
+    """Tests for resolve_imports — non-relative paths, Go modules, inheritance."""
+
+    def test_module_to_file_resolution(self):
+        symbols = []
+        edges = [Edge("file:main.py", "module:pkg.utils", "imports")]
+        file_map = {"main.py": "python", "pkg/utils.py": "python"}
+        result = resolve_imports(symbols, edges, file_map, [])
+        resolved = [e for e in result if e.type == "imports"]
+        self.assertTrue(any(e.target == "file:pkg/utils.py" for e in resolved))
+
+    def test_go_module_prefix_stripping(self):
+        symbols = []
+        edges = [Edge("file:cmd/main.go", "module:github.com/org/repo/pkg/util", "imports")]
+        file_map = {"cmd/main.go": "go", "pkg/util/util.go": "go"}
+        boundary = ModuleBoundary(root_dir="", build_file="go.mod",
+                                  name="github.com/org/repo", language="go")
+        result = resolve_imports(symbols, edges, file_map, [boundary])
+        resolved = [e for e in result if e.type == "imports"]
+        self.assertTrue(any(e.target == "file:pkg/util/util.go" for e in resolved))
+
+    def test_inheritance_resolution(self):
+        parent = Symbol(
+            id="class:a.py:Base", type="class", name="Base",
+            file="a.py", language="python", line_start=1, line_end=10,
+        )
+        child = Symbol(
+            id="class:b.py:Child", type="class", name="Child",
+            file="b.py", language="python", line_start=1, line_end=10, bases=["Base"],
+        )
+        edges = [Edge("class:b.py:Child", "class:?:Base", "inherits", {"unresolved": True})]
+        result = resolve_imports([parent, child], edges, {"a.py": "python", "b.py": "python"}, [])
+        inherits = [e for e in result if e.type == "inherits"]
+        self.assertEqual(len(inherits), 1)
+        self.assertEqual(inherits[0].target, "class:a.py:Base")
+        self.assertFalse(inherits[0].metadata.get("unresolved", False))
+
+    def test_inheritance_same_file_disambiguation(self):
+        """When multiple classes share a name, prefer the one in the same file."""
+        base_a = Symbol(
+            id="class:a.py:Base", type="class", name="Base",
+            file="a.py", language="python", line_start=1, line_end=10,
+        )
+        base_c = Symbol(
+            id="class:c.py:Base", type="class", name="Base",
+            file="c.py", language="python", line_start=1, line_end=10,
+        )
+        child = Symbol(
+            id="class:a.py:Child", type="class", name="Child",
+            file="a.py", language="python", line_start=15, line_end=25, bases=["Base"],
+        )
+        edges = [Edge("class:a.py:Child", "class:?:Base", "inherits", {"unresolved": True})]
+        result = resolve_imports([base_a, base_c, child], edges,
+                                 {"a.py": "python", "c.py": "python"}, [])
+        inherits = [e for e in result if e.type == "inherits"]
+        self.assertEqual(inherits[0].target, "class:a.py:Base")
+
+    def test_non_import_edges_passed_through(self):
+        edges = [
+            Edge("file:a.py", "function:a.py:foo", "contains"),
+            Edge("function:a.py:foo", "function:b.py:bar", "calls"),
+        ]
+        result = resolve_imports([], edges, {"a.py": "python", "b.py": "python"}, [])
+        types = {e.type for e in result}
+        self.assertIn("contains", types)
+        self.assertIn("calls", types)
+
+
+class TestComputeDirectoryStats(unittest.TestCase):
+    """Tests for compute_directory_stats."""
+
+    def test_basic_stats(self):
+        files = [
+            ("/abs/src/a.py", "src/a.py", "python", False),
+            ("/abs/src/b.py", "src/b.py", "python", False),
+            ("/abs/tests/test_a.py", "tests/test_a.py", "python", True),
+        ]
+        symbols = [
+            Symbol(id="class:src/a.py:Foo", type="class", name="Foo",
+                   file="src/a.py", language="python", line_start=1, line_end=10),
+            Symbol(id="function:src/a.py:bar", type="function", name="bar",
+                   file="src/a.py", language="python", line_start=15, line_end=20),
+        ]
+        stats = compute_directory_stats(files, symbols)
+        self.assertIn("src", stats)
+        self.assertIn("tests", stats)
+        self.assertEqual(stats["src"]["files"], 2)
+        self.assertEqual(stats["src"]["test_files"], 0)
+        self.assertEqual(stats["tests"]["test_files"], 1)
+        self.assertEqual(stats["src"]["classes"], 1)
+        self.assertEqual(stats["src"]["functions"], 1)
+        self.assertIn("python", stats["src"]["languages"])
+
+
+class TestComputeGraphStats(unittest.TestCase):
+    """Tests for compute_graph_stats."""
+
+    def test_counts(self):
+        files = [
+            ("/a", "a.py", "python", False),
+            ("/b", "b.go", "go", False),
+            ("/t", "test_a.py", "python", True),
+        ]
+        symbols = [
+            Symbol(id="f:a.py:foo", type="function", name="foo",
+                   file="a.py", language="python", line_start=1, line_end=5),
+            Symbol(id="c:a.py:Bar", type="class", name="Bar",
+                   file="a.py", language="python", line_start=10, line_end=20),
+        ]
+        edges = [
+            Edge("file:a.py", "f:a.py:foo", "contains"),
+            Edge("file:b.go", "file:a.py", "imports"),
+        ]
+        stats = compute_graph_stats(symbols, edges, files)
+        self.assertEqual(stats["lang_counts"]["python"], 2)
+        self.assertEqual(stats["lang_counts"]["go"], 1)
+        self.assertEqual(stats["type_counts"]["function"], 1)
+        self.assertEqual(stats["type_counts"]["class"], 1)
+        self.assertEqual(stats["edge_type_counts"]["contains"], 1)
+        self.assertEqual(stats["edge_type_counts"]["imports"], 1)
+        self.assertEqual(stats["test_count"], 1)
+
+
+class TestGenerateTagsJson(unittest.TestCase):
+    """Tests for generate_tags_json output."""
+
+    def test_basic_tags(self):
+        symbols = [
+            Symbol(id="function:b.py:bar", type="function", name="bar",
+                   file="b.py", language="python", line_start=5, line_end=15,
+                   params=["x", "y"], signature="(x, y)"),
+            Symbol(id="class:a.py:Foo", type="class", name="Foo",
+                   file="a.py", language="python", line_start=1, line_end=10,
+                   bases=["Base"], docstring="A foo class."),
+        ]
+        tags = generate_tags_json(symbols)
+        # Should be sorted by file then line
+        self.assertEqual(tags[0]["file"], "a.py")
+        self.assertEqual(tags[1]["file"], "b.py")
+        # Check fields present
+        foo_tag = tags[0]
+        self.assertEqual(foo_tag["name"], "Foo")
+        self.assertEqual(foo_tag["bases"], ["Base"])
+        self.assertEqual(foo_tag["doc"], "A foo class.")
+        bar_tag = tags[1]
+        self.assertEqual(bar_tag["params"], ["x", "y"])
+        self.assertEqual(bar_tag["signature"], "(x, y)")
+
+    def test_private_flag(self):
+        sym = Symbol(id="function:a.py:_helper", type="function", name="_helper",
+                     file="a.py", language="python", line_start=1, line_end=3,
+                     exported=False)
+        tags = generate_tags_json([sym])
+        self.assertTrue(tags[0].get("private"))
+
+    def test_test_flag(self):
+        sym = Symbol(id="function:test_a.py:test_foo", type="function", name="test_foo",
+                     file="test_a.py", language="python", line_start=1, line_end=3,
+                     is_test=True)
+        tags = generate_tags_json([sym])
+        self.assertTrue(tags[0].get("is_test"))
+
+    def test_optional_fields_omitted(self):
+        sym = Symbol(id="function:a.py:simple", type="function", name="simple",
+                     file="a.py", language="python", line_start=1, line_end=2)
+        tags = generate_tags_json([sym])
+        self.assertNotIn("scope", tags[0])
+        self.assertNotIn("params", tags[0])
+        self.assertNotIn("bases", tags[0])
+        self.assertNotIn("doc", tags[0])
+        self.assertNotIn("signature", tags[0])
+
+
+class TestDetectTestRelationships(unittest.TestCase):
+    """Tests for detect_test_relationships beyond qualified matching."""
+
+    def test_path_mirror_strategy(self):
+        files = [
+            ("/abs/src/utils.py", "src/utils.py", "python", False),
+            ("/abs/tests/test_utils.py", "tests/test_utils.py", "python", True),
+        ]
+        test_edges = detect_test_relationships([], [], files, {})
+        path_edges = [e for e in test_edges if e.metadata.get("strategy") == "path_mirror"]
+        self.assertEqual(len(path_edges), 1)
+        self.assertEqual(path_edges[0].source, "file:tests/test_utils.py")
+        self.assertEqual(path_edges[0].target, "file:src/utils.py")
+
+    def test_no_duplicate_edges(self):
+        """Same test-source pair should not produce duplicate edges."""
+        source_func = Symbol(
+            id="function:src/utils.py:parse", type="function", name="parse",
+            file="src/utils.py", language="python", line_start=1, line_end=5,
+            is_test=False,
+        )
+        test_func = Symbol(
+            id="function:tests/test_utils.py:test_parse", type="function", name="test_parse",
+            file="tests/test_utils.py", language="python", line_start=1, line_end=5,
+            is_test=True,
+        )
+        files = [
+            ("/abs/src/utils.py", "src/utils.py", "python", False),
+            ("/abs/tests/test_utils.py", "tests/test_utils.py", "python", True),
+        ]
+        test_edges = detect_test_relationships(
+            [source_func, test_func], [], files, {},
+        )
+        # Count unique (source, target) pairs
+        pairs = [(e.source, e.target) for e in test_edges]
+        self.assertEqual(len(pairs), len(set(pairs)))
+
+
+class TestResolveCallsBeforeImportNormalization(unittest.TestCase):
+    """Validate that call resolution depends on raw module:/symbol: import
+    edges.  If resolve_imports() runs first, those edges are rewritten to
+    file: targets and resolve_calls() can no longer recover alias info."""
+
+    def _build_scenario(self):
+        """Two files: pkg1/a.py defines foo(), main.py imports and calls it.
+
+        Returns (symbols, raw_edges, call_refs, file_map).
+        raw_edges contain the original module:/symbol: targets that
+        parse_python would emit.
+        """
+        sym_foo = Symbol(
+            id="function:pkg1/a.py:foo", type="function", name="foo",
+            file="pkg1/a.py", language="python", line_start=1, line_end=5,
+        )
+        sym_main = Symbol(
+            id="function:main.py:do_work", type="function", name="do_work",
+            file="main.py", language="python", line_start=1, line_end=10,
+        )
+        symbols = [sym_foo, sym_main]
+
+        # Edges as emitted by parse_python (before resolve_imports)
+        raw_edges = [
+            Edge("file:main.py", "module:pkg1.a", "imports"),
+            Edge("file:main.py", "symbol:pkg1.a.foo", "imports",
+                 {"from_import": True}),
+            Edge("file:main.py", "function:main.py:do_work", "contains"),
+            Edge("file:pkg1/a.py", "function:pkg1/a.py:foo", "contains"),
+        ]
+
+        # do_work() calls foo() — unqualified, relying on the from-import
+        call_refs = [
+            CallRef("function:main.py:do_work", "foo", 5, "main.py"),
+        ]
+
+        file_map = {"main.py": "python", "pkg1/a.py": "python"}
+        return symbols, raw_edges, call_refs, file_map
+
+    def test_resolve_calls_before_imports_succeeds(self):
+        """Correct order: resolve_calls THEN resolve_imports."""
+        symbols, raw_edges, call_refs, file_map = self._build_scenario()
+
+        # Step 1: resolve calls while raw module:/symbol: edges exist
+        call_edges = resolve_calls(call_refs, symbols, raw_edges, file_map)
+
+        # Step 2: normalize imports
+        all_edges = raw_edges + call_edges
+        all_edges = resolve_imports(symbols, all_edges, file_map, [])
+
+        # The call from do_work -> foo must be present
+        calls = [e for e in all_edges if e.type == "calls"]
+        self.assertEqual(len(calls), 1,
+                         "do_work() -> foo() call edge must be resolved")
+        self.assertEqual(calls[0].source, "function:main.py:do_work")
+        self.assertEqual(calls[0].target, "function:pkg1/a.py:foo")
+
+    def test_resolve_calls_after_imports_loses_alias(self):
+        """Wrong order: resolve_imports THEN resolve_calls — alias is lost."""
+        symbols, raw_edges, call_refs, file_map = self._build_scenario()
+
+        # Step 1: normalize imports first (rewrites module:/symbol: -> file:)
+        normalized_edges = resolve_imports(symbols, raw_edges, file_map, [])
+
+        # Verify the raw alias edges are gone
+        alias_edges = [
+            e for e in normalized_edges
+            if e.target.startswith("symbol:") or e.target.startswith("module:")
+        ]
+        self.assertEqual(len(alias_edges), 0,
+                         "After resolve_imports, module:/symbol: targets "
+                         "should be rewritten")
+
+        # Step 2: resolve calls — can no longer find alias info
+        call_edges = resolve_calls(call_refs, symbols, normalized_edges,
+                                   file_map)
+
+        # With the bug, foo() is NOT resolvable via import alias because
+        # the symbol:pkg1.a.foo edge was rewritten to file:pkg1/a.py or
+        # function:pkg1/a.py:foo.  resolve_calls only checks symbol: and
+        # module: targets for building file_imports, so alias lookup fails.
+        #
+        # The call might still resolve via the last-resort global name
+        # match (strategy 4) IF foo is unique.  To make the test robust
+        # we add a second foo() so global name match is ambiguous.
+        pass
+
+    def test_ambiguous_name_needs_alias(self):
+        """Two different foo() definitions — only import alias disambiguates."""
+        sym_foo1 = Symbol(
+            id="function:pkg1/a.py:foo", type="function", name="foo",
+            file="pkg1/a.py", language="python", line_start=1, line_end=5,
+        )
+        sym_foo2 = Symbol(
+            id="function:pkg2/b.py:foo", type="function", name="foo",
+            file="pkg2/b.py", language="python", line_start=1, line_end=5,
+        )
+        sym_main = Symbol(
+            id="function:main.py:do_work", type="function", name="do_work",
+            file="main.py", language="python", line_start=1, line_end=10,
+        )
+        symbols = [sym_foo1, sym_foo2, sym_main]
+
+        raw_edges = [
+            Edge("file:main.py", "module:pkg1.a", "imports"),
+            Edge("file:main.py", "symbol:pkg1.a.foo", "imports",
+                 {"from_import": True}),
+            Edge("file:main.py", "function:main.py:do_work", "contains"),
+        ]
+
+        call_refs = [
+            CallRef("function:main.py:do_work", "foo", 5, "main.py"),
+        ]
+        file_map = {
+            "main.py": "python",
+            "pkg1/a.py": "python",
+            "pkg2/b.py": "python",
+        }
+
+        # Correct order: calls first, imports second
+        call_edges = resolve_calls(call_refs, symbols, raw_edges, file_map)
+        self.assertEqual(len(call_edges), 1,
+                         "With raw import edges, alias resolves to pkg1.a.foo")
+        self.assertEqual(call_edges[0].target, "function:pkg1/a.py:foo")
+
+        # Wrong order: imports first, calls second
+        normalized = resolve_imports(symbols, list(raw_edges), file_map, [])
+        bad_call_edges = resolve_calls(call_refs, symbols, normalized,
+                                       file_map)
+        # With two foo() definitions and no alias info, last-resort name
+        # match refuses to guess (candidates > 1), so the call is lost.
+        self.assertEqual(len(bad_call_edges), 0,
+                         "After import normalization, ambiguous foo() cannot "
+                         "be resolved — demonstrates the bug")
+
+    def test_module_import_alias_resolution(self):
+        """import pkg1.a; pkg1.a.foo() should resolve via module: edge."""
+        sym_foo = Symbol(
+            id="function:pkg1/a.py:foo", type="function", name="foo",
+            file="pkg1/a.py", language="python", line_start=1, line_end=5,
+        )
+        sym_main = Symbol(
+            id="function:main.py:caller", type="function", name="caller",
+            file="main.py", language="python", line_start=1, line_end=10,
+        )
+        symbols = [sym_foo, sym_main]
+
+        raw_edges = [
+            Edge("file:main.py", "module:pkg1.a", "imports"),
+        ]
+        call_refs = [
+            CallRef("function:main.py:caller", "a.foo", 5, "main.py"),
+        ]
+        file_map = {"main.py": "python", "pkg1/a.py": "python"}
+
+        # Correct order
+        call_edges = resolve_calls(call_refs, symbols, raw_edges, file_map)
+        self.assertEqual(len(call_edges), 1)
+        self.assertEqual(call_edges[0].target, "function:pkg1/a.py:foo")
+
+    def test_end_to_end_parse_and_resolve(self):
+        """Full pipeline: parse Python, resolve calls, resolve imports."""
+        code_a = textwrap.dedent("""\
+            def foo():
+                return 42
+        """)
+        code_main = textwrap.dedent("""\
+            from pkg1.a import foo
+
+            def do_work():
+                result = foo()
+                return result
+        """)
+
+        syms_a, edges_a, calls_a = parse_python(code_a, "pkg1/a.py", False)
+        syms_main, edges_main, calls_main = parse_python(
+            code_main, "main.py", False,
+        )
+
+        all_symbols = syms_a + syms_main
+        all_edges = edges_a + edges_main
+        all_calls = calls_a + calls_main
+        file_map = {"main.py": "python", "pkg1/a.py": "python"}
+
+        # Verify parse produced the expected raw import edges
+        symbol_imports = [
+            e for e in all_edges
+            if e.target.startswith("symbol:") and e.type == "imports"
+        ]
+        self.assertTrue(len(symbol_imports) > 0,
+                        "parse_python should emit symbol: import edges")
+
+        # Correct order: calls before imports
+        call_edges = resolve_calls(all_calls, all_symbols, all_edges,
+                                   file_map)
+        all_edges.extend(call_edges)
+        all_edges = resolve_imports(all_symbols, all_edges, file_map, [])
+
+        calls = [e for e in all_edges if e.type == "calls"]
+        self.assertTrue(
+            any(e.source == "function:main.py:do_work"
+                and e.target == "function:pkg1/a.py:foo"
+                for e in calls),
+            "do_work -> foo call edge must survive the full pipeline",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/code-tree/test_query_graph.py
+++ b/tools/code-tree/test_query_graph.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Unit tests for query_graph.py — covers start-ID resolution, BFS depth
+limiting, edge-type filtering, and output determinism."""
+
+import json
+import os
+import tempfile
+import unittest
+
+from query_graph import GraphQuery
+
+
+def _build_test_graph():
+    """Build a minimal but representative graph for testing."""
+    return {
+        "metadata": {
+            "repo_root": "/fake",
+            "total_files": 5,
+            "total_symbols": 8,
+            "languages": {"python": 3, "go": 2},
+            "symbol_types": {"function": 4, "class": 2, "method": 2},
+            "edge_types": {"imports": 4, "calls": 3, "tests": 2, "inherits": 1, "contains": 5},
+            "generated_at": "2026-01-01T00:00:00",
+        },
+        "nodes": [
+            {"id": "file:src/a.py", "type": "file", "name": "a.py", "path": "src/a.py", "language": "python"},
+            {"id": "file:src/b.py", "type": "file", "name": "b.py", "path": "src/b.py", "language": "python"},
+            {"id": "file:src/c.py", "type": "file", "name": "c.py", "path": "src/c.py", "language": "python"},
+            {"id": "file:tests/test_a.py", "type": "file", "name": "test_a.py", "path": "tests/test_a.py", "language": "python", "is_test": True},
+            {"id": "file:pkg/d.go", "type": "file", "name": "d.go", "path": "pkg/d.go", "language": "go"},
+            {"id": "function:src/a.py:foo", "type": "function", "name": "foo", "file": "src/a.py", "language": "python", "line_start": 10, "line_end": 20},
+            {"id": "function:src/b.py:bar", "type": "function", "name": "bar", "file": "src/b.py", "language": "python", "line_start": 5, "line_end": 15},
+            {"id": "function:src/c.py:baz", "type": "function", "name": "baz", "file": "src/c.py", "language": "python", "line_start": 1, "line_end": 8},
+            {"id": "class:src/a.py:Base", "type": "class", "name": "Base", "file": "src/a.py", "language": "python", "line_start": 25, "line_end": 50},
+            {"id": "class:src/b.py:Child", "type": "class", "name": "Child", "file": "src/b.py", "language": "python", "line_start": 20, "line_end": 40, "bases": ["Base"]},
+            {"id": "method:src/b.py:Child.process", "type": "method", "name": "process", "file": "src/b.py", "language": "python", "line_start": 25, "line_end": 35, "scope": "Child"},
+            {"id": "function:pkg/d.go:Handle", "type": "function", "name": "Handle", "file": "pkg/d.go", "language": "go", "line_start": 10, "line_end": 30},
+        ],
+        "edges": [
+            # imports: b imports a, c imports b, d imports a
+            {"source": "file:src/b.py", "target": "file:src/a.py", "type": "imports"},
+            {"source": "file:src/c.py", "target": "file:src/b.py", "type": "imports"},
+            {"source": "file:pkg/d.go", "target": "file:src/a.py", "type": "imports"},
+            # calls: bar -> foo, baz -> bar, Handle -> foo
+            {"source": "function:src/b.py:bar", "target": "function:src/a.py:foo", "type": "calls", "metadata": {"line": 8}},
+            {"source": "function:src/c.py:baz", "target": "function:src/b.py:bar", "type": "calls", "metadata": {"line": 3}},
+            {"source": "function:pkg/d.go:Handle", "target": "function:src/a.py:foo", "type": "calls", "metadata": {"line": 15}},
+            # inherits: Child -> Base
+            {"source": "class:src/b.py:Child", "target": "class:src/a.py:Base", "type": "inherits"},
+            # tests: test_a tests a.py and foo
+            {"source": "file:tests/test_a.py", "target": "file:src/a.py", "type": "tests", "metadata": {"strategy": "path_mirror"}},
+            {"source": "file:tests/test_a.py", "target": "function:src/a.py:foo", "type": "tests", "metadata": {"strategy": "name_match"}},
+            # contains
+            {"source": "file:src/a.py", "target": "function:src/a.py:foo", "type": "contains"},
+            {"source": "file:src/a.py", "target": "class:src/a.py:Base", "type": "contains"},
+            {"source": "file:src/b.py", "target": "function:src/b.py:bar", "type": "contains"},
+            {"source": "file:src/b.py", "target": "class:src/b.py:Child", "type": "contains"},
+            {"source": "class:src/b.py:Child", "target": "method:src/b.py:Child.process", "type": "contains"},
+        ],
+    }
+
+
+def _build_test_tags():
+    """Build tags matching the test graph."""
+    return [
+        {"name": "foo", "type": "function", "file": "src/a.py", "line": 10, "end_line": 20, "language": "python"},
+        {"name": "bar", "type": "function", "file": "src/b.py", "line": 5, "end_line": 15, "language": "python"},
+        {"name": "baz", "type": "function", "file": "src/c.py", "line": 1, "end_line": 8, "language": "python"},
+        {"name": "Base", "type": "class", "file": "src/a.py", "line": 25, "end_line": 50, "language": "python"},
+        {"name": "Child", "type": "class", "file": "src/b.py", "line": 20, "end_line": 40, "language": "python", "bases": ["Base"]},
+        {"name": "process", "type": "method", "file": "src/b.py", "line": 25, "end_line": 35, "language": "python", "scope": "Child"},
+        {"name": "Handle", "type": "function", "file": "pkg/d.go", "line": 10, "end_line": 30, "language": "go"},
+    ]
+
+
+class TestGraphQuery(unittest.TestCase):
+    """Tests for GraphQuery using an in-memory test graph."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Write test graph artifacts to a temp directory."""
+        cls._tmpdir_obj = tempfile.TemporaryDirectory()
+        cls.tmpdir = cls._tmpdir_obj.name
+        with open(os.path.join(cls.tmpdir, "graph.json"), "w", encoding="utf-8") as f:
+            json.dump(_build_test_graph(), f)
+        with open(os.path.join(cls.tmpdir, "tags.json"), "w", encoding="utf-8") as f:
+            json.dump(_build_test_tags(), f)
+        with open(os.path.join(cls.tmpdir, "modules.json"), "w", encoding="utf-8") as f:
+            json.dump({"modules": {
+                "src": {"files": ["src/a.py", "src/b.py", "src/c.py"], "depends_on": []},
+                "pkg": {"files": ["pkg/d.go"], "depends_on": ["src"]},
+            }}, f)
+        cls.gq = GraphQuery(cls.tmpdir, "/fake")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up the temporary directory."""
+        cls._tmpdir_obj.cleanup()
+
+    # ── Start-ID resolution ──────────────────────────────────────
+
+    def test_impact_resolves_file_path(self):
+        """Impact analysis should resolve a file path to its file node and contained symbols."""
+        impact = self.gq.get_impact("src/a.py", max_depth=1)
+        self.assertNotIn("error", impact)
+        # b.py imports a.py, d.go imports a.py
+        self.assertIn("src/b.py", impact["affected_files"])
+        self.assertIn("pkg/d.go", impact["affected_files"])
+
+    def test_impact_resolves_symbol_name(self):
+        """Impact analysis should resolve a symbol name and find its dependents."""
+        impact = self.gq.get_impact("foo", max_depth=1)
+        self.assertNotIn("error", impact)
+        # bar calls foo, Handle calls foo
+        affected_names = [s["name"] for s in impact["affected_symbols"]]
+        self.assertIn("bar", affected_names)
+        self.assertIn("Handle", affected_names)
+
+    def test_impact_unknown_target_returns_error(self):
+        """Impact analysis on a nonexistent target should return an error."""
+        impact = self.gq.get_impact("nonexistent_symbol_xyz")
+        self.assertIn("error", impact)
+
+    # ── BFS depth limiting ───────────────────────────────────────
+
+    def test_impact_depth_1_excludes_transitive(self):
+        """Depth 1 should find direct dependents only, not transitive ones."""
+        impact = self.gq.get_impact("src/a.py", max_depth=1)
+        # c.py depends on b.py which depends on a.py — transitive, should NOT appear at depth 1
+        self.assertNotIn("src/c.py", impact["affected_files"])
+
+    def test_impact_depth_2_includes_transitive(self):
+        """Depth 2 should find transitive dependents through one hop."""
+        impact = self.gq.get_impact("src/a.py", max_depth=2)
+        # c.py imports b.py which imports a.py — should appear at depth 2
+        self.assertIn("src/c.py", impact["affected_files"])
+
+    def test_impact_depth_0_returns_no_affected(self):
+        """Depth 0 should return only origin nodes, no affected items."""
+        impact = self.gq.get_impact("src/a.py", max_depth=0)
+        self.assertEqual(impact["total_affected_files"], 0)
+        self.assertEqual(impact["total_affected_symbols"], 0)
+
+    # ── Edge-type filtering ──────────────────────────────────────
+
+    def test_impact_follows_imports(self):
+        """Impact BFS should follow import edges."""
+        impact = self.gq.get_impact("src/a.py", max_depth=1)
+        self.assertIn("src/b.py", impact["affected_files"])
+
+    def test_impact_follows_calls(self):
+        """Impact BFS should follow call edges."""
+        impact = self.gq.get_impact("foo", max_depth=1)
+        affected_names = [s["name"] for s in impact["affected_symbols"]]
+        self.assertIn("bar", affected_names)
+
+    def test_impact_follows_inherits(self):
+        """Impact BFS should follow inheritance edges."""
+        impact = self.gq.get_impact("Base", max_depth=1)
+        affected_names = [s["name"] for s in impact["affected_symbols"]]
+        self.assertIn("Child", affected_names)
+
+    def test_impact_does_not_follow_contains(self):
+        """Impact BFS should not follow 'contains' edges (not a dependency)."""
+        impact = self.gq.get_impact("foo", max_depth=5)
+        # 'contains' edge from file:src/a.py -> function:foo should NOT make
+        # a.py appear as affected by foo
+        affected_names = [s["name"] for s in impact["affected_symbols"]]
+        self.assertNotIn("Base", affected_names)  # Base is contained by a.py, not dependent on foo
+
+    def test_impact_does_not_follow_tests(self):
+        """Impact BFS should not follow 'tests' edges as dependency edges."""
+        # tests edges are separate from dependency edges
+        impact = self.gq.get_impact("src/a.py", max_depth=1)
+        # test_a.py tests a.py, but tests is not a dependency direction for impact
+        affected_names = [s["name"] for s in impact["affected_symbols"]]
+        # The test file should NOT appear in affected_symbols (it's not importing/calling a.py)
+        # But it appears in affected_files via import — let's check edge types used
+        # Actually tests/test_a.py has a "tests" edge, not "imports", so it should NOT appear
+        self.assertNotIn("tests/test_a.py", impact["affected_files"])
+
+    # ── Test impact ──────────────────────────────────────────────
+
+    def test_test_impact_finds_test_files(self):
+        """Test impact should find tests for affected code."""
+        ti = self.gq.get_test_impact("src/a.py")
+        self.assertNotIn("error", ti)
+        self.assertIn("tests/test_a.py", ti["affected_test_files"])
+
+    def test_test_impact_by_symbol(self):
+        """Test impact should work with symbol names."""
+        ti = self.gq.get_test_impact("foo")
+        self.assertNotIn("error", ti)
+        self.assertGreaterEqual(ti["total_test_files"], 1)
+
+    # ── Symbol lookup ────────────────────────────────────────────
+
+    def test_find_symbol_exact(self):
+        """Exact symbol lookup should return matching nodes."""
+        results = self.gq.find_symbol("foo")
+        self.assertTrue(len(results) >= 1)
+        self.assertEqual(results[0]["name"], "foo")
+
+    def test_find_symbol_partial(self):
+        """Partial symbol lookup should work as fallback."""
+        results = self.gq.find_symbol("Handl")
+        self.assertTrue(len(results) >= 1)
+        names = [r["name"] for r in results]
+        self.assertIn("Handle", names)
+
+    def test_find_symbol_not_found(self):
+        """Missing symbol should return empty list."""
+        results = self.gq.find_symbol("totally_nonexistent_xyz_123")
+        self.assertEqual(len(results), 0)
+
+    # ── Dependency queries ───────────────────────────────────────
+
+    def test_get_dependencies(self):
+        """get_dependencies should return files imported by a given file."""
+        deps = self.gq.get_dependencies("src/b.py")
+        self.assertIn("src/a.py", deps["imports"])
+
+    def test_get_reverse_dependencies(self):
+        """get_reverse_dependencies should return files that import a given file."""
+        rdeps = self.gq.get_reverse_dependencies("src/a.py")
+        self.assertIn("src/b.py", rdeps)
+        self.assertIn("pkg/d.go", rdeps)
+
+    # ── Call graph ───────────────────────────────────────────────
+
+    def test_get_callers(self):
+        """get_callers should find functions that call a given symbol."""
+        callers = self.gq.get_callers("foo")
+        caller_names = [c["caller"] for c in callers]
+        self.assertIn("bar", caller_names)
+        self.assertIn("Handle", caller_names)
+
+    def test_get_callees(self):
+        """get_callees should find functions called by a given symbol."""
+        callees = self.gq.get_callees("bar")
+        callee_names = [c["callee"] for c in callees]
+        self.assertIn("foo", callee_names)
+
+    def test_call_chain(self):
+        """get_call_chain should find paths between symbols."""
+        chains = self.gq.get_call_chain("baz", "foo")
+        self.assertTrue(len(chains) >= 1)
+        # baz -> bar -> foo
+        self.assertEqual(len(chains[0]), 3)
+
+    # ── Hierarchy ────────────────────────────────────────────────
+
+    def test_hierarchy_descendants(self):
+        """Hierarchy should show classes that inherit from a base."""
+        h = self.gq.get_hierarchy("Base")
+        descendant_names = [d["name"] for d in h["descendants"]]
+        self.assertIn("Child", descendant_names)
+
+    def test_hierarchy_ancestors(self):
+        """Hierarchy should show parent classes."""
+        h = self.gq.get_hierarchy("Child")
+        ancestor_names = [a["name"] for a in h["ancestors"]]
+        self.assertIn("Base", ancestor_names)
+
+    # ── Output determinism ───────────────────────────────────────
+
+    def test_reverse_deps_sorted(self):
+        """Reverse dependencies should be returned in sorted order."""
+        rdeps = self.gq.get_reverse_dependencies("src/a.py")
+        self.assertEqual(rdeps, sorted(rdeps))
+
+    def test_impact_files_sorted(self):
+        """Impact affected_files should be returned in sorted order."""
+        impact = self.gq.get_impact("src/a.py", max_depth=3)
+        self.assertEqual(impact["affected_files"], sorted(impact["affected_files"]))
+
+    def test_impact_symbols_sorted_by_depth(self):
+        """Impact affected_symbols should be sorted by depth."""
+        impact = self.gq.get_impact("src/a.py", max_depth=3)
+        depths = [s["depth"] for s in impact["affected_symbols"]]
+        self.assertEqual(depths, sorted(depths))
+
+    def test_callers_sorted_by_file_and_line(self):
+        """Callers should be sorted by file then line for deterministic output."""
+        callers = self.gq.get_callers("foo")
+        keys = [(str(c.get("file", "")), c.get("line", 0)) for c in callers]
+        self.assertEqual(keys, sorted(keys))
+
+    # ── Test coverage ────────────────────────────────────────────
+
+    def test_get_test_coverage(self):
+        """get_test_coverage should find tests for a file."""
+        cov = self.gq.get_test_coverage("src/a.py")
+        self.assertGreaterEqual(cov["total"], 1)
+        test_files = [t["test"] for t in cov["tests"]]
+        self.assertTrue(any("test_a" in t for t in test_files))
+
+    # ── Search ───────────────────────────────────────────────────
+
+    def test_search_by_name(self):
+        """Search should find symbols by name."""
+        results = self.gq.search("bar")
+        names = [r["name"] for r in results]
+        self.assertIn("bar", names)
+
+    def test_search_by_file_path(self):
+        """Search should match on file paths."""
+        results = self.gq.search("pkg/d")
+        self.assertTrue(len(results) >= 1)
+
+    # ── Module overview ──────────────────────────────────────────
+
+    def test_get_module_returns_files_and_deps(self):
+        """get_module should return files and dependencies for a known module."""
+        mod = self.gq.get_module("src")
+        self.assertEqual(mod["path"], "src")
+        self.assertIn("src/a.py", mod["files"])
+        self.assertIn("src/b.py", mod["files"])
+
+    def test_get_module_returns_symbols_in_path(self):
+        """get_module should return symbols whose file starts with module path."""
+        mod = self.gq.get_module("src")
+        symbol_names = [s["name"] for s in mod["symbols"]]
+        self.assertIn("foo", symbol_names)
+        self.assertIn("bar", symbol_names)
+        self.assertNotIn("Handle", symbol_names)
+
+    def test_get_module_unknown_returns_empty(self):
+        """get_module for unknown module should return empty lists."""
+        mod = self.gq.get_module("nonexistent")
+        self.assertEqual(mod["files"], [])
+        self.assertEqual(mod["depends_on"], [])
+        self.assertEqual(mod["symbols"], [])
+
+    # ── Entry points ────────────────────────────────────────────
+
+    def test_find_entry_points_returns_list(self):
+        """find_entry_points should return a list of entry point candidates."""
+        entries = self.gq.find_entry_points()
+        self.assertIsInstance(entries, list)
+        for entry in entries:
+            self.assertIn("file", entry)
+            self.assertIn("priority", entry)
+            self.assertIn("symbols", entry)
+
+    def test_find_entry_points_excludes_imported_files(self):
+        """Entry points should not include files that are imported by others."""
+        entries = self.gq.find_entry_points()
+        entry_files = [e["file"] for e in entries]
+        # src/a.py is imported by b.py and d.go — should NOT be an entry point
+        self.assertNotIn("src/a.py", entry_files)
+        # src/b.py is imported by c.py — should NOT be an entry point
+        self.assertNotIn("src/b.py", entry_files)
+
+    # ── Chunk extraction ────────────────────────────────────────
+
+    def test_extract_chunks_file_not_found(self):
+        """extract_chunks should return error for nonexistent file."""
+        chunks = self.gq.extract_chunks("nonexistent/file.py")
+        self.assertEqual(len(chunks), 1)
+        self.assertIn("error", chunks[0])
+
+    def test_extract_chunks_with_real_file(self):
+        """extract_chunks should return symbol-based chunks for an existing file."""
+        with tempfile.TemporaryDirectory() as tmproot:
+            # Create a GraphQuery with a writable repo root
+            src_dir = os.path.join(tmproot, "src")
+            os.makedirs(src_dir)
+            test_file = os.path.join(src_dir, "a.py")
+            with open(test_file, "w", encoding="utf-8") as f:
+                for i in range(50):
+                    f.write(f"# line {i + 1}\n")
+
+            gq = GraphQuery(self.tmpdir, tmproot)
+            chunks = gq.extract_chunks("src/a.py")
+            self.assertTrue(len(chunks) >= 1)
+            for chunk in chunks:
+                self.assertIn("file", chunk)
+                self.assertIn("line_start", chunk)
+                self.assertIn("content", chunk)
+
+    # ── Stats ────────────────────────────────────────────────────
+
+    def test_graph_metadata_present(self):
+        """Graph metadata should be accessible."""
+        meta = self.gq.graph.get("metadata", {})
+        self.assertEqual(meta["total_files"], 5)
+        self.assertEqual(meta["total_symbols"], 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 ### Summary                                                   

  - Restructure monolithic AGENTS.md (600 lines) into a slim entry point (65 lines) with 7 topic-specific guides under docs/agents/, enabling agents to
  load only the context relevant to their current task
  - Add code-tree knowledge graph tooling (tools/code-tree/) with pre-built artifacts (docs/code-tree/) -- 24,766 nodes, 86,988 edges covering 2,736
  files across 7 languages -- for symbol lookup, dependency tracing, impact analysis, and test mapping without reading source files
  - Restructure .github/copilot-instructions.md with batch-based review strategy, context pruning rules, and code-tree integration for PR reviews
  - Add 5 focused review guides under .github/review-guides/ (architecture-context, impact-analysis, language-checklists, security-review, test-quality)
  - Add CLAUDE.md as a task-routing operational playbook for Claude Code sessions with development strategy, validation checklists, and on-demand guide loading

  ### New files

  | Path | Purpose |                                                                                                                                    
  |------|---------|                                                                                                                                    
  | `tools/code-tree/code_tree.py` | Builds knowledge graph from repo (parser + call graph + test mapping) |                                            
  | `tools/code-tree/query_graph.py` | Queries the graph (symbol lookup, deps, impact, callers, hierarchy) |
  | `docs/code-tree/{graph,modules,tags}.json` | Pre-built graph artifacts |                                                                            
  | `docs/code-tree/summary.md` | Architecture overview generated from the graph |                                                                      
  | `docs/agents/*.md` (7 files) | Topic-specific agent guides split from AGENTS.md |
  | `.github/review-guides/*.md` (5 files) | PR review checklists by concern area |
  | `CLAUDE.md` | Claude Code session playbook |

  ### Motivation

  AI agents (Copilot, Claude Code, etc.) working in this monorepo previously loaded the entire 600-line AGENTS.md into context regardless of task. This
  wastes context window and reduces response quality. The new approach:

  1. Load on demand -- agents load only the guide matching their task type
  2. Code-tree first -- query the knowledge graph to locate symbols and assess blast radius before reading source files, reducing unnecessary file reads
  3. Structured PR reviews -- batch files by subsystem, prune context between batches, use impact analysis to flag untested blast radius

### How Knowledge graph is generated:

1. **Discover**

  Walks the repo with os.walk(), finds all source files (.py, .go, .js, .ts, .java, .rs, etc.), skips binary/generated/vendored directories, and detects
   build files (go.mod, package.json, pyproject.toml) as module boundaries.

2. **Parse**

  Extracts symbols (classes, functions, methods, constants) and edges (imports, inheritance, calls) from each file using three parser tiers:
  - Python AST (ast module) — for .py files, most accurate
  - Tree-sitter — for Go/JS/TS/Java/Rust if installed, good accuracy
  - Regex patterns — fallback for everything else

  It also extracts raw call references (e.g., "function A calls something named foo" at line 42).

3. **Resolve**

  - Import resolution: maps import X to the actual file path in the repo
  - Call resolution: matches raw call names (foo, self.bar, pkg.func) to known symbol IDs using same-file lookup, import tracking, and name matching
  - Test mapping: links test files/functions to the source they test via path mirroring (test_foo.py → foo.py), imports, and naming conventions (test_X
  → X)

4. **Output**

  Writes 4 files to docs/code-tree/:
  - graph.json — full knowledge graph (nodes + edges + metadata)
  - tags.json — flat symbol index for quick lookup
  - modules.json — directory-level dependency map
  - summary.md — human-readable overview with hub files, inheritance trees, stats

  **Key data model**

  Symbol  = { id, type, name, file, line_start, line_end, params, bases, ... }
  Edge    = { source, target, type }  # types: contains, imports, inherits, calls, tests
  CallRef = { caller_id, raw_name, line, file }  # unresolved, gets resolved in step 3

  It also supports incremental mode (--incremental): hashes files, compares to previous run, only reparses changed files and merges with cached results.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
