### PR TITLE
fix(backend): Resolves credentials failure. Fixes #12960

### DIFF
--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -93,7 +93,7 @@ func init() {
 	}
 }
 
-// Container for all service clients.
+// ClientManager contains all service clients.
 type ClientManager struct {
 	db                        *storage.DB
 	experimentStore           storage.ExperimentStoreInterface
@@ -955,9 +955,25 @@ func initBlobObjectStore(ctx context.Context, initConnectionTimeout time.Duratio
 		return nil, fmt.Errorf("failed to build config from environment variables: %w", err)
 	}
 
-	if err := ensureBucketExists(ctx, blobConfig); err != nil {
-		// Best-effort: some S3-compatible stores (e.g., MinIO/SeaweedFS) can return non-AWS-ish errors for bucket
-		// creation/existence checks even when the bucket is usable; don't fail apiserver init on those false negatives.
+	// Use a bounded timeout to prevent indefinite hangs when credential providers
+	// (e.g. EC2 IMDS) are unreachable outside of AWS.
+	ensureCtx, ensureCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer ensureCancel()
+
+	if err := ensureBucketExists(ensureCtx, blobConfig); err != nil {
+		if isCredentialError(err) {
+			glog.Errorf("========================================")
+			glog.Errorf("FATAL: Object store credential error.")
+			glog.Errorf("The API server cannot start without valid credentials.")
+			glog.Errorf("")
+			glog.Errorf("If using IRSA   : ensure AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE are set correctly.")
+			glog.Errorf("If using static  : ensure OBJECTSTORECONFIG_ACCESSKEY and OBJECTSTORECONFIG_SECRETACCESSKEY are set.")
+			glog.Errorf("Details: %v", err)
+			glog.Errorf("========================================")
+			glog.Exitf("Exiting due to object store credential error.")
+		}
+		// Best-effort: some S3-compatible stores (e.g., MinIO/SeaweedFS) can return non-AWS-ish errors
+		// for bucket creation/existence checks even when the bucket is usable.
 		glog.Warningf("Failed to ensure bucket exists: %v", err)
 	}
 
@@ -968,6 +984,20 @@ func initBlobObjectStore(ctx context.Context, initConnectionTimeout time.Duratio
 
 	glog.Infof("Successfully initialized blob storage for bucket: %s", blobConfig.bucketName)
 	return storage.NewBlobObjectStore(bucket, pipelinePath), nil
+}
+
+// isCredentialError returns true when the error is caused by missing or invalid
+// AWS credentials, as opposed to a bucket-not-found or transient network error.
+// This distinguishes IRSA/IMDS failures (fatal) from S3-compatible store quirks (warning).
+func isCredentialError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "get credentials") ||
+		strings.Contains(msg, "failed to refresh cached credentials") ||
+		strings.Contains(msg, "no EC2 IMDS role found") ||
+		strings.Contains(msg, "failed to retrieve jwt")
 }
 
 // blobStorageConfig holds the bucket configuration and credentials


### PR DESCRIPTION
**Description of your changes:**
---

**Fixes #12960**

### Problem

After the AWS SDK v2 refactor in #12512, the KFP API server had two bugs when configured for S3 with IRSA (empty `OBJECTSTORECONFIG_ACCESSKEY` / `OBJECTSTORECONFIG_SECRETACCESSKEY`):

1. **Hang** — `ensureBucketExists` was called with an unbounded context. On environments where EC2 IMDS is unreachable (non-AWS, Minikube), the AWS SDK retried the metadata endpoint indefinitely, blocking startup forever.

2. **Silent failure** — Credential errors (missing IRSA token, failed IMDS lookup) were silently swallowed and treated as benign warnings. The server logged `Successfully initialized blob storage` despite having a completely broken object store, giving operators no indication anything was wrong.

### Changes

- Added a **30-second timeout** on `ensureBucketExists` to bound IMDS retries and prevent indefinite hangs.
- Added `isCredentialError()` to distinguish fatal credential failures from benign S3-compatible store quirks (MinIO/SeaweedFS).
- On credential errors, the server now **logs a clear, actionable error message and exits cleanly** (`glog.Exitf`) instead of silently proceeding with a broken object store.
- Benign S3-compatible store errors continue to be treated as warnings, preserving existing behavior for MinIO/SeaweedFS users.

### Behavior after fix

Before:
```
Initializing Object store client...
W  Failed to ensure bucket exists: ... no EC2 IMDS role found ...
I  Successfully initialized blob storage for bucket: my-bucket  ← misleading
I  Object store client initialized successfully                  ← misleading
```

After:
```
Initializing Object store client...
E  ========================================
E  FATAL: Object store credential error.
E  The API server cannot start without valid credentials.
E
E  If using IRSA   : ensure AWS_ROLE_ARN and AWS_WEB_IDENTITY_TOKEN_FILE are set correctly.
E  If using static  : ensure OBJECTSTORECONFIG_ACCESSKEY and OBJECTSTORECONFIG_SECRETACCESSKEY are set.
E  Details: failed to retrieve jwt from token file ...
E  ========================================
F  Exiting due to object store credential error.
```

### Testing

Reproduced and verified on Minikube by simulating IRSA with `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` pointing to a non-existent token file, confirming clean exit with actionable error message.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 


