### PR TITLE
chore(ci): upgrade trivy-action to 0.34.0 and golangci-lint-action to v9

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version-file: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.3
           args: --new --new-from-merge-base=origin/${{ github.base_ref || github.ref_name }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.34.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
## Summary
- Upgrade `aquasecurity/trivy-action` from 0.33.1 to **0.34.0** (includes Trivy v0.69.1)
- Upgrade `golangci/golangci-lint-action` from v8 to **v9** (updated Node.js runtime to node24, added module plugin system support)

## Test plan
- [ ] Verify Trivy scheduled scan workflow runs successfully
- [ ] Verify pre-commit golangci-lint workflow runs on PR

Signed-off-by: Jaison Paul <paul.jaison@gmail.com>