### PR TITLE
chore: add file size limits to object store downloads

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -197,5 +197,5 @@ func GetDefaultSecurityContextRunAsNonRoot() string {
 }
 
 func GetObjectSizeLimit() int64 {
-	return GetInt64ConfigWithDefault(ObjectStoreFileSizeLimit, 104857600)
+	return GetInt64ConfigWithDefault(ObjectStoreFileSizeLimit, 104857600) // Default limit is 100MB
 }

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -44,6 +44,7 @@ const (
 	DefaultSecurityContextRunAsUser         string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_USER"
 	DefaultSecurityContextRunAsGroup        string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_GROUP"
 	DefaultSecurityContextRunAsNonRoot      string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_NON_ROOT"
+	ObjectStoreFileSizeLimit                string = "OBJECT_STORE_FILE_SIZE_LIMIT"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {
@@ -92,6 +93,13 @@ func GetFloat64ConfigWithDefault(configName string, value float64) float64 {
 		return value
 	}
 	return viper.GetFloat64(configName)
+}
+
+func GetInt64ConfigWithDefault(configName string, value int64) int64 {
+	if !viper.IsSet(configName) {
+		return value
+	}
+	return viper.GetInt64(configName)
 }
 
 func GetIntConfigWithDefault(configName string, value int) int {
@@ -186,4 +194,8 @@ func GetDefaultSecurityContextRunAsGroup() string {
 
 func GetDefaultSecurityContextRunAsNonRoot() string {
 	return GetStringConfigWithDefault(DefaultSecurityContextRunAsNonRoot, "")
+}
+
+func GetObjectSizeLimit() int64 {
+	return GetInt64ConfigWithDefault(ObjectStoreFileSizeLimit, 104857600)
 }

--- a/backend/src/apiserver/storage/blob_object_store.go
+++ b/backend/src/apiserver/storage/blob_object_store.go
@@ -18,9 +18,11 @@ package storage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"path"
 
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"gocloud.dev/blob"
 	"sigs.k8s.io/yaml"
@@ -71,10 +73,19 @@ func (b *BlobObjectStore) GetFile(ctx context.Context, filePath string) ([]byte,
 	}
 	defer reader.Close()
 
+	// Limit file size to prevent memory exhaustion
+	maxFileSize := common.GetObjectSizeLimit()
+	limitedReader := &io.LimitedReader{R: reader, N: maxFileSize + 1}
+
 	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(reader)
+	_, err = buf.ReadFrom(limitedReader)
 	if err != nil {
 		return nil, util.NewInternalServerError(err, "Failed to read file %v", filePath)
+	}
+
+	// Check if file exceeded size limit
+	if limitedReader.N == 0 {
+		return nil, util.NewInternalServerError(errors.New("file size limit exceeded"), "File %v exceeds maximum size limit of %d bytes", filePath, maxFileSize)
 	}
 
 	return buf.Bytes(), nil

--- a/backend/src/apiserver/storage/blob_object_store_test.go
+++ b/backend/src/apiserver/storage/blob_object_store_test.go
@@ -372,3 +372,41 @@ func TestBlobObjectStore_Streaming_Large_File(t *testing.T) {
 
 	t.Log("All assertions passed: file was streamed in chunks without loading into memory")
 }
+
+// TestBlobObjectStore_GetFile_SizeLimit validates that GetFile rejects files
+// that exceed the maximum size limit.
+func TestBlobObjectStore_GetFile_SizeLimit(t *testing.T) {
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	store := NewBlobObjectStore(bucket, "pipelines")
+	ctx := context.Background()
+
+	// Create a file larger than the 100MB limit
+	// Use 101MB to exceed the limit
+	largeFileSize := 101 * 1024 * 1024
+	content := make([]byte, largeFileSize)
+
+	// Fill with minimal pattern for performance
+	for i := range content {
+		content[i] = byte(i % 256)
+	}
+
+	err := store.AddFile(ctx, content, "test/oversized.bin")
+	require.NoError(t, err, "Should be able to add large file")
+
+	// GetFile should reject the oversized file
+	_, err = store.GetFile(ctx, "test/oversized.bin")
+	require.Error(t, err, "GetFile should reject oversized files")
+	require.Contains(t, err.Error(), "exceeds maximum size limit", "Error should mention size limit")
+
+	// GetFileReader should still work for streaming access
+	reader, err := store.GetFileReader(ctx, "test/oversized.bin")
+	require.NoError(t, err, "GetFileReader should work for large files")
+	require.NotNil(t, reader, "Reader should not be nil")
+	reader.Close()
+
+	// Cleanup
+	err = store.DeleteFile(ctx, "test/oversized.bin")
+	require.NoError(t, err, "Should be able to delete the test file")
+}


### PR DESCRIPTION
**Description of your changes:**
Address Ada logistics security audit issue `ADA-KUBEFL-04` object store read-all DoS, in which anyone with write permissions to the Minio ObjectStore can overwrite all objects and cause denial of service of the node whenever someone downloads any file in Kubeflow Pipelines.

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
