### PR TITLE
fix(frontend): Vite dev CJS-to-ESM bridge for generated protobufs. Fixes #13016

### DIFF
--- a/frontend/scripts/generated-cjs-bridge.test.ts
+++ b/frontend/scripts/generated-cjs-bridge.test.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { transformGeneratedCjsToEsm, isGeneratedCjs } from '../vite-plugins/generated-cjs-bridge';
+
+describe('isGeneratedCjs', () => {
+  it('matches MLMD generated JS files', () => {
+    expect(isGeneratedCjs('/abs/third_party/mlmd/generated/proto/foo_pb.js')).toBe(true);
+  });
+
+  it('matches src/generated JS files', () => {
+    expect(isGeneratedCjs('/abs/src/generated/pipeline_spec/pipeline_spec_pb.js')).toBe(true);
+  });
+
+  it('rejects non-.js files in generated paths', () => {
+    expect(isGeneratedCjs('/abs/src/generated/pipeline_spec/pipeline_spec.ts')).toBe(false);
+  });
+
+  it('rejects JS files outside generated paths', () => {
+    expect(isGeneratedCjs('/abs/src/components/App.js')).toBe(false);
+  });
+
+  it('handles Vite query strings appended to module IDs', () => {
+    expect(isGeneratedCjs('/abs/third_party/mlmd/generated/proto/foo_pb.js?t=123')).toBe(true);
+  });
+
+  it('handles Windows-style backslash paths', () => {
+    expect(isGeneratedCjs('C:\\project\\src\\generated\\pipeline_spec\\pipeline_spec_pb.js')).toBe(
+      true,
+    );
+  });
+});
+
+describe('transformGeneratedCjsToEsm', () => {
+  it('converts var require to import (single quotes)', () => {
+    const input = `var jspb = require('google-protobuf');`;
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.code).toContain(`import jspb from 'google-protobuf';`);
+    expect(result.code).not.toContain('require');
+    expect(result.requireMatches).toBe(1);
+  });
+
+  it('converts const require to import', () => {
+    const input = `const proto = require('google-protobuf');`;
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.code).toContain(`import proto from 'google-protobuf';`);
+    expect(result.requireMatches).toBe(1);
+  });
+
+  it('converts let require to import', () => {
+    const input = `let jspb = require('google-protobuf');`;
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.code).toContain(`import jspb from 'google-protobuf';`);
+    expect(result.requireMatches).toBe(1);
+  });
+
+  it('handles double-quoted require', () => {
+    const input = `var jspb = require("google-protobuf");`;
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.code).toContain(`import jspb from 'google-protobuf';`);
+    expect(result.requireMatches).toBe(1);
+  });
+
+  it('converts property-assignment require', () => {
+    const input = `grpc.web = require('grpc-web');`;
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.code).toContain(`import __cjsImport0 from 'grpc-web';`);
+    expect(result.code).toContain(`grpc.web = __cjsImport0;`);
+    expect(result.requireMatches).toBe(1);
+  });
+
+  it('converts goog.object.extend(exports, ...) to ESM exports', () => {
+    const input = [
+      `goog.exportSymbol('proto.test.Foo', null, global);`,
+      `goog.exportSymbol('proto.test.Bar', null, global);`,
+      `goog.exportSymbol('proto.test.Foo.Nested', null, global);`,
+      `goog.object.extend(exports, proto.test);`,
+    ].join('\n');
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.code).toContain('export default proto.test;');
+    expect(result.code).toContain('export const Foo = proto.test.Foo;');
+    expect(result.code).toContain('export const Bar = proto.test.Bar;');
+    expect(result.code).not.toMatch(/export const Nested\b/);
+    expect(result.exportMatches).toBe(1);
+    expect(result.exportSymbolNames).toContain('Foo');
+    expect(result.exportSymbolNames).toContain('Bar');
+  });
+
+  it('converts module.exports to ESM exports', () => {
+    const input = [
+      `goog.exportSymbol('proto.ns.Alpha', null, global);`,
+      `module.exports = proto.ns;`,
+    ].join('\n');
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.code).toContain('export default proto.ns;');
+    expect(result.code).toContain('export const Alpha = proto.ns.Alpha;');
+    expect(result.exportMatches).toBe(1);
+  });
+
+  it('returns zero matches for a file with no CJS patterns', () => {
+    const input = `export const x = 42;`;
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.requireMatches).toBe(0);
+    expect(result.exportMatches).toBe(0);
+  });
+
+  it('handles optional semicolons', () => {
+    const input = `var jspb = require('google-protobuf')`;
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.code).toContain(`import jspb from 'google-protobuf';`);
+    expect(result.requireMatches).toBe(1);
+  });
+
+  it('handles double-quoted goog.exportSymbol', () => {
+    const input = [
+      `goog.exportSymbol("proto.ns.Thing", null, global);`,
+      `goog.object.extend(exports, proto.ns);`,
+    ].join('\n');
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.exportSymbolNames).toContain('Thing');
+  });
+
+  it('emits only one export default when both goog.object.extend and module.exports exist', () => {
+    const input = [
+      `goog.exportSymbol('proto.ns.Alpha', null, global);`,
+      `goog.object.extend(exports, proto.ns);`,
+      `module.exports = proto.ns;`,
+    ].join('\n');
+    const result = transformGeneratedCjsToEsm(input);
+    const defaultCount = (result.code.match(/^export default /gm) || []).length;
+    expect(defaultCount).toBe(1);
+    expect(result.exportMatches).toBe(2);
+  });
+
+  it('falls back to namespace property assignments when no goog.exportSymbol', () => {
+    const input = [
+      `proto.svc.MyClient =`,
+      `    function(hostname) { this.hostname = hostname; };`,
+      `proto.svc.MyPromiseClient =`,
+      `    function(hostname) { this.hostname = hostname; };`,
+      `proto.svc.MyPromiseClient.prototype.doThing =`,
+      `    function(request) { return null; };`,
+      `module.exports = proto.svc;`,
+    ].join('\n');
+    const result = transformGeneratedCjsToEsm(input);
+    expect(result.exportSymbolNames).toContain('MyClient');
+    expect(result.exportSymbolNames).toContain('MyPromiseClient');
+    expect(result.exportSymbolNames).not.toContain('prototype');
+    expect(result.code).toContain('export const MyClient = proto.svc.MyClient;');
+    expect(result.code).toContain('export const MyPromiseClient = proto.svc.MyPromiseClient;');
+  });
+});
+
+describe('transformGeneratedCjsToEsm against real generated files', () => {
+  const generatedFiles = [
+    'src/third_party/mlmd/generated/ml_metadata/proto/metadata_store_pb.js',
+    'src/third_party/mlmd/generated/ml_metadata/proto/metadata_store_service_pb.js',
+    'src/third_party/mlmd/generated/ml_metadata/proto/metadata_store_service_grpc_web_pb.js',
+    'src/generated/pipeline_spec/pipeline_spec_pb.js',
+    'src/generated/pipeline_spec/google/rpc/status_pb.js',
+    'src/generated/platform_spec/kubernetes_platform/kubernetes_executor_config_pb.js',
+  ];
+
+  const frontendRoot = path.resolve(__dirname, '..');
+
+  for (const relPath of generatedFiles) {
+    const fullPath = path.join(frontendRoot, relPath);
+
+    it(`transforms ${relPath} with no remaining require() calls`, () => {
+      const code = fs.readFileSync(fullPath, 'utf-8');
+      const result = transformGeneratedCjsToEsm(code);
+
+      expect(result.requireMatches).toBeGreaterThan(0);
+      expect(result.exportMatches).toBeGreaterThan(0);
+
+      const remainingRequires = result.code.match(/^(var|let|const)\s+\w+\s*=\s*require\(/gm);
+      expect(remainingRequires).toBeNull();
+
+      const remainingPropRequires = result.code.match(/^[\w.]+\s*=\s*require\(/gm);
+      expect(remainingPropRequires).toBeNull();
+    });
+
+    it(`transforms ${relPath} with valid ESM export`, () => {
+      const code = fs.readFileSync(fullPath, 'utf-8');
+      const result = transformGeneratedCjsToEsm(code);
+
+      expect(result.code).toMatch(/^export default /m);
+
+      const noRemainingCjsExport =
+        !result.code.match(/^goog\.object\.extend\(exports,/m) &&
+        !result.code.match(/^module\.exports\s*=/m);
+      expect(noRemainingCjsExport).toBe(true);
+    });
+  }
+});

--- a/frontend/vite-plugins/generated-cjs-bridge.ts
+++ b/frontend/vite-plugins/generated-cjs-bridge.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Plugin } from 'vite';
+
+/**
+ * Paths that contain generated CJS protobuf files. If new generated
+ * directories are added, extend this list.
+ */
+const GENERATED_CJS_PATH_MARKERS = ['third_party/mlmd/generated', '/src/generated/'] as const;
+
+export function isGeneratedCjs(id: string): boolean {
+  const cleanId = id.split(/[?#]/)[0].replace(/\\/g, '/');
+  if (!cleanId.endsWith('.js')) return false;
+  return GENERATED_CJS_PATH_MARKERS.some((marker) => cleanId.includes(marker));
+}
+
+export interface TransformResult {
+  code: string;
+  requireMatches: number;
+  exportMatches: number;
+  exportSymbolNames: string[];
+}
+
+/**
+ * Transforms a generated CJS protobuf file's source code into ESM-compatible
+ * syntax for Vite's dev server. Returns the transformed code along with match
+ * counts that callers can use to detect silent failures (zero matches on a file
+ * that should have had them).
+ *
+ * Handles:
+ *   - `var|let|const X = require('...')` / `require("...")`
+ *   - `EXPR.PROP = require('...')` / `require("...")`
+ *   - `goog.object.extend(exports, NAMESPACE)`
+ *   - `module.exports = NAMESPACE`
+ *   - `goog.exportSymbol('full.name', ...)` → derives named ESM exports
+ */
+export function transformGeneratedCjsToEsm(code: string): TransformResult {
+  let transformed = code;
+  const hoistedImports: string[] = [];
+  let importCounter = 0;
+  let requireMatches = 0;
+  let exportMatches = 0;
+
+  // Determine the export namespace (e.g. "proto.ml_metadata") so we can
+  // derive named exports from goog.exportSymbol calls.
+  let namespace = '';
+  const nsExtend = code.match(/goog\.object\.extend\(exports,\s*([\w.]+)\)/);
+  if (nsExtend) {
+    namespace = nsExtend[1];
+  } else {
+    const nsModule = code.match(/module\.exports\s*=\s*([\w.]+)/);
+    if (nsModule) namespace = nsModule[1];
+  }
+
+  // Collect top-level export names from goog.exportSymbol calls.
+  // 'proto.ml_metadata.Artifact'       → 'Artifact' (direct child, exported)
+  // 'proto.ml_metadata.Artifact.State' → nested, skipped
+  const exportSymbolNames: string[] = [];
+  if (namespace) {
+    const nsPrefix = namespace + '.';
+    const symbolRegex = /goog\.exportSymbol\(\s*['"]([\w.]+)['"]\s*,/g;
+    let match;
+    while ((match = symbolRegex.exec(code)) !== null) {
+      const fullName = match[1];
+      if (fullName.startsWith(nsPrefix)) {
+        const relative = fullName.slice(nsPrefix.length);
+        if (!relative.includes('.')) {
+          exportSymbolNames.push(relative);
+        }
+      }
+    }
+
+    // Fallback: grpc-web files define names via direct property assignment
+    // (e.g. proto.ml_metadata.MetadataStoreServicePromiseClient = ...)
+    // instead of goog.exportSymbol. Scan for namespace.Name = patterns
+    // where Name is NOT followed by another dot (excludes .prototype).
+    if (exportSymbolNames.length === 0) {
+      const escapedNs = namespace.replace(/\./g, '\\.');
+      const propRegex = new RegExp('^' + escapedNs + '\\.(\\w+)\\s*=', 'gm');
+      let propMatch;
+      while ((propMatch = propRegex.exec(code)) !== null) {
+        exportSymbolNames.push(propMatch[1]);
+      }
+    }
+  }
+  const uniqueExportNames = [...new Set(exportSymbolNames)];
+
+  // var/let/const VARNAME = require('MODULE') or require("MODULE")
+  transformed = transformed.replace(
+    /^(var|let|const)\s+(\w+)\s*=\s*require\(\s*(['"])(.*?)\3\s*\)\s*;?\s*$/gm,
+    (_match, _kw, varName, _q, modPath) => {
+      requireMatches++;
+      hoistedImports.push(`import ${varName} from '${modPath}';`);
+      return '';
+    },
+  );
+
+  // EXPR.PROP = require('MODULE') or require("MODULE")
+  transformed = transformed.replace(
+    /^([\w.]+)\s*=\s*require\(\s*(['"])(.*?)\2\s*\)\s*;?\s*$/gm,
+    (_match, expression, _q, modPath) => {
+      requireMatches++;
+      const tempVar = `__cjsImport${importCounter++}`;
+      hoistedImports.push(`import ${tempVar} from '${modPath}';`);
+      return `${expression} = ${tempVar};`;
+    },
+  );
+
+  let defaultExported = false;
+
+  function buildExportBlock(expr: string): string {
+    const lines: string[] = [];
+    if (!defaultExported) {
+      lines.push(`export default ${expr};`);
+      defaultExported = true;
+    }
+    for (const name of uniqueExportNames) {
+      lines.push(`export const ${name} = ${expr}.${name};`);
+    }
+    return lines.join('\n');
+  }
+
+  // goog.object.extend(exports, EXPR)
+  transformed = transformed.replace(
+    /^goog\.object\.extend\(exports,\s*([\w.]+)\)\s*;?\s*$/gm,
+    (_match, expr) => {
+      exportMatches++;
+      return buildExportBlock(expr);
+    },
+  );
+
+  // module.exports = EXPR
+  transformed = transformed.replace(
+    /^module\.exports\s*=\s*([\w.]+)\s*;?\s*$/gm,
+    (_match, expr) => {
+      exportMatches++;
+      return buildExportBlock(expr);
+    },
+  );
+
+  if (hoistedImports.length > 0) {
+    transformed = hoistedImports.join('\n') + '\n' + transformed;
+  }
+
+  return {
+    code: transformed,
+    requireMatches,
+    exportMatches,
+    exportSymbolNames: uniqueExportNames,
+  };
+}
+
+/**
+ * Vite plugin that transforms generated protobuf JS files from CommonJS to ESM
+ * during development. These files use Google Closure Library patterns
+ * (goog.exportSymbol, goog.object.extend) that standard CJS-to-ESM plugins
+ * cannot handle. Only active in dev (`serve`) mode; the production build uses
+ * Rollup's @rollup/plugin-commonjs via `build.commonjsOptions` instead.
+ */
+export function generatedCjsBridge(): Plugin {
+  return {
+    name: 'generated-cjs-bridge',
+    enforce: 'pre',
+    apply: 'serve',
+
+    transform(code, id) {
+      if (!isGeneratedCjs(id)) {
+        return null;
+      }
+
+      const result = transformGeneratedCjsToEsm(code);
+
+      if (result.requireMatches === 0 && result.exportMatches === 0) {
+        this.warn(
+          `[generated-cjs-bridge] Processed ${id} but found no CJS patterns ` +
+            `(0 require, 0 export). The generated file format may have changed. ` +
+            `Verify the protobuf generators still produce the expected output.`,
+        );
+      }
+
+      return { code: result.code, map: null };
+    },
+  };
+}

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
+import { generatedCjsBridge } from './vite-plugins/generated-cjs-bridge';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -31,6 +32,7 @@ const proxy = proxyPaths.reduce<Record<string, { target: string; changeOrigin: b
 export default defineConfig(({ mode }) => ({
   base: './',
   plugins: [
+    generatedCjsBridge(),
     react(),
     mode === 'analyze' &&
       visualizer({


### PR DESCRIPTION
## Description

`npm start` shows a blank white screen because 6 generated protobuf `_pb.js` files use CommonJS (`require`/`module.exports`/`goog.object.extend`), but Vite's dev server expects ES Modules. The production build (`npm run build`) is unaffected because Rollup handles CJS via `build.commonjsOptions`.

The generated files use Google Closure Library patterns (`goog.exportSymbol`, `goog.object.extend(exports, ...)`) that standard CJS-to-ESM plugins (like `vite-plugin-commonjs`) cannot handle. This PR adds a custom dev-only Vite plugin that rewrites these patterns to ESM during serving.

### How the plugin works

1. **File detection**: Only processes `.js` files inside `third_party/mlmd/generated/` and `src/generated/`. All other files are untouched.
2. **Rewrite `require()`**: Converts `var jspb = require('google-protobuf')` → `import jspb from 'google-protobuf'` and `grpc.web = require('grpc-web')` → `import __cjsImport0 from 'grpc-web'; grpc.web = __cjsImport0;`
3. **Rewrite exports**: Converts `goog.object.extend(exports, proto.ml_metadata)` and `module.exports = proto.ml_metadata` → `export default proto.ml_metadata;` plus individual named exports derived from `goog.exportSymbol` calls (or namespace property assignments for grpc-web files).
4. **Silent failure detection**: If a matched file yields zero CJS pattern matches, the plugin emits a Vite warning so developers know the generated file format may have changed.

The rewritten files only exist in memory during the dev server session. Nothing is written to disk.

### Why not just regenerate the protos as ESM?

That is the permanent fix but requires more work:
- For `pipeline_spec` and `platform_spec`: ESM `.ts` files already exist alongside the CJS files, so it's mostly deleting the CJS files and updating 1 import.
- For MLMD: no ESM alternative exists. Would need adding `ts-proto` to the generation script and migrating ~55 consumer files from the class-based API (`artifact.getId()`) to the plain object API (`artifact.id`). Estimated 2-4 day effort.

This plugin unblocks `npm start` now while the permanent migration is planned.

## Changes

- **`vite-plugins/generated-cjs-bridge.ts`** -- The plugin. Transforms CJS → ESM for 6 generated files. Handles `var`/`let`/`const`, single/double quotes, optional semicolons, `goog.exportSymbol`, `goog.object.extend(exports, ...)`, `module.exports`, and direct namespace property assignments (grpc-web fallback). Only active in dev mode (`apply: 'serve'`).
- **`vite.config.mts`** -- 2 lines added: import the plugin and activate it.
- **`scripts/generated-cjs-bridge.test.ts`** -- 27 unit tests in 3 groups:
  - 4 path filter tests (correct file detection)
  - 12 synthetic pattern tests (each CJS variant produces correct ESM)
  - 12 real-file integration tests (transforms all 6 actual generated files, verifies zero remaining `require()` and valid `export default`)

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | 0 errors |
| `npm run build` | Success, identical output hash to master |
| `vitest run` | 1764 pass (27 new + 1737 existing) |
| `npm start` | UI loads, no SyntaxError |

## Blast radius

- Dev-only (`apply: 'serve'`), cannot run during production builds
- Zero new npm dependencies
- Zero modifications to existing source files (only 2 lines added to config)
- Production build output is byte-for-byte identical to master

Fixes #13016