### PR TITLE
fix(backend): fail run on image pull errors. Fixes #12973

### DIFF
--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -459,11 +459,17 @@ func (w *Workflow) FinishedAt() int64 {
 	return w.Status.FinishedAt.Unix()
 }
 
+// imagePullErrorGracePeriod is the duration to wait before treating an
+// image pull error as terminal. ImagePullBackOff is often transient and
+// Kubernetes will retry for up to ~5 minutes before giving up.
+const imagePullErrorGracePeriod = 5 * time.Minute
+
+// Condition returns the execution phase of the workflow. If the workflow is
+// still in a non-final phase but one of its nodes reports a terminal image
+// pull error that has persisted beyond the grace period, surface this as a
+// failed condition to Kubeflow Pipelines so that the corresponding run can
+// be marked as failed instead of remaining in a misleading running state.
 func (w *Workflow) Condition() exec.ExecutionPhase {
-	// If the workflow is still in a non-final phase but one of its nodes
-	// reports a terminal image pull error, surface this as a failed condition
-	// to Kubeflow Pipelines so that the corresponding run can be marked as
-	// failed instead of remaining in a misleading running state.
 	if !w.IsInFinalState() && w.hasImagePullError() {
 		return exec.ExecutionFailed
 	}
@@ -472,12 +478,43 @@ func (w *Workflow) Condition() exec.ExecutionPhase {
 
 // hasImagePullError returns true if any node in the workflow reports a message
 // indicating a terminal container image pull error (for example,
-// ImagePullBackOff or ErrImagePull). This is based on the node status message
-// surfaced by Argo Workflows, which in turn reflects the underlying Pod's
-// container waiting reason.
+// ImagePullBackOff or ErrImagePull) that has persisted beyond the grace period.
+// This is based on the node status message surfaced by Argo Workflows, which
+// in turn reflects the underlying Pod's container waiting reason.
 func (w *Workflow) hasImagePullError() bool {
 	if w.Status.Nodes == nil {
 		return false
+	}
+	now := time.Now()
+	for _, node := range w.Status.Nodes {
+		if node.Message == "" {
+			continue
+		}
+		if !strings.Contains(node.Message, "ImagePullBackOff") &&
+			!strings.Contains(node.Message, "ErrImagePull") {
+			continue
+		}
+		// Check if the error has persisted beyond the grace period.
+		// Use the node's start time to determine how long it has been in this state.
+		if node.StartedAt.IsZero() {
+			// If no start time, treat as immediate failure (shouldn't happen in practice)
+			return true
+		}
+		elapsed := now.Sub(node.StartedAt.Time)
+		if elapsed >= imagePullErrorGracePeriod {
+			return true
+		}
+	}
+	return false
+}
+
+// ImagePullErrorMessage returns the image pull error message from any node
+// that reports ImagePullBackOff or ErrImagePull, or empty string if none found.
+// This is used to surface the error to users when a run fails due to image
+// pull issues.
+func (w *Workflow) ImagePullErrorMessage() string {
+	if w.Status.Nodes == nil {
+		return ""
 	}
 	for _, node := range w.Status.Nodes {
 		if node.Message == "" {
@@ -485,14 +522,20 @@ func (w *Workflow) hasImagePullError() bool {
 		}
 		if strings.Contains(node.Message, "ImagePullBackOff") ||
 			strings.Contains(node.Message, "ErrImagePull") {
-			return true
+			return fmt.Sprintf("Node %q failed: %s", node.DisplayName, node.Message)
 		}
 	}
-	return false
+	return ""
 }
 
+// Message returns the workflow status message. If the workflow has an image
+// pull error but no top-level message, returns the image pull error message
+// to surface the error to users.
 func (w *Workflow) Message() string {
-	return w.Status.Message
+	if w.Status.Message != "" {
+		return w.Status.Message
+	}
+	return w.ImagePullErrorMessage()
 }
 
 func (w *Workflow) FinishedAtTime() metav1.Time {

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -460,7 +460,35 @@ func (w *Workflow) FinishedAt() int64 {
 }
 
 func (w *Workflow) Condition() exec.ExecutionPhase {
+	// If the workflow is still in a non-final phase but one of its nodes
+	// reports a terminal image pull error, surface this as a failed condition
+	// to Kubeflow Pipelines so that the corresponding run can be marked as
+	// failed instead of remaining in a misleading running state.
+	if !w.IsInFinalState() && w.hasImagePullError() {
+		return exec.ExecutionFailed
+	}
 	return exec.ExecutionPhase(w.Status.Phase)
+}
+
+// hasImagePullError returns true if any node in the workflow reports a message
+// indicating a terminal container image pull error (for example,
+// ImagePullBackOff or ErrImagePull). This is based on the node status message
+// surfaced by Argo Workflows, which in turn reflects the underlying Pod's
+// container waiting reason.
+func (w *Workflow) hasImagePullError() bool {
+	if w.Status.Nodes == nil {
+		return false
+	}
+	for _, node := range w.Status.Nodes {
+		if node.Message == "" {
+			continue
+		}
+		if strings.Contains(node.Message, "ImagePullBackOff") ||
+			strings.Contains(node.Message, "ErrImagePull") {
+			return true
+		}
+	}
+	return false
 }
 
 func (w *Workflow) Message() string {

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -238,13 +238,31 @@ func TestCondition(t *testing.T) {
 		assert.Equal(t, "", string(workflow.Condition()))
 	})
 
-	t.Run("running phase with ImagePullBackOff message is treated as Failed", func(t *testing.T) {
+	t.Run("running phase with ImagePullBackOff message within grace period is not failed", func(t *testing.T) {
 		workflow := NewWorkflow(&workflowapi.Workflow{
 			Status: workflowapi.WorkflowStatus{
 				Phase: workflowapi.WorkflowRunning,
 				Nodes: map[string]workflowapi.NodeStatus{
 					"step-image-pull-failure": {
-						Message: "ImagePullBackOff: Back-off pulling image \"gcr.io/example/non-existent\"",
+						Message:   "ImagePullBackOff: Back-off pulling image \"gcr.io/example/non-existent\"",
+						StartedAt: metav1.Now(),
+					},
+				},
+			},
+		})
+		assert.Equal(t, "Running", string(workflow.Condition()))
+	})
+
+	t.Run("running phase with ImagePullBackOff message beyond grace period is failed", func(t *testing.T) {
+		// Node started 6 minutes ago (beyond 5 minute grace period)
+		startedAt := metav1.NewTime(time.Now().Add(-6 * time.Minute))
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase: workflowapi.WorkflowRunning,
+				Nodes: map[string]workflowapi.NodeStatus{
+					"step-image-pull-failure": {
+						Message:   "ImagePullBackOff: Back-off pulling image \"gcr.io/example/non-existent\"",
+						StartedAt: startedAt,
 					},
 				},
 			},
@@ -252,18 +270,133 @@ func TestCondition(t *testing.T) {
 		assert.Equal(t, "Failed", string(workflow.Condition()))
 	})
 
-	t.Run("running phase with ErrImagePull message is treated as Failed", func(t *testing.T) {
+	t.Run("running phase with ErrImagePull message beyond grace period is failed", func(t *testing.T) {
+		// Node started 6 minutes ago (beyond 5 minute grace period)
+		startedAt := metav1.NewTime(time.Now().Add(-6 * time.Minute))
 		workflow := NewWorkflow(&workflowapi.Workflow{
 			Status: workflowapi.WorkflowStatus{
 				Phase: workflowapi.WorkflowRunning,
 				Nodes: map[string]workflowapi.NodeStatus{
 					"step-err-image-pull": {
-						Message: "ErrImagePull: rpc error: code = Unknown desc = failed to pull and unpack image",
+						Message:   "ErrImagePull: rpc error: code = Unknown desc = failed to pull and unpack image",
+						StartedAt: startedAt,
 					},
 				},
 			},
 		})
 		assert.Equal(t, "Failed", string(workflow.Condition()))
+	})
+
+	t.Run("workflow already in Failed phase with image pull message remains Failed", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase: workflowapi.WorkflowFailed,
+				Nodes: map[string]workflowapi.NodeStatus{
+					"step-image-pull-failure": {
+						Message: "ImagePullBackOff: Back-off pulling image",
+					},
+				},
+			},
+		})
+		assert.Equal(t, "Failed", string(workflow.Condition()))
+	})
+
+	t.Run("workflow already in Succeeded phase with image pull message remains Succeeded", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase: workflowapi.WorkflowSucceeded,
+				Nodes: map[string]workflowapi.NodeStatus{
+					"step-image-pull-failure": {
+						Message: "ImagePullBackOff: Back-off pulling image",
+					},
+				},
+			},
+		})
+		assert.Equal(t, "Succeeded", string(workflow.Condition()))
+	})
+}
+
+func TestImagePullErrorMessage(t *testing.T) {
+	t.Run("no image pull error returns empty string", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase: workflowapi.WorkflowRunning,
+				Nodes: map[string]workflowapi.NodeStatus{},
+			},
+		})
+		assert.Equal(t, "", workflow.ImagePullErrorMessage())
+	})
+
+	t.Run("image pull error returns formatted message", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase: workflowapi.WorkflowRunning,
+				Nodes: map[string]workflowapi.NodeStatus{
+					"step-image-pull-failure": {
+						DisplayName: "step-image-pull-failure",
+						Message:     "ImagePullBackOff: Back-off pulling image \"gcr.io/example/non-existent\"",
+					},
+				},
+			},
+		})
+		assert.Contains(t, workflow.ImagePullErrorMessage(), "ImagePullBackOff")
+		assert.Contains(t, workflow.ImagePullErrorMessage(), "step-image-pull-failure")
+	})
+
+	t.Run("ErrImagePull returns formatted message", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase: workflowapi.WorkflowRunning,
+				Nodes: map[string]workflowapi.NodeStatus{
+					"step-err-image-pull": {
+						DisplayName: "step-err-image-pull",
+						Message:     "ErrImagePull: rpc error: code = Unknown desc = failed to pull image",
+					},
+				},
+			},
+		})
+		assert.Contains(t, workflow.ImagePullErrorMessage(), "ErrImagePull")
+		assert.Contains(t, workflow.ImagePullErrorMessage(), "step-err-image-pull")
+	})
+}
+
+func TestMessage(t *testing.T) {
+	t.Run("workflow status message is returned when present", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase:   workflowapi.WorkflowFailed,
+				Message: "workflow failed due to timeout",
+			},
+		})
+		assert.Equal(t, "workflow failed due to timeout", workflow.Message())
+	})
+
+	t.Run("image pull error message is returned when status message is empty", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase:   workflowapi.WorkflowRunning,
+				Message: "",
+				Nodes: map[string]workflowapi.NodeStatus{
+					"step-image-pull-failure": {
+						DisplayName: "step-image-pull-failure",
+						Message:     "ImagePullBackOff: Back-off pulling image",
+					},
+				},
+			},
+		})
+		assert.Contains(t, workflow.Message(), "ImagePullBackOff")
+		assert.Contains(t, workflow.Message(), "step-image-pull-failure")
+	})
+
+	t.Run("empty string when no messages", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase:   workflowapi.WorkflowRunning,
+				Message: "",
+				Nodes:   map[string]workflowapi.NodeStatus{},
+			},
+		})
+		assert.Equal(t, "", workflow.Message())
 	})
 }
 

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -221,19 +221,50 @@ func TestWorkflow_ScheduledAtInSecOr0(t *testing.T) {
 }
 
 func TestCondition(t *testing.T) {
-	// Base case
-	workflow := NewWorkflow(&workflowapi.Workflow{
-		Status: workflowapi.WorkflowStatus{
-			Phase: workflowapi.WorkflowRunning,
-		},
+	t.Run("base case - running phase without image pull error", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase: workflowapi.WorkflowRunning,
+				Nodes: map[string]workflowapi.NodeStatus{},
+			},
+		})
+		assert.Equal(t, "Running", string(workflow.Condition()))
 	})
