### PR TITLE
fix(test): re-enable and add all snapshot tests for kfp-kubernetes

### DIFF
--- a/kubernetes_platform/python/test/snapshot/test_data_config.yaml
+++ b/kubernetes_platform/python/test/snapshot/test_data_config.yaml
@@ -13,26 +13,35 @@
 # limitations under the License.
 
 test_cases:
-  #  Disabled while https://github.com/kubeflow/pipelines/issues/10918 is failing
-  #  - module: create_mount_delete_dynamic_pvc
-  #    name: my_pipeline
-
+  - module: config_map_as_env
+    name: my_pipeline
+  - module: config_map_as_vol
+    name: my_pipeline
+  - module: create_mount_delete_dynamic_pvc
+    name: my_pipeline
   - module: create_mount_delete_existing_pvc
     name: my_pipeline
   - module: create_mount_delete_existing_pvc_from_task_output
     name: my_pipeline
+  - module: empty_dir_mounts
+    name: my_pipeline
+  - module: field_path_as_env
+    name: my_pipeline
+  - module: general_ephemeral_volume
+    name: my_pipeline
+  - module: image_pull_secrets
+    name: my_pipeline
+  - module: node_selector
+    name: my_pipeline
   - module: nodeaffinity
+    name: my_pipeline
+  - module: secret_as_env
+    name: my_pipeline
+  - module: secret_as_vol
     name: my_pipeline
   - module: security_context
     name: my_pipeline
-#  Disabled while https://github.com/kubeflow/pipelines/issues/10918 is failing
-#  - module: secret_as_env
-#    name: my_pipeline
-
-#  Disabled while https://github.com/kubeflow/pipelines/issues/10918 is failing
-#  - module: secret_as_vol
-#    name: my_pipeline
-
-#  Disabled while https://github.com/kubeflow/pipelines/issues/10918 is failing
-#  - module: node_selector
-#    name: my_pipeline
+  - module: timeout
+    name: my_pipeline
+  - module: toleration
+    name: my_pipeline


### PR DESCRIPTION
## Summary

- Re-enabled 4 snapshot tests that were disabled referencing #10918 (`create_mount_delete_dynamic_pvc`, `secret_as_env`, `secret_as_vol`, `node_selector`)
- Added 8 snapshot test cases that had data files (.py/.yaml) but were never registered in `test_data_config.yaml` (`config_map_as_env`, `config_map_as_vol`, `empty_dir_mounts`, `field_path_as_env`, `general_ephemeral_volume`, `image_pull_secrets`, `timeout`, `toleration`)

Issue #10918 is about **execution tests** (running pipelines on a real K8s cluster in `data-science-pipelines`) failing because `my-secret` doesn't exist on the test cluster. The **snapshot tests** only verify serialization/compilation correctness (Python → YAML golden file comparison) and don't require a cluster, so they were incorrectly disabled as a workaround for that issue.

This PR does not fix the execution test failures described in #10918 — those need to be addressed in the `data-science-pipelines` repo by ensuring test secrets exist on the cluster before running execution tests.

All 16 snapshot tests and 122 unit tests pass.

Related to #10918

## Test plan

- [x] Verified all 16 snapshot tests pass locally (`pytest kubernetes_platform/python/test/snapshot/`)
- [x] Verified all 122 unit tests pass locally (`pytest kubernetes_platform/python/test/unit/`)
- [x] CI `kfp-kubernetes-library-test` workflow passes (Python 3.9 and 3.13)

/area testing