### PR TITLE
docs(frontend): refresh React 18/19 upgrade checklist

### DIFF
--- a/frontend/docs/react-18-19-upgrade-checklist.md
+++ b/frontend/docs/react-18-19-upgrade-checklist.md
@@ -1,36 +1,37 @@
 # GitHub Issues: React 18/19 Upgrade & Testing Modernization
 
-**Tracking Issue**: React 18/19 Frontend Upgrade — Modernize Kubeflow Pipelines UI
+**Tracking Issue**: React 18/19 Frontend Upgrade - Modernize Kubeflow Pipelines UI
 **Repository**: [kubeflow/pipelines](https://github.com/kubeflow/pipelines)
 
-**Strategy**: Deps-first where possible, bump-last where necessary. Most dependency migrations land on the stable React 17 runtime first; the remaining React 18-coupled testing-library work is intentionally deferred to `#9.5` after the React 18 bump.
+**Strategy**: Deps-first where possible, bump-last where necessary. The React 17 staging work is complete, the React 18 core bump is now on `master`, and the remaining near-term work is cleanup around the test stack before moving deeper into React 18 stabilization and React 19.
 **Canonical source**: This checklist is the canonical execution plan and supersedes earlier draft planning notes.
 
-## Status at a glance (March 18, 2026)
+## Status at a glance (updated March 18, 2026 ET)
 
-- [x] ~~#1 Prereq warning/test cleanup~~ (`issue`: n/a; `PRs`: [#12855](https://github.com/kubeflow/pipelines/pull/12855), [#12856](https://github.com/kubeflow/pipelines/pull/12856), [#12858](https://github.com/kubeflow/pipelines/pull/12858), [#12872](https://github.com/kubeflow/pipelines/pull/12872))
-- [x] ~~#2 Add React peer compatibility gate~~ (`issue`: n/a; `PR`: [#12881](https://github.com/kubeflow/pipelines/pull/12881))
+- [x] ~~#1 Prereq warning/test cleanup~~ (`PRs`: [#12855](https://github.com/kubeflow/pipelines/pull/12855), [#12856](https://github.com/kubeflow/pipelines/pull/12856), [#12858](https://github.com/kubeflow/pipelines/pull/12858), [#12872](https://github.com/kubeflow/pipelines/pull/12872))
+- [x] ~~#2 Add React peer compatibility gate~~ (`PR`: [#12881](https://github.com/kubeflow/pipelines/pull/12881))
 - [x] ~~#3 Storybook modernization~~ (`issue`: [#12891](https://github.com/kubeflow/pipelines/issues/12891); `PR`: [#12940](https://github.com/kubeflow/pipelines/pull/12940))
 - [x] ~~#4 react-query -> @tanstack/react-query~~ (`issue`: [#12892](https://github.com/kubeflow/pipelines/issues/12892); `PR`: [#12946](https://github.com/kubeflow/pipelines/pull/12946))
 - [x] ~~#5 react-flow-renderer -> @xyflow/react~~ (`issue`: [#12893](https://github.com/kubeflow/pipelines/issues/12893); `PR`: [#12945](https://github.com/kubeflow/pipelines/pull/12945))
 - [x] ~~#6 Material-UI v4 -> MUI v5~~ (`issue`: [#12894](https://github.com/kubeflow/pipelines/issues/12894); `PR`: [#12925](https://github.com/kubeflow/pipelines/pull/12925))
-- [x] ~~#7 Modernize JSX runtime and test utilities~~ (`issue`: [#12895](https://github.com/kubeflow/pipelines/issues/12895); `PR`: [#13019](https://github.com/kubeflow/pipelines/pull/13019))
-- [x] ~~#8 Update remaining ecosystem dependencies~~ (`issue`: [#12896](https://github.com/kubeflow/pipelines/issues/12896); `PR`: [#13025](https://github.com/kubeflow/pipelines/pull/13025))
-- [ ] #9 Upgrade React to v18 (`issue`: [#12897](https://github.com/kubeflow/pipelines/issues/12897); `PR`: none yet)
-- [ ] #9.5 Finish React 18-coupled testing-library work (`issue`: [#12895](https://github.com/kubeflow/pipelines/issues/12895); `PR`: none yet)
+- [x] ~~#7 JSX runtime and test modernization~~ (`issue`: [#12895](https://github.com/kubeflow/pipelines/issues/12895); `PR`: [#13019](https://github.com/kubeflow/pipelines/pull/13019))
+- [x] ~~#8 Remaining React 17 ecosystem deps~~ (`issue`: [#12896](https://github.com/kubeflow/pipelines/issues/12896); `PR`: [#13025](https://github.com/kubeflow/pipelines/pull/13025))
+- [x] ~~#9 Upgrade React to v18~~ (`issue`: [#12897](https://github.com/kubeflow/pipelines/issues/12897); `PR`: [#13070](https://github.com/kubeflow/pipelines/pull/13070))
+- [ ] #9.5 Finish React 18 test-stack cleanup (`issue`: none yet; follow-up split out of closed [#12895](https://github.com/kubeflow/pipelines/issues/12895); `PR`: none yet)
 - [ ] #10 Stabilize React 18 runtime (`issue`: [#12898](https://github.com/kubeflow/pipelines/issues/12898); `PR`: none yet)
 - [ ] #11 React 18.3 deprecation checkpoint (`issue`: [#12899](https://github.com/kubeflow/pipelines/issues/12899); `PR`: none yet)
 - [ ] #12 Dependency sweep for React 19 (`issue`: [#12900](https://github.com/kubeflow/pipelines/issues/12900); `PR`: none yet)
 - [ ] #13 Upgrade React to v19 (`issue`: [#12901](https://github.com/kubeflow/pipelines/issues/12901); `PR`: none yet)
 - [ ] #14 Enable StrictMode in dev/test (`issue`: [#12902](https://github.com/kubeflow/pipelines/issues/12902); `PR`: none yet)
-- [ ] #15 Update documentation for React 19 stack (`issue`: [#12903](https://github.com/kubeflow/pipelines/issues/12903); `PR`: none yet)
+- [ ] #15 Update documentation for the post-upgrade stack (`issue`: [#12903](https://github.com/kubeflow/pipelines/issues/12903); `PR`: none yet)
 
 **Current focus**:
-- Start #9 ([#12897](https://github.com/kubeflow/pipelines/issues/12897)): bump `react` and `react-dom` to v18, migrate `ReactDOM.render()` to `createRoot()`, and flip the peer gate. The remaining `#12895` testing-library work is deferred to `#9.5`, after the React 18 bump.
-- Most recent roadmap merges: [#13025](https://github.com/kubeflow/pipelines/pull/13025) for #8 on March 18, 2026, [#13019](https://github.com/kubeflow/pipelines/pull/13019) for #7 on March 12, 2026, and [#12945](https://github.com/kubeflow/pipelines/pull/12945) for #5 on March 10, 2026.
-- No open PRs were found for the remaining work on #9, #9.5, and #10 through #15.
+- `master` already runs React 18 and `createRoot()` via [#13070](https://github.com/kubeflow/pipelines/pull/13070), so the next real milestone is `#9.5`: upgrade `@testing-library/react` off v12 and remove the last React 18 compatibility workaround.
+- That workaround is still visible in source today: `frontend/docs/react-peer-allowlist.json` still allowlists `@testing-library/react@12.1.5` for React 18, `frontend/.npmrc` still sets `legacy-peer-deps=true`, and `frontend/src/vitest.setup.ts` / `frontend/src/TestUtils.ts` still filter `ReactDOM.render()` / `unmountComponentAtNode()` deprecation noise emitted by testing-library v12.
+- After `#9.5`, move to `#10` React 18 stabilization and `#11` explicit React 18.3 warning review.
+- No open PRs were found for `#9.5` or `#10` through `#15`.
 
-**How to contribute**: Each issue below maps to one independently mergeable PR. As of March 18, 2026, #1 through #8 are complete — the entire React 17 staging phase is finished. #9 ([#12897](https://github.com/kubeflow/pipelines/issues/12897)) is now the next actionable item, while the remaining React 18-coupled work from [#12895](https://github.com/kubeflow/pipelines/issues/12895) is explicitly deferred to `#9.5` after `#9`. Every PR must pass `npm run test:ci` and `npm run build` before merge.
+**How to contribute**: `#1` through `#9` are complete. The next actionable work is `#9.5`, followed by `#10`. Every PR should pass `npm run test:ci` and `npm run build` before merge.
 
 ---
 
@@ -44,7 +45,7 @@
 Completed via [#12855](https://github.com/kubeflow/pipelines/pull/12855), [#12856](https://github.com/kubeflow/pipelines/pull/12856), [#12858](https://github.com/kubeflow/pipelines/pull/12858), and [#12872](https://github.com/kubeflow/pipelines/pull/12872).
 
 **Description**:
-Land cleanup PRs ([#12855](https://github.com/kubeflow/pipelines/pull/12855), [#12856](https://github.com/kubeflow/pipelines/pull/12856), [#12858](https://github.com/kubeflow/pipelines/pull/12858), [#12872](https://github.com/kubeflow/pipelines/pull/12872)) that remove `react-dom/test-utils` imports, `snapshot-diff`, upgrade `re-resizable`, add DOM nesting warning coverage, and remove dead dependencies. Goal: reduce warning/test noise before dependency migrations begin.
+Land cleanup PRs that remove `react-dom/test-utils` imports, remove `snapshot-diff`, upgrade `re-resizable`, add DOM nesting warning coverage, and drop dead dependencies. Goal: reduce warning/test noise before dependency migrations begin.
 
 ---
 
@@ -58,28 +59,31 @@ Land cleanup PRs ([#12855](https://github.com/kubeflow/pipelines/pull/12855), [#
 Completed via [#12881](https://github.com/kubeflow/pipelines/pull/12881).
 
 **Description**:
-Add `check-react-peers.mjs` script ([#12881](https://github.com/kubeflow/pipelines/pull/12881)) and wire it into `npm run test:ci`. Introduces `npm run check:react-peers` (target 17), `check:react-peers:18`, and `check:react-peers:19`. The gate enforces that all dependencies declare peer ranges supporting the target React version. An allowlist tracks known exceptions with documented justifications.
+Add `check-react-peers.mjs` and wire it into `npm run test:ci`. The repo now exposes:
+- `npm run check:react-peers`
+- `npm run check:react-peers:18`
+- `npm run check:react-peers:19`
 
-This CI guardrail ensures no new dependency can silently break React version compatibility.
+This CI guardrail prevents new dependency additions from silently breaking the targeted React major.
 
 ---
 
-## 3. ~~Upgrade Storybook 6 to 7~~ Completed via Storybook 10 ([#12891](https://github.com/kubeflow/pipelines/issues/12891), [#12940](https://github.com/kubeflow/pipelines/pull/12940))
+## 3. ~~Upgrade Storybook 6~~ Completed via Storybook 10 ([#12891](https://github.com/kubeflow/pipelines/issues/12891), [#12940](https://github.com/kubeflow/pipelines/pull/12940))
 
 **Labels**: `area/frontend`, `priority/p1`, `kind/chore`, `good first issue`
 **Depends on**: #2
 
 **Status**:
-Completed by [#12940](https://github.com/kubeflow/pipelines/pull/12940). The original Storybook 7 target was superseded by a direct upgrade from Storybook 6 to Storybook 10 using the Vite builder, which clears the same React-compatibility blockers with fewer intermediate steps.
+Completed by [#12940](https://github.com/kubeflow/pipelines/pull/12940). The original Storybook 7 target was superseded by a direct upgrade from Storybook 6 to Storybook 10 on the Vite builder.
 
 **Description**:
-Upgrade Storybook from 6.3.x to a React-17-compatible modern release while staying on the React 17 runtime. Replace the legacy builder setup with the Vite builder (`@storybook/react-vite`), remove transitive React-incompatible deps (`@reach/router`, `create-react-context`), remove the corresponding peer gate allowlist entries, and migrate story config/files as needed.
+Modernize Storybook while staying compatible with the staged pre-React-18 environment. Replace the old Webpack builder setup with `@storybook/react-vite`, clear obsolete transitive deps, and keep the story set rendering under the modern frontend toolchain.
 
 **Acceptance Criteria**:
 - [x] `npm run storybook` renders the migrated stories without errors
 - [x] `npm run build:storybook` succeeds
 - [x] `npm run test:ci` passes
-- [x] Peer gate allowlist entries for Storybook removed
+- [x] Storybook no longer appears as a React peer gate blocker
 
 ---
 
@@ -89,14 +93,14 @@ Upgrade Storybook from 6.3.x to a React-17-compatible modern release while stayi
 **Depends on**: #2
 
 **Status**:
-Completed by [#12946](https://github.com/kubeflow/pipelines/pull/12946); issue [#12892](https://github.com/kubeflow/pipelines/issues/12892) was closed on March 9, 2026. Migrated from `react-query` v3 to `@tanstack/react-query` v4, the latest version compatible with the staged React 17 runtime.
+Completed by [#12946](https://github.com/kubeflow/pipelines/pull/12946). The repo now uses `@tanstack/react-query` v4.
 
 **Description**:
-Replace `react-query` v3 with `@tanstack/react-query` while staying on the React 17 runtime. Update all query hooks (`useQuery`, `useMutation`), `QueryClientProvider` setup, cache configuration, and test wrappers to the TanStack API. Remove `react-query` as a React 18/19 peer-gate blocker.
+Replace `react-query` v3 with TanStack Query while preserving existing data fetching, polling, and caching behavior.
 
 **Acceptance Criteria**:
-- [x] Data fetching, polling, and cache behavior work identically to pre-migration
-- [x] `npm run check:react-peers:18` no longer reports `react-query` as a direct blocker
+- [x] Data fetching, polling, and cache behavior remain intact
+- [x] `react-query` is removed as a React peer blocker
 - [x] `npm run test:ci` passes
 
 ---
@@ -107,14 +111,14 @@ Replace `react-query` v3 with `@tanstack/react-query` while staying on the React
 **Depends on**: #2
 
 **Status**:
-Completed by [#12945](https://github.com/kubeflow/pipelines/pull/12945); issue [#12893](https://github.com/kubeflow/pipelines/issues/12893) was closed on March 10, 2026. Migrated from deprecated `react-flow-renderer` v9 to `@xyflow/react`, removing `react-flow-renderer` from the React 18/19 peer-gate direct blocker list and completing the full pre-#7 dependency migration tranche.
+Completed by [#12945](https://github.com/kubeflow/pipelines/pull/12945). The repo now uses `@xyflow/react`.
 
 **Description**:
-Replace deprecated `react-flow-renderer` v9 with `@xyflow/react`. Update DAG visualization components, node/edge type definitions, event handlers, and related stories/tests. Remove peer gate allowlist entry.
+Replace deprecated `react-flow-renderer` v9 with `@xyflow/react`, updating the DAG visualization code, stories, and tests.
 
 **Acceptance Criteria**:
 - [x] Pipeline graph renders correctly with drag, zoom, and pan interactions
-- [x] `npm run check:react-peers:18` no longer reports `react-flow-renderer` as a direct blocker
+- [x] `react-flow-renderer` is removed as a React peer blocker
 - [x] `npm run test:ci` passes
 
 ---
@@ -125,157 +129,143 @@ Replace deprecated `react-flow-renderer` v9 with `@xyflow/react`. Update DAG vis
 **Depends on**: #2
 
 **Status**:
-Completed by [#12925](https://github.com/kubeflow/pipelines/pull/12925); issue [#12894](https://github.com/kubeflow/pipelines/issues/12894) was closed on March 2, 2026. Exact pixel parity was intentionally not required; visual smoke comparisons found only minor button/icon rendering differences from MUI v5 internals, and those new visuals were accepted to avoid migration-specific styling hacks.
+Completed by [#12925](https://github.com/kubeflow/pipelines/pull/12925). The repo now uses `@mui/material`, `@mui/icons-material`, and Emotion.
 
 **Description**:
-Migrate `@material-ui/core` and `@material-ui/icons` to `@mui/material` and `@mui/icons-material` v5 with Emotion (`@emotion/react`, `@emotion/styled`) as the styling engine.
-
-Run MUI codemods in order:
-1. `npx @mui/codemod v5.0.0/preset-safe frontend/src`
-2. `npx @mui/codemod v5.0.0/variant-prop frontend/src`
-3. `npx @mui/codemod v5.0.0/top-level-imports frontend/src`
-
-Manually migrate theme files (`src/Css.tsx`, `src/mlmd/Css.tsx`): convert `overrides` to `components.styleOverrides` format. Migrate `withStyles` HOC to `styled` in `src/atoms/CardTooltip.tsx`. Verify codemods did NOT touch generated directories (`src/apis/`, `src/apisv2beta1/`, `src/third_party/`). Run `npm run format` after codemods. Capture visual regression screenshots before/after.
-
-**Impact**: 64 files import `@material-ui/core`, 25 import `@material-ui/icons`, 2 theme files, 1 `withStyles` file.
+Migrate `@material-ui/core` and `@material-ui/icons` to MUI v5, including theme migration and the few non-codemod-safe styling updates.
 
 **Acceptance Criteria**:
-- [x] ~~Visual parity on all pages (Pipeline List, Run Details, Experiment List, Side Nav)~~ Visual smoke comparison completed on all primary pages; only minor cosmetic MUI v5 rendering deltas were observed and intentionally accepted
+- [x] Visual smoke comparison completed on the primary pages
 - [x] `npm run test:ci && npm run build` pass
-- [x] No codemod changes in generated directories
-- [x] ~~Theme colors, typography, and spacing unchanged~~ Theme styling is preserved aside from the accepted MUI v5 cosmetic rendering differences
+- [x] Generated directories remain untouched by migration codemods
+- [x] Styling remains acceptable without migration-specific hacks
 
 ---
 
-## 7. ~~Modernize JSX runtime and test utilities~~ Completed React 17-safe portion ([#12895](https://github.com/kubeflow/pipelines/issues/12895))
+## 7. ~~Modernize JSX runtime and test utilities~~ Completed with one follow-up extracted ([#12895](https://github.com/kubeflow/pipelines/issues/12895), [#13019](https://github.com/kubeflow/pipelines/pull/13019))
 
 **Labels**: `area/frontend`, `priority/p2`, `kind/chore`
-**Depends on**: #3 ([#12891](https://github.com/kubeflow/pipelines/issues/12891)), #4 ([#12892](https://github.com/kubeflow/pipelines/issues/12892)), #5 ([#12893](https://github.com/kubeflow/pipelines/issues/12893)), #6 ([#12894](https://github.com/kubeflow/pipelines/issues/12894))
+**Depends on**: #3, #4, #5, #6
 
 **Status**:
-Completed for the React 17-safe scope by [#13019](https://github.com/kubeflow/pipelines/pull/13019), merged on March 12, 2026. The remaining React 18-coupled `@testing-library/react` upgrade work is intentionally deferred to `#9.5` against the same issue.
+The shipped work is complete: [#13019](https://github.com/kubeflow/pipelines/pull/13019) enabled the modern JSX transform, removed `react-test-renderer`, removed `react-dom/test-utils` imports, and added coverage-baseline tooling. The part of the original issue that called for upgrading `@testing-library/react` to a React 18-native version did not land before [#12895](https://github.com/kubeflow/pipelines/issues/12895) was closed, so that remaining work is now tracked here as `#9.5`.
 
 **Description**:
-Ship the React 17-safe JSX/test modernization work: enable the modern JSX transform (`react-jsx`), remove `react-test-renderer`, migrate remaining `act` imports off `react-dom/test-utils`, and add coverage baseline tooling. Defer the React 18-coupled `@testing-library/react` upgrade work to `#9.5`.
-
-Migrate 5 files from `react-test-renderer` to `render()` + `asFragment()`:
-- `src/atoms/BusyButton.test.tsx`
-- `src/atoms/Hr.test.tsx`
-- `src/atoms/IconWithTooltip.test.tsx`
-- `src/components/viewers/ROCCurve.test.tsx`
-- `src/components/viewers/VisualizationCreator.test.tsx`
-
-Migrate remaining `act` imports from `react-dom/test-utils` to `@testing-library/react` in 5 files:
-- `src/mlmd/LineageActionBar.test.tsx`
-- `src/components/viewers/VisualizationCreator.test.tsx`
-- `src/components/viewers/Tensorboard.test.tsx`
-- `src/components/UploadPipelineDialog.test.tsx`
-- `src/components/SideNav.test.tsx`
-
-Capture coverage baseline before and compare after -- coverage must not decrease.
-  - Scripts: `npm run coverage:baseline` (capture) and `npm run coverage:compare` (verify).
+Land the React 17-safe JSX and test modernization work, then carry the remaining React 18-specific testing-library cleanup as a follow-up once React 18 is on `master`.
 
 **Acceptance Criteria**:
 - [x] `react-jsx` is enabled in `tsconfig.json`
 - [x] `react-test-renderer` / `@types/react-test-renderer` are removed
 - [x] No `react-dom/test-utils` imports remain
-- [x] Coverage baseline tooling is available for later comparison
+- [x] Coverage baseline tooling is available
 
 ---
 
 ## 8. ~~Update remaining ecosystem dependencies~~ Completed ([#12896](https://github.com/kubeflow/pipelines/issues/12896), [#13025](https://github.com/kubeflow/pipelines/pull/13025))
 
 **Labels**: `area/frontend`, `priority/p2`, `kind/chore`, `good first issue`
-**Depends on**: #7 ([#12895](https://github.com/kubeflow/pipelines/issues/12895))
+**Depends on**: #7
 
 **Status**:
-Completed by [#13025](https://github.com/kubeflow/pipelines/pull/13025), merged on March 18, 2026; issue [#12896](https://github.com/kubeflow/pipelines/issues/12896) is closed. Upgraded `markdown-to-jsx` v6 → v7, `react-dropzone` v5 → v14, and `react-textarea-autosize` 8.3.3 → 8.5.9. Added `src/atoms/DropzoneArea.tsx` to bridge the hook-based v14 API with existing class components. React 17 peer gate now passes with an empty allowlist; previous transitive blockers (`use-composed-ref`, `use-isomorphic-layout-effect`, `use-latest`) are cleared.
+Completed by [#13025](https://github.com/kubeflow/pipelines/pull/13025). The repo now uses `markdown-to-jsx` v7, `react-dropzone` v14, and `react-textarea-autosize` 8.5.9. React 17 peer compatibility is fully green with an empty allowlist.
 
 **Description**:
-Upgrade remaining deps with React 17-limited peer ranges: `markdown-to-jsx` v6 to v7, `react-dropzone` v5 to v14, and any `re-resizable` residuals. Review and update `package.json` `overrides` and `resolutions` entries -- remove stale ones, add new ones as needed. Drive peer gate allowlist to empty.
+Upgrade the remaining React 17-limited ecosystem packages and drive the React 17 peer gate to green before the React 18 bump.
 
-**Remaining peer-gate blockers for React 18 to clear in #9 and #9.5 (as of March 18, 2026):**
-- `react-dom@17.0.2` (`react=17.0.2`) - handled in #9 ([#12897](https://github.com/kubeflow/pipelines/issues/12897))
-- `@testing-library/react@12.1.5` (`react-dom=<18.0.0`, `react=<18.0.0`) - deferred to #9.5 ([#12895](https://github.com/kubeflow/pipelines/issues/12895))
+**Current note after #13070**:
+The React 18 core bump is now complete. The only remaining React 18 peer-gate exception is `@testing-library/react@12.1.5`, which is intentionally allowlisted until `#9.5`.
 
 **Acceptance Criteria**:
-- [x] `npm run check:react-peers` passes with empty allowlist
-- [x] `npm run check:react-peers:18` direct blockers are reduced to only planned `#9` / `#9.5` items
+- [x] `npm run check:react-peers` passes with an empty allowlist
 - [x] `npm run test:ci && npm run build` pass
-- [x] Markdown rendering and file upload work identically to pre-migration
+- [x] Markdown rendering and file upload continue to work
 
 ---
 
-## 9. Upgrade React to v18 ([#12897](https://github.com/kubeflow/pipelines/issues/12897))
+## 9. ~~Upgrade React to v18~~ Completed ([#12897](https://github.com/kubeflow/pipelines/issues/12897), [#13070](https://github.com/kubeflow/pipelines/pull/13070))
 
 **Labels**: `area/frontend`, `priority/p1`, `kind/feature`
-**Depends on**: #8 ([#12896](https://github.com/kubeflow/pipelines/issues/12896))
+**Depends on**: #8
 
 **Status**:
-Not started.
+Completed by [#13070](https://github.com/kubeflow/pipelines/pull/13070), merged on March 19, 2026 UTC. `master` now uses React 18, ReactDOM 18, `createRoot()` in `frontend/src/index.tsx`, and a default peer gate target of React 18 in `frontend/package.json`.
+
+**Current caveat**:
+`#9` landed with one explicit compatibility shim that still needs cleanup in `#9.5`:
+- `frontend/docs/react-peer-allowlist.json` allowlists `@testing-library/react@12.1.5` for React 18.
+- `frontend/.npmrc` sets `legacy-peer-deps=true` because npm would otherwise reject the testing-library v12 peer range.
+- `frontend/src/vitest.setup.ts` and `frontend/src/TestUtils.ts` filter React 18 deprecation warnings emitted by testing-library v12 internals.
 
 **Description**:
-Bump `react` and `react-dom` to ^18.2.0. Bump `@types/react` and `@types/react-dom` to ^18. Migrate `ReactDOM.render()` to `createRoot()` in `src/index.tsx`. Fix TypeScript errors from `@types/react@18`. Flip peer gate to `check:react-peers:18`. Regenerate all snapshots (`npm test -- -u`) and review every diff (~55 files, ~280 assertions) for correctness. Capture visual regression screenshots.
+Bump `react` and `react-dom` to v18, migrate the entrypoint to `createRoot()`, fix the type-level React 18 breakages, and keep the app running cleanly on `master`.
 
 **Acceptance Criteria**:
-- [ ] `npm run test:ci && npm run build` pass
-- [ ] `npm run check:react-peers:18` passes
-- [ ] Manual smoke test of all primary pages -- zero console errors
-- [ ] Every regenerated snapshot diff reviewed for correctness
+- [x] `npm run test:ci && npm run build` pass
+- [x] `npm run check:react-peers:18` passes
+- [x] Manual smoke testing was completed during [#13070](https://github.com/kubeflow/pipelines/pull/13070)
+- [x] Snapshot updates were regenerated and reviewed in the React 18 PR
 
 ---
 
-## 9.5. Finish React 18-coupled testing-library work ([#12895](https://github.com/kubeflow/pipelines/issues/12895))
+## 9.5. Finish React 18 test-stack cleanup (follow-up from closed [#12895](https://github.com/kubeflow/pipelines/issues/12895))
 
 **Labels**: `area/frontend`, `priority/p2`, `kind/chore`
-**Depends on**: #9 ([#12897](https://github.com/kubeflow/pipelines/issues/12897))
+**Depends on**: #9
 
 **Status**:
-Not started.
+Not started as standalone follow-up work.
 
 **Description**:
-Complete the remaining React 18-coupled portion of [#12895](https://github.com/kubeflow/pipelines/issues/12895): upgrade `@testing-library/react` from v12 to a React-18-compatible release, keep the test stack stable with `@testing-library/user-event` on the React 18 runtime, and fix any remaining `@xyflow/react` / `d3-drag` test failures that only reproduce once the React 18-compatible testing-library stack is in place.
+Upgrade `@testing-library/react` from v12 to a React 18-native release, remove the last React 18 peer-compatibility exception, and delete the temporary shims added in [#13070](https://github.com/kubeflow/pipelines/pull/13070). This includes:
+- removing the React 18 allowlist entry from `frontend/docs/react-peer-allowlist.json`
+- removing `legacy-peer-deps=true` from `frontend/.npmrc`
+- removing the testing-library-v12-specific warning filtering from `frontend/src/vitest.setup.ts` and `frontend/src/TestUtils.ts`
+- fixing any remaining `@xyflow/react` / `d3-drag` test behavior that only reproduces once the newer testing-library stack is in place
 
 **Acceptance Criteria**:
-- [ ] `npm run check:react-peers:18` no longer reports `@testing-library/react`
-- [ ] The affected `@xyflow/react` / `d3-drag` tests pass on the React 18 runtime
-- [ ] Issue [#12895](https://github.com/kubeflow/pipelines/issues/12895) can be fully closed
+- [ ] `npm run check:react-peers:18` passes with an empty allowlist
+- [ ] `npm ci` no longer depends on `legacy-peer-deps=true` for the frontend
+- [ ] React 18 test runs no longer emit the currently filtered `ReactDOM.render()` / `unmountComponentAtNode()` deprecation warnings
+- [ ] `npm run test:ci && npm run build` pass
 
 ---
 
 ## 10. Stabilize React 18 runtime ([#12898](https://github.com/kubeflow/pipelines/issues/12898))
 
 **Labels**: `area/frontend`, `priority/p1`, `kind/bug`
-**Depends on**: #9.5 ([#12895](https://github.com/kubeflow/pipelines/issues/12895))
+**Depends on**: #9.5
 
 **Status**:
 Not started.
 
 **Description**:
-Resolve any regressions or flaky tests introduced by the React 18 runtime. Address automatic batching behavior changes if any components depend on intermediate render states. Compare bundle size against pre-upgrade baseline (< 5% increase). Smoke test both single-user and multi-user deployment modes.
+With the React 18 core bump already landed, this phase is now about removing regressions and flaky behavior that remain after the test-stack cleanup. Audit automatic batching assumptions, compare bundle size against the pre-React-18 baseline, and smoke test both single-user and multi-user deployments.
 
 **Acceptance Criteria**:
-- [ ] `npm run test:ci` stable with zero flaky tests
-- [ ] Visual regression clean
-- [ ] Bundle size within 5% of baseline
-- [ ] Both single-user and multi-user modes functional
+- [ ] `npm run test:ci` is stable with zero flaky tests
+- [ ] Visual regression comparison is clean
+- [ ] Bundle size remains within 5% of the pre-upgrade baseline
+- [ ] Both single-user and multi-user modes function correctly
 
 ---
 
 ## 11. React 18.3 deprecation checkpoint ([#12899](https://github.com/kubeflow/pipelines/issues/12899))
 
 **Labels**: `area/frontend`, `priority/p2`, `kind/chore`
-**Depends on**: #10 ([#12898](https://github.com/kubeflow/pipelines/issues/12898))
+**Depends on**: #10
 
 **Status**:
-Not started.
+Not started as an explicit audit step.
+
+**Current note**:
+The current lockfile already resolves `react-dom@18.3.1` under the `^18.2.0` range in `package.json`, so this item is now less about the first 18.3 install and more about explicitly auditing, documenting, and clearing any React 19 deprecation warnings before the React 19 bump.
 
 **Description**:
-Bump `react` and `react-dom` to ^18.3.0. Run `npm run test:ci` and review test output for React 19 deprecation warnings. Document each warning found. Address any deprecation warnings before proceeding to React 19. This is a low-cost step that surfaces React 19 issues early.
+Make the React 18.3 state explicit in package metadata, run the full verification suite, document all React 19 deprecation warnings, and either fix or track them before proceeding.
 
 **Acceptance Criteria**:
-- [ ] All React 19 deprecation warnings documented
-- [ ] Warnings addressed or tracked for resolution in subsequent issues
+- [ ] All React 19 deprecation warnings are documented
+- [ ] Warnings are addressed or tracked before `#13`
 - [ ] `npm run test:ci` passes
 
 ---
@@ -283,23 +273,23 @@ Bump `react` and `react-dom` to ^18.3.0. Run `npm run test:ci` and review test o
 ## 12. Dependency sweep for React 19 ([#12900](https://github.com/kubeflow/pipelines/issues/12900))
 
 **Labels**: `area/frontend`, `priority/p2`, `kind/chore`
-**Depends on**: #11 ([#12899](https://github.com/kubeflow/pipelines/issues/12899))
+**Depends on**: #11
 
 **Status**:
 Not started.
 
 **Description**:
-Run `npm run check:react-peers:19` and upgrade any remaining deps that declare peer ranges excluding React 19. Drive the peer gate to green for React 19.
+Run `npm run check:react-peers:19`, upgrade any remaining React 19-incompatible dependencies, and drive the React 19 peer gate to green.
 
-**Current peer-gate blockers for React 19 (as of March 18, 2026):**
-- `react-ace@10.1.0` (`react-dom=^0.13.0 || … || ^18.0.0`, `react=^0.13.0 || … || ^18.0.0`) - to clear in #12
-- `react-dom@17.0.2` (`react=17.0.2`) - handled in #9 ([#12897](https://github.com/kubeflow/pipelines/issues/12897))
-- `@testing-library/react@12.1.5` (`react-dom=<18.0.0`, `react=<18.0.0`) - deferred to #9.5 ([#12895](https://github.com/kubeflow/pipelines/issues/12895))
+**Current `check:react-peers:19` blockers (verified against `origin/master` on March 18, 2026 ET)**:
+- `@testing-library/react@12.1.5` (`react-dom=<18.0.0`, `react=<18.0.0`) - to clear in `#9.5`
+- `react-ace@10.1.0` (`react-dom=... || ^18.0.0`, `react=... || ^18.0.0`) - to clear in `#12`
+- `react-dom@18.3.1` (`react=^18.3.1`) - expected until `#13`
 - Transitive: `react-redux@8.1.3` (`react-dom=^16.8 || ^17.0 || ^18.0`, `react=^16.8 || ^17.0 || ^18.0`)
 
 **Acceptance Criteria**:
 - [ ] `npm run check:react-peers:19` passes
-- [ ] No direct dependencies remain in `check:react-peers:19` output
+- [ ] No direct React 19 blockers remain
 - [ ] `npm run test:ci` passes
 
 ---
@@ -307,24 +297,24 @@ Run `npm run check:react-peers:19` and upgrade any remaining deps that declare p
 ## 13. Upgrade React to v19 ([#12901](https://github.com/kubeflow/pipelines/issues/12901))
 
 **Labels**: `area/frontend`, `priority/p1`, `kind/feature`
-**Depends on**: #12 ([#12900](https://github.com/kubeflow/pipelines/issues/12900))
+**Depends on**: #12
 
 **Status**:
 Not started.
 
 **Description**:
-Bump `react` and `react-dom` to ^19. Bump `@types/react` and `@types/react-dom` to ^19. Migrate 4 `forwardRef` test mocks to ref-as-prop pattern:
-- `src/pages/RecurringRunList.test.tsx` (line 38)
-- `src/pages/ArchivedRuns.test.tsx` (line 31)
-- `src/pages/ArchivedExperiments.test.tsx` (line 30)
-- `src/pages/AllRunsList.test.tsx` (line 31)
+Bump `react`, `react-dom`, `@types/react`, and `@types/react-dom` to v19, then handle the small set of React 19-specific source changes still visible in the repo today. Known examples include the `forwardRef`-based test mocks still present in:
+- `frontend/src/pages/RecurringRunList.test.tsx`
+- `frontend/src/pages/ArchivedRuns.test.tsx`
+- `frontend/src/pages/ArchivedExperiments.test.tsx`
+- `frontend/src/pages/AllRunsList.test.tsx`
 
-Fix TypeScript errors from `@types/react@19`. Flip peer gate to `check:react-peers:19`. Regenerate and review all snapshots.
+Regenerate and review the affected snapshots after the bump.
 
 **Acceptance Criteria**:
 - [ ] `npm run test:ci && npm run build` pass
-- [ ] `npm install` has zero peer dependency warnings
-- [ ] Manual smoke test with zero console warnings or deprecation messages
+- [ ] `npm install` completes without peer-dependency warnings
+- [ ] Manual smoke testing shows zero new console warnings or deprecation messages
 - [ ] `npm run check:react-peers:19` passes
 
 ---
@@ -332,70 +322,75 @@ Fix TypeScript errors from `@types/react@19`. Flip peer gate to `check:react-pee
 ## 14. Enable StrictMode in dev/test ([#12902](https://github.com/kubeflow/pipelines/issues/12902))
 
 **Labels**: `area/frontend`, `priority/p3`, `kind/chore`
-**Depends on**: #13 ([#12901](https://github.com/kubeflow/pipelines/issues/12901))
+**Depends on**: #13
 
 **Status**:
-Not started.
+Not started. `frontend/src/index.tsx` still renders without `<StrictMode>`.
 
 **Description**:
-Enable `<StrictMode>` in the development and test rendering trees. Identify and fix double-invoke side effects. Production behavior remains unchanged -- strict mode is NOT active in production builds. This is deferrable without blocking the React 19 milestone if it surfaces a large number of issues.
+Enable `<StrictMode>` in development and test rendering paths, fix double-invoke side effects, and keep production behavior unchanged.
 
 **Acceptance Criteria**:
 - [ ] `npm run test:ci` passes with strict mode enabled
-- [ ] Dev server (`npm start`) runs without strict-mode-related warnings
-- [ ] Production builds do NOT include strict mode
+- [ ] `npm start` runs without strict-mode-related warnings
+- [ ] Production builds do not include strict mode
 
 ---
 
-## 15. Update documentation for React 19 stack ([#12903](https://github.com/kubeflow/pipelines/issues/12903))
+## 15. Update documentation for the post-upgrade stack ([#12903](https://github.com/kubeflow/pipelines/issues/12903))
 
 **Labels**: `area/frontend`, `priority/p2`, `kind/documentation`, `good first issue`
-**Depends on**: #13 ([#12901](https://github.com/kubeflow/pipelines/issues/12901)) (or included inline in prior PRs)
+**Depends on**: #13 (or inline updates in prior PRs)
 
 **Status**:
-Not started.
+Not started. Some docs are already stale today; for example, `AGENTS.md` still describes the frontend as React 17 with Material-UI v3 and says the current peer gate target is React 17.
 
 **Description**:
-Update `AGENTS.md` "Frontend development" section with React 19, MUI v5, @testing-library/react v14, Storybook 10, and `@tanstack/react-query`. Update `frontend/CONTRIBUTING.md` testing FAQ -- remove references to Enzyme, `react-test-renderer`, React 16-specific patterns. Update `frontend/README.md` stack description. Ensure `frontend/docs/react-17-upgrade-checklist.md` remains removed (or archive/update if it is reintroduced).
+Update the top-level docs once the stack is settled:
+- `AGENTS.md`
+- `frontend/CONTRIBUTING.md`
+- `frontend/README.md`
+- any remaining upgrade checklists or archived planning docs
+
+The final state should reflect the post-upgrade stack without leaving references to removed tools or old migration-only instructions.
 
 **Acceptance Criteria**:
-- [ ] All referenced versions match actual installed versions in `package.json`
-- [ ] No references to Enzyme, `react-test-renderer`, or React 16-specific patterns remain
-- [ ] New contributor can follow `CONTRIBUTING.md` without encountering outdated instructions
+- [ ] All referenced versions match `frontend/package.json`
+- [ ] No stale references to Enzyme, `react-test-renderer`, or pre-upgrade React guidance remain
+- [ ] A new contributor can follow the frontend docs without hitting outdated instructions
 
 ---
 
 ## Dependency Graph
 
-```
-#1 Prereq Cleanup [done] (@jeffspahr)
- └── #2 Peer Gate [done] (@jeffspahr)
-      ├── #3  Storybook [done] (#12891) ─────┐
-      ├── #4  react-query [done] (#12892) ───┤  (completed pre-#7 batch)
-      ├── #5  react-flow [done] (#12893) ────┤
-      └── #6  MUI v5 [done] (#12894) ────────┘
-                                              │
-                              #7  JSX + Tests [done] (#12895)
-                                              │
-                              #8  Ecosystem Deps [done] (#12896)
-                                              │
-                              #9  React 18 Core [next] (#12897)
-                                              │
-                              #9.5 Testing-Library (#12895)
-                                              │
-                              #10 React 18 Stabilization (#12898)
-                                              │
-                              #11 React 18.3 Checkpoint (#12899)
-                                              │
-                              #12 Dep Sweep for 19 (#12900)
-                                              │
-                              #13 React 19 Core (#12901)
-                                              │
-                              #14 Strict Mode (#12902)
-                                              │
-                              #15 Documentation (#12903)
+```text
+#1 Prereq Cleanup [done]
+ \- #2 Peer Gate [done]
+     |- #3  Storybook [done]
+     |- #4  TanStack Query [done]
+     |- #5  XYFlow [done]
+     \- #6  MUI v5 [done]
+                   |
+                   #7  JSX + Tests (React 17-safe portion) [done]
+                   |
+                   #8  Ecosystem Deps [done]
+                   |
+                   #9  React 18 Core [done]
+                   |
+                   #9.5 Test-Stack Cleanup [next]
+                   |
+                   #10 React 18 Stabilization
+                   |
+                   #11 React 18.3 Checkpoint
+                   |
+                   #12 React 19 Dependency Sweep
+                   |
+                   #13 React 19 Core
+                   |
+                   #14 StrictMode
+                   |
+                   #15 Documentation
 ```
 
-**Parallelizable**: The entire React 17 staging phase (#1 through #8) is complete. As of March 18, 2026, #9 ([#12897](https://github.com/kubeflow/pipelines/issues/12897)) is the next start point — the core React 18 bump. The remaining React 18-coupled testing-library work from [#12895](https://github.com/kubeflow/pipelines/issues/12895) is explicitly deferred to `#9.5` after `#9`.
-
-**Good first issues**: #15 ([#12903](https://github.com/kubeflow/pipelines/issues/12903) — documentation — no code logic changes).
+**Parallelizable**:
+The old React 17 staging tranche is complete. The practical next start point is `#9.5`, followed by `#10`. `#15` remains a good first issue once the stack stops moving.


### PR DESCRIPTION
**Description of your changes:**

- refresh `frontend/docs/react-18-19-upgrade-checklist.md` after the React 18 merge in [#13070](https://github.com/kubeflow/pipelines/pull/13070)
- mark `#9` as completed and make the remaining React 18 test-stack cleanup the actual next step
- update the remaining roadmap items to match current `master`, including the React 18 peer allowlist, `legacy-peer-deps=true`, current React 19 peer blockers, and the still-open StrictMode and documentation follow-ups

No application code changes are included in this PR.

## Verification

- compared the checklist against `origin/master` frontend state (`package.json`, `src/index.tsx`, `docs/react-peer-allowlist.json`, `.npmrc`, `src/vitest.setup.ts`, `src/TestUtils.ts`)
- checked GitHub issue/PR state for `#12895` through `#12903` and `#13070`
- ran `check-react-peers.mjs --target 18` and `--target 19` against an `origin/master` worktree to refresh the blocker list
- ran `git diff --check` on the updated markdown

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
