### PR TITLE
feat: introduce minimal Kubeflow Pipelines Helm chart with base parity

### DIFF
--- a/charts/kubeflow-pipelines/Chart.yaml
+++ b/charts/kubeflow-pipelines/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kubeflow-pipelines
+description: Minimal Helm chart for Kubeflow Pipelines (V1 parity)
+type: application
+version: 0.1.0
+appVersion: "2.16.0"

--- a/charts/kubeflow-pipelines/scripts/helm_kustomize_compare.py
+++ b/charts/kubeflow-pipelines/scripts/helm_kustomize_compare.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+
+import yaml
+import sys
+import re
+from typing import Dict, List, Any
+
+
+# ----------------------------
+# YAML Loading (Defensive)
+# ----------------------------
+
+def load_manifests(file_path: str) -> List[Dict]:
+    """Load YAML manifests from file with safe fallback parsing."""
+    with open(file_path, "r") as f:
+        content = f.read()
+
+    docs: List[Dict] = []
+
+    try:
+        for doc in yaml.safe_load_all(content):
+            if doc:
+                docs.append(doc)
+    except yaml.YAMLError:
+        # Fallback manual split
+        for doc_str in content.split("---"):
+            doc_str = doc_str.strip()
+            if not doc_str:
+                continue
+            try:
+                doc = yaml.safe_load(doc_str)
+                if doc:
+                    docs.append(doc)
+            except yaml.YAMLError:
+                continue
+
+    return docs
+
+
+# ----------------------------
+# Metadata Normalization
+# ----------------------------
+
+def clean_helm_metadata(obj: Any) -> Any:
+    """Remove Helm-injected metadata fields while preserving canonical metadata."""
+    if isinstance(obj, dict):
+        cleaned = {}
+
+        for key, value in obj.items():
+            if key == "metadata" and isinstance(value, dict):
+                cleaned_metadata = {}
+
+                for meta_key, meta_value in value.items():
+
+                    # Strip runtime-managed fields
+                    if meta_key in [
+                        "generation",
+                        "resourceVersion",
+                        "uid",
+                        "creationTimestamp",
+                        "managedFields",
+                    ]:
+                        continue
+
+                    if meta_key == "labels" and isinstance(meta_value, dict):
+                        cleaned_labels = {}
+
+                        for label_key, label_value in meta_value.items():
+                            if (
+                                not label_key.startswith("helm.sh/")
+                                and label_key != "app.kubernetes.io/managed-by"
+                                and label_key != "app.kubernetes.io/instance"
+                                and label_key != "app.kubernetes.io/version"
+                                and label_key != "app.kubernetes.io/name"
+                                and label_key != "app.kubernetes.io/component"
+                            ):
+                                cleaned_labels[label_key] = label_value
+
+                        if cleaned_labels:
+                            cleaned_metadata["labels"] = cleaned_labels
+                        continue
+
+                    if meta_key == "annotations" and isinstance(meta_value, dict):
+                        cleaned_annotations = {}
+
+                        for ann_key, ann_value in meta_value.items():
+                            if not ann_key.startswith(
+                                ("helm.sh/", "meta.helm.sh/")
+                            ):
+                                cleaned_annotations[ann_key] = ann_value
+
+                        if cleaned_annotations:
+                            cleaned_metadata["annotations"] = cleaned_annotations
+                        continue
+
+                    cleaned_metadata[meta_key] = meta_value
+
+                cleaned[key] = cleaned_metadata
+            else:
+                cleaned[key] = clean_helm_metadata(value)
+
+        return cleaned
+
+    if isinstance(obj, list):
+        return [clean_helm_metadata(item) for item in obj]
+
+    return obj
+
+
+# ----------------------------
+# Hash Normalization
+# ----------------------------
+
+def normalize_hash_suffix(name: str) -> str:
+    """Remove Kustomize hash suffix from resource names."""
+    return re.sub(r"-[a-z0-9]{10}$", "", name)
+
+
+def normalize_manifest(manifest: Dict) -> Dict:
+    """Normalize manifest for deterministic comparison."""
+    normalized = manifest.copy()
+
+    normalized = clean_helm_metadata(normalized)
+
+    # Remove status block
+    normalized.pop("status", None)
+
+    if "metadata" in normalized and "name" in normalized["metadata"]:
+        kind = normalized.get("kind", "")
+        if kind in ["Secret", "ConfigMap"]:
+            normalized["metadata"]["name"] = normalize_hash_suffix(
+                normalized["metadata"]["name"]
+            )
+
+    def remove_empty_values(obj):
+        if isinstance(obj, dict):
+            return {
+                k: remove_empty_values(v)
+                for k, v in obj.items()
+                if v is not None and v != {} and v != []
+            }
+        if isinstance(obj, list):
+            return [remove_empty_values(item) for item in obj if item is not None]
+        return obj
+
+    return remove_empty_values(normalized)
+
+
+# ----------------------------
+# Resource Keying
+# ----------------------------
+
+def get_resource_key(manifest: Dict) -> str:
+    """Generate stable key for resource comparison."""
+    kind = manifest.get("kind", "Unknown")
+    metadata = manifest.get("metadata", {})
+    name = metadata.get("name", "unknown")
+    namespace = metadata.get("namespace", "")
+
+    if kind in ["Secret", "ConfigMap"]:
+        name = normalize_hash_suffix(name)
+
+    if namespace:
+        return f"{kind}/{namespace}/{name}"
+
+    return f"{kind}/{name}"
+
+
+# ----------------------------
+# Deep Structural Diff
+# ----------------------------
+
+def deep_diff(obj1: Any, obj2: Any, path: str = "") -> List[str]:
+    differences: List[str] = []
+
+    if type(obj1) != type(obj2):
+        differences.append(
+            f"{path}: type mismatch ({type(obj1).__name__} vs {type(obj2).__name__})"
+        )
+        return differences
+
+    if isinstance(obj1, dict):
+        all_keys = set(obj1.keys()) | set(obj2.keys())
+
+        for key in sorted(all_keys):
+            key_path = f"{path}.{key}" if path else key
+
+            if key not in obj1:
+                differences.append(f"{key_path}: missing in kustomize")
+            elif key not in obj2:
+                differences.append(f"{key_path}: missing in helm")
+            else:
+                differences.extend(
+                    deep_diff(obj1[key], obj2[key], key_path)
+                )
+
+    elif isinstance(obj1, list):
+        if len(obj1) != len(obj2):
+            differences.append(
+                f"{path}: list length mismatch ({len(obj1)} vs {len(obj2)})"
+            )
+        else:
+            for i, (item1, item2) in enumerate(zip(obj1, obj2)):
+                differences.extend(
+                    deep_diff(item1, item2, f"{path}[{i}]")
+                )
+
+    elif obj1 != obj2:
+        differences.append(f"{path}: '{obj1}' != '{obj2}'")
+
+    return differences
+
+
+# ----------------------------
+# Comparison Logic
+# ----------------------------
+
+def compare_manifests(
+    kustomize_file: str,
+    helm_file: str,
+) -> bool:
+    """Compare Kustomize and Helm manifests with strict parity."""
+
+    kustomize_manifests = load_manifests(kustomize_file)
+    helm_manifests = load_manifests(helm_file)
+
+    kustomize_resources: Dict[str, Dict] = {}
+    helm_resources: Dict[str, Dict] = {}
+
+    for manifest in kustomize_manifests:
+        normalized = normalize_manifest(manifest)
+        key = get_resource_key(normalized)
+        kustomize_resources[key] = normalized
+
+    for manifest in helm_manifests:
+        normalized = normalize_manifest(manifest)
+        key = get_resource_key(normalized)
+        helm_resources[key] = normalized
+
+    kustomize_keys = set(kustomize_resources.keys())
+    helm_keys = set(helm_resources.keys())
+
+    only_in_kustomize = kustomize_keys - helm_keys
+    only_in_helm = helm_keys - kustomize_keys
+
+    success = True
+
+    if only_in_kustomize:
+        print(f"Resources only in Kustomize: {len(only_in_kustomize)}")
+        for key in sorted(only_in_kustomize):
+            print(f"  {key}")
+        success = False
+
+    if only_in_helm:
+        print(f"Unexpected resources only in Helm: {len(only_in_helm)}")
+        for key in sorted(only_in_helm):
+            print(f"  {key}")
+        success = False
+
+    for key in sorted(kustomize_keys & helm_keys):
+        differences = deep_diff(
+            kustomize_resources[key],
+            helm_resources[key],
+        )
+
+        if differences:
+            print(f"Differences in {key}: {len(differences)} fields")
+            for diff in differences:
+                print(f"  {diff}")
+            success = False
+
+    return success
+
+
+# ----------------------------
+# Entry Point
+# ----------------------------
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(
+            "Usage: python helm_kustomize_compare.py <kustomize_file> <helm_file>"
+        )
+        sys.exit(1)
+
+    kustomize_file = sys.argv[1]
+    helm_file = sys.argv[2]
+
+    result = compare_manifests(kustomize_file, helm_file)
+    sys.exit(0 if result else 1)

