### PR TITLE
fix(frontend): add typecheck regression guard for mock-backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,6 +421,7 @@ For full integration testing against a real KFP deployment:
 - `npm run test -u` - Update Vitest snapshots
 - `npm run lint` - Run ESLint
 - `npm run typecheck` - Run TypeScript typecheck (`tsc --noEmit`)
+- `npm run typecheck:mock-backend` - Typecheck mock-backend against generated API types
 - `npm run check:react-peers` - Enforce lockfile React peer compatibility for current target (React 17 today)
 - `npm run check:react-peers:18` - Preview lockfile React peer compatibility against React 18
 - `npm run check:react-peers:19` - Preview lockfile React peer compatibility against React 19

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,6 +86,7 @@
     "lint:ui": "eslint --ext js,ts,tsx src --max-warnings=0",
     "lint:server": "eslint --ext ts server --max-warnings=0",
     "typecheck": "tsc --noEmit",
+    "typecheck:mock-backend": "tsc --noEmit -p mock-backend/tsconfig.json",
     "mock:api": "ts-node-dev -O '{\"module\": \"commonjs\"}' --project mock-backend/tsconfig.json -r tsconfig-paths/register mock-backend/mock-api-server.ts 3001",
     "mock:server": "node server/dist/server.js build",
     "mock:server:inspect": "node inspect server/dist/server.js build",
@@ -110,7 +111,7 @@
     "visual:diff": "node scripts/visual-compare.mjs diff --baseline-dir .visual/baseline --current-dir .visual/current --diff-dir .visual/diff --report .visual/report.html",
     "test:server:coverage": "cd ./server && npm test -- --coverage && cd ..",
     "test:coverage": "npm run test:ui:coverage && npm run test:server:coverage",
-    "test:ci": "export CI=true && npm run format:check && npm run lint && npm run typecheck && npm run check:react-peers && npm run test:coverage",
+    "test:ci": "export CI=true && npm run format:check && npm run lint && npm run typecheck && npm run typecheck:mock-backend && npm run check:react-peers && npm run test:coverage",
     "storybook": "storybook dev -p 6006",
     "build:storybook": "storybook build"
   },


### PR DESCRIPTION

**Description of your changes:**
Wire `tsc --noEmit` against the mock-backend tsconfig into `test:ci` so that generated enum/type drift is caught automatically instead of requiring a manual `npm run mock:api` startup.

Closes #13108

Made-with: Cursor


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
