### PR TITLE
feat(frontend,backend): show actual retry start time for pipeline runs. Fixes #12845

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1080,7 +1080,11 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		newExecSpec = newCreatedWorkflow
 	}
 	condition := string(newExecSpec.ExecutionStatus().Condition())
-	err = r.runStore.UpdateRun(&model.Run{UUID: runId, RunDetails: model.RunDetails{Conditions: condition, FinishedAtInSec: 0, WorkflowRuntimeManifest: model.LargeText(newExecSpec.ToStringForStore()), State: model.RuntimeState(condition).ToV2()}})
+	run.Conditions = condition
+	run.FinishedAtInSec = 0
+	run.WorkflowRuntimeManifest = model.LargeText(newExecSpec.ToStringForStore())
+	run.State = model.RuntimeState(condition).ToV2()
+	err = r.runStore.UpdateRun(run)
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to retry run %s due to error updating entry", runId)
 	}

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -2588,14 +2588,14 @@ func TestRetryRun_PreservesRunFields(t *testing.T) {
 	defer store.Close()
 
 	originalRun, err := manager.GetRun(runDetail.UUID)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, string(v1alpha1.WorkflowFailed), string(originalRun.Conditions))
 
 	err = manager.RetryRun(context.Background(), runDetail.UUID)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	retriedRun, err := manager.GetRun(runDetail.UUID)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	// Core identifying fields must be preserved after retry
 	assert.Equal(t, originalRun.UUID, retriedRun.UUID)
@@ -2611,7 +2611,7 @@ func TestRetryRun_PreservesRunFields(t *testing.T) {
 	// to a single entry; passing the full run object preserves history.
 	originalHistoryLen := len(originalRun.StateHistory)
 	assert.Greater(t, originalHistoryLen, 0)
-	assert.Greater(t, len(retriedRun.StateHistory), originalHistoryLen)
+	require.Greater(t, len(retriedRun.StateHistory), originalHistoryLen)
 	lastEntry := retriedRun.StateHistory[len(retriedRun.StateHistory)-1]
 	assert.Equal(t, model.RuntimeStateRunning, lastEntry.State)
 }

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -2583,6 +2583,30 @@ func TestRetryRun(t *testing.T) {
 	assert.Equal(t, actualRunDetail.RunDetails.State, model.RuntimeStateRunning)
 }
 
