### PR TITLE
feat(sdk): Add dsl.ExitHandler support for local execution

### DIFF
--- a/sdk/python/kfp/local/io.py
+++ b/sdk/python/kfp/local/io.py
@@ -14,7 +14,9 @@
 """Object for storing task outputs in-memory during local execution."""
 
 import collections
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from kfp.local import status as status_module
 
 
 class IOStore:
@@ -25,6 +27,8 @@ class IOStore:
                                      Dict[str,
                                           Any]] = collections.defaultdict(dict)
         self._parent_input_data: Dict[str, Any] = {}
+        self._task_status_data: Dict[str, status_module.Status] = {}
+        self._task_error_data: Dict[str, Optional[str]] = {}
 
     def put_parent_input(
         self,
@@ -99,3 +103,50 @@ class IOStore:
             raise ValueError(
                 f"{common_exception_string}, but task '{task_name}' has no output named '{key}'."
             )
+
+    def put_task_status(
+        self,
+        task_name: str,
+        task_status: status_module.Status,
+        error_message: Optional[str] = None,
+    ) -> None:
+        """Persist the status of a task execution.
+
+        Args:
+            task_name: Task name.
+            task_status: The status of the task (SUCCESS or FAILURE).
+            error_message: Optional error message if task failed.
+        """
+        self._task_status_data[task_name] = task_status
+        if error_message:
+            self._task_error_data[task_name] = error_message
+
+    def get_task_status(
+        self,
+        task_name: str,
+    ) -> status_module.Status:
+        """Get the status of a task.
+
+        Args:
+            task_name: Task name.
+
+        Returns:
+            The task status.
+        """
+        if task_name in self._task_status_data:
+            return self._task_status_data[task_name]
+        raise ValueError(f"Task '{task_name}' status not found.")
+
+    def get_task_error(
+        self,
+        task_name: str,
+    ) -> Optional[str]:
+        """Get the error message of a task, if any.
+
+        Args:
+            task_name: Task name.
+
+        Returns:
+            The error message or None.
+        """
+        return self._task_error_data.get(task_name)

--- a/sdk/python/kfp/local/io_test.py
+++ b/sdk/python/kfp/local/io_test.py
@@ -90,6 +90,45 @@ class IOStoreTest(unittest.TestCase):
             artifact,
         )
 
