### PR TITLE
chore(frontend): add jeffspahr to OWNERS reviewers

### DIFF
--- a/frontend/OWNERS
+++ b/frontend/OWNERS
@@ -4,3 +4,4 @@ approvers:
 reviewers:
   - mprahl
   - droctothorpe
+  - jeffspahr


### PR DESCRIPTION
## Summary
- Adds `jeffspahr` to the `reviewers` list in `frontend/OWNERS`

I've been actively contributing to the frontend, focused on tackling long-standing tech debt and getting it into a maintainable state. Looking forward to helping with code reviews as well.

cc @droctothorpe @zazulam