### PR TITLE
docs(agents): add commit signoff and no-AI-co-author policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-03-03
+- Last updated: 2026-03-04
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 17)
 
 ### Maintenance (agents and contributors)


### PR DESCRIPTION
## Summary

- Adds a **Commit policy** section to `AGENTS.md` instructing agents and contributors to always sign off commits (`git commit -s`) and never list AI agents (Claude Code, Copilot, etc.) as co-authors.