### PR TITLE
docs(AGENTS.md): reference backend/README.md for backend work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,7 +322,7 @@ The following files are generated; edit their sources and regenerate:
 - Platform integration (Python): `kubernetes_platform/python/kfp/`
 - Platform spec proto: `kubernetes_platform/proto/`
 - API definitions (Protobufs): `api/`
-- Backend (API server, driver, launcher, etc.): `backend/`
+- Backend (API server, driver, launcher, etc.): `backend/` (see `backend/README.md` for build, test, and local development setup)
 - Backend test suites: `backend/test/compiler`, `backend/test/v2/api`, `backend/test/end2end`
 - Frontend: `frontend/` (React TypeScript, see `frontend/CONTRIBUTING.md`)
 - Manifests (Kustomize bases/overlays for deployments): `manifests/`


### PR DESCRIPTION
## Summary

- Adds a pointer to `backend/README.md` in the AGENTS.md key paths section
- Ensures agents and contributors discover the build, test, and local development instructions when working on backend code

## Test plan

- [ ] Verify the link is correct and renders properly