--- a/charts/kubeflow-pipelines/scripts/helm_kustomize_compare.sh
+++ b/charts/kubeflow-pipelines/scripts/helm_kustomize_compare.sh
@@ -90,7 +90,3 @@ echo "Running strict parity comparison..."
 python3 "$SCRIPT_DIR/helm_kustomize_compare.py" \
     "$KUSTOMIZE_OUTPUT" \
     "$HELM_OUTPUT"
-
-COMPARISON_RESULT=$?
-
-exit $COMPARISON_RESULT

--- a/charts/kubeflow-pipelines/scripts/helm_kustomize_compare.sh
+++ b/charts/kubeflow-pipelines/scripts/helm_kustomize_compare.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Compare Helm vs Kustomize manifests for Kubeflow Pipelines (base only)
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$SCRIPT_DIR/../../.." && pwd )"
+
+KUSTOMIZE_PATH="${1:-}"
+CHART_DIR="${2:-}"
+
+if [[ -z "$KUSTOMIZE_PATH" || -z "$CHART_DIR" ]]; then
+    echo "ERROR: Missing required arguments"
+    echo "Usage: $0 <kustomize-base-path> <helm-chart-path>"
+    echo ""
+    echo "Example:"
+    echo "  $0 ../manifests/kustomize/base charts/kubeflow-pipelines"
+    exit 1
+fi
+
+echo "Comparing kubeflow-pipelines manifests (base)"
+
+# ----------------------------
+# Validate Paths
+# ----------------------------
+
+if [ ! -d "$KUSTOMIZE_PATH" ]; then
+    echo "ERROR: Kustomize path does not exist: $KUSTOMIZE_PATH"
+    exit 1
+fi
+
+if [ ! -d "$CHART_DIR" ]; then
+    echo "ERROR: Helm chart directory does not exist: $CHART_DIR"
+    exit 1
+fi
+
+if ! command -v kustomize >/dev/null 2>&1; then
+    echo "ERROR: kustomize binary not found"
+    exit 1
+fi
+
+if ! command -v helm >/dev/null 2>&1; then
+    echo "ERROR: helm binary not found"
+    exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 binary not found"
+    exit 1
+fi
+
+# ----------------------------
+# Temp Files
+# ----------------------------
+
+KUSTOMIZE_OUTPUT="$(mktemp)"
+HELM_OUTPUT="$(mktemp)"
+
+cleanup() {
+    rm -f "$KUSTOMIZE_OUTPUT" "$HELM_OUTPUT"
+}
+trap cleanup EXIT
+
+# ----------------------------
+# Build Kustomize Output
+# ----------------------------
+
+cd "$ROOT_DIR"
+
+echo "Building Kustomize output..."
+kustomize build "$KUSTOMIZE_PATH" > "$KUSTOMIZE_OUTPUT"
+
+# ----------------------------
+# Render Helm Output
+# ----------------------------
+
+echo "Rendering Helm chart..."
+
+helm template kubeflow-pipelines "$CHART_DIR" \
+    --namespace kubeflow \
+    --include-crds \
+    > "$HELM_OUTPUT"
+
+# ----------------------------
+# Run Strict Parity Comparison
+# ----------------------------
+
+echo "Running strict parity comparison..."
+
+python3 "$SCRIPT_DIR/helm_kustomize_compare.py" \
+    "$KUSTOMIZE_OUTPUT" \
+    "$HELM_OUTPUT"
+
+COMPARISON_RESULT=$?
+
+exit $COMPARISON_RESULT

