### PR TITLE
refactor(apiserver): extract resolveWebhookTLSPaths for testability

### DIFF
--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -445,44 +445,58 @@ func startWebhook(client ctrlclient.Client, clientNoCahe ctrlclient.Client, wg *
 
 	go func() {
 		defer wg.Done()
-		var resolvedTLSCertPath string
-		var resolvedTLSKeyPath string
-
-		// Use webhook TLS key/cert if specified.
-		if *webhookTLSCertPath != "" && *webhookTLSKeyPath != "" {
-			if !common.FileExists(*webhookTLSCertPath) || !common.FileExists(*webhookTLSKeyPath) {
-				glog.Fatalf("Webhook TLS certificate/key paths are set but files do not exist")
-				return
-			} else {
-				resolvedTLSCertPath = *webhookTLSCertPath
-				resolvedTLSKeyPath = *webhookTLSKeyPath
-			}
-		} else {
-			// If a webhook TLS key/cert are not specified, default to API server's TLS key/cert if specified.
-			if *tlsCertPath != "" && *tlsCertKeyPath != "" {
-				if !common.FileExists(*tlsCertPath) || !common.FileExists(*tlsCertKeyPath) {
-					glog.Fatalf("API server TLS certificate/key paths are set but files do not exist")
-					return
-				}
-				resolvedTLSCertPath = *tlsCertPath
-				resolvedTLSKeyPath = *tlsCertKeyPath
-			} else {
-				glog.Warning("TLS certificate/key paths are not set. Starting webhook server without TLS.")
-				err = webhookServer.ListenAndServe()
-				if err != nil && !errors.Is(err, http.ErrServerClosed) {
-					glog.Fatalf("Failed to start Kubernetes webhook server: %v", err)
-				}
-				return
-			}
+		certPath, keyPath, useTLS, resolveErr := resolveWebhookTLSPaths(
+			*webhookTLSCertPath, *webhookTLSKeyPath,
+			*tlsCertPath, *tlsCertKeyPath,
+			common.FileExists,
+		)
+		if resolveErr != nil {
+			glog.Fatalf("Failed to resolve webhook TLS paths: %v", resolveErr)
+			return
 		}
+
+		if !useTLS {
+			glog.Warning("TLS certificate/key paths are not set. Starting webhook server without TLS.")
+			err = webhookServer.ListenAndServe()
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				glog.Fatalf("Failed to start Kubernetes webhook server: %v", err)
+			}
+			return
+		}
+
 		glog.Info("Starting the Kubernetes webhook with TLS")
-		err := webhookServer.ListenAndServeTLS(resolvedTLSCertPath, resolvedTLSKeyPath)
+		err := webhookServer.ListenAndServeTLS(certPath, keyPath)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			glog.Fatalf("Failed to start the Kubernetes webhook with TLS: %v", err)
 		}
 	}()
 
 	return webhookServer, nil
+}
+
+// resolveWebhookTLSPaths determines which TLS certificate and key paths to use for the
+// webhook server. It checks webhook-specific paths first, then falls back to the API server's
+// TLS paths. Returns the resolved cert/key paths, whether TLS should be used, and any error.
+// The fileExists parameter allows injecting a file-existence checker for testability.
+func resolveWebhookTLSPaths(webhookCert, webhookKey, serverCert, serverKey string, fileExists func(string) bool) (certPath, keyPath string, useTLS bool, err error) {
+	// Use webhook-specific TLS cert/key if both are specified.
+	if webhookCert != "" && webhookKey != "" {
+		if !fileExists(webhookCert) || !fileExists(webhookKey) {
+			return "", "", false, fmt.Errorf("webhook TLS certificate/key paths are set but files do not exist (cert: %q, key: %q)", webhookCert, webhookKey)
+		}
+		return webhookCert, webhookKey, true, nil
+	}
+
+	// Fall back to the API server's TLS cert/key if both are specified.
+	if serverCert != "" && serverKey != "" {
+		if !fileExists(serverCert) || !fileExists(serverKey) {
+			return "", "", false, fmt.Errorf("API server TLS certificate/key paths are set but files do not exist (cert: %q, key: %q)", serverCert, serverKey)
+		}
+		return serverCert, serverKey, true, nil
+	}
+
+	// No TLS paths configured at all.
+	return "", "", false, nil
 }
 
 func registerHTTPHandlerFromEndpoint(ctx context.Context, handler RegisterHttpHandlerFromEndpoint, serviceName string, mux *runtime.ServeMux, tlsCfg *tls.Config) error {

--- a/backend/src/apiserver/main_test.go
+++ b/backend/src/apiserver/main_test.go
@@ -409,5 +409,154 @@ func TestRegisterHTTPHandlerFromEndpoint(t *testing.T) {
 	})
 }
 
