### PR TITLE
chore(frontend): speed up OpenAPI codegen by parallelizing Docker runs

### DIFF
--- a/frontend/scripts/generate_openapi_typescript_fetch.js
+++ b/frontend/scripts/generate_openapi_typescript_fetch.js
@@ -2,8 +2,9 @@
 'use strict';
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 
 // Keep this pinned to the latest stable non-snapshot release.
 const GENERATOR_IMAGE =
@@ -20,6 +21,8 @@ const GLOBAL_PROPERTIES = [
   'apiTests=false',
   'modelTests=false',
 ].join(',');
+
+const DEFAULT_CONCURRENCY = Math.max(1, Math.min(os.cpus().length, 4));
 
 const SPEC_TARGETS = {
   'v1:experiment': {
@@ -81,8 +84,8 @@ const SPEC_TARGETS = {
 };
 
 const GROUPS = {
-  v1: Object.keys(SPEC_TARGETS).filter(key => key.startsWith('v1:')),
-  v2beta1: Object.keys(SPEC_TARGETS).filter(key => key.startsWith('v2beta1:')),
+  v1: Object.keys(SPEC_TARGETS).filter((key) => key.startsWith('v1:')),
+  v2beta1: Object.keys(SPEC_TARGETS).filter((key) => key.startsWith('v2beta1:')),
   all: Object.keys(SPEC_TARGETS),
 };
 
@@ -137,12 +140,47 @@ function runCommand(command, args) {
   }
 }
 
+const MAX_STDERR_BYTES = 1024 * 1024;
+
+function runCommandAsync(command, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const stderrChunks = [];
+    let stderrLength = 0;
+    child.stderr.on('data', (chunk) => {
+      if (stderrLength >= MAX_STDERR_BYTES) return;
+      const remaining = MAX_STDERR_BYTES - stderrLength;
+      const toStore = chunk.length <= remaining ? chunk : chunk.subarray(0, remaining);
+      stderrChunks.push(toStore);
+      stderrLength += toStore.length;
+    });
+    child.on('error', (err) => reject(new Error(`Failed to run ${command}: ${err.message}`)));
+    child.on('close', (code) => {
+      if (code !== 0) {
+        const error = new Error(`${command} exited with code ${code}`);
+        error.stderr = Buffer.concat(stderrChunks).toString();
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
 function ensureDockerAvailable() {
   const result = spawnSync('docker', ['--version'], { encoding: 'utf8' });
   if (result.error || result.status !== 0) {
-    fatal(
-      'Docker is required for API generation. Install/start Docker and retry `npm run apis`.',
-    );
+    fatal('Docker is required for API generation. Install/start Docker and retry `npm run apis`.');
+  }
+}
+
+function ensureImageAvailable() {
+  const result = spawnSync('docker', ['image', 'inspect', GENERATOR_IMAGE], {
+    stdio: 'ignore',
+  });
+  if (result.status !== 0) {
+    console.log(`Pulling ${GENERATOR_IMAGE}...`);
+    runCommand('docker', ['pull', GENERATOR_IMAGE]);
   }
 }
 
@@ -273,30 +311,20 @@ async function formatGeneratedTypeScript(repoRoot, outputDirs) {
   }
 }
 
-function generateTarget(repoRoot, targetKey) {
+function isServerTarget(target) {
+  return target.output.startsWith('frontend/server/src/generated/');
+}
+
+function buildDockerArgs(repoRoot, targetKey) {
   const target = SPEC_TARGETS[targetKey];
-  const specPath = path.join(repoRoot, target.spec);
-  const outputPath = path.join(repoRoot, target.output);
-  const swaggerConfigPath = path.join(repoRoot, 'frontend/swagger-config.json');
-
-  if (!fs.existsSync(specPath)) {
-    fatal(`Spec not found: ${specPath}`);
-  }
-  if (!fs.existsSync(swaggerConfigPath)) {
-    fatal(`Config not found: ${swaggerConfigPath}`);
-  }
-
-  fs.rmSync(outputPath, { recursive: true, force: true });
-
   const uid = process.getuid ? String(process.getuid()) : '1000';
   const gid = process.getgid ? String(process.getgid()) : '1000';
   const additionalProperties = [...BASE_ADDITIONAL_PROPERTIES];
-  const isServerTarget = target.output.startsWith('frontend/server/src/generated/');
-  if (isServerTarget) {
+  if (isServerTarget(target)) {
     additionalProperties.push('importFileExtension=.js');
   }
 
-  const dockerArgs = [
+  return [
     'run',
     '--rm',
     '-u',
@@ -319,14 +347,104 @@ function generateTarget(repoRoot, targetKey) {
     '--global-property',
     GLOBAL_PROPERTIES,
   ];
+}
 
-  console.log(`Generating ${targetKey} -> ${target.output}`);
-  runCommand('docker', dockerArgs);
+function prepareTarget(repoRoot, targetKey) {
+  const target = SPEC_TARGETS[targetKey];
+  const specPath = path.join(repoRoot, target.spec);
+  const outputPath = path.join(repoRoot, target.output);
+  const swaggerConfigPath = path.join(repoRoot, 'frontend/swagger-config.json');
+
+  if (!fs.existsSync(specPath)) {
+    fatal(`Spec not found: ${specPath}`);
+  }
+  if (!fs.existsSync(swaggerConfigPath)) {
+    fatal(`Config not found: ${swaggerConfigPath}`);
+  }
+
+  fs.rmSync(outputPath, { recursive: true, force: true });
+}
+
+function postProcessTarget(repoRoot, targetKey) {
+  const target = SPEC_TARGETS[targetKey];
+  const outputPath = path.join(repoRoot, target.output);
+
   removeGeneratorMetadata(outputPath);
   normalizeGeneratedTypeScript(outputPath, {
-    nodeCompatibleFetchTypes: isServerTarget,
+    nodeCompatibleFetchTypes: isServerTarget(target),
     renameV1ApiSymbols: targetKey.startsWith('v1:'),
   });
+}
+
+function generateTarget(repoRoot, targetKey) {
+  prepareTarget(repoRoot, targetKey);
+  console.log(`Generating ${targetKey} -> ${SPEC_TARGETS[targetKey].output}`);
+  runCommand('docker', buildDockerArgs(repoRoot, targetKey));
+  postProcessTarget(repoRoot, targetKey);
+}
+
+async function runPool(taskFns, concurrency) {
+  let nextIdx = 0;
+  let failed = false;
+
+  async function worker() {
+    while (!failed && nextIdx < taskFns.length) {
+      const idx = nextIdx++;
+      try {
+        await taskFns[idx]();
+      } catch (err) {
+        failed = true;
+        throw err;
+      }
+    }
+  }
+
+  const results = await Promise.allSettled(
+    Array.from({ length: Math.min(concurrency, taskFns.length) }, () => worker()),
+  );
+  const firstFailure = results.find((r) => r.status === 'rejected');
+  if (firstFailure) {
+    throw firstFailure.reason;
+  }
+}
+
+async function generateTargetsParallel(repoRoot, targets, concurrency, hooks) {
+  const {
+    prepare = prepareTarget,
+    dockerGenerate = (rr, tk) => runCommandAsync('docker', buildDockerArgs(rr, tk)),
+    postProcess = postProcessTarget,
+    pullImage = ensureImageAvailable,
+  } = hooks || {};
+
+  pullImage();
+
+  const effectiveConcurrency = Math.min(concurrency, targets.length);
+  console.log(`Generating ${targets.length} target(s) with concurrency ${effectiveConcurrency}...`);
+  const startTime = Date.now();
+
+  const tasks = targets.map((targetKey) => async () => {
+    const target = SPEC_TARGETS[targetKey];
+    prepare(repoRoot, targetKey);
+    console.log(`  [start] ${targetKey} -> ${target.output}`);
+    const taskStart = Date.now();
+    try {
+      await dockerGenerate(repoRoot, targetKey);
+      postProcess(repoRoot, targetKey);
+      const elapsed = ((Date.now() - taskStart) / 1000).toFixed(1);
+      console.log(`  [done]  ${targetKey} (${elapsed}s)`);
+    } catch (error) {
+      console.error(`  [fail]  ${targetKey}`);
+      if (error.stderr) {
+        process.stderr.write(error.stderr);
+      }
+      throw error;
+    }
+  });
+
+  await runPool(tasks, effectiveConcurrency);
+
+  const totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(`Generated ${targets.length} target(s) in ${totalElapsed}s`);
 }
 
 async function main() {
@@ -334,23 +452,32 @@ async function main() {
   const repoRoot = path.resolve(scriptDir, '..', '..');
   const args = process.argv.slice(2);
   const targets = resolveTargets(args);
+  const concurrency = Math.max(
+    1,
+    parseInt(process.env.OPENAPI_CONCURRENCY || '', 10) || DEFAULT_CONCURRENCY,
+  );
 
   ensureDockerAvailable();
-  for (const targetKey of targets) {
-    generateTarget(repoRoot, targetKey);
+
+  if (targets.length === 1) {
+    generateTarget(repoRoot, targets[0]);
+  } else {
+    await generateTargetsParallel(repoRoot, targets, concurrency);
   }
+
   const outputDirs = [
-    ...new Set(targets.map(targetKey => path.join(repoRoot, SPEC_TARGETS[targetKey].output))),
+    ...new Set(targets.map((targetKey) => path.join(repoRoot, SPEC_TARGETS[targetKey].output))),
   ];
   await formatGeneratedTypeScript(repoRoot, outputDirs);
 }
 
 if (require.main === module) {
-  main().catch(error => fatal(error.stack || error.message));
+  main().catch((error) => fatal(error.stack || error.message));
 }
 
 module.exports = {
   formatGeneratedTypeScript,
+  generateTargetsParallel,
   listTypeScriptFiles,
   main,
   normalizeGeneratedTypeScript,
@@ -359,4 +486,5 @@ module.exports = {
   normalizeV1ApiSymbols,
   resolvePrettierModule,
   resolveTargets,
+  runPool,
 };

--- a/frontend/scripts/generate_openapi_typescript_fetch.test.js
+++ b/frontend/scripts/generate_openapi_typescript_fetch.test.js
@@ -1,8 +1,10 @@
 const path = require('path');
 
 const {
+  generateTargetsParallel,
   normalizeGeneratedTypeScriptSource,
   resolvePrettierModule,
+  runPool,
 } = require('./generate_openapi_typescript_fetch.js');
 
 describe('generate_openapi_typescript_fetch', () => {
@@ -55,6 +57,172 @@ private fetchApi = async (url: string, init: RequestInit) => {
     expect(updated).toContain(
       'private fetchApi = async (url: string, init: RequestInit): Promise<Response> => {',
     );
+  });
+
+  describe('runPool', () => {
+    it('limits concurrency to the specified bound', async () => {
+      let running = 0;
+      let peak = 0;
+      const tasks = Array.from({ length: 6 }, () => async () => {
+        running++;
+        peak = Math.max(peak, running);
+        await new Promise((r) => setTimeout(r, 10));
+        running--;
+      });
+
+      await runPool(tasks, 2);
+
+      expect(peak).toBeLessThanOrEqual(2);
+    });
+
+    it('runs all tasks to completion', async () => {
+      const results = [];
+      const tasks = Array.from({ length: 5 }, (_, i) => async () => {
+        results.push(i);
+      });
+
+      await runPool(tasks, 3);
+
+      expect(results).toHaveLength(5);
+      expect(results.sort()).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it('propagates the first task failure', async () => {
+      const tasks = [
+        async () => {},
+        async () => {
+          throw new Error('task 1 failed');
+        },
+        async () => {},
+      ];
+
+      await expect(runPool(tasks, 2)).rejects.toThrow('task 1 failed');
+    });
+
+    it('stops dequeuing new tasks after a failure', async () => {
+      const started = [];
+      const tasks = Array.from({ length: 6 }, (_, i) => async () => {
+        started.push(i);
+        if (i === 1) throw new Error('fail');
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      await expect(runPool(tasks, 2)).rejects.toThrow('fail');
+
+      expect(started).toContain(0);
+      expect(started).toContain(1);
+      for (let i = 2; i < 6; i++) {
+        expect(started).not.toContain(i);
+      }
+    });
+
+    it('waits for in-flight tasks to complete before rejecting', async () => {
+      const completed = [];
+      const tasks = [
+        async () => {
+          await new Promise((r) => setTimeout(r, 50));
+          completed.push(0);
+        },
+        async () => {
+          throw new Error('fail');
+        },
+      ];
+
+      await expect(runPool(tasks, 2)).rejects.toThrow('fail');
+
+      expect(completed).toContain(0);
+    });
+
+    it('handles a single task', async () => {
+      let called = false;
+      await runPool(
+        [
+          async () => {
+            called = true;
+          },
+        ],
+        4,
+      );
+      expect(called).toBe(true);
+    });
+
+    it('handles empty task list', async () => {
+      await expect(runPool([], 4)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('generateTargetsParallel', () => {
+    let logSpy;
+    let errorSpy;
+    let stderrSpy;
+
+    beforeEach(() => {
+      logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('does not clean later targets when an early target fails', async () => {
+      const prepared = [];
+
+      await expect(
+        generateTargetsParallel('/fake', ['v1:experiment', 'v1:job', 'v1:pipeline'], 1, {
+          prepare: (_rr, tk) => prepared.push(tk),
+          dockerGenerate: async (_rr, tk) => {
+            if (tk === 'v1:experiment') throw new Error('gen fail');
+          },
+          postProcess: () => {},
+          pullImage: () => {},
+        }),
+      ).rejects.toThrow('gen fail');
+
+      expect(prepared).toEqual(['v1:experiment']);
+    });
+
+    it('post-processes successful targets even when a later target fails', async () => {
+      const postProcessed = [];
+
+      await expect(
+        generateTargetsParallel('/fake', ['v1:experiment', 'v1:job', 'v1:pipeline'], 2, {
+          prepare: () => {},
+          dockerGenerate: async (_rr, tk) => {
+            if (tk === 'v1:job') throw new Error('gen fail');
+            await new Promise((r) => setTimeout(r, 10));
+          },
+          postProcess: (_rr, tk) => postProcessed.push(tk),
+          pullImage: () => {},
+        }),
+      ).rejects.toThrow('gen fail');
+
+      expect(postProcessed).toContain('v1:experiment');
+      expect(postProcessed).not.toContain('v1:job');
+      expect(postProcessed).not.toContain('v1:pipeline');
+    });
+
+    it('runs the full prepare-generate-postprocess lifecycle per target', async () => {
+      const events = [];
+
+      await generateTargetsParallel('/fake', ['v1:experiment', 'v1:job'], 1, {
+        prepare: (_rr, tk) => events.push(`prepare:${tk}`),
+        dockerGenerate: async (_rr, tk) => events.push(`generate:${tk}`),
+        postProcess: (_rr, tk) => events.push(`postprocess:${tk}`),
+        pullImage: () => events.push('pull'),
+      });
+
+      expect(events).toEqual([
+        'pull',
+        'prepare:v1:experiment',
+        'generate:v1:experiment',
+        'postprocess:v1:experiment',
+        'prepare:v1:job',
+        'generate:v1:job',
+        'postprocess:v1:job',
+      ]);
+    });
   });
 
   it('preserves modern TypeScript syntax under the current formatter', () => {


### PR DESCRIPTION
**Description of your changes:**

Run independent API generation targets concurrently instead of sequentially, reducing wall time from ~14× to ~4× the per-target duration. This addresses the main bottleneck identified in #12958: repeated Docker container startup and JVM startup overhead when `npm run apis:all` processes 14 targets one at a time.

### What changed

The script (`frontend/scripts/generate_openapi_typescript_fetch.js`) is refactored into discrete phases:

| Phase | Function | What it does |
|-------|----------|-------------|
| Prepare | `prepareTarget` | Validate spec exists, clean output directory |
| Build args | `buildDockerArgs` | Construct the Docker CLI args (extracted from the old monolithic `generateTarget`) |
| Generate | `runCommandAsync` + `runPool` | Run Docker containers in parallel with bounded concurrency |
| Post-process | `postProcessTarget` | Strip `.openapi-generator` metadata, normalize TypeScript |
| Format | `formatGeneratedTypeScript` | Prettier-format all generated files (unchanged) |

For **multi-target** invocations (`npm run apis:all`, `npm run apis`, `npm run apis:v2beta1`):
- Targets run in parallel via an async worker pool
- Concurrency defaults to `min(cpus, 4)`, tunable via `OPENAPI_CONCURRENCY` env var
- A pre-pull step (`ensureImageAvailable`) caches the Docker image before parallel runs start, avoiding image-pull races

For **single-target** invocations (`npm run apis:experiment`):
- The original synchronous path with `stdio: 'inherit'` is preserved — no behavioral change

### Why parallel Docker runs (not batch mode)

The issue lists both OpenAPI Generator batch mode and parallel Docker runs as potential approaches. This PR uses parallel Docker runs because:
- Each Docker invocation uses the **exact same CLI arguments** as before, guaranteeing byte-identical generated output
- No dependency on batch-mode config file format or its support for all flags (`-c`, `--remove-operation-id-prefix`, etc.)
- Simpler to reason about and debug

Batch mode (single container, single JVM) could be explored as a follow-up for further optimization.

### How to verify output is unchanged

```bash
# On master: generate and checksum
npm run apis:all
find src/apis src/apisv2beta1 server/src/generated -name '*.ts' | sort | xargs shasum > /tmp/before.sha

# On this branch: regenerate and compare
npm run apis:all
find src/apis src/apisv2beta1 server/src/generated -name '*.ts' | sort | xargs shasum > /tmp/after.sha

diff /tmp/before.sha /tmp/after.sha  # should be empty
```

Fixes #12958

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->