### PR TITLE
fix(ci): handle fork PR metadata in frontend e2e freshness check

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -46,6 +46,8 @@ jobs:
             const repo = context.repo.repo;
             const prNumber = context.payload.pull_request.number;
             const headSha = context.payload.pull_request.head.sha;
+            const headRef = context.payload.pull_request.head.ref;
+            const headRepoFullName = context.payload.pull_request.head.repo?.full_name;
             const workflowId = '.github/workflows/e2e-test-frontend.yml';
             const maxAttempts = 30;
             const pollingIntervalMs = 30 * 1000;
@@ -74,7 +76,13 @@ jobs:
                   const pullRequests = Array.isArray(run.pull_requests)
                     ? run.pull_requests
                     : [];
-                  return pullRequests.some(pr => pr.number === prNumber);
+                  const matchesPrNumber = pullRequests.some(pr => pr.number === prNumber);
+                  const matchesHeadContext =
+                    run.head_sha === headSha &&
+                    run.head_branch === headRef &&
+                    run.head_repository?.full_name === headRepoFullName;
+                  // For fork PRs, GitHub may return empty pull_requests metadata for workflow runs.
+                  return matchesPrNumber || (pullRequests.length === 0 && matchesHeadContext);
                 })
                 .sort(
                   (a, b) => Date.parse(b.created_at) - Date.parse(a.created_at),


### PR DESCRIPTION
## Summary
- update ci-checks workflow fresh frontend e2e lookup to support fork PR runs where GitHub returns empty pull_requests metadata
- keep PR-number matching when metadata is present
- add fallback match by head_sha + head_branch + head_repository.full_name when pull_requests is empty

## Why
check_ci_status can time out on fork PRs even when frontend e2e succeeds, because workflow runs may report pull_requests: [] for fork heads.

## Verification
- confirmed this reproduces on PR #12829: frontend e2e run succeeded for the PR head SHA but run metadata had pull_requests_count: 0
- this change keeps existing behavior and adds only the minimal fallback for that case