### PR TITLE
Reduce effect-driven state handling in frontend pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-03-09
+- Last updated: 2026-03-21
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 17)
 
 ### Maintenance (agents and contributors)
@@ -408,6 +408,30 @@ For full integration testing against a real KFP deployment:
 - **Storybook** for component development
 - **Tailwind CSS** for utility-first styling
 
+### React effect discipline
+
+When writing or reviewing React code in `frontend/src`:
+
+- Treat every `useEffect` as an escape hatch for external synchronization.
+  Valid cases include browser APIs, timers, subscriptions, storage, imperative DOM APIs,
+  or coordinating with async systems that exist outside React render.
+- Do not use `useEffect` for derived UI state.
+  If state can be computed from props, query results, or existing state, derive it during render
+  or with a memoized pure helper.
+- Do not put user-action behavior in an effect.
+  Navigation, snackbars, dialog open/close behavior, and mutation success/failure handling should
+  live in event handlers or mutation callbacks.
+- Avoid effect chains where one effect sets state that triggers another.
+  If a page needs several coupled state transitions, prefer a reducer or a single explicit update path.
+- Preserve user-controlled state across refreshes and refetches.
+  Query refreshes must not silently reset selected runs, selected artifacts, typed names, or toggles
+  unless that reset is an explicit product requirement.
+- Treat `eslint-disable react-hooks/exhaustive-deps` as a code smell.
+  Only keep it when the invariant is documented in code and covered by a targeted test.
+- During reviews, classify each new or changed effect as one of:
+  `external sync`, `derived state`, `event-driven`, `state reset`, or `effect chain`.
+  Anything except `external sync` requires explicit justification in the diff or review notes.
+
 ### Essential commands (frontend)
 
 - `npm start` - Start Vite dev server with hot reload (port 3000)
@@ -425,6 +449,7 @@ For full integration testing against a real KFP deployment:
 - `npm run check:react-peers:18` - Preview lockfile React peer compatibility against React 18
 - `npm run check:react-peers:19` - Preview lockfile React peer compatibility against React 19
 - `npm run format` - Format code with Prettier
+- `npm run format:check` - Fast pre-push check for frontend formatting; for a small TS/TSX diff, `npx prettier --check <changed files>` is the quickest equivalent
 - `npm run storybook` - Start Storybook on port 6006
 
 ### Code generation
@@ -459,6 +484,15 @@ The frontend includes several generated code components:
 - **CI pipeline**: `npm run test:ci` (format check + lint + typecheck + lockfile React peer check + Vitest UI coverage + Jest coverage)
 - **Snapshot tests**: Auto-update with `npm test -u` or `npm run test:ui -- -u` (Vitest)
 - **Frontend integration tests**: See `test/frontend-integration-test/README.md` for the containerized local flow. Supported debug env vars include `DEBUG=1`, `HEADLESS=false`, and `WDIO_SPECS=./tensorboard-example.spec.js`; headful runs expose Selenium's noVNC desktop on port `7900`.
+
+### Effect-focused frontend verification
+
+When changing an effect-heavy frontend component, add or run the smallest relevant regression test:
+
+- mutation success runs exactly once even if related async work resolves later
+- refresh/refetch does not overwrite user selection or form edits unless intended
+- error banners and dialogs clear after a successful retry or recovery path
+- mount-time logic does not emit parent callbacks unless the component contract explicitly requires it
 
 ## CI/CD (GitHub Actions)
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -90,7 +90,7 @@
         "playwright": "^1.58.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.4.5",
-        "prettier": "^3.5.0",
+        "prettier": "^3.8.1",
         "rollup-plugin-visualizer": "^5.12.0",
         "semver": "^7.7.4",
         "storybook": "^10.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -153,7 +153,7 @@
     "playwright": "^1.58.0",
     "pngjs": "^7.0.0",
     "postcss": "^8.4.5",
-    "prettier": "^3.5.0",
+    "prettier": "^3.8.1",
     "rollup-plugin-visualizer": "^5.12.0",
     "semver": "^7.7.4",
     "storybook": "^10.2.0",

--- a/frontend/src/components/PrivateSharedSelector.test.tsx
+++ b/frontend/src/components/PrivateSharedSelector.test.tsx
@@ -32,9 +32,10 @@ describe('PrivateSharedSelector', () => {
   });
 
   it('it changes checked input on click', async () => {
+    const props = generateProps();
     render(
       <BuildInfoContext.Provider value={{ apiServerMultiUser: true }}>
-        <PrivateSharedSelector {...generateProps()} />
+        <PrivateSharedSelector {...props} />
       </BuildInfoContext.Provider>,
     );
 
@@ -47,5 +48,6 @@ describe('PrivateSharedSelector', () => {
 
     expect(privateInput.checked).toBe(false);
     expect(sharedInput.checked).toBe(true);
+    expect(props.onChange).toHaveBeenCalledWith(false);
   });
 });

