### PR TITLE
fix(frontend): remove duplicate overrides key in .eslintrc.yaml

### DIFF
--- a/frontend/.eslintrc.yaml
+++ b/frontend/.eslintrc.yaml
@@ -78,8 +78,3 @@ rules:
     react/react-in-jsx-scope: off
     react/prop-types: off
     react/jsx-no-target-blank: ['error', { "allowReferrer": true }]
-overrides:
-    # Server uses .js extension in imports (TS compiles to ESM); node resolver can't resolve these.
-    - files: ['server/**/*.ts']
-      rules:
-          import/no-unresolved: off


### PR DESCRIPTION
## Summary
- The `overrides` key appears twice in `frontend/.eslintrc.yaml` with identical content
- `js-yaml` rejects duplicated mapping keys, causing ESLint to crash during `npm run build`
- This breaks the frontend Docker image build and blocks CI for all PRs

## Test plan
- [ ] Frontend Docker image build (`build / image-build (frontend, ...)`) should pass
- [ ] ESLint lint step (`npm run lint`) should complete without YAML parse errors