### PR TITLE
fix(sdk): accept any non-negative integer in set_accelerator_limit. F…

### DIFF
--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -429,8 +429,11 @@ class PipelineTask:
         else:
             if isinstance(limit, int):
                 limit = str(limit)
-            if isinstance(limit, str) and re.match(r'^[0-9]+$',
-                                                   limit) is None:
+            if not isinstance(limit, str):
+                raise TypeError(
+                    f'Invalid accelerator limit type {type(limit).__name__!r}.'
+                    ' Must be an int, str, or PipelineChannel.')
+            if re.match(r'^(0|[1-9][0-9]*)$', limit) is None:
                 raise ValueError(
                     f'Invalid accelerator limit {limit!r}.'
                     ' Must be a non-negative integer.')

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -429,10 +429,11 @@ class PipelineTask:
         else:
             if isinstance(limit, int):
                 limit = str(limit)
-            if isinstance(limit, str) and re.match(r'^0$|^1$|^2$|^4$|^8$|^16$',
+            if isinstance(limit, str) and re.match(r'^[0-9]+$',
                                                    limit) is None:
                 raise ValueError(
-                    f'{"limit"!r} must be one of 0, 1, 2, 4, 8, 16.')
+                    f'Invalid accelerator limit {limit!r}.'
+                    ' Must be a non-negative integer.')
 
         if self.container_spec.resources is not None:
             self.container_spec.resources.accelerator_count = limit

--- a/sdk/python/kfp/dsl/pipeline_task_test.py
+++ b/sdk/python/kfp/dsl/pipeline_task_test.py
@@ -250,6 +250,8 @@ class PipelineTaskTest(parameterized.TestCase):
         {'limit': '-1'},
         {'limit': '1.5'},
         {'limit': 'abc'},
+        {'limit': '007'},
+        {'limit': '00128'},
     )
     def test_set_accelerator_limit_invalid(self, limit):
         task = pipeline_task.PipelineTask(
@@ -259,6 +261,21 @@ class PipelineTaskTest(parameterized.TestCase):
         )
         with self.assertRaisesRegex(ValueError,
                                     'Invalid accelerator limit'):
+            task.set_accelerator_limit(limit)
+
+    @parameterized.parameters(
+        {'limit': 1.5},
+        {'limit': [1]},
+        {'limit': None},
+    )
+    def test_set_accelerator_limit_invalid_type(self, limit):
+        task = pipeline_task.PipelineTask(
+            component_spec=structures.ComponentSpec.from_yaml_documents(
+                V2_YAML),
+            args={'input1': 'value'},
+        )
+        with self.assertRaisesRegex(TypeError,
+                                    'Invalid accelerator limit type'):
             task.set_accelerator_limit(limit)
 
     @parameterized.parameters(

--- a/sdk/python/kfp/dsl/pipeline_task_test.py
+++ b/sdk/python/kfp/dsl/pipeline_task_test.py
@@ -218,6 +218,22 @@ class PipelineTaskTest(parameterized.TestCase):
             'limit': 16,
             'expected_limit': '16',
         },
+        {
+            'limit': 3,
+            'expected_limit': '3',
+        },
+        {
+            'limit': 32,
+            'expected_limit': '32',
+        },
+        {
+            'limit': 128,
+            'expected_limit': '128',
+        },
+        {
+            'limit': '0',
+            'expected_limit': '0',
+        },
     )
     def test_set_accelerator_limit(self, limit, expected_limit):
         task = pipeline_task.PipelineTask(
@@ -229,6 +245,21 @@ class PipelineTaskTest(parameterized.TestCase):
         task.set_accelerator_limit(limit)
         self.assertEqual(expected_limit,
                          task.container_spec.resources.accelerator_count)
+
+    @parameterized.parameters(
+        {'limit': '-1'},
+        {'limit': '1.5'},
+        {'limit': 'abc'},
+    )
+    def test_set_accelerator_limit_invalid(self, limit):
+        task = pipeline_task.PipelineTask(
+            component_spec=structures.ComponentSpec.from_yaml_documents(
+                V2_YAML),
+            args={'input1': 'value'},
+        )
+        with self.assertRaisesRegex(ValueError,
+                                    'Invalid accelerator limit'):
+            task.set_accelerator_limit(limit)
 
     @parameterized.parameters(
         {


### PR DESCRIPTION
fixes #12865

Previously, set_accelerator_limit() only accepted values 0, 1, 2, 4, 8, 16 due to a hardcoded regex allowlist. Kubernetes has no such restriction on accelerator counts, so this was an incorrect SDK-side validation.

Changes:
- Replaced the hardcoded regex with a pattern accepting any non-negative integer
- Fixed the error message f-string which was printing the literal string 'limit' instead of the actual value
- Added test cases for previously rejected valid values (3, 32, 128)
- Added test cases for invalid inputs (-1, 1.5, abc)