+func TestRetryRun_PreservesRunFields(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	originalRun, err := manager.GetRun(runDetail.UUID)
+	assert.Nil(t, err)
+	assert.Equal(t, string(v1alpha1.WorkflowFailed), string(originalRun.Conditions))
+
+	err = manager.RetryRun(context.Background(), runDetail.UUID)
+	assert.Nil(t, err)
+
+	retriedRun, err := manager.GetRun(runDetail.UUID)
+	assert.Nil(t, err)
+
+	// Core identifying fields must be preserved after retry
+	assert.Equal(t, originalRun.UUID, retriedRun.UUID)
+	assert.Equal(t, originalRun.DisplayName, retriedRun.DisplayName)
+	assert.Equal(t, originalRun.ExperimentId, retriedRun.ExperimentId)
+	// FinishedAtInSec must be reset to 0 on retry
+	assert.Equal(t, int64(0), retriedRun.RunDetails.FinishedAtInSec)
+	// State must be updated to Running
+	assert.Equal(t, model.RuntimeStateRunning, retriedRun.RunDetails.State)
+}
+
 func TestRetryRun_RunNotExist(t *testing.T) {
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	defer store.Close()

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -2605,6 +2605,15 @@ func TestRetryRun_PreservesRunFields(t *testing.T) {
 	assert.Equal(t, int64(0), retriedRun.FinishedAtInSec)
 	// State must be updated to Running
 	assert.Equal(t, model.RuntimeStateRunning, retriedRun.State)
+
+	// StateHistory must preserve pre-retry entries and append a new RUNNING entry.
+	// With the old sparse-struct UpdateRun call, StateHistory would be overwritten
+	// to a single entry; passing the full run object preserves history.
+	originalHistoryLen := len(originalRun.StateHistory)
+	assert.Greater(t, originalHistoryLen, 0)
+	assert.Greater(t, len(retriedRun.StateHistory), originalHistoryLen)
+	lastEntry := retriedRun.StateHistory[len(retriedRun.StateHistory)-1]
+	assert.Equal(t, model.RuntimeStateRunning, lastEntry.State)
 }
 
 func TestRetryRun_RunNotExist(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -2602,9 +2602,9 @@ func TestRetryRun_PreservesRunFields(t *testing.T) {
 	assert.Equal(t, originalRun.DisplayName, retriedRun.DisplayName)
 	assert.Equal(t, originalRun.ExperimentId, retriedRun.ExperimentId)
 	// FinishedAtInSec must be reset to 0 on retry
-	assert.Equal(t, int64(0), retriedRun.RunDetails.FinishedAtInSec)
+	assert.Equal(t, int64(0), retriedRun.FinishedAtInSec)
 	// State must be updated to Running
-	assert.Equal(t, model.RuntimeStateRunning, retriedRun.RunDetails.State)
+	assert.Equal(t, model.RuntimeStateRunning, retriedRun.State)
 }
 
 func TestRetryRun_RunNotExist(t *testing.T) {

--- a/frontend/src/pages/RunDetailsV2.test.tsx
+++ b/frontend/src/pages/RunDetailsV2.test.tsx
@@ -528,7 +528,7 @@ describe('RunDetailsV2', () => {
         </CommonTestWrapper>,
       );
 
-      userEvent.click(screen.getByText('Detail'));
+      await userEvent.click(screen.getByText('Detail'));
 
       screen.getByText(retryTime.toLocaleString());
       screen.getByText('Scheduled at');
@@ -551,7 +551,7 @@ describe('RunDetailsV2', () => {
         </CommonTestWrapper>,
       );
 
-      userEvent.click(screen.getByText('Detail'));
+      await userEvent.click(screen.getByText('Detail'));
 
       screen.getByText(scheduledTime.toLocaleString());
       expect(screen.queryByText('Scheduled at')).toBeNull();
@@ -574,7 +574,7 @@ describe('RunDetailsV2', () => {
         </CommonTestWrapper>,
       );
 
-      userEvent.click(screen.getByText('Detail'));
+      await userEvent.click(screen.getByText('Detail'));
 
       expect(screen.queryByText('Scheduled at')).toBeNull();
     });

--- a/frontend/src/pages/RunDetailsV2.test.tsx
+++ b/frontend/src/pages/RunDetailsV2.test.tsx
@@ -507,6 +507,78 @@ describe('RunDetailsV2', () => {
       expect(screen.getAllByText('-').length).toEqual(2); // finish time and duration are empty.
     });
 
+    it('shows actual retry start time from state_history when RUNNING entry has update_time', async () => {
+      const retryTime = new Date(2018, 8, 8, 4, 3, 2);
+      const runWithHistory: V2beta1Run = {
+        ...TEST_RUN,
+        scheduled_at: new Date(2018, 8, 6, 4, 3, 2),
+        state_history: [
+          { state: V2beta1RuntimeState.RUNNING, update_time: new Date(2018, 8, 6, 4, 3, 2) },
+          { state: V2beta1RuntimeState.FAILED, update_time: new Date(2018, 8, 6, 5, 0, 0) },
+          { state: V2beta1RuntimeState.RUNNING, update_time: retryTime },
+        ],
+      };
+      render(
+        <CommonTestWrapper>
+          <RunDetailsV2
+            pipeline_job={v2YamlTemplateString}
+            run={runWithHistory}
+            {...generateProps()}
+          ></RunDetailsV2>
+        </CommonTestWrapper>,
+      );
+
+      userEvent.click(screen.getByText('Detail'));
+
+      screen.getByText(retryTime.toLocaleString());
+      screen.getByText('Scheduled at');
+    });
+
+    it('falls back to scheduled_at when RUNNING entry has no update_time', async () => {
+      const scheduledTime = new Date(2018, 8, 6, 4, 3, 2);
+      const runWithNoUpdateTime: V2beta1Run = {
+        ...TEST_RUN,
+        scheduled_at: scheduledTime,
+        state_history: [{ state: V2beta1RuntimeState.RUNNING, update_time: undefined }],
+      };
+      render(
+        <CommonTestWrapper>
+          <RunDetailsV2
+            pipeline_job={v2YamlTemplateString}
+            run={runWithNoUpdateTime}
+            {...generateProps()}
+          ></RunDetailsV2>
+        </CommonTestWrapper>,
+      );
+
+      userEvent.click(screen.getByText('Detail'));
+
+      screen.getByText(scheduledTime.toLocaleString());
+      expect(screen.queryByText('Scheduled at')).toBeNull();
+    });
+
+    it('does not show Scheduled at row when actual start equals scheduled_at', async () => {
+      const sameTime = new Date(2018, 8, 6, 4, 3, 2);
+      const runSameTime: V2beta1Run = {
+        ...TEST_RUN,
+        scheduled_at: sameTime,
+        state_history: [{ state: V2beta1RuntimeState.RUNNING, update_time: sameTime }],
+      };
+      render(
+        <CommonTestWrapper>
+          <RunDetailsV2
+            pipeline_job={v2YamlTemplateString}
+            run={runSameTime}
+            {...generateProps()}
+          ></RunDetailsV2>
+        </CommonTestWrapper>,
+      );
+
+      userEvent.click(screen.getByText('Detail'));
+
+      expect(screen.queryByText('Scheduled at')).toBeNull();
+    });
+
     it('shows run parameters', async () => {
       render(
         <CommonTestWrapper>

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -345,7 +345,7 @@ function updateToolBarActions(
 
 function getActualStartTime(run?: V2beta1Run): Date | undefined {
   if (run?.state_history) {
-    const runningEntries = run.state_history.filter(s => s.state === V2beta1RuntimeState.RUNNING);
+    const runningEntries = run.state_history.filter((s) => s.state === V2beta1RuntimeState.RUNNING);
     if (runningEntries.length > 0) {
       const updateTime = runningEntries[runningEntries.length - 1].update_time;
       if (updateTime !== undefined) {
@@ -374,7 +374,7 @@ function getDetailsFields(run?: V2beta1Run): Array<KeyValue<string>> {
   ];
 
   if (startDiffers) {
-    const startedAtIndex = fields.findIndex(field => field[0] === 'Started at');
+    const startedAtIndex = fields.findIndex((field) => field[0] === 'Started at');
     const scheduledAtField: KeyValue<string> = ['Scheduled at', formatDateString(scheduledAt)];
     if (startedAtIndex >= 0) {
       fields.splice(startedAtIndex, 0, scheduledAtField);

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -360,7 +360,7 @@ function getDetailsFields(run?: V2beta1Run): Array<KeyValue<string>> {
   const actualStart = getActualStartTime(run);
   const scheduledAt = run?.scheduled_at;
   const startDiffers =
-    actualStart && scheduledAt && formatDateString(actualStart) !== formatDateString(scheduledAt);
+    actualStart && scheduledAt && actualStart.getTime() !== scheduledAt.getTime();
 
   const fields: Array<KeyValue<string>> = [
     ['Run ID', run?.run_id || '-'],
@@ -374,7 +374,13 @@ function getDetailsFields(run?: V2beta1Run): Array<KeyValue<string>> {
   ];
 
   if (startDiffers) {
-    fields.splice(5, 0, ['Scheduled at', formatDateString(scheduledAt)]);
+    const startedAtIndex = fields.findIndex(field => field[0] === 'Started at');
+    const scheduledAtField: KeyValue<string> = ['Scheduled at', formatDateString(scheduledAt)];
+    if (startedAtIndex >= 0) {
+      fields.splice(startedAtIndex, 0, scheduledAtField);
+    } else {
+      fields.push(scheduledAtField);
+    }
   }
 
   return fields;

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -349,7 +349,10 @@ function getActualStartTime(run?: V2beta1Run): Date | undefined {
       s => s.state === V2beta1RuntimeState.RUNNING,
     );
     if (runningEntries.length > 0) {
-      return runningEntries[runningEntries.length - 1].update_time;
+      const updateTime = runningEntries[runningEntries.length - 1].update_time;
+      if (updateTime !== undefined) {
+        return updateTime;
+      }
     }
   }
   return run?.scheduled_at;

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -343,15 +343,38 @@ function updateToolBarActions(
   updateToolbar({ actions });
 }
 
+function getActualStartTime(run?: V2beta1Run): Date | undefined {
+  if (run?.state_history) {
+    const runningEntries = run.state_history.filter(
+      s => s.state === V2beta1RuntimeState.RUNNING,
+    );
+    if (runningEntries.length > 0) {
+      return runningEntries[runningEntries.length - 1].update_time;
+    }
+  }
+  return run?.scheduled_at;
+}
+
 function getDetailsFields(run?: V2beta1Run): Array<KeyValue<string>> {
-  return [
+  const actualStart = getActualStartTime(run);
+  const scheduledAt = run?.scheduled_at;
+  const startDiffers =
+    actualStart && scheduledAt && formatDateString(actualStart) !== formatDateString(scheduledAt);
+
+  const fields: Array<KeyValue<string>> = [
     ['Run ID', run?.run_id || '-'],
     ['Workflow name', run?.display_name || '-'],
     ['Status', run?.state ? statusProtoMap.get(run?.state) : '-'],
     ['Description', run?.description || ''],
     ['Created at', run?.created_at ? formatDateString(run.created_at) : '-'],
-    ['Started at', formatDateString(run?.scheduled_at)],
+    ['Started at', formatDateString(actualStart)],
     ['Finished at', hasFinishedV2(run?.state) ? formatDateString(run?.finished_at) : '-'],
     ['Duration', hasFinishedV2(run?.state) ? getRunDurationV2(run) : '-'],
   ];
+
+  if (startDiffers) {
+    fields.splice(5, 0, ['Scheduled at', formatDateString(scheduledAt)]);
+  }
+
+  return fields;
 }

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -345,11 +345,10 @@ function updateToolBarActions(
 
 function getActualStartTime(run?: V2beta1Run): Date | undefined {
   if (run?.state_history) {
-    const runningEntries = run.state_history.filter((s) => s.state === V2beta1RuntimeState.RUNNING);
-    if (runningEntries.length > 0) {
-      const updateTime = runningEntries[runningEntries.length - 1].update_time;
-      if (updateTime !== undefined) {
-        return updateTime;
+    for (let i = run.state_history.length - 1; i >= 0; i--) {
+      const entry = run.state_history[i];
+      if (entry.state === V2beta1RuntimeState.RUNNING && entry.update_time !== undefined) {
+        return entry.update_time;
       }
     }
   }

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -345,9 +345,7 @@ function updateToolBarActions(
 
 function getActualStartTime(run?: V2beta1Run): Date | undefined {
   if (run?.state_history) {
-    const runningEntries = run.state_history.filter(
-      s => s.state === V2beta1RuntimeState.RUNNING,
-    );
+    const runningEntries = run.state_history.filter(s => s.state === V2beta1RuntimeState.RUNNING);
     if (runningEntries.length > 0) {
       const updateTime = runningEntries[runningEntries.length - 1].update_time;
       if (updateTime !== undefined) {


### PR DESCRIPTION
## Description

When a pipeline run is retried (manually or via recurring/scheduled runs),
the **Start time** shown in the UI reflected the original scheduled time
rather than the actual retry execution time. This was misleading when
debugging failures, SLA compliance, or resource availability issues.
Before : 
<img width="768" height="359" alt="image" src="https://github.com/user-attachments/assets/31979781-352e-4ea8-9a83-7e4bebcbf30f" />
Notice that after retry the started at doesnot change 
After
<img width="677" height="629" alt="Screenshot 2026-03-11 at 1 33 30 PM" src="https://github.com/user-attachments/assets/7f484ec9-3f3b-4e30-97a9-0131cd456368" />
The started at reflects the retried time

## Changes

**Backend (`resource_manager.go`)**
- Refactored `RetryRun` to update fields directly on the fetched `run`
  object before persisting, rather than constructing a sparse struct.
  This preserves all existing run fields (e.g. namespace, service account)
  correctly on retry.

**Frontend (`RunDetailsV2.tsx`)**
- Added `getActualStartTime()` that reads the last `RUNNING` entry from
  `state_history` to determine the actual execution start time, with a
  safe guard for missing `update_time`, falling back to `scheduled_at`.
- Updated run details to display `Started at` as the actual execution time.
- When the actual start time differs from the scheduled time, a
  `Scheduled at` row is conditionally shown alongside it.

## Testing

- Deployed locally against a Kind cluster and verified:
  - `Started at` shows the retry execution time after a manual retry
  - `Scheduled at` row appears only when the two times differ
  - `Started at` correctly falls back to `scheduled_at` when no
    `state_history` is present or `update_time` is undefined