--- a/charts/kubeflow-pipelines/templates/cache-deployer/deployment.yaml
+++ b/charts/kubeflow-pipelines/templates/cache-deployer/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cache-deployer
+  name: cache-deployer-deployment
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cache-deployer
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: cache-deployer
+    spec:
+      containers:
+      - env:
+        - name: NAMESPACE_TO_WATCH
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: ghcr.io/kubeflow/kfp-cache-deployer:2.16.0
+        imagePullPolicy: Always
+        name: main
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          runAsGroup: 0
+          runAsNonRoot: true
+          runAsUser: 1000
+          seccompProfile:
+            type: RuntimeDefault
+      restartPolicy: Always
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kubeflow-pipelines-cache-deployer-sa

--- a/charts/kubeflow-pipelines/templates/cache-deployer/rbac.yaml
+++ b/charts/kubeflow-pipelines/templates/cache-deployer/rbac.yaml
@@ -31,3 +31,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kubeflow-pipelines-cache-deployer-sa
+  namespace: {{ .Release.Namespace }}

--- a/charts/kubeflow-pipelines/templates/cache-deployer/rbac.yaml
+++ b/charts/kubeflow-pipelines/templates/cache-deployer/rbac.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: cache-deployer
+  name: kubeflow-pipelines-cache-deployer-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: cache-deployer
+  name: kubeflow-pipelines-cache-deployer-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubeflow-pipelines-cache-deployer-role
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-pipelines-cache-deployer-sa

--- a/charts/kubeflow-pipelines/templates/cache/rbac.yaml
+++ b/charts/kubeflow-pipelines/templates/cache/rbac.yaml
@@ -1,0 +1,50 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: cache-server
+  name: kubeflow-pipelines-cache-role
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - argoproj.io
+  resources:
+  - workflows
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: cache-server
+  name: kubeflow-pipelines-cache-binding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubeflow-pipelines-cache-role
+subjects:
+- kind: ServiceAccount
+  name: kubeflow-pipelines-cache
+  namespace: {{ .Release.Namespace }}

--- a/charts/kubeflow-pipelines/templates/cache/service.yaml
+++ b/charts/kubeflow-pipelines/templates/cache/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: cache-server
+  name: cache-server
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-api
+  selector:
+    app: cache-server

--- a/charts/kubeflow-pipelines/templates/cache/service.yaml
+++ b/charts/kubeflow-pipelines/templates/cache/service.yaml
@@ -11,3 +11,30 @@ spec:
     targetPort: webhook-api
   selector:
     app: cache-server
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: cache-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cache-server
+  template:
+    metadata:
+      labels:
+        app: cache-server
+    spec:
+      serviceAccountName: cache-server
+      containers:
+      - name: cache-server
+        image: "{{ .Values.cacheServer.image }}"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: webhook-api
+          containerPort: 8443

--- a/charts/kubeflow-pipelines/templates/cache/serviceaccount.yaml
+++ b/charts/kubeflow-pipelines/templates/cache/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: cache-server
+  name: kubeflow-pipelines-cache
+  namespace: {{ .Release.Namespace }}

--- a/charts/kubeflow-pipelines/templates/config/pipeline-install-config.yaml
+++ b/charts/kubeflow-pipelines/templates/config/pipeline-install-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pipeline-install-config
+  namespace: {{ .Release.Namespace }}
+data:
+  dbHost: mysql
+  dbPort: "3306"
+  pipelineDb: mlpipeline
+  cacheDb: cache
+  mlmdDb: metadb
+  bucketName: mlpipeline
+  autoUpdatePipelineDefaultVersion: "true"
+  dbType: mysql
+  ConMaxLifeTime: "120s"
+  cronScheduleTimezone: UTC

--- a/charts/kubeflow-pipelines/templates/metadata-writer/deployment.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata-writer/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metadata-writer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: metadata-writer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metadata-writer
+  template:
+    metadata:
+      labels:
+        app: metadata-writer
+    spec:
+      serviceAccountName: kubeflow-pipelines-metadata-writer
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: main
+          image: ghcr.io/kubeflow/kfp-metadata-writer:2.16.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NAMESPACE_TO_WATCH
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault

