### PR TITLE
feat(sdk/backend): support PipelineChannel in set_env_variable

### DIFF
--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -267,7 +267,11 @@ func initPodSpecPatch(
 	// Convert environment variables
 	userEnvVar := make([]k8score.EnvVar, 0)
 	for _, envVar := range container.GetEnv() {
-		userEnvVar = append(userEnvVar, k8score.EnvVar{Name: envVar.GetName(), Value: envVar.GetValue()})
+		resolvedValue, err := resolveInputParameterPlaceholders(envVar.GetValue(), executorInput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve environment variable %q: %w", envVar.GetName(), err)
+		}
+		userEnvVar = append(userEnvVar, k8score.EnvVar{Name: envVar.GetName(), Value: resolvedValue})
 	}
 
 	userEnvVar = append(userEnvVar, proxy.GetConfig().GetEnvVars()...)

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -1081,6 +1081,112 @@ implementation:
                     'empty-component']
                 self.assertTrue('inputs' not in dag_task)
 
+    def test_pipeline_with_pipeline_channel_env_variable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+
+            @dsl.component(base_image='python:3.11')
+            def empty_component():
+                pass
+
+            @dsl.pipeline()
+            def simple_pipeline(my_var: str):
+                task = empty_component()
+                task.set_env_variable('MY_VAR', my_var)
+
+            output_yaml = os.path.join(tmpdir, 'result.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=simple_pipeline,
+                package_path=output_yaml,
+                pipeline_parameters={'my_var': 'default'})
+            self.assertTrue(os.path.exists(output_yaml))
+
+            with open(output_yaml, 'r') as f:
+                pipeline_spec = yaml.safe_load(f)
+                container = pipeline_spec['deploymentSpec']['executors'][
+                    'exec-empty-component']['container']
+                env_vars = {
+                    e['name']: e['value'] for e in container.get('env', [])
+                }
+                self.assertEqual(
+                    env_vars['MY_VAR'],
+                    "{{$.inputs.parameters['pipelinechannel--my_var']}}")
+                input_parameters = pipeline_spec['root']['dag']['tasks'][
+                    'empty-component']['inputs']['parameters']
+                self.assertIn('pipelinechannel--my_var', input_parameters)
+
+    def test_pipeline_with_task_output_env_variable(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+
+            @dsl.component(base_image='python:3.11')
+            def producer() -> str:
+                return 'hello'
+
+            @dsl.component(base_image='python:3.11')
+            def consumer():
+                pass
+
+            @dsl.pipeline()
+            def task_output_pipeline():
+                prod_task = producer()
+                cons_task = consumer()
+                cons_task.set_env_variable('MY_VAR', prod_task.output)
+
+            output_yaml = os.path.join(tmpdir, 'result.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=task_output_pipeline, package_path=output_yaml)
+            self.assertTrue(os.path.exists(output_yaml))
+
+            with open(output_yaml, 'r') as f:
+                pipeline_spec = yaml.safe_load(f)
+                container = pipeline_spec['deploymentSpec']['executors'][
+                    'exec-consumer']['container']
+                env_vars = {
+                    e['name']: e['value'] for e in container.get('env', [])
+                }
+                self.assertEqual(
+                    env_vars['MY_VAR'],
+                    "{{$.inputs.parameters['pipelinechannel--producer-Output']}}"
+                )
+                input_parameters = pipeline_spec['root']['dag']['tasks'][
+                    'consumer']['inputs']['parameters']
+                self.assertIn('pipelinechannel--producer-Output',
+                              input_parameters)
+                self.assertEqual(
+                    input_parameters['pipelinechannel--producer-Output']
+                    ['taskOutputParameter']['producerTask'], 'producer')
+
+    def test_pipeline_env_variable_no_collision_with_component_input(self):
+        """Env var name matching a component input should not cause a
+        collision error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+
+            @dsl.component(base_image='python:3.11')
+            def my_component(token: str) -> str:
+                return token
+
+            @dsl.pipeline()
+            def collision_pipeline(token: str):
+                task = my_component(token=token)
+                task.set_env_variable('token', token)
+
+            output_yaml = os.path.join(tmpdir, 'result.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=collision_pipeline,
+                package_path=output_yaml,
+                pipeline_parameters={'token': 'default'})
+            self.assertTrue(os.path.exists(output_yaml))
+
+            with open(output_yaml, 'r') as f:
+                pipeline_spec = yaml.safe_load(f)
+                container = pipeline_spec['deploymentSpec']['executors'][
+                    'exec-my-component']['container']
+                env_vars = {
+                    e['name']: e['value'] for e in container.get('env', [])
+                }
+                self.assertEqual(
+                    env_vars['token'],
+                    "{{$.inputs.parameters['pipelinechannel--token']}}")
+
     def test_compile_with_kubernetes_manifest_format(self):
         with tempfile.TemporaryDirectory() as tmpdir:
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -145,6 +145,13 @@ def build_task_spec_for_task(
         if val and pipeline_channel.extract_pipeline_channels_from_any(val):
             task.inputs['base_image'] = val
 
+    if task.container_spec and task.container_spec.env:
+        for env_name, env_val in task.container_spec.env.items():
+            if env_val and pipeline_channel.extract_pipeline_channels_from_any(
+                    env_val):
+                synthetic_key = f'pipelinechannel--env-{env_name}'
+                task.inputs[synthetic_key] = env_val
+
     for input_name, input_value in task.inputs.items():
         # Since LoopParameterArgument and LoopArtifactArgument and LoopArgumentVariable are narrower
         # types than PipelineParameterChannel, start with them.
@@ -729,9 +736,7 @@ def build_container_spec_for_task(
         compiler injected input name."""
         pipeline_channels = (
             pipeline_channel.extract_pipeline_channels_from_any(input_value))
-        if pipeline_channels:
-            assert len(pipeline_channels) == 1
-            channel = pipeline_channels[0]
+        for channel in pipeline_channels:
             additional_input_name = (
                 compiler_utils.additional_input_name_for_pipeline_channel(
                     channel))
@@ -748,7 +753,7 @@ def build_container_spec_for_task(
             args=task.container_spec.args,
             env=[
                 pipeline_spec_pb2.PipelineDeploymentConfig.PipelineContainerSpec
-                .EnvVar(name=name, value=value)
+                .EnvVar(name=name, value=convert_to_placeholder(value))
                 for name, value in (task.container_spec.env or {}).items()
             ]))
 

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -687,22 +687,51 @@ class PipelineTask:
         return self
 
     @block_if_final()
-    def set_env_variable(self, name: str, value: str) -> 'PipelineTask':
+    def set_env_variable(
+        self,
+        name: str,
+        value: Union[str, pipeline_channel.PipelineChannel],
+    ) -> 'PipelineTask':
         """Sets environment variable for the task.
 
         Args:
             name: Environment variable name.
-            value: Environment variable value.
+            value: Environment variable value. Supports dynamic values such as
+                Pipeline Parameters or outputs from previous tasks, which are
+                resolved at runtime.
 
         Returns:
             Self return to allow chained setting calls.
         """
         self._ensure_container_spec_exists()
 
+        pipeline_channels = (
+            pipeline_channel.extract_pipeline_channels_from_any(value))
+
+        for channel in pipeline_channels:
+            if isinstance(channel, pipeline_channel.PipelineArtifactChannel):
+                raise ValueError(
+                    f'Artifact channels are not supported as environment '
+                    f'variable values. Got artifact channel {channel.name!r} '
+                    f'for env var {name!r}. Only parameter channels are '
+                    f'supported.')
+
+        if isinstance(value, pipeline_channel.PipelineChannel):
+            value = str(value)
+
         if self.container_spec.env is not None:
             self.container_spec.env[name] = value
         else:
             self.container_spec.env = {name: value}
+
+        if pipeline_channels:
+            existing_channel_patterns = {
+                channel.pattern for channel in self._channel_inputs
+            }
+            for channel in pipeline_channels:
+                if channel.pattern not in existing_channel_patterns:
+                    self._channel_inputs.append(channel)
+                    existing_channel_patterns.add(channel.pattern)
         return self
 
     @block_if_final()

--- a/sdk/python/kfp/dsl/pipeline_task_test.py
+++ b/sdk/python/kfp/dsl/pipeline_task_test.py
@@ -382,6 +382,37 @@ class PipelineTaskTest(parameterized.TestCase):
         task.set_env_variable('env_name', 'env_value')
         self.assertEqual({'env_name': 'env_value'}, task.container_spec.env)
 
+    def test_set_env_variable_with_pipeline_channel(self):
+        task = pipeline_task.PipelineTask(
+            component_spec=structures.ComponentSpec.from_yaml_documents(
+                V2_YAML),
+            args={'input1': 'value'},
+        )
+        channel = pipeline_channel.PipelineParameterChannel(
+            name='param', channel_type='String', task_name='upstream')
+        task.set_env_variable('MY_VAR', channel)
+        self.assertIn('MY_VAR', task.container_spec.env)
+        self.assertEqual(str(channel), task.container_spec.env['MY_VAR'])
+        self.assertEqual(1, len(task._channel_inputs))
+        self.assertEqual(channel.pattern, task._channel_inputs[0].pattern)
+
+    def test_set_env_variable_rejects_artifact_channel(self):
+        task = pipeline_task.PipelineTask(
+            component_spec=structures.ComponentSpec.from_yaml_documents(
+                V2_YAML),
+            args={'input1': 'value'},
+        )
+        artifact_channel = pipeline_channel.PipelineArtifactChannel(
+            name='model',
+            channel_type='system.Artifact',
+            task_name='upstream',
+            is_artifact_list=False,
+        )
+        with self.assertRaisesRegex(
+                ValueError,
+                'Artifact channels are not supported'):
+            task.set_env_variable('MY_VAR', artifact_channel)
+
     def test_set_display_name(self):
         task = pipeline_task.PipelineTask(
             component_spec=structures.ComponentSpec.from_yaml_documents(


### PR DESCRIPTION
**Description of your changes:**
  - SDK: accept `PipelineChannel` in `set_env_variable` and register channel inputs
  - Compiler: inject env var channels into task inputs and convert placeholders
  - Backend: resolve env var placeholders at runtime via
  `resolvePodSpecInputRuntimeParameter`

## Live Cluster Testing Evidence:

### SDK

Before:
```
Traceback (most recent call last):
  File "/Users/jer/Projects/kfp/pipelines/issue_11035/test_simple_dynamic_env_var.py", line 19, in <module>
    @dsl.pipeline(name="test-dynamic-env-var")
     ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jer/Projects/kfp/pipelines/venv/lib/python3.14/site-packages/kfp/dsl/pipeline_context.py", line 71, in pipeline
    return component_factory.create_graph_component_from_func(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        func,
        ^^^^^
    ...<3 lines>...
        pipeline_config=pipeline_config,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/jer/Projects/kfp/pipelines/venv/lib/python3.14/site-packages/kfp/dsl/component_factory.py", line 915, in create_graph_component_from_func
    return graph_component.GraphComponent(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        component_spec=component_spec,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        pipeline_config=pipeline_config,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/jer/Projects/kfp/pipelines/venv/lib/python3.14/site-packages/kfp/dsl/graph_component.py", line 77, in __init__
    pipeline_spec, platform_spec = builder.create_pipeline_spec(
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        pipeline=dsl_pipeline,
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        pipeline_config=pipeline_config,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/jer/Projects/kfp/pipelines/venv/lib/python3.14/site-packages/kfp/compiler/pipeline_spec_builder.py", line 2048, in create_pipeline_spec
    build_spec_by_group(
    ~~~~~~~~~~~~~~~~~~~^
        pipeline_spec=pipeline_spec,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<10 lines>...
        is_compiled_component=False,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/jer/Projects/kfp/pipelines/venv/lib/python3.14/site-packages/kfp/compiler/pipeline_spec_builder.py", line 1409, in build_spec_by_group
    subgroup_container_spec = build_container_spec_for_task(
        task=subgroup)
  File "/Users/jer/Projects/kfp/pipelines/venv/lib/python3.14/site-packages/kfp/compiler/pipeline_spec_builder.py", line 751, in build_container_spec_for_task
    .EnvVar(name=name, value=value)
     ~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: bad argument type for built-in operation
```
After:
```
# PIPELINE DEFINITION
# Name: test-dynamic-env-var
# Inputs:
#    name: str [Default: 'test-value']
components:
  comp-produce-value:
    executorLabel: exec-produce-value
    outputDefinitions:
      parameters:
        Output:
          parameterType: STRING
  comp-read-env-var:
    executorLabel: exec-read-env-var
    inputDefinitions:
      parameters:
        expected:
          parameterType: STRING
    outputDefinitions:
      parameters:
        Output:
          parameterType: STRING
  comp-read-env-var-2:
    executorLabel: exec-read-env-var-2
    inputDefinitions:
      parameters:
        expected:
          parameterType: STRING
    outputDefinitions:
      parameters:
        Output:
          parameterType: STRING
deploymentSpec:
  executors:
    exec-produce-value:
      container:
        args:
        - --executor_input
        - '{{$}}'
        - --function_to_execute
        - produce_value
        command:
        - sh
        - -c
        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
          $0\" \"$@\"\n"
        - sh
        - -ec
        - 'program_path=$(mktemp -d)


          printf "%s" "$0" > "$program_path/ephemeral_component.py"

          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"

          '
        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
          \ *\n\ndef produce_value() -> str:\n    return \"from-upstream-task\"\n\n"
        image: python:3.11
    exec-read-env-var:
      container:
        args:
        - --executor_input
        - '{{$}}'
        - --function_to_execute
        - read_env_var
        command:
        - sh
        - -c
        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
          $0\" \"$@\"\n"
        - sh
        - -ec
        - 'program_path=$(mktemp -d)


          printf "%s" "$0" > "$program_path/ephemeral_component.py"

          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"

          '
        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
          \ *\n\ndef read_env_var(expected: str) -> str:\n    \"\"\"Read MY_VAR from\
          \ env and verify it matches expected value.\"\"\"\n    import os\n    value\
          \ = os.environ.get('MY_VAR', '')\n    print(f\"MY_VAR={value}\")\n    if\
          \ value != expected:\n        raise ValueError(f\"Expected MY_VAR='{expected}',\
          \ got '{value}'\")\n    return value\n\n"
        env:
        - name: MY_VAR
          value: '{{$.inputs.parameters[''pipelinechannel--name'']}}'
        image: python:3.11
    exec-read-env-var-2:
      container:
        args:
        - --executor_input
        - '{{$}}'
        - --function_to_execute
        - read_env_var
        command:
        - sh
        - -c
        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
          $0\" \"$@\"\n"
        - sh
        - -ec
        - 'program_path=$(mktemp -d)


          printf "%s" "$0" > "$program_path/ephemeral_component.py"

          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"

          '
        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
          \ *\n\ndef read_env_var(expected: str) -> str:\n    \"\"\"Read MY_VAR from\
          \ env and verify it matches expected value.\"\"\"\n    import os\n    value\
          \ = os.environ.get('MY_VAR', '')\n    print(f\"MY_VAR={value}\")\n    if\
          \ value != expected:\n        raise ValueError(f\"Expected MY_VAR='{expected}',\
          \ got '{value}'\")\n    return value\n\n"
        env:
        - name: MY_VAR
          value: '{{$.inputs.parameters[''pipelinechannel--produce-value-Output'']}}'
        image: python:3.11
pipelineInfo:
  name: test-dynamic-env-var
root:
  dag:
    tasks:
      produce-value:
        cachingOptions:
          enableCache: true
        componentRef:
          name: comp-produce-value
        taskInfo:
          name: produce-value
      read-env-var:
        cachingOptions:
          enableCache: true
        componentRef:
          name: comp-read-env-var
        inputs:
          parameters:
            MY_VAR:
              runtimeValue:
                constant: '{{$.inputs.parameters[''pipelinechannel--name'']}}'
            expected:
              componentInputParameter: name
            pipelinechannel--name:
              componentInputParameter: name
        taskInfo:
          name: read-env-var
      read-env-var-2:
        cachingOptions:
          enableCache: true
        componentRef:
          name: comp-read-env-var-2
        dependentTasks:
        - produce-value
        inputs:
          parameters:
            MY_VAR:
              runtimeValue:
                constant: '{{$.inputs.parameters[''pipelinechannel--produce-value-Output'']}}'
            expected:
              taskOutputParameter:
                outputParameterKey: Output
                producerTask: produce-value
            pipelinechannel--produce-value-Output:
              taskOutputParameter:
                outputParameterKey: Output
                producerTask: produce-value
        taskInfo:
          name: read-env-var-2
  inputDefinitions:
    parameters:
      name:
        defaultValue: test-value
        isOptional: true
        parameterType: STRING
schemaVersion: 2.1.0
sdkVersion: kfp-2.15.2

```

### Driver

Before:

<img width="1122" height="453" alt="Screenshot 2026-03-13 at 11 18 10 PM" src="https://github.com/user-attachments/assets/dc18fd50-3f81-4f39-9aae-2eeb9158139e" />

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/local/lib/python3.11/site-packages/kfp/dsl/executor_main.py", line 109, in <module>
    executor_main()
  File "/usr/local/lib/python3.11/site-packages/kfp/dsl/executor_main.py", line 101, in executor_main
    output_file = executor.execute()
                  ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kfp/dsl/executor.py", line 417, in execute
    result = self.func(**func_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmp.5gkGg93xUl/ephemeral_component.py", line 13, in read_env_var
    raise ValueError(f"Expected MY_VAR='{expected}', got '{value}'")
ValueError: Expected MY_VAR='from-upstream-task', got '{{channel:task=produce-value;name=Output;type=String;}}'
MY_VAR={{channel:task=produce-value;name=Output;type=String;}}
```

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/local/lib/python3.11/site-packages/kfp/dsl/executor_main.py", line 109, in <module>
    executor_main()
  File "/usr/local/lib/python3.11/site-packages/kfp/dsl/executor_main.py", line 101, in executor_main
    output_file = executor.execute()
                  ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/kfp/dsl/executor.py", line 417, in execute
    result = self.func(**func_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/tmp.m8B9XomrYf/ephemeral_component.py", line 13, in read_env_var
    raise ValueError(f"Expected MY_VAR='{expected}', got '{value}'")
ValueError: Expected MY_VAR='test_manual_input_value', got '{{channel:task=;name=name;type=String;}}'
MY_VAR={{channel:task=;name=name;type=String;}}
```

After:

<img width="1239" height="629" alt="Screenshot 2026-03-14 at 2 05 50 PM" src="https://github.com/user-attachments/assets/916cdbdd-a3f8-4dc6-a9a0-be584aeab148" />
<img width="1245" height="653" alt="Screenshot 2026-03-14 at 2 06 11 PM" src="https://github.com/user-attachments/assets/33159840-31a7-4850-8bb6-28ffd07836ae" />
<img width="447" height="65" alt="Screenshot 2026-03-14 at 2 08 15 PM" src="https://github.com/user-attachments/assets/914ccf96-b9f0-4308-8e27-89f000bc3fa4" />

<img width="1226" height="700" alt="Screenshot 2026-03-14 at 2 06 55 PM" src="https://github.com/user-attachments/assets/a7fd9ad4-ba87-4ed2-adda-b77f95deb686" />
<img width="501" height="93" alt="Screenshot 2026-03-14 at 2 04 53 PM" src="https://github.com/user-attachments/assets/b8575f1e-2f3a-4af0-ad04-adf66f9f04ac" />





**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