-	assert.Equal(t, "Running", string(workflow.Condition()))
 
-	// No status
-	workflow = NewWorkflow(&workflowapi.Workflow{
-		Status: workflowapi.WorkflowStatus{},
+	t.Run("no status", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{},
+		})
+		assert.Equal(t, "", string(workflow.Condition()))
 	})
-	assert.Equal(t, "", string(workflow.Condition()))
+
+	t.Run("running phase with ImagePullBackOff message is treated as Failed", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase: workflowapi.WorkflowRunning,
+				Nodes: map[string]workflowapi.NodeStatus{
+					"step-image-pull-failure": {
+						Message: "ImagePullBackOff: Back-off pulling image \"gcr.io/example/non-existent\"",
+					},
+				},
+			},
+		})
+		assert.Equal(t, "Failed", string(workflow.Condition()))
+	})
+
+	t.Run("running phase with ErrImagePull message is treated as Failed", func(t *testing.T) {
+		workflow := NewWorkflow(&workflowapi.Workflow{
+			Status: workflowapi.WorkflowStatus{
+				Phase: workflowapi.WorkflowRunning,
+				Nodes: map[string]workflowapi.NodeStatus{
+					"step-err-image-pull": {
+						Message: "ErrImagePull: rpc error: code = Unknown desc = failed to pull and unpack image",
+					},
+				},
+			},
+		})
+		assert.Equal(t, "Failed", string(workflow.Condition()))
+	})
 }
 
 func TestToStringForStore(t *testing.T) {


### PR DESCRIPTION
Fail run when underlying Argo workflow nodes report terminal image pull errors (ImagePullBackOff / ErrImagePull), so runs do not remain in Running state when component images cannot be pulled.
