### PR TITLE
fix(test): upgrade Node.js 18 to 24 in frontend integration test Dockerfile

### DIFF
--- a/test/frontend-integration-test/Dockerfile
+++ b/test/frontend-integration-test/Dockerfile
@@ -4,7 +4,7 @@ FROM selenium/standalone-chromium:143.0
 USER root
 RUN apt-get update -qqy && \
     apt-get install -qqy curl && \
-    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 USER seluser


### PR DESCRIPTION
## Summary

- Upgrades Node.js from 18.x to 24.x in `test/frontend-integration-test/Dockerfile`
- Node 18 reached end-of-life in April 2025
- The rest of the repo already uses Node 22/24, making this a stale pin

## Test plan

- [ ] Frontend integration test Docker image builds successfully
- [ ] Frontend integration tests pass