### PR TITLE
feat(backend): add pod lifecycle timeout environment variable constants. Part of #12843

### DIFF
--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -88,3 +88,26 @@ const (
 // empty map from nil, so this header preserves the intent across the
 // HTTP→gRPC proxy roundtrip.
 const ClearTagsMetadataKey = "x-clear-tags"
+// Pod lifecycle failure timeout configuration.
+// These environment variables allow operators to configure how long KFP
+// waits before marking a run as FAILED when a pod is stuck in a
+// lifecycle failure state. Each category maps to the three failure types
+// described in issue #12843.
+const (
+	// Provisioning timeout covers failures like ImagePullBackOff,
+	// ErrImagePull and Unschedulable where the pod cannot be scheduled
+	// or its container image cannot be pulled.
+	PodLifecycleProvisioningTimeoutEnvVar = "KFP_POD_LIFECYCLE_PROVISIONING_TIMEOUT_SECONDS"
+
+	// Runtime timeout covers failures like OOMKilled and CrashLoopBackOff
+	// where the pod starts but fails during execution.
+	PodLifecycleRuntimeTimeoutEnvVar = "KFP_POD_LIFECYCLE_RUNTIME_TIMEOUT_SECONDS"
+
+	// Node timeout covers infrastructure failures like NodeLost,
+	// Preempted and Evicted where the underlying node fails.
+	PodLifecycleNodeTimeoutEnvVar = "KFP_POD_LIFECYCLE_NODE_TIMEOUT_SECONDS"
+
+	// Default timeout of 1 hour for all pod lifecycle failure categories
+	// if no environment variable is set.
+	DefaultPodLifecycleTimeoutSeconds = 3600
+)


### PR DESCRIPTION
When a pod hits a lifecycle failure (ImagePullBackOff, OOMKilled, 
NodeLost etc.), KFP currently has no timeout mechanism — runs hang 
indefinitely with no way to automatically recover.

This PR adds named constants to backend/src/apiserver/common/const.go 
for the three pod lifecycle failure timeout environment variables 
proposed in issue #12843:

- KFP_POD_LIFECYCLE_PROVISIONING_TIMEOUT_SECONDS
  For provisioning failures: ImagePullBackOff, ErrImagePull, Unschedulable

- KFP_POD_LIFECYCLE_RUNTIME_TIMEOUT_SECONDS
  For runtime failures: OOMKilled, CrashLoopBackOff

- KFP_POD_LIFECYCLE_NODE_TIMEOUT_SECONDS
  For node-level failures: NodeLost, Preempted, Evicted

- DefaultPodLifecycleTimeoutSeconds = 3600 (1 hour default)

These constants establish the configuration foundation for timeout 
enforcement logic which will read these env vars and automatically 
mark stuck runs as FAILED.

Relationship to other PRs:
- Builds on failure detection work in #13097
- Extends timeout env var approach started in #12989
- Timeout enforcement implementation is follow-up GSoC work