### PR TITLE
docs(frontend): refresh React upgrade checklist after React 18.3

### DIFF
--- a/frontend/docs/react-18-19-upgrade-checklist.md
+++ b/frontend/docs/react-18-19-upgrade-checklist.md
@@ -268,7 +268,7 @@ Completed via [#13075](https://github.com/kubeflow/pipelines/pull/13075) and [#1
 **Depends on**: #10
 
 **Status**:
-Completed by [#13080](https://github.com/kubeflow/pipelines/pull/13080), merged on March 19, 2026 UTC. `frontend/package.json` now pins `react`, `react-dom`, `@types/react`, and `@types/react-dom` to `^18.3.0`, and the React 19 deprecation audit reported no React-specific warnings. Issue [#12899](https://github.com/kubeflow/pipelines/issues/12899) remains open as of March 19, 2026 and should be closed or updated separately.
+Completed by [#13080](https://github.com/kubeflow/pipelines/pull/13080), merged on March 19, 2026 UTC. `frontend/package.json` now pins `react`, `react-dom`, `@types/react`, and `@types/react-dom` to `^18.3.0`, and the React 19 deprecation audit reported no React-specific warnings. Issue [#12899](https://github.com/kubeflow/pipelines/issues/12899) was closed on March 19, 2026.
 
 **Current note**:
 The React 18.3 state is now explicit in package metadata. The audit run for [#13080](https://github.com/kubeflow/pipelines/pull/13080) found no React deprecation warnings in browser-console or test output; the only deprecation observed was Node's unrelated `util._extend` (`DEP0060`).


### PR DESCRIPTION
## Summary
- review the latest React roadmap merges on `master` and update the checklist through the React 18.3 checkpoint
- mark `#11` complete via `#13080` and shift current focus from `#11` to `#12` / `#13`
- refresh the React 19 blocker snapshot so it reflects the current post-`#13077` / post-`#13080` state
- note that issue `#12899` is still open even though the React 18.3 checkpoint work has landed

## Verification
- `node scripts/check-react-peers.mjs --target 18` against current `origin/master` frontend checkout
- `node scripts/check-react-peers.mjs --target 19` against current `origin/master` frontend checkout
- `gh pr view 13075 --repo kubeflow/pipelines`
- `gh pr view 13077 --repo kubeflow/pipelines`
- `gh pr view 13080 --repo kubeflow/pipelines`
- `gh issue view 12899 --repo kubeflow/pipelines`
- `git diff --check -- frontend/docs/react-18-19-upgrade-checklist.md`
