### PR TITLE
fix(security): validate namespace in getArtifactServiceGetter to prevent SSRF (CVE-2023-6570)

### DIFF
--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -502,5 +502,11 @@ function getNamespaceFromUrl(path: string): string | undefined {
 const DUMMY_BASE_PATH = 'http://dummy-base-path';
 
 export function getArtifactServiceGetter({ serviceName, servicePort }: ArtifactsProxyConfig) {
-  return (namespace: string) => `http://${serviceName}.${namespace}:${servicePort}`;
+  return (namespace: string) => {
+    // Validate namespace to prevent SSRF attacks (CVE-2023-6570)
+    if (!isAllowedResourceName(namespace)) {
+      throw new Error(`Invalid namespace format: ${namespace}`);
+    }
+    return `http://${serviceName}.${namespace}:${servicePort}`;
+  };
 }


### PR DESCRIPTION
## Summary

- Add `isAllowedResourceName()` validation on the `namespace` parameter in `getArtifactServiceGetter()` before constructing the internal service URL
- Prevents SSRF attacks where an attacker supplies a crafted namespace to proxy requests to arbitrary internal services

## Security

| Field | Value |
|---|---|
| CVE | CVE-2023-6570 |
| Severity | High (7.7) |
| Attack vector | Malicious `namespace` query param in artifact proxy requests |
| File | `frontend/server/handlers/artifacts.ts` |

## Test plan

- [x] Supply a valid namespace (e.g. `kubeflow`) → request proceeds normally
- [x] Supply a malicious namespace (e.g. `../../etc`) → request rejected with `Invalid namespace format` error
- [x] Existing frontend server unit tests pass