### PR TITLE
fix(components): bump model-evaluation image to v0.9.5 in automl tabular pipeline

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/v1/automl/tabular/automl_tabular_pipeline.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/v1/automl/tabular/automl_tabular_pipeline.yaml
@@ -9769,7 +9769,7 @@ deploymentSpec:
         command:
         - python
         - /main.py
-        image: gcr.io/ml-pipeline/model-evaluation:v0.9.5 
+        image: gcr.io/ml-pipeline/model-evaluation:v0.9.5
     exec-model-evaluation-2:
       container:
         args:


### PR DESCRIPTION
**Description:**
Bumps the `gcr.io/ml-pipeline/model-evaluation` image to `v0.9.5` across the AutoML tabular pipeline file as requested.

Fixes #12678