### PR TITLE
docs(frontend): fix generated pipeline spec outputs

### DIFF
--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -316,7 +316,7 @@ Prerequisite: Add `protoc` ([download](https://github.com/protocolbuffers/protob
 Compile pipeline_spec.proto to Typed classes in TypeScript,
 so it can convert a payload stream to a PipelineSpec object during runtime.
 
-You can check out the result like `pipeline_spec_pb.js`, `pipeline_spec_pb.d.ts` in [frontend/src/generated/pipeline_spec](/frontend/src/generated/pipeline_spec).
+You can check out the generated TypeScript outputs like `pipeline_spec.ts` and `google/rpc/status.ts` in [frontend/src/generated/pipeline_spec](/frontend/src/generated/pipeline_spec).
 
 The plugin tool for conversion we currently use is [ts-proto](https://github.com/stephenh/ts-proto). We previously use
 [protobuf.js](https://github.com/protobufjs/protobuf.js) but it doesn't natively support Protobuf.Value processing.


### PR DESCRIPTION
## Summary

- update the frontend protobuf regeneration docs to point at the current generated TypeScript files
- remove the stale references to deleted `_pb.js` / `_pb.d.ts` outputs

## Test plan

- `rg -n "pipeline_spec_pb\\.js|pipeline_spec_pb\\.d\\.ts" frontend/CONTRIBUTING.md`
- `git diff --check`

Follow-up to #13063.
