### PR TITLE
test(backend): add test coverage for apiserver/validation package

### DIFF
--- a/backend/src/apiserver/validation/length_test.go
+++ b/backend/src/apiserver/validation/length_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,4 +41,66 @@ func TestValidateFieldLength_NoSpec(t *testing.T) {
 	err := ValidateFieldLength("NonExistentModel", "NonExistentField", "value")
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Length spec missing for NonExistentModel.NonExistentField")
+}
+
+func TestValidateModel(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         interface{}
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:          "nil pointer returns InternalServerError",
+			input:         nil,
+			expectError:   true,
+			errorContains: "non-nil pointer",
+		},
+		{
+			name:          "non-pointer value type returns InternalServerError",
+			input:         model.Pipeline{},
+			expectError:   true,
+			errorContains: "non-nil pointer",
+		},
+		{
+			name: "valid model passes validation",
+			input: &model.Pipeline{
+				UUID:      "abc",
+				Name:      "test",
+				Namespace: "ns",
+			},
+			expectError: false,
+		},
+		{
+			name: "field exceeding max length returns InvalidInputError",
+			input: &model.Pipeline{
+				Name: strings.Repeat("a", 129),
+			},
+			expectError:   true,
+			errorContains: "Pipeline.Name length cannot exceed 128",
+		},
+		{
+			name: "fields without length specs are skipped",
+			input: &model.Experiment{
+				UUID:                  "x",
+				Name:                  "y",
+				Namespace:             "z",
+				CreatedAtInSec:        9999999,
+				LastRunCreatedAtInSec: 9999999,
+			},
+			expectError: false,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := ValidateModel(testCase.input)
+			if testCase.expectError {
+				assert.NotNil(t, err)
+				assert.Contains(t, err.Error(), testCase.errorContains)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
 }

--- a/backend/src/apiserver/validation/namespace_test.go
+++ b/backend/src/apiserver/validation/namespace_test.go
@@ -1,0 +1,80 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateNamespaceRequired(t *testing.T) {
+	tests := []struct {
+		name                         string
+		multiUser                    string
+		requireNamespaceForPipelines string
+		namespace                    string
+		expectError                  bool
+		errorContains                string
+	}{
+		{
+			name:                         "single-user mode with empty namespace passes",
+			multiUser:                    "false",
+			requireNamespaceForPipelines: "false",
+			namespace:                    "",
+			expectError:                  false,
+		},
+		{
+			name:                         "multi-user mode with namespace not required and empty namespace passes",
+			multiUser:                    "true",
+			requireNamespaceForPipelines: "false",
+			namespace:                    "",
+			expectError:                  false,
+		},
+		{
+			name:                         "multi-user mode with namespace required and non-empty namespace passes",
+			multiUser:                    "true",
+			requireNamespaceForPipelines: "true",
+			namespace:                    "team-a",
+			expectError:                  false,
+		},
+		{
+			name:                         "multi-user mode with namespace required and empty namespace returns error",
+			multiUser:                    "true",
+			requireNamespaceForPipelines: "true",
+			namespace:                    "",
+			expectError:                  true,
+			errorContains:                "Namespace is required",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Cleanup(viper.Reset)
+			viper.Set(common.MultiUserMode, testCase.multiUser)
+			viper.Set(common.RequireNamespaceForPipelines, testCase.requireNamespaceForPipelines)
+
+			err := ValidateNamespaceRequired(testCase.namespace)
+			if testCase.expectError {
+				assert.NotNil(t, err)
+				assert.Contains(t, err.Error(), testCase.errorContains)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `TestValidateModel` with 5 subtests covering nil pointer, non-pointer value type, valid model, field exceeding max length, and non-string field handling
- Add `TestValidateNamespaceRequired` with 4 table-driven subtests covering single-user mode, multi-user with/without namespace requirement, and missing namespace error case
- Brings `apiserver/validation` package from 36.4% to 100% statement coverage

## Test plan
- [x] `CGO_ENABLED=0 go test -v -cover ./backend/src/apiserver/validation/...` — all 12 tests pass, 100% coverage
- [x] `gofmt -w` applied to test files
- [ ] CI presubmit passes