### PR TITLE
fix(sdk): fix for passing input pipelines parameters to parallelfor group

### DIFF
--- a/kubernetes_platform/python/kfp/kubernetes/common.py
+++ b/kubernetes_platform/python/kfp/kubernetes/common.py
@@ -50,6 +50,14 @@ def parse_k8s_parameter_input(
     if isinstance(input_param, (str, dict)):
         param_spec.runtime_value.constant.CopyFrom(to_protobuf_value(input_param))
     elif isinstance(input_param, pipeline_channel.PipelineParameterChannel):
+        # Add the channel to the task's channel inputs so the compiler
+        # propagates it through sub-DAGs (e.g. ParallelFor "punch the hole").
+        existing_channel_patterns = {
+            ch.pattern for ch in task._channel_inputs
+        }
+        if input_param.pattern not in existing_channel_patterns:
+            task._channel_inputs.append(input_param)
+
         if input_param.task_name is None:
             param_spec.component_input_parameter = input_param.full_name
 

--- a/kubernetes_platform/python/test/unit/test_secret.py
+++ b/kubernetes_platform/python/test/unit/test_secret.py
@@ -971,6 +971,139 @@ class TestUseSecretAsEnv:
             }
         }
 
+class TestParseK8sParameterInputChannelPropagation:
+    def test_pipeline_param_added_to_channel_inputs(self):
+        """When a PipelineParameterChannel is passed as secret_name,
+        it should be added to the task's _channel_inputs for sub-DAG
+        propagation."""
+
+        @dsl.pipeline
+        def my_pipeline(secret_name: str):
+            task = comp()
+            kubernetes.use_secret_as_env(
+                task,
+                secret_name=secret_name,
+                secret_key_to_env={"key": "VAR"},
+            )
+
+        # The pipeline should compile without error and the platform spec
+        # should reference the componentInputParameter
+        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
+            "platforms": {
+                "kubernetes": {
+                    "deploymentSpec": {
+                        "executors": {
+                            "exec-comp": {
+                                "secretAsEnv": [
+                                    {
+                                        "secretNameParameter": {
+                                            "componentInputParameter": "secret_name"
+                                        },
+                                        "keyToEnv": [
+                                            {"secretKey": "key", "envVar": "VAR"}
+                                        ],
+                                        "optional": False,
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    def test_duplicate_pipeline_param_not_added_twice(self):
+        """When the same PipelineParameterChannel is used for two different
+        secret configs on the same task, _channel_inputs should not contain
+        duplicates."""
+
+        @dsl.pipeline
+        def my_pipeline(secret_name: str):
+            task = comp()
+            kubernetes.use_secret_as_env(
+                task,
+                secret_name=secret_name,
+                secret_key_to_env={"key1": "VAR1"},
+            )
+            kubernetes.use_secret_as_volume(
+                task,
+                secret_name=secret_name,
+                mount_path="/mnt/secret",
+            )
+
+        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
+            "platforms": {
+                "kubernetes": {
+                    "deploymentSpec": {
+                        "executors": {
+                            "exec-comp": {
+                                "secretAsEnv": [
+                                    {
+                                        "secretNameParameter": {
+                                            "componentInputParameter": "secret_name"
+                                        },
+                                        "keyToEnv": [
+                                            {"secretKey": "key1", "envVar": "VAR1"}
+                                        ],
+                                        "optional": False,
+                                    }
+                                ],
+                                "secretAsVolume": [
+                                    {
+                                        "secretNameParameter": {
+                                            "componentInputParameter": "secret_name"
+                                        },
+                                        "mountPath": "/mnt/secret",
+                                        "optional": False,
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    def test_string_input_does_not_add_channel_inputs(self):
+        """When a literal string is passed as secret_name, _channel_inputs
+        should not be modified (no PipelineParameterChannel to propagate)."""
+
+        @dsl.pipeline
+        def my_pipeline():
+            task = comp()
+            kubernetes.use_secret_as_env(
+                task,
+                secret_name="literal-secret",
+                secret_key_to_env={"key": "VAR"},
+            )
+
+        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
+            "platforms": {
+                "kubernetes": {
+                    "deploymentSpec": {
+                        "executors": {
+                            "exec-comp": {
+                                "secretAsEnv": [
+                                    {
+                                        "secretName": "literal-secret",
+                                        "secretNameParameter": {
+                                            "runtimeValue": {
+                                                "constant": "literal-secret"
+                                            }
+                                        },
+                                        "keyToEnv": [
+                                            {"secretKey": "key", "envVar": "VAR"}
+                                        ],
+                                        "optional": False,
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        
 @dsl.component
 def comp():
     pass

--- a/kubernetes_platform/python/test/unit/test_secret.py
+++ b/kubernetes_platform/python/test/unit/test_secret.py
@@ -974,48 +974,31 @@ class TestUseSecretAsEnv:
 class TestParseK8sParameterInputChannelPropagation:
     def test_pipeline_param_added_to_channel_inputs(self):
         """When a PipelineParameterChannel is passed as secret_name,
-        it should be added to the task's _channel_inputs for sub-DAG
-        propagation."""
+        it should be appended to the task's _channel_inputs so the
+        compiler propagates it through sub-DAGs."""
+        tasks = {}
 
         @dsl.pipeline
         def my_pipeline(secret_name: str):
             task = comp()
+            initial_count = len(task._channel_inputs)
             kubernetes.use_secret_as_env(
                 task,
                 secret_name=secret_name,
                 secret_key_to_env={"key": "VAR"},
             )
+            tasks['task'] = task
+            tasks['initial_count'] = initial_count
+            tasks['channel_pattern'] = secret_name.pattern
 
-        # The pipeline should compile without error and the platform spec
-        # should reference the componentInputParameter
-        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
-            "platforms": {
-                "kubernetes": {
-                    "deploymentSpec": {
-                        "executors": {
-                            "exec-comp": {
-                                "secretAsEnv": [
-                                    {
-                                        "secretNameParameter": {
-                                            "componentInputParameter": "secret_name"
-                                        },
-                                        "keyToEnv": [
-                                            {"secretKey": "key", "envVar": "VAR"}
-                                        ],
-                                        "optional": False,
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        assert len(tasks['task']._channel_inputs) == tasks['initial_count'] + 1
+        channel_patterns = {ch.pattern for ch in tasks['task']._channel_inputs}
+        assert tasks['channel_pattern'] in channel_patterns
 
     def test_duplicate_pipeline_param_not_added_twice(self):
-        """When the same PipelineParameterChannel is used for two different
-        secret configs on the same task, _channel_inputs should not contain
-        duplicates."""
+        """When the same PipelineParameterChannel is passed twice,
+        _channel_inputs should not contain duplicates."""
+        tasks = {}
 
         @dsl.pipeline
         def my_pipeline(secret_name: str):
@@ -1025,84 +1008,35 @@ class TestParseK8sParameterInputChannelPropagation:
                 secret_name=secret_name,
                 secret_key_to_env={"key1": "VAR1"},
             )
+            count_after_first = len(task._channel_inputs)
             kubernetes.use_secret_as_volume(
                 task,
                 secret_name=secret_name,
                 mount_path="/mnt/secret",
             )
+            tasks['task'] = task
+            tasks['count_after_first'] = count_after_first
 
-        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
-            "platforms": {
-                "kubernetes": {
-                    "deploymentSpec": {
-                        "executors": {
-                            "exec-comp": {
-                                "secretAsEnv": [
-                                    {
-                                        "secretNameParameter": {
-                                            "componentInputParameter": "secret_name"
-                                        },
-                                        "keyToEnv": [
-                                            {"secretKey": "key1", "envVar": "VAR1"}
-                                        ],
-                                        "optional": False,
-                                    }
-                                ],
-                                "secretAsVolume": [
-                                    {
-                                        "secretNameParameter": {
-                                            "componentInputParameter": "secret_name"
-                                        },
-                                        "mountPath": "/mnt/secret",
-                                        "optional": False,
-                                    }
-                                ],
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        assert len(tasks['task']._channel_inputs) == tasks['count_after_first']
 
     def test_string_input_does_not_add_channel_inputs(self):
-        """When a literal string is passed as secret_name, _channel_inputs
-        should not be modified (no PipelineParameterChannel to propagate)."""
+        """When a literal string is passed, _channel_inputs should not
+        be modified (no PipelineParameterChannel to propagate)."""
+        tasks = {}
 
         @dsl.pipeline
         def my_pipeline():
             task = comp()
+            initial_count = len(task._channel_inputs)
             kubernetes.use_secret_as_env(
                 task,
                 secret_name="literal-secret",
                 secret_key_to_env={"key": "VAR"},
             )
+            tasks['task'] = task
+            tasks['initial_count'] = initial_count
 
-        assert json_format.MessageToDict(my_pipeline.platform_spec) == {
-            "platforms": {
-                "kubernetes": {
-                    "deploymentSpec": {
-                        "executors": {
-                            "exec-comp": {
-                                "secretAsEnv": [
-                                    {
-                                        "secretName": "literal-secret",
-                                        "secretNameParameter": {
-                                            "runtimeValue": {
-                                                "constant": "literal-secret"
-                                            }
-                                        },
-                                        "keyToEnv": [
-                                            {"secretKey": "key", "envVar": "VAR"}
-                                        ],
-                                        "optional": False,
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        assert len(tasks['task']._channel_inputs) == tasks['initial_count']
         
 @dsl.component
 def comp():

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -1410,8 +1410,14 @@ def build_spec_by_group(
                     task=subgroup)
                 deployment_config.executors[executor_label].container.CopyFrom(
                     subgroup_container_spec)
+                task_platform_config = subgroup.platform_config
+                if not is_parent_component_root and task_platform_config:
+                    task_platform_config = _rewrite_platform_config_component_input_params(
+                        task_platform_config,
+                        group_component_spec.input_definitions,
+                    )
                 single_task_platform_spec = platform_config_to_platform_spec(
-                    subgroup.platform_config,
+                    task_platform_config,
                     executor_label,
                 )
                 merge_platform_specs(
@@ -1613,6 +1619,42 @@ def modify_task_for_ignore_upstream_failure(
             pipeline_task_spec.inputs.parameters[
                 input_name].task_final_status.producer_task = pipeline_task_spec.dependent_tasks[
                     0]
+
+
+def _rewrite_platform_config_component_input_params(
+    platform_config: dict,
+    parent_component_inputs: pipeline_spec_pb2.ComponentInputsSpec,
+) -> dict:
+    """Rewrites componentInputParameter references in a platform_config dict
+    to match the parent DAG's input names.
+
+    When a task is inside a sub-DAG (e.g. ParallelFor), pipeline-level
+    inputs are propagated with a 'pipelinechannel--' prefix. The
+    KubernetesExecutorConfig may reference the original (unprefixed) name,
+    so this function rewrites those references to the prefixed variant.
+    """
+    parent_params = set(parent_component_inputs.parameters.keys())
+
+    def _rewrite(obj):
+        if isinstance(obj, dict):
+            result = {}
+            for key, value in obj.items():
+                if key == 'componentInputParameter' and isinstance(
+                        value, str):
+                    if value not in parent_params:
+                        prefixed = 'pipelinechannel--' + value
+                        if prefixed in parent_params:
+                            result[key] = prefixed
+                            continue
+                    result[key] = value
+                else:
+                    result[key] = _rewrite(value)
+            return result
+        elif isinstance(obj, list):
+            return [_rewrite(item) for item in obj]
+        return obj
+
+    return _rewrite(platform_config)
 
 
 def platform_config_to_platform_spec(

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -1642,7 +1642,8 @@ def _rewrite_platform_config_component_input_params(
                 if key == 'componentInputParameter' and isinstance(
                         value, str):
                     if value not in parent_params:
-                        prefixed = 'pipelinechannel--' + value
+                        prefixed = compiler_utils.additional_input_name_for_pipeline_channel(
+                            value)
                         if prefixed in parent_params:
                             result[key] = prefixed
                             continue

--- a/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
@@ -599,8 +599,10 @@ class TestParallelForWithPlatformConfigInput(unittest.TestCase):
 
             # Also verify the sub-DAG component has the propagated input
             components = pipeline_dict.get('components', {})
+            found_for_loop_component = False
             for comp_name, comp_def in components.items():
-                if 'for-loop' in comp_name.lower() or 'for-loop' in comp_name:
+                if 'for-loop' in comp_name.lower():
+                    found_for_loop_component = True
                     input_params = comp_def.get('inputDefinitions',
                                                 {}).get('parameters', {})
                     self.assertIn(
@@ -610,6 +612,11 @@ class TestParallelForWithPlatformConfigInput(unittest.TestCase):
                         f'"pipelinechannel--secret_name" in its inputs, '
                         f'got: {list(input_params.keys())}',
                     )
+            self.assertTrue(
+                found_for_loop_component,
+                f'Expected to find a for-loop sub-DAG component, '
+                f'got components: {list(components.keys())}',
+            )
 
 
 class TestTaskConfigPassthroughValidation(unittest.TestCase):

--- a/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
@@ -413,6 +413,205 @@ class TestMergePlatformSpecs(unittest.TestCase):
         self.assertEqual(base_spec, expected)
 
 
+class TestRewritePlatformConfigComponentInputParams(unittest.TestCase):
+
+    def test_rewrites_unprefixed_param_to_prefixed(self):
+        platform_config = {
+            'kubernetes': {
+                'secretAsEnv': [{
+                    'secretNameParameter': {
+                        'componentInputParameter': 'secret_name'
+                    },
+                    'keyToEnv': [{
+                        'secretKey': 'pw',
+                        'envVar': 'PASSWORD'
+                    }],
+                }]
+            }
+        }
+        parent_inputs = pipeline_spec_pb2.ComponentInputsSpec()
+        parent_inputs.parameters[
+            'pipelinechannel--secret_name'].parameter_type = (
+                pipeline_spec_pb2.ParameterType.STRING)
+
+        result = pipeline_spec_builder._rewrite_platform_config_component_input_params(
+            platform_config, parent_inputs)
+
+        self.assertEqual(
+            result['kubernetes']['secretAsEnv'][0]['secretNameParameter']
+            ['componentInputParameter'],
+            'pipelinechannel--secret_name',
+        )
+
+    def test_no_rewrite_when_param_already_exists(self):
+        platform_config = {
+            'kubernetes': {
+                'secretAsEnv': [{
+                    'secretNameParameter': {
+                        'componentInputParameter': 'secret_name'
+                    },
+                }]
+            }
+        }
+        parent_inputs = pipeline_spec_pb2.ComponentInputsSpec()
+        parent_inputs.parameters['secret_name'].parameter_type = (
+            pipeline_spec_pb2.ParameterType.STRING)
+
+        result = pipeline_spec_builder._rewrite_platform_config_component_input_params(
+            platform_config, parent_inputs)
+
+        self.assertEqual(
+            result['kubernetes']['secretAsEnv'][0]['secretNameParameter']
+            ['componentInputParameter'],
+            'secret_name',
+        )
+
+    def test_no_rewrite_when_prefixed_not_in_parent(self):
+        platform_config = {
+            'kubernetes': {
+                'secretAsEnv': [{
+                    'secretNameParameter': {
+                        'componentInputParameter': 'unknown_param'
+                    },
+                }]
+            }
+        }
+        parent_inputs = pipeline_spec_pb2.ComponentInputsSpec()
+        parent_inputs.parameters[
+            'pipelinechannel--other_param'].parameter_type = (
+                pipeline_spec_pb2.ParameterType.STRING)
+
+        result = pipeline_spec_builder._rewrite_platform_config_component_input_params(
+            platform_config, parent_inputs)
+
+        self.assertEqual(
+            result['kubernetes']['secretAsEnv'][0]['secretNameParameter']
+            ['componentInputParameter'],
+            'unknown_param',
+        )
+
+    def test_rewrites_multiple_params_in_nested_structure(self):
+        platform_config = {
+            'kubernetes': {
+                'secretAsEnv': [{
+                    'secretNameParameter': {
+                        'componentInputParameter': 'secret1'
+                    },
+                }],
+                'pvcMount': [{
+                    'pvcNameParameter': {
+                        'componentInputParameter': 'pvc_name'
+                    },
+                }],
+            }
+        }
+        parent_inputs = pipeline_spec_pb2.ComponentInputsSpec()
+        parent_inputs.parameters[
+            'pipelinechannel--secret1'].parameter_type = (
+                pipeline_spec_pb2.ParameterType.STRING)
+        parent_inputs.parameters[
+            'pipelinechannel--pvc_name'].parameter_type = (
+                pipeline_spec_pb2.ParameterType.STRING)
+
+        result = pipeline_spec_builder._rewrite_platform_config_component_input_params(
+            platform_config, parent_inputs)
+
+        self.assertEqual(
+            result['kubernetes']['secretAsEnv'][0]['secretNameParameter']
+            ['componentInputParameter'],
+            'pipelinechannel--secret1',
+        )
+        self.assertEqual(
+            result['kubernetes']['pvcMount'][0]['pvcNameParameter']
+            ['componentInputParameter'],
+            'pipelinechannel--pvc_name',
+        )
+
+    def test_non_component_input_keys_unchanged(self):
+        platform_config = {
+            'kubernetes': {
+                'secretAsEnv': [{
+                    'secretKey': 'my-key',
+                    'envVar': 'MY_ENV',
+                }]
+            }
+        }
+        parent_inputs = pipeline_spec_pb2.ComponentInputsSpec()
+
+        result = pipeline_spec_builder._rewrite_platform_config_component_input_params(
+            platform_config, parent_inputs)
+
+        self.assertEqual(result, platform_config)
+
+
+class TestParallelForWithPlatformConfigInput(unittest.TestCase):
+
+    def test_compile_parallel_for_with_secret_pipeline_param(self):
+        """End-to-end: secret_name from a pipeline param inside ParallelFor."""
+
+        @dsl.component
+        def my_comp(item: str):
+            print(item)
+
+        @dsl.pipeline
+        def my_pipeline(secret_name: str):
+            with dsl.ParallelFor(items=['a', 'b']) as item:
+                t = my_comp(item=item)
+                kubernetes.use_secret_as_env(
+                    t,
+                    secret_name=secret_name,
+                    secret_key_to_env={'key': 'SECRET_VAL'},
+                )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            package_path = os.path.join(tmpdir, 'pipeline.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=my_pipeline, package_path=package_path)
+
+            with open(package_path, 'r') as f:
+                docs = list(yaml.safe_load_all(f))
+            pipeline_dict = docs[0]
+            platform_dict = docs[1] if len(docs) > 1 else {}
+
+            # Verify the platform spec references the prefixed param name
+            k8s_platform = platform_dict.get('platforms',
+                                             {}).get('kubernetes', {})
+            executors = k8s_platform.get('deploymentSpec',
+                                         {}).get('executors', {})
+
+            # Find the executor for my_comp
+            found_rewritten_param = False
+            for _exec_label, exec_config in executors.items():
+                for secret_env in exec_config.get('secretAsEnv', []):
+                    param_ref = secret_env.get('secretNameParameter',
+                                               {}).get(
+                                                   'componentInputParameter',
+                                                   '')
+                    if 'pipelinechannel--secret_name' == param_ref:
+                        found_rewritten_param = True
+
+            self.assertTrue(
+                found_rewritten_param,
+                f'Expected to find componentInputParameter with '
+                f'"pipelinechannel--secret_name" in platform spec executors, '
+                f'got: {executors}',
+            )
+
+            # Also verify the sub-DAG component has the propagated input
+            components = pipeline_dict.get('components', {})
+            for comp_name, comp_def in components.items():
+                if 'for-loop' in comp_name.lower() or 'for-loop' in comp_name:
+                    input_params = comp_def.get('inputDefinitions',
+                                                {}).get('parameters', {})
+                    self.assertIn(
+                        'pipelinechannel--secret_name',
+                        input_params,
+                        f'Expected sub-DAG component {comp_name} to have '
+                        f'"pipelinechannel--secret_name" in its inputs, '
+                        f'got: {list(input_params.keys())}',
+                    )
+
+
 class TestTaskConfigPassthroughValidation(unittest.TestCase):
 
     def test_resources_set_without_passthrough_raises(self):


### PR DESCRIPTION
**Description of your changes:**
These changes fixes the bug: https://github.com/kubeflow/pipelines/issues/13078 

1. kubernetes_platform/python/kfp/kubernetes/common.py — In parse_k8s_parameter_input, when the input is a PipelineParameterChannel, it now appends it to task._channel_inputs. This tells the compiler to propagate that parameter through intermediate sub-DAGs like ParallelFor.                                                          
  2. sdk/python/kfp/compiler/pipeline_spec_builder.py — Added `_rewrite_platform_config_component_input_params()` which rewrites componentInputParameter references in the platform config dict. When a task is inside a non-root sub-DAG, it replaces unprefixed  param names (e.g. secret_name) with their prefixed equivalents (pipelinechannel--secret_name) if the prefixed version exists in the parent component's inputs. This is called in build_spec_by_group before converting the platform config to a platform spec. 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
