### PR TITLE
docs(frontend): refresh React upgrade checklist status

### DIFF
--- a/frontend/docs/react-18-19-upgrade-checklist.md
+++ b/frontend/docs/react-18-19-upgrade-checklist.md
@@ -189,7 +189,7 @@ Capture coverage baseline before and compare after -- coverage must not decrease
 Not started.
 
 **Description**:
-Upgrade remaining deps with React 17-limited peer ranges: `markdown-to-jsx` v6 to v7, `react-dropzone` v5 to v14, any `re-resizable` residuals, `snapshot-diff` update. Review and update `package.json` `overrides` and `resolutions` entries -- remove stale ones, add new ones as needed. Drive peer gate allowlist to empty.
+Upgrade remaining deps with React 17-limited peer ranges: `markdown-to-jsx` v6 to v7, `react-dropzone` v5 to v14, and any `re-resizable` residuals. Review and update `package.json` `overrides` and `resolutions` entries -- remove stale ones, add new ones as needed. Drive peer gate allowlist to empty.
 
 **Current peer-gate blockers for React 18 to clear across #7, #8, and #9 (as of March 10, 2026):**
 - `react-dom@17.0.2` (`react=17.0.2`) - handled in #9 ([#12897](https://github.com/kubeflow/pipelines/issues/12897))


### PR DESCRIPTION
## Summary
- rebase the checklist refresh on top of current `master`
- add an at-a-glance status block with issue and PR links
- reflect `#4` and `#5` complete and `#7` as the next start point
- refresh the React 18/19 blocker summaries and dependency graph

## Testing
- `git diff --check origin/master..HEAD -- frontend/docs/react-18-19-upgrade-checklist.md`

Doc-only change.