### PR TITLE
test(frontend): guard PagedTable against DOM nesting warnings

### DIFF
--- a/frontend/src/components/viewers/PagedTable.test.tsx
+++ b/frontend/src/components/viewers/PagedTable.test.tsx
@@ -76,7 +76,7 @@ describe('PagedTable', () => {
   });
 
   it('does not emit DOM nesting warnings when rendering pagination', () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const consoleErrorSpy = vi.spyOn(console, 'error');
     try {
       render(<PagedTable configs={[{ data, labels, type: PlotType.TABLE }]} />);
 


### PR DESCRIPTION
## Context
- The React 17 frontend upgrade has been merged (`#12849`) under tracking issue [`#11594`](https://github.com/kubeflow/pipelines/issues/11594).
- During the upgrade/follow-up period, `TablePagination`/table DOM nesting warnings (`validateDOMNesting`) were observed and tracked as a cleanup item.
- In the current code, that warning path is no longer reproduced in the targeted suites (`PagedTable`, `ViewerContainer`, `CompareV1`).

## Why This PR
- We want to preserve that resolved state.
- This PR adds a regression guard so if invalid nesting is reintroduced by future table/pagination refactors, CI fails immediately.

## Backstory and Outcome
- **Before:** warning class had been observed and was explicitly tracked in the React 17 post-upgrade TODO list.
- **Now:** warning is resolved in current behavior (targeted recheck passes).
- **With this PR:** we prevent silent reintroduction by asserting no `validateDOMNesting` warning is emitted during `PagedTable` render.

## What This Test Actually Enforces
- In `frontend/src/components/viewers/PagedTable.test.tsx`, we:
  1. spy on `console.error`
  2. render `PagedTable` with pagination
  3. scan captured logs for `validateDOMNesting`
  4. assert none exist
- If React emits a DOM nesting warning, the test fails.

## Changes
- Add one focused test in `frontend/src/components/viewers/PagedTable.test.tsx`:
  - `does not emit DOM nesting warnings when rendering pagination`

## Scope
- Test-only change.
- No runtime/UI behavior changes.

Ref: #11594

## Verification
- `npm run test:ui -- --maxWorkers=2 src/components/viewers/PagedTable.test.tsx`
- `npm run test:ui -- --maxWorkers=2 src/components/viewers/PagedTable.test.tsx src/components/viewers/ViewerContainer.test.tsx src/pages/CompareV1.test.tsx`
- `npx prettier --check src/components/viewers/PagedTable.test.tsx`