--- a/charts/kubeflow-pipelines/templates/metadata/configmap-envoy.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/configmap-envoy.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metadata-envoy-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  envoy-config.yaml: |-
+    admin:
+      access_log:
+        name: admin_access
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          path: /tmp/admin_access.log
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+    static_resources:
+      listeners:
+        - name: listener_0
+          address:
+            socket_address: { address: 0.0.0.0, port_value: 9090 }
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    codec_type: auto
+                    stat_prefix: ingress_http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                        - name: local_service
+                          domains: [ "*" ]
+                          routes:
+                            - match: { prefix: "/" }
+                              route:
+                                cluster: metadata-cluster
+                                max_stream_duration:
+                                  grpc_timeout_header_max: '0s'
+                              typed_per_filter_config:
+                                envoy.filter.http.cors:
+                                  "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                                  allow_origin_string_match:
+                                    - safe_regex:
+                                        regex: ".*"
+                                  allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                                  allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                                  max_age: "1728000"
+                                  expose_headers: custom-header-1,grpc-status,grpc-message
+                    http_filters:
+                      - name: envoy.filters.http.grpc_web
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                      - name: envoy.filters.http.cors
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+                      - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+      clusters:
+        - name: metadata-cluster
+          connect_timeout: 30.0s
+          type: logical_dns
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: metadata-grpc
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: metadata-grpc-service
+                          port_value: 8080

--- a/charts/kubeflow-pipelines/templates/metadata/configmap-grpc.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/configmap-grpc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    component: metadata-grpc-server
+  name: metadata-grpc-configmap
+  namespace: {{ .Release.Namespace }}
+data:
+  METADATA_GRPC_SERVICE_HOST: metadata-grpc-service
+  METADATA_GRPC_SERVICE_PORT: "8080"

--- a/charts/kubeflow-pipelines/templates/metadata/deployment-envoy.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/deployment-envoy.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    component: metadata-envoy
   name: metadata-envoy-deployment
   namespace: {{ .Release.Namespace }}
+  labels:
+    component: metadata-envoy
 spec:
   replicas: 1
   selector:
@@ -16,16 +16,23 @@ spec:
         component: metadata-envoy
         sidecar.istio.io/inject: "false"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - args:
-            - /etc/envoy/envoy-config.yaml
+        - name: container
           image: ghcr.io/kubeflow/kfp-metadata-envoy:2.16.0
-          name: container
+          args:
+            - /etc/envoy/envoy-config.yaml
           ports:
             - containerPort: 9090
               name: md-envoy
             - containerPort: 9901
               name: envoy-admin
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /etc/envoy
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -36,14 +43,7 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-          volumeMounts:
-            - mountPath: /etc/envoy
-              name: envoy-config
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       volumes:
-        - configMap:
+        - name: envoy-config
+          configMap:
             name: metadata-envoy-configmap
-          name: envoy-config

--- a/charts/kubeflow-pipelines/templates/metadata/deployment-envoy.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/deployment-envoy.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: metadata-envoy
+  name: metadata-envoy-deployment
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: metadata-envoy
+  template:
+    metadata:
+      labels:
+        component: metadata-envoy
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+        - args:
+            - /etc/envoy/envoy-config.yaml
+          image: ghcr.io/kubeflow/kfp-metadata-envoy:2.16.0
+          name: container
+          ports:
+            - containerPort: 9090
+              name: md-envoy
+            - containerPort: 9901
+              name: envoy-admin
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /etc/envoy
+              name: envoy-config
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - configMap:
+            name: metadata-envoy-configmap
+          name: envoy-config

--- a/charts/kubeflow-pipelines/templates/metadata/deployment-grpc.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/deployment-grpc.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: metadata-grpc-server
+  name: metadata-grpc-deployment
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: metadata-grpc-server
+  template:
+    metadata:
+      labels:
+        component: metadata-grpc-server
+    spec:
+      containers:
+        - command:
+            - /bin/metadata_store_server
+          args:
+            - --grpc_port=8080
+            - --mysql_config_database=$(MYSQL_DATABASE)
+            - --mysql_config_host=$(MYSQL_HOST)
+            - --mysql_config_port=$(MYSQL_PORT)
+            - --mysql_config_user=$(DBCONFIG_USER)
+            - --mysql_config_password=$(DBCONFIG_PASSWORD)
+            - --enable_database_upgrade=true
+            - --grpc_channel_arguments=grpc.max_metadata_size=16384,grpc.max_receive_message_length=104857600,grpc.max_send_message_length=104857600
+          env:
+            - name: DBCONFIG_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: mysql-secret
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: mysql-secret
+            - name: MYSQL_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  key: mlmdDb
+                  name: pipeline-install-config
+            - name: MYSQL_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: dbHost
+                  name: pipeline-install-config
+            - name: MYSQL_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: dbPort
+                  name: pipeline-install-config
+          image: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
+          name: container
+          ports:
+            - containerPort: 8080
+              name: grpc-api
+          livenessProbe:
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            tcpSocket:
+              port: grpc-api
+            timeoutSeconds: 2
+          readinessProbe:
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            tcpSocket:
+              port: grpc-api
+            timeoutSeconds: 2
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: metadata-grpc-server

--- a/charts/kubeflow-pipelines/templates/metadata/deployment-grpc.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/deployment-grpc.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    component: metadata-grpc-server
   name: metadata-grpc-deployment
   namespace: {{ .Release.Namespace }}
+  labels:
+    component: metadata-grpc-server
 spec:
   replicas: 1
   selector:
@@ -15,8 +15,15 @@ spec:
       labels:
         component: metadata-grpc-server
     spec:
+      serviceAccountName: metadata-grpc-server
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - command:
+        - name: container
+          image: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
+          command:
             - /bin/metadata_store_server
           args:
             - --grpc_port=8080
