### PR TITLE
fix(ci): exclude Copilot review checks from CI status gate

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -34,6 +34,10 @@ jobs:
           delay: '5'
           retries: '10'
           polling_interval: '5'
+          # Exclude checks dynamically created by the GitHub Copilot pull request reviewer.
+          # These checks fail with HTTP 403 on fork PRs due to permission limitations,
+          # causing false negatives in the status gate. If the Copilot reviewer adds or
+          # renames checks, update this list accordingly.
           checks_exclude: '^Cleanup artifacts$,^Upload results$,^Agent$,^Prepare$'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The GitHub Copilot pull request reviewer creates dynamic checks (`Cleanup artifacts`, `Upload results`, `Agent`, `Prepare`) that fail on fork PRs with `HTTP 403` due to insufficient permissions.
- This causes `check_ci_status` to fail even when all actual CI checks pass.
- Exclude these Copilot-managed checks from the `allcheckspassed` gate via the `checks_exclude` parameter.

## Test plan
- Verify that `check_ci_status` no longer fails due to Copilot review checks on fork PRs.
- Confirm that actual CI checks (pre-commit, DCO, build, tests) are still gated correctly.