### PR TITLE
chore(ci): rotate supported Kubernetes versions

### DIFF
--- a/.github/workflows/api-server-tests.yml
+++ b/.github/workflows/api-server-tests.yml
@@ -63,23 +63,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.34.0" ]
+        k8s_version: [ "v1.35.0" ]
         cache_enabled: [ "true", "false" ]
         proxy: [ "true", "false" ]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         pipeline_store: [ "database" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.29.2"
+          - k8s_version: "v1.29.14"
             cache_enabled: "true"
             argo_version: "v3.7.3"
-          - k8s_version: "v1.29.2"
+          - k8s_version: "v1.29.14"
             cache_enabled: "true"
             argo_version: "v3.5.14"
-          - k8s_version: "v1.29.2"
+          - k8s_version: "v1.29.14"
             cache_enabled: "true"
             argo_version: "v4.0.4"
-          - k8s_version: "v1.34.0"
+          - k8s_version: "v1.35.0"
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
       fail-fast: false # So that failure in 1 type of parameterized job does not cause other jobs to terminate prematurely
@@ -167,14 +167,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.34.0", "v1.29.2" ]
+        k8s_version: [ "v1.35.0", "v1.29.14" ]
         cache_enabled: [ "true" ]
         uploadPipelinesWithKubernetesClient: [ "true", "false" ]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         pipeline_store: [ "kubernetes" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.34.0"
+          - k8s_version: "v1.35.0"
             cache_enabled: "true"
             # Pod to Pod TLS manifests are not yet implemented for Kubernetes Native API mode
             pipeline_store: "database"
@@ -226,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.34.0"]
+        k8s_version: [ "v1.35.0"]
         cache_enabled: [ "true", "false" ]
         multi_user: [ "true" ]
       fail-fast: false # So that failure in 1 type of parameterized job does not cause other jobs to terminate prematurely

--- a/.github/workflows/api-server-tests.yml
+++ b/.github/workflows/api-server-tests.yml
@@ -63,23 +63,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.1" ]
+        k8s_version: [ "v1.35.0" ]
         cache_enabled: [ "true", "false" ]
         proxy: [ "true", "false" ]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         pipeline_store: [ "database" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.30.13"
+          - k8s_version: "v1.31.14"
             cache_enabled: "true"
             argo_version: "v3.7.3"
-          - k8s_version: "v1.30.13"
+          - k8s_version: "v1.31.14"
             cache_enabled: "true"
             argo_version: "v3.5.14"
-          - k8s_version: "v1.30.13"
+          - k8s_version: "v1.31.14"
             cache_enabled: "true"
             argo_version: "v4.0.4"
-          - k8s_version: "v1.35.1"
+          - k8s_version: "v1.35.0"
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
       fail-fast: false # So that failure in 1 type of parameterized job does not cause other jobs to terminate prematurely
@@ -167,14 +167,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.1", "v1.30.13" ]
+        k8s_version: [ "v1.35.0", "v1.31.14" ]
         cache_enabled: [ "true" ]
         uploadPipelinesWithKubernetesClient: [ "true", "false" ]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         pipeline_store: [ "kubernetes" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.35.1"
+          - k8s_version: "v1.35.0"
             cache_enabled: "true"
             # Pod to Pod TLS manifests are not yet implemented for Kubernetes Native API mode
             pipeline_store: "database"
@@ -226,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.1"]
+        k8s_version: [ "v1.35.0"]
         cache_enabled: [ "true", "false" ]
         multi_user: [ "true" ]
       fail-fast: false # So that failure in 1 type of parameterized job does not cause other jobs to terminate prematurely

--- a/.github/workflows/api-server-tests.yml
+++ b/.github/workflows/api-server-tests.yml
@@ -63,23 +63,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.0" ]
+        k8s_version: [ "v1.35.1" ]
         cache_enabled: [ "true", "false" ]
         proxy: [ "true", "false" ]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         pipeline_store: [ "database" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.29.14"
+          - k8s_version: "v1.30.13"
             cache_enabled: "true"
             argo_version: "v3.7.3"
-          - k8s_version: "v1.29.14"
+          - k8s_version: "v1.30.13"
             cache_enabled: "true"
             argo_version: "v3.5.14"
-          - k8s_version: "v1.29.14"
+          - k8s_version: "v1.30.13"
             cache_enabled: "true"
             argo_version: "v4.0.4"
-          - k8s_version: "v1.35.0"
+          - k8s_version: "v1.35.1"
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
       fail-fast: false # So that failure in 1 type of parameterized job does not cause other jobs to terminate prematurely
@@ -167,14 +167,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.0", "v1.29.14" ]
+        k8s_version: [ "v1.35.1", "v1.30.13" ]
         cache_enabled: [ "true" ]
         uploadPipelinesWithKubernetesClient: [ "true", "false" ]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         pipeline_store: [ "kubernetes" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.35.0"
+          - k8s_version: "v1.35.1"
             cache_enabled: "true"
             # Pod to Pod TLS manifests are not yet implemented for Kubernetes Native API mode
             pipeline_store: "database"
@@ -226,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.0"]
+        k8s_version: [ "v1.35.1"]
         cache_enabled: [ "true", "false" ]
         multi_user: [ "true" ]
       fail-fast: false # So that failure in 1 type of parameterized job does not cause other jobs to terminate prematurely

--- a/.github/workflows/e2e-test-frontend.yml
+++ b/.github/workflows/e2e-test-frontend.yml
@@ -26,7 +26,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.34.0" ]
+        k8s_version: [ "v1.29.14", "v1.35.0" ]
         pod_to_pod_tls_enabled: [ "true", "false" ]
     name: Frontend Integration Tests - K8s ${{ matrix.k8s_version }} pod_to_pod_tls_enabled=${{ matrix.pod_to_pod_tls_enabled }}
     steps:

--- a/.github/workflows/e2e-test-frontend.yml
+++ b/.github/workflows/e2e-test-frontend.yml
@@ -26,7 +26,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.30.13", "v1.35.1" ]
+        k8s_version: [ "v1.31.14", "v1.35.0" ]
         pod_to_pod_tls_enabled: [ "true", "false" ]
     name: Frontend Integration Tests - K8s ${{ matrix.k8s_version }} pod_to_pod_tls_enabled=${{ matrix.pod_to_pod_tls_enabled }}
     steps:

--- a/.github/workflows/e2e-test-frontend.yml
+++ b/.github/workflows/e2e-test-frontend.yml
@@ -26,7 +26,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.14", "v1.35.0" ]
+        k8s_version: [ "v1.30.13", "v1.35.1" ]
         pod_to_pod_tls_enabled: [ "true", "false" ]
     name: Frontend Integration Tests - K8s ${{ matrix.k8s_version }} pod_to_pod_tls_enabled=${{ matrix.pod_to_pod_tls_enabled }}
     steps:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,25 +61,25 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.35.0"]
+        k8s_version: ["v1.35.1"]
         cache_enabled: ["true", "false"]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         proxy: [ "false" ]
         test_label: [ "E2ECritical", "E2EEssential", "E2EParallelNested" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.29.14"
+          - k8s_version: "v1.30.13"
             cache_enabled: "false"
             argo_version: "v3.5.14"
             test_label: "E2ECritical"
-          - k8s_version: "v1.35.0"
+          - k8s_version: "v1.35.1"
             cache_enabled: "false"
             proxy: "true"
             test_label: "E2EProxy"
-          - k8s_version: "v1.35.0"
+          - k8s_version: "v1.35.1"
             cache_enabled: "false"
             test_label: "E2EFailure"
-          - k8s_version: "v1.35.0"
+          - k8s_version: "v1.35.1"
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
             test_label: "E2ECritical"
@@ -166,14 +166,14 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.35.0"]
+        k8s_version: ["v1.35.1"]
         cache_enabled: ["true", "false"]
         multi_user: [ "true" ]
         test_label: [ "E2ECritical" ]
         include:
         - multi_user: "true"
           artifact_proxy: "true"
-          k8s_version: "v1.35.0"
+          k8s_version: "v1.35.1"
           cache_enabled: "true"
           test_label: "E2ECritical"
       fail-fast: false

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,25 +61,25 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.34.0"]
+        k8s_version: ["v1.35.0"]
         cache_enabled: ["true", "false"]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         proxy: [ "false" ]
         test_label: [ "E2ECritical", "E2EEssential", "E2EParallelNested" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.29.2"
+          - k8s_version: "v1.29.14"
             cache_enabled: "false"
             argo_version: "v3.5.14"
             test_label: "E2ECritical"
-          - k8s_version: "v1.34.0"
+          - k8s_version: "v1.35.0"
             cache_enabled: "false"
             proxy: "true"
             test_label: "E2EProxy"
-          - k8s_version: "v1.34.0"
+          - k8s_version: "v1.35.0"
             cache_enabled: "false"
             test_label: "E2EFailure"
-          - k8s_version: "v1.34.0"
+          - k8s_version: "v1.35.0"
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
             test_label: "E2ECritical"
@@ -166,14 +166,14 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.34.0"]
+        k8s_version: ["v1.35.0"]
         cache_enabled: ["true", "false"]
         multi_user: [ "true" ]
         test_label: [ "E2ECritical" ]
         include:
         - multi_user: "true"
           artifact_proxy: "true"
-          k8s_version: "v1.34.0"
+          k8s_version: "v1.35.0"
           cache_enabled: "true"
           test_label: "E2ECritical"
       fail-fast: false

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,25 +61,25 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.35.1"]
+        k8s_version: ["v1.35.0"]
         cache_enabled: ["true", "false"]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         proxy: [ "false" ]
         test_label: [ "E2ECritical", "E2EEssential", "E2EParallelNested" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.30.13"
+          - k8s_version: "v1.31.14"
             cache_enabled: "false"
             argo_version: "v3.5.14"
             test_label: "E2ECritical"
-          - k8s_version: "v1.35.1"
+          - k8s_version: "v1.35.0"
             cache_enabled: "false"
             proxy: "true"
             test_label: "E2EProxy"
-          - k8s_version: "v1.35.1"
+          - k8s_version: "v1.35.0"
             cache_enabled: "false"
             test_label: "E2EFailure"
-          - k8s_version: "v1.35.1"
+          - k8s_version: "v1.35.0"
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
             test_label: "E2ECritical"
@@ -166,14 +166,14 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.35.1"]
+        k8s_version: ["v1.35.0"]
         cache_enabled: ["true", "false"]
         multi_user: [ "true" ]
         test_label: [ "E2ECritical" ]
         include:
         - multi_user: "true"
           artifact_proxy: "true"
-          k8s_version: "v1.35.1"
+          k8s_version: "v1.35.0"
           cache_enabled: "true"
           test_label: "E2ECritical"
       fail-fast: false

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.34.0" ]
+        k8s_version: [ "v1.29.14", "v1.35.0" ]
     name: Initialization & Integration tests v1 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.14", "v1.35.0" ]
+        k8s_version: [ "v1.30.13", "v1.35.1" ]
     name: Initialization & Integration tests v1 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.30.13", "v1.35.1" ]
+        k8s_version: [ "v1.31.14", "v1.35.0" ]
     name: Initialization & Integration tests v1 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
+++ b/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.30.13", "v1.35.1"]
+        k8s_version: ["v1.31.14", "v1.35.0"]
     name: KFP Kubernetes Native Migration Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
+++ b/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.29.2", "v1.34.0"]
+        k8s_version: ["v1.29.14", "v1.35.0"]
     name: KFP Kubernetes Native Migration Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
+++ b/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.29.14", "v1.35.0"]
+        k8s_version: ["v1.30.13", "v1.35.1"]
     name: KFP Kubernetes Native Migration Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-sdk-client-tests.yml
+++ b/.github/workflows/kfp-sdk-client-tests.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.14", "v1.35.0" ]
+        k8s_version: [ "v1.30.13", "v1.35.1" ]
     name: KFP SDK Client Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-sdk-client-tests.yml
+++ b/.github/workflows/kfp-sdk-client-tests.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.30.13", "v1.35.1" ]
+        k8s_version: [ "v1.31.14", "v1.35.0" ]
     name: KFP SDK Client Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-sdk-client-tests.yml
+++ b/.github/workflows/kfp-sdk-client-tests.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.34.0" ]
+        k8s_version: [ "v1.29.14", "v1.35.0" ]
     name: KFP SDK Client Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-webhooks.yml
+++ b/.github/workflows/kfp-webhooks.yml
@@ -24,7 +24,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.34.0" ]
+        k8s_version: [ "v1.29.14", "v1.35.0" ]
     name: KFP Webhooks - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/.github/workflows/kfp-webhooks.yml
+++ b/.github/workflows/kfp-webhooks.yml
@@ -24,7 +24,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.14", "v1.35.0" ]
+        k8s_version: [ "v1.30.13", "v1.35.1" ]
     name: KFP Webhooks - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/.github/workflows/kfp-webhooks.yml
+++ b/.github/workflows/kfp-webhooks.yml
@@ -24,7 +24,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.30.13", "v1.35.1" ]
+        k8s_version: [ "v1.31.14", "v1.35.0" ]
     name: KFP Webhooks - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/.github/workflows/legacy-v2-api-integration-tests.yml
+++ b/.github/workflows/legacy-v2-api-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         pipeline_store: [ "database", "kubernetes" ]
-        k8s_version: [ "v1.35.1" ]
+        k8s_version: [ "v1.35.0" ]
         pod_to_pod_tls_enabled: [ "true", "false" ]
         exclude:
           # Pod to Pod TLS manifests are not yet implemented for Kubernetes Native API mode

--- a/.github/workflows/legacy-v2-api-integration-tests.yml
+++ b/.github/workflows/legacy-v2-api-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         pipeline_store: [ "database", "kubernetes" ]
-        k8s_version: [ "v1.34.0" ]
+        k8s_version: [ "v1.35.0" ]
         pod_to_pod_tls_enabled: [ "true", "false" ]
         exclude:
           # Pod to Pod TLS manifests are not yet implemented for Kubernetes Native API mode

--- a/.github/workflows/legacy-v2-api-integration-tests.yml
+++ b/.github/workflows/legacy-v2-api-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         pipeline_store: [ "database", "kubernetes" ]
-        k8s_version: [ "v1.35.0" ]
+        k8s_version: [ "v1.35.1" ]
         pod_to_pod_tls_enabled: [ "true", "false" ]
         exclude:
           # Pod to Pod TLS manifests are not yet implemented for Kubernetes Native API mode

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.34.0" ]
+        k8s_version: [ "v1.35.0" ]
     name: KFP upgrade tests - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.1" ]
+        k8s_version: [ "v1.35.0" ]
     name: KFP upgrade tests - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.0" ]
+        k8s_version: [ "v1.35.1" ]
     name: KFP upgrade tests - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -516,7 +516,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 ### Test matrices and variants (Kubernetes, stores, proxy, cache)
 
-- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.30.13` and `v1.35.1`.
+- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.31.14` and `v1.35.0`.
   - Examples: `e2e-test.yml`, `sdk-execution.yml`, `upgrade-test.yml`, `kfp-kubernetes-execution-tests.yml`, `kfp-webhooks.yml`, `api-server-tests.yml`, `compiler-tests.yml`, `legacy-v2-api-integration-tests.yml`, `integration-tests-v1.yml`, and frontend integration in `e2e-test-frontend.yml`.
 - Pipeline store variants (v2 engine): tests run with `database` and `kubernetes` stores, and a dedicated job compiles pipelines to Kubernetes-native manifests.
   - Example: `e2e-test.yml` job "API integration tests v2 - K8s with ${pipeline_store}" and "compile pipelines with Kubernetes".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-04-15
+- Last updated: 2026-04-20
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -516,7 +516,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 ### Test matrices and variants (Kubernetes, stores, proxy, cache)
 
-- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.29.2` and `v1.31.0`.
+- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.29.14` and `v1.35.0`.
   - Examples: `e2e-test.yml`, `sdk-execution.yml`, `upgrade-test.yml`, `kfp-kubernetes-execution-tests.yml`, `kfp-webhooks.yml`, `api-server-tests.yml`, `compiler-tests.yml`, `legacy-v2-api-integration-tests.yml`, `integration-tests-v1.yml`, and frontend integration in `e2e-test-frontend.yml`.
 - Pipeline store variants (v2 engine): tests run with `database` and `kubernetes` stores, and a dedicated job compiles pipelines to Kubernetes-native manifests.
   - Example: `e2e-test.yml` job "API integration tests v2 - K8s with ${pipeline_store}" and "compile pipelines with Kubernetes".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -516,7 +516,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 ### Test matrices and variants (Kubernetes, stores, proxy, cache)
 
-- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.29.14` and `v1.35.0`.
+- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.30.13` and `v1.35.1`.
   - Examples: `e2e-test.yml`, `sdk-execution.yml`, `upgrade-test.yml`, `kfp-kubernetes-execution-tests.yml`, `kfp-webhooks.yml`, `api-server-tests.yml`, `compiler-tests.yml`, `legacy-v2-api-integration-tests.yml`, `integration-tests-v1.yml`, and frontend integration in `e2e-test-frontend.yml`.
 - Pipeline store variants (v2 engine): tests run with `database` and `kubernetes` stores, and a dedicated job compiles pipelines to Kubernetes-native manifests.
   - Example: `e2e-test.yml` job "API integration tests v2 - K8s with ${pipeline_store}" and "compile pipelines with Kubernetes".


### PR DESCRIPTION
**Description of your changes:**

Updates the CI Kubernetes version matrix to keep a low/high compatibility policy using Kubernetes node images that are both relevant to managed-cloud support and actually available for the Kind version pinned in CI.

Changes:
- use `v1.31.14` as the low Kubernetes CI lane
- use `v1.35.0` as the high Kubernetes CI lane
- keep the repo's low/high testing policy rather than widening the matrix
- update `AGENTS.md` to reflect the CI version pins

Why `v1.31.14` / `v1.35.0` as of **April 26, 2026**?
- Official Kubernetes upstream support now covers `1.34`, `1.35`, and `1.36`; Kubernetes `1.36.0` was released on **April 22, 2026**: https://kubernetes.io/releases/ and https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/
- Amazon EKS still lists `1.31` in extended support through **November 26, 2026**: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
- Azure AKS still lists `1.31` LTS through **November 2026**: https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions and https://learn.microsoft.com/en-us/azure/aks/long-term-support
- Google GKE Extended channel still lists `1.31` end of extended support on **October 22, 2026**: https://cloud.google.com/kubernetes-engine/docs/release-schedule

Why not bump the high lane to `1.36.0` yet?
- The workflow is still pinned to Kind `v0.31.0`: https://github.com/kubernetes-sigs/kind/releases/tag/v0.31.0
- That Kind release pre-builds node images only through `kindest/node:v1.35.0` and does **not** publish `kindest/node:v1.36.0`
- A direct `docker manifest inspect kindest/node:v1.36.0` still fails today, so moving the CI matrix to `1.36.0` in this PR would require a separate change in the Kind toolchain rather than just rotating workflow values

This keeps the PR scoped to a safe CI update:
- low lane stays on the oldest version still covered by major managed-cloud extended support (`v1.31.14`)
- high lane stays on the newest Kubernetes version currently available from the repo's pinned Kind release (`v1.35.0`)

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) follows the repository title convention

**Testing**

- [x] `docker manifest inspect kindest/node:v1.31.14`
- [x] `docker manifest inspect kindest/node:v1.35.0`
- [x] confirmed `kindest/node:v1.36.0` is not published yet
- [x] `ruby -e 'require "yaml"; ... YAML.load_file(...)'` for the touched workflow files
- [x] `git diff --check origin/master...HEAD`
- [x] `git diff --check`
