### PR TITLE
feat(manifests): add init containers for startup ordering to all critical deployments

### DIFF
--- a/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
@@ -53,7 +53,7 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
-            MAX_RETRIES=12; i=0
+            MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))
               if [ "$i" -ge "$MAX_RETRIES" ]; then

--- a/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
@@ -18,6 +18,51 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      # Init container template: keep securityContext, resources, and script
+      # in sync across all wait-for-* containers in this repo.
+      initContainers:
+      - name: wait-for-database
+        image: docker.io/alpine:3.23
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        env:
+        - name: WAIT_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: dbHost
+        - name: WAIT_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: dbPort
+        command: ["/bin/sh", "-ec"]
+        args:
+          - |
+            MAX_RETRIES=12; i=0
+            while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
+              i=$((i+1))
+              if [ "$i" -ge "$MAX_RETRIES" ]; then
+                echo "ERROR: Timed out waiting for ${WAIT_HOST}:${WAIT_PORT} after ${MAX_RETRIES} attempts."
+                exit 1
+              fi
+              echo "Waiting for ${WAIT_HOST}:${WAIT_PORT} (attempt ${i}/${MAX_RETRIES})..."
+              sleep 5
+            done
       containers:
       - name: container
         # ! Sync to the same MLMD version:

--- a/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
@@ -53,6 +53,10 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
+            if [ -z "${WAIT_HOST}" ] || [ -z "${WAIT_PORT}" ]; then
+              echo "ERROR: WAIT_HOST or WAIT_PORT is not set."
+              exit 1
+            fi
             MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))

--- a/manifests/kustomize/base/metadata/overlays/db/patches/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/overlays/db/patches/metadata-grpc-deployment.yaml
@@ -10,7 +10,7 @@ spec:
         env:
         - $patch: replace
         - name: WAIT_HOST
-          value: $(MLMD_DB_HOST)
+          value: metadata-db
         - name: WAIT_PORT
           value: "3306"
       containers:

--- a/manifests/kustomize/base/metadata/overlays/db/patches/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/overlays/db/patches/metadata-grpc-deployment.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: wait-for-database
+        env:
+        - $patch: replace
+        - name: WAIT_HOST
+          value: $(MLMD_DB_HOST)
+        - name: WAIT_PORT
+          value: "3306"
       containers:
         - name: container
           # Remove existing environment variables

--- a/manifests/kustomize/base/metadata/overlays/postgres/patches/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/overlays/postgres/patches/metadata-grpc-deployment.yaml
@@ -5,6 +5,14 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: wait-for-database
+        env:
+        - $patch: replace
+        - name: WAIT_HOST
+          value: $(MLMD_DB_HOST)
+        - name: WAIT_PORT
+          value: "5432"
       containers:
         - name: container
           # Remove existing environment variables

--- a/manifests/kustomize/base/metadata/overlays/postgres/patches/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/overlays/postgres/patches/metadata-grpc-deployment.yaml
@@ -10,7 +10,7 @@ spec:
         env:
         - $patch: replace
         - name: WAIT_HOST
-          value: $(MLMD_DB_HOST)
+          value: metadata-postgres-db
         - name: WAIT_PORT
           value: "5432"
       containers:

--- a/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
@@ -47,6 +47,10 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
+            if [ -z "${WAIT_HOST}" ] || [ -z "${WAIT_PORT}" ]; then
+              echo "ERROR: WAIT_HOST or WAIT_PORT is not set."
+              exit 1
+            fi
             MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))

--- a/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
-            MAX_RETRIES=12; i=0
+            MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))
               if [ "$i" -ge "$MAX_RETRIES" ]; then

