### PR TITLE
fix: switch Python base images to slim to resolve CVEs

### DIFF
--- a/backend/Dockerfile.visualization
+++ b/backend/Dockerfile.visualization
@@ -18,14 +18,21 @@
 # and exporter.py files in the directory specified above.
 
 # This image should run Python 3.11 to satisfy protobuf v4-compatible deps.
-FROM python:3.11
+FROM python:3.11-slim
+
+ARG CLOUD_SDK_VERSION=557.0.0
+ARG CLOUD_SDK_SHA256=6b048c0cb3057517a2a71e94a5a2a712fe7d30c6928f73e458bd5946187ca470
 
 RUN apt-get update \
-  && apt-get install -y wget curl tar openssl \
-  && curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz \
+  && apt-get install -y --no-install-recommends wget curl tar openssl \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" \
+       -o /tmp/google-cloud-sdk.tar.gz \
+  && echo "${CLOUD_SDK_SHA256}  /tmp/google-cloud-sdk.tar.gz" | sha256sum -c - \
   && mkdir -p /usr/local/gcloud \
   && tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz \
-  && /usr/local/gcloud/google-cloud-sdk/install.sh
+  && /usr/local/gcloud/google-cloud-sdk/install.sh \
+  && rm /tmp/google-cloud-sdk.tar.gz
 
 ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
 

--- a/backend/metadata_writer/Dockerfile
+++ b/backend/metadata_writer/Dockerfile
@@ -1,5 +1,4 @@
-# ml-metadata package depends on tensorflow package
-FROM python:3.11
+FROM python:3.11-slim
 COPY backend/metadata_writer/requirements.txt /kfp/metadata_writer/
 RUN python3 -m pip install -r /kfp/metadata_writer/requirements.txt
 


### PR DESCRIPTION
## Summary
- Switch `python:3.11` → `python:3.11-slim` in visualization server and metadata writer Dockerfiles to eliminate multiple urllib/asyncio CVEs present in the full image
- Add `--no-install-recommends`, apt list cleanup, and SDK tarball removal to the visualization server Dockerfile to keep the slim image minimal

## Key CVEs mitigated by removing system packages in the full image:
- https://github.com/advisories/GHSA-784x-7qm2-gp97 (CRITICAL 9.8) libexpat: integer overflow in dtdCopy
- https://github.com/advisories/GHSA-4hvh-m426-wv8w (CRITICAL 9.8) libexpat: negative length not rejected
- https://github.com/advisories/GHSA-84p5-cqqq-h4gr (HIGH) libxml2: use-after-free in xmlXIncludeAddNode
- https://github.com/advisories/GHSA-m366-8h8r-6fqr (HIGH) libxml2: use-after-free in schema validation
- https://github.com/advisories/GHSA-fgfv-9xqc-v794 (HIGH) libxml2: stack buffer overflow in DTD validation
- https://github.com/advisories/GHSA-gh68-jm46-84rf (HIGH 7.5) libexpat: DoS via large token reparsing
- https://github.com/advisories/GHSA-qppj-fm5r-hxr3 (HIGH 7.5) nghttp2: HTTP/2 Rapid Reset DoS
- https://github.com/advisories/GHSA-5v8j-jfmm-6x86 (HIGH 8.1) perl CPAN: no TLS certificate verification

## Test plan
- [ ] `docker build -f backend/Dockerfile.visualization .` — verify gcloud SDK installs on slim
- [ ] `docker build -f backend/metadata_writer/Dockerfile .` — verify pip install succeeds on slim

