### PR TITLE
chore(frontend): add jeffspahr as frontend approver

### DIFF
--- a/frontend/OWNERS
+++ b/frontend/OWNERS
@@ -1,7 +1,7 @@
 approvers:
   - chensun
   - HumairAK
+  - jeffspahr
 reviewers:
   - mprahl
   - droctothorpe
-  - jeffspahr


### PR DESCRIPTION
## What this changes
- Moves `jeffspahr` from `reviewers` to `approvers` in `frontend/OWNERS`.

## Why
Frontend PRs that touch `frontend/**` currently require approval from frontend approvers for Tide merge.

Example: https://github.com/kubeflow/pipelines/pull/12867 was blocked with:
- "Needs approval from an approver in each of these files: frontend/OWNERS"

This change aligns OWNERS permissions with current maintainer responsibilities so `/approve` can satisfy frontend ownership requirements.

## Scope
- OWNERS-only metadata update (no runtime code changes).
