### PR TITLE
fix(ci): exclude Copilot 'Cleanup artifacts' from CI status check

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -30,10 +30,11 @@ jobs:
 
       - name: Check if all CI checks passed
         uses: wechuli/allcheckspassed@0b68b3b7d92e595bcbdea0c860d05605720cf479
-        with:                                 
+        with:
           delay: '5'
           retries: '10'
           polling_interval: '5'
+          checks_exclude: 'Cleanup artifacts'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Save PR payload


### PR DESCRIPTION
## Summary
The GitHub Copilot code review workflow includes a `Cleanup artifacts` job that attempts to delete workflow artifacts. On fork PRs, this fails with **HTTP 403** because the `GITHUB_TOKEN` from a fork doesn't have write permissions on the upstream repo.

This causes `check_ci_status` (`wechuli/allcheckspassed`) to report failure on **every fork PR**, even when all actual CI checks pass.

### Fix
Add `checks_exclude: 'Cleanup artifacts'` to the `wechuli/allcheckspassed` action configuration in `ci-checks.yml`, so the Copilot cleanup job is excluded from CI status evaluation.

### Root cause
```
Cleanup artifacts → gh api -X DELETE /repos/kubeflow/pipelines/actions/artifacts/...
→ HTTP 403: Resource not accessible by integration
```

## Test plan
- [ ] Verify `check_ci_status` passes on this PR (self-validating)
- [ ] Verify other CI checks are still evaluated correctly

Signed-off-by: Jaison Paul <paul.jaison@gmail.com>