@@ -27,49 +34,56 @@ spec:
             - --mysql_config_password=$(DBCONFIG_PASSWORD)
             - --enable_database_upgrade=true
             - --grpc_channel_arguments=grpc.max_metadata_size=16384,grpc.max_receive_message_length=104857600,grpc.max_send_message_length=104857600
+
           env:
             - name: DBCONFIG_USER
               valueFrom:
                 secretKeyRef:
                   key: username
                   name: mysql-secret
+
             - name: DBCONFIG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   key: password
                   name: mysql-secret
+
             - name: MYSQL_DATABASE
               valueFrom:
                 configMapKeyRef:
                   key: mlmdDb
                   name: pipeline-install-config
+
             - name: MYSQL_HOST
               valueFrom:
                 configMapKeyRef:
                   key: dbHost
                   name: pipeline-install-config
+
             - name: MYSQL_PORT
               valueFrom:
                 configMapKeyRef:
                   key: dbPort
                   name: pipeline-install-config
-          image: gcr.io/tfx-oss-public/ml_metadata_store_server:1.14.0
-          name: container
+
           ports:
             - containerPort: 8080
               name: grpc-api
+
           livenessProbe:
             initialDelaySeconds: 3
             periodSeconds: 5
+            timeoutSeconds: 2
             tcpSocket:
               port: grpc-api
-            timeoutSeconds: 2
+
           readinessProbe:
             initialDelaySeconds: 3
             periodSeconds: 5
+            timeoutSeconds: 2
             tcpSocket:
               port: grpc-api
-            timeoutSeconds: 2
+
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -80,8 +94,3 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
-      serviceAccountName: metadata-grpc-server

--- a/charts/kubeflow-pipelines/templates/metadata/service-envoy.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/service-envoy.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metadata-envoy
+  name: metadata-envoy-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: md-envoy
+    port: 9090
+    protocol: TCP
+  selector:
+    component: metadata-envoy
+  type: ClusterIP

--- a/charts/kubeflow-pipelines/templates/metadata/service-envoy.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/service-envoy.yaml
@@ -1,15 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: metadata-envoy
   name: metadata-envoy-service
   namespace: {{ .Release.Namespace }}
+  labels:
+    component: metadata-envoy
 spec:
   ports:
-  - name: md-envoy
-    port: 9090
-    protocol: TCP
+    - name: md-envoy
+      port: 9090
+      targetPort: md-envoy
   selector:
     component: metadata-envoy
-  type: ClusterIP

--- a/charts/kubeflow-pipelines/templates/metadata/service-grpc.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/service-grpc.yaml
@@ -1,15 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: metadata
   name: metadata-grpc-service
   namespace: {{ .Release.Namespace }}
+  labels:
+    component: metadata-grpc-server
 spec:
   ports:
-  - name: grpc-api
-    port: 8080
-    protocol: TCP
+    - name: grpc-api
+      port: 8080
+      targetPort: grpc-api
   selector:
     component: metadata-grpc-server
-  type: ClusterIP

--- a/charts/kubeflow-pipelines/templates/metadata/service-grpc.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/service-grpc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metadata
+  name: metadata-grpc-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: grpc-api
+    port: 8080
+    protocol: TCP
+  selector:
+    component: metadata-grpc-server
+  type: ClusterIP

--- a/charts/kubeflow-pipelines/templates/metadata/serviceaccount.yaml
+++ b/charts/kubeflow-pipelines/templates/metadata/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metadata-grpc-server
+  namespace: {{ .Release.Namespace }}

--- a/charts/kubeflow-pipelines/templates/ml-pipeline-ui/deployment.yaml
+++ b/charts/kubeflow-pipelines/templates/ml-pipeline-ui/deployment.yaml
@@ -28,23 +28,62 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
+              name: http
+
           env:
             - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
               value: /etc/config/viewer-pod-template.json
+
             - name: MINIO_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+
+            - name: MINIO_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: accesskey
+                  name: mlpipeline-minio-artifact
+
+            - name: MINIO_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: secretkey
+                  name: mlpipeline-minio-artifact
+
             - name: ALLOW_CUSTOM_VISUALIZATIONS
               value: "true"
+
             - name: FRONTEND_SERVER_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+
             - name: ARGO_ARCHIVE_LOGS
               value: "true"
+
             - name: DISABLE_GKE_METADATA
               value: "true"
+
+            - name: CLUSTER_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  key: CLUSTER_DOMAIN
+                  name: pipeline-install-config
+                  optional: true
+
+            - name: ARTIFACTS_SERVICE_PROXY_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  key: ARTIFACTS_PROXY_ENABLED
+                  name: pipeline-install-config
+                  optional: true
+
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+              readOnly: true
+
           livenessProbe:
             httpGet:
               path: /apis/v1beta1/healthz
@@ -52,6 +91,7 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
             timeoutSeconds: 2
+
           readinessProbe:
             httpGet:
               path: /apis/v1beta1/healthz
@@ -59,10 +99,12 @@ spec:
             initialDelaySeconds: 3
             periodSeconds: 5
             timeoutSeconds: 2
+
           resources:
             requests:
               cpu: 10m
               memory: 70Mi
+
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -73,3 +115,8 @@ spec:
             runAsUser: 1000
             seccompProfile:
               type: RuntimeDefault
+
+      volumes:
+        - name: config-volume
+          configMap:
+            name: ml-pipeline-ui-configmap