+func TestResolveWebhookTLSPaths(t *testing.T) {
+	allFilesExist := func(string) bool { return true }
+	noFilesExist := func(string) bool { return false }
+
+	t.Run("webhook-specific paths used when both are set and files exist", func(t *testing.T) {
+		certPath, keyPath, useTLS, err := resolveWebhookTLSPaths(
+			"/webhook/cert.pem", "/webhook/key.pem",
+			"/server/cert.pem", "/server/key.pem",
+			allFilesExist,
+		)
+		assert.NoError(t, err)
+		assert.True(t, useTLS)
+		assert.Equal(t, "/webhook/cert.pem", certPath)
+		assert.Equal(t, "/webhook/key.pem", keyPath)
+	})
+
+	t.Run("webhook paths set but files missing returns error", func(t *testing.T) {
+		_, _, useTLS, err := resolveWebhookTLSPaths(
+			"/webhook/cert.pem", "/webhook/key.pem",
+			"/server/cert.pem", "/server/key.pem",
+			noFilesExist,
+		)
+		assert.Error(t, err)
+		assert.False(t, useTLS)
+		assert.Contains(t, err.Error(), "webhook TLS certificate/key paths are set but files do not exist")
+	})
+
+	t.Run("falls back to server paths when webhook paths are empty", func(t *testing.T) {
+		certPath, keyPath, useTLS, err := resolveWebhookTLSPaths(
+			"", "",
+			"/server/cert.pem", "/server/key.pem",
+			allFilesExist,
+		)
+		assert.NoError(t, err)
+		assert.True(t, useTLS)
+		assert.Equal(t, "/server/cert.pem", certPath)
+		assert.Equal(t, "/server/key.pem", keyPath)
+	})
+
+	t.Run("server paths set but files missing returns error", func(t *testing.T) {
+		_, _, useTLS, err := resolveWebhookTLSPaths(
+			"", "",
+			"/server/cert.pem", "/server/key.pem",
+			noFilesExist,
+		)
+		assert.Error(t, err)
+		assert.False(t, useTLS)
+		assert.Contains(t, err.Error(), "API server TLS certificate/key paths are set but files do not exist")
+	})
+
+	t.Run("no TLS paths configured returns useTLS false", func(t *testing.T) {
+		certPath, keyPath, useTLS, err := resolveWebhookTLSPaths(
+			"", "",
+			"", "",
+			allFilesExist,
+		)
+		assert.NoError(t, err)
+		assert.False(t, useTLS)
+		assert.Empty(t, certPath)
+		assert.Empty(t, keyPath)
+	})
+
+	t.Run("webhook cert missing but key exists checks both", func(t *testing.T) {
+		fileExistsOnlyKey := func(path string) bool {
+			return path == "/webhook/key.pem"
+		}
+		_, _, useTLS, err := resolveWebhookTLSPaths(
+			"/webhook/cert.pem", "/webhook/key.pem",
+			"", "",
+			fileExistsOnlyKey,
+		)
+		assert.Error(t, err)
+		assert.False(t, useTLS)
+	})
+
+	t.Run("server cert exists but key missing returns error", func(t *testing.T) {
+		fileExistsOnlyCert := func(path string) bool {
+			return path == "/server/cert.pem"
+		}
+		_, _, useTLS, err := resolveWebhookTLSPaths(
+			"", "",
+			"/server/cert.pem", "/server/key.pem",
+			fileExistsOnlyCert,
+		)
+		assert.Error(t, err)
+		assert.False(t, useTLS)
+	})
+
+	t.Run("only webhook cert path set (no key) falls through to server paths", func(t *testing.T) {
+		// When only one of the webhook paths is set, it doesn't match the
+		// "both set" condition, so it falls through to server path logic.
+		certPath, keyPath, useTLS, err := resolveWebhookTLSPaths(
+			"/webhook/cert.pem", "",
+			"/server/cert.pem", "/server/key.pem",
+			allFilesExist,
+		)
+		assert.NoError(t, err)
+		assert.True(t, useTLS)
+		assert.Equal(t, "/server/cert.pem", certPath)
+		assert.Equal(t, "/server/key.pem", keyPath)
+	})
+
+	t.Run("only server cert path set (no key) returns no TLS", func(t *testing.T) {
+		certPath, keyPath, useTLS, err := resolveWebhookTLSPaths(
+			"", "",
+			"/server/cert.pem", "",
+			allFilesExist,
+		)
+		assert.NoError(t, err)
+		assert.False(t, useTLS)
+		assert.Empty(t, certPath)
+		assert.Empty(t, keyPath)
+	})
+
+	t.Run("uses real temp files to verify file existence check", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certFile := filepath.Join(tempDir, "cert.pem")
+		keyFile := filepath.Join(tempDir, "key.pem")
+		require.NoError(t, os.WriteFile(certFile, []byte("cert"), 0600))
+		require.NoError(t, os.WriteFile(keyFile, []byte("key"), 0600))
+
+		certPath, keyPath, useTLS, err := resolveWebhookTLSPaths(
+			certFile, keyFile,
+			"", "",
+			common.FileExists,
+		)
+		assert.NoError(t, err)
+		assert.True(t, useTLS)
+		assert.Equal(t, certFile, certPath)
+		assert.Equal(t, keyFile, keyPath)
+	})
+
+	t.Run("real temp files only cert exists returns error", func(t *testing.T) {
+		tempDir := t.TempDir()
+		certFile := filepath.Join(tempDir, "cert.pem")
+		keyFile := filepath.Join(tempDir, "key.pem")
+		require.NoError(t, os.WriteFile(certFile, []byte("cert"), 0600))
+		// keyFile intentionally not created
+
+		_, _, useTLS, err := resolveWebhookTLSPaths(
+			certFile, keyFile,
+			"", "",
+			common.FileExists,
+		)
+		assert.Error(t, err)
+		assert.False(t, useTLS)
+	})
+}
+
 func int64Ptr(v int64) *int64 { return &v }
 func boolPtr(v bool) *bool    { return &v }


### PR DESCRIPTION
## Summary
- Extract TLS cert/key resolution logic from `startWebhook()` into a standalone pure function `resolveWebhookTLSPaths()` that returns errors instead of calling `glog.Fatalf`
- Accept a `fileExists` function parameter to enable unit testing without real filesystem dependencies
- Add 10 test cases covering all branches: webhook-specific paths, server fallback, no TLS, missing files, partial configs, and real filesystem integration

## Test plan
- [ ] CI `backend-tests` pass (all existing + new `TestResolveWebhookTLSPaths` tests)
- [ ] `go vet ./backend/src/apiserver/...` passes
- [ ] `golangci-lint` reports no new issues