--- a/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/metadata-writer/metadata-writer-deployment.yaml
@@ -18,7 +18,45 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-    
+      # Init container template: keep securityContext, resources, and script
+      # in sync across all wait-for-* containers in this repo.
+      initContainers:
+      - name: wait-for-metadata-grpc
+        image: docker.io/alpine:3.23
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        env:
+        - name: WAIT_HOST
+          value: metadata-grpc-service
+        - name: WAIT_PORT
+          value: "8080"
+        command: ["/bin/sh", "-ec"]
+        args:
+          - |
+            MAX_RETRIES=12; i=0
+            while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
+              i=$((i+1))
+              if [ "$i" -ge "$MAX_RETRIES" ]; then
+                echo "ERROR: Timed out waiting for ${WAIT_HOST}:${WAIT_PORT} after ${MAX_RETRIES} attempts."
+                exit 1
+              fi
+              echo "Waiting for ${WAIT_HOST}:${WAIT_PORT} (attempt ${i}/${MAX_RETRIES})..."
+              sleep 5
+            done
       containers:
       - name: main
         image: ghcr.io/kubeflow/kfp-metadata-writer:dummy

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
-            MAX_RETRIES=12; i=0
+            MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))
               if [ "$i" -ge "$MAX_RETRIES" ]; then
@@ -90,7 +90,7 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
-            MAX_RETRIES=12; i=0
+            MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))
               if [ "$i" -ge "$MAX_RETRIES" ]; then

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -54,6 +54,10 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
+            if [ -z "${WAIT_HOST}" ] || [ -z "${WAIT_PORT}" ]; then
+              echo "ERROR: WAIT_HOST or WAIT_PORT is not set."
+              exit 1
+            fi
             MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))
@@ -90,6 +94,10 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
+            if [ -z "${WAIT_HOST}" ] || [ -z "${WAIT_PORT}" ]; then
+              echo "ERROR: WAIT_HOST or WAIT_PORT is not set."
+              exit 1
+            fi
             MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -19,6 +19,87 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      # Init container template: keep securityContext, resources, and script
+      # in sync across all wait-for-* containers in this repo.
+      initContainers:
+      - name: wait-for-database
+        image: docker.io/alpine:3.23
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        env:
+        - name: WAIT_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: dbHost
+        - name: WAIT_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: dbPort
+        command: ["/bin/sh", "-ec"]
+        args:
+          - |
+            MAX_RETRIES=12; i=0
+            while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
+              i=$((i+1))
+              if [ "$i" -ge "$MAX_RETRIES" ]; then
+                echo "ERROR: Timed out waiting for ${WAIT_HOST}:${WAIT_PORT} after ${MAX_RETRIES} attempts."
+                exit 1
+              fi
+              echo "Waiting for ${WAIT_HOST}:${WAIT_PORT} (attempt ${i}/${MAX_RETRIES})..."
+              sleep 5
+            done
+      - name: wait-for-metadata-grpc
+        image: docker.io/alpine:3.23
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        env:
+        - name: WAIT_HOST
+          value: metadata-grpc-service
+        - name: WAIT_PORT
+          value: "8080"
+        command: ["/bin/sh", "-ec"]
+        args:
+          - |
+            MAX_RETRIES=12; i=0
+            while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
+              i=$((i+1))
+              if [ "$i" -ge "$MAX_RETRIES" ]; then
+                echo "ERROR: Timed out waiting for ${WAIT_HOST}:${WAIT_PORT} after ${MAX_RETRIES} attempts."
+                exit 1
+              fi
+              echo "Waiting for ${WAIT_HOST}:${WAIT_PORT} (attempt ${i}/${MAX_RETRIES})..."
+              sleep 5
+            done
       containers:
         - env:
             # Whether or not to publish component logs to the object store.

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -19,6 +19,45 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      # Init container template: keep securityContext, resources, and script
+      # in sync across all wait-for-* containers in this repo.
+      initContainers:
+      - name: wait-for-ml-pipeline
+        image: docker.io/alpine:3.23
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        env:
+        - name: WAIT_HOST
+          value: ml-pipeline
+        - name: WAIT_PORT
+          value: "8888"
+        command: ["/bin/sh", "-ec"]
+        args:
+          - |
+            MAX_RETRIES=12; i=0
+            while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
+              i=$((i+1))
+              if [ "$i" -ge "$MAX_RETRIES" ]; then
+                echo "ERROR: Timed out waiting for ${WAIT_HOST}:${WAIT_PORT} after ${MAX_RETRIES} attempts."
+                exit 1
+              fi
+              echo "Waiting for ${WAIT_HOST}:${WAIT_PORT} (attempt ${i}/${MAX_RETRIES})..."
+              sleep 5
+            done
       containers:
       - env:
           - name: NAMESPACE

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -48,6 +48,10 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
+            if [ -z "${WAIT_HOST}" ] || [ -z "${WAIT_PORT}" ]; then
+              echo "ERROR: WAIT_HOST or WAIT_PORT is not set."
+              exit 1
+            fi
             MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))

