### PR TITLE
ci: workflow fixes

### DIFF
--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -62,21 +62,155 @@ inputs:
     description: "Path to the CA certificate file."
     required: false
     default: ""
+  # Deployment metadata inputs (from deploy action outputs)
+  deployment_name:
+    description: "Name of the KFP API server deployment/service (from deploy action)"
+    required: false
+    default: ""
+  deployment_service_account_name:
+    description: "Service account name from deployment (from deploy action)"
+    required: false
+    default: ""
+  deployment_mode:
+    description: "Deployment mode used - operator or direct (from deploy action)"
+    required: false
+    default: ""
+  # Optional API overrides (for custom scenarios)
+  api_url:
+    description: "Override API server URL (leave empty for auto-detection)"
+    required: false
+    default: ""
+  auth_token:
+    description: "Override authentication token (leave empty for auto-generation)"
+    required: false
+    default: ""
+  service_account_name:
+    description: "Override service account name for pipeline execution (leave empty to use deployment SA)"
+    required: false
+    default: ""
+  base_image:
+    description: "Base container image for pipeline components"
+    required: false
+    default: ""
+  skip_api_config:
+    description: "Skip API access configuration and token generation (for tests that do not need a cluster)"
+    required: false
+    default: 'false'
 
 
 runs:
   using: "composite"
   steps:
-    - name: Port-forward MinIO service for archived workflow logs
-      id: port-forward-minio
+    - name: Port-forward SeaweedFS service for archived workflow logs
+      id: port-forward-seaweedfs
       if: (!cancelled())
       shell: bash
       run: |
         NAMESPACE="${{ inputs.default_namespace }}"
-        pkill -f "kubectl port-forward.*minio" || true
-        kubectl port-forward -n "$NAMESPACE" service/minio-service 9000:9000 > /dev/null 2>&1 &
+        pkill -f "kubectl port-forward.*seaweedfs" || true
+        kubectl port-forward -n "$NAMESPACE" service/seaweedfs 9000:9000 > /dev/null 2>&1 &
         sleep 5
       continue-on-error: true
