### PR TITLE
fix: replace bare except: with except Exception: in metadata helpers

### DIFF
--- a/backend/metadata_writer/src/metadata_helpers.py
+++ b/backend/metadata_writer/src/metadata_helpers.py
@@ -83,7 +83,7 @@ def get_or_create_artifact_type(store, type_name, properties: dict = None) -> me
     try:
         artifact_type = store.get_artifact_type(type_name=type_name)
         return artifact_type
-    except:
+    except Exception:
         artifact_type = metadata_store_pb2.ArtifactType(
             name=type_name,
             properties=properties,
@@ -96,7 +96,7 @@ def get_or_create_execution_type(store, type_name, properties: dict = None) -> m
     try:
         execution_type = store.get_execution_type(type_name=type_name)
         return execution_type
-    except:
+    except Exception:
         execution_type = metadata_store_pb2.ExecutionType(
             name=type_name,
             properties=properties,
@@ -109,7 +109,7 @@ def get_or_create_context_type(store, type_name, properties: dict = None) -> met
     try:
         context_type = store.get_context_type(type_name=type_name)
         return context_type
-    except:
+    except Exception:
         context_type = metadata_store_pb2.ContextType(
             name=type_name,
             properties=properties,
@@ -208,7 +208,7 @@ def get_or_create_context_with_type(
 ) -> metadata_store_pb2.Context:
     try:
         context = get_context_by_name(store, context_name)
-    except:
+    except Exception:
         context = create_context_with_type(
             store=store,
             context_name=context_name,


### PR DESCRIPTION
## Summary

Replaces 4 bare `except:` clauses with `except Exception:` in the ML Metadata helpers module.

Bare `except:` catches everything including `KeyboardInterrupt`, `SystemExit`, and `GeneratorExit` — signals that should propagate up the call stack. In all 4 cases here the intent is to handle MLMD gRPC/store errors when looking up artifact, execution, and context types. `except Exception:` correctly scopes the catch to runtime errors only.

**Change (4 occurrences):**
```python
# Before
try:
    artifact_type = mlmd_store.get_artifact_type(...)
except:
    artifact_type = mlmd_store.put_artifact_type(...)

# After
try:
    artifact_type = mlmd_store.get_artifact_type(...)
except Exception:
    artifact_type = mlmd_store.put_artifact_type(...)
```

## Testing
No behavior change for normal exception flows. Resolves PEP 8 E722 `bare-except` lint warnings.