--- a/charts/kubeflow-pipelines/templates/ml-pipeline-ui/deployment.yaml
+++ b/charts/kubeflow-pipelines/templates/ml-pipeline-ui/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ml-pipeline-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ml-pipeline-ui
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ml-pipeline-ui
+    spec:
+      serviceAccountName: ml-pipeline-ui
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ml-pipeline-ui
+          image: ghcr.io/kubeflow/kfp-frontend:2.16.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
+          env:
+            - name: VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH
+              value: /etc/config/viewer-pod-template.json
+            - name: MINIO_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ALLOW_CUSTOM_VISUALIZATIONS
+              value: "true"
+            - name: FRONTEND_SERVER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ARGO_ARCHIVE_LOGS
+              value: "true"
+            - name: DISABLE_GKE_METADATA
+              value: "true"
+          livenessProbe:
+            httpGet:
+              path: /apis/v1beta1/healthz
+              port: 3000
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /apis/v1beta1/healthz
+              port: 3000
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 10m
+              memory: 70Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault

--- a/charts/kubeflow-pipelines/templates/ml-pipeline-ui/service.yaml
+++ b/charts/kubeflow-pipelines/templates/ml-pipeline-ui/service.yaml
@@ -6,11 +6,9 @@ metadata:
   labels:
     app: ml-pipeline-ui
 spec:
-  type: ClusterIP
-  selector:
-    app: ml-pipeline-ui
   ports:
     - name: http
       port: 80
-      protocol: TCP
       targetPort: 3000
+  selector:
+    app: ml-pipeline-ui

--- a/charts/kubeflow-pipelines/templates/ml-pipeline-ui/service.yaml
+++ b/charts/kubeflow-pipelines/templates/ml-pipeline-ui/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-pipeline-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ml-pipeline-ui
+spec:
+  type: ClusterIP
+  selector:
+    app: ml-pipeline-ui
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 3000

--- a/charts/kubeflow-pipelines/templates/ml-pipeline/deployment.yaml
+++ b/charts/kubeflow-pipelines/templates/ml-pipeline/deployment.yaml
@@ -1,0 +1,224 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ml-pipeline
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ml-pipeline
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ml-pipeline
+    spec:
+      serviceAccountName: ml-pipeline
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ml-pipeline-api-server
+          image: ghcr.io/kubeflow/kfp-api-server:2.16.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+              name: http
+            - containerPort: 8887
+              name: grpc
+
+          env:
+            - name: PUBLISH_LOGS
+              value: "true"
+            - name: LOG_LEVEL
+              value: info
+            - name: PIPELINE_LOG_LEVEL
+              value: "1"
+
+            - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
+              valueFrom:
+                configMapKeyRef:
+                  key: autoUpdatePipelineDefaultVersion
+                  name: pipeline-install-config
+
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+
+            - name: CLUSTER_DOMAIN
+              value: cluster.local
+
+            - name: OBJECTSTORECONFIG_SECURE
+              value: "false"
+
+            - name: OBJECTSTORECONFIG_BUCKETNAME
+              valueFrom:
+                configMapKeyRef:
+                  key: bucketName
+                  name: pipeline-install-config
+
+            - name: OBJECTSTORECONFIG_HOST
+              value: seaweedfs.kubeflow
+
+            - name: OBJECTSTORECONFIG_PORT
+              value: "9000"
+
+            - name: DBCONFIG_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: mysql-secret
+
+            - name: DBCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: mysql-secret
+
+            - name: DBCONFIG_DBNAME
+              valueFrom:
+                configMapKeyRef:
+                  key: pipelineDb
+                  name: pipeline-install-config
+
+            - name: DBCONFIG_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: dbHost
+                  name: pipeline-install-config
+
+            - name: DBCONFIG_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: dbPort
+                  name: pipeline-install-config
+
+            - name: DBCONFIG_CONMAXLIFETIME
+              valueFrom:
+                configMapKeyRef:
+                  key: ConMaxLifeTime
+                  name: pipeline-install-config
+
+            - name: DB_DRIVER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  key: dbType
+                  name: pipeline-install-config
+
+            - name: DBCONFIG_MYSQLCONFIG_USER
+              valueFrom:
+                secretKeyRef:
+                  key: username
+                  name: mysql-secret
+
+            - name: DBCONFIG_MYSQLCONFIG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: password
+                  name: mysql-secret
+
+            - name: DBCONFIG_MYSQLCONFIG_DBNAME
+              valueFrom:
+                configMapKeyRef:
+                  key: pipelineDb
+                  name: pipeline-install-config
+
+            - name: DBCONFIG_MYSQLCONFIG_HOST
+              valueFrom:
+                configMapKeyRef:
+                  key: mysqlHost
+                  name: pipeline-install-config
+
+            - name: DBCONFIG_MYSQLCONFIG_PORT
+              valueFrom:
+                configMapKeyRef:
+                  key: mysqlPort
+                  name: pipeline-install-config
+
+            - name: OBJECTSTORECONFIG_ACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: accesskey
+                  name: mlpipeline-minio-artifact
+
+            - name: OBJECTSTORECONFIG_SECRETACCESSKEY
+              valueFrom:
+                secretKeyRef:
+                  key: secretkey
+                  name: mlpipeline-minio-artifact
+
+            - name: V2_DRIVER_IMAGE
+              value: ghcr.io/kubeflow/kfp-driver:2.16.0
+
+            - name: V2_LAUNCHER_IMAGE
+              value: ghcr.io/kubeflow/kfp-launcher:2.16.0
+
+            - name: COMPILED_PIPELINE_SPEC_PATCH
+              value: '{}'
+
+            - name: DEFAULT_SECURITY_CONTEXT_RUN_AS_USER
+              valueFrom:
+                configMapKeyRef:
+                  key: defaultSecurityContextRunAsUser
+                  name: pipeline-install-config
+                  optional: true
+
+            - name: DEFAULT_SECURITY_CONTEXT_RUN_AS_GROUP
+              valueFrom:
+                configMapKeyRef:
+                  key: defaultSecurityContextRunAsGroup
+                  name: pipeline-install-config
+                  optional: true
+
+            - name: DEFAULT_SECURITY_CONTEXT_RUN_AS_NON_ROOT
+              valueFrom:
+                configMapKeyRef:
+                  key: defaultSecurityContextRunAsNonRoot
+                  name: pipeline-install-config
+                  optional: true
+
+          resources:
+            requests:
+              cpu: 250m
+              memory: 500Mi
+
+          livenessProbe:
+            httpGet:
+              path: /apis/v1beta1/healthz
+              port: 8888
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+
+          readinessProbe:
+            httpGet:
+              path: /apis/v1beta1/healthz
+              port: 8888
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+
+          startupProbe:
+            httpGet:
+              path: /apis/v1beta1/healthz
+              port: 8888
+            failureThreshold: 12
+            periodSeconds: 5
+            timeoutSeconds: 2
+
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault

