### PR TITLE
chore(frontend): centralize filtering for reserved artifact custom properties

### DIFF
--- a/frontend/src/components/ResourceInfo.test.tsx
+++ b/frontend/src/components/ResourceInfo.test.tsx
@@ -102,4 +102,32 @@ describe('ResourceInfo', () => {
       ]
     `);
   });
+
+  it('filters reserved artifact custom properties from display', async () => {
+    const artifact = new Artifact();
+    artifact.setState(Artifact.State.LIVE);
+    artifact.getCustomPropertiesMap().set('accuracy', new Value().setDoubleValue(0.95));
+    artifact
+      .getCustomPropertiesMap()
+      .set('store_session_info', new Value().setStringValue('internal-data'));
+    render(
+      <ResourceInfo
+        resourceType={ResourceType.ARTIFACT}
+        resource={artifact}
+        typeName='system.Metrics'
+      />,
+    );
+    const keyEquals = (key: string) => (property: HTMLElement) => {
+      return getByTestId(property, 'resource-info-property-key').textContent === key;
+    };
+    const accuracyProperty = screen
+      .getAllByTestId('resource-info-property')
+      .find(keyEquals('accuracy'));
+    expect(accuracyProperty).toBeTruthy();
+
+    const storeSessionProperty = screen
+      .getAllByTestId('resource-info-property')
+      .find(keyEquals('store_session_info'));
+    expect(storeSessionProperty).toBeUndefined();
+  });
 });

--- a/frontend/src/components/ResourceInfo.tsx
+++ b/frontend/src/components/ResourceInfo.tsx
@@ -17,6 +17,7 @@ import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import * as React from 'react';
 import { getMetadataValue } from 'src/mlmd/library';
 import { Artifact, Execution } from 'src/third_party/mlmd';
+import { isReservedArtifactProperty } from 'src/lib/ReservedArtifactProperties';
 import { stylesheet } from 'typestyle';
 import { color, commonCss } from '../Css';
 import { ArtifactLink } from './ArtifactLink';
@@ -111,17 +112,20 @@ export class ResourceInfo extends React.Component<ResourceInfoProps, {}> {
         </dl>
         <h2 className={commonCss.header2}>Custom Properties</h2>
         <dl className={css.resourceInfo}>
-          {customPropertyMap.getEntryList().map((k) => (
-            <div className={css.field} key={k[0]} data-testid='resource-info-property'>
-              <dt className={css.term} data-testid='resource-info-property-key'>
-                {k[0]}
-              </dt>
-              <dd className={css.value} data-testid='resource-info-property-value'>
-                {customPropertyMap &&
-                  prettyPrintValue(getMetadataValue(customPropertyMap.get(k[0])))}
-              </dd>
-            </div>
-          ))}
+          {customPropertyMap
+            .getEntryList()
+            .filter((k) => !isReservedArtifactProperty(k[0]))
+            .map((k) => (
+              <div className={css.field} key={k[0]} data-testid='resource-info-property'>
+                <dt className={css.term} data-testid='resource-info-property-key'>
+                  {k[0]}
+                </dt>
+                <dd className={css.value} data-testid='resource-info-property-value'>
+                  {customPropertyMap &&
+                    prettyPrintValue(getMetadataValue(customPropertyMap.get(k[0])))}
+                </dd>
+              </div>
+            ))}
         </dl>
       </section>
     );

--- a/frontend/src/components/tabs/MetricsTab.test.tsx
+++ b/frontend/src/components/tabs/MetricsTab.test.tsx
@@ -340,19 +340,14 @@ describe('MetricsTab with Scalar Metrics', () => {
     await waitFor(() => getByText('struct'));
   });
 
-  it('does not show store_session_info in Scalar Metrics', async () => {
+  it('filters out store_session_info from Scalar Metrics', async () => {
     const execution = buildBasicExecution().setLastKnownState(Execution.State.COMPLETE);
     const artifact = buildMetricsArtifact();
     artifact.getCustomPropertiesMap().set('display_name', new Value().setStringValue('metrics'));
-    artifact.getCustomPropertiesMap().set('a', new Value().setDoubleValue(100));
+    artifact.getCustomPropertiesMap().set('accuracy', new Value().setDoubleValue(0.95));
     artifact
       .getCustomPropertiesMap()
-      .set(
-        'store_session_info',
-        new Value().setStringValue(
-          '{"Provider":"minio","Params":{"accessKeyKey":"accesskey","disableSSL":"true","endpoint":"seaweedfs.kubeflow:9000","fromEnv":"false","region":"minio","secretKeyKey":"secretkey","secretName":"mlpipeline-minio-artifact"}}',
-        ),
-      );
+      .set('store_session_info', new Value().setStringValue('internal-session-data'));
     const linkedArtifact = { event: new Event(), artifact: artifact };
     vi.spyOn(mlmdUtils, 'getOutputLinkedArtifactsInExecution').mockResolvedValueOnce([
       linkedArtifact,
@@ -365,7 +360,7 @@ describe('MetricsTab with Scalar Metrics', () => {
     );
     getByText('Metrics is loading.');
     await waitFor(() => getByText('Scalar Metrics: metrics'));
-    await waitFor(() => getByText('a'));
+    await waitFor(() => getByText('accuracy'));
     expect(queryByText('store_session_info')).toBeNull();
   });
 });

--- a/frontend/src/components/viewers/MetricsVisualizations.tsx
+++ b/frontend/src/components/viewers/MetricsVisualizations.tsx
@@ -25,6 +25,7 @@ import { Apis, ListRequest } from 'src/lib/Apis';
 import { OutputArtifactLoader } from 'src/lib/OutputArtifactLoader';
 import WorkflowParser, { StoragePath } from 'src/lib/WorkflowParser';
 import { getMetadataValue } from 'src/mlmd/library';
+import { isReservedArtifactProperty } from 'src/lib/ReservedArtifactProperties';
 import {
   filterArtifactsByType,
   filterLinkedArtifactsByType,
@@ -806,11 +807,12 @@ function ScalarMetricsSection({ artifact }: ScalarMetricsSectionProps) {
   const name = customProperties.get('display_name')?.getStringValue();
   const data = customProperties
     .getEntryList()
-    .filter(([key]) => key !== 'display_name' && key !== 'store_session_info')
     .map(([key]) => ({
       key,
       value: JSON.stringify(getMetadataValue(customProperties.get(key))),
-    }));
+    }))
+    .filter((metric) => metric.key !== 'display_name')
+    .filter((metric) => !isReservedArtifactProperty(metric.key));
 
   if (data.length === 0) {
     return null;

--- a/frontend/src/lib/ReservedArtifactProperties.test.ts
+++ b/frontend/src/lib/ReservedArtifactProperties.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isReservedArtifactProperty } from './ReservedArtifactProperties';
+
+describe('isReservedArtifactProperty', () => {
+  it('returns true for store_session_info', () => {
+    expect(isReservedArtifactProperty('store_session_info')).toBe(true);
+  });
+
+  it('returns false for non-reserved keys', () => {
+    expect(isReservedArtifactProperty('user_metric')).toBe(false);
+    expect(isReservedArtifactProperty('accuracy')).toBe(false);
+  });
+
+  it('returns false for display_name (filtered separately)', () => {
+    expect(isReservedArtifactProperty('display_name')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isReservedArtifactProperty('')).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isReservedArtifactProperty(undefined)).toBe(false);
+  });
+
+  it('is case-sensitive', () => {
+    expect(isReservedArtifactProperty('STORE_SESSION_INFO')).toBe(false);
+    expect(isReservedArtifactProperty('Store_Session_Info')).toBe(false);
+  });
+});

--- a/frontend/src/lib/ReservedArtifactProperties.ts
+++ b/frontend/src/lib/ReservedArtifactProperties.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Internal artifact custom-property keys that should not be rendered as user content. */
+export const RESERVED_ARTIFACT_CUSTOM_PROPERTIES: ReadonlySet<string> = new Set([
+  'store_session_info',
+]);
+
+/** Returns true if the key is an internal/reserved artifact custom property. */
+export function isReservedArtifactProperty(key?: string): boolean {
+  return !!key && RESERVED_ARTIFACT_CUSTOM_PROPERTIES.has(key);
+}

--- a/frontend/src/lib/v2/CompareUtils.test.ts
+++ b/frontend/src/lib/v2/CompareUtils.test.ts
@@ -360,4 +360,36 @@ describe('CompareUtils', () => {
       ],
     });
   });
+
+  it('Scalar metrics table omits reserved artifact custom properties', () => {
+    // Build an artifact with display_name, a real metric, and store_session_info
+    const artifact = new Artifact();
+    artifact.setId(10);
+    const customPropertiesMap: jspb.Map<string, Value> = jspb.Map.fromObject([], null, null);
+    customPropertiesMap.set('display_name', new Value().setStringValue('metrics'));
+    customPropertiesMap.set('accuracy', new Value().setDoubleValue(0.95));
+    customPropertiesMap.set('store_session_info', new Value().setStringValue('internal-data'));
+    vi.spyOn(artifact, 'getCustomPropertiesMap').mockReturnValue(customPropertiesMap);
+
+    const event = newMockEvent(10, 1, 'artifact1');
+    const linkedArtifact: LinkedArtifact = { artifact, event };
+
+    const scalarMetricsArtifacts: RunArtifact[] = [
+      {
+        run: { run_id: '1', display_name: 'run1' },
+        executionArtifacts: [
+          {
+            execution: newMockExecution(1, 'execution1'),
+            linkedArtifacts: [linkedArtifact],
+          },
+        ],
+      },
+    ];
+
+    const result = getScalarTableProps(scalarMetricsArtifacts, 1);
+    expect(result).toBeDefined();
+    expect(result!.yLabels).toContain('accuracy');
+    expect(result!.yLabels).not.toContain('store_session_info');
+    expect(result!.yLabels).not.toContain('display_name');
+  });
 });

--- a/frontend/src/lib/v2/CompareUtils.ts
+++ b/frontend/src/lib/v2/CompareUtils.ts
@@ -15,6 +15,7 @@
  */
 
 import { CompareTableProps, xParentLabel } from 'src/components/CompareTable';
+import { isReservedArtifactProperty } from 'src/lib/ReservedArtifactProperties';
 import { getArtifactName, getExecutionDisplayName, LinkedArtifact } from 'src/mlmd/MlmdUtils';
 import { getMetadataValue } from 'src/mlmd/Utils';
 import { Execution, Value } from 'src/third_party/mlmd';
@@ -306,7 +307,7 @@ const addScalarDataItems = (
 ) => {
   for (const entry of customProperties.getEntryList()) {
     const scalarMetricName: string = entry[0];
-    if (scalarMetricName === 'display_name') {
+    if (scalarMetricName === 'display_name' || isReservedArtifactProperty(scalarMetricName)) {
       continue;
     }
 


### PR DESCRIPTION
**Description of your changes:**
Introduces a shared module for reserved/internal MLMD artifact custom-property keys and applies it across all generic renderers. This replaces per-component checks with a single source of truth.

### Changes

- **New:** [src/lib/ReservedArtifactProperties.ts]
     shared constant `RESERVED_ARTIFACT_CUSTOM_PROPERTIES` and helper [isReservedArtifactProperty()]

- **New:** [src/lib/ReservedArtifactProperties.test.ts]
      unit tests for the shared helper

- **Modified:** [MetricsVisualizations.tsx]
      uses shared filter in ScalarMetricsSection

- **Modified:** [ResourceInfo.tsx]
     uses shared filter in Custom Properties section

- **Modified:** [CompareUtils.ts]
      uses shared filter in scalar metrics comparison

- **Modified:** [MetricsTab.test.tsx]
     added test to verify store_session_info is filtered

### Context
PR #13098 fixed the immediate bug from #13093 by filtering `store_session_info`. This PR centralizes that logic so all generic artifact-property renderers use the same shared definition, making it easy to add new reserved keys in the future.

Fixes #13104 