+
+    - name: Configure API Access
+      id: configure-api
+      if: ${{ inputs.skip_api_config != 'true' }}
+      shell: bash
+      env:
+        INPUT_API_URL: ${{ inputs.api_url }}
+        INPUT_TLS_ENABLED: ${{ inputs.tls_enabled }}
+        INPUT_AUTH_TOKEN: ${{ inputs.auth_token }}
+        INPUT_MULTI_USER: ${{ inputs.multi_user }}
+        INPUT_SERVICE_ACCOUNT_NAME: ${{ inputs.service_account_name }}
+        INPUT_DEPLOYMENT_SERVICE_ACCOUNT_NAME: ${{ inputs.deployment_service_account_name }}
+        INPUT_DEPLOYMENT_NAME: ${{ inputs.deployment_name }}
+        INPUT_DEFAULT_NAMESPACE: ${{ inputs.default_namespace }}
+      run: |
+        echo "Configuring API access for tests..."
+
+        # Use provided API URL if available, otherwise detect from deployment
+        if [ -n "$INPUT_API_URL" ]; then
+          # Validate URL: must use http(s) scheme with safe characters only
+          if ! echo "$INPUT_API_URL" | grep -qE '^https?://[A-Za-z0-9._:/@%?&=+-]+$'; then
+            echo "Invalid API URL: contains disallowed characters or invalid scheme"
+            exit 1
+          fi
+          API_URL="$INPUT_API_URL"
+          echo "Using provided API URL: $API_URL"
+        else
+          # Auto-detect API URL based on TLS configuration
+          TLS_ENABLED="$INPUT_TLS_ENABLED"
+          if [ "$TLS_ENABLED" = "true" ]; then
+            API_URL="https://localhost:8888"
+          else
+            API_URL="http://localhost:8888"
+          fi
+          echo "Auto-detected API URL: $API_URL"
+        fi
+
+        # Determine service account name (needed regardless of token source)
+        if [ -n "$INPUT_SERVICE_ACCOUNT_NAME" ]; then
+          SERVICE_ACCOUNT_NAME="$INPUT_SERVICE_ACCOUNT_NAME"
+          echo "Using provided service account: $SERVICE_ACCOUNT_NAME"
+        elif [ -n "$INPUT_DEPLOYMENT_SERVICE_ACCOUNT_NAME" ]; then
+          SERVICE_ACCOUNT_NAME="$INPUT_DEPLOYMENT_SERVICE_ACCOUNT_NAME"
+          echo "Using deployment service account: $SERVICE_ACCOUNT_NAME"
+        else
+          # Fallback based on deployment name
+          DEPLOYMENT_NAME="${INPUT_DEPLOYMENT_NAME:-}"
+          if [ -n "$DEPLOYMENT_NAME" ]; then
+            SERVICE_ACCOUNT_NAME="$DEPLOYMENT_NAME"
+            echo "Using deployment name as service account: $SERVICE_ACCOUNT_NAME"
+          else
+            SERVICE_ACCOUNT_NAME="pipeline-runner"  # Final fallback — matches the SA with workflow RBAC permissions
+            echo "Using fallback service account: $SERVICE_ACCOUNT_NAME"
+          fi
+        fi
+
+        # Use provided token if available, otherwise generate from service account
+        # In multi-user mode without an explicit token, skip token generation here
+        # and let the test code handle it via CreateUserToken with the user namespace/SA.
+        MULTI_USER="${INPUT_MULTI_USER}"
+        if [ -n "$INPUT_AUTH_TOKEN" ]; then
+          API_TOKEN="$INPUT_AUTH_TOKEN"
+          echo "Using provided auth token"
+        elif [ "$MULTI_USER" = "true" ]; then
+          API_TOKEN=""
+          echo "Multi-user mode: skipping token generation, tests will create user token"
+        else
+          # Wait for deployment to be ready
+          DEPLOYMENT_NAME="${INPUT_DEPLOYMENT_NAME:-}"
+          DEFAULT_NAMESPACE="${INPUT_DEFAULT_NAMESPACE:-}"
+          if [ -n "$DEPLOYMENT_NAME" ]; then
+            echo "Waiting for service $DEPLOYMENT_NAME to be available..."
+            end_time=$((SECONDS + 120))
+            while [ $SECONDS -lt $end_time ]; do
+              if kubectl get service "$DEPLOYMENT_NAME" -n "$DEFAULT_NAMESPACE" &> /dev/null; then
+                break
+              fi
+              echo "Waiting for service $DEPLOYMENT_NAME..."
+              sleep 10
+            done
+          fi
+
+          # Generate API token
+          echo "Generating token for $SERVICE_ACCOUNT_NAME..."
+          API_TOKEN=$(kubectl create token "$SERVICE_ACCOUNT_NAME" --namespace "$DEFAULT_NAMESPACE" --duration=60m)
+          if [ $? -eq 0 ]; then
+            echo "Token generated successfully"
+          else
+            echo "Token generation failed"
+            exit 1
+          fi
+        fi
+
+        # Output for next step
+        if [ -n "$API_TOKEN" ]; then
+          echo "::add-mask::$API_TOKEN"
+        fi
+        echo "API_URL=$API_URL" >> "$GITHUB_OUTPUT"
+        echo "API_TOKEN=$API_TOKEN" >> "$GITHUB_OUTPUT"
+        echo "SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-${INPUT_SERVICE_ACCOUNT_NAME:-}}" >> "$GITHUB_OUTPUT"
 
     - name: Run Tests
       id: run-tests
@@ -86,24 +220,47 @@ runs:
         PIPELINE_STORE: ${{ inputs.pipeline_store }}
       run: |
         USE_PROXY=${{ inputs.proxy }}
-        if [ -z $USE_PROXY ]; then
+        if [ -z "$USE_PROXY" ]; then
             USE_PROXY='false'
         fi
         MULTI_USER=${{ inputs.multi_user}}
-        if [ -z $MULTI_USER ]; then
+        if [ -z "$MULTI_USER" ]; then
           MULTI_USER='false'
         fi
         TLS_ENABLED=${{ inputs.tls_enabled }}