--- a/charts/kubeflow-pipelines/templates/ml-pipeline/service.yaml
+++ b/charts/kubeflow-pipelines/templates/ml-pipeline/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-pipeline
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ml-pipeline
+spec:
+  type: ClusterIP
+  selector:
+    app: ml-pipeline
+  ports:
+    - name: http
+      port: 8888
+      protocol: TCP
+      targetPort: 8888
+    - name: grpc
+      port: 8887
+      protocol: TCP
+      targetPort: 8887

--- a/charts/kubeflow-pipelines/templates/ml-pipeline/service.yaml
+++ b/charts/kubeflow-pipelines/templates/ml-pipeline/service.yaml
@@ -6,15 +6,12 @@ metadata:
   labels:
     app: ml-pipeline
 spec:
-  type: ClusterIP
-  selector:
-    app: ml-pipeline
   ports:
     - name: http
       port: 8888
-      protocol: TCP
-      targetPort: 8888
+      targetPort: http
     - name: grpc
       port: 8887
-      protocol: TCP
-      targetPort: 8887
+      targetPort: grpc
+  selector:
+    app: ml-pipeline

--- a/charts/kubeflow-pipelines/templates/persistenceagent/deployment.yaml
+++ b/charts/kubeflow-pipelines/templates/persistenceagent/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-persistenceagent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ml-pipeline-persistenceagent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ml-pipeline-persistenceagent
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ml-pipeline-persistenceagent
+    spec:
+      serviceAccountName: ml-pipeline-persistenceagent
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ml-pipeline-persistenceagent
+          image: ghcr.io/kubeflow/kfp-persistence-agent:2.16.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: TTL_SECONDS_AFTER_WORKFLOW_FINISH
+              value: "86400"
+            - name: NUM_WORKERS
+              value: "2"
+            - name: LOG_LEVEL
+              value: info
+          resources:
+            requests:
+              cpu: 120m
+              memory: 500Mi
+          volumeMounts:
+            - mountPath: /var/run/secrets/kubeflow/tokens
+              name: persistenceagent-sa-token
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: persistenceagent-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: pipelines.kubeflow.org
+                  expirationSeconds: 3600
+                  path: persistenceagent-sa-token

