### PR TITLE
chore: upgrade golangci-lint to v2.11.3 and yapf to v0.43.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,7 +24,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10
+          version: v2.11.3
           args: --new --new-from-merge-base=origin/${{ github.base_ref || github.ref_name }}
     #- uses: pre-commit/action@v3.0.1
     #  # This is set to only run the golangci-lint pre-commit hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         name: isort
         entry: isort --profile google
   - repo: https://github.com/google/yapf
-    rev: "v0.32.0"
+    rev: "v0.43.0"
     hooks:
       - id: yapf
   - repo: https://github.com/pycqa/docformatter
@@ -57,7 +57,7 @@ repos:
 
   # Golang pre-submit hooks
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.10.1
+    rev: v2.11.3
     hooks:
       - id: golangci-lint
         name: golangci-lint


### PR DESCRIPTION
## Summary
- Upgrade `golangci-lint` from previous version to `v2.11.3` to support Go 1.26.1 — fixes the error `the Go language version used to build golangci-lint is lower than the targeted Go version`
- Update `.github/workflows/pre-commit.yml` to use the same `v2.11.3` version for CI consistency
- Upgrade `yapf` from `v0.32.0` to `v0.43.0` to remove `lib2to3` dependency, which was removed in Python 3.13