-        if [ -z $TLS_ENABLED ]; then
+        if [ -z "$TLS_ENABLED" ]; then
           TLS_ENABLED='false'
         fi
-        CA_CERT_PATH=${{ inputs.ca_cert_path }}
-        if [ -z $CA_CERT_PATH ]; then
-          CA_CERT_PATH=''
+
+        # Set API scheme and CA cert path based on TLS configuration
+        if [[ "$TLS_ENABLED" == 'true' ]]; then
+          API_SCHEME='https'
+          CA_CERT_PATH=${{ inputs.ca_cert_path }}
+          if [ -z "$CA_CERT_PATH" ]; then
+            CA_CERT_PATH=''
+          fi
+        else
+          API_SCHEME='http'
+          CA_CERT_PATH=''  # Force empty when TLS is disabled
         fi
         PULL_NUMBER="${{ github.event.inputs.pull_number || github.event.pull_request.number }}"
         REPO_NAME="${{ github.repository }}"
-        go run github.com/onsi/ginkgo/v2/ginkgo -r -v --cover -p --keep-going --github-output=true --nodes=${{ inputs.num_parallel_nodes }} --label-filter=${{ inputs.test_label }} --silence-skips=true -- -namespace=${{ inputs.default_namespace }} -multiUserMode=$MULTI_USER -useProxy=$USE_PROXY -userNamespace=${{ inputs.user_namespace }} -uploadPipelinesWithKubernetes=${{ inputs.upload_pipelines_with_kubernetes_client}} -tlsEnabled=$TLS_ENABLED -caCertPath=$CA_CERT_PATH -pullNumber=$PULL_NUMBER -repoName=$REPO_NAME
+        API_URL="${{ steps.configure-api.outputs.API_URL }}"
+        AUTH_TOKEN="${{ steps.configure-api.outputs.API_TOKEN }}"
+        SERVICE_ACCOUNT_NAME="${{ steps.configure-api.outputs.SERVICE_ACCOUNT_NAME }}"
+        BASE_IMAGE_FLAG=""
+        if [ -n "${{ inputs.base_image }}" ]; then
+          BASE_IMAGE_FLAG="-baseImage=${{ inputs.base_image }}"
+        fi
+
+        # Only disable TLS verification when TLS is enabled but no CA cert is provided
+        if [[ "$TLS_ENABLED" == 'true' ]] && [ -z "$CA_CERT_PATH" ]; then
+          DISABLE_TLS_CHECK='true'
+        else
+          DISABLE_TLS_CHECK='false'
+        fi
+
+        go run github.com/onsi/ginkgo/v2/ginkgo -r -v --cover -p --keep-going --github-output=true --nodes=${{ inputs.num_parallel_nodes }} --label-filter=${{ inputs.test_label }} --silence-skips=true -- -namespace=${{ inputs.default_namespace }} -multiUserMode=$MULTI_USER -useProxy=$USE_PROXY -userNamespace=${{ inputs.user_namespace }} -uploadPipelinesWithKubernetes=${{ inputs.upload_pipelines_with_kubernetes_client}} -disableTlsCheck=$DISABLE_TLS_CHECK -apiScheme=$API_SCHEME -tlsEnabled=$TLS_ENABLED -caCertPath=$CA_CERT_PATH -pullNumber=$PULL_NUMBER -repoName=$REPO_NAME -apiUrl="$API_URL" -authToken="$AUTH_TOKEN" -serviceAccountName="$SERVICE_ACCOUNT_NAME" $BASE_IMAGE_FLAG
       continue-on-error: true
 
     - name: Collect Pod logs in case of Test Failures

--- a/.github/resources/scripts/deploy-kfp.sh
+++ b/.github/resources/scripts/deploy-kfp.sh
@@ -183,7 +183,6 @@ fi
 if [ "${MULTI_USER}" == "true" ]; then
   echo "Creating KF Profile..."
   kubectl apply -f test_data/kubernetes/seaweedfs/test-profiles.yaml
-  sleep 30 # Let the profile controler reconcile the namespace
 
   echo "Applying kubeflow-edit ClusterRole with proper aggregation..."
   kubectl apply -f test_data/kubernetes/seaweedfs/kubeflow-edit-clusterrole.yaml