--- a/charts/kubeflow-pipelines/templates/rbac/ml-pipeline-rbac.yaml
+++ b/charts/kubeflow-pipelines/templates/rbac/ml-pipeline-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ml-pipeline-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "configmaps", "secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["argoproj.io"]
+    resources: ["workflows", "workflows/finalizers"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ml-pipeline-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline-role
+subjects:
+  - kind: ServiceAccount
+    name: ml-pipeline
+    namespace: {{ .Release.Namespace }}

--- a/charts/kubeflow-pipelines/templates/rbac/scheduledworkflow-rbac.yaml
+++ b/charts/kubeflow-pipelines/templates/rbac/scheduledworkflow-rbac.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ml-pipeline-scheduledworkflow-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources: ["workflows"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ml-pipeline-scheduledworkflow-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline-scheduledworkflow-role
+subjects:
+  - kind: ServiceAccount
+    name: ml-pipeline-scheduledworkflow
+    namespace: {{ .Release.Namespace }}

--- a/charts/kubeflow-pipelines/templates/rbac/serviceaccounts.yaml
+++ b/charts/kubeflow-pipelines/templates/rbac/serviceaccounts.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ml-pipeline
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ml-pipeline-ui
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ml-pipeline-persistenceagent
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ml-pipeline-scheduledworkflow
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ml-pipeline-viewer-crd-service-account
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeflow-pipelines-metadata-writer
+  namespace: {{ .Release.Namespace }}

--- a/charts/kubeflow-pipelines/templates/rbac/viewer-crd-rbac.yaml
+++ b/charts/kubeflow-pipelines/templates/rbac/viewer-crd-rbac.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ml-pipeline-viewer-crd-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["kubeflow.org"]
+    resources: ["viewers"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ml-pipeline-viewer-crd-rolebinding
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ml-pipeline-viewer-crd-role
+subjects:
+  - kind: ServiceAccount
+    name: ml-pipeline-viewer-crd-service-account
+    namespace: {{ .Release.Namespace }}

--- a/charts/kubeflow-pipelines/templates/scheduledworkflow/deployment.yaml
+++ b/charts/kubeflow-pipelines/templates/scheduledworkflow/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-scheduledworkflow
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ml-pipeline-scheduledworkflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ml-pipeline-scheduledworkflow
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ml-pipeline-scheduledworkflow
+    spec:
+      serviceAccountName: ml-pipeline-scheduledworkflow
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ml-pipeline-scheduledworkflow
+          image: ghcr.io/kubeflow/kfp-scheduled-workflow-controller:2.16.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9090
+              name: http
+          env:
+            - name: METRICS_PORT
+              value: "9090"
+            - name: CLIENT_QPS
+              value: "10"
+            - name: RESYNC_INTERVAL_SECONDS
+              value: "30"
+            - name: CLIENT_BURST
+              value: "20"
+            - name: LOG_LEVEL
+              value: info
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /var/run/secrets/kubeflow/tokens
+              name: scheduledworkflow-sa-token
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: scheduledworkflow-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: pipelines.kubeflow.org
+                  expirationSeconds: 3600
+                  path: scheduledworkflow-sa-token

--- a/charts/kubeflow-pipelines/templates/scheduledworkflow/service.yaml
+++ b/charts/kubeflow-pipelines/templates/scheduledworkflow/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-pipeline-scheduledworkflow
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ml-pipeline-scheduledworkflow
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9090"
+spec:
+  type: ClusterIP
+  selector:
+    app: ml-pipeline-scheduledworkflow
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+      protocol: TCP

--- a/charts/kubeflow-pipelines/templates/viewer-crd/deployment.yaml
+++ b/charts/kubeflow-pipelines/templates/viewer-crd/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-viewer-crd
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ml-pipeline-viewer-crd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ml-pipeline-viewer-crd
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ml-pipeline-viewer-crd
+    spec:
+      serviceAccountName: ml-pipeline-viewer-crd-service-account
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ml-pipeline-viewer-crd
+          image: ghcr.io/kubeflow/kfp-viewer-crd-controller:2.16.0
+          imagePullPolicy: Always
+          env:
+            - name: MAX_NUM_VIEWERS
+              value: "50"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault

--- a/charts/kubeflow-pipelines/templates/visualizationserver/deployment.yaml
+++ b/charts/kubeflow-pipelines/templates/visualizationserver/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-visualizationserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ml-pipeline-visualizationserver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ml-pipeline-visualizationserver
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        app: ml-pipeline-visualizationserver
+    spec:
+      serviceAccountName: ml-pipeline-visualizationserver
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ml-pipeline-visualizationserver
+          image: ghcr.io/kubeflow/kfp-visualization-server:2.16.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8888
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8888
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8888
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 30m
+              memory: 500Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 0
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault

--- a/charts/kubeflow-pipelines/templates/visualizationserver/service.yaml
+++ b/charts/kubeflow-pipelines/templates/visualizationserver/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ml-pipeline-visualizationserver
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: ml-pipeline-visualizationserver
+spec:
+  type: ClusterIP
+  selector:
+    app: ml-pipeline-visualizationserver
+  ports:
+    - name: http
+      port: 8888
+      protocol: TCP
+      targetPort: 8888

--- a/charts/kubeflow-pipelines/templates/visualizationserver/service.yaml
+++ b/charts/kubeflow-pipelines/templates/visualizationserver/service.yaml
@@ -6,11 +6,9 @@ metadata:
   labels:
     app: ml-pipeline-visualizationserver
 spec:
-  type: ClusterIP
-  selector:
-    app: ml-pipeline-visualizationserver
   ports:
     - name: http
       port: 8888
-      protocol: TCP
-      targetPort: 8888
+      targetPort: http
+  selector:
+    app: ml-pipeline-visualizationserver

--- a/charts/kubeflow-pipelines/values.yaml
+++ b/charts/kubeflow-pipelines/values.yaml
@@ -1,0 +1,19 @@
+image:
+  repository: ""
+  tag: ""
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+resources:
+  requests:
+    cpu: ""
+    memory: ""
+  limits:
+    cpu: ""
+    memory: ""
+
+persistence:
+  enabled: false
+  size: ""
+  storageClass: ""

--- a/charts/kubeflow-pipelines/values.yaml
+++ b/charts/kubeflow-pipelines/values.yaml
@@ -1,19 +1,3 @@
-image:
-  repository: ""
-  tag: ""
-  pullPolicy: IfNotPresent
-
-replicaCount: 1
-
-resources:
-  requests:
-    cpu: ""
-    memory: ""
-  limits:
-    cpu: ""
-    memory: ""
-
-persistence:
-  enabled: false
-  size: ""
-  storageClass: ""
+# Default values for the kubeflow-pipelines chart.
+# NOTE: This chart currently does not expose configurable values via values.yaml.
+# Add values here only when they are actually consumed by templates.


### PR DESCRIPTION
##Summary

This PR introduces a minimal Helm chart for Kubeflow Pipelines with structural parity to the existing manifests/kustomize/base configuration.

The goal is to establish a Helm-based representation of the canonical base deployment while keeping the scope intentionally limited and aligned 1:1 with the current Kustomize resources.

##Scope (Initial Version)

This PR includes Helm templates for:

- Core Deployments:
    - ml-pipeline (API server)
    - ml-pipeline-ui
    - persistence agent
    - scheduled workflow controller
    - viewer CRD controller
    - visualization server

- Metadata (gRPC + Envoy)
- Cache server and cache deployer
- Required Services, ServiceAccounts, and RBAC
- Static namespace targeting (kubeflow)

The focus is strict structural parity with the base Kustomize manifests.

##Out of Scope

To keep this iteration minimal and reviewable, the following are intentionally not included:

- Installation overlays
- Multi-profile or multi-namespace support
- Extensive values parameterization
- CI-based parity enforcement (planned for follow-up)

##Validation

Templates were validated using:

`helm template charts/kubeflow-pipelines --namespace kubeflow`
`kubectl apply --dry-run=server -f <rendered-output>`

All resources render successfully and pass server-side dry-run validation.

##Intent

This PR is submitted as a Draft to gather architectural and structural feedback before expanding the Helm chart further.