--- a/frontend/src/components/PrivateSharedSelector.tsx
+++ b/frontend/src/components/PrivateSharedSelector.tsx
@@ -33,10 +33,10 @@ export enum PipelineButtonTooltips {
 const PrivateSharedSelector: React.FC<PrivateSharedSelectorProps> = (props): JSX.Element | null => {
   const [namespacedPipeline, setNamespacedPipeline] = React.useState(true);
 
-  React.useEffect(() => {
-    props.onChange(namespacedPipeline);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [namespacedPipeline]);
+  const updateSelection = (isPrivate: boolean) => {
+    setNamespacedPipeline(isPrivate);
+    props.onChange(isPrivate);
+  };
 
   return (
     <React.Fragment>
@@ -48,9 +48,7 @@ const PrivateSharedSelector: React.FC<PrivateSharedSelectorProps> = (props): JSX
             label={PipelineTabsHeaders.PRIVATE}
             checked={namespacedPipeline === true}
             control={<Radio color='primary' />}
-            onChange={() => {
-              setNamespacedPipeline(true);
-            }}
+            onChange={() => updateSelection(true)}
           />
         </Tooltip>
         <Tooltip title={PipelineButtonTooltips.SHARED} placement='top-start'>
@@ -59,9 +57,7 @@ const PrivateSharedSelector: React.FC<PrivateSharedSelectorProps> = (props): JSX
             label={PipelineTabsHeaders.SHARED}
             checked={namespacedPipeline === false}
             control={<Radio color='primary' />}
-            onChange={() => {
-              setNamespacedPipeline(false);
-            }}
+            onChange={() => updateSelection(false)}
           />
         </Tooltip>
       </div>

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ApiRunDetail } from 'src/apis/run';
 import { QUERY_PARAMS } from 'src/components/Router';
@@ -42,7 +42,6 @@ export const METRICS_SECTION_NAME = 'Metrics';
 // This is a router to determine whether to show V1 or V2 compare page.
 export default function Compare(props: PageProps) {
   const { updateBanner } = props;
-  const [compareVersion, setCompareVersion] = useState<CompareVersion>(CompareVersion.Unknown);
   const queryParamRunIds = new URLParser(props).get(QUERY_PARAMS.runlist);
   const runIds = (queryParamRunIds && queryParamRunIds.split(',')) || [];
 
@@ -53,23 +52,22 @@ export default function Compare(props: PageProps) {
     staleTime: Infinity,
   });
 
-  useEffect(() => {
-    // Set the version based on the runs included.
-    if (data) {
-      if (data.length < 2 || data.length > 10) {
-        setCompareVersion(CompareVersion.InvalidRunCount);
-      } else {
-        const v2runs = data.filter((run) => 'pipeline_manifest' in (run.run?.pipeline_spec ?? {}));
-        if (v2runs.length === 0) {
-          setCompareVersion(CompareVersion.V1);
-        } else if (v2runs.length === data.length) {
-          setCompareVersion(CompareVersion.V2);
-        } else {
-          setCompareVersion(CompareVersion.Mixed);
-        }
-      }
-    }
-  }, [data]);
+  const compareVersion = !data
+    ? CompareVersion.Unknown
+    : data.length < 2 || data.length > 10
+      ? CompareVersion.InvalidRunCount
+      : (() => {
+          const v2runs = data.filter(
+            (run) => 'pipeline_manifest' in (run.run?.pipeline_spec ?? {}),
+          );
+          if (v2runs.length === 0) {
+            return CompareVersion.V1;
+          }
+          if (v2runs.length === data.length) {
+            return CompareVersion.V2;
+          }
+          return CompareVersion.Mixed;
+        })();
 
   useEffect(() => {
     if (isLoading) {

--- a/frontend/src/pages/CompareV2.test.tsx
+++ b/frontend/src/pages/CompareV2.test.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { CommonTestWrapper } from 'src/TestWrapper';
 import TestUtils, { expectErrors, testBestPractices } from 'src/TestUtils';
 import { Artifact, Context, Event, Execution } from 'src/third_party/mlmd';
 import { Apis } from 'src/lib/Apis';
+import { ButtonKeys } from 'src/lib/Buttons';
 import { QUERY_PARAMS } from 'src/components/Router';
 import * as mlmdUtils from 'src/mlmd/MlmdUtils';
 import * as Utils from 'src/lib/Utils';
@@ -36,6 +37,7 @@ describe('CompareV2', () => {
   const MOCK_RUN_2_ID = 'mock-run-2-id';
   const MOCK_RUN_3_ID = 'mock-run-3-id';
   const updateBannerSpy = vi.fn();
+  const updateToolbarSpy = vi.fn();
   const getBodyText = (): string => (document.body.textContent || '').replace(/\s+/g, ' ').trim();
 
   function generateProps(): PageProps {
@@ -49,7 +51,7 @@ describe('CompareV2', () => {
       updateBanner: updateBannerSpy,
       updateDialog: () => null,
       updateSnackbar: () => null,
-      updateToolbar: () => null,
+      updateToolbar: updateToolbarSpy,
     };
     return pageProps;
   }
@@ -57,6 +59,7 @@ describe('CompareV2', () => {
   let runs: V2beta1Run[] = [];
 
   beforeEach(() => {
+    vi.clearAllMocks();
     const getRunSpy = vi.spyOn(Apis.runServiceApiV2, 'getRun');
     getRunSpy.mockImplementation(
       (id: string) => runs.find((r) => r.run_id === id) || newMockRun(id),
@@ -187,6 +190,18 @@ describe('CompareV2', () => {
       throw new Error('Header checkbox not found in run list.');
     }
     return headerCheckbox;
+  }
+
+  function getRunRow(id: string): HTMLElement {
+    const runListContainer = getRunListContainer();
+    const runRows = Array.from(
+      runListContainer.querySelectorAll('[data-testid="table-row"]'),
+    ) as HTMLElement[];
+    const runRow = runRows.find((row) => row.textContent?.includes(`test run ${id}`));
+    if (!runRow) {
+      throw new Error(`Run row not found for ${id}`);
+    }
+    return runRow;
   }
 
   async function waitForRunCheckboxes(expectedCount: number): Promise<HTMLElement[]> {
@@ -486,6 +501,93 @@ describe('CompareV2', () => {
     // Uncheck all run checkboxes.
     fireEvent.click(headerCheckbox);
     await waitForRunCheckboxes(0);
+  });
+
+  it('updates the selected run count when a single run is toggled', async () => {
+    const getRunSpy = vi.spyOn(Apis.runServiceApiV2, 'getRun');
+    runs = [newMockRun(MOCK_RUN_1_ID), newMockRun(MOCK_RUN_2_ID), newMockRun(MOCK_RUN_3_ID)];
+    getRunSpy.mockImplementation((id: string) => runs.find((r) => r.run_id === id));
+
+    render(
+      <CommonTestWrapper>
+        <CompareV2 {...generateProps()} />
+      </CommonTestWrapper>,
+    );
+    await TestUtils.flushPromises();
+
+    await waitForRunCheckboxes(3);
+    fireEvent.click(getRunRow(MOCK_RUN_2_ID));
+    await TestUtils.flushPromises();
+
+    await waitForRunCheckboxes(2);
+    expect(getHeaderCheckbox()).not.toBeChecked();
+  });
+
+  it('preserves a manual run selection when the toolbar refresh returns the same run ids', async () => {
+    const getRunSpy = vi.spyOn(Apis.runServiceApiV2, 'getRun');
+    runs = [newMockRun(MOCK_RUN_1_ID), newMockRun(MOCK_RUN_2_ID), newMockRun(MOCK_RUN_3_ID)];
+    getRunSpy.mockImplementation((id: string) => ({ ...runs.find((r) => r.run_id === id)! }));
+
+    render(
+      <CommonTestWrapper>
+        <CompareV2 {...generateProps()} />
+      </CommonTestWrapper>,
+    );
+    await TestUtils.flushPromises();
+
+    await waitFor(() => {
+      expect(updateToolbarSpy).toHaveBeenCalled();
+    });
+    await waitForRunCheckboxes(3);
+
+    fireEvent.click(getRunRow(MOCK_RUN_2_ID));
+    await TestUtils.flushPromises();
+    await waitForRunCheckboxes(2);
+    expect(getRunRow(MOCK_RUN_2_ID)).toHaveAttribute('aria-checked', 'false');
+
+    const refreshAction = updateToolbarSpy.mock.lastCall?.[0].actions[ButtonKeys.REFRESH]
+      .action as () => Promise<void>;
+    await act(async () => {
+      await refreshAction();
+    });
+    await TestUtils.flushPromises();
+
+    await waitForRunCheckboxes(2);
+    expect(getRunRow(MOCK_RUN_1_ID)).toHaveAttribute('aria-checked', 'true');
+    expect(getRunRow(MOCK_RUN_2_ID)).toHaveAttribute('aria-checked', 'false');
+    expect(getRunRow(MOCK_RUN_3_ID)).toHaveAttribute('aria-checked', 'true');
+    expect(getHeaderCheckbox()).not.toBeChecked();
+  });
+
+  it('reinitializes selection to the new runlist after a route change', async () => {
+    const getRunSpy = vi.spyOn(Apis.runServiceApiV2, 'getRun');
+    runs = [newMockRun(MOCK_RUN_1_ID), newMockRun(MOCK_RUN_2_ID), newMockRun(MOCK_RUN_3_ID)];
+    getRunSpy.mockImplementation((id: string) => ({ ...runs.find((r) => r.run_id === id)! }));
+
+    const renderResult = render(
+      <CommonTestWrapper>
+        <CompareV2 {...generateProps()} />
+      </CommonTestWrapper>,
+    );
+    await TestUtils.flushPromises();
+
+    await waitForRunCheckboxes(3);
+    fireEvent.click(getRunRow(MOCK_RUN_2_ID));
+    await TestUtils.flushPromises();
+    await waitForRunCheckboxes(2);
+
+    const nextProps = generateProps();
+    nextProps.location.search = `?${QUERY_PARAMS.runlist}=${MOCK_RUN_2_ID},${MOCK_RUN_3_ID}`;
+    renderResult.rerender(
+      <CommonTestWrapper>
+        <CompareV2 {...nextProps} />
+      </CommonTestWrapper>,
+    );
+    await TestUtils.flushPromises();
+
+    await waitForRunCheckboxes(2);
+    expect(getRunRow(MOCK_RUN_2_ID)).toHaveAttribute('aria-checked', 'true');
+    expect(getRunRow(MOCK_RUN_3_ID)).toHaveAttribute('aria-checked', 'true');
   });
 
   it('Parameters and Scalar metrics tab initially enabled with loading then error, and switch tabs', async () => {

--- a/frontend/src/pages/CompareV2.tsx
+++ b/frontend/src/pages/CompareV2.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { V2beta1Run } from 'src/apisv2beta1/run';
 import Separator from 'src/atoms/Separator';
@@ -246,8 +246,8 @@ function CompareV2(props: CompareV2Props) {
   const [isParamsCollapsed, setIsParamsCollapsed] = useState(false);
   const [isMetricsCollapsed, setIsMetricsCollapsed] = useState(false);
   const [isLoadingArtifacts, setIsLoadingArtifacts] = useState<boolean>(true);
-  const [paramsTableProps, setParamsTableProps] = useState<CompareTableProps | undefined>();
   const [isInitialArtifactsLoad, setIsInitialArtifactsLoad] = useState<boolean>(true);
+  const selectionRunIdsKeyRef = useRef<string>('');
 
   // Scalar Metrics
   const [scalarMetricsTableData, setScalarMetricsTableData] = useState<
@@ -548,18 +548,28 @@ function CompareV2(props: CompareV2Props) {
 
   useEffect(() => {
     if (runs) {
-      setSelectedIds(runs.map((r) => r.run_id!));
+      const nextRunIds = runs.map((run) => run.run_id!).filter((id): id is string => !!id);
+      const nextRunIdsKey = nextRunIds.join(',');
+      const routeChanged = selectionRunIdsKeyRef.current !== nextRunIdsKey;
+      selectionRunIdsKeyRef.current = nextRunIdsKey;
+
+      setSelectedIds((currentSelectedIds) => {
+        if (routeChanged) {
+          return nextRunIds;
+        }
+        const nextRunIdsSet = new Set(nextRunIds);
+        return currentSelectedIds.filter((id) => nextRunIdsSet.has(id));
+      });
     }
   }, [runs]);
 
-  useEffect(() => {
-    if (runs) {
-      const selectedIdsSet = new Set(selectedIds);
-      const selectedRuns: V2beta1Run[] = runs.filter((run) => selectedIdsSet.has(run.run_id!));
-      setParamsTableProps(getParamsTableProps(selectedRuns));
-    } else {
-      setParamsTableProps(undefined);
+  const paramsTableProps = useMemo(() => {
+    if (!runs) {
+      return undefined;
     }
+    const selectedIdsSet = new Set(selectedIds);
+    const selectedRuns: V2beta1Run[] = runs.filter((run) => selectedIdsSet.has(run.run_id!));
+    return getParamsTableProps(selectedRuns);
   }, [runs, selectedIds]);
 
   const showPageError = async (message: string, error: Error | undefined) => {

--- a/frontend/src/pages/functional_components/NewExperimentFC.test.tsx
+++ b/frontend/src/pages/functional_components/NewExperimentFC.test.tsx
@@ -229,6 +229,104 @@ describe('NewExperiment', () => {
     );
   });
 
+  it('uses an empty pipeline version query param when no latest version is returned', async () => {
+    const pipelineId = 'some-pipeline-id';
+    let resolveVersions: (value: {
+      pipeline_versions?: Array<{ pipeline_version_id: string }>;
+    }) => void = () => {};
+    const listPipelineVersionsSpy = vi.spyOn(Apis.pipelineServiceApiV2, 'listPipelineVersions');
+    listPipelineVersionsSpy.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveVersions = resolve;
+        }),
+    );
+
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.pipelineId}=${pipelineId}`;
+
+    render(
+      <CommonTestWrapper>
+        <NewExperimentFC {...props} />
+      </CommonTestWrapper>,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Experiment name/), {
+      target: { value: 'new-experiment-name' },
+    });
+    fireEvent.click(screen.getByText('Next'));
+
+    await waitFor(() => {
+      expect(createExperimentSpy).toHaveBeenCalled();
+      expect(listPipelineVersionsSpy).toHaveBeenCalledWith(
+        pipelineId,
+        undefined,
+        1,
+        'created_at desc',
+      );
+    });
+
+    resolveVersions({ pipeline_versions: [] });
+
+    await waitFor(() => {
+      expect(historyPushSpy).toHaveBeenCalledTimes(1);
+      expect(updateSnackbarSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(historyPushSpy).toHaveBeenCalledWith(
+      RoutePage.NEW_RUN +
+        `?experimentId=${TEST_EXPERIMENT_ID}` +
+        `&pipelineId=${pipelineId}` +
+        `&pipelineVersionId=` +
+        `&firstRunInExperiment=1`,
+    );
+  });
+
+  it('continues to navigate when retrieving the latest pipeline version fails', async () => {
+    const pipelineId = 'some-pipeline-id';
+    const listPipelineVersionsSpy = vi.spyOn(Apis.pipelineServiceApiV2, 'listPipelineVersions');
+    listPipelineVersionsSpy.mockRejectedValue(new Error('version lookup failed'));
+
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.pipelineId}=${pipelineId}`;
+
+    render(
+      <CommonTestWrapper>
+        <NewExperimentFC {...props} />
+      </CommonTestWrapper>,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Experiment name/), {
+      target: { value: 'new-experiment-name' },
+    });
+    const nextButton = screen.getByText('Next');
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      expect(createExperimentSpy).toHaveBeenCalled();
+      expect(listPipelineVersionsSpy).toHaveBeenCalledWith(
+        pipelineId,
+        undefined,
+        1,
+        'created_at desc',
+      );
+    });
+
+    await waitFor(() => {
+      expect(historyPushSpy).toHaveBeenCalledTimes(1);
+      expect(updateSnackbarSpy).toHaveBeenCalledTimes(1);
+      expect(nextButton.closest('button')?.disabled).toBe(false);
+    });
+
+    expect(historyPushSpy).toHaveBeenCalledWith(
+      RoutePage.NEW_RUN +
+        `?experimentId=${TEST_EXPERIMENT_ID}` +
+        `&pipelineId=${pipelineId}` +
+        `&pipelineVersionId=` +
+        `&firstRunInExperiment=1`,
+    );
+    expect(updateDialogSpy).not.toHaveBeenCalled();
+  });
+
   it('shows snackbar confirmation after experiment is created', async () => {
     render(
       <CommonTestWrapper>

--- a/frontend/src/pages/functional_components/NewExperimentFC.tsx
+++ b/frontend/src/pages/functional_components/NewExperimentFC.tsx
@@ -15,11 +15,9 @@
  */
 
 import { useEffect, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { commonCss, fontsize, padding } from 'src/Css';
-import { queryKeys } from 'src/hooks/queryKeys';
 import { V2beta1Experiment } from 'src/apisv2beta1/experiment';
-import { V2beta1PipelineVersion } from 'src/apisv2beta1/pipeline';
 import BusyButton from 'src/atoms/BusyButton';
 import Input from 'src/atoms/Input';
 import { QUERY_PARAMS, RoutePage } from 'src/components/Router';
@@ -54,21 +52,7 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
   const [description, setDescription] = useState<string>('');
   const [experimentName, setExperimentName] = useState<string>('');
   const [isbeingCreated, setIsBeingCreated] = useState<boolean>(false);
-  const [experimentResponse, setExperimentResponse] = useState<V2beta1Experiment>();
-  const [errMsgFromApi, setErrMsgFromApi] = useState<string>();
   const pipelineId = urlParser.get(QUERY_PARAMS.pipelineId);
-
-  const { data: latestVersion } = useQuery<V2beta1PipelineVersion | undefined, Error>({
-    queryKey: queryKeys.pipelineVersions(pipelineId),
-    queryFn: () => {
-      if (!pipelineId) {
-        // This branch should not be hit because the query is disabled when there is no pipelineId.
-        return Promise.reject(new Error('Pipeline ID is not available'));
-      }
-      return getLatestVersion(pipelineId);
-    },
-    enabled: !!pipelineId,
-  });
 
   useEffect(() => {
     updateToolbar({
@@ -79,47 +63,6 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
     // Initialize toolbar only once during the first render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // Handle the redirection work when createExperiment is succeed
-  useEffect(() => {
-    if (experimentResponse) {
-      const searchString = pipelineId
-        ? new URLParser(props).build({
-            [QUERY_PARAMS.experimentId]: experimentResponse.experiment_id || '',
-            [QUERY_PARAMS.pipelineId]: pipelineId,
-            [QUERY_PARAMS.pipelineVersionId]: latestVersion?.pipeline_version_id || '',
-            [QUERY_PARAMS.firstRunInExperiment]: '1',
-          })
-        : new URLParser(props).build({
-            [QUERY_PARAMS.experimentId]: experimentResponse.experiment_id || '',
-            [QUERY_PARAMS.firstRunInExperiment]: '1',
-          });
-      props.history.push(RoutePage.NEW_RUN + searchString);
-
-      updateSnackbar({
-        autoHideDuration: 10000,
-        message: `Successfully created new Experiment: ${experimentResponse.display_name}`,
-        open: true,
-      });
-    }
-    // Only trigger this effect when search string parameters change.
-    // Do not rerun this effect if updateSnackbar callback has changes to avoid re-rendering.
-    // Do not rerun this effect if pipelineId has changes to avoid re-rendering.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [experimentResponse, latestVersion]);
-
-  useEffect(() => {
-    if (errMsgFromApi) {
-      updateDialog({
-        buttons: [{ text: 'Dismiss' }],
-        onClose: () => setIsBeingCreated(false),
-        content: errMsgFromApi,
-        title: 'Experiment creation failed',
-      });
-    }
-    // Do not rerun this effect if updateDialog callback has changes to avoid re-rendering.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [errMsgFromApi, updateDialog]);
 
   const newExperimentMutation = useMutation({
     mutationFn: (experiment: V2beta1Experiment) => {
@@ -135,13 +78,39 @@ export function NewExperimentFC(props: NewExperimentFCProps) {
     };
     setIsBeingCreated(true);
 
-    try {
-      const response = await newExperimentMutation.mutateAsync(newExperiment);
-      setExperimentResponse(response);
-      setErrMsgFromApi(undefined);
-    } catch (err) {
-      setErrMsgFromApi(await errorToMessage(err));
-    }
+    newExperimentMutation.mutate(newExperiment, {
+      onSuccess: async (response) => {
+        const latestVersion = pipelineId ? await getLatestVersion(pipelineId) : undefined;
+        const searchString = pipelineId
+          ? new URLParser(props).build({
+              [QUERY_PARAMS.experimentId]: response.experiment_id || '',
+              [QUERY_PARAMS.pipelineId]: pipelineId,
+              [QUERY_PARAMS.pipelineVersionId]: latestVersion?.pipeline_version_id || '',
+              [QUERY_PARAMS.firstRunInExperiment]: '1',
+            })
+          : new URLParser(props).build({
+              [QUERY_PARAMS.experimentId]: response.experiment_id || '',
+              [QUERY_PARAMS.firstRunInExperiment]: '1',
+            });
+
+        setIsBeingCreated(false);
+        props.history.push(RoutePage.NEW_RUN + searchString);
+
+        updateSnackbar({
+          autoHideDuration: 10000,
+          message: `Successfully created new Experiment: ${response.display_name}`,
+          open: true,
+        });
+      },
+      onError: async (err) => {
+        updateDialog({
+          buttons: [{ text: 'Dismiss' }],
+          onClose: () => setIsBeingCreated(false),
+          content: (await errorToMessage(err)) || 'Unknown error',
+          title: 'Experiment creation failed',
+        });
+      },
+    });
   };
 
   const onCancel = () =>

--- a/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.test.tsx
+++ b/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.test.tsx
@@ -328,6 +328,38 @@ describe('RecurringRunDetailsV2FC', () => {
     screen.getByText('value1');
   });
 
+  it('refresh retries the recurring run query', async () => {
+    render(
+      <CommonTestWrapper>
+        <RecurringRunDetailsRouter {...generateProps()} />
+      </CommonTestWrapper>,
+    );
+    await waitFor(() => {
+      expect(getRecurringRunSpy).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Enabled')).toBeInTheDocument();
+      expect(screen.getByText('Every 1 hours')).toBeInTheDocument();
+    });
+
+    const refreshAction = updateToolbarSpy.mock.lastCall?.[0].actions.refresh.action as
+      | (() => Promise<void>)
+      | undefined;
+    expect(refreshAction).toBeDefined();
+    const refreshCallCount = getRecurringRunSpy.mock.calls.length;
+
+    await refreshAction?.();
+
+    await waitFor(() => {
+      expect(getRecurringRunSpy.mock.calls.length).toBeGreaterThan(refreshCallCount);
+    });
+
+    screen.getByText('Enabled');
+    screen.getByText('Yes');
+    screen.getByText('Trigger');
+    screen.getByText('Every 1 hours');
+  });
+
   it('shows top bar buttons', async () => {
     render(
       <CommonTestWrapper>
@@ -336,7 +368,10 @@ describe('RecurringRunDetailsV2FC', () => {
     );
     await waitFor(() => {
       expect(getRecurringRunSpy).toHaveBeenCalled();
-      expect(updateToolbarSpy).toHaveBeenCalledWith(
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Enabled')).toBeInTheDocument();
+      expect(updateToolbarSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
           actions: expect.objectContaining({
             cloneRecurringRun: expect.objectContaining({ title: 'Clone recurring run' }),
@@ -345,6 +380,7 @@ describe('RecurringRunDetailsV2FC', () => {
             disableRecurringRun: expect.objectContaining({ title: 'Disable', disabled: false }),
             deleteRun: expect.objectContaining({ title: 'Delete' }),
           }),
+          pageTitle: fullTestV2RecurringRun.display_name,
         }),
       );
     });

--- a/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.tsx
+++ b/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Buttons, { ButtonKeys } from 'src/lib/Buttons';
 import { queryKeys } from 'src/hooks/queryKeys';
@@ -33,19 +33,8 @@ import { triggerDisplayString } from 'src/lib/TriggerUtils';
 
 export function RecurringRunDetailsV2FC(props: PageProps) {
   const { updateBanner, updateToolbar } = props;
-  const [refresh, setRefresh] = useState(true);
-  const [getRecurringRunErrMsg, setGetRecurringRunErrMsg] = useState<string>('');
-  const [getExperimentErrMsg, setGetExperimentErrMsg] = useState<string>('');
-
-  // Related to Api Response
-  const [experimentName, setExperimentName] = useState<string>();
-  const [experimentIdFromApi, setExperimentIdFromApi] = useState<string>();
-  const [recurringRunName, setRecurringRunName] = useState<string>();
-  const [recurringRunIdFromApi, setRecurringRunIdFromApi] = useState<string>();
-  const [recurringRunStatus, setRecurringRunStatus] = useState<V2beta1RecurringRunStatus>();
 
   const recurringRunId = props.match.params[RouteParams.recurringRunId];
-  const Refresh = () => setRefresh((refreshed) => !refreshed);
 
   const {
     data: recurringRun,
@@ -63,7 +52,11 @@ export function RecurringRunDetailsV2FC(props: PageProps) {
   });
 
   const experimentId = recurringRun?.experiment_id;
-  const { data: experiment, error: getExperimentError } = useQuery<V2beta1Experiment, Error>({
+  const {
+    data: experiment,
+    error: getExperimentError,
+    refetch: refetchExperiment,
+  } = useQuery<V2beta1Experiment, Error>({
     queryKey: queryKeys.experiment(experimentId),
     queryFn: async () => {
       if (!experimentId) {
@@ -76,86 +69,73 @@ export function RecurringRunDetailsV2FC(props: PageProps) {
     staleTime: 0,
   });
 
-  useEffect(() => {
-    if (recurringRun) {
-      setRecurringRunName(recurringRun.display_name);
-      setRecurringRunStatus(recurringRun.status);
-      setRecurringRunIdFromApi(recurringRun.recurring_run_id);
+  const refreshRecurringRun = async () => {
+    await refetchRecurringRun();
+    if (experimentId) {
+      await refetchExperiment();
     }
-  }, [recurringRun]);
-
-  useEffect(() => {
-    if (experiment) {
-      setExperimentName(experiment.display_name);
-      setExperimentIdFromApi(experiment.experiment_id);
-    }
-  }, [experiment]);
+  };
 
   useEffect(() => {
     const toolbarState = getInitialToolbarState();
 
     toolbarState.actions[ButtonKeys.ENABLE_RECURRING_RUN].disabled =
-      recurringRunStatus === V2beta1RecurringRunStatus.ENABLED;
+      recurringRun?.status === V2beta1RecurringRunStatus.ENABLED;
     toolbarState.actions[ButtonKeys.DISABLE_RECURRING_RUN].disabled =
-      recurringRunStatus !== V2beta1RecurringRunStatus.ENABLED;
-    toolbarState.pageTitle = recurringRunName || recurringRunIdFromApi || 'Unknown recurring run';
-    toolbarState.breadcrumbs = getBreadcrumbs(experimentIdFromApi, experimentName);
+      recurringRun?.status !== V2beta1RecurringRunStatus.ENABLED;
+    toolbarState.pageTitle =
+      recurringRun?.display_name || recurringRun?.recurring_run_id || 'Unknown recurring run';
+    toolbarState.breadcrumbs = getBreadcrumbs(experiment?.experiment_id, experiment?.display_name);
     updateToolbar(toolbarState);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    recurringRunIdFromApi,
-    recurringRunName,
-    recurringRunStatus,
-    experimentIdFromApi,
-    experimentName,
+    recurringRun?.recurring_run_id,
+    recurringRun?.display_name,
+    recurringRun?.status,
+    experiment?.experiment_id,
+    experiment?.display_name,
   ]);
 
   useEffect(() => {
-    if (getRecurringRunError) {
-      (async () => {
+    let cancelled = false;
+
+    const syncBanner = async () => {
+      if (getRecurringRunError) {
         const errorMessage = await errorToMessage(getRecurringRunError);
-        setGetRecurringRunErrMsg(errorMessage);
-      })();
-    }
+        if (!cancelled) {
+          updateBanner({
+            additionalInfo: errorMessage ? errorMessage : undefined,
+            message:
+              `Error: failed to retrieve recurring run: ${recurringRunId}.` +
+              (errorMessage ? ' Click Details for more information.' : ''),
+            mode: 'error',
+          });
+        }
+        return;
+      }
 
-    // getExperimentError is from the getExperiment useQuery which is enabled by the
-    // experiment ID in recurringRun object. => when getExperimentError changed,
-    // getRecurringRun useQuery must be successful (getRecurringRunError is null)
-    if (getExperimentError) {
-      (async () => {
+      if (getExperimentError) {
         const errorMessage = await errorToMessage(getExperimentError);
-        setGetExperimentErrMsg(errorMessage);
-      })();
-    }
-  }, [getRecurringRunError, getExperimentError]);
+        if (!cancelled) {
+          updateBanner({
+            additionalInfo: errorMessage ? errorMessage : undefined,
+            message:
+              `Error: failed to retrieve this recurring run's experiment.` +
+              (errorMessage ? ' Click Details for more information.' : ''),
+            mode: 'warning',
+          });
+        }
+        return;
+      }
 
-  useEffect(() => {
-    if (getRecurringRunErrMsg) {
-      updateBanner({
-        additionalInfo: getRecurringRunErrMsg ? getRecurringRunErrMsg : undefined,
-        message:
-          `Error: failed to retrieve recurring run: ${recurringRunId}.` +
-          (getRecurringRunErrMsg ? ' Click Details for more information.' : ''),
-        mode: 'error',
-      });
-    }
+      updateBanner({});
+    };
 
-    if (getExperimentErrMsg) {
-      updateBanner({
-        additionalInfo: getExperimentErrMsg ? getExperimentErrMsg : undefined,
-        message:
-          `Error: failed to retrieve this recurring run's experiment.` +
-          (getExperimentErrMsg ? ' Click Details for more information.' : ''),
-        mode: 'warning',
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getRecurringRunErrMsg, getExperimentErrMsg]);
-
-  useEffect(() => {
-    refetchRecurringRun();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refresh]);
+    syncBanner();
+    return () => {
+      cancelled = true;
+    };
+  }, [getRecurringRunError, getExperimentError, recurringRunId, updateBanner]);
 
   const deleteCallback = (_: string[], success: boolean) => {
     if (success) {
@@ -168,11 +148,11 @@ export function RecurringRunDetailsV2FC(props: PageProps) {
   };
 
   const getInitialToolbarState = (): ToolbarProps => {
-    const buttons = new Buttons(props, Refresh);
+    const buttons = new Buttons(props, refreshRecurringRun);
     return {
       actions: buttons
         .cloneRecurringRun(() => (recurringRun ? [recurringRun.recurring_run_id!] : []), true)
-        .refresh(Refresh)
+        .refresh(refreshRecurringRun)
         .enableRecurringRun(() => (recurringRun ? recurringRun.recurring_run_id! : ''))
         .disableRecurringRun(() => (recurringRun ? recurringRun.recurring_run_id! : ''))
         .delete(


### PR DESCRIPTION
## Why
Several frontend pages were using `useEffect` as control flow for work that is not actually render synchronization:

- mutation success and failure behavior was happening after the fact in effects instead of in the initiating mutation callbacks
- derived view state was being copied into local state and recomputed by effects
- query refreshes could reset user-driven selection state
- error/banner state was being mirrored through effect chains, which makes recovery paths harder to reason about and test

That pattern makes components harder to reason about, increases the chance of duplicate side effects, and tends to create brittle `exhaustive-deps` tradeoffs. This PR removes the highest-risk cases first and documents the guardrails in the repo guide.

## What changed
- Add React effect-discipline guidance to `AGENTS.md`, including explicit review categories for `useEffect` usage and effect-focused frontend verification expectations.
- `NewExperimentFC`
  Move create-success navigation/snackbar and create-failure dialog behavior into the mutation callbacks so the page no longer depends on effect timing around experiment creation and pipeline-version lookup.
- `PrivateSharedSelector`
  Stop using a mount/update effect to notify the parent. The parent callback now only fires from explicit user interaction.
- `Compare`
  Remove the derived `compareVersion` state/effect pair and compute the page mode directly from the fetched runs.
- `CompareV2`
  Stop mirroring parameter-table props through effect state and preserve run selection across refetches while still reinitializing correctly when the compared runlist changes.
- `RecurringRunDetailsV2FC`
  Remove the mirrored toolbar/banner state and derive toolbar state directly from live query results. Refresh now explicitly refetches the relevant queries, and banner handling follows the current query error state instead of a multi-step effect chain.

## Why this shape
This stays intentionally narrow:

- no broad component rewrites
- no new dependencies or abstractions
- no attempt to clean up every remaining `useEffect` in the frontend

The goal is to remove the most failure-prone effect patterns first, add regression coverage around those paths, and leave the remaining heavier cleanup (for example `NewRunV2`) for follow-up work.

## Testing
- `cd frontend && fnm exec --using .nvmrc -- npm run test:ui -- src/components/PrivateSharedSelector.test.tsx src/pages/CompareV2.test.tsx src/pages/functional_components/NewExperimentFC.test.tsx src/pages/functional_components/RecurringRunDetailsV2FC.test.tsx src/pages/NewPipelineVersion.test.tsx src/components/UploadPipelineDialog.test.tsx`
