### PR TITLE
chore: upgrade EOL base images (alpine, envoy)

### DIFF
--- a/backend/Dockerfile.cacheserver
+++ b/backend/Dockerfile.cacheserver
@@ -31,7 +31,7 @@ COPY . .
 
 RUN GO111MODULE=on go build -o /bin/cache_server backend/src/cache/*.go
 
-FROM alpine
+FROM alpine:3.21
 
 RUN adduser -S appuser
 USER appuser

--- a/backend/Dockerfile.conformance
+++ b/backend/Dockerfile.conformance
@@ -40,7 +40,7 @@ RUN chmod +x /test/integration/run.sh
 RUN tar -czvf /test.tar.gz /test
 
 
-FROM alpine:3.9
+FROM alpine:3.21
 
 COPY --from=builder /test.tar.gz /
 RUN tar -xzvf /test.tar.gz

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -29,7 +29,7 @@ COPY . .
 
 RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -tags netgo -gcflags="${GCFLAGS}" -ldflags '-extldflags "-static"' -o /bin/driver ./backend/src/v2/cmd/driver/*.go
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 RUN adduser -S -u 65532 appuser
 USER 65532

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -27,7 +27,7 @@ COPY . .
 
 RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -tags netgo -ldflags '-extldflags "-static"' -o /bin/launcher-v2 ./backend/src/v2/cmd/launcher-v2/*.go
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 RUN adduser -S -u 65532 appuser
 USER 65532

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -31,7 +31,7 @@ COPY . .
 
 RUN GO111MODULE=on go build -o /bin/persistence_agent backend/src/agent/persistence/*.go
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 RUN adduser -S appuser
 USER appuser

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -31,7 +31,7 @@ COPY . .
 
 RUN GO111MODULE=on go build -o /bin/controller backend/src/crd/controller/scheduledworkflow/*.go
 
-FROM alpine:3.19
+FROM alpine:3.21
 
 RUN apk --no-cache add tzdata
 

--- a/backend/Dockerfile.viewercontroller
+++ b/backend/Dockerfile.viewercontroller
@@ -30,7 +30,7 @@ COPY . .
 
 RUN GO111MODULE=on go build -o /bin/controller backend/src/crd/controller/viewer/*.go
 
-FROM alpine
+FROM alpine:3.21
 WORKDIR /bin
 
 COPY --from=builder /bin/controller /bin/controller

--- a/test_data/sdk_compiled_pipelines/valid/critical/modelcar/Dockerfile
+++ b/test_data/sdk_compiled_pipelines/valid/critical/modelcar/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install huggingface-hub
 RUN python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='openai/whisper-tiny', local_dir='/models',allow_patterns=['*.safetensors', '*.json', '*.txt'], revision='169d4a4341b33bc18d8881c4b69c2e104e1cc0af')"
 
 # Final image containing only the essential model files
-FROM alpine:3.19
+FROM alpine:3.21
 
 RUN mkdir /models
 

--- a/third_party/metadata_envoy/Dockerfile
+++ b/third_party/metadata_envoy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM envoyproxy/envoy:v1.33.14
+FROM envoyproxy/envoy:v1.37.0
 
 RUN apt-get update -y && \
   apt-get install --no-install-recommends -y -q gettext openssl


### PR DESCRIPTION
## Summary
Upgrade end-of-life and outdated base images in Dockerfiles:

| Dockerfile | Old Image | New Image | Reason |
|-----------|-----------|-----------|--------|
| `backend/Dockerfile.conformance` | `alpine:3.9` | `alpine:3.21` | EOL since Jan 2021 |
| `backend/Dockerfile.driver` | `alpine:3.19` | `alpine:3.21` | EOL |
| `backend/Dockerfile.launcher` | `alpine:3.19` | `alpine:3.21` | EOL |
| `backend/Dockerfile.persistenceagent` | `alpine:3.19` | `alpine:3.21` | EOL |
| `backend/Dockerfile.scheduledworkflow` | `alpine:3.19` | `alpine:3.21` | EOL |
| `backend/Dockerfile.cacheserver` | `alpine` (unpinned) | `alpine:3.21` | Pin for reproducibility |
| `backend/Dockerfile.viewercontroller` | `alpine` (unpinned) | `alpine:3.21` | Pin for reproducibility |
| `third_party/metadata_envoy/Dockerfile` | `envoyproxy/envoy:v1.33.14` | `envoyproxy/envoy:v1.37.0` | v1.33 past 12-month support window |
| `test_data/.../modelcar/Dockerfile` | `alpine:3.19` | `alpine:3.21` | EOL |

### Notes:
- Alpine 3.21 is the latest stable release in the current LTS support window
- Envoy v1.37.0 is the latest stable release (Jan 2026)
- No application code changes, only base image version bumps
- Builder stages (`golang:1.24-alpine`) are not changed as they are already current

## Test plan
- [ ] Verify all backend Docker images build successfully
- [ ] Verify metadata-envoy image builds and starts correctly
- [ ] Run E2E tests to verify no runtime regressions from base image changes

Signed-off-by: Jaison Paul <paul.jaison@gmail.com>