### PR TITLE
docs(frontend): clean contributor docs and improve integration-test error wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ request issue to help reviewers catch up on the context.
 
 ## Project Structure
 
-Kubeflow Pipelines consists of multiple components. Before you begin, learn how to [build the Kubeflow Pipelines component container images](./developer_guide.md##build-image). To get started, see the development guides:
+Kubeflow Pipelines consists of multiple components. Before you begin, learn how to [build the Kubeflow Pipelines component container images](./developer_guide.md#build-image). To get started, see the development guides:
 
 * [Frontend development guide](./frontend/README.md)
 * [Backend development guide](./backend/README.md)
@@ -183,7 +183,7 @@ omit the scope because it's optional, or propose an additional scope here.
 
 ## Adding Kubernetes Enhancement Proposals (KEPs)
 
-When a change requires a significant change to the underlying system, it should be preceded with an Kubernetes Enhancement Proposal (KEP).
+When a change requires a significant change to the underlying system, it should be preceded with a Kubernetes Enhancement Proposal (KEP).
 
 KEPs are found in the `proposals` folder at the root of this repo. Read more about the process [here](proposals/README.md).
 

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -97,7 +97,7 @@ $ docker build -t ml-pipeline-api-server -f backend/Dockerfile .
 Python based visualizations are a new method to visualize results within the
 Kubeflow Pipelines UI. For more information about Python based visualizations
 please visit the [documentation page](https://www.kubeflow.org/docs/pipelines/sdk/python-based-visualizations).
-To create predefine visualizations please check the [developer guide](https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/visualization/README.md).
+To create predefined visualizations, check the [developer guide](https://github.com/kubeflow/pipelines/blob/master/backend/src/apiserver/visualization/README.md).
 
 ## Unit test
 
@@ -111,13 +111,19 @@ cd backend/src/ && go test ./...
 
 ### Frontend
 
-TODO: add instruction
+Run frontend unit tests from the `frontend/` directory:
+
+```bash
+cd frontend
+npm ci
+npm run test:ui
+```
 
 ### DSL
 
 ```bash
-pip install ./dsl/ --upgrade && python ./dsl/tests/main.py
-pip install ./dsl-compiler/ --upgrade && python ./dsl-compiler/tests/main.py
+pip install -r sdk/python/requirements-dev.txt
+pytest -v sdk/python/kfp
 ```
 
 ## Integration test & E2E test
@@ -126,9 +132,9 @@ Check [this](https://github.com/kubeflow/pipelines/blob/master/test/README.md) p
 
 ## Troubleshooting
 
-**Q: How to access to the database directly?**
+**Q: How do I access the database directly?**
 
-You can inspect mysql database directly by running:
+You can inspect the MySQL database directly by running:
 
 ```bash
 kubectl run -it --rm --image=docker.io/library/mysql:8.4 --restart=Never mysql-client -- mysql -h mysql
@@ -146,7 +152,7 @@ Access Key:minio
 Secret Key:minio123
 ```
 
-**Q: I see an error of exceeding Github rate limit when deploying the system. What can I do?**
+**Q: I see an error about exceeding the GitHub rate limit when deploying the system. What can I do?**
 
 See [Ksonnet troubleshooting page](https://github.com/ksonnet/ksonnet/blob/master/docs/troubleshooting.md#github-rate-limiting-errors)
 

--- a/frontend/server/integration-tests/tensorboard.test.ts
+++ b/frontend/server/integration-tests/tensorboard.test.ts
@@ -213,7 +213,7 @@ describe('/apps/tensorboard', () => {
         .get('/apis/v1beta1/auth', (_, res) => {
           res.status(400).send(
             JSON.stringify({
-              error: 'User xxx is not unauthorized to list viewers',
+              error: 'User xxx is not authorized to list viewers',
               details: ['unauthorized', 'callstack'],
             }),
           );
@@ -231,13 +231,13 @@ describe('/apps/tensorboard', () => {
         .get(`/apps/tensorboard?logdir=some-log-dir&namespace=test-ns`)
         .expect(
           401,
-          'User is not authorized to GET VIEWERS in namespace test-ns: User xxx is not unauthorized to list viewers',
+          'User is not authorized to GET VIEWERS in namespace test-ns: User xxx is not authorized to list viewers',
         );
       expect(errorSpy).toHaveBeenCalledTimes(1);
       expect(
         errorSpy,
       ).toHaveBeenCalledWith(
-        'User is not authorized to GET VIEWERS in namespace test-ns: User xxx is not unauthorized to list viewers',
+        'User is not authorized to GET VIEWERS in namespace test-ns: User xxx is not authorized to list viewers',
         ['unauthorized', 'callstack'],
       );
     });

--- a/manifests/gcp_marketplace/cli.md
+++ b/manifests/gcp_marketplace/cli.md
@@ -108,13 +108,13 @@ export APP_INSTANCE_NAME=kubeflow-pipelines-app
 export NAMESPACE=<namespace>
 ```
 
-Creat the namespace
+Create the namespace
 ```shell
 kubectl create namespace $NAMESPACE
 ```
 
 Follow the [instruction](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/tool-prerequisites.md#tool-prerequisites) and install mpdev
-TODO: The official mpdev won't work because it doesn't have permission to deploy CRD. The latest unofficial build will have right permission. Remove following instruction when change is in prod.
+Note: The official `mpdev` image may not have permission to deploy CRDs. Use the temporary image below until upstream permissions are fixed.
 ```
 BIN_FILE="$HOME/bin/mpdev"
 docker run gcr.io/cloud-marketplace-staging/marketplace-k8s-app-tools/k8s/dev:remove-ui-ownerrefs cat /scripts/dev > "$BIN_FILE"


### PR DESCRIPTION
*Summary*
Improves contributor-facing docs and fixes misleading test assertion text.


*Why*
Reduces onboarding friction from outdated instructions.
Removes ambiguous “not unauthorized” phrasing in integration tests.


*What changed
*
Updated unit-test instructions in [developer_guide.md].

Fixed contributor guide anchor link in [CONTRIBUTING.md).

Improved wording/grammar in [developer_guide.md].

Corrected auth error message wording in [tensorboard.test.ts].

Validation
Checked diagnostics on edited files; no errors reported.

Risk/impact
Low risk: docs/test-text only, no runtime logic changes.

Checklist
Tests added/updated if needed: Not needed (no behavior change).
Docs updated: Yes.
Backward compatibility impact: None.