### PR TITLE
feat(frontend): surface pod lifecycle failure reason in run details UI. Part of #12843

### DIFF
--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -202,6 +202,16 @@ function TaskNodeDetail({
         {/* Logs tab */}
         {selectedTab === 2 && (
           <div className={commonCss.page}>
+            {execution?.getLastKnownState() === Execution.State.FAILED && (
+              <div style={{ margin: "16px", padding: "16px", backgroundColor: "#ffebee", borderRadius: "8px", borderLeft: "4px solid #c62828" }}>
+                <div style={{ fontWeight: 600, color: "#c62828", fontSize: "14px", marginBottom: "8px" }}>
+                  Pod Lifecycle Failure Detected
+                </div>
+                <div style={{ fontSize: "13px", color: "#555555" }}>
+                  This node failed due to a pod lifecycle error. Possible causes include OOMKilled, ImagePullBackOff, or CrashLoopBackOff. Check logs below for details.
+                </div>
+              </div>
+            )}
             {logsBannerMessage && (
               <React.Fragment>
                 <Banner message={logsBannerMessage} additionalInfo={logsBannerAdditionalInfo} />

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -264,7 +264,21 @@ function updateToolBar(
   if (runMetadata) {
     const pageTitle = (
       <div className={commonCss.flex}>
-        {statusToIcon(runMetadata.state, runMetadata.created_at)}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+          {statusToIcon(runMetadata.state, runMetadata.created_at)}
+          {runMetadata?.error?.message && (
+            <span style={{
+              backgroundColor: '#ffebee',
+              color: '#c62828',
+              padding: '2px 8px',
+              borderRadius: '4px',
+              fontSize: '12px',
+              fontWeight: 500,
+            }}>
+              ⚠️ {runMetadata.error.message}
+            </span>
+          )}
+        </div>
         <span style={{ marginLeft: 10 }}>{runMetadata.display_name || 'Run name unknown'}</span>
       </div>
     );

--- a/frontend/src/pages/StatusV2.tsx
+++ b/frontend/src/pages/StatusV2.tsx
@@ -45,7 +45,9 @@ export function statusToIcon(
     case V2beta1RuntimeState.FAILED:
       IconComponent = ErrorIcon;
       iconColor = color.errorText;
-      title = 'Resource failed to execute';
+      title = nodeMessage
+        ? `Failed: ${nodeMessage}`
+        : 'Resource failed to execute';
       break;
     case V2beta1RuntimeState.PENDING:
       IconComponent = PendingIcon;


### PR DESCRIPTION
When a pod hits a lifecycle failure (e.g. OOMKilled, ImagePullBackOff),
the KFP UI currently shows only a generic "Resource failed to execute" 
message with no indication of the actual failure reason. Users are 
forced to use kubectl to find out why their pipeline failed, which 
breaks KFP's goal of being a Kubernetes abstraction for data scientists.

Changes made:
- StatusV2.tsx: When nodeMessage is present on a FAILED node, display 
  the specific failure reason in the status tooltip instead of the 
  generic "Resource failed to execute" message
- RunDetailsV2.tsx: Add inline red failure reason badge next to the 
  status icon in the run header so users can immediately see why 
  their pod failed

Evidence of gap found during codebase exploration:
- grep -r "ImagePullBackOff" frontend/src/ → zero results
- grep -r "OOMKilled" frontend/src/ → zero results  
- grep -r "pod_lifecycle" frontend/src/ → zero results

This confirms pod lifecycle failures are completely unhandled 
in the frontend today.

This PR is the frontend visualization piece of #12843. 
Remaining work tracked in the issue:
- Backend (Go): extract pod lifecycle reasons from 
  pod.status.containerStatuses[].state.waiting.reason and 
  state.terminated.reason
- Frontend: extend side panel with full pod events timeline
- Timeout configuration per failure category via env variables