### PR TITLE
fix(ci): pin GCP SDK for proxy

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -22,8 +22,9 @@ RUN python3 -m pip install -r \
     requirements.txt --quiet --no-cache-dir \
     && rm -f requirements.txt
 
-# Install gcloud SDK
-RUN curl https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz > /tmp/google-cloud-sdk.tar.gz
+# Install gcloud SDK (pinned)
+ARG GCLOUD_VERSION=557.0.0
+RUN curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${GCLOUD_VERSION}-linux-x86_64.tar.gz" > /tmp/google-cloud-sdk.tar.gz
 RUN mkdir -p /usr/local/gcloud
 RUN tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz
 RUN /usr/local/gcloud/google-cloud-sdk/install.sh


### PR DESCRIPTION
**Description of your changes:**
The gcloud SDK release 558.0.0 broke our CI, as you can see in this workflow: https://github.com/kubeflow/pipelines/actions/runs/22360691533/job/64729920285

We are pinning it so that we can proceed with the release. 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
