### PR TITLE
chore(backend): use slim base images for API server Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,8 +28,8 @@ COPY . .
 RUN GO111MODULE=on go build -o /bin/apiserver backend/src/apiserver/*.go
 
 # 2. Compile preloaded pipeline samples
-FROM python:3.11 AS compiler
-RUN apt-get update -y && apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev jq
+FROM python:3.11-slim AS compiler
+RUN apt-get update -y && apt-get install --no-install-recommends -y -q default-jdk python3-setuptools python3-dev jq wget curl
 RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
 COPY backend/requirements.txt .
 RUN python3 -m pip install -r requirements.txt --no-cache-dir
@@ -59,7 +59,7 @@ RUN set -e; \
     done
 
 # 3. Start api web server
-FROM debian:stable
+FROM debian:stable-slim
 
 ARG COMMIT_SHA=unknown
 ENV COMMIT_SHA=${COMMIT_SHA}
@@ -70,7 +70,8 @@ ENV LOG_LEVEL=info
 WORKDIR /bin
 
 # Adding CA certificate so API server can download pipeline through URL and wget is used for liveness/readiness probe command
-RUN apt-get update && apt-get install -y ca-certificates wget
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY backend/src/apiserver/config/ /config
 COPY --from=builder /bin/apiserver /bin/apiserver


### PR DESCRIPTION
## Summary
- Switch the final stage base image from `debian:stable` to `debian:stable-slim`
- Switch the compiler stage from `python:3.11` to `python:3.11-slim`, adding `wget` and `curl` to `apt-get install` since they are not included in the slim variant
- Add `--no-install-recommends` and clean up apt lists (`rm -rf /var/lib/apt/lists/*`) in the final stage

## Test plan
- [ ] Verify the API server image builds successfully
- [ ] Verify the API server starts and responds to health checks (`wget`-based liveness/readiness probes)
- [ ] Verify preloaded pipeline samples compile correctly in the compiler stage
- [ ] Verify `sed` commands for pinning sample doc links still work in the slim image