### PR TITLE
fix(frontend): replace comma operators in ArtifactList test

### DIFF
--- a/frontend/src/pages/ArtifactList.test.tsx
+++ b/frontend/src/pages/ArtifactList.test.tsx
@@ -48,31 +48,31 @@ describe('ArtifactList', () => {
   const listOperationOpts = new metadataStorePb.ListOperationOptions();
   listOperationOpts.setMaxResultSize(10);
   const getArtifactsRequest = new GetArtifactsRequest();
-  (getArtifactsRequest.setOptions(listOperationOpts),
-    beforeEach(() => {
-      updateBannerSpy = vi.fn();
-      updateDialogSpy = vi.fn();
-      updateSnackbarSpy = vi.fn();
-      updateToolbarSpy = vi.fn();
-      historyPushSpy = vi.fn();
-      getArtifactsSpy = vi.spyOn(Api.getInstance().metadataStoreService, 'getArtifacts');
-      getArtifactTypesSpy = vi.spyOn(Api.getInstance().metadataStoreService, 'getArtifactTypes');
+  getArtifactsRequest.setOptions(listOperationOpts);
+  beforeEach(() => {
+    updateBannerSpy = vi.fn();
+    updateDialogSpy = vi.fn();
+    updateSnackbarSpy = vi.fn();
+    updateToolbarSpy = vi.fn();
+    historyPushSpy = vi.fn();
+    getArtifactsSpy = vi.spyOn(Api.getInstance().metadataStoreService, 'getArtifacts');
+    getArtifactTypesSpy = vi.spyOn(Api.getInstance().metadataStoreService, 'getArtifactTypes');
 
-      getArtifactTypesSpy.mockImplementation(() => {
-        const artifactType = new ArtifactType();
-        artifactType.setId(6);
-        artifactType.setName('String');
-        const response = new GetArtifactTypesResponse();
-        response.setArtifactTypesList([artifactType]);
-        return Promise.resolve(response);
-      });
-      getArtifactsSpy.mockImplementation(() => {
-        const artifacts = generateNArtifacts(5);
-        const response = new GetArtifactsResponse();
-        response.setArtifactsList(artifacts);
-        return Promise.resolve(response);
-      });
-    }));
+    getArtifactTypesSpy.mockImplementation(() => {
+      const artifactType = new ArtifactType();
+      artifactType.setId(6);
+      artifactType.setName('String');
+      const response = new GetArtifactTypesResponse();
+      response.setArtifactTypesList([artifactType]);
+      return Promise.resolve(response);
+    });
+    getArtifactsSpy.mockImplementation(() => {
+      const artifacts = generateNArtifacts(5);
+      const response = new GetArtifactsResponse();
+      response.setArtifactsList(artifacts);
+      return Promise.resolve(response);
+    });
+  });
 
   function generateNArtifacts(n: number) {
     let artifacts: Artifact[] = [];
@@ -169,12 +169,12 @@ describe('ArtifactList', () => {
     fireEvent.click(newRowsPerPage);
 
     listOperationOpts.setMaxResultSize(20);
-    (getArtifactsRequest.setOptions(listOperationOpts),
-      await waitFor(() => {
-        // API will be called again if "Rows per page" is changed
-        expect(getArtifactTypesSpy).toHaveBeenCalledTimes(1);
-        expect(getArtifactsSpy).toHaveBeenLastCalledWith(getArtifactsRequest);
-      }));
+    getArtifactsRequest.setOptions(listOperationOpts);
+    await waitFor(() => {
+      // API will be called again if "Rows per page" is changed
+      expect(getArtifactTypesSpy).toHaveBeenCalledTimes(1);
+      expect(getArtifactsSpy).toHaveBeenLastCalledWith(getArtifactsRequest);
+    });
 
     screen.getByText('test artifact 20'); // The 20th artifacts appears.
   });


### PR DESCRIPTION
## Summary
- replace the two comma-operator sequence expressions in `ArtifactList.test.tsx` with standalone statements
- keep the test behavior unchanged while making the setup and assertion flow explicit

## Testing
- fnm exec --using=v22.19.0 -- zsh -lc 'cd frontend && npx prettier --check src/pages/ArtifactList.test.tsx'
- fnm exec --using=v22.19.0 -- zsh -lc 'cd frontend && npm run test:ui -- src/pages/ArtifactList.test.tsx'

Refs #12959