### PR TITLE
chore(deps): upgrade Kubernetes stack, go-openapi, and cel-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -250,7 +250,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/apiextensions-apiserver v0.35.0 // indirect
+	k8s.io/apiextensions-apiserver v0.35.2 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect

--- a/go.sum
+++ b/go.sum
@@ -747,8 +747,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.35.2 h1:tW7mWc2RpxW7HS4CoRXhtYHSzme1PN1UjGHJ1bdrtdw=
 k8s.io/api v0.35.2/go.mod h1:7AJfqGoAZcwSFhOjcGM7WV05QxMMgUaChNfLTXDRE60=
-k8s.io/apiextensions-apiserver v0.35.0 h1:3xHk2rTOdWXXJM+RDQZJvdx0yEOgC0FgQ1PlJatA5T4=
-k8s.io/apiextensions-apiserver v0.35.0/go.mod h1:E1Ahk9SADaLQ4qtzYFkwUqusXTcaV2uw3l14aqpL2LU=
+k8s.io/apiextensions-apiserver v0.35.2 h1:iyStXHoJZsUXPh/nFAsjC29rjJWdSgUmG1XpApE29c0=
+k8s.io/apiextensions-apiserver v0.35.2/go.mod h1:OdyGvcO1FtMDWQ+rRh/Ei3b6X3g2+ZDHd0MSRGeS8rU=
 k8s.io/apimachinery v0.35.2 h1:NqsM/mmZA7sHW02JZ9RTtk3wInRgbVxL8MPfzSANAK8=
 k8s.io/apimachinery v0.35.2/go.mod h1:jQCgFZFR1F4Ik7hvr2g84RTJSZegBc8yHgFWKn//hns=
 k8s.io/client-go v0.35.2 h1:YUfPefdGJA4aljDdayAXkc98DnPkIetMl4PrKX97W9o=


### PR DESCRIPTION
## Summary

- Upgrades the Kubernetes platform stack as a single unit to prevent partial-upgrade breakage:
  - `k8s.io/{api,apimachinery,client-go}`: v0.33.1 → v0.35.2
  - `k8s.io/code-generator`: v0.31.0 → v0.35.2
  - `sigs.k8s.io/controller-runtime`: v0.19.0 → v0.23.3
  - `sigs.k8s.io/yaml`: v1.4.0 → v1.6.0
- Upgrades older go-openapi packages to current stable:
  - `go-openapi/errors`: v0.20.2 → v0.22.7
  - `go-openapi/runtime`: v0.21.1 → v0.29.3
  - `go-openapi/strfmt`: v0.21.1 → v0.26.0
  - `go-openapi/swag`: v0.23.1 → v0.25.5
  - `go-openapi/validate`: v0.20.3 → v0.25.2
- Upgrades `google/cel-go`: v0.25.0 → v0.27.0

No source code changes required — `go vet ./backend/...` passes clean.

`third_party/ml-metadata/go.mod` is intentionally excluded; its grpc 1.58.3 → 1.79.2 and protobuf 1.33.0 → 1.36.11 jumps deserve separate validation.

## Test plan

- [ ] CI backend unit tests pass (`presubmit-backend.yml`)
- [ ] CI compiler tests pass
- [ ] CI e2e tests pass with both `database` and `kubernetes` pipeline stores
- [ ] `go vet ./backend/...` clean (verified locally)
- [ ] `go mod tidy` produces no diff