### PR TITLE
chore: add pyproject.toml for sdk/python package (Issue #12245)

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,84 @@
+# Copyright 2018-2022 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "kfp"
+version = "2.15.2"
+description = "Kubeflow Pipelines SDK"
+readme = "README.md"
+license = { text = "Apache License 2.0" }
+authors = [{ name = "The Kubeflow Authors" }]
+requires-python = ">=3.9.0"
+dependencies = [
+    "click>=8.1.8",
+    "click-option-group==0.5.7",
+    "docstring-parser>=0.7.3,<1",
+    "google-api-core>=1.31.5,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
+    "google-auth>=1.6.1,<3",
+    "google-cloud-storage>=2.2.1,<4",
+    "kfp-pipeline-spec>=2.15.0,<3",
+    "kfp-server-api>=2.15.0,<3",
+    "kubernetes>=8.0.0,<31",
+    "protobuf>=6.31.1,<7.0",
+    "PyYAML>=5.3,<7",
+    "requests-toolbelt>=0.8.0,<2",
+    "tabulate>=0.8.6,<1",
+    "urllib3<3.0.0",
+]
+classifiers = [
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.optional-dependencies]
+kubernetes = ["kfp-kubernetes==2.15.2"]
+notebooks = ["nbclient>=0.10,<1", "ipykernel>=6,<7", "jupyter_client>=7,<9"]
+all = [
+    "docker",
+    "kfp-kubernetes==2.15.2",
+    "nbclient>=0.10,<1",
+    "ipykernel>=6,<7",
+    "jupyter_client>=7,<9",
+]
+
+[project.urls]
+Homepage = "https://github.com/kubeflow/pipelines"
+Documentation = "https://kubeflow-pipelines.readthedocs.io/en/stable/"
+"Bug Tracker" = "https://github.com/kubeflow/pipelines/issues"
+Source = "https://github.com/kubeflow/pipelines/tree/master/sdk"
+Changelog = "https://github.com/kubeflow/pipelines/blob/master/sdk/RELEASE.md"
+
+[project.scripts]
+dsl-compile = "kfp.cli.compile_:main"
+kfp = "kfp.cli.__main__:main"
+
+[tool.setuptools.packages.find]
+exclude = ["*test*"]


### PR DESCRIPTION
## Summary
Adds `pyproject.toml` for the `sdk/python` package as part of the 
migration from `setup.py` to the modern Python packaging standard.

## Changes
- Added `sdk/python/pyproject.toml` with all metadata, dependencies, 
  extras, entry points and classifiers from the existing `setup.py`

## Notes
- Version is currently hardcoded as `2.15.2` from `kfp/version.py`. 
  Happy to switch to a dynamic approach using `setuptools-scm` if preferred.
- `setup.py` is left in place intentionally — removal can follow once 
  maintainers confirm the new file works correctly.

Closes #12245