### PR TITLE
chore(ci): upgrade kind to v0.31.0 and helm/kind-action to v1.13.0

### DIFF
--- a/.github/actions/create-cluster/action.yml
+++ b/.github/actions/create-cluster/action.yml
@@ -36,21 +36,21 @@ runs:
         docker save kindest/node:${{ inputs.k8s_version }} -o /tmp/kind-node-${{ inputs.k8s_version }}.tar
 
     - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1.12.0
+      uses: helm/kind-action@v1.13.0
       id: cluster-create
       with:
         cluster_name: ${{ inputs.cluster_name }}
         kubectl_version: ${{ inputs.k8s_version }}
-        version: v0.29.0
+        version: v0.31.0
         node_image: kindest/node:${{ inputs.k8s_version }}
         registry: true
 
     - name: Retry Create k8s Kind Cluster
-      uses: helm/kind-action@v1.12.0
+      uses: helm/kind-action@v1.13.0
       if: ${{ steps.cluster-create.outcome == 'failure' }}
       with:
         cluster_name: ${{ inputs.cluster_name }}
         kubectl_version: ${{ inputs.k8s_version }}
-        version: v0.29.0
+        version: v0.31.0
         node_image: kindest/node:${{ inputs.k8s_version }}
         registry: true


### PR DESCRIPTION
## Summary
- Upgrade Kind CLI from v0.29.0 to v0.31.0
- Upgrade `helm/kind-action` from v1.12.0 to v1.13.0

## Test plan
- [ ] Verify CI workflows create Kind clusters successfully with the updated versions
- [ ] Confirm existing e2e and integration tests pass