### PR TITLE
fix: replace bare except with except Exception in KFP client

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -302,7 +302,7 @@ class Client:
         in_cluster = True
         try:
             k8s.config.load_incluster_config()
-        except:
+        except Exception:
             in_cluster = False
 
         if in_cluster:
@@ -313,7 +313,7 @@ class Client:
         try:
             k8s.config.load_kube_config(
                 client_configuration=config, context=kube_context)
-        except:
+        except Exception:
             print('Failed to load kube config.')
             return config
 


### PR DESCRIPTION
## Summary

Replace two bare `except:` clauses with `except Exception:` in `sdk/python/kfp/client/client.py`.

**Changes (lines 305 and 316):**
```python
# Before
except:
    in_cluster = False

# After
except Exception:
    in_cluster = False
```

Bare `except:` catches BaseException including KeyboardInterrupt and SystemExit. These two blocks are config-loading fallbacks that should only handle normal exceptions. Using `except Exception:` is the correct scope.

## Testing
No behavior change for normal exception paths. Ctrl-C signals now propagate correctly instead of being silently swallowed.