### PR TITLE
fix(frontend): restore initial sidenav auto-collapse behavior

### DIFF
--- a/frontend/src/components/SideNav.test.tsx
+++ b/frontend/src/components/SideNav.test.tsx
@@ -20,7 +20,7 @@ import { act } from 'react-dom/test-utils';
 import { MemoryRouter } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { vi } from 'vitest';
-import { LocalStorage } from '../lib/LocalStorage';
+import { LocalStorage, LocalStorageKey } from '../lib/LocalStorage';
 import { RoutePage } from './Router';
 import { css, SideNav } from './SideNav';
 import { GkeMetadata } from '../lib/GkeMetadata';
@@ -73,6 +73,7 @@ describe('SideNav', () => {
   let localStorageIsCollapsedSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    localStorage.clear();
     localStorageHasKeySpy = vi.spyOn(LocalStorage, 'hasKey').mockImplementation(() => false);
     localStorageIsCollapsedSpy = vi
       .spyOn(LocalStorage, 'isNavbarCollapsed')
@@ -82,6 +83,7 @@ describe('SideNav', () => {
   });
 
   afterEach(() => {
+    localStorage.clear();
     vi.restoreAllMocks();
     (window as any).innerWidth = wideWidth;
   });
@@ -393,5 +395,15 @@ describe('SideNav', () => {
         date: 'unknown',
       }),
     );
+  });
+
+  it('auto-collapses on first load when localStorage key is missing and window is narrow', async () => {
+    localStorageHasKeySpy.mockRestore();
+    localStorageIsCollapsedSpy.mockRestore();
+    localStorage.removeItem(LocalStorageKey.navbarCollapsed);
+    (window as any).innerWidth = narrowWidth;
+
+    const { renderResult } = renderSideNav(RoutePage.COMPARE);
+    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(true));
   });
 });

--- a/frontend/src/lib/LocalStorage.test.ts
+++ b/frontend/src/lib/LocalStorage.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LocalStorage, LocalStorageKey } from './LocalStorage';
+
+describe('LocalStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns false for hasKey when key does not exist', () => {
+    expect(LocalStorage.hasKey(LocalStorageKey.navbarCollapsed)).toBe(false);
+  });
+
+  it('returns true for hasKey when key exists', () => {
+    localStorage.setItem(LocalStorageKey.navbarCollapsed, 'false');
+    expect(LocalStorage.hasKey(LocalStorageKey.navbarCollapsed)).toBe(true);
+  });
+
+  it('reads and writes navbar collapsed state', () => {
+    LocalStorage.saveNavbarCollapsed(true);
+    expect(LocalStorage.isNavbarCollapsed()).toBe(true);
+  });
+});

--- a/frontend/src/lib/LocalStorage.ts
+++ b/frontend/src/lib/LocalStorage.ts
@@ -20,7 +20,7 @@ export enum LocalStorageKey {
 
 export class LocalStorage {
   public static hasKey(key: LocalStorageKey): boolean {
-    return localStorage.getItem(key) !== undefined;
+    return localStorage.getItem(key) !== null;
   }
 
   public static isNavbarCollapsed(): boolean {


### PR DESCRIPTION
## Summary
- fix `LocalStorage.hasKey` to correctly treat missing keys as absent (`getItem(...) !== null`)
- restore first-load SideNav auto-collapse behavior when `navbarCollapsed` has never been set and viewport is narrow
- add LocalStorage unit tests and a SideNav regression test for the missing-key + narrow viewport case

Fixes #12801.

## Testing
- `npm --prefix frontend run test:ui -- src/lib/LocalStorage.test.ts src/components/SideNav.test.tsx`
