### PR TITLE
chore(ci): upgrade Python from 3.9/3.10 to 3.11 across CI workflows

### DIFF
--- a/.github/workflows/api-server-tests.yml
+++ b/.github/workflows/api-server-tests.yml
@@ -7,7 +7,7 @@ env:
   CLUSTER_NAME: "kfp"
   NAMESPACE: "kubeflow"
   USER_NAMESPACE: "kubeflow-user-example-com"
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.11"
   CA_CERT_PATH: ""
 
 on:

--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -3,7 +3,7 @@ name: Workflow Compiler Tests
 env:
   TESTS_DIR: "./backend/test/compiler"
   TESTS_LABEL: "WorkflowCompiler"
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.11"
 
 on:
   push:

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: 'pip'
 
       - name: Install Dependencies

--- a/.github/workflows/e2e-test-frontend.yml
+++ b/.github/workflows/e2e-test-frontend.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.11'
 
 
       - name: Create KFP cluster

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -4,7 +4,7 @@ env:
   NUMBER_OF_PARALLEL_NODES: 10
   CLUSTER_NAME: "kfp"
   NAMESPACE: "kubeflow"
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.11"
   USER_NAMESPACE: "kubeflow-user-example-com"
   CA_CERT_PATH: ""
 

--- a/.github/workflows/gcpc-modules-tests.yml
+++ b/.github/workflows/gcpc-modules-tests.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.11'
           cache: 'pip'
 
       - name: Install protobuf-compiler

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.11'
 
       - name: Create KFP cluster
         id: create-kfp-cluster

--- a/.github/workflows/kfp-kubernetes-library-test.yml
+++ b/.github/workflows/kfp-kubernetes-library-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         python: [
-          { 'version': '3.9' },
+          { 'version': '3.11' },
           { 'version': '3.13' }
         ]
     steps:

--- a/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
+++ b/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.11"
           cache: 'pip'
 
       - name: Create KFP cluster

--- a/.github/workflows/kfp-sdk-tests.yml
+++ b/.github/workflows/kfp-sdk-tests.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.11', '3.13']
 
     steps:
     - name: Checkout code

--- a/.github/workflows/kfp-sdk-unit-tests.yml
+++ b/.github/workflows/kfp-sdk-unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.11', '3.13']
 
     steps:
     - name: Checkout code

--- a/.github/workflows/legacy-v2-api-integration-tests.yml
+++ b/.github/workflows/legacy-v2-api-integration-tests.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.11'
 
       - name: Create KFP cluster
         id: create-kfp-cluster

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -23,7 +23,7 @@ on:
         description: "Dry run - build packages without publishing to PyPI"
 
 env:
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.11"
 
 jobs:
   publish-kfp-pipeline-spec:

--- a/.github/workflows/readthedocs-builds.yml
+++ b/.github/workflows/readthedocs-builds.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: 'pip'
 
       - name: Install protobuf dependencies & kfp-pipeline-spec

--- a/.github/workflows/sdk-component-yaml.yml
+++ b/.github/workflows/sdk-component-yaml.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.11'
           cache: 'pip'
 
       - name: Install protobuf dependencies

--- a/.github/workflows/sdk-docformatter.yml
+++ b/.github/workflows/sdk-docformatter.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.11'
           cache: 'pip'
 
       - name: Run docformatter tests

--- a/.github/workflows/sdk-isort.yml
+++ b/.github/workflows/sdk-isort.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.11'
           cache: 'pip'
 
       - name: Run isort tests

--- a/.github/workflows/sdk-upgrade.yml
+++ b/.github/workflows/sdk-upgrade.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.11'
           cache: 'pip'
 
       - name: Install protobuf dependencies & kfp-pipeline-spec

--- a/.github/workflows/sdk-yapf.yml
+++ b/.github/workflows/sdk-yapf.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.9'
+        python-version: '3.11'
         cache: 'pip'
 
     - name: Install dependencies

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -6,7 +6,7 @@ env:
   NUMBER_OF_PARALLEL_NODES: 15
   CLUSTER_NAME: "kfp"
   NAMESPACE: "kubeflow"
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.11"
 
 on:
   push:
@@ -52,7 +52,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.11'
 
       - name: Get last release tag
         shell: bash

--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: '3.11'
           cache: 'pip'
 
       - name: Install protobuf dependencies & kfp-pipeline-spec

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,4 +8,4 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"


### PR DESCRIPTION
## Summary
- Upgrade all CI workflow Python versions from **3.9** (EOL Oct 2025) and **3.10** (security-only) to **3.11** (actively maintained)
- Updates 22 files across workflows, matrix tests, environment variables, and `.readthedocs.yml`

### Changes by category:
- **SDK tooling workflows** (yapf, isort, docformatter, component-yaml, upgrade, validate-generated-files): 3.9 -> 3.11
- **Integration/E2E test workflows** (api-server-tests, e2e-test, e2e-test-frontend, integration-tests-v1, legacy-v2-api-integration-tests, upgrade-test, kfp-kubernetes-native-migration-tests): 3.9 -> 3.11
- **SDK matrix tests** (kfp-sdk-unit-tests, kfp-sdk-tests, kfp-kubernetes-library-test): lower bound 3.9 -> 3.11
- **Other workflows** (compiler-tests, gcpc-modules-tests, publish-packages): 3.9 -> 3.11
- **Docs workflows** (readthedocs-builds, docs-freshness): 3.10 -> 3.11
- **ReadTheDocs config** (`.readthedocs.yml`): 3.9 -> 3.11

## Test plan
- [ ] Verify SDK unit tests pass on Python 3.11 and 3.13 matrix
- [ ] Verify SDK tests pass on Python 3.11 and 3.13 matrix
- [ ] Verify tooling workflows (yapf, isort, docformatter) run successfully
- [ ] Verify E2E and integration test workflows run successfully
- [ ] Verify ReadTheDocs build succeeds with Python 3.11

Signed-off-by: Jaison Paul <paul.jaison@gmail.com>