@@ -192,16 +191,40 @@ if [ "${MULTI_USER}" == "true" ]; then
   kubectl apply -f test_data/kubernetes/seaweedfs/allow-user-namespace-access.yaml
 fi
 
-# Verify pipeline integration for multi-user mode
+# Wait for profile controller to reconcile and verify pipeline integration
 if [ "${MULTI_USER}" == "true" ]; then
-  echo "Verifying Pipeline Integration..."
   KF_PROFILE=kubeflow-user-example-com
-  if ! kubectl get secret mlpipeline-minio-artifact -n $KF_PROFILE > /dev/null 2>&1; then
-    echo "Error: Secret mlpipeline-minio-artifact not found in namespace $KF_PROFILE"
+  echo "Waiting for profile controller to reconcile namespace ${KF_PROFILE}..."
+
+  TIMEOUT=300
+  INTERVAL=5
+  ELAPSED=0
+  while [ $ELAPSED -lt $TIMEOUT ]; do
+    if kubectl get secret mlpipeline-minio-artifact -n "$KF_PROFILE" > /dev/null 2>&1; then
+      echo "Secret mlpipeline-minio-artifact found in namespace ${KF_PROFILE} after ${ELAPSED}s"
+      break
+    fi
+    echo "Waiting for secret mlpipeline-minio-artifact in namespace ${KF_PROFILE}... (${ELAPSED}s/${TIMEOUT}s)"
+    sleep $INTERVAL
+    ELAPSED=$((ELAPSED + INTERVAL))
+  done
+
+  if ! kubectl get secret mlpipeline-minio-artifact -n "$KF_PROFILE" > /dev/null 2>&1; then
+    echo "ERROR: Secret mlpipeline-minio-artifact not found in namespace ${KF_PROFILE} after ${TIMEOUT}s"
+    echo "Checking namespace labels:"
+    kubectl get namespace "$KF_PROFILE" --show-labels 2>&1 || true
+    echo "Checking profile controller logs:"
+    kubectl -n kubeflow logs deploy/kubeflow-pipelines-profile-controller --tail=50 2>&1 || true
+    echo "Checking metacontroller logs:"
+    kubectl -n kubeflow logs -l app.kubernetes.io/name=metacontroller --tail=50 2>&1 || true
+    exit 1
   fi
-  kubectl get secret mlpipeline-minio-artifact -n "$KF_PROFILE" -o json | jq -r '.data | keys[] as $k | "\($k): \(. | .[$k] | @base64d)"' | tr '\n' ' '
+
+  echo "Verifying Pipeline Integration..."
+  echo "Secret keys present: $(kubectl get secret mlpipeline-minio-artifact -n "$KF_PROFILE" -o json | jq -r '.data | keys | join(", ")')"
 fi
 
 collect_artifacts kubeflow
 
 echo "Finished KFP deployment."
+exit 0

--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -63,3 +63,4 @@ jobs:
           test_label: ${{ steps.configure.outputs.TEST_LABEL }}
           python_version: ${{ env.PYTHON_VERSION }}
           report_name: "Workflow Compiler Tests"
+          skip_api_config: 'true'

--- a/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
+++ b/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
@@ -55,6 +55,7 @@ jobs:
           image_path: ${{ needs.build.outputs.IMAGE_PATH }}
           image_tag: ${{ needs.build.outputs.IMAGE_TAG }}
           image_registry: ${{ needs.build.outputs.IMAGE_REGISTRY }}
+          pod_to_pod_tls_enabled: 'false'
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         if: ${{ steps.deploy.outcome == 'success' }}
@@ -93,7 +94,7 @@ jobs:
         run: |
           echo "Installing cert-manager..."
 
-          # Install cert-manager 
+          # Install cert-manager
           kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.yaml
 
           # Wait for cert-manager to be ready
@@ -108,7 +109,7 @@ jobs:
         if: ${{ steps.install-cert-manager.outcome == 'success' }}
         id: switch-to-k8s-mode
         run: |