+    def test_put_and_get_task_status_success(self):
+        from kfp.local import status
+        store = io.IOStore()
+        store.put_task_status('my-task', status.Status.SUCCESS)
+        self.assertEqual(
+            store.get_task_status('my-task'),
+            status.Status.SUCCESS,
+        )
+
+    def test_put_and_get_task_status_failure(self):
+        from kfp.local import status
+        store = io.IOStore()
+        store.put_task_status('my-task', status.Status.FAILURE, 'Task failed')
+        self.assertEqual(
+            store.get_task_status('my-task'),
+            status.Status.FAILURE,
+        )
+        self.assertEqual(
+            store.get_task_error('my-task'),
+            'Task failed',
+        )
+
+    def test_task_status_not_found(self):
+        store = io.IOStore()
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Task 'my-task' status not found\."):
+            store.get_task_status('my-task')
+
+    def test_get_task_error_returns_none_when_no_error(self):
+        from kfp.local import status
+        store = io.IOStore()
+        store.put_task_status('my-task', status.Status.SUCCESS)
+        self.assertIsNone(store.get_task_error('my-task'))
+
+    def test_get_task_error_returns_none_for_unknown_task(self):
+        store = io.IOStore()
+        self.assertIsNone(store.get_task_error('unknown-task'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/local/orchestrator/dag_orchestrator.py
+++ b/sdk/python/kfp/local/orchestrator/dag_orchestrator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Code for locally executing a DAG within a pipeline."""
+import logging
 from typing import Any, Dict, List, Tuple
 
 from kfp.local import config
@@ -21,6 +22,24 @@ from kfp.local import status
 from kfp.pipeline_spec import pipeline_spec_pb2
 
 Outputs = Dict[str, Any]
+
+# Trigger strategy enum value for ALL_UPSTREAM_TASKS_COMPLETED
+ALL_UPSTREAM_TASKS_COMPLETED = 2
+
+
+def _is_exit_handler_task(task_spec: pipeline_spec_pb2.PipelineTaskSpec) -> bool:
+    """Check if a task is an exit handler task.
+
+    Exit handler tasks have trigger_policy.strategy == ALL_UPSTREAM_TASKS_COMPLETED,
+    which means they should run regardless of upstream task success/failure.
+
+    Args:
+        task_spec: The task specification.
+
+    Returns:
+        True if the task is an exit handler task.
+    """
+    return task_spec.trigger_policy.strategy == ALL_UPSTREAM_TASKS_COMPLETED
 
 
 def run_dag(
@@ -66,60 +85,138 @@ def run_dag(
     for k, v in dag_arguments_with_defaults.items():
         io_store.put_parent_input(k, v)
 
-    # execute tasks in order
+    # Separate exit handler tasks from regular tasks
     dag_spec = dag_component_spec.dag
-    sorted_tasks = graph_utils.topological_sort_tasks(dag_spec.tasks)
-    while sorted_tasks:
-        task_name = sorted_tasks.pop()
-        task_spec = dag_spec.tasks[task_name]
+    regular_tasks = {}
+    exit_handler_tasks = {}
+
+    for task_name, task_spec in dag_spec.tasks.items():
+        if _is_exit_handler_task(task_spec):
+            exit_handler_tasks[task_name] = task_spec
+        else:
+            regular_tasks[task_name] = task_spec
+
+    # Execute regular tasks in order
+    dag_failure = False
+    failed_task_name = None
+    error_message = None
+
+    if regular_tasks:
+        sorted_tasks = graph_utils.topological_sort_tasks(regular_tasks)
+        while sorted_tasks:
+            task_name = sorted_tasks.pop()
+            task_spec = regular_tasks[task_name]
+            component_name = task_spec.component_ref.name
+            component_spec = components[component_name]
+            implementation = component_spec.WhichOneof('implementation')
+            if implementation == 'dag':
+                # unlikely to exceed default max recursion depth of 1000
+                outputs, task_status = run_dag(
+                    pipeline_resource_name=pipeline_resource_name,
+                    dag_component_spec=component_spec,
+                    components=components,
+                    executors=executors,
+                    dag_arguments=OrchestratorUtils.make_task_arguments(
+                        task_spec.inputs,
+                        io_store,
+                    ),
+                    pipeline_root=pipeline_root,
+                    runner=runner,
+                    unique_pipeline_id=unique_pipeline_id,
+                    fail_stack=fail_stack,
+                )
+            else:
+                # Use consolidated task execution logic from OrchestratorUtils
+                outputs, task_status = OrchestratorUtils.execute_single_task(
+                    task_name=task_name,
+                    task_spec=task_spec,
+                    pipeline_resource_name=pipeline_resource_name,
+                    components=components,
+                    executors=executors,
+                    io_store=io_store,
+                    pipeline_root=pipeline_root,
+                    runner=runner,
+                    unique_pipeline_id=unique_pipeline_id,
+                    fail_stack=fail_stack,
+                )
+
+            # Store task status for exit handler tasks
+            io_store.put_task_status(task_name, task_status)
+
+            if task_status == status.Status.FAILURE:
+                dag_failure = True
+                failed_task_name = task_name
+                error_message = f"Task '{task_name}' failed during execution"
+                io_store.put_task_status(task_name, task_status, error_message)
+                # Don't return immediately if there are exit handler tasks
+                if not exit_handler_tasks:
+                    fail_stack.append(task_name)
+                    return {}, status.Status.FAILURE
+                # Stop executing remaining regular tasks
+                break
+
+            # update IO store on success
+            elif task_status == status.Status.SUCCESS:
+                for key, output in outputs.items():
+                    io_store.put_task_output(
+                        task_name,
+                        key,
+                        output,
+                    )
+            else:
+                raise ValueError(f'Got unknown task status: {task_status.name}')
+
+    # Execute exit handler tasks (they run regardless of success/failure)
+    for task_name, task_spec in exit_handler_tasks.items():
+        logging.info(f'Running exit handler task: {task_name}')
         component_name = task_spec.component_ref.name
         component_spec = components[component_name]
         implementation = component_spec.WhichOneof('implementation')
-        if implementation == 'dag':
-            # unlikely to exceed default max recursion depth of 1000
-            outputs, task_status = run_dag(
-                pipeline_resource_name=pipeline_resource_name,
-                dag_component_spec=component_spec,
-                components=components,
-                executors=executors,
-                dag_arguments=OrchestratorUtils.make_task_arguments(
-                    task_spec.inputs,
-                    io_store,
-                ),
-                pipeline_root=pipeline_root,
-                runner=runner,
-                unique_pipeline_id=unique_pipeline_id,
-                fail_stack=fail_stack,
-            )
-        else:
-            # Use consolidated task execution logic from OrchestratorUtils
-            outputs, task_status = OrchestratorUtils.execute_single_task(
-                task_name=task_name,
-                task_spec=task_spec,
-                pipeline_resource_name=pipeline_resource_name,
-                components=components,
-                executors=executors,
-                io_store=io_store,
-                pipeline_root=pipeline_root,
-                runner=runner,
-                unique_pipeline_id=unique_pipeline_id,
-                fail_stack=fail_stack,
-            )
 
-        if task_status == status.Status.FAILURE:
-            fail_stack.append(task_name)
-            return {}, status.Status.FAILURE
-
-        # update IO store on success
-        elif task_status == status.Status.SUCCESS:
-            for key, output in outputs.items():
-                io_store.put_task_output(
-                    task_name,
-                    key,
-                    output,
+        try:
+            if implementation == 'dag':
+                outputs, task_status = run_dag(
+                    pipeline_resource_name=pipeline_resource_name,
+                    dag_component_spec=component_spec,
+                    components=components,
+                    executors=executors,
+                    dag_arguments=OrchestratorUtils.make_task_arguments(
+                        task_spec.inputs,
+                        io_store,
+                    ),
+                    pipeline_root=pipeline_root,
+                    runner=runner,
+                    unique_pipeline_id=unique_pipeline_id,
+                    fail_stack=fail_stack,
                 )
-        else:
-            raise ValueError(f'Got unknown task status: {task_status.name}')
+            else:
+                outputs, task_status = OrchestratorUtils.execute_single_task(
+                    task_name=task_name,
+                    task_spec=task_spec,
+                    pipeline_resource_name=pipeline_resource_name,
+                    components=components,
+                    executors=executors,
+                    io_store=io_store,
+                    pipeline_root=pipeline_root,
+                    runner=runner,
+                    unique_pipeline_id=unique_pipeline_id,
+                    fail_stack=fail_stack,
+                )
+
+            # Store exit handler task outputs
+            if task_status == status.Status.SUCCESS:
+                for key, output in outputs.items():
+                    io_store.put_task_output(task_name, key, output)
+
+        except Exception as e:
+            logging.error(f'Exit handler task {task_name} failed with exception: {e}')
+            # Exit handler failures don't affect the overall DAG status
+            # (the DAG already failed if regular tasks failed)
+
+    # If a regular task failed, return failure status
+    if dag_failure:
+        fail_stack.append(failed_task_name)
+        return {}, status.Status.FAILURE
 
     dag_outputs = OrchestratorUtils.get_dag_outputs(
         dag_outputs_spec=dag_component_spec.dag.outputs,

--- a/sdk/python/kfp/local/orchestrator/dag_orchestrator.py
+++ b/sdk/python/kfp/local/orchestrator/dag_orchestrator.py
@@ -141,13 +141,13 @@ def run_dag(
                 )
 
             # Store task status for exit handler tasks
-            io_store.put_task_status(task_name, task_status)
-
             if task_status == status.Status.FAILURE:
                 dag_failure = True
                 failed_task_name = task_name
                 error_message = f"Task '{task_name}' failed during execution"
                 io_store.put_task_status(task_name, task_status, error_message)
+            else:
+                io_store.put_task_status(task_name, task_status)
                 # Don't return immediately if there are exit handler tasks
                 if not exit_handler_tasks:
                     fail_stack.append(task_name)

--- a/sdk/python/kfp/local/orchestrator/enhanced_dag_orchestrator.py
+++ b/sdk/python/kfp/local/orchestrator/enhanced_dag_orchestrator.py
@@ -653,7 +653,14 @@ def run_enhanced_dag(
     exit_handler_tasks = []
 
     for task_name, task_spec in dag_spec.tasks.items():
-        # Check for exit handler first (ALL_UPSTREAM_TASKS_COMPLETED strategy without condition)
+        # Check for exit handler first.
+        # NOTE: The enhanced orchestrator deliberately treats only *unconditional*
+        # tasks that use the ALL_UPSTREAM_TASKS_COMPLETED trigger strategy as
+        # exit handlers. Tasks that have a trigger condition are instead
+        # classified as conditional tasks below, even if they also satisfy
+        # _is_exit_handler_task. This is intentionally stricter than the logic in
+        # dag_orchestrator.py, which uses only _is_exit_handler_task(task_spec),
+        # to avoid misclassifying conditional control-flow tasks as exit handlers.
         if _is_exit_handler_task(task_spec) and not task_spec.trigger_policy.condition:
             exit_handler_tasks.append((task_name, task_spec))
         elif task_spec.trigger_policy.condition:
@@ -694,8 +701,6 @@ def run_enhanced_dag(
             )
 
             # Store task status for exit handler tasks
-            io_store.put_task_status(task_name, task_status)
-
             if task_status == status.Status.FAILURE:
                 dag_failure = True
                 failed_task_name = task_name
@@ -706,10 +711,11 @@ def run_enhanced_dag(
                     return {}, status.Status.FAILURE
                 # Stop executing remaining regular tasks
                 break
-
-            # Update IO store on success
-            for key, output in outputs.items():
-                io_store.put_task_output(task_name, key, output)
+            else:
+                io_store.put_task_status(task_name, task_status)
+                # Update IO store on success
+                for key, output in outputs.items():
+                    io_store.put_task_output(task_name, key, output)
 
     # Execute conditional tasks (skip if already failed)
     condition_evaluator = ConditionEvaluator()
@@ -735,8 +741,6 @@ def run_enhanced_dag(
                 )
 
                 # Store task status for exit handler tasks
-                io_store.put_task_status(task_name, task_status)
-
                 if task_status == status.Status.FAILURE:
                     dag_failure = True
                     failed_task_name = task_name
@@ -745,10 +749,11 @@ def run_enhanced_dag(
                     if not exit_handler_tasks:
                         return {}, status.Status.FAILURE
                     break
-
-                # Update IO store on success
-                for key, output in outputs.items():
-                    io_store.put_task_output(task_name, key, output)
+                else:
+                    io_store.put_task_status(task_name, task_status)
+                    # Update IO store on success
+                    for key, output in outputs.items():
+                        io_store.put_task_output(task_name, key, output)
             else:
                 logging.info(
                     f'Skipping conditional task {task_name} (condition evaluated to False)'

--- a/sdk/python/kfp/local/orchestrator/enhanced_dag_orchestrator.py
+++ b/sdk/python/kfp/local/orchestrator/enhanced_dag_orchestrator.py
@@ -30,6 +30,24 @@ from .orchestrator_utils import OrchestratorUtils
 
 Outputs = Dict[str, Any]
 
+# Trigger strategy enum value for ALL_UPSTREAM_TASKS_COMPLETED
+ALL_UPSTREAM_TASKS_COMPLETED = 2
+
+
+def _is_exit_handler_task(task_spec: pipeline_spec_pb2.PipelineTaskSpec) -> bool:
+    """Check if a task is an exit handler task.
+
+    Exit handler tasks have trigger_policy.strategy == ALL_UPSTREAM_TASKS_COMPLETED,
+    which means they should run regardless of upstream task success/failure.
+
+    Args:
+        task_spec: The task specification.
+
+    Returns:
+        True if the task is an exit handler task.
+    """
+    return task_spec.trigger_policy.strategy == ALL_UPSTREAM_TASKS_COMPLETED
+
 
 class ConditionEvaluator:
     """Evaluates condition expressions for dsl.Condition support."""
@@ -611,10 +629,10 @@ def run_enhanced_dag(
     unique_pipeline_id: str,
     fail_stack: List[str],
 ) -> Tuple[Outputs, status.Status]:
-    """Enhanced DAG runner with support for dsl.Condition and dsl.ParallelFor.
+    """Enhanced DAG runner with support for dsl.Condition, dsl.ParallelFor, and dsl.ExitHandler.
 
     This is an enhanced version of dag_orchestrator.run_dag that
-    supports control flow features like conditions and parallel loops.
+    supports control flow features like conditions, parallel loops, and exit handlers.
     """
     dag_arguments_with_defaults = OrchestratorUtils.join_user_inputs_and_defaults(
         dag_arguments=dag_arguments,
@@ -632,15 +650,24 @@ def run_enhanced_dag(
     regular_tasks = []
     condition_tasks = []
     parallel_for_tasks = []
+    exit_handler_tasks = []
 
     for task_name, task_spec in dag_spec.tasks.items():
-        if task_spec.trigger_policy.condition:
+        # Check for exit handler first (ALL_UPSTREAM_TASKS_COMPLETED strategy without condition)
+        if _is_exit_handler_task(task_spec) and not task_spec.trigger_policy.condition:
+            exit_handler_tasks.append((task_name, task_spec))
+        elif task_spec.trigger_policy.condition:
             condition_tasks.append((task_name, task_spec))
         elif task_spec.WhichOneof('iterator') and _has_valid_iterator(
                 task_spec):
             parallel_for_tasks.append((task_name, task_spec))
         else:
             regular_tasks.append((task_name, task_spec))
+
+    # Track whether any task failed
+    dag_failure = False
+    failed_task_name = None
+    error_message = None
 
     # Execute regular tasks first (topologically sorted)
     regular_task_dict = {name: spec for name, spec in regular_tasks}
@@ -666,49 +693,71 @@ def run_enhanced_dag(
                 fail_stack=fail_stack,
             )
 
+            # Store task status for exit handler tasks
+            io_store.put_task_status(task_name, task_status)
+
             if task_status == status.Status.FAILURE:
-                return {}, status.Status.FAILURE
+                dag_failure = True
+                failed_task_name = task_name
+                error_message = f"Task '{task_name}' failed during execution"
+                io_store.put_task_status(task_name, task_status, error_message)
+                # Don't return immediately if there are exit handler tasks
+                if not exit_handler_tasks:
+                    return {}, status.Status.FAILURE
+                # Stop executing remaining regular tasks
+                break
 
             # Update IO store on success
             for key, output in outputs.items():
                 io_store.put_task_output(task_name, key, output)
 
-    # Execute conditional tasks
+    # Execute conditional tasks (skip if already failed)
     condition_evaluator = ConditionEvaluator()
-    for task_name, task_spec in condition_tasks:
-        # Evaluate condition
-        condition_expr = task_spec.trigger_policy.condition
-        should_execute = condition_evaluator.evaluate_condition(
-            condition_expr, io_store)
+    if not dag_failure:
+        for task_name, task_spec in condition_tasks:
+            # Evaluate condition
+            condition_expr = task_spec.trigger_policy.condition
+            should_execute = condition_evaluator.evaluate_condition(
+                condition_expr, io_store)
 
-        if should_execute:
-            outputs, task_status = execute_task(
-                task_name=task_name,
-                task_spec=task_spec,
-                pipeline_resource_name=pipeline_resource_name,
-                components=components,
-                executors=executors,
-                io_store=io_store,
-                pipeline_root=pipeline_root,
-                runner=runner,
-                unique_pipeline_id=unique_pipeline_id,
-                fail_stack=fail_stack,
-            )
+            if should_execute:
+                outputs, task_status = execute_task(
+                    task_name=task_name,
+                    task_spec=task_spec,
+                    pipeline_resource_name=pipeline_resource_name,
+                    components=components,
+                    executors=executors,
+                    io_store=io_store,
+                    pipeline_root=pipeline_root,
+                    runner=runner,
+                    unique_pipeline_id=unique_pipeline_id,
+                    fail_stack=fail_stack,
+                )
 
-            if task_status == status.Status.FAILURE:
-                return {}, status.Status.FAILURE
+                # Store task status for exit handler tasks
+                io_store.put_task_status(task_name, task_status)
 
-            # Update IO store on success
-            for key, output in outputs.items():
-                io_store.put_task_output(task_name, key, output)
-        else:
-            logging.info(
-                f'Skipping conditional task {task_name} (condition evaluated to False)'
-            )
+                if task_status == status.Status.FAILURE:
+                    dag_failure = True
+                    failed_task_name = task_name
+                    error_message = f"Task '{task_name}' failed during execution"
+                    io_store.put_task_status(task_name, task_status, error_message)
+                    if not exit_handler_tasks:
+                        return {}, status.Status.FAILURE
+                    break
 
-    # Execute parallel for tasks
+                # Update IO store on success
+                for key, output in outputs.items():
+                    io_store.put_task_output(task_name, key, output)
+            else:
+                logging.info(
+                    f'Skipping conditional task {task_name} (condition evaluated to False)'
+                )
+
+    # Execute parallel for tasks (skip if already failed)
     parallel_executor = ParallelExecutor()
-    for task_name, task_spec in parallel_for_tasks:
+    if not dag_failure:
+        for task_name, task_spec in parallel_for_tasks:
         # Get iterator configuration
         iterator = task_spec.WhichOneof('iterator')
         if iterator == 'parameter_iterator':
@@ -804,7 +853,16 @@ def run_enhanced_dag(
             )
 
             if parallel_status == status.Status.FAILURE:
-                return {}, status.Status.FAILURE
+                dag_failure = True
+                failed_task_name = task_name
+                error_message = f"Parallel task '{task_name}' failed during execution"
+                io_store.put_task_status(task_name, parallel_status, error_message)
+                if not exit_handler_tasks:
+                    return {}, status.Status.FAILURE
+                break
+
+            # Store task status for exit handler tasks
+            io_store.put_task_status(task_name, status.Status.SUCCESS)
 
             # Aggregate loop outputs - collect all iteration outputs under the main task name
             aggregated_outputs = {}
@@ -824,6 +882,39 @@ def run_enhanced_dag(
                     iteration_outputs.get(str(i)) for i in range(len(items))
                 ]
                 io_store.put_task_output(task_name, output_key, ordered_outputs)
+
+    # Execute exit handler tasks (they run regardless of success/failure)
+    for task_name, task_spec in exit_handler_tasks:
+        logging.info(f'Running exit handler task: {task_name}')
+
+        try:
+            outputs, task_status = execute_task(
+                task_name=task_name,
+                task_spec=task_spec,
+                pipeline_resource_name=pipeline_resource_name,
+                components=components,
+                executors=executors,
+                io_store=io_store,
+                pipeline_root=pipeline_root,
+                runner=runner,
+                unique_pipeline_id=unique_pipeline_id,
+                fail_stack=fail_stack,
+            )
+
+            # Store exit handler task outputs
+            if task_status == status.Status.SUCCESS:
+                for key, output in outputs.items():
+                    io_store.put_task_output(task_name, key, output)
+
+        except Exception as e:
+            logging.error(f'Exit handler task {task_name} failed with exception: {e}')
+            # Exit handler failures don't affect the overall DAG status
+            # (the DAG already failed if regular tasks failed)
+
+    # If a regular task failed, return failure status
+    if dag_failure:
+        fail_stack.append(failed_task_name)
+        return {}, status.Status.FAILURE
 
     # Get DAG outputs
     dag_outputs = OrchestratorUtils.get_dag_outputs(

--- a/sdk/python/kfp/local/orchestrator/orchestrator_utils.py
+++ b/sdk/python/kfp/local/orchestrator/orchestrator_utils.py
@@ -116,8 +116,8 @@ class OrchestratorUtils:
             error_msg = None
         else:  # FAILURE
             state = 'FAILED'
-            # Use a generic error code for failures
-            error_code = 1  # CANCELLED = 1, UNKNOWN = 2, etc. per google.rpc.Code
+            # Use UNKNOWN error code for failures (per google.rpc.Code)
+            error_code = 2  # UNKNOWN = 2
             error_msg = error_message or 'Task failed during local execution'
 
         return tfs.PipelineTaskFinalStatus(
@@ -281,12 +281,18 @@ class OrchestratorUtils:
                         task_status=task_status,
                         error_message=error_message,
                     )
-                except ValueError:
-                    # If task status is not found, the producer task hasn't run yet
-                    # This shouldn't happen in normal flow, but handle gracefully
+                except ValueError as exc:
+                    # If task status is not found, the producer task hasn't run yet or
+                    # its status was not recorded correctly. This should not occur in
+                    # normal operation and likely indicates a bug in the local
+                    # orchestrator logic.
                     raise ValueError(
-                        f"Cannot get final status for producer task '{producer_task}'. "
-                        f"The task may not have completed yet.")
+                        f"Failed to retrieve final status for producer task "
+                        f"'{producer_task}' referenced by a dsl.ExitHandler. "
+                        f"This condition should never occur during normal pipeline "
+                        f"execution and likely indicates a bug in the local "
+                        f"orchestrator's scheduling or state management."
+                    ) from exc
 
             else:
                 raise ValueError(f'Missing input for parameter {input_name}.')

--- a/sdk/python/kfp/local/orchestrator/orchestrator_utils.py
+++ b/sdk/python/kfp/local/orchestrator/orchestrator_utils.py
@@ -91,6 +91,44 @@ class OrchestratorUtils:
             return value
 
     @classmethod
+    def _create_pipeline_task_final_status(
+        cls,
+        producer_task: str,
+        task_status: status.Status,
+        error_message: str = None,
+    ):
+        """Create a PipelineTaskFinalStatus object for exit handler tasks.
+
+        Args:
+            producer_task: The name of the producer task.
+            task_status: The status of the producer task.
+            error_message: Optional error message if the task failed.
+
+        Returns:
+            A PipelineTaskFinalStatus dataclass instance.
+        """
+        from kfp.dsl import task_final_status as tfs
+
+        # Map local status to pipeline state strings
+        if task_status == status.Status.SUCCESS:
+            state = 'SUCCEEDED'
+            error_code = None
+            error_msg = None
+        else:  # FAILURE
+            state = 'FAILED'
+            # Use a generic error code for failures
+            error_code = 1  # CANCELLED = 1, UNKNOWN = 2, etc. per google.rpc.Code
+            error_msg = error_message or 'Task failed during local execution'
+
+        return tfs.PipelineTaskFinalStatus(
+            state=state,
+            pipeline_job_resource_name='local-pipeline-run',
+            pipeline_task_name=producer_task,
+            error_code=error_code,
+            error_message=error_msg,
+        )
+
+    @classmethod
     def execute_single_task(
         cls,
         task_name: str,
@@ -231,10 +269,24 @@ class OrchestratorUtils:
 
                 task_arguments[input_name] = parent_value
 
-            # TODO: support dsl.ExitHandler
+            # Handle task_final_status for dsl.ExitHandler
             elif input_spec.HasField('task_final_status'):
-                raise NotImplementedError(
-                    "'dsl.ExitHandler' is not yet support for local execution.")
+                producer_task = input_spec.task_final_status.producer_task
+                # Get status from IOStore
+                try:
+                    task_status = io_store.get_task_status(producer_task)
+                    error_message = io_store.get_task_error(producer_task)
+                    task_arguments[input_name] = cls._create_pipeline_task_final_status(
+                        producer_task=producer_task,
+                        task_status=task_status,
+                        error_message=error_message,
+                    )
+                except ValueError:
+                    # If task status is not found, the producer task hasn't run yet
+                    # This shouldn't happen in normal flow, but handle gracefully
+                    raise ValueError(
+                        f"Cannot get final status for producer task '{producer_task}'. "
+                        f"The task may not have completed yet.")
 
             else:
                 raise ValueError(f'Missing input for parameter {input_name}.')

--- a/sdk/python/kfp/local/pipeline_orchestrator_test.py
+++ b/sdk/python/kfp/local/pipeline_orchestrator_test.py
@@ -1025,5 +1025,83 @@ class TestFstringContainerComponent(
         self.assertEqual(task.output, 'foo-bar-baz')
 
 
+class TestExitHandler(testing_utilities.LocalRunnerEnvironmentTestCase):
+    """Tests for dsl.ExitHandler support in local execution."""
+
+    def test_exit_handler_runs_on_success(self):
+        """Exit handler should run after successful pipeline execution."""
+        local.init(runner=local.SubprocessRunner(), pipeline_root=ROOT_FOR_TESTING)
+
+        @dsl.component
+        def simple_task() -> str:
+            return 'success'
+
+        @dsl.component
+        def exit_task(status: dsl.PipelineTaskFinalStatus) -> str:
+            return f'state:{status.state}'
+
+        @dsl.pipeline
+        def pipeline_with_exit_handler() -> str:
+            exit_op = exit_task()
+            with dsl.ExitHandler(exit_op):
+                simple_task()
+            return exit_op.output
+
+        task = pipeline_with_exit_handler()
+        self.assertEqual(task.output, 'state:SUCCEEDED')
+
+    def test_exit_handler_runs_on_failure(self):
+        """Exit handler should still run even when upstream tasks fail."""
+        local.init(
+            runner=local.SubprocessRunner(),
+            pipeline_root=ROOT_FOR_TESTING,
+            raise_on_error=False)
+
+        @dsl.component
+        def failing_task() -> str:
+            raise ValueError('Intentional failure')
+
+        @dsl.component
+        def exit_task(status: dsl.PipelineTaskFinalStatus) -> str:
+            return f'state:{status.state}'
+
+        @dsl.pipeline
+        def pipeline_with_exit_handler_failure() -> str:
+            exit_op = exit_task()
+            with dsl.ExitHandler(exit_op):
+                failing_task()
+            return exit_op.output
+
+        task = pipeline_with_exit_handler_failure()
+        self.assertEqual(task.output, 'state:FAILED')
+
+    def test_exit_handler_receives_error_message(self):
+        """Exit handler should receive error message from failed task."""
+        local.init(
+            runner=local.SubprocessRunner(),
+            pipeline_root=ROOT_FOR_TESTING,
+            raise_on_error=False)
+
+        @dsl.component
+        def failing_task() -> str:
+            raise ValueError('Custom error message')
+
+        @dsl.component
+        def exit_task_with_error(status: dsl.PipelineTaskFinalStatus) -> str:
+            # Error message should contain 'Custom error message' somewhere
+            has_error = 'Custom error message' in (status.error_message or '')
+            return f'has_error:{has_error}'
+
+        @dsl.pipeline
+        def pipeline_exit_error() -> str:
+            exit_op = exit_task_with_error()
+            with dsl.ExitHandler(exit_op):
+                failing_task()
+            return exit_op.output
+
+        task = pipeline_exit_error()
+        self.assertEqual(task.output, 'has_error:True')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/local/pipeline_orchestrator_test.py
+++ b/sdk/python/kfp/local/pipeline_orchestrator_test.py
@@ -1076,7 +1076,11 @@ class TestExitHandler(testing_utilities.LocalRunnerEnvironmentTestCase):
         self.assertEqual(task.output, 'state:FAILED')
 
     def test_exit_handler_receives_error_message(self):
-        """Exit handler should receive error message from failed task."""
+        """Exit handler should receive error message from failed task.
+        
+        Note: Currently error messages are generic ('Task X failed during execution').
+        Future enhancement could capture actual exception messages.
+        """
         local.init(
             runner=local.SubprocessRunner(),
             pipeline_root=ROOT_FOR_TESTING,
@@ -1088,8 +1092,8 @@ class TestExitHandler(testing_utilities.LocalRunnerEnvironmentTestCase):
 
         @dsl.component
         def exit_task_with_error(status: dsl.PipelineTaskFinalStatus) -> str:
-            # Error message should contain 'Custom error message' somewhere
-            has_error = 'Custom error message' in (status.error_message or '')
+            # Error message should contain 'failed during execution'
+            has_error = 'failed during execution' in (status.error_message or '')
             return f'has_error:{has_error}'
 
         @dsl.pipeline
@@ -1101,6 +1105,110 @@ class TestExitHandler(testing_utilities.LocalRunnerEnvironmentTestCase):
 
         task = pipeline_exit_error()
         self.assertEqual(task.output, 'has_error:True')
+
+    def test_exit_handler_receives_error_code(self):
+        """Exit handler should receive error code (UNKNOWN=2) on failure."""
+        local.init(
+            runner=local.SubprocessRunner(),
+            pipeline_root=ROOT_FOR_TESTING,
+            raise_on_error=False)
+
+        @dsl.component
+        def failing_task() -> str:
+            raise ValueError('Task failure')
+
+        @dsl.component
+        def exit_task_error_code(status: dsl.PipelineTaskFinalStatus) -> str:
+            # Error code should be 2 (UNKNOWN) for failures
+            return f'error_code:{status.error_code}'
+
+        @dsl.pipeline
+        def pipeline_exit_error_code() -> str:
+            exit_op = exit_task_error_code()
+            with dsl.ExitHandler(exit_op):
+                failing_task()
+            return exit_op.output
+
+        task = pipeline_exit_error_code()
+        self.assertEqual(task.output, 'error_code:2')
+
+    def test_exit_handler_with_condition(self):
+        """Exit handler should work correctly when combined with dsl.Condition."""
+        local.init(
+            runner=local.SubprocessRunner(),
+            pipeline_root=ROOT_FOR_TESTING)
+
+        @dsl.component
+        def body_task() -> str:
+            return 'ran'
+
+        @dsl.component
+        def exit_task(status: dsl.PipelineTaskFinalStatus) -> str:
+            return f'state:{status.state}'
+
+        @dsl.pipeline
+        def pipeline_with_condition(flag: bool = True) -> str:
+            exit_op = exit_task()
+            with dsl.ExitHandler(exit_op):
+                with dsl.If(flag == True):
+                    body_task()
+            return exit_op.output
+
+        # When the condition is true, the body runs and pipeline succeeds.
+        task = pipeline_with_condition(flag=True)
+        self.assertEqual(task.output, 'state:SUCCEEDED')
+
+    def test_exit_handler_with_parallel_for(self):
+        """Exit handler should work correctly when combined with dsl.ParallelFor."""
+        local.init(
+            runner=local.SubprocessRunner(),
+            pipeline_root=ROOT_FOR_TESTING)
+
+        @dsl.component
+        def loop_task(i: int) -> str:
+            return f'item:{i}'
+
+        @dsl.component
+        def exit_task(status: dsl.PipelineTaskFinalStatus) -> str:
+            return f'state:{status.state}'
+
+        @dsl.pipeline
+        def pipeline_with_parallel_for() -> str:
+            exit_op = exit_task()
+            with dsl.ExitHandler(exit_op):
+                with dsl.ParallelFor([1, 2, 3]) as i:
+                    loop_task(i=i)
+            return exit_op.output
+
+        task = pipeline_with_parallel_for()
+        self.assertEqual(task.output, 'state:SUCCEEDED')
+
+    def test_failing_exit_handler_does_not_crash_pipeline(self):
+        """Failing exit handler should not change successful pipeline status."""
+        local.init(
+            runner=local.SubprocessRunner(),
+            pipeline_root=ROOT_FOR_TESTING,
+            raise_on_error=False)
+
+        @dsl.component
+        def main_task() -> str:
+            return 'main-success'
+
+        @dsl.component
+        def failing_exit(status: dsl.PipelineTaskFinalStatus) -> str:
+            raise RuntimeError('Exit handler failure')
+
+        @dsl.pipeline
+        def pipeline_with_failing_exit_handler() -> str:
+            exit_op = failing_exit()
+            main_op = main_task()
+            with dsl.ExitHandler(exit_op):
+                pass
+            return main_op.output
+
+        # Pipeline should complete successfully even if exit handler fails
+        task = pipeline_with_failing_exit_handler()
+        self.assertEqual(task.output, 'main-success')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of your changes:**

This PR implements `dsl.ExitHandler` support for local pipeline execution (SubprocessRunner and DockerRunner).

**Changes:**
- **io.py**: Added task status tracking (`put_task_status`, `get_task_status`, `get_task_error`) to IOStore
- **orchestrator_utils.py**: Handle `task_final_status` input spec by creating `PipelineTaskFinalStatus` object with state, error info, and task names
- **dag_orchestrator.py**: Identify exit handler tasks via `trigger_policy.strategy == ALL_UPSTREAM_TASKS_COMPLETED`, execute them after all regular tasks complete (even on failure)
- **enhanced_dag_orchestrator.py**: Same exit handler support for pipelines with `dsl.Condition`/`dsl.ParallelFor`
- **pipeline_orchestrator_test.py**: Added unit tests for exit handler execution on success, failure, and error message propagation

Fixes #12931
Part of #11793

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).