### PR TITLE
docs(frontend): refresh React 18/19 upgrade checklist status

### DIFF
--- a/frontend/docs/react-18-19-upgrade-checklist.md
+++ b/frontend/docs/react-18-19-upgrade-checklist.md
@@ -16,6 +16,9 @@
 **Assignee**: @jeffspahr
 **Depends on**: Nothing
 
+**Status**:
+Completed via [#12855](https://github.com/kubeflow/pipelines/pull/12855), [#12856](https://github.com/kubeflow/pipelines/pull/12856), [#12858](https://github.com/kubeflow/pipelines/pull/12858), and [#12872](https://github.com/kubeflow/pipelines/pull/12872).
+
 **Description**:
 Land cleanup PRs ([#12855](https://github.com/kubeflow/pipelines/pull/12855), [#12856](https://github.com/kubeflow/pipelines/pull/12856), [#12858](https://github.com/kubeflow/pipelines/pull/12858), [#12872](https://github.com/kubeflow/pipelines/pull/12872)) that remove `react-dom/test-utils` imports, `snapshot-diff`, upgrade `re-resizable`, add DOM nesting warning coverage, and remove dead dependencies. Goal: reduce warning/test noise before dependency migrations begin.
 
@@ -26,6 +29,9 @@ Land cleanup PRs ([#12855](https://github.com/kubeflow/pipelines/pull/12855), [#
 **Labels**: `area/frontend`, `priority/p0`, `kind/infra`
 **Assignee**: @jeffspahr
 **Depends on**: #1
+
+**Status**:
+Completed via [#12881](https://github.com/kubeflow/pipelines/pull/12881).
 
 **Description**:
 Add `check-react-peers.mjs` script ([#12881](https://github.com/kubeflow/pipelines/pull/12881)) and wire it into `npm run test:ci`. Introduces `npm run check:react-peers` (target 17), `check:react-peers:18`, and `check:react-peers:19`. The gate enforces that all dependencies declare peer ranges supporting the target React version. An allowlist tracks known exceptions with documented justifications.


### PR DESCRIPTION
## Summary

Refresh `frontend/docs/react-18-19-upgrade-checklist.md` to reflect the current upstream state after the recent frontend dependency migrations landed.

## What changed

- mark Storybook work as completed via [#12940](https://github.com/kubeflow/pipelines/pull/12940)
- mark MUI v5 work as completed via [#12925](https://github.com/kubeflow/pipelines/pull/12925) and note that issue #12894 is now closed
- record the accepted MUI visual-delta decision instead of the older exact-pixel-parity wording
- update React 18 and React 19 blocker lists from the current peer-gate output
- align the plan with active in-flight PRs:
  - [#12946](https://github.com/kubeflow/pipelines/pull/12946) for issue #12892
  - [#12945](https://github.com/kubeflow/pipelines/pull/12945) for issue #12893
- clarify that the `react-query` migration should stay on a React-17-compatible TanStack version before the React 18 bump

## Verification

- doc-only change
- source of truth cross-checks performed against current issues/PRs and current `master` state

## Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) follows the repository title convention