-          kubectl delete deployment ml-pipeline -n kubeflow     
+          kubectl delete deployment ml-pipeline -n kubeflow
           # Deploy KFP in K8s mode
           echo "Deploying KFP in K8s mode..."
           kubectl kustomize --load-restrictor LoadRestrictionsNone  ".github/resources/manifests/kubernetes-native/default" | kubectl apply -f -

--- a/.github/workflows/legacy-v2-api-integration-tests.yml
+++ b/.github/workflows/legacy-v2-api-integration-tests.yml
@@ -35,11 +35,12 @@ jobs:
       matrix:
         pipeline_store: [ "database", "kubernetes" ]
         k8s_version: [ "v1.34.0" ]
-        pod_to_pod_tls_enabled: [ true, false ]
+        pod_to_pod_tls_enabled: [ "true", "false" ]
         exclude:
           # Pod to Pod TLS manifests are not yet implemented for Kubernetes Native API mode
           - pipeline_store: "kubernetes"
-            pod_to_pod_tls_enabled: true
+            pod_to_pod_tls_enabled: "true"
+      fail-fast: false
 
     name: API integration tests v2 - K8s with ${{ matrix.pipeline_store }} ${{ matrix.k8s_version }} pod_to_pod_tls_enabled=${{ matrix.pod_to_pod_tls_enabled }}
     steps:
@@ -76,7 +77,7 @@ jobs:
 
       - name: Configure Cluster CA Cert for TLS-Enabled Tests
         shell: bash
-        if: ${{ matrix.pod_to_pod_tls_enabled }}
+        if: ${{ matrix.pod_to_pod_tls_enabled == 'true' }}
         run: |
           kubectl get secret kfp-api-tls-cert -n kubeflow -o jsonpath='{.data.ca\.crt}' | base64 -d > "${{ github.workspace }}/ca.crt"
           echo "CA_CERT_PATH=${{ github.workspace }}/ca.crt" >> "$GITHUB_ENV"

--- a/backend/src/common/client/api_server/util.go
+++ b/backend/src/common/client/api_server/util.go
@@ -85,7 +85,7 @@ func NewHTTPRuntime(clientConfig clientcmd.ClientConfig, debug bool, tlsCfg *tls
 			httpClient = &http.Client{Transport: tr}
 		}
 		var runtimeClient *httptransport.Runtime
-		if tlsCfg != nil {
+		if tlsCfg != nil && !*testconfig.DisableTLSCheck {
 			scheme = []string{"https"}
 			tr := &http.Transport{
 				TLSClientConfig: tlsCfg,
@@ -122,6 +122,7 @@ func NewKubeflowInClusterHTTPRuntime(namespace string, debug bool, tlsCfg *tls.C
 	var schemes []string
 	var httpClient *http.Client
 	if tlsCfg != nil {
+		schemes = []string{"https"}
 		tr := &http.Transport{TLSClientConfig: tlsCfg}
 		httpClient = &http.Client{Transport: tr}
 	} else {


### PR DESCRIPTION
**Description of your changes:**
Cherry-picks targeted bug fixes and hardening improvements from https://github.com/opendatahub-io/data-science-pipelines/pull/286, limited to changes
  that apply cleanly to upstream without the operator deployment refactor.

  - Security: stop leaking secrets in CI logs — deploy-kfp.sh was decoding and printing secret values via jq @base64d; now only prints key names
  - Replace sleep 30 with retry loop — polls for mlpipeline-minio-artifact secret up to 300s with diagnostic logging on timeout (profile controller
  logs, namespace labels, metacontroller logs)
  - Fix Go test infrastructure bugs — DisableTLSCheck flag had no effect when a TLS config was present; NewKubeflowInClusterHTTPRuntime was missing
  schemes = []string{"https"} for TLS connections
  - Add API access configuration to test-and-report — auto-detects API URL from TLS config, generates auth tokens from service accounts, adds
  skip_api_config for tests that don't need a cluster
  - Fix workflow correctness — quote boolean matrix values in legacy-v2-api-integration-tests.yml to prevent type-mismatch bugs, fix TLS condition
  evaluation, add fail-fast: false



**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
