### PR TITLE
test(backend): add unit tests for apiserver main package

### DIFF
--- a/backend/src/apiserver/main_test.go
+++ b/backend/src/apiserver/main_test.go
@@ -166,6 +166,13 @@ func TestApiServerInterceptor(t *testing.T) {
 }
 
 func TestInitCerts(t *testing.T) {
+	originalCertPath := *tlsCertPath
+	originalKeyPath := *tlsCertKeyPath
+	t.Cleanup(func() {
+		*tlsCertPath = originalCertPath
+		*tlsCertKeyPath = originalKeyPath
+	})
+
 	t.Run("no certs provided returns nil", func(t *testing.T) {
 		*tlsCertPath = ""
 		*tlsCertKeyPath = ""
@@ -224,12 +231,6 @@ func TestInitCerts(t *testing.T) {
 		assert.NotNil(t, tlsCfg)
 		assert.Len(t, tlsCfg.Certificates, 1)
 	})
-
-	// Reset flags after tests
-	t.Cleanup(func() {
-		*tlsCertPath = ""
-		*tlsCertKeyPath = ""
-	})
 }
 
 func TestGetPVCSpec(t *testing.T) {
@@ -248,8 +249,9 @@ func TestGetPVCSpec(t *testing.T) {
 		viper.Set("workspace.volumeclaimtemplatespec.storageclassname", storageName)
 
 		pvcSpec, err := getPVCSpec()
-		assert.NoError(t, err)
-		assert.NotNil(t, pvcSpec)
+		require.NoError(t, err)
+		require.NotNil(t, pvcSpec)
+		require.NotNil(t, pvcSpec.StorageClassName)
 		assert.Equal(t, storageName, *pvcSpec.StorageClassName)
 	})
 


### PR DESCRIPTION
## Summary
- Add unit tests for `grpcCustomMatcher`, `apiServerInterceptor`, `initCerts`, and `getPVCSpec` in the apiserver main package
- Improves coverage from 7.3% by testing all unit-testable functions (the remaining untested functions require full infrastructure mocking)
- Includes TLS cert validation tests with self-signed cert generation, viper-based PVC config tests, and gRPC interceptor error conversion tests

## Test plan
- [ ] CI backend tests pass (`presubmit-backend.yml`)
- [ ] Verify coverage increase for `backend/src/apiserver` package