### PR TITLE
fix: validate GitHub API response in upgrade-test.yml

### DIFF
--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -58,7 +58,17 @@ jobs:
         shell: bash
         id: get-tag
         run: |
-          lastRelease=$(curl -sSL -H "Accept: application/vnd.github+json" "https://api.github.com/repos/kubeflow/pipelines/releases/latest" | jq -r .tag_name)
+          lastRelease=$(curl -sSLf \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/kubeflow/pipelines/releases/latest" \
+            | jq -r .tag_name)
+
+          if [[ -z "$lastRelease" || "$lastRelease" == "null" ]]; then
+            echo "ERROR: Failed to fetch a valid release tag from GitHub API."
+            echo "The response was empty or null. Check API rate limits or network connectivity."
+            exit 1
+          fi
+
           echo "Fetched last release tag: $lastRelease"
           echo "lastRelease=$lastRelease" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Problem
If the GitHub API fails (rate limit, timeout, or outage), `lastRelease` 
becomes empty or "null". The workflow then runs kubectl apply with an 
invalid ref like `?ref=null`, causing a confusing failure that hides 
the real cause.

## Fix
- `curl -sSLf` now fails immediately on HTTP errors (4xx/5xx)
- Validation checks that lastRelease is not empty or "null"
- Workflow exits with a clear error message before kubectl ever runs

Fixes #12875