--- a/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-persistenceagent-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
-            MAX_RETRIES=12; i=0
+            MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))
               if [ "$i" -ge "$MAX_RETRIES" ]; then

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -19,6 +19,45 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      # Init container template: keep securityContext, resources, and script
+      # in sync across all wait-for-* containers in this repo.
+      initContainers:
+      - name: wait-for-ml-pipeline
+        image: docker.io/alpine:3.23
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          runAsUser: 1000
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        env:
+        - name: WAIT_HOST
+          value: ml-pipeline
+        - name: WAIT_PORT
+          value: "8888"
+        command: ["/bin/sh", "-ec"]
+        args:
+          - |
+            MAX_RETRIES=12; i=0
+            while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
+              i=$((i+1))
+              if [ "$i" -ge "$MAX_RETRIES" ]; then
+                echo "ERROR: Timed out waiting for ${WAIT_HOST}:${WAIT_PORT} after ${MAX_RETRIES} attempts."
+                exit 1
+              fi
+              echo "Waiting for ${WAIT_HOST}:${WAIT_PORT} (attempt ${i}/${MAX_RETRIES})..."
+              sleep 5
+            done
       containers:
       - image: ghcr.io/kubeflow/kfp-scheduled-workflow-controller:dummy
         imagePullPolicy: IfNotPresent

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -48,6 +48,10 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
+            if [ -z "${WAIT_HOST}" ] || [ -z "${WAIT_PORT}" ]; then
+              echo "ERROR: WAIT_HOST or WAIT_PORT is not set."
+              exit 1
+            fi
             MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))

--- a/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-scheduledworkflow-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         command: ["/bin/sh", "-ec"]
         args:
           - |
-            MAX_RETRIES=12; i=0
+            MAX_RETRIES=60; i=0
             while ! nc -z -w 2 "${WAIT_HOST}" "${WAIT_PORT}"; do
               i=$((i+1))
               if [ "$i" -ge "$MAX_RETRIES" ]; then

--- a/manifests/kustomize/env/openshift/base/kustomization.yaml
+++ b/manifests/kustomize/env/openshift/base/kustomization.yaml
@@ -37,6 +37,45 @@ patches:
 
   # Openshift provides its own default restricted SCC's
   # Thus the following can be omitted:
+
+  # Remove fixed UID from init containers so OpenShift SCC can assign UIDs
+  - path: patches/remove-sc-init.json
+    target:
+      group: apps
+      kind: Deployment
+      name: metadata-grpc-deployment
+      version: v1
+  - path: patches/remove-sc-init.json
+    target:
+      group: apps
+      kind: Deployment
+      name: metadata-writer
+      version: v1
+  - path: patches/remove-sc-init.json
+    target:
+      group: apps
+      kind: Deployment
+      name: ml-pipeline
+      version: v1
+  - path: patches/remove-sc-init-1.json
+    target:
+      group: apps
+      kind: Deployment
+      name: ml-pipeline
+      version: v1
+  - path: patches/remove-sc-init.json
+    target:
+      group: apps
+      kind: Deployment
+      name: ml-pipeline-persistenceagent
+      version: v1
+  - path: patches/remove-sc-init.json
+    target:
+      group: apps
+      kind: Deployment
+      name: ml-pipeline-scheduledworkflow
+      version: v1
+
   - path: patches/remove-sc.json
     target:
       group: apps

--- a/manifests/kustomize/env/openshift/base/patches/remove-sc-init-1.json
+++ b/manifests/kustomize/env/openshift/base/patches/remove-sc-init-1.json
@@ -1,0 +1,6 @@
+[
+  {
+    "op": "remove",
+    "path": "/spec/template/spec/initContainers/1/securityContext"
+  }
+]

--- a/manifests/kustomize/env/openshift/base/patches/remove-sc-init.json
+++ b/manifests/kustomize/env/openshift/base/patches/remove-sc-init.json
@@ -1,0 +1,6 @@
+[
+  {
+    "op": "remove",
+    "path": "/spec/template/spec/initContainers/0/securityContext"
+  }
+]

--- a/manifests/kustomize/hack/test.sh
+++ b/manifests/kustomize/hack/test.sh
@@ -31,6 +31,8 @@ kpt version
 kustomization_yamls=(
   "cluster-scoped-resources"
   "base/installs/generic"
+  "base/metadata/overlays/db"
+  "base/metadata/overlays/postgres"
   "env/dev"
   "env/gcp"
   "env/platform-agnostic"


### PR DESCRIPTION
## Summary
- Add init containers to critical deployments to wait for their dependencies before starting, preventing CrashLoopBackOff during fresh installations
- Uses `docker.io/alpine:3.23` (parametrized via kustomize image transformers) with `nc -z` for protocol-agnostic TCP connectivity checks
- All init containers follow the same security context constraints (non-root, drop ALL capabilities, seccomp RuntimeDefault) and include resource requests/limits
- Incorporates work from #12703 with all reviewer feedback addressed

## Deployments

| Deployment | Init Container | Waits For |
|---|---|---|
| `metadata-grpc` | `wait-for-database` | MySQL/Postgres via `pipeline-install-config` ConfigMap |
| `metadata-writer` | `wait-for-metadata-grpc` | `metadata-grpc-service:8080` |
| `ml-pipeline` (apiserver) | `wait-for-database` + `wait-for-metadata-grpc` | MySQL + `metadata-grpc-service:8080` |
| `ml-pipeline-persistenceagent` | `wait-for-ml-pipeline` | `ml-pipeline:8888` |
| `ml-pipeline-scheduledworkflow` | `wait-for-ml-pipeline` | `ml-pipeline:8888` |

## Problem
Critical deployments start simultaneously during `kubectl apply -k`. When dependencies aren't ready, pods crash immediately, entering CrashLoopBackOff with exponentially increasing backoff (10s -> 20s -> 40s -> 80s -> 160s). This causes cascading failures across the pipeline infrastructure and flaky CI test suites.

This is a flaky infrastructure issue — not caused by any code change. Recent master commits show 0-14 failures depending on whether MySQL starts fast enough.

## Design decisions
- **`docker.io/alpine:3.23`**: Explicit registry prefix for reproducibility, Alpine has documented security support until late 2027. Image tag is parametrized via kustomize `images` transformers in each base kustomization for single-point version management.
- **`nc -z` over healthz endpoints**: Protocol-agnostic, works in both plain and TLS-enabled configurations. The `ml-pipeline` service runs on HTTPS in TLS mode, which breaks `wget`-based healthz checks.
- **300s timeout** (60 retries x 5s): CI logs show MySQL takes ~67s to start on GitHub Actions runners, and the full dependency chain (MySQL → metadata-grpc → ml-pipeline) takes ~100s. A shorter 60s timeout caused persistenceagent and scheduledworkflow init containers to timeout and restart, defeating the purpose of startup ordering.
- **Resource limits** (`10m/16Mi` requests, `100m/64Mi` limits): Prevents unbounded resource usage during init phase.
- **Overlay patches use `$patch: replace`**: Cleanly overrides base env vars in db/postgres overlays without merging conflicts between `value` and `valueFrom` fields.
- **Env var validation**: Database-dependent init containers validate `DB_HOST` and `DB_PORT` are non-empty before entering the retry loop, failing fast with a clear error on misconfiguration.

Fixes #12702

## Test plan
- [x] `kubectl kustomize` renders correctly for `platform-agnostic-emissary`, `metadata/overlays/db`, and `metadata/overlays/postgres`
- [x] All init containers detected and working in CI (verified from CI logs: pods progress through Init → PodInitializing → Running with 0 restarts when timeout is sufficient)
- [x] CI API Server tests pass without CrashLoopBackOff
- [ ] CI E2E tests pass