### PR TITLE
fix(frontend): add npm cache retry to prevent EEXIST race condition in Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,7 +14,9 @@ COPY . .
 
 WORKDIR ./frontend
 
-RUN npm ci && npm run postinstall
+# Retry with cache clean as a workaround for an intermittent npm EEXIST/ENOENT
+# race condition where parallel download workers collide on the same cache entry.
+RUN npm ci && npm run postinstall || (npm cache clean --force && npm ci && npm run postinstall)
 RUN npm run build
 
 RUN mkdir -p ./server/dist && \
@@ -30,7 +32,9 @@ COPY --from=build ./src/frontend/build /client
 WORKDIR /server
 
 EXPOSE 3000
-RUN npm ci
+# Retry with cache clean as a workaround for an intermittent npm EEXIST/ENOENT
+# race condition where parallel download workers collide on the same cache entry.
+RUN npm ci || (npm cache clean --force && npm ci)
 RUN npm run build
 ENV API_SERVER_ADDRESS http://localhost:3001
 CMD node dist/server.js ../client/ 3000


### PR DESCRIPTION
## Summary

- `frontend/Dockerfile` intermittently fails during `npm ci` with an `EEXIST`/`ENOENT` race condition: npm's parallel download workers race to rename a temp file to the same cache destination; one worker succeeds, and the other's rename fails because the tmp source is gone (`ENOENT`) while the target already exists (`EEXIST`)
- Adds a retry with `npm cache clean --force` on failure in both the build stage (full frontend deps) and the final stage (server-only deps)
- Fixes the `KFP upgrade tests` failure seen at https://github.com/kubeflow/pipelines/actions/runs/22699025197


Signed-off-by: droctothorpe <mythicalsunlight@gmail.com>