### PR TITLE
feat(frontend/backend): Add Pod Status tab with real-time pod lifecycle visibility

### DIFF
--- a/backend/src/apiserver/model/task.go
+++ b/backend/src/apiserver/model/task.go
@@ -44,6 +44,45 @@ type Task struct {
 	StateHistory       []*RuntimeStatus `gorm:"-;"`
 	ChildrenPods       []string         `gorm:"-;"`
 	Payload            LargeText        `gorm:"column:Payload; default:null;"`
+	// PodStatus stores the last known pod status for debugging even after pod termination.
+	PodStatusString LargeText  `gorm:"column:PodStatus; default:null;"`
+	PodStatus       *PodStatus `gorm:"-;"`
+	// PodEvents stores the pod events for debugging even after pod termination.
+	PodEventsString LargeText   `gorm:"column:PodEvents; default:null;"`
+	PodEvents       []*PodEvent `gorm:"-;"`
+}
+
+// PodStatus represents the status of a Kubernetes pod.
+type PodStatus struct {
+	Phase             string             `json:"phase"`
+	Message           string             `json:"message"`
+	Reason            string             `json:"reason"`
+	PodIP             string             `json:"podIP"`
+	NodeName          string             `json:"nodeName"`
+	LastUpdated       int64              `json:"lastUpdated"`
+	ContainerStatuses []*ContainerStatus `json:"containerStatuses"`
+}
+
+// ContainerStatus represents the status of a container in a pod.
+type ContainerStatus struct {
+	Name         string `json:"name"`
+	Ready        bool   `json:"ready"`
+	RestartCount int32  `json:"restartCount"`
+	State        string `json:"state"`
+	Reason       string `json:"reason"`
+	Message      string `json:"message"`
+	ExitCode     int32  `json:"exitCode"`
+}
+
+// PodEvent represents a Kubernetes event associated with a pod.
+type PodEvent struct {
+	Type           string `json:"type"`
+	Reason         string `json:"reason"`
+	Message        string `json:"message"`
+	FirstTimestamp int64  `json:"firstTimestamp"`
+	LastTimestamp  int64  `json:"lastTimestamp"`
+	Count          int32  `json:"count"`
+	Source         string `json:"source"`
 }
 
 func (t Task) ToString() string {

--- a/backend/src/apiserver/storage/task_store.go
+++ b/backend/src/apiserver/storage/task_store.go
@@ -46,6 +46,8 @@ var taskColumns = []string{
 	"MLMDInputs",
 	"MLMDOutputs",
 	"ChildrenPods",
+	"PodStatus",
+	"PodEvents",
 }
 
 var taskColumnsWithPayload = append(taskColumns, "Payload")
@@ -112,6 +114,20 @@ func (s *TaskStore) CreateTask(task *model.Task) (*model.Task, error) {
 		return nil, util.NewInternalServerError(err, "Failed to marshal children pods in a new run")
 	}
 
+	podStatusString := ""
+	if newTask.PodStatus != nil {
+		if status, err := json.Marshal(newTask.PodStatus); err == nil {
+			podStatusString = string(status)
+		}
+	}
+
+	podEventsString := ""
+	if len(newTask.PodEvents) > 0 {
+		if events, err := json.Marshal(newTask.PodEvents); err == nil {
+			podEventsString = string(events)
+		}
+	}
+
 	sql, args, err := sq.
 		Insert(table_name).
 		SetMap(
@@ -133,6 +149,8 @@ func (s *TaskStore) CreateTask(task *model.Task) (*model.Task, error) {
 				"MLMDInputs":        newTask.MLMDInputs,
 				"MLMDOutputs":       newTask.MLMDOutputs,
 				"ChildrenPods":      childrenPodsString,
+				"PodStatus":         podStatusString,
+				"PodEvents":         podEventsString,
 				"Payload":           newTask.ToString(),
 			},
 		).
@@ -153,7 +171,7 @@ func (s *TaskStore) scanRows(rows *sql.Rows) ([]*model.Task, error) {
 	var tasks []*model.Task
 	for rows.Next() {
 		var uuid, namespace, pipelineName, runUUID, podName, mlmdExecutionID, fingerprint string
-		var name, parentTaskId, state, stateHistory, inputs, outputs, children sql.NullString
+		var name, parentTaskID, state, stateHistory, inputs, outputs, children, podStatus, podEvents sql.NullString
 		var createdTimestamp, startedTimestamp, finishedTimestamp sql.NullInt64
 		err := rows.Scan(
 			&uuid,
@@ -167,12 +185,14 @@ func (s *TaskStore) scanRows(rows *sql.Rows) ([]*model.Task, error) {
 			&finishedTimestamp,
 			&fingerprint,
 			&name,
-			&parentTaskId,
+			&parentTaskID,
 			&state,
 			&stateHistory,
 			&inputs,
 			&outputs,
 			&children,
+			&podStatus,
+			&podEvents,
 		)
 		if err != nil {
 			fmt.Printf("scan error is %v", err)
@@ -186,6 +206,14 @@ func (s *TaskStore) scanRows(rows *sql.Rows) ([]*model.Task, error) {
 		if children.Valid {
 			json.Unmarshal([]byte(children.String), &childrenPods)
 		}
+		var podStatusParsed *model.PodStatus
+		if podStatus.Valid && podStatus.String != "" {
+			json.Unmarshal([]byte(podStatus.String), &podStatusParsed)
+		}
+		var podEventsParsed []*model.PodEvent
+		if podEvents.Valid && podEvents.String != "" {
+			json.Unmarshal([]byte(podEvents.String), &podEventsParsed)
+		}
 		task := &model.Task{
 			UUID:              uuid,
 			Namespace:         namespace,
@@ -198,11 +226,13 @@ func (s *TaskStore) scanRows(rows *sql.Rows) ([]*model.Task, error) {
 			FinishedTimestamp: finishedTimestamp.Int64,
 			Fingerprint:       fingerprint,
 			Name:              name.String,
-			ParentTaskId:      parentTaskId.String,
+			ParentTaskId:      parentTaskID.String,
 			StateHistory:      stateHistoryNew,
 			MLMDInputs:        model.LargeText(inputs.String),
 			MLMDOutputs:       model.LargeText(outputs.String),
 			ChildrenPods:      childrenPods,
+			PodStatus:         podStatusParsed,
+			PodEvents:         podEventsParsed,
 		}
 		tasks = append(tasks, task)
 	}
@@ -379,6 +409,18 @@ func (s *TaskStore) CreateOrUpdateTasks(tasks []*model.Task, runID string) ([]*m
 				}
 				stateHistoryString = string(history)
 			}
+			podStatusString := ""
+			if t.PodStatus != nil {
+				if status, err := json.Marshal(t.PodStatus); err == nil {
+					podStatusString = string(status)
+				}
+			}
+			podEventsString := ""
+			if len(t.PodEvents) > 0 {
+				if events, err := json.Marshal(t.PodEvents); err == nil {
+					podEventsString = string(events)
+				}
+			}
 			sqlInsert = sqlInsert.Values(
 				t.UUID,
 				t.Namespace,
@@ -397,6 +439,8 @@ func (s *TaskStore) CreateOrUpdateTasks(tasks []*model.Task, runID string) ([]*m
 				t.MLMDInputs,
 				t.MLMDOutputs,
 				childrenPodsString,
+				podStatusString,
+				podEventsString,
 				t.ToString(),
 			)
 		}
@@ -490,4 +534,46 @@ func patchTask(original *model.Task, patch *model.Task) {
 	if len(original.ChildrenPods) == 0 {
 		original.ChildrenPods = patch.ChildrenPods
 	}
+	// For PodStatus, always take the newest non-nil value.
+	if patch.PodStatus != nil {
+		original.PodStatus = patch.PodStatus
+	}
+	// For PodEvents, merge and deduplicate so events accumulate over time.
+	if len(patch.PodEvents) > 0 {
+		original.PodEvents = mergePodEvents(original.PodEvents, patch.PodEvents)
+	}
+}
+
+// mergePodEvents merges two slices of pod events, deduplicating by event identity
+// (type + reason + message + firstTimestamp).
+func mergePodEvents(existing []*model.PodEvent, incoming []*model.PodEvent) []*model.PodEvent {
+	if len(existing) == 0 {
+		return incoming
+	}
+	if len(incoming) == 0 {
+		return existing
+	}
+
+	type eventKey struct {
+		Type           string
+		Reason         string
+		Message        string
+		FirstTimestamp int64
+	}
+
+	seen := make(map[eventKey]struct{}, len(existing))
+	for _, evt := range existing {
+		seen[eventKey{evt.Type, evt.Reason, evt.Message, evt.FirstTimestamp}] = struct{}{}
+	}
+
+	merged := existing
+	for _, evt := range incoming {
+		key := eventKey{evt.Type, evt.Reason, evt.Message, evt.FirstTimestamp}
+		if _, found := seen[key]; !found {
+			merged = append(merged, evt)
+			seen[key] = struct{}{}
+		}
+	}
+
+	return merged
 }

--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -477,6 +477,7 @@ const (
 	paramComponent               = "component"      // component spec
 	paramTask                    = "task"           // task spec
 	paramTaskName                = "task-name"      // task name
+	paramTaskPath                = "task-path"      // full task path including parent DAG names (e.g., "root.for-loop-1.process-item")
 	paramContainer               = "container"      // container spec
 	paramImporter                = "importer"       // importer spec
 	paramRuntimeConfig           = "runtime-config" // job runtime config, pipeline level inputs

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -91,6 +91,7 @@ type containerDriverInputs struct {
 	component        string
 	task             string
 	taskName         string // preserve the original task name for input resolving
+	taskPath         string // full task path including parent DAG names (e.g., "root.for-loop-1.process-item")
 	container        string
 	parentDagID      string
 	iterationIndex   string // optional, when this is an iteration task
@@ -174,6 +175,12 @@ func (c *workflowCompiler) containerDriverTask(name string, inputs containerDriv
 			wfapi.Parameter{Name: paramKubernetesConfig, Value: wfapi.AnyStringPtr(inputs.kubernetesConfig)},
 		)
 	}
+	if inputs.taskPath != "" {
+		dagTask.Arguments.Parameters = append(
+			dagTask.Arguments.Parameters,
+			wfapi.Parameter{Name: paramTaskPath, Value: wfapi.AnyStringPtr(inputs.taskPath)},
+		)
+	}
 	outputs := &containerDriverOutputs{
 		podSpecPatch: taskOutputParameter(name, paramPodSpecPatch),
 		cached:       taskOutputParameter(name, paramCachedDecision),
@@ -248,12 +255,23 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 
 	template := &wfapi.Template{
 		Name: name,
+		Metadata: wfapi.Metadata{
+			Labels: map[string]string{
+				// Simple task name for backward compatibility (max 63 chars for K8s labels)
+				"pipelines.kubeflow.org/task_name": inputParameter(paramTaskName),
+			},
+			Annotations: map[string]string{
+				// Full task path for sub-DAG differentiation (no length limit)
+				"pipelines.kubeflow.org/task_path": inputParameter(paramTaskPath),
+			},
+		},
 		Inputs: wfapi.Inputs{
 			Parameters: []wfapi.Parameter{
 				{Name: paramComponent},
 				{Name: paramTask},
 				{Name: paramContainer},
 				{Name: paramTaskName},
+				{Name: paramTaskPath, Default: wfapi.AnyStringPtr("")},
 				{Name: paramParentDagID},
 				{Name: paramIterationIndex, Default: wfapi.AnyStringPtr("-1")},
 				{Name: paramKubernetesConfig, Default: wfapi.AnyStringPtr("")},
@@ -295,6 +313,10 @@ type containerExecutorInputs struct {
 	exitTemplate string
 	// this will be provided as the parent-dag-id input to the Argo Workflow exit lifecycle hook.
 	hookParentDagID string
+	// taskName is the simple task name for pod labeling (max 63 chars for K8s labels)
+	taskName string
+	// taskPath is the full task path for sub-DAG differentiation (no length limit for annotations)
+	taskPath string
 }
 
 // containerExecutorTask returns an argo workflows DAGTask.
@@ -336,6 +358,14 @@ func (c *workflowCompiler) containerExecutorTask(name string, inputs containerEx
 						Name:    paramCachedDecision,
 						Value:   wfapi.AnyStringPtr(inputs.cachedDecision),
 						Default: wfapi.AnyStringPtr("false"),
+					},
+					{
+						Name:  paramTaskName,
+						Value: wfapi.AnyStringPtr(inputs.taskName),
+					},
+					{
+						Name:  paramTaskPath,
+						Value: wfapi.AnyStringPtr(inputs.taskPath),
 					},
 				},
 				append(
@@ -398,6 +428,14 @@ func (c *workflowCompiler) addContainerExecutorTemplate(task *pipelinespec.Pipel
 						Name:    paramCachedDecision,
 						Default: wfapi.AnyStringPtr("false"),
 					},
+					{
+						Name:    paramTaskName,
+						Default: wfapi.AnyStringPtr(""),
+					},
+					{
+						Name:    paramTaskPath,
+						Default: wfapi.AnyStringPtr(""),
+					},
 				},
 				append(
 					c.getPodMetadataParameters(k8sExecCfg.GetPodMetadata(), false),
@@ -413,6 +451,14 @@ func (c *workflowCompiler) addContainerExecutorTemplate(task *pipelinespec.Pipel
 							{
 								Name:  paramPodSpecPatch,
 								Value: wfapi.AnyStringPtr(inputParameter(paramPodSpecPatch)),
+							},
+							{
+								Name:  paramTaskName,
+								Value: wfapi.AnyStringPtr(inputParameter(paramTaskName)),
+							},
+							{
+								Name:  paramTaskPath,
+								Value: wfapi.AnyStringPtr(inputParameter(paramTaskPath)),
 							},
 						},
 						append(
@@ -444,11 +490,29 @@ func (c *workflowCompiler) addContainerExecutorTemplate(task *pipelinespec.Pipel
 	}
 	executor := &wfapi.Template{
 		Name: nameContainerImpl,
+		Metadata: wfapi.Metadata{
+			Labels: map[string]string{
+				// Simple task name for backward compatibility (max 63 chars for K8s labels)
+				"pipelines.kubeflow.org/task_name": inputParameter(paramTaskName),
+			},
+			Annotations: map[string]string{
+				// Full task path for sub-DAG differentiation (no length limit)
+				"pipelines.kubeflow.org/task_path": inputParameter(paramTaskPath),
+			},
+		},
 		Inputs: wfapi.Inputs{
 			Parameters: append(
 				[]wfapi.Parameter{
 					{
 						Name: paramPodSpecPatch,
+					},
+					{
+						Name:    paramTaskName,
+						Default: wfapi.AnyStringPtr(""),
+					},
+					{
+						Name:    paramTaskPath,
+						Default: wfapi.AnyStringPtr(""),
 					},
 				},
 				append(

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -74,7 +74,8 @@ func (c *workflowCompiler) DAG(name string, componentSpec *pipelinespec.Componen
 		}
 
 		tasks, err := c.task(taskName, kfpTask, taskInputs{
-			parentDagID: inputParameter(paramParentDagID),
+			parentDagID:   inputParameter(paramParentDagID),
+			parentDagName: name,
 		})
 		if err != nil {
 			return err
@@ -128,7 +129,7 @@ func (c *workflowCompiler) DAG(name string, componentSpec *pipelinespec.Componen
 		exitTemplate := taskToExitTemplate[taskName]
 
 		tasks, err := c.task(
-			taskName, kfpTask, taskInputs{parentDagID: inputParameter(paramParentDagID), exitTemplate: exitTemplate},
+			taskName, kfpTask, taskInputs{parentDagID: inputParameter(paramParentDagID), exitTemplate: exitTemplate, parentDagName: name},
 		)
 		if err != nil {
 			return err
@@ -216,6 +217,9 @@ type taskInputs struct {
 	// if provided, this will be the template the Argo Workflow exit lifecycle hook will execute.
 	exitTemplate string
 	taskName     string
+	// parentDagName is the name of the parent DAG, used to construct the full task path for pod labeling.
+	// For root-level tasks, this is "root". For sub-DAG tasks, this is the sub-DAG name.
+	parentDagName string
 }
 
 // parentDagID: placeholder for parent DAG execution ID
@@ -238,11 +242,17 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 	if err != nil {
 		return nil, err
 	}
+	// Construct full task path for pod labeling.
+	// Root-level tasks keep simple names; sub-DAG tasks get full path.
+	taskPath := name
+	if inputs.parentDagName != "" && inputs.parentDagName != "root" {
+		taskPath = "root." + inputs.parentDagName + "." + name
+	}
 	// For iterator task, we need to use argo withSequence to iterate.
 	isIteratorTask := inputs.iterationIndex == "" &&
 		(task.GetParameterIterator() != nil || task.GetArtifactIterator() != nil)
 	if isIteratorTask {
-		return c.iteratorTask(name, task, taskSpecJson, inputs.parentDagID)
+		return c.iteratorTask(name, task, taskSpecJson, inputs.parentDagID, inputs.parentDagName)
 	}
 	switch impl := componentSpec.GetImplementation().(type) {
 	case *pipelinespec.ComponentSpec_Dag:
@@ -258,6 +268,7 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 			task:           taskSpecJson,
 			iterationIndex: inputs.iterationIndex,
 			taskName:       effectiveTaskName,
+			taskPath:       taskPath,
 		})
 		if err != nil {
 			return nil, err
@@ -305,6 +316,7 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 				iterationIndex:   inputs.iterationIndex,
 				kubernetesConfig: kubernetesConfigPlaceholder,
 				taskName:         effectiveTaskName,
+				taskPath:         taskPath,
 			})
 			if task.GetTriggerPolicy().GetCondition() == "" {
 				driverOutputs.condition = ""
@@ -327,6 +339,8 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 				condition:       driverOutputs.condition,
 				exitTemplate:    inputs.exitTemplate,
 				hookParentDagID: inputs.parentDagID,
+				taskName:        name,
+				taskPath:        taskPath,
 			}, task)
 			if err != nil {
 				return nil, fmt.Errorf("error creating executor for %q: %v", name, err)
@@ -356,7 +370,7 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 	}
 }
 
-func (c *workflowCompiler) iteratorTask(name string, task *pipelinespec.PipelineTaskSpec, taskJSON string, parentDagID string) (tasks []wfapi.DAGTask, err error) {
+func (c *workflowCompiler) iteratorTask(name string, task *pipelinespec.PipelineTaskSpec, taskJSON string, parentDagID string, parentDagName string) (tasks []wfapi.DAGTask, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("iterator task: %w", err)
@@ -364,7 +378,8 @@ func (c *workflowCompiler) iteratorTask(name string, task *pipelinespec.Pipeline
 	}()
 	componentName := task.GetComponentRef().GetName()
 	// Set up Loop Control Template
-	iteratorTasks, err := c.iterationItemTask("iteration", task, taskJSON, parentDagID, name)
+	// Pass the iterator task name as the parent DAG name for iteration items
+	iteratorTasks, err := c.iterationItemTask("iteration", task, taskJSON, parentDagID, name, parentDagName)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +421,7 @@ func (c *workflowCompiler) iteratorTask(name string, task *pipelinespec.Pipeline
 	return tasks, nil
 }
 
-func (c *workflowCompiler) iterationItemTask(name string, task *pipelinespec.PipelineTaskSpec, taskJSON string, parentDagID string, parallelForTaskKey string) (tasks []wfapi.DAGTask, err error) {
+func (c *workflowCompiler) iterationItemTask(name string, task *pipelinespec.PipelineTaskSpec, taskJSON string, parentDagID string, parallelForTaskKey string, grandParentDagName string) (tasks []wfapi.DAGTask, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("iterationItem task: %w", err)
@@ -431,6 +446,14 @@ func (c *workflowCompiler) iterationItemTask(name string, task *pipelinespec.Pip
 		return nil, err
 	}
 
+	// Construct the parent DAG name for iteration items.
+	// For iteration tasks, the parent is the iterator (e.g., "for-loop-1").
+	// If the iterator itself is nested, include the grandparent path.
+	iterationParentDagName := parallelForTaskKey
+	if grandParentDagName != "" && grandParentDagName != "root" {
+		iterationParentDagName = grandParentDagName + "." + parallelForTaskKey
+	}
+
 	iterationCount := intstr.FromString(driverOutputs.iterationCount)
 	iterationTasks, err := c.task(
 		"iteration-item",
@@ -439,6 +462,7 @@ func (c *workflowCompiler) iterationItemTask(name string, task *pipelinespec.Pip
 			parentDagID:    inputParameter(paramParentDagID),
 			iterationIndex: inputParameter(paramIterationIndex),
 			taskName:       parallelForTaskKey,
+			parentDagName:  iterationParentDagName,
 		},
 	)
 	if err != nil {
@@ -497,6 +521,7 @@ type dagDriverInputs struct {
 	component      string                                  // input placeholder for component spec
 	task           string                                  // optional, the root DAG does not have task spec.
 	taskName       string                                  // optional, the name of the task, used for input resolving
+	taskPath       string                                  // optional, full task path including parent DAG names (e.g., "root.for-loop-1.process-item")
 	runtimeConfig  *pipelinespec.PipelineJob_RuntimeConfig // optional, only root DAG needs this
 	iterationIndex string                                  // optional, iterator passes iteration index to iteration tasks
 }
@@ -545,6 +570,12 @@ func (c *workflowCompiler) dagDriverTask(name string, inputs dagDriverInputs) (*
 		params = append(params, wfapi.Parameter{
 			Name:  paramTaskName,
 			Value: wfapi.AnyStringPtr(inputs.taskName),
+		})
+	}
+	if inputs.taskPath != "" {
+		params = append(params, wfapi.Parameter{
+			Name:  paramTaskPath,
+			Value: wfapi.AnyStringPtr(inputs.taskPath),
 		})
 	}
 	t := &wfapi.DAGTask{
@@ -617,12 +648,23 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 
 	template := &wfapi.Template{
 		Name: name,
+		Metadata: wfapi.Metadata{
+			Labels: map[string]string{
+				// Simple task name for backward compatibility (max 63 chars for K8s labels)
+				"pipelines.kubeflow.org/task_name": inputParameter(paramTaskName),
+			},
+			Annotations: map[string]string{
+				// Full task path for sub-DAG differentiation (no length limit)
+				"pipelines.kubeflow.org/task_path": inputParameter(paramTaskPath),
+			},
+		},
 		Inputs: wfapi.Inputs{
 			Parameters: []wfapi.Parameter{
 				{Name: paramComponent}, // Required.
 				{Name: paramRuntimeConfig, Default: wfapi.AnyStringPtr("")},
 				{Name: paramTask, Default: wfapi.AnyStringPtr("")},
 				{Name: paramTaskName, Default: wfapi.AnyStringPtr("")},
+				{Name: paramTaskPath, Default: wfapi.AnyStringPtr("")},
 				{Name: paramParentDagID, Default: wfapi.AnyStringPtr("0")},
 				{Name: paramIterationIndex, Default: wfapi.AnyStringPtr("-1")},
 				{Name: paramDriverType, Default: wfapi.AnyStringPtr("DAG")},

--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -489,6 +489,126 @@ describe('UIServer apis', () => {
     });
   });
 
+  describe('/k8s/pods/byRunId', () => {
+    let request: requests.SuperTest<requests.Test>;
+    beforeEach(() => {
+      app = new UIServer(loadConfigs(argv, {}));
+      request = requests(app.app);
+    });
+
+    it('asks for runid if not provided', async () => {
+      await request.get('/k8s/pods/byRunId').expect(422, 'runid argument is required');
+    });
+
+    it('asks for podnamespace if not provided', async () => {
+      await request
+        .get('/k8s/pods/byRunId?runid=test-run')
+        .expect(422, 'podnamespace argument is required');
+    });
+
+    it('responds with pod list in JSON', async () => {
+      const listPodSpy = vi.spyOn(K8S_TEST_EXPORT.k8sV1Client, 'listNamespacedPod');
+      listPodSpy.mockImplementation(() =>
+        Promise.resolve({
+          body: {
+            items: [{ metadata: { name: 'test-pod', namespace: 'test-ns' } }],
+          },
+        } as any),
+      );
+      await request.get('/k8s/pods/byRunId?runid=test-run&podnamespace=test-ns').expect(200);
+    });
+  });
+
+  describe('/k8s/pods/byRunId with authorization enabled', () => {
+    let authServer: Server;
+    const authPort = 3010;
+
+    beforeEach(async () => {
+      authServer = await new Promise<Server>((resolve) => {
+        const server = express()
+          .post('/apis/v1beta1/auth', (_, res) => {
+            res.status(401).send('Unauthorized');
+          })
+          .listen(authPort, () => resolve(server));
+      });
+
+      app = new UIServer(
+        loadConfigs(argv, {
+          ENABLE_AUTHZ: 'true',
+          ML_PIPELINE_SERVICE_PORT: `${authPort}`,
+          ML_PIPELINE_SERVICE_HOST: 'localhost',
+        }),
+      );
+    });
+
+    afterEach(async () => {
+      if (authServer) {
+        await new Promise<void>((resolve) => authServer.close(() => resolve()));
+      }
+    });
+
+    it('responds with 403 when authorization is rejected', async () => {
+      const authRequest = requests(app.app);
+      await authRequest
+        .get('/k8s/pods/byRunId?runid=test-run&podnamespace=test-ns')
+        .expect(403, 'Access denied to namespace');
+    });
+  });
+
+  describe('/k8s/pod/cached', () => {
+    let request: requests.SuperTest<requests.Test>;
+    beforeEach(() => {
+      app = new UIServer(loadConfigs(argv, {}));
+      request = requests(app.app);
+    });
+
+    it('asks for podnamespace if not provided', async () => {
+      await request.get('/k8s/pod/cached').expect(422, 'podnamespace argument is required');
+    });
+
+    it('asks for podname or runid if neither provided', async () => {
+      await request
+        .get('/k8s/pod/cached?podnamespace=test-ns')
+        .expect(422, 'Either podname or runid argument is required');
+    });
+  });
+
+  describe('/k8s/pod/cached with authorization enabled', () => {
+    let authServer: Server;
+    const authPort = 3011;
+
+    beforeEach(async () => {
+      authServer = await new Promise<Server>((resolve) => {
+        const server = express()
+          .post('/apis/v1beta1/auth', (_, res) => {
+            res.status(401).send('Unauthorized');
+          })
+          .listen(authPort, () => resolve(server));
+      });
+
+      app = new UIServer(
+        loadConfigs(argv, {
+          ENABLE_AUTHZ: 'true',
+          ML_PIPELINE_SERVICE_PORT: `${authPort}`,
+          ML_PIPELINE_SERVICE_HOST: 'localhost',
+        }),
+      );
+    });
+
+    afterEach(async () => {
+      if (authServer) {
+        await new Promise<void>((resolve) => authServer.close(() => resolve()));
+      }
+    });
+
+    it('responds with 403 when authorization is rejected', async () => {
+      const authRequest = requests(app.app);
+      await authRequest
+        .get('/k8s/pod/cached?podnamespace=test-ns&podname=test-pod')
+        .expect(403, 'Access denied to namespace');
+    });
+  });
+
   describe('/k8s/pod/logs', () => {
     let request: requests.SuperTest<requests.Test>;
     beforeEach(() => {

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -312,9 +312,12 @@ function createUIServer(options: UIConfigs) {
   }
 
   /** Pod info */
-  const { podInfoHandler, podEventsHandler } = getPodInfoHandlers(authorizeFn);
+  const { podInfoHandler, podEventsHandler, podsByRunIdHandler, cachedPodInfoHandler } =
+    getPodInfoHandlers(authorizeFn);
   registerHandler(app.get, '/k8s/pod', podInfoHandler);
   registerHandler(app.get, '/k8s/pod/events', podEventsHandler);
+  registerHandler(app.get, '/k8s/pods/byRunId', podsByRunIdHandler);
+  registerHandler(app.get, '/k8s/pod/cached', cachedPodInfoHandler);
 
   /** Cluster metadata (GKE only) */
   registerHandler(app.get, '/system/cluster-name', getClusterNameHandler(options.gkeMetadata));

--- a/frontend/server/handlers/pod-info.ts
+++ b/frontend/server/handlers/pod-info.ts
@@ -14,6 +14,7 @@
 
 import { Handler } from 'express';
 import * as k8sHelper from '../k8s-helper.js';
+import * as podEventsCache from '../pod-events-cache.js';
 import {
   AuthorizeRequestResources,
   AuthorizeRequestVerb,
@@ -21,55 +22,10 @@ import {
 import { AuthorizeFn } from '../helpers/auth.js';
 
 /**
- * Get pod info handlers.
+ * Get pod info handlers with authorization.
  */
 export function getPodInfoHandlers(authorizeFn: AuthorizeFn) {
-  const podInfoHandler: Handler = async (req, res) => {
-    const { podname, podnamespace } = req.query;
-    if (!podname) {
-      // 422 status code "Unprocessable entity", refer to https://stackoverflow.com/a/42171674
-      res.status(422).send('podname argument is required');
-      return;
-    }
-    if (!podnamespace) {
-      res.status(422).send('podnamespace argument is required');
-      return;
-    }
-
-    // Check access to namespace
-    try {
-      const authError = await authorizeFn(
-        {
-          verb: AuthorizeRequestVerb.GET,
-          resources: AuthorizeRequestResources.VIEWERS,
-          namespace: podnamespace as string,
-        },
-        req,
-      );
-      if (authError) {
-        res.status(403).send('Access denied to namespace');
-        return;
-      }
-    } catch (error) {
-      console.error('Authorization error:', error);
-      res.status(500).send('Authorization check failed');
-      return;
-    }
-
-    const podName = decodeURIComponent(podname as string);
-    const podNamespace = decodeURIComponent(podnamespace as string);
-
-    const [pod, err] = await k8sHelper.getPod(podName, podNamespace);
-    if (err) {
-      const { message, additionalInfo } = err;
-      console.error(message, additionalInfo);
-      res.status(500).send(message);
-      return;
-    }
-    res.status(200).send(JSON.stringify(pod));
-  };
-
-  const podEventsHandler: Handler = async (req, res) => {
+  const authedPodInfoHandler: Handler = async (req, res) => {
     const { podname, podnamespace } = req.query;
     if (!podname) {
       res.status(422).send('podname argument is required');
@@ -100,18 +56,509 @@ export function getPodInfoHandlers(authorizeFn: AuthorizeFn) {
       return;
     }
 
-    const podName = decodeURIComponent(podname as string);
-    const podNamespace = decodeURIComponent(podnamespace as string);
-
-    const [eventList, err] = await k8sHelper.listPodEvents(podName, podNamespace);
-    if (err) {
-      const { message, additionalInfo } = err;
-      console.error(message, additionalInfo);
-      res.status(500).send(message);
-      return;
-    }
-    res.status(200).send(JSON.stringify(eventList));
+    // Delegate to the main podInfoHandler
+    return podInfoHandler(req, res, () => {});
   };
 
-  return { podInfoHandler, podEventsHandler };
+  const authedPodEventsHandler: Handler = async (req, res) => {
+    const { podname, podnamespace } = req.query;
+    if (!podname) {
+      res.status(422).send('podname argument is required');
+      return;
+    }
+    if (!podnamespace) {
+      res.status(422).send('podnamespace argument is required');
+      return;
+    }
+
+    // Check access to namespace
+    try {
+      const authError = await authorizeFn(
+        {
+          verb: AuthorizeRequestVerb.GET,
+          resources: AuthorizeRequestResources.VIEWERS,
+          namespace: podnamespace as string,
+        },
+        req,
+      );
+      if (authError) {
+        res.status(403).send('Access denied to namespace');
+        return;
+      }
+    } catch (error) {
+      console.error('Authorization error:', error);
+      res.status(500).send('Authorization check failed');
+      return;
+    }
+
+    // Delegate to the main podEventsHandler
+    return podEventsHandler(req, res, () => {});
+  };
+
+  const authedPodsByRunIdHandler: Handler = async (req, res) => {
+    const { runid, podnamespace } = req.query;
+    if (!runid) {
+      res.status(422).send('runid argument is required');
+      return;
+    }
+    if (!podnamespace) {
+      res.status(422).send('podnamespace argument is required');
+      return;
+    }
+
+    try {
+      const authError = await authorizeFn(
+        {
+          verb: AuthorizeRequestVerb.GET,
+          resources: AuthorizeRequestResources.VIEWERS,
+          namespace: podnamespace as string,
+        },
+        req,
+      );
+      if (authError) {
+        res.status(403).send('Access denied to namespace');
+        return;
+      }
+    } catch (error) {
+      console.error('Authorization error:', error);
+      res.status(500).send('Authorization check failed');
+      return;
+    }
+
+    return podsByRunIdHandler(req, res, () => {});
+  };
+
+  const authedCachedPodInfoHandler: Handler = async (req, res) => {
+    const { podnamespace } = req.query;
+    if (!podnamespace) {
+      res.status(422).send('podnamespace argument is required');
+      return;
+    }
+
+    try {
+      const authError = await authorizeFn(
+        {
+          verb: AuthorizeRequestVerb.GET,
+          resources: AuthorizeRequestResources.VIEWERS,
+          namespace: podnamespace as string,
+        },
+        req,
+      );
+      if (authError) {
+        res.status(403).send('Access denied to namespace');
+        return;
+      }
+    } catch (error) {
+      console.error('Authorization error:', error);
+      res.status(500).send('Authorization check failed');
+      return;
+    }
+
+    return cachedPodInfoHandler(req, res, () => {});
+  };
+
+  return {
+    podInfoHandler: authedPodInfoHandler,
+    podEventsHandler: authedPodEventsHandler,
+    podsByRunIdHandler: authedPodsByRunIdHandler,
+    cachedPodInfoHandler: authedCachedPodInfoHandler,
+  };
 }
+
+// Helper to extract pod status from K8s pod object
+function extractPodStatus(pod: any): any | null {
+  if (!pod || !pod.status) return null;
+
+  const parseContainerStatus = (cs: any) => ({
+    name: cs.name,
+    ready: cs.ready,
+    restartCount: cs.restartCount,
+    state: cs.state ? Object.keys(cs.state)[0] : undefined,
+    reason: cs.state?.waiting?.reason || cs.state?.terminated?.reason,
+    message: cs.state?.waiting?.message || cs.state?.terminated?.message,
+    exitCode: cs.state?.terminated?.exitCode,
+  });
+
+  const containerStatuses = (pod.status.containerStatuses || []).map(parseContainerStatus);
+  const initContainerStatuses = (pod.status.initContainerStatuses || []).map(parseContainerStatus);
+
+  return {
+    phase: pod.status.phase,
+    message: pod.status.message,
+    reason: pod.status.reason,
+    podIP: pod.status.podIP,
+    nodeName: pod.spec?.nodeName,
+    lastUpdated: Date.now(),
+    containerStatuses: [...initContainerStatuses, ...containerStatuses],
+  };
+}
+
+// Helper to extract events from K8s event list
+function extractEvents(eventList: any): any[] {
+  if (!eventList || !eventList.items) return [];
+
+  return eventList.items.map((event: any) => ({
+    type: event.type,
+    reason: event.reason,
+    message: event.message,
+    firstTimestamp: event.firstTimestamp,
+    lastTimestamp: event.lastTimestamp,
+    count: event.count || 1,
+    source: event.source?.component,
+  }));
+}
+
+/**
+ * podInfoHandler retrieves pod info and sends back as JSON format.
+ * Also caches the pod status for later retrieval.
+ */
+export const podInfoHandler: Handler = async (req, res) => {
+  const { podname, podnamespace, runid, taskname } = req.query;
+  if (!podname) {
+    res.status(422).send('podname argument is required');
+    return;
+  }
+  if (!podnamespace) {
+    res.status(422).send('podnamespace argument is required');
+    return;
+  }
+  const podName = decodeURIComponent(podname as string);
+  const podNamespace = decodeURIComponent(podnamespace as string);
+  const runId = runid ? decodeURIComponent(runid as string) : undefined;
+  const taskName = taskname ? decodeURIComponent(taskname as string) : undefined;
+
+  const [pod, err] = await k8sHelper.getPod(podName, podNamespace);
+  if (err) {
+    const { message, additionalInfo } = err;
+    console.error(message, additionalInfo);
+
+    // Try to return cached data if K8s pod is not available
+    const cached = await podEventsCache.getCachedPodInfo(podNamespace, podName);
+    if (cached && cached.status) {
+      console.log('[podInfoHandler] Returning cached pod status for', podName);
+
+      const stateHistory = runId
+        ? await podEventsCache.getMergedStateHistory(podNamespace, runId, taskName)
+        : cached.stateHistory || [];
+
+      res.status(200).send(
+        JSON.stringify({
+          metadata: { name: podName, namespace: podNamespace },
+          status: {
+            phase: cached.status.phase,
+            message: cached.status.message,
+            reason: cached.status.reason,
+            podIP: cached.status.podIP,
+            containerStatuses: cached.status.containerStatuses,
+          },
+          spec: { nodeName: cached.status.nodeName },
+          _cached: true,
+          _cachedAt: cached.lastUpdated,
+          _stateHistory: stateHistory,
+        }),
+      );
+      return;
+    }
+
+    res.status(500).send(message);
+    return;
+  }
+
+  // Cache the pod status (fire-and-forget, don't block response)
+  const status = extractPodStatus(pod);
+  if (status) {
+    podEventsCache
+      .getCachedPodInfo(podNamespace, podName)
+      .then((existing) => {
+        podEventsCache
+          .savePodInfo(podName, podNamespace, status, existing?.events || [], runId, taskName)
+          .catch(() => {});
+      })
+      .catch(() => {});
+  }
+
+  // Read back state history from cache and attach to response
+  const response = JSON.parse(JSON.stringify(pod));
+  if (runId) {
+    const mergedHistory = await podEventsCache.getMergedStateHistory(podNamespace, runId, taskName);
+    if (mergedHistory.length > 0) {
+      response._stateHistory = mergedHistory;
+    }
+  } else {
+    const updatedCache = await podEventsCache.getCachedPodInfo(podNamespace, podName);
+    if (updatedCache?.stateHistory && updatedCache.stateHistory.length > 0) {
+      response._stateHistory = updatedCache.stateHistory;
+    }
+  }
+
+  res.status(200).send(JSON.stringify(response));
+};
+
+/**
+ * podEventsHandler retrieves pod events and sends back as JSON format.
+ * Also caches the events for later retrieval when K8s events expire.
+ */
+export const podEventsHandler: Handler = async (req, res) => {
+  const { podname, podnamespace, runid, taskname } = req.query;
+  if (!podname) {
+    res.status(422).send('podname argument is required');
+    return;
+  }
+  if (!podnamespace) {
+    res.status(422).send('podnamespace argument is required');
+    return;
+  }
+  const podName = decodeURIComponent(podname as string);
+  const podNamespace = decodeURIComponent(podnamespace as string);
+  const runId = runid ? decodeURIComponent(runid as string) : undefined;
+  const taskName = taskname ? decodeURIComponent(taskname as string) : undefined;
+
+  const [eventList, err] = await k8sHelper.listPodEvents(podName, podNamespace);
+
+  // Extract events from K8s
+  const events = err ? [] : extractEvents(eventList);
+
+  // Get existing cached info
+  const cached = await podEventsCache.getCachedPodInfo(podNamespace, podName);
+
+  // If we have events from K8s, cache them (fire-and-forget)
+  if (events.length > 0) {
+    podEventsCache
+      .savePodInfo(podName, podNamespace, cached?.status || null, events, runId, taskName)
+      .catch(() => {});
+  }
+
+  // Get merged cached events from all pods for this run/task
+  const mergedCachedEvents = runId
+    ? await podEventsCache.getMergedEvents(podNamespace, runId, taskName)
+    : cached?.events || [];
+
+  // If K8s returned no events, fall back to merged cached events
+  if (events.length === 0 && mergedCachedEvents.length > 0) {
+    console.log(
+      '[podEventsHandler] Returning merged cached events for',
+      podName,
+      '(',
+      mergedCachedEvents.length,
+      'events)',
+    );
+
+    const cachedEventItems = mergedCachedEvents.map((e) => ({
+      type: e.type,
+      reason: e.reason,
+      message: e.message,
+      firstTimestamp: e.firstTimestamp,
+      lastTimestamp: e.lastTimestamp,
+      count: e.count,
+      source: { component: e.source },
+      _cached: true,
+    }));
+
+    const stateHistory = runId
+      ? await podEventsCache.getMergedStateHistory(podNamespace, runId, taskName)
+      : cached?.stateHistory || [];
+
+    res.status(200).send(
+      JSON.stringify({
+        items: cachedEventItems,
+        _cached: true,
+        _cachedAt: cached?.lastUpdated || Date.now(),
+        _stateHistory: stateHistory,
+      }),
+    );
+    return;
+  }
+
+  if (err) {
+    const { message, additionalInfo } = err;
+    console.error(message, additionalInfo);
+    res.status(500).send(message);
+    return;
+  }
+
+  // Build response from fresh K8s events
+  const eventResponse = JSON.parse(JSON.stringify(eventList));
+
+  // Supplement with cached events from other pods
+  if (runId && mergedCachedEvents.length > 0) {
+    const freshKeys = new Set(
+      events.map((e) => `${e.type}:${e.reason}:${e.message.substring(0, 100)}`),
+    );
+    const supplementEvents = mergedCachedEvents
+      .filter((e) => !freshKeys.has(`${e.type}:${e.reason}:${e.message.substring(0, 100)}`))
+      .map((e) => ({
+        type: e.type,
+        reason: e.reason,
+        message: e.message,
+        firstTimestamp: e.firstTimestamp,
+        lastTimestamp: e.lastTimestamp,
+        count: e.count,
+        source: { component: e.source },
+        _cached: true,
+      }));
+
+    if (supplementEvents.length > 0) {
+      eventResponse.items = [...(eventResponse.items || []), ...supplementEvents];
+    }
+  }
+
+  // Attach merged state history
+  if (runId) {
+    const mergedHistory = await podEventsCache.getMergedStateHistory(podNamespace, runId, taskName);
+    if (mergedHistory.length > 0) {
+      eventResponse._stateHistory = mergedHistory;
+    }
+  } else {
+    const updatedEventsCache = await podEventsCache.getCachedPodInfo(podNamespace, podName);
+    if (updatedEventsCache?.stateHistory && updatedEventsCache.stateHistory.length > 0) {
+      eventResponse._stateHistory = updatedEventsCache.stateHistory;
+    }
+  }
+
+  res.status(200).send(JSON.stringify(eventResponse));
+};
+
+/**
+ * podsByRunIdHandler lists pods by run ID label.
+ * Also caches pod info AND events for later retrieval.
+ * K8s API calls are parallelized to reduce total request time.
+ */
+export const podsByRunIdHandler: Handler = async (req, res) => {
+  const { runid, podnamespace, taskname } = req.query;
+  if (!runid) {
+    res.status(422).send('runid argument is required');
+    return;
+  }
+  if (!podnamespace) {
+    res.status(422).send('podnamespace argument is required');
+    return;
+  }
+  const runId = decodeURIComponent(runid as string);
+  const podNamespace = decodeURIComponent(podnamespace as string);
+  const taskName = taskname ? decodeURIComponent(taskname as string) : undefined;
+
+  const [pods, err] = await k8sHelper.listPodsByRunId(runId, podNamespace, taskName);
+
+  // Cache pod status AND fetch events for each pod found
+  // Parallelized: all pods are processed concurrently instead of sequentially
+  if (pods && pods.length > 0) {
+    const cachePromises = pods.map(async (pod) => {
+      const podName = (pod as any).metadata?.name;
+      if (!podName) return;
+
+      const status = extractPodStatus(pod);
+      if (!status) return;
+
+      const labels = (pod as any).metadata?.labels || {};
+      const annotations = (pod as any).metadata?.annotations || {};
+      const podTaskName =
+        annotations['pipelines.kubeflow.org/task_path'] ||
+        labels['pipelines.kubeflow.org/task_name'] ||
+        labels['component'] ||
+        taskName;
+
+      // Fetch existing cache and events in parallel
+      const [existing, eventResult] = await Promise.all([
+        podEventsCache.getCachedPodInfo(podNamespace, podName),
+        k8sHelper
+          .listPodEvents(podName, podNamespace)
+          .catch(() => [undefined, { message: 'error' }] as const),
+      ]);
+
+      let events = existing?.events || [];
+      const [eventList] = eventResult;
+      if (eventList) {
+        const freshEvents = extractEvents(eventList);
+        events = freshEvents.length > 0 ? freshEvents : events;
+      }
+
+      await podEventsCache.savePodInfo(podName, podNamespace, status, events, runId, podTaskName);
+    });
+
+    // Fire-and-forget caching: don't block the response
+    Promise.all(cachePromises).catch(() => {});
+  }
+
+  // If no pods found in K8s, try to return cached pod info
+  if ((!pods || pods.length === 0) && !err) {
+    const cachedPod = await podEventsCache.getCachedPodInfoByRunId(podNamespace, runId, taskName);
+    if (cachedPod) {
+      console.log('[podsByRunIdHandler] Returning cached pod info for run', runId);
+      res.status(200).send(
+        JSON.stringify([
+          {
+            metadata: { name: cachedPod.podName, namespace: cachedPod.namespace },
+            status: cachedPod.status
+              ? {
+                  phase: cachedPod.status.phase,
+                  message: cachedPod.status.message,
+                  reason: cachedPod.status.reason,
+                  podIP: cachedPod.status.podIP,
+                  containerStatuses: cachedPod.status.containerStatuses,
+                }
+              : undefined,
+            spec: cachedPod.status ? { nodeName: cachedPod.status.nodeName } : undefined,
+            _cached: true,
+            _cachedAt: cachedPod.lastUpdated,
+          },
+        ]),
+      );
+      return;
+    }
+  }
+
+  if (err) {
+    const { message, additionalInfo } = err;
+    console.error('[podsByRunIdHandler] Error:', message, additionalInfo);
+    res.status(500).send(message);
+    return;
+  }
+
+  res.status(200).send(JSON.stringify(pods));
+};
+
+/**
+ * cachedPodInfoHandler retrieves cached pod info by run ID.
+ */
+export const cachedPodInfoHandler: Handler = async (req, res) => {
+  const { podname, podnamespace, taskname } = req.query;
+
+  const podNamespace = podnamespace ? decodeURIComponent(podnamespace as string) : undefined;
+
+  if (!podNamespace) {
+    res.status(422).send('podnamespace argument is required');
+    return;
+  }
+
+  // If pod name provided, get by pod name
+  if (podname) {
+    const podName = decodeURIComponent(podname as string);
+    const cached = await podEventsCache.getCachedPodInfo(podNamespace, podName);
+
+    if (!cached) {
+      res.status(404).send('No cached data found');
+      return;
+    }
+
+    res.status(200).send(JSON.stringify(cached));
+    return;
+  }
+
+  // If run ID provided, search by run ID
+  if (req.query.runid) {
+    const runId = decodeURIComponent(req.query.runid as string);
+    const taskName = taskname ? decodeURIComponent(taskname as string) : undefined;
+
+    const cached = await podEventsCache.getCachedPodInfoByRunId(podNamespace, runId, taskName);
+
+    if (!cached) {
+      res.status(404).send('No cached data found');
+      return;
+    }
+
+    res.status(200).send(JSON.stringify(cached));
+    return;
+  }
+
+  res.status(422).send('Either podname or runid argument is required');
+};

--- a/frontend/server/k8s-helper.test.ts
+++ b/frontend/server/k8s-helper.test.ts
@@ -18,6 +18,7 @@ import {
   getPod,
   getConfigMap,
   listPodEvents,
+  listPodsByRunId,
   getArgoWorkflow,
   getK8sSecret,
 } from './k8s-helper.js';
@@ -480,6 +481,214 @@ describe('k8s-helper', () => {
       await expect(getK8sSecret('test-secret', 'secret-key')).rejects.toThrow(
         'Cannot get namespace from /var/run/secrets/kubernetes.io/serviceaccount/namespace',
       );
+    });
+  });
+
+  describe('listPodsByRunId', () => {
+    let listPodSpy: SpyInstance;
+
+    beforeEach(() => {
+      listPodSpy = vi.spyOn(K8S_TEST_EXPORT.k8sV1Client, 'listNamespacedPod');
+    });
+
+    afterEach(() => {
+      listPodSpy.mockRestore();
+    });
+
+    it('follows continuation tokens across multiple pages', async () => {
+      const makePod = (name: string) => ({
+        metadata: { name, namespace: 'test-ns', labels: { 'pipeline/runid': 'run-1' } },
+        status: { phase: 'Running' },
+      });
+
+      // Page 1 returns continue token
+      listPodSpy.mockResolvedValueOnce({
+        items: Array.from({ length: 100 }, (_, i) => makePod(`pod-${i}`)),
+        metadata: { _continue: 'page2-token' },
+      });
+      // Page 2 has no continue token
+      listPodSpy.mockResolvedValueOnce({
+        items: Array.from({ length: 30 }, (_, i) => makePod(`pod-${100 + i}`)),
+        metadata: {},
+      });
+
+      const [pods, err] = await listPodsByRunId('run-1', 'test-ns');
+
+      expect(err).toBeUndefined();
+      expect(pods).toHaveLength(130);
+      expect(listPodSpy).toHaveBeenCalledTimes(2);
+      expect(listPodSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ _continue: 'page2-token' }),
+      );
+    });
+
+    it('stops at MAX_PAGES safety cap', async () => {
+      listPodSpy.mockImplementation(() =>
+        Promise.resolve({
+          items: [
+            {
+              metadata: {
+                name: `pod-${Math.random()}`,
+                namespace: 'test-ns',
+                labels: { 'pipeline/runid': 'run-1' },
+              },
+              status: { phase: 'Running' },
+            },
+          ],
+          metadata: { _continue: 'always-more' },
+        }),
+      );
+
+      const [pods, err] = await listPodsByRunId('run-1', 'test-ns');
+
+      expect(err).toBeUndefined();
+      // MAX_PAGES is 20, each page has 1 pod
+      expect(pods).toHaveLength(20);
+      expect(listPodSpy).toHaveBeenCalledTimes(20);
+    });
+
+    it('filters by dotted task_path annotation (exact match)', async () => {
+      const pods = [
+        {
+          metadata: {
+            name: 'pod-nested-1',
+            namespace: 'test-ns',
+            labels: {
+              'pipeline/runid': 'run-1',
+              'pipelines.kubeflow.org/task_name': 'print-op1',
+            },
+            annotations: {
+              'pipelines.kubeflow.org/task_path': 'root.comp-inner-pipeline.print-op1',
+            },
+          },
+          status: { phase: 'Succeeded' },
+        },
+        {
+          metadata: {
+            name: 'pod-nested-2',
+            namespace: 'test-ns',
+            labels: {
+              'pipeline/runid': 'run-1',
+              'pipelines.kubeflow.org/task_name': 'print-op1',
+            },
+            annotations: {
+              'pipelines.kubeflow.org/task_path': 'root.comp-other-pipeline.print-op1',
+            },
+          },
+          status: { phase: 'Succeeded' },
+        },
+      ];
+
+      listPodSpy.mockResolvedValueOnce({ items: pods, metadata: {} });
+
+      const [result, err] = await listPodsByRunId(
+        'run-1',
+        'test-ns',
+        'root.comp-inner-pipeline.print-op1',
+      );
+
+      expect(err).toBeUndefined();
+      expect(result).toHaveLength(1);
+      expect(result![0].metadata?.name).toBe('pod-nested-1');
+    });
+
+    it('filters by dotted task_path suffix match', async () => {
+      const pods = [
+        {
+          metadata: {
+            name: 'driver-pod',
+            namespace: 'test-ns',
+            labels: { 'pipeline/runid': 'run-1' },
+            annotations: {
+              'pipelines.kubeflow.org/task_path': 'root.comp-dag.train-model',
+            },
+          },
+          status: { phase: 'Succeeded' },
+        },
+        {
+          metadata: {
+            name: 'other-pod',
+            namespace: 'test-ns',
+            labels: {
+              'pipeline/runid': 'run-1',
+              'pipelines.kubeflow.org/task_name': 'preprocess',
+            },
+            annotations: {},
+          },
+          status: { phase: 'Succeeded' },
+        },
+      ];
+
+      listPodSpy.mockResolvedValueOnce({ items: pods, metadata: {} });
+
+      const [result, err] = await listPodsByRunId('run-1', 'test-ns', 'train-model');
+
+      expect(err).toBeUndefined();
+      expect(result).toHaveLength(1);
+      expect(result![0].metadata?.name).toBe('driver-pod');
+    });
+
+    it('returns all pods when no task name filter is provided', async () => {
+      const pods = [
+        {
+          metadata: {
+            name: 'pod-a',
+            namespace: 'test-ns',
+            labels: { 'pipeline/runid': 'run-1' },
+            annotations: {},
+          },
+          status: { phase: 'Running' },
+        },
+        {
+          metadata: {
+            name: 'pod-b',
+            namespace: 'test-ns',
+            labels: { 'pipeline/runid': 'run-1' },
+            annotations: {},
+          },
+          status: { phase: 'Succeeded' },
+        },
+      ];
+
+      listPodSpy.mockResolvedValueOnce({ items: pods, metadata: {} });
+
+      const [result, err] = await listPodsByRunId('run-1', 'test-ns');
+
+      expect(err).toBeUndefined();
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns error for invalid resource names', async () => {
+      const [pods, err] = await listPodsByRunId('../invalid', 'test-ns');
+
+      expect(pods).toBeUndefined();
+      expect(err).toEqual({ message: 'Invalid resource name' });
+      expect(listPodSpy).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates pods by name across label selectors', async () => {
+      const pod = {
+        metadata: {
+          name: 'same-pod',
+          namespace: 'test-ns',
+          labels: {
+            'pipeline/runid': 'run-1',
+            'pipelines.kubeflow.org/run_id': 'run-1',
+          },
+          annotations: {},
+        },
+        status: { phase: 'Running' },
+      };
+
+      // First selector returns the pod
+      listPodSpy.mockResolvedValueOnce({ items: [pod], metadata: {} });
+
+      const [result, err] = await listPodsByRunId('run-1', 'test-ns');
+
+      expect(err).toBeUndefined();
+      // Should stop after first successful selector, so only 1 pod
+      expect(result).toHaveLength(1);
     });
   });
 });

--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -348,6 +348,217 @@ export async function listPodEvents(podName: string, podNamespace: string): Prom
 }
 
 /**
+ * Lists pods by run ID label.
+ * This is useful for finding pods that failed early (e.g., ImagePullBackOff)
+ * before the KFP driver/launcher could record the pod name in MLMD.
+ * Tries multiple label selectors to support different KFP versions.
+ *
+ * @param runId - The pipeline run ID
+ * @param podNamespace - The namespace to search in
+ * @param taskName - Optional task name to filter pods
+ */
+export async function listPodsByRunId(
+  runId: string,
+  podNamespace: string,
+  taskName?: string,
+): Promise<Result<V1Pod[]>> {
+  try {
+    if (!isAllowedResourceName(runId) || !isAllowedResourceName(podNamespace)) {
+      return [undefined, { message: 'Invalid resource name' }];
+    }
+
+    // Try multiple label selectors to support different KFP versions
+    const labelSelectors = [
+      `pipeline/runid=${runId}`, // KFP v1/v2 common label
+      `pipelines.kubeflow.org/run_id=${runId}`, // Alternative KFP label
+      `workflows.argoproj.io/workflow=${runId}`, // Argo workflow label (workflow name = run ID)
+    ];
+
+    let allPods: V1Pod[] = [];
+    const PAGE_SIZE = 100;
+    const MAX_PAGES = 20; // Safety cap: at most 2000 pods total
+
+    for (const labelSelector of labelSelectors) {
+      try {
+        let continueToken: string | undefined;
+        let pages = 0;
+
+        do {
+          const result = await k8sV1Client.listNamespacedPod({
+            namespace: podNamespace,
+            labelSelector,
+            limit: PAGE_SIZE,
+            _continue: continueToken,
+          });
+          if (result.items && result.items.length > 0) {
+            allPods = [...allPods, ...result.items];
+          }
+          continueToken = result.metadata?._continue || undefined;
+          pages++;
+        } while (continueToken && pages < MAX_PAGES);
+
+        // If we found pods with this selector, skip the others
+        if (allPods.length > 0) {
+          break;
+        }
+      } catch (err) {
+        // Continue trying other selectors - this is expected for non-matching labels
+      }
+    }
+
+    // Deduplicate pods by name
+    const uniquePods = allPods.reduce((acc: V1Pod[], pod) => {
+      if (!acc.find((p) => p.metadata?.name === pod.metadata?.name)) {
+        acc.push(pod);
+      }
+      return acc;
+    }, []);
+
+    // Helper to check if a pod has container errors (impl pods may not have task_name label)
+    const hasContainerError = (pod: V1Pod): boolean => {
+      const containerStatuses = pod.status?.containerStatuses || [];
+      const initContainerStatuses = pod.status?.initContainerStatuses || [];
+      const allStatuses = [...containerStatuses, ...initContainerStatuses];
+      const errorReasons = [
+        'ErrImagePull',
+        'ImagePullBackOff',
+        'CrashLoopBackOff',
+        'CreateContainerConfigError',
+        'InvalidImageName',
+        'CreateContainerError',
+        'RunContainerError',
+        'OOMKilled',
+        'Error',
+      ];
+      return allStatuses.some((cs: any) => {
+        const waitingReason = cs.state?.waiting?.reason;
+        const terminatedReason = cs.state?.terminated?.reason;
+        const exitCode = cs.state?.terminated?.exitCode;
+        return (
+          errorReasons.includes(waitingReason) ||
+          errorReasons.includes(terminatedReason) ||
+          (exitCode !== undefined && exitCode !== 0)
+        );
+      });
+    };
+
+    // Helper to check if a pod is an impl/executor pod (vs driver)
+    // Impl pods have names like <workflow>-system-container-impl-<hash>
+    // As of version I, impl pods now have task_name labels and task_path annotations
+    const isImplPod = (pod: V1Pod): boolean => {
+      const name = pod.metadata?.name || '';
+      return (
+        (name.includes('-impl-') || name.includes('system-container-impl')) &&
+        !name.includes('driver')
+      );
+    };
+
+    // If task name provided, try to filter (but don't require it)
+    let filteredPods = uniquePods;
+    if (taskName && uniquePods.length > 1) {
+      // Helper to check if a pod matches the task by labels/annotations/name
+      const podMatchesTask = (pod: V1Pod): boolean => {
+        const labels = pod.metadata?.labels || {};
+        const annotations = pod.metadata?.annotations || {};
+        const podTaskLabel = labels['pipelines.kubeflow.org/task_name'] || '';
+        const podTaskPath = annotations['pipelines.kubeflow.org/task_path'] || '';
+        const podName = pod.metadata?.name || '';
+
+        return (
+          podTaskPath === taskName ||
+          podTaskPath.endsWith('.' + taskName) ||
+          podTaskLabel === taskName ||
+          podTaskLabel.endsWith('.' + taskName) ||
+          labels['component'] === taskName ||
+          podName.includes(taskName)
+        );
+      };
+
+      // Helper to get the task name from a driver pod
+      const getDriverTaskName = (pod: V1Pod): string => {
+        const labels = pod.metadata?.labels || {};
+        const annotations = pod.metadata?.annotations || {};
+        return (
+          annotations['pipelines.kubeflow.org/task_path'] ||
+          labels['pipelines.kubeflow.org/task_name'] ||
+          labels['component'] ||
+          ''
+        );
+      };
+
+      // Legacy fallback: For error impl pods WITHOUT task labels (created before version I),
+      // find which task they belong to by timestamp.
+      // An impl pod belongs to the driver that was created closest to (but before) it.
+      // With version I, impl pods have task_name labels and are matched directly via podMatchesTask().
+      const getImplPodOwnerTask = (implPod: V1Pod): string | null => {
+        const implTime = new Date(implPod.metadata?.creationTimestamp || 0).getTime();
+
+        // Get all driver pods (non-impl) with task labels
+        const driverPods = uniquePods.filter((p) => !isImplPod(p) && getDriverTaskName(p));
+
+        let bestMatch: { task: string; timeDiff: number } | null = null;
+
+        for (const driver of driverPods) {
+          const driverTime = new Date(driver.metadata?.creationTimestamp || 0).getTime();
+          const timeDiff = implTime - driverTime;
+
+          // Impl should be created after driver (timeDiff >= 0)
+          // And within a reasonable window (5 minutes)
+          if (timeDiff >= 0 && timeDiff < 300000) {
+            const driverTask = getDriverTaskName(driver);
+            if (!bestMatch || timeDiff < bestMatch.timeDiff) {
+              bestMatch = { task: driverTask, timeDiff };
+            }
+          }
+        }
+
+        return bestMatch?.task || null;
+      };
+
+      const taskFilteredPods = uniquePods.filter((pod) => {
+        const labels = pod.metadata?.labels || {};
+        const annotations = pod.metadata?.annotations || {};
+        const podTaskLabel = labels['pipelines.kubeflow.org/task_name'] || '';
+        const podTaskPath = annotations['pipelines.kubeflow.org/task_path'] || '';
+
+        // Direct match by label, annotation, or pod name
+        if (podMatchesTask(pod)) {
+          return true;
+        }
+
+        // Legacy fallback for error impl pods WITHOUT task labels (pre-version I):
+        // Match by timestamp. As of version I, impl pods have task_name labels and
+        // are matched directly via podMatchesTask() above.
+        if (isImplPod(pod) && hasContainerError(pod) && !podTaskLabel && !podTaskPath) {
+          const ownerTask = getImplPodOwnerTask(pod);
+          if (ownerTask) {
+            // Check if owner task matches the current task we're filtering for
+            const matches =
+              ownerTask === taskName ||
+              ownerTask.endsWith('.' + taskName) ||
+              taskName.endsWith('.' + ownerTask);
+            if (matches) {
+              return true;
+            }
+          }
+        }
+
+        return false;
+      });
+
+      if (taskFilteredPods.length > 0) {
+        filteredPods = taskFilteredPods;
+      }
+    }
+
+    return [filteredPods, undefined];
+  } catch (error) {
+    const userMessage = `Error listing pods for run ${runId} in namespace ${podNamespace}`;
+    return [undefined, { message: userMessage, additionalInfo: error }];
+  }
+}
+
+/**
  * Retrieves the argo workflow CRD.
  * @param workflowName name of the argo workflow
  */

--- a/frontend/server/pod-events-cache.ts
+++ b/frontend/server/pod-events-cache.ts
@@ -1,0 +1,720 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as fsp from 'fs/promises';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+/**
+ * PodEventsCache provides persistence for pod events, status, and state history.
+ *
+ * ARCHITECTURE (V5 rewrite):
+ * - ALL file I/O is async (fs/promises) to never block the event loop
+ * - In-memory index maps runId → pod entries, eliminating full directory scans
+ * - Atomic writes (write to temp file, then rename) prevent JSON corruption
+ * - Per-file write locks prevent concurrent write races
+ */
+
+// Directory to store cached pod events
+const CACHE_DIR = process.env.POD_EVENTS_CACHE_DIR || '/tmp/kfp-pod-events-cache';
+
+// How long to keep cached events (30 days in milliseconds)
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface ContainerStatus {
+  name: string;
+  ready: boolean;
+  restartCount: number;
+  state?: string;
+  reason?: string;
+  message?: string;
+  exitCode?: number;
+}
+
+export interface CachedPodStatus {
+  phase?: string;
+  message?: string;
+  reason?: string;
+  podIP?: string;
+  nodeName?: string;
+  lastUpdated: number;
+  containerStatuses?: ContainerStatus[];
+}
+
+export interface CachedPodEvent {
+  type: string;
+  reason: string;
+  message: string;
+  firstTimestamp?: string;
+  lastTimestamp?: string;
+  count: number;
+  source?: string;
+}
+
+/** A snapshot of the pod's state at a point in time */
+export interface PodStateSnapshot {
+  timestamp: number;
+  phase?: string;
+  reason?: string;
+  message?: string;
+  containerStatuses?: ContainerStatus[];
+  isError: boolean;
+}
+
+export interface CachedPodInfo {
+  podName: string;
+  namespace: string;
+  runId?: string;
+  taskName?: string;
+  status: CachedPodStatus | null;
+  events: CachedPodEvent[];
+  stateHistory: PodStateSnapshot[];
+  lastUpdated: number;
+}
+
+// Error reasons that indicate a failed/problematic state
+const ERROR_REASONS = new Set([
+  'ErrImagePull',
+  'ImagePullBackOff',
+  'CrashLoopBackOff',
+  'CreateContainerConfigError',
+  'InvalidImageName',
+  'CreateContainerError',
+  'RunContainerError',
+  'PreCreateHookError',
+  'PostStartHookError',
+  'ContainerCannotRun',
+  'OOMKilled',
+  'Error',
+]);
+
+export function isErrorReason(reason: string): boolean {
+  return ERROR_REASONS.has(reason);
+}
+
+// ─── In-Memory Index ────────────────────────────────────────────────
+// Maps "namespace/runId" → Map<podName, IndexEntry>
+// This eliminates the need to scan every file for runId lookups.
+
+interface IndexEntry {
+  podName: string;
+  namespace: string;
+  runId: string;
+  taskName?: string;
+  lastUpdated: number;
+  fileName: string;
+}
+
+// runKey ("namespace/runId") → Map<podName, IndexEntry>
+const runIndex = new Map<string, Map<string, IndexEntry>>();
+// podKey ("namespace/podName") → fileName
+const podIndex = new Map<string, string>();
+
+let indexInitialized = false;
+let indexInitPromise: Promise<void> | null = null;
+
+function runKey(namespace: string, runId: string): string {
+  return `${namespace}/${runId}`;
+}
+
+function podKey(namespace: string, podName: string): string {
+  return `${namespace}/${podName}`;
+}
+
+function addToIndex(entry: IndexEntry): void {
+  // Add to runIndex
+  if (entry.runId) {
+    const key = runKey(entry.namespace, entry.runId);
+    let podMap = runIndex.get(key);
+    if (!podMap) {
+      podMap = new Map();
+      runIndex.set(key, podMap);
+    }
+    podMap.set(entry.podName, entry);
+  }
+  // Add to podIndex
+  podIndex.set(podKey(entry.namespace, entry.podName), entry.fileName);
+}
+
+function removeFromIndex(namespace: string, podName: string, runId?: string): void {
+  podIndex.delete(podKey(namespace, podName));
+  if (runId) {
+    const key = runKey(namespace, runId);
+    const podMap = runIndex.get(key);
+    if (podMap) {
+      podMap.delete(podName);
+      if (podMap.size === 0) {
+        runIndex.delete(key);
+      }
+    }
+  }
+}
+
+// ─── Per-File Write Locks ───────────────────────────────────────────
+// Prevents concurrent writes to the same cache file.
+const writeLocks = new Map<string, Promise<void>>();
+
+async function withWriteLock(filePath: string, fn: () => Promise<void>): Promise<void> {
+  // Chain onto existing lock for this file
+  const existing = writeLocks.get(filePath) || Promise.resolve();
+  const next = existing.then(fn, fn); // Run fn regardless of previous result
+  writeLocks.set(filePath, next);
+  try {
+    await next;
+  } finally {
+    // Clean up if this is still the latest lock
+    if (writeLocks.get(filePath) === next) {
+      writeLocks.delete(filePath);
+    }
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+async function ensureCacheDir(): Promise<void> {
+  try {
+    await fsp.mkdir(CACHE_DIR, { recursive: true });
+  } catch (err) {
+    // EEXIST is fine
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') {
+      console.error('[PodEventsCache] Failed to create cache directory:', err);
+    }
+  }
+}
+
+// Generate a cache key from pod identifiers
+function getCacheKey(namespace: string, podName: string): string {
+  return Buffer.from(`${namespace}/${podName}`).toString('base64').replace(/[/+=]/g, '_');
+}
+
+// Generate cache file path
+function getCachePath(namespace: string, podName: string): string {
+  return path.join(CACHE_DIR, `${getCacheKey(namespace, podName)}.json`);
+}
+
+/**
+ * Create a fingerprint of the current state to detect changes.
+ */
+function stateFingerprint(status: CachedPodStatus | null): string {
+  if (!status) return 'null';
+  const containerParts = (status.containerStatuses || [])
+    .map((cs) => `${cs.name}:${cs.state}:${cs.reason || ''}:${cs.ready}:${cs.exitCode ?? ''}`)
+    .sort()
+    .join('|');
+  return `${status.phase}:${status.reason || ''}:${containerParts}`;
+}
+
+/**
+ * Check if a status snapshot represents an error state
+ */
+function isErrorState(status: CachedPodStatus | null): boolean {
+  if (!status) return false;
+  if (status.reason && isErrorReason(status.reason)) return true;
+  if (status.containerStatuses) {
+    return status.containerStatuses.some(
+      (cs) =>
+        (cs.reason && isErrorReason(cs.reason)) ||
+        (cs.state === 'terminated' && cs.exitCode !== undefined && cs.exitCode !== 0),
+    );
+  }
+  return false;
+}
+
+/**
+ * Atomic write: write to temp file then rename.
+ * Prevents corrupted JSON from partial writes.
+ */
+async function atomicWriteFile(filePath: string, data: string): Promise<void> {
+  const tmpPath = filePath + '.' + crypto.randomBytes(4).toString('hex') + '.tmp';
+  await fsp.writeFile(tmpPath, data, 'utf8');
+  await fsp.rename(tmpPath, filePath);
+}
+
+/**
+ * Safely read and parse a cache file. Returns null on any error.
+ */
+async function readCacheFile(filePath: string): Promise<CachedPodInfo | null> {
+  try {
+    const content = await fsp.readFile(filePath, 'utf8');
+    if (!content || content.trim().length === 0) {
+      // Delete empty file
+      await fsp.unlink(filePath).catch(() => {});
+      return null;
+    }
+    const parsed = JSON.parse(content) as CachedPodInfo;
+    if (!parsed.stateHistory) {
+      parsed.stateHistory = [];
+    }
+    return parsed;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    // Corrupted file - delete it
+    await fsp.unlink(filePath).catch(() => {});
+    return null;
+  }
+}
+
+// ─── Index Initialization ───────────────────────────────────────────
+
+/**
+ * Build the in-memory index by scanning existing cache files once at startup.
+ * This is the only time we do a full directory scan.
+ */
+export async function initIndex(): Promise<void> {
+  if (indexInitialized) return;
+  if (indexInitPromise) return indexInitPromise;
+
+  indexInitPromise = (async () => {
+    await ensureCacheDir();
+    const startTime = Date.now();
+
+    try {
+      const files = await fsp.readdir(CACHE_DIR);
+      const jsonFiles = files.filter((f) => f.endsWith('.json'));
+
+      let indexed = 0;
+      let corrupted = 0;
+
+      // Process files in batches to avoid overwhelming the event loop
+      const BATCH_SIZE = 50;
+      for (let i = 0; i < jsonFiles.length; i += BATCH_SIZE) {
+        const batch = jsonFiles.slice(i, i + BATCH_SIZE);
+        const results = await Promise.all(
+          batch.map(async (file) => {
+            const filePath = path.join(CACHE_DIR, file);
+            const cached = await readCacheFile(filePath);
+            if (!cached) {
+              return { ok: false };
+            }
+
+            // Skip expired
+            if (Date.now() - cached.lastUpdated > CACHE_TTL_MS) {
+              await fsp.unlink(filePath).catch(() => {});
+              return { ok: false };
+            }
+
+            return { ok: true, cached, file };
+          }),
+        );
+
+        for (const result of results) {
+          if (result.ok && result.cached && result.file) {
+            addToIndex({
+              podName: result.cached.podName,
+              namespace: result.cached.namespace,
+              runId: result.cached.runId || '',
+              taskName: result.cached.taskName,
+              lastUpdated: result.cached.lastUpdated,
+              fileName: result.file,
+            });
+            indexed++;
+          } else {
+            corrupted++;
+          }
+        }
+
+        // Yield to the event loop between batches
+        if (i + BATCH_SIZE < jsonFiles.length) {
+          await new Promise((resolve) => setImmediate(resolve));
+        }
+      }
+
+      const elapsed = Date.now() - startTime;
+      console.log(
+        `[PodEventsCache] Index initialized: ${indexed} entries indexed, ${corrupted} skipped/corrupted (${elapsed}ms)`,
+      );
+    } catch (err) {
+      console.error('[PodEventsCache] Failed to initialize index:', err);
+    }
+
+    indexInitialized = true;
+    indexInitPromise = null;
+  })();
+
+  return indexInitPromise;
+}
+
+// ─── Public API (all async) ─────────────────────────────────────────
+
+/**
+ * Save pod status and events to cache.
+ * Tracks state history to preserve the full pod lifecycle.
+ * Uses atomic writes and per-file locking.
+ */
+export async function savePodInfo(
+  podName: string,
+  namespace: string,
+  status: CachedPodStatus | null,
+  events: CachedPodEvent[],
+  runId?: string,
+  taskName?: string,
+): Promise<void> {
+  await initIndex();
+
+  const cachePath = getCachePath(namespace, podName);
+  const now = Date.now();
+
+  await withWriteLock(cachePath, async () => {
+    try {
+      // Read existing cache (async)
+      const existingCache = await readCacheFile(cachePath);
+
+      // Build state history
+      let stateHistory: PodStateSnapshot[] = existingCache?.stateHistory || [];
+
+      // Check if state changed since last snapshot
+      const lastFingerprint =
+        stateHistory.length > 0
+          ? stateFingerprint({
+              phase: stateHistory[stateHistory.length - 1].phase,
+              reason: stateHistory[stateHistory.length - 1].reason,
+              containerStatuses: stateHistory[stateHistory.length - 1].containerStatuses,
+              lastUpdated: 0,
+            })
+          : '';
+      const currentFingerprint = stateFingerprint(status);
+
+      if (currentFingerprint !== lastFingerprint && status) {
+        stateHistory.push({
+          timestamp: now,
+          phase: status.phase,
+          reason: status.reason,
+          message: status.message,
+          containerStatuses: status.containerStatuses ? [...status.containerStatuses] : undefined,
+          isError: isErrorState(status),
+        });
+      }
+
+      // Merge events: keep all unique events
+      let mergedEvents = events;
+      if (existingCache && existingCache.events && existingCache.events.length > 0) {
+        const newEventKeys = new Set(
+          events.map((e) => `${e.type}:${e.reason}:${e.message.substring(0, 100)}`),
+        );
+        const preservedEvents = existingCache.events.filter(
+          (e) => !newEventKeys.has(`${e.type}:${e.reason}:${e.message.substring(0, 100)}`),
+        );
+        mergedEvents = [...events, ...preservedEvents];
+      }
+
+      const resolvedRunId = runId || existingCache?.runId;
+      const resolvedTaskName = taskName || existingCache?.taskName;
+
+      const cachedInfo: CachedPodInfo = {
+        podName,
+        namespace,
+        runId: resolvedRunId,
+        taskName: resolvedTaskName,
+        status,
+        events: mergedEvents,
+        stateHistory,
+        lastUpdated: now,
+      };
+
+      // Atomic write
+      await atomicWriteFile(cachePath, JSON.stringify(cachedInfo));
+
+      // Update in-memory index
+      const fileName = `${getCacheKey(namespace, podName)}.json`;
+      addToIndex({
+        podName,
+        namespace,
+        runId: resolvedRunId || '',
+        taskName: resolvedTaskName,
+        lastUpdated: now,
+        fileName,
+      });
+    } catch (err) {
+      console.error('[PodEventsCache] Failed to save pod info:', err);
+    }
+  });
+}
+
+/**
+ * Get cached pod info by pod name (async, single file read).
+ */
+export async function getCachedPodInfo(
+  namespace: string,
+  podName: string,
+): Promise<CachedPodInfo | null> {
+  await initIndex();
+
+  const cachePath = getCachePath(namespace, podName);
+
+  try {
+    const cached = await readCacheFile(cachePath);
+    if (!cached) return null;
+
+    // Check if cache has expired
+    if (Date.now() - cached.lastUpdated > CACHE_TTL_MS) {
+      await fsp.unlink(cachePath).catch(() => {});
+      removeFromIndex(namespace, podName, cached.runId);
+      return null;
+    }
+
+    return cached;
+  } catch (err) {
+    console.error('[PodEventsCache] Failed to read cached pod info:', err);
+    return null;
+  }
+}
+
+/**
+ * Get cached pod info by run ID (async, uses in-memory index).
+ * Instead of scanning ALL files, we look up the index first.
+ */
+export async function getCachedPodInfoByRunId(
+  namespace: string,
+  runId: string,
+  taskName?: string,
+): Promise<CachedPodInfo | null> {
+  await initIndex();
+
+  const key = runKey(namespace, runId);
+  const podMap = runIndex.get(key);
+
+  if (!podMap || podMap.size === 0) {
+    return null;
+  }
+
+  let bestMatch: CachedPodInfo | null = null;
+  let bestScore = -1;
+
+  // Only read files for pods in this run (from the index)
+  for (const [, entry] of podMap) {
+    // Quick filter by taskName from index metadata
+    if (taskName && entry.taskName !== taskName) continue;
+
+    // Check expiry from index metadata
+    if (Date.now() - entry.lastUpdated > CACHE_TTL_MS) continue;
+
+    const filePath = path.join(CACHE_DIR, entry.fileName);
+    const cached = await readCacheFile(filePath);
+    if (!cached) {
+      // File gone or corrupted, remove from index
+      removeFromIndex(entry.namespace, entry.podName, runId);
+      continue;
+    }
+
+    if (Date.now() - cached.lastUpdated > CACHE_TTL_MS) {
+      await fsp.unlink(filePath).catch(() => {});
+      removeFromIndex(entry.namespace, entry.podName, runId);
+      continue;
+    }
+
+    let score = 0;
+    if (taskName && cached.taskName === taskName) score += 100;
+    if (cached.status?.reason && isErrorReason(cached.status.reason)) score += 50;
+    if (cached.status?.phase && cached.status.phase !== 'Succeeded') score += 25;
+    if (cached.stateHistory?.some((s) => s.isError)) score += 30;
+    score += Math.max(0, 10 - Math.floor((Date.now() - cached.lastUpdated) / (60 * 60 * 1000)));
+
+    if (score > bestScore) {
+      bestScore = score;
+      bestMatch = cached;
+    }
+  }
+
+  if (bestMatch) {
+    console.log(
+      `[PodEventsCache] Found cached pod for runId=${runId}, taskName=${taskName}: ${bestMatch.podName}`,
+    );
+  }
+
+  return bestMatch;
+}
+
+/**
+ * Get cached entries matching a given run ID and task name (async, index-based).
+ */
+async function getCachedEntriesForRunTask(
+  namespace: string,
+  runId: string,
+  taskName?: string,
+): Promise<CachedPodInfo[]> {
+  await initIndex();
+
+  const key = runKey(namespace, runId);
+  const podMap = runIndex.get(key);
+
+  if (!podMap || podMap.size === 0) {
+    return [];
+  }
+
+  const results: CachedPodInfo[] = [];
+
+  for (const [, entry] of podMap) {
+    if (taskName && entry.taskName !== taskName) continue;
+    if (Date.now() - entry.lastUpdated > CACHE_TTL_MS) continue;
+
+    const filePath = path.join(CACHE_DIR, entry.fileName);
+    const cached = await readCacheFile(filePath);
+    if (!cached) {
+      removeFromIndex(entry.namespace, entry.podName, runId);
+      continue;
+    }
+
+    if (Date.now() - cached.lastUpdated > CACHE_TTL_MS) {
+      await fsp.unlink(filePath).catch(() => {});
+      removeFromIndex(entry.namespace, entry.podName, runId);
+      continue;
+    }
+
+    results.push(cached);
+  }
+
+  return results;
+}
+
+/**
+ * Get merged state history from all cached pods for a given run ID and task name (async).
+ */
+export async function getMergedStateHistory(
+  namespace: string,
+  runId: string,
+  taskName?: string,
+): Promise<PodStateSnapshot[]> {
+  try {
+    const entries = await getCachedEntriesForRunTask(namespace, runId, taskName);
+    const allSnapshots: PodStateSnapshot[] = [];
+
+    for (const cached of entries) {
+      if (cached.stateHistory && cached.stateHistory.length > 0) {
+        allSnapshots.push(...cached.stateHistory);
+      }
+    }
+
+    // Deduplicate by timestamp + phase + reason
+    const seen = new Set<string>();
+    const unique = allSnapshots.filter((s) => {
+      const key = `${s.timestamp}:${s.phase}:${s.reason || ''}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    // Sort by timestamp ascending
+    unique.sort((a, b) => a.timestamp - b.timestamp);
+
+    return unique;
+  } catch (err) {
+    console.error('[PodEventsCache] Failed to get merged state history:', err);
+    return [];
+  }
+}
+
+/**
+ * Get merged events from all cached pods for a given run ID and task name (async).
+ */
+export async function getMergedEvents(
+  namespace: string,
+  runId: string,
+  taskName?: string,
+): Promise<CachedPodEvent[]> {
+  try {
+    const entries = await getCachedEntriesForRunTask(namespace, runId, taskName);
+    const allEvents: CachedPodEvent[] = [];
+
+    for (const cached of entries) {
+      if (cached.events && cached.events.length > 0) {
+        allEvents.push(...cached.events);
+      }
+    }
+
+    // Deduplicate by type + reason + message (first 100 chars)
+    const seen = new Set<string>();
+    return allEvents.filter((e) => {
+      const key = `${e.type}:${e.reason}:${e.message.substring(0, 100)}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  } catch (err) {
+    console.error('[PodEventsCache] Failed to get merged events:', err);
+    return [];
+  }
+}
+
+/**
+ * Clean up expired cache files (async).
+ */
+export async function cleanupExpiredCache(): Promise<void> {
+  await ensureCacheDir();
+
+  try {
+    const files = await fsp.readdir(CACHE_DIR);
+    let cleaned = 0;
+
+    // Process in batches
+    const BATCH_SIZE = 50;
+    for (let i = 0; i < files.length; i += BATCH_SIZE) {
+      const batch = files.slice(i, i + BATCH_SIZE);
+      await Promise.all(
+        batch.map(async (file) => {
+          if (!file.endsWith('.json')) return;
+
+          const filePath = path.join(CACHE_DIR, file);
+          const cached = await readCacheFile(filePath);
+          if (!cached) return;
+
+          if (Date.now() - cached.lastUpdated > CACHE_TTL_MS) {
+            await fsp.unlink(filePath).catch(() => {});
+            removeFromIndex(cached.namespace, cached.podName, cached.runId);
+            cleaned++;
+          }
+        }),
+      );
+
+      // Yield between batches
+      if (i + BATCH_SIZE < files.length) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+    }
+
+    if (cleaned > 0) {
+      console.log(`[PodEventsCache] Cleaned up ${cleaned} expired cache files`);
+    }
+  } catch (err) {
+    console.error('[PodEventsCache] Failed to cleanup expired cache:', err);
+  }
+}
+
+/**
+ * Start the periodic cleanup scheduler for expired cache files.
+ * Uses .unref() so it does not keep the Node.js event loop alive on its own.
+ * Disabled when NODE_ENV === 'test' to avoid interfering with unit tests.
+ */
+export function startPodEventsCacheCleanupScheduler(): void {
+  if (process.env.NODE_ENV === 'test') {
+    return;
+  }
+
+  const intervalHandle = setInterval(
+    () => {
+      cleanupExpiredCache().catch((err) => {
+        console.error('[PodEventsCache] Cleanup error:', err);
+      });
+    },
+    60 * 60 * 1000,
+  );
+
+  if (typeof (intervalHandle as any).unref === 'function') {
+    (intervalHandle as any).unref();
+  }
+}
+
+// Start the cleanup scheduler on module load.
+startPodEventsCacheCleanupScheduler();

--- a/frontend/server/pod-watcher.test.ts
+++ b/frontend/server/pod-watcher.test.ts
@@ -1,0 +1,208 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { vi, describe, it, expect, afterEach, beforeEach } from 'vitest';
+
+// Use vi.hoisted so the mock fns are available when vi.mock factory runs (it's hoisted above imports)
+const { mockListNamespacedPod, mockListNamespacedEvent } = vi.hoisted(() => ({
+  mockListNamespacedPod: vi.fn(),
+  mockListNamespacedEvent: vi.fn(),
+}));
+
+vi.mock('./k8s-helper.js', () => ({
+  TEST_ONLY: {
+    k8sV1Client: {
+      listNamespacedPod: mockListNamespacedPod,
+      listNamespacedEvent: mockListNamespacedEvent,
+    },
+  },
+}));
+
+vi.mock('./pod-events-cache.js', () => ({
+  getCachedPodInfo: vi.fn().mockResolvedValue(null),
+  savePodInfo: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { TEST_ONLY as WATCHER_TEST_EXPORT } from './pod-watcher.js';
+
+describe('pod-watcher', () => {
+  describe('getTaskNameFromPod', () => {
+    it('prefers task_path annotation over task_name label', () => {
+      const pod = {
+        metadata: {
+          labels: {
+            'pipelines.kubeflow.org/task_name': 'print-op1',
+            component: 'print-op1',
+          },
+          annotations: {
+            'pipelines.kubeflow.org/task_path': 'root.comp-inner-pipeline.print-op1',
+          },
+        },
+      } as any;
+      expect(WATCHER_TEST_EXPORT.getTaskNameFromPod(pod)).toBe(
+        'root.comp-inner-pipeline.print-op1',
+      );
+    });
+
+    it('falls back to task_name label when task_path is absent', () => {
+      const pod = {
+        metadata: {
+          labels: {
+            'pipelines.kubeflow.org/task_name': 'print-op1',
+            component: 'print-op1',
+          },
+          annotations: {},
+        },
+      } as any;
+      expect(WATCHER_TEST_EXPORT.getTaskNameFromPod(pod)).toBe('print-op1');
+    });
+
+    it('falls back to component label when both annotation and task_name are absent', () => {
+      const pod = {
+        metadata: {
+          labels: {
+            component: 'train-model',
+          },
+          annotations: {},
+        },
+      } as any;
+      expect(WATCHER_TEST_EXPORT.getTaskNameFromPod(pod)).toBe('train-model');
+    });
+
+    it('returns undefined when no labels or annotations match', () => {
+      const pod = {
+        metadata: {
+          labels: {},
+          annotations: {},
+        },
+      } as any;
+      expect(WATCHER_TEST_EXPORT.getTaskNameFromPod(pod)).toBeUndefined();
+    });
+  });
+
+  describe('getRunIdFromPod', () => {
+    it('returns pipeline/runid label', () => {
+      const pod = {
+        metadata: {
+          labels: { 'pipeline/runid': 'run-123' },
+        },
+      } as any;
+      expect(WATCHER_TEST_EXPORT.getRunIdFromPod(pod)).toBe('run-123');
+    });
+
+    it('falls back to pipelines.kubeflow.org/run_id label', () => {
+      const pod = {
+        metadata: {
+          labels: { 'pipelines.kubeflow.org/run_id': 'run-456' },
+        },
+      } as any;
+      expect(WATCHER_TEST_EXPORT.getRunIdFromPod(pod)).toBe('run-456');
+    });
+  });
+
+  describe('listRunningPipelinePods pagination', () => {
+    beforeEach(() => {
+      mockListNamespacedPod.mockReset();
+      vi.spyOn(console, 'error').mockImplementation(() => null);
+      vi.spyOn(console, 'log').mockImplementation(() => null);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('follows continuation tokens across multiple pages', async () => {
+      const makePod = (name: string) => ({
+        metadata: { name, namespace: 'test-ns' },
+        status: { phase: 'Running' },
+      });
+
+      // Page 1: 100 pods with a continue token
+      mockListNamespacedPod.mockResolvedValueOnce({
+        items: Array.from({ length: 100 }, (_, i) => makePod(`pod-${i}`)),
+        metadata: { _continue: 'token-page-2' },
+      });
+      // Page 2: 50 pods, no more pages
+      mockListNamespacedPod.mockResolvedValueOnce({
+        items: Array.from({ length: 50 }, (_, i) => makePod(`pod-${100 + i}`)),
+        metadata: {},
+      });
+
+      const pods = await WATCHER_TEST_EXPORT.listRunningPipelinePods('test-ns');
+
+      expect(pods).toHaveLength(150);
+      expect(mockListNamespacedPod).toHaveBeenCalledTimes(2);
+
+      // Verify second call used the continue token
+      expect(mockListNamespacedPod).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ _continue: 'token-page-2' }),
+      );
+    });
+
+    it('stops at MAX_PAGES safety cap', async () => {
+      const makePod = (name: string) => ({
+        metadata: { name, namespace: 'test-ns' },
+        status: { phase: 'Running' },
+      });
+
+      // Return a continue token on every page
+      mockListNamespacedPod.mockImplementation(() =>
+        Promise.resolve({
+          items: [makePod(`pod-${Math.random()}`)],
+          metadata: { _continue: 'next-token' },
+        }),
+      );
+
+      const pods = await WATCHER_TEST_EXPORT.listRunningPipelinePods('test-ns');
+
+      // MAX_PAGES is 20, so we should get exactly 20 pods (one per page)
+      expect(pods).toHaveLength(20);
+      expect(mockListNamespacedPod).toHaveBeenCalledTimes(20);
+    });
+
+    it('falls back to unfiltered listing when field selector fails', async () => {
+      const makePod = (name: string, phase: string) => ({
+        metadata: { name, namespace: 'test-ns' },
+        status: { phase },
+      });
+
+      // First call (with fieldSelector) fails
+      mockListNamespacedPod.mockRejectedValueOnce(new Error('field selector not supported'));
+      // Fallback call (no fieldSelector) succeeds with mixed phases
+      mockListNamespacedPod.mockResolvedValueOnce({
+        items: [
+          makePod('running-pod', 'Running'),
+          makePod('pending-pod', 'Pending'),
+          makePod('succeeded-pod', 'Succeeded'),
+        ],
+        metadata: {},
+      });
+
+      const pods = await WATCHER_TEST_EXPORT.listRunningPipelinePods('test-ns');
+
+      // Only Running and Pending pods should be returned in fallback mode
+      expect(pods).toHaveLength(2);
+      expect(pods.map((p: any) => p.metadata.name)).toContain('running-pod');
+      expect(pods.map((p: any) => p.metadata.name)).toContain('pending-pod');
+    });
+
+    it('returns empty array when both listing strategies fail', async () => {
+      mockListNamespacedPod.mockRejectedValue(new Error('forbidden'));
+
+      const pods = await WATCHER_TEST_EXPORT.listRunningPipelinePods('test-ns');
+
+      expect(pods).toHaveLength(0);
+    });
+  });
+});

--- a/frontend/server/pod-watcher.test.ts
+++ b/frontend/server/pod-watcher.test.ts
@@ -28,9 +28,14 @@ vi.mock('./k8s-helper.js', () => ({
   },
 }));
 
+const { mockGetCachedPodInfo, mockSavePodInfo } = vi.hoisted(() => ({
+  mockGetCachedPodInfo: vi.fn().mockResolvedValue(null),
+  mockSavePodInfo: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('./pod-events-cache.js', () => ({
-  getCachedPodInfo: vi.fn().mockResolvedValue(null),
-  savePodInfo: vi.fn().mockResolvedValue(undefined),
+  getCachedPodInfo: mockGetCachedPodInfo,
+  savePodInfo: mockSavePodInfo,
 }));
 
 import { TEST_ONLY as WATCHER_TEST_EXPORT } from './pod-watcher.js';
@@ -203,6 +208,116 @@ describe('pod-watcher', () => {
       const pods = await WATCHER_TEST_EXPORT.listRunningPipelinePods('test-ns');
 
       expect(pods).toHaveLength(0);
+    });
+  });
+
+  describe('processPod event refresh for stable pods', () => {
+    const basePod = {
+      metadata: {
+        name: 'pod-1',
+        namespace: 'test-ns',
+        resourceVersion: '100',
+        labels: { 'pipeline/runid': 'run-1' },
+        annotations: {},
+      },
+      status: { phase: 'Pending' },
+    } as any;
+
+    const existingEvent = {
+      type: 'Normal',
+      reason: 'Pulling',
+      message: 'Pulling image kfp/op:latest',
+      count: 1,
+    };
+    const newEvent = {
+      type: 'Warning',
+      reason: 'BackOff',
+      message: 'Back-off pulling image kfp/op:latest',
+      count: 3,
+    };
+
+    beforeEach(() => {
+      mockListNamespacedEvent.mockReset();
+      mockGetCachedPodInfo.mockReset();
+      mockSavePodInfo.mockReset();
+      mockSavePodInfo.mockResolvedValue(undefined);
+      WATCHER_TEST_EXPORT.resetPodStates();
+      vi.spyOn(console, 'error').mockImplementation(() => null);
+      vi.spyOn(console, 'log').mockImplementation(() => null);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('fetches events on every tick even when the pod object is unchanged', async () => {
+      // Prime podStates so the pod is considered unchanged on the second tick
+      mockListNamespacedEvent.mockResolvedValue({ items: [existingEvent] });
+      mockGetCachedPodInfo.mockResolvedValue(null);
+      await WATCHER_TEST_EXPORT.processPod(basePod);
+
+      // Second tick: same pod, events unchanged. We should STILL hit the event API.
+      mockListNamespacedEvent.mockClear();
+      mockGetCachedPodInfo.mockResolvedValue({
+        podName: 'pod-1',
+        namespace: 'test-ns',
+        events: [existingEvent],
+        stateHistory: [],
+        status: null,
+        lastUpdated: Date.now(),
+      });
+      await WATCHER_TEST_EXPORT.processPod(basePod);
+
+      expect(mockListNamespacedEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('persists new events that arrive while pod stays stable', async () => {
+      // First tick: cache existing event
+      mockListNamespacedEvent.mockResolvedValueOnce({ items: [existingEvent] });
+      mockGetCachedPodInfo.mockResolvedValueOnce(null);
+      await WATCHER_TEST_EXPORT.processPod(basePod);
+
+      mockSavePodInfo.mockClear();
+
+      // Second tick: pod object unchanged, but a new BackOff event has appeared.
+      // savePodInfo must still be called so the new event is persisted past
+      // the cluster event TTL.
+      mockListNamespacedEvent.mockResolvedValueOnce({ items: [existingEvent, newEvent] });
+      mockGetCachedPodInfo.mockResolvedValueOnce({
+        podName: 'pod-1',
+        namespace: 'test-ns',
+        events: [existingEvent],
+        stateHistory: [],
+        status: null,
+        lastUpdated: Date.now(),
+      });
+      const result = await WATCHER_TEST_EXPORT.processPod(basePod);
+
+      expect(result).toBe(true);
+      expect(mockSavePodInfo).toHaveBeenCalledTimes(1);
+      const savedEvents = mockSavePodInfo.mock.calls[0][3];
+      expect(savedEvents).toEqual(expect.arrayContaining([existingEvent, newEvent]));
+    });
+
+    it('skips save when pod and events are both unchanged', async () => {
+      mockListNamespacedEvent.mockResolvedValue({ items: [existingEvent] });
+      mockGetCachedPodInfo.mockResolvedValue(null);
+      await WATCHER_TEST_EXPORT.processPod(basePod);
+
+      mockSavePodInfo.mockClear();
+
+      mockGetCachedPodInfo.mockResolvedValue({
+        podName: 'pod-1',
+        namespace: 'test-ns',
+        events: [existingEvent],
+        stateHistory: [],
+        status: null,
+        lastUpdated: Date.now(),
+      });
+      const result = await WATCHER_TEST_EXPORT.processPod(basePod);
+
+      expect(result).toBe(false);
+      expect(mockSavePodInfo).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/server/pod-watcher.test.ts
+++ b/frontend/server/pod-watcher.test.ts
@@ -299,6 +299,40 @@ describe('pod-watcher', () => {
       expect(savedEvents).toEqual(expect.arrayContaining([existingEvent, newEvent]));
     });
 
+    it('persists in-place event updates (bumped count / lastTimestamp)', async () => {
+      // K8s coalesces repeated events by bumping count and advancing
+      // lastTimestamp on the existing Event object instead of creating new
+      // ones. These updates must still be saved.
+      const t1 = '2026-04-15T10:00:00Z';
+      const t2 = '2026-04-15T10:05:00Z';
+
+      mockListNamespacedEvent.mockResolvedValueOnce({
+        items: [{ ...newEvent, count: 3, lastTimestamp: t1 }],
+      });
+      mockGetCachedPodInfo.mockResolvedValueOnce(null);
+      await WATCHER_TEST_EXPORT.processPod(basePod);
+
+      mockSavePodInfo.mockClear();
+
+      mockListNamespacedEvent.mockResolvedValueOnce({
+        items: [{ ...newEvent, count: 7, lastTimestamp: t2 }],
+      });
+      mockGetCachedPodInfo.mockResolvedValueOnce({
+        podName: 'pod-1',
+        namespace: 'test-ns',
+        events: [{ ...newEvent, count: 3, lastTimestamp: t1 }],
+        stateHistory: [],
+        status: null,
+        lastUpdated: Date.now(),
+      });
+      const result = await WATCHER_TEST_EXPORT.processPod(basePod);
+
+      expect(result).toBe(true);
+      expect(mockSavePodInfo).toHaveBeenCalledTimes(1);
+      const savedEvents = mockSavePodInfo.mock.calls[0][3];
+      expect(savedEvents[0]).toMatchObject({ count: 7, lastTimestamp: t2 });
+    });
+
     it('skips save when pod and events are both unchanged', async () => {
       mockListNamespacedEvent.mockResolvedValue({ items: [existingEvent] });
       mockGetCachedPodInfo.mockResolvedValue(null);

--- a/frontend/server/pod-watcher.ts
+++ b/frontend/server/pod-watcher.ts
@@ -212,21 +212,32 @@ async function processPod(pod: V1Pod): Promise<boolean> {
 
   if (!podName || !namespace) return false;
 
-  if (!hasPodChanged(pod)) return false;
-
   const status = extractPodStatus(pod);
   if (!status) return false;
 
+  const podChanged = hasPodChanged(pod);
   const runId = getRunIdFromPod(pod);
   const taskName = getTaskNameFromPod(pod);
 
-  // Fetch existing cache and events in parallel (all async)
+  // Always fetch events — K8s Event objects are separate resources that can
+  // keep evolving (e.g. repeated BackOff/Pulling/Pulled) while the pod's
+  // phase/resourceVersion stays stable. Persisting them past the cluster's
+  // event TTL is the whole point of this watcher.
   const [existing, events] = await Promise.all([
     podEventsCache.getCachedPodInfo(namespace, podName),
     fetchPodEvents(podName, namespace),
   ]);
 
-  // Save to cache (async)
+  const eventKey = (e: podEventsCache.CachedPodEvent): string =>
+    `${e.type}:${e.reason}:${(e.message || '').substring(0, 100)}`;
+  const existingKeys = new Set((existing?.events || []).map(eventKey));
+  const hasNewEvents = events.some((e) => !existingKeys.has(eventKey(e)));
+
+  if (!podChanged && !hasNewEvents) {
+    updatePodState(pod);
+    return false;
+  }
+
   await podEventsCache.savePodInfo(
     podName,
     namespace,
@@ -379,4 +390,6 @@ export const TEST_ONLY = {
   listRunningPipelinePods,
   getTaskNameFromPod,
   getRunIdFromPod,
+  processPod,
+  resetPodStates: () => podStates.clear(),
 };

--- a/frontend/server/pod-watcher.ts
+++ b/frontend/server/pod-watcher.ts
@@ -228,10 +228,13 @@ async function processPod(pod: V1Pod): Promise<boolean> {
     fetchPodEvents(podName, namespace),
   ]);
 
-  const eventKey = (e: podEventsCache.CachedPodEvent): string =>
-    `${e.type}:${e.reason}:${(e.message || '').substring(0, 100)}`;
-  const existingKeys = new Set((existing?.events || []).map(eventKey));
-  const hasNewEvents = events.some((e) => !existingKeys.has(eventKey(e)));
+  // Include count/lastTimestamp so in-place K8s event updates (which coalesce
+  // repeated occurrences by bumping count and advancing lastTimestamp on the
+  // same Event object) are detected as "changed" and get persisted.
+  const eventChangeKey = (e: podEventsCache.CachedPodEvent): string =>
+    `${e.type}:${e.reason}:${(e.message || '').substring(0, 100)}|${e.count ?? 0}|${e.lastTimestamp || ''}`;
+  const existingKeys = new Set((existing?.events || []).map(eventChangeKey));
+  const hasNewEvents = events.some((e) => !existingKeys.has(eventChangeKey(e)));
 
   if (!podChanged && !hasNewEvents) {
     updatePodState(pod);

--- a/frontend/server/pod-watcher.ts
+++ b/frontend/server/pod-watcher.ts
@@ -1,0 +1,382 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Background Pod Watcher (V5 - Non-blocking)
+ *
+ * Automatically caches pod status/events for RUNNING KFP pipeline pods.
+ * Uses the shared K8s client and fully async cache operations.
+ *
+ * Key improvements over V4:
+ * - Uses shared K8s client from k8s-helper (no duplicate connections)
+ * - All cache operations are async (never blocks event loop)
+ * - Bounded podStates map with timestamp-based eviction
+ * - Concurrency-limited pod processing
+ */
+
+import { V1Pod } from '@kubernetes/client-node';
+import * as fs from 'fs';
+import { TEST_ONLY as K8S_TEST_ONLY } from './k8s-helper.js';
+import * as podEventsCache from './pod-events-cache.js';
+
+// Lazily access the shared K8s client from k8s-helper to avoid
+// ESM temporal dead zone issues during test module loading.
+function getK8sV1Client() {
+  return K8S_TEST_ONLY.k8sV1Client;
+}
+
+// Configuration from environment variables
+const POD_WATCHER_ENABLED = process.env.POD_WATCHER_ENABLED !== 'false';
+const POD_WATCHER_INTERVAL_MS = parseInt(process.env.POD_WATCHER_INTERVAL_MS || '30000', 10);
+const POD_WATCHER_NAMESPACES = (process.env.POD_WATCHER_NAMESPACES || '')
+  .split(',')
+  .filter(Boolean);
+
+// If no namespaces configured, try to detect from service account
+const namespaceFilePath = '/var/run/secrets/kubernetes.io/serviceaccount/namespace';
+let serverNamespace: string | undefined = undefined;
+if (fs.existsSync(namespaceFilePath)) {
+  serverNamespace = fs.readFileSync(namespaceFilePath, 'utf-8').trim();
+}
+
+// Track pod states to detect changes: podKey -> { phase, resourceVersion, lastSeen }
+const podStates = new Map<string, { phase: string; resourceVersion: string; lastSeen: number }>();
+
+// Max entries in podStates map
+const MAX_POD_STATES = 500;
+
+// Evict entries older than 1 hour
+const POD_STATE_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Extract pod status from K8s pod object
+ */
+function extractPodStatus(pod: V1Pod): podEventsCache.CachedPodStatus | null {
+  if (!pod || !pod.status) return null;
+
+  const parseContainerStatus = (cs: any): podEventsCache.ContainerStatus => ({
+    name: cs.name,
+    ready: cs.ready,
+    restartCount: cs.restartCount,
+    state: cs.state ? Object.keys(cs.state)[0] : undefined,
+    reason: cs.state?.waiting?.reason || cs.state?.terminated?.reason,
+    message: cs.state?.waiting?.message || cs.state?.terminated?.message,
+    exitCode: cs.state?.terminated?.exitCode,
+  });
+
+  const containerStatuses = (pod.status.containerStatuses || []).map(parseContainerStatus);
+  const initContainerStatuses = (pod.status.initContainerStatuses || []).map(parseContainerStatus);
+
+  return {
+    phase: pod.status.phase,
+    message: pod.status.message,
+    reason: pod.status.reason,
+    podIP: pod.status.podIP,
+    nodeName: pod.spec?.nodeName,
+    lastUpdated: Date.now(),
+    containerStatuses: [...initContainerStatuses, ...containerStatuses],
+  };
+}
+
+/**
+ * Extract events from K8s event list
+ */
+function extractEvents(eventList: any): podEventsCache.CachedPodEvent[] {
+  if (!eventList || !eventList.items) return [];
+
+  return eventList.items.map((event: any) => ({
+    type: event.type,
+    reason: event.reason,
+    message: event.message,
+    firstTimestamp: event.firstTimestamp,
+    lastTimestamp: event.lastTimestamp,
+    count: event.count || 1,
+    source: event.source?.component,
+  }));
+}
+
+/**
+ * Fetch events for a specific pod
+ */
+async function fetchPodEvents(
+  podName: string,
+  namespace: string,
+): Promise<podEventsCache.CachedPodEvent[]> {
+  try {
+    const fieldSelector = `involvedObject.name=${podName},involvedObject.kind=Pod`;
+    const result = await getK8sV1Client().listNamespacedEvent({
+      namespace,
+      fieldSelector,
+    });
+    return extractEvents(result);
+  } catch (err) {
+    return [];
+  }
+}
+
+/**
+ * Get runId from pod labels
+ */
+function getRunIdFromPod(pod: V1Pod): string | undefined {
+  const labels = pod.metadata?.labels || {};
+  return labels['pipeline/runid'] || labels['pipelines.kubeflow.org/run_id'];
+}
+
+/**
+ * Get taskName from pod labels/annotations
+ */
+function getTaskNameFromPod(pod: V1Pod): string | undefined {
+  const labels = pod.metadata?.labels || {};
+  const annotations = pod.metadata?.annotations || {};
+  return (
+    annotations['pipelines.kubeflow.org/task_path'] ||
+    labels['pipelines.kubeflow.org/task_name'] ||
+    labels['component']
+  );
+}
+
+/**
+ * Check if pod state has changed since last processing
+ */
+function hasPodChanged(pod: V1Pod): boolean {
+  const podName = pod.metadata?.name;
+  const namespace = pod.metadata?.namespace;
+  if (!podName || !namespace) return false;
+
+  const key = `${namespace}/${podName}`;
+  const currentPhase = pod.status?.phase || 'Unknown';
+  const currentVersion = pod.metadata?.resourceVersion || '';
+
+  const lastState = podStates.get(key);
+  if (!lastState) return true;
+
+  return lastState.phase !== currentPhase || lastState.resourceVersion !== currentVersion;
+}
+
+/**
+ * Update tracked pod state
+ */
+function updatePodState(pod: V1Pod): void {
+  const podName = pod.metadata?.name;
+  const namespace = pod.metadata?.namespace;
+  if (!podName || !namespace) return;
+
+  const key = `${namespace}/${podName}`;
+  podStates.set(key, {
+    phase: pod.status?.phase || 'Unknown',
+    resourceVersion: pod.metadata?.resourceVersion || '',
+    lastSeen: Date.now(),
+  });
+}
+
+/**
+ * Evict stale entries from podStates map
+ */
+function evictStalePodStates(): void {
+  const now = Date.now();
+
+  // First: remove entries older than TTL
+  for (const [key, state] of podStates) {
+    if (now - state.lastSeen > POD_STATE_TTL_MS) {
+      podStates.delete(key);
+    }
+  }
+
+  // If still over limit, remove oldest entries
+  if (podStates.size > MAX_POD_STATES) {
+    const entries = Array.from(podStates.entries()).sort((a, b) => a[1].lastSeen - b[1].lastSeen);
+    const toRemove = entries.slice(0, podStates.size - MAX_POD_STATES);
+    for (const [key] of toRemove) {
+      podStates.delete(key);
+    }
+  }
+}
+
+/**
+ * Process a single pod: extract status, fetch events, and cache (all async)
+ */
+async function processPod(pod: V1Pod): Promise<boolean> {
+  const podName = pod.metadata?.name;
+  const namespace = pod.metadata?.namespace;
+
+  if (!podName || !namespace) return false;
+
+  if (!hasPodChanged(pod)) return false;
+
+  const status = extractPodStatus(pod);
+  if (!status) return false;
+
+  const runId = getRunIdFromPod(pod);
+  const taskName = getTaskNameFromPod(pod);
+
+  // Fetch existing cache and events in parallel (all async)
+  const [existing, events] = await Promise.all([
+    podEventsCache.getCachedPodInfo(namespace, podName),
+    fetchPodEvents(podName, namespace),
+  ]);
+
+  // Save to cache (async)
+  await podEventsCache.savePodInfo(
+    podName,
+    namespace,
+    status,
+    events.length > 0 ? events : existing?.events || [],
+    runId,
+    taskName,
+  );
+
+  updatePodState(pod);
+  return true;
+}
+
+/**
+ * List only RUNNING pipeline pods in a namespace
+ */
+async function listRunningPipelinePods(namespace: string): Promise<V1Pod[]> {
+  const allPods: V1Pod[] = [];
+  const PAGE_SIZE = 100;
+  const MAX_PAGES = 20;
+
+  const collectPods = async (fieldSelector?: string): Promise<void> => {
+    let continueToken: string | undefined;
+    let pages = 0;
+
+    do {
+      const result = await getK8sV1Client().listNamespacedPod({
+        namespace,
+        labelSelector: 'pipeline/runid',
+        fieldSelector,
+        limit: PAGE_SIZE,
+        _continue: continueToken,
+      });
+
+      if (result.items) {
+        for (const pod of result.items) {
+          const phase = pod.status?.phase;
+          if (phase === 'Running' || (!fieldSelector && phase === 'Pending')) {
+            allPods.push(pod);
+          }
+        }
+      }
+
+      continueToken = result.metadata?._continue || undefined;
+      pages++;
+    } while (continueToken && pages < MAX_PAGES);
+  };
+
+  try {
+    await collectPods('status.phase=Running');
+  } catch (err) {
+    try {
+      await collectPods();
+    } catch (fallbackErr) {
+      console.error(`[PodWatcher] Error listing pods in ${namespace}:`, fallbackErr);
+    }
+  }
+
+  return allPods;
+}
+
+/**
+ * Main watcher loop iteration (fully async, never blocks event loop)
+ */
+async function watcherLoop(): Promise<void> {
+  let namespaces = POD_WATCHER_NAMESPACES;
+  if (namespaces.length === 0 && serverNamespace) {
+    namespaces = [serverNamespace];
+  }
+
+  if (namespaces.length === 0) return;
+
+  let totalProcessed = 0;
+  let totalPods = 0;
+
+  for (const namespace of namespaces) {
+    try {
+      const pods = await listRunningPipelinePods(namespace);
+      totalPods += pods.length;
+
+      // Process pods with concurrency limit to avoid overwhelming K8s API
+      const CONCURRENCY = 5;
+      for (let i = 0; i < pods.length; i += CONCURRENCY) {
+        const batch = pods.slice(i, i + CONCURRENCY);
+        const results = await Promise.all(batch.map((pod) => processPod(pod).catch(() => false)));
+        totalProcessed += results.filter(Boolean).length;
+      }
+    } catch (err) {
+      // Skip problematic namespaces
+    }
+  }
+
+  // Evict stale pod state entries
+  evictStalePodStates();
+
+  if (totalProcessed > 0) {
+    console.log(
+      `[PodWatcher] Cached ${totalProcessed} new/changed pods (${totalPods} running total)`,
+    );
+  }
+}
+
+let watcherIntervalId: NodeJS.Timeout | null = null;
+
+/**
+ * Start the background pod watcher
+ */
+export function startPodWatcher(): void {
+  if (!POD_WATCHER_ENABLED) {
+    console.log('[PodWatcher] Pod watcher is disabled (POD_WATCHER_ENABLED=false)');
+    return;
+  }
+
+  if (watcherIntervalId) return;
+
+  const namespaces =
+    POD_WATCHER_NAMESPACES.length > 0
+      ? POD_WATCHER_NAMESPACES
+      : serverNamespace
+        ? [serverNamespace]
+        : [];
+  console.log(`[PodWatcher] Starting background pod watcher`);
+  console.log(`[PodWatcher] - Interval: ${POD_WATCHER_INTERVAL_MS}ms`);
+  console.log(
+    `[PodWatcher] - Namespaces: ${namespaces.length > 0 ? namespaces.join(', ') : '(none configured)'}`,
+  );
+  console.log(`[PodWatcher] - Mode: Running/Pending pods only (async, non-blocking)`);
+
+  // Run immediately on start
+  watcherLoop().catch(() => {});
+
+  // Then run on interval
+  watcherIntervalId = setInterval(() => {
+    watcherLoop().catch(() => {});
+  }, POD_WATCHER_INTERVAL_MS);
+}
+
+/**
+ * Stop the background pod watcher
+ */
+export function stopPodWatcher(): void {
+  if (watcherIntervalId) {
+    clearInterval(watcherIntervalId);
+    watcherIntervalId = null;
+    console.log('[PodWatcher] Background pod watcher stopped');
+  }
+}
+
+export const TEST_ONLY = {
+  listRunningPipelinePods,
+  getTaskNameFromPod,
+  getRunIdFromPod,
+};

--- a/frontend/server/server.ts
+++ b/frontend/server/server.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 import { UIServer } from './app.js';
 import { loadConfigs } from './configs.js';
+import { initIndex } from './pod-events-cache.js';
+import { startPodWatcher } from './pod-watcher.js';
 
 const configs = loadConfigs(process.argv, process.env);
 if (process.env.NODE_ENV !== 'test') {
@@ -21,5 +23,21 @@ if (process.env.NODE_ENV !== 'test') {
     artifacts: 'Artifacts config contains credentials, so it is omitted',
   });
 }
-const app = new UIServer(configs);
-app.start();
+
+// Initialize the cache index before starting the server.
+// This builds the in-memory runId index from existing cache files.
+initIndex()
+  .then(() => {
+    const app = new UIServer(configs);
+    app.start();
+
+    // Start the background pod watcher for automatic pod status caching
+    startPodWatcher();
+  })
+  .catch((err) => {
+    console.error('Failed to initialize pod events cache index:', err);
+    // Start anyway - the index will init lazily on first use
+    const app = new UIServer(configs);
+    app.start();
+    startPodWatcher();
+  });

--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -58,6 +58,14 @@ import RuntimeInputOutputTab, {
 import { convertYamlToPlatformSpec, convertYamlToV2PipelineSpec } from 'src/lib/v2/WorkflowUtils';
 import { PlatformDeploymentConfig } from 'src/generated/pipeline_spec/pipeline_spec';
 import { getComponentSpec } from 'src/lib/v2/NodeUtils';
+import {
+  usePodStatus,
+  ERROR_REASONS,
+  PodStatusInfo,
+  ContainerStatusInfo,
+  PodEventInfo,
+  PodStateSnapshot,
+} from 'src/hooks/usePodStatus';
 
 export const LOGS_DETAILS = 'logs_details';
 export const LOGS_BANNER_MESSAGE = 'logs_banner_message';
@@ -170,6 +178,17 @@ function TaskNodeDetail({
     enabled: !!execution,
   });
 
+  // Fetch pod status and events
+  // Enabled even without execution to catch early failures like ImagePullBackOff
+  const { data: podStatusInfo, error: podStatusError } = usePodStatus(
+    execution,
+    namespace,
+    runId,
+    element,
+    layers,
+    pipelineJobString,
+  );
+
   const logsDetails = logsInfo?.get(LOGS_DETAILS);
   const logsBannerMessage =
     logsInfo?.get(LOGS_BANNER_MESSAGE) ||
@@ -182,7 +201,7 @@ function TaskNodeDetail({
   return (
     <div className={commonCss.page}>
       <MD2Tabs
-        tabs={['Input/Output', 'Task Details', 'Logs']}
+        tabs={['Input/Output', 'Task Details', 'Logs', 'Pod Status']}
         selectedTab={selectedTab}
         onSwitch={(tab) => setSelectedTab(tab)}
       />
@@ -217,6 +236,19 @@ function TaskNodeDetail({
                 <LogViewer logLines={(logsDetails || '').split(/[\r\n]+/)} />
               </div>
             )}
+          </div>
+        )}
+        {/* Pod Status tab */}
+        {selectedTab === 3 && (
+          <div className={padding(20)}>
+            <PodStatusTab
+              podStatus={podStatusInfo?.status || null}
+              podEvents={podStatusInfo?.events || []}
+              stateHistory={podStatusInfo?.stateHistory || []}
+              error={podStatusError}
+              cached={podStatusInfo?.cached}
+              cachedAt={podStatusInfo?.cachedAt}
+            />
           </div>
         )}
       </div>
@@ -304,6 +336,466 @@ function getNodeVolumeMounts(
   }
 
   return volumeMounts;
+}
+
+// Component to display pod status, lifecycle history, and events
+interface PodStatusTabProps {
+  podStatus: PodStatusInfo | null;
+  podEvents: PodEventInfo[];
+  stateHistory: PodStateSnapshot[];
+  error?: Error | null;
+  cached?: boolean;
+  cachedAt?: number;
+}
+
+// Color helpers
+const getPhaseColor = (phase?: string) => {
+  switch (phase) {
+    case 'Running':
+      return '#4caf50';
+    case 'Succeeded':
+      return '#2196f3';
+    case 'Failed':
+      return '#f44336';
+    case 'Pending':
+      return '#ff9800';
+    default:
+      return '#9e9e9e';
+  }
+};
+
+const getPhaseBackgroundColor = (phase?: string) => {
+  switch (phase) {
+    case 'Failed':
+      return '#ffebee';
+    case 'Running':
+      return '#e8f5e9';
+    case 'Succeeded':
+      return '#e3f2fd';
+    case 'Pending':
+      return '#fff3e0';
+    default:
+      return '#fafafa';
+  }
+};
+
+const getContainerStatusColor = (cs: ContainerStatusInfo) => {
+  if (cs.reason && ERROR_REASONS.includes(cs.reason)) return '#f44336';
+  if (cs.state === 'terminated' && cs.exitCode !== undefined && cs.exitCode !== 0) return '#f44336';
+  if (cs.state === 'terminated' && cs.exitCode === 0) return '#2196f3';
+  if (cs.state === 'terminated') return '#e57373';
+  if (cs.state === 'running' && cs.ready) return '#4caf50';
+  if (cs.state === 'waiting') return '#ff9800';
+  return '#9e9e9e';
+};
+
+const getContainerBackgroundColor = (cs: ContainerStatusInfo) => {
+  if (cs.reason && ERROR_REASONS.includes(cs.reason)) return '#ffebee';
+  if (cs.state === 'terminated' && cs.exitCode !== undefined && cs.exitCode !== 0) return '#ffebee';
+  return '#fff';
+};
+
+function PodStatusTab({
+  podStatus,
+  podEvents,
+  stateHistory,
+  error,
+  cached,
+  cachedAt,
+}: PodStatusTabProps) {
+  if (error) {
+    return (
+      <Banner message='Failed to retrieve pod status' additionalInfo={error.message} mode='error' />
+    );
+  }
+
+  const formatTime = (timestamp?: number) => {
+    if (!timestamp) return '';
+    return new Date(timestamp).toLocaleString();
+  };
+
+  // Summarize a state snapshot into a short label
+  const getStateLabel = (snapshot: PodStateSnapshot): string => {
+    const phase = snapshot.phase || 'Unknown';
+    if (snapshot.reason) {
+      return `${phase} (${snapshot.reason})`;
+    }
+    return phase;
+  };
+
+  // Get container summary for a snapshot (only main container, filter out Argo-internal init/wait)
+  const getContainerSummary = (snapshot: PodStateSnapshot): string[] => {
+    if (!snapshot.containerStatuses) return [];
+    return snapshot.containerStatuses
+      .filter((cs) => cs.name === 'main')
+      .map((cs) => {
+        const parts: string[] = [];
+        if (cs.state) parts.push(cs.state);
+        if (cs.reason) parts.push(`(${cs.reason})`);
+        if (cs.exitCode !== undefined) {
+          parts.push(cs.exitCode === 0 ? 'exit:0' : `exit:${cs.exitCode}`);
+        }
+        return parts.join(' ');
+      });
+  };
+
+  return (
+    <div>
+      {/* Cached Data Indicator */}
+      {cached && (
+        <div
+          style={{
+            backgroundColor: '#e3f2fd',
+            border: '1px solid #90caf9',
+            borderRadius: '4px',
+            padding: '12px 16px',
+            marginBottom: '16px',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <div>
+            <strong style={{ color: '#1565c0' }}>Cached Data</strong>
+            <div style={{ fontSize: '12px', color: '#666', marginTop: '2px' }}>
+              Pod status and events cached from a previous query.
+              {cachedAt && ` Last updated: ${formatTime(cachedAt)}`}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Current Pod Status */}
+      <div style={{ marginBottom: '24px' }}>
+        <h3 style={{ marginBottom: '12px', fontSize: '16px', fontWeight: 500 }}>Current Status</h3>
+        {podStatus ? (
+          <div
+            style={{
+              border: `1px solid ${podStatus.phase === 'Failed' ? '#f44336' : '#e0e0e0'}`,
+              borderRadius: '4px',
+              padding: '16px',
+              backgroundColor: getPhaseBackgroundColor(podStatus.phase),
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '12px' }}>
+              <span
+                style={{
+                  display: 'inline-block',
+                  width: '12px',
+                  height: '12px',
+                  borderRadius: '50%',
+                  backgroundColor: getPhaseColor(podStatus.phase),
+                  marginRight: '8px',
+                }}
+              />
+              <strong
+                style={{
+                  fontSize: '14px',
+                  color: podStatus.phase === 'Failed' ? '#c62828' : 'inherit',
+                }}
+              >
+                Phase: {podStatus.phase || 'Unknown'}
+              </strong>
+            </div>
+
+            {podStatus.phase === 'Failed' && podStatus.reason && (
+              <div
+                style={{
+                  backgroundColor: '#f44336',
+                  color: '#fff',
+                  padding: '12px',
+                  borderRadius: '4px',
+                  marginBottom: '12px',
+                }}
+              >
+                <strong>Error: {podStatus.reason}</strong>
+                {podStatus.message && (
+                  <div style={{ marginTop: '4px', fontSize: '13px' }}>{podStatus.message}</div>
+                )}
+              </div>
+            )}
+
+            {podStatus.reason && podStatus.phase !== 'Failed' && (
+              <div style={{ marginBottom: '8px' }}>
+                <strong>Reason:</strong> {podStatus.reason}
+              </div>
+            )}
+            {podStatus.message && podStatus.phase !== 'Failed' && (
+              <div style={{ marginBottom: '8px' }}>
+                <strong>Message:</strong> {podStatus.message}
+              </div>
+            )}
+            {podStatus.nodeName && (
+              <div style={{ marginBottom: '8px' }}>
+                <strong>Node:</strong> {podStatus.nodeName}
+              </div>
+            )}
+            {podStatus.podIP && (
+              <div style={{ marginBottom: '8px' }}>
+                <strong>Pod IP:</strong> {podStatus.podIP}
+              </div>
+            )}
+
+            {/* Container Status - show only main container (filter out Argo-internal init/wait) */}
+            {podStatus.containerStatuses &&
+              podStatus.containerStatuses.filter((cs) => cs.name === 'main').length > 0 && (
+                <div style={{ marginTop: '16px' }}>
+                  <strong>Container:</strong>
+                  {podStatus.containerStatuses
+                    .filter((cs) => cs.name === 'main')
+                    .map((cs, idx) => (
+                      <div
+                        key={idx}
+                        style={{
+                          marginTop: '8px',
+                          padding: '12px',
+                          backgroundColor: getContainerBackgroundColor(cs),
+                          border: `1px solid ${cs.reason && ERROR_REASONS.includes(cs.reason) ? '#f44336' : '#e0e0e0'}`,
+                          borderRadius: '4px',
+                        }}
+                      >
+                        <div style={{ display: 'flex', alignItems: 'center' }}>
+                          <span
+                            style={{
+                              display: 'inline-block',
+                              width: '8px',
+                              height: '8px',
+                              borderRadius: '50%',
+                              backgroundColor: getContainerStatusColor(cs),
+                              marginRight: '8px',
+                            }}
+                          />
+                          <strong>{cs.name}</strong>
+                          <span style={{ marginLeft: '8px', color: '#666' }}>
+                            {cs.state || 'unknown'}
+                          </span>
+                          <span
+                            style={{
+                              marginLeft: '4px',
+                              color:
+                                cs.state === 'terminated'
+                                  ? cs.exitCode === 0
+                                    ? '#2196f3'
+                                    : '#c62828'
+                                  : '#666',
+                              fontWeight:
+                                cs.state === 'terminated' && cs.exitCode !== 0 ? 500 : 'normal',
+                            }}
+                          >
+                            {cs.state === 'terminated'
+                              ? cs.exitCode === 0
+                                ? '(Completed)'
+                                : '(Failed)'
+                              : cs.ready
+                                ? '(Ready)'
+                                : '(Not Ready)'}
+                          </span>
+                        </div>
+                        {cs.restartCount > 0 && (
+                          <div style={{ color: '#ff9800', marginTop: '4px' }}>
+                            Restarts: {cs.restartCount}
+                          </div>
+                        )}
+                        {cs.reason && (
+                          <div
+                            style={{
+                              marginTop: '4px',
+                              color: ERROR_REASONS.includes(cs.reason) ? '#c62828' : '#333',
+                              fontWeight: ERROR_REASONS.includes(cs.reason) ? 500 : 'normal',
+                            }}
+                          >
+                            Reason: {cs.reason}
+                          </div>
+                        )}
+                        {cs.message && (
+                          <div
+                            style={{
+                              color: '#666',
+                              fontSize: '12px',
+                              marginTop: '4px',
+                              wordBreak: 'break-word',
+                            }}
+                          >
+                            {cs.message}
+                          </div>
+                        )}
+                        {cs.exitCode !== undefined && (
+                          <div
+                            style={{
+                              color: cs.exitCode !== 0 ? '#f44336' : '#4caf50',
+                              marginTop: '4px',
+                              fontWeight: cs.exitCode !== 0 ? 500 : 'normal',
+                            }}
+                          >
+                            Exit Code: {cs.exitCode}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                </div>
+              )}
+          </div>
+        ) : (
+          <div style={{ color: '#666', fontStyle: 'italic' }}>
+            Pod status not available. The pod may have been deleted.
+          </div>
+        )}
+      </div>
+
+      {/* Pod Lifecycle Timeline */}
+      {stateHistory.length > 0 && (
+        <div style={{ marginBottom: '24px' }}>
+          <h3 style={{ marginBottom: '12px', fontSize: '16px', fontWeight: 500 }}>
+            Pod Lifecycle ({stateHistory.length} state changes)
+          </h3>
+          <div style={{ position: 'relative', paddingLeft: '24px' }}>
+            {/* Vertical timeline line */}
+            <div
+              style={{
+                position: 'absolute',
+                left: '7px',
+                top: '4px',
+                bottom: '4px',
+                width: '2px',
+                backgroundColor: '#e0e0e0',
+              }}
+            />
+            {stateHistory.map((snapshot, idx) => {
+              const isLast = idx === stateHistory.length - 1;
+              const containerSummary = getContainerSummary(snapshot);
+              return (
+                <div key={idx} style={{ position: 'relative', marginBottom: isLast ? 0 : '16px' }}>
+                  {/* Timeline dot */}
+                  <div
+                    style={{
+                      position: 'absolute',
+                      left: '-20px',
+                      top: '3px',
+                      width: '12px',
+                      height: '12px',
+                      borderRadius: '50%',
+                      backgroundColor: snapshot.isError ? '#f44336' : getPhaseColor(snapshot.phase),
+                      border: '2px solid #fff',
+                      boxShadow:
+                        '0 0 0 1px ' +
+                        (snapshot.isError ? '#f44336' : getPhaseColor(snapshot.phase)),
+                    }}
+                  />
+                  <div
+                    style={{
+                      padding: '8px 12px',
+                      borderRadius: '4px',
+                      backgroundColor: snapshot.isError
+                        ? '#ffebee'
+                        : isLast
+                          ? getPhaseBackgroundColor(snapshot.phase)
+                          : '#fafafa',
+                      border: `1px solid ${snapshot.isError ? '#ef9a9a' : '#e0e0e0'}`,
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <span
+                        style={{
+                          fontWeight: 500,
+                          color: snapshot.isError ? '#c62828' : '#333',
+                          fontSize: '13px',
+                        }}
+                      >
+                        {getStateLabel(snapshot)}
+                      </span>
+                      <span style={{ color: '#999', fontSize: '11px' }}>
+                        {formatTime(snapshot.timestamp)}
+                      </span>
+                    </div>
+                    {snapshot.message && (
+                      <div
+                        style={{
+                          color: '#666',
+                          fontSize: '12px',
+                          marginTop: '4px',
+                          wordBreak: 'break-word',
+                        }}
+                      >
+                        {snapshot.message}
+                      </div>
+                    )}
+                    {containerSummary.length > 0 && (
+                      <div style={{ marginTop: '4px' }}>
+                        {containerSummary.map((cs, csIdx) => (
+                          <div key={csIdx} style={{ color: '#666', fontSize: '11px' }}>
+                            {cs}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Pod Events */}
+      <div>
+        <h3 style={{ marginBottom: '12px', fontSize: '16px', fontWeight: 500 }}>
+          Pod Events {podEvents.length > 0 && `(${podEvents.length})`}
+        </h3>
+        {podEvents.length > 0 ? (
+          <div style={{ border: '1px solid #e0e0e0', borderRadius: '4px', overflow: 'hidden' }}>
+            {podEvents.map((event, idx) => (
+              <div
+                key={idx}
+                style={{
+                  padding: '12px 16px',
+                  borderBottom: idx < podEvents.length - 1 ? '1px solid #e0e0e0' : 'none',
+                  backgroundColor: event.type === 'Warning' ? '#fff3e0' : '#fff',
+                }}
+              >
+                <div
+                  style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}
+                >
+                  <span>
+                    <span
+                      style={{
+                        color: event.type === 'Warning' ? '#ff9800' : '#4caf50',
+                        fontWeight: 500,
+                        marginRight: '8px',
+                      }}
+                    >
+                      [{event.type}]
+                    </span>
+                    <strong>{event.reason}</strong>
+                    {event.count > 1 && (
+                      <span style={{ color: '#666', marginLeft: '8px' }}>(x{event.count})</span>
+                    )}
+                  </span>
+                  <span style={{ color: '#666', fontSize: '12px' }}>
+                    {event.lastTimestamp ? new Date(event.lastTimestamp).toLocaleString() : '-'}
+                  </span>
+                </div>
+                <div style={{ color: '#333', fontSize: '13px' }}>{event.message}</div>
+                {event.source && (
+                  <div style={{ color: '#999', fontSize: '11px', marginTop: '4px' }}>
+                    Source: {event.source}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={{ color: '#666', fontStyle: 'italic' }}>
+            No events available. Events may have expired or the pod may have been deleted.
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
 async function getLogsInfo(

--- a/frontend/src/hooks/usePodStatus.ts
+++ b/frontend/src/hooks/usePodStatus.ts
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2024 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { Apis } from 'src/lib/Apis';
+import { getTaskKeyFromNodeKey, PipelineFlowElement } from 'src/lib/v2/StaticFlow';
+import { convertYamlToV2PipelineSpec } from 'src/lib/v2/WorkflowUtils';
+import { KfpExecutionProperties } from 'src/mlmd/MlmdUtils';
+import { Execution } from 'src/third_party/mlmd';
+
+// Pod status/events related interfaces
+export interface PodStatusInfo {
+  phase?: string;
+  message?: string;
+  reason?: string;
+  podIP?: string;
+  nodeName?: string;
+  containerStatuses?: ContainerStatusInfo[];
+  cached?: boolean;
+  cachedAt?: number;
+}
+
+export interface ContainerStatusInfo {
+  name: string;
+  ready: boolean;
+  restartCount: number;
+  state?: string;
+  reason?: string;
+  message?: string;
+  exitCode?: number;
+}
+
+export interface PodEventInfo {
+  type: string;
+  reason: string;
+  message: string;
+  firstTimestamp?: string;
+  lastTimestamp?: string;
+  count: number;
+  source?: string;
+  cached?: boolean;
+}
+
+export interface PodStateSnapshot {
+  timestamp: number;
+  phase?: string;
+  reason?: string;
+  message?: string;
+  containerStatuses?: ContainerStatusInfo[];
+  isError: boolean;
+}
+
+export interface PodStatusResult {
+  status: PodStatusInfo | null;
+  events: PodEventInfo[];
+  stateHistory: PodStateSnapshot[];
+  cached?: boolean;
+  cachedAt?: number;
+}
+
+export const ERROR_REASONS = [
+  'ErrImagePull',
+  'ImagePullBackOff',
+  'CrashLoopBackOff',
+  'CreateContainerConfigError',
+  'InvalidImageName',
+  'CreateContainerError',
+  'RunContainerError',
+  'PreCreateHookError',
+  'PostStartHookError',
+  'ContainerCannotRun',
+  'OOMKilled',
+  'Error',
+];
+
+// Derives the effective pod state based on container statuses.
+// Pod phase might be "Pending" while containers are in error state.
+export function deriveEffectiveState(
+  phase?: string,
+  containerStatuses?: ContainerStatusInfo[],
+  initContainerStatuses?: ContainerStatusInfo[],
+): { effectivePhase: string; errorReason?: string; errorMessage?: string } {
+  // Check init containers first (they run before regular containers)
+  if (initContainerStatuses && initContainerStatuses.length > 0) {
+    for (const cs of initContainerStatuses) {
+      if (cs.reason && ERROR_REASONS.includes(cs.reason)) {
+        return { effectivePhase: 'Failed', errorReason: cs.reason, errorMessage: cs.message };
+      }
+      if (cs.state === 'terminated' && cs.exitCode !== undefined && cs.exitCode !== 0) {
+        return {
+          effectivePhase: 'Failed',
+          errorReason: cs.reason || `Exit code ${cs.exitCode}`,
+          errorMessage: cs.message,
+        };
+      }
+    }
+  }
+
+  // Check regular containers
+  if (containerStatuses && containerStatuses.length > 0) {
+    for (const cs of containerStatuses) {
+      if (cs.reason && ERROR_REASONS.includes(cs.reason)) {
+        return { effectivePhase: 'Failed', errorReason: cs.reason, errorMessage: cs.message };
+      }
+      if (cs.state === 'terminated' && cs.exitCode !== undefined && cs.exitCode !== 0) {
+        return {
+          effectivePhase: 'Failed',
+          errorReason: cs.reason || `Exit code ${cs.exitCode}`,
+          errorMessage: cs.message,
+        };
+      }
+    }
+  }
+
+  return { effectivePhase: phase || 'Unknown' };
+}
+
+// Resolve the component ref name of the immediate parent DAG from layers.
+// The compiler (dag.go) uses component ref names as parentDagName, not task keys.
+// layers = ['root'] → root DAG → returns undefined (root-level)
+// layers = ['root', 'inner-pipeline'] → returns componentRef name of 'inner-pipeline'
+function resolveParentDagComponentName(
+  layers: string[] | undefined,
+  pipelineJobString: string | undefined,
+): string | undefined {
+  if (!layers || layers.length <= 1 || !pipelineJobString) {
+    return undefined;
+  }
+  try {
+    const pipelineSpec = convertYamlToV2PipelineSpec(pipelineJobString);
+    let currentDag = pipelineSpec.root?.dag;
+    // Walk layers[1:] to find the componentRef name of the last (immediate parent) layer.
+    // layers[0] is always 'root', so we skip it.
+    for (let i = 1; i < layers.length; i++) {
+      const taskKey = layers[i];
+      const taskSpec = currentDag?.tasks[taskKey];
+      const componentName = taskSpec?.componentRef?.name;
+      if (!componentName) return undefined;
+      if (i === layers.length - 1) {
+        return componentName;
+      }
+      const componentSpec = pipelineSpec.components[componentName];
+      currentDag = componentSpec?.dag;
+      if (!currentDag) return undefined;
+    }
+  } catch {
+    // If pipeline spec parsing fails, fall back to undefined
+  }
+  return undefined;
+}
+
+// Build the full task path from layers and element ID for nested DAG disambiguation.
+// Must match the compiler's task_path annotation format (dag.go):
+//   - Root-level tasks (parentDagName == "root"): bare task name
+//   - Nested tasks: "root.<componentRefName>.<taskName>"
+function buildTaskPath(
+  elementId: string | undefined,
+  layers: string[] | undefined,
+  pipelineJobString: string | undefined,
+): string | undefined {
+  const leafTaskKey = elementId ? getTaskKeyFromNodeKey(elementId) : undefined;
+  if (!leafTaskKey) return undefined;
+  // Resolve the parent DAG's componentRef name to match the compiler's format.
+  const parentComponentName = resolveParentDagComponentName(layers, pipelineJobString);
+  if (parentComponentName) {
+    return 'root.' + parentComponentName + '.' + leafTaskKey;
+  }
+  return leafTaskKey;
+}
+
+// Helper to find the best matching pod from a list.
+function findBestPod(
+  pods: any[],
+  taskName: string | undefined,
+  elementId: string | undefined,
+): any {
+  const hasContainerError = (pod: any): boolean => {
+    const containerStatuses = pod.status?.containerStatuses || [];
+    const initContainerStatuses = pod.status?.initContainerStatuses || [];
+    const allStatuses = [...containerStatuses, ...initContainerStatuses];
+    return allStatuses.some((cs: any) => {
+      const waitingReason = cs.state?.waiting?.reason;
+      const terminatedReason = cs.state?.terminated?.reason;
+      return (
+        ERROR_REASONS.includes(waitingReason) ||
+        ERROR_REASONS.includes(terminatedReason) ||
+        (cs.state?.terminated?.exitCode !== undefined && cs.state?.terminated?.exitCode !== 0)
+      );
+    });
+  };
+
+  const isImplPod = (pod: any): boolean => {
+    const name = pod.metadata?.name || '';
+    return name.includes('-impl-') || name.includes('-launcher-') || name.includes('-user-');
+  };
+
+  const isDriverPod = (pod: any): boolean => {
+    const name = pod.metadata?.name || '';
+    return name.includes('-driver-') || name.includes('-dag-driver-');
+  };
+
+  const scorePod = (pod: any): number => {
+    let score = 0;
+    if (hasContainerError(pod)) score += 100;
+    if (isImplPod(pod)) score += 50;
+    if (!isDriverPod(pod)) score += 10;
+    if (pod.status?.phase !== 'Succeeded') score += 25;
+    return score;
+  };
+
+  const sortedPods = [...pods].sort((a: any, b: any) => scorePod(b) - scorePod(a));
+  let matchingPod = sortedPods[0];
+
+  if (taskName && sortedPods.length > 1) {
+    const leafKey = elementId ? getTaskKeyFromNodeKey(elementId) : taskName;
+    const found = sortedPods.find((p: any) => {
+      const labels = p.metadata?.labels || {};
+      const annotations = p.metadata?.annotations || {};
+      const podTaskLabel = labels['pipelines.kubeflow.org/task_name'] || '';
+      const podTaskPath = annotations['pipelines.kubeflow.org/task_path'] || '';
+      const pName = p.metadata?.name || '';
+      return (
+        podTaskPath === taskName ||
+        podTaskLabel === taskName ||
+        podTaskLabel === leafKey ||
+        podTaskPath.endsWith('.' + leafKey) ||
+        podTaskLabel.endsWith('.' + leafKey) ||
+        labels['component'] === leafKey ||
+        pName.includes((leafKey || '').replace(/_/g, '-')) ||
+        pName.includes(leafKey || '')
+      );
+    });
+    if (found) {
+      matchingPod = found;
+    }
+  }
+
+  return matchingPod;
+}
+
+// Helper to parse a raw K8s container status object.
+function parseContainerStatus(cs: any): ContainerStatusInfo {
+  return {
+    name: cs.name,
+    ready: cs.ready,
+    restartCount: cs.restartCount,
+    state: cs.state ? Object.keys(cs.state)[0] : undefined,
+    reason: cs.state?.waiting?.reason || cs.state?.terminated?.reason,
+    message: cs.state?.waiting?.message || cs.state?.terminated?.message,
+    exitCode: cs.state?.terminated?.exitCode,
+  };
+}
+
+// Fetch pod status and events from Kubernetes API.
+// Execution is optional to support early failures where MLMD execution doesn't exist yet.
+export async function getPodStatusAndEvents(
+  execution: Execution | undefined,
+  namespace?: string,
+  runId?: string,
+  element?: PipelineFlowElement | null,
+  layers?: string[],
+  pipelineJobString?: string,
+): Promise<PodStatusResult> {
+  let podName = '';
+  let podNameSpace = namespace || '';
+
+  // Try to get pod info from MLMD execution custom properties
+  if (execution) {
+    const customPropertiesMap = execution.getCustomPropertiesMap();
+    podName = customPropertiesMap.get(KfpExecutionProperties.POD_NAME)?.getStringValue() || '';
+    podNameSpace = customPropertiesMap.get('namespace')?.getStringValue() || namespace || '';
+  }
+
+  // If pod name is not in MLMD, try to find it by run ID label.
+  // This handles early failures like ImagePullBackOff where the driver never ran.
+  if (!podName && runId && podNameSpace) {
+    try {
+      const taskName = buildTaskPath(element?.id, layers, pipelineJobString);
+      const pods = await Apis.getPodsByRunId(runId, podNameSpace, taskName);
+      if (pods && pods.length > 0) {
+        const matchingPod = findBestPod(pods, taskName, element?.id);
+        podName = matchingPod?.metadata?.name || '';
+      }
+    } catch (err) {
+      // Failed to get pods - this might be expected if no pods exist yet
+    }
+  }
+
+  if (!podName || !podNameSpace) {
+    return { status: null, events: [], stateHistory: [], cached: false };
+  }
+
+  const resolvedTaskName = buildTaskPath(element?.id, layers, pipelineJobString);
+
+  let status: PodStatusInfo | null = null;
+  let events: PodEventInfo[] = [];
+  let stateHistory: PodStateSnapshot[] = [];
+  let cached = false;
+  let cachedAt: number | undefined;
+
+  // Try to get pod info
+  try {
+    const podInfo = await Apis.getPodInfo(podName, podNameSpace, runId, resolvedTaskName);
+    if (podInfo && podInfo.status) {
+      const podStatus = podInfo.status as any;
+
+      if ((podInfo as any)._cached) {
+        cached = true;
+        cachedAt = (podInfo as any)._cachedAt;
+      }
+
+      if ((podInfo as any)._stateHistory) {
+        stateHistory = (podInfo as any)._stateHistory;
+      }
+
+      const containerStatuses = (podStatus.containerStatuses || []).map(parseContainerStatus);
+      const initContainerStatuses = (podStatus.initContainerStatuses || []).map(
+        parseContainerStatus,
+      );
+
+      const { effectivePhase, errorReason, errorMessage } = deriveEffectiveState(
+        podStatus.phase,
+        containerStatuses,
+        initContainerStatuses,
+      );
+
+      status = {
+        phase: effectivePhase,
+        message: errorMessage || podStatus.message,
+        reason: errorReason || podStatus.reason,
+        podIP: podStatus.podIP,
+        nodeName: (podInfo.spec as any)?.nodeName,
+        containerStatuses: [...initContainerStatuses, ...containerStatuses],
+        cached,
+        cachedAt,
+      };
+    }
+  } catch (err) {
+    // Pod may not exist anymore - we'll show events if available
+  }
+
+  // Try to get pod events
+  try {
+    const eventList = await Apis.getPodEvents(podName, podNameSpace, runId, resolvedTaskName);
+    if (eventList && eventList.items) {
+      if ((eventList as any)._cached) {
+        cached = true;
+        cachedAt = cachedAt || (eventList as any)._cachedAt;
+      }
+
+      if ((eventList as any)._stateHistory && stateHistory.length === 0) {
+        stateHistory = (eventList as any)._stateHistory;
+      }
+
+      events = (eventList.items as any[]).map((event: any) => ({
+        type: event.type,
+        reason: event.reason,
+        message: event.message,
+        firstTimestamp: event.firstTimestamp,
+        lastTimestamp: event.lastTimestamp,
+        count: event.count || 1,
+        source: event.source?.component,
+        cached: (event as any)._cached,
+      }));
+      events.sort((a, b) => {
+        const timeA = a.lastTimestamp ? new Date(a.lastTimestamp).getTime() : 0;
+        const timeB = b.lastTimestamp ? new Date(b.lastTimestamp).getTime() : 0;
+        return timeB - timeA;
+      });
+    }
+  } catch (err) {
+    // Events may not be available
+  }
+
+  return { status, events, stateHistory, cached, cachedAt };
+}
+
+// React hook wrapping getPodStatusAndEvents with useQuery.
+export function usePodStatus(
+  execution: Execution | undefined,
+  namespace: string | undefined,
+  runId: string | undefined,
+  element: PipelineFlowElement | null | undefined,
+  layers: string[],
+  pipelineJobString?: string,
+) {
+  return useQuery<PodStatusResult, Error>({
+    queryKey: ['podStatus', execution?.getId(), runId, element?.id, namespace, layers.join('/')],
+    queryFn: () =>
+      getPodStatusAndEvents(execution, namespace, runId, element, layers, pipelineJobString),
+    enabled: !!(runId && namespace),
+    refetchInterval: 30000,
+  });
+}

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -155,10 +155,17 @@ export class Apis {
   /**
    * Get pod info
    */
-  public static async getPodInfo(podName: string, podNamespace: string): Promise<JSONObject> {
-    const query = `k8s/pod?podname=${encodeURIComponent(podName)}&podnamespace=${encodeURIComponent(
+  public static async getPodInfo(
+    podName: string,
+    podNamespace: string,
+    runId?: string,
+    taskName?: string,
+  ): Promise<JSONObject> {
+    let query = `k8s/pod?podname=${encodeURIComponent(podName)}&podnamespace=${encodeURIComponent(
       podNamespace,
     )}`;
+    if (runId) query += `&runid=${encodeURIComponent(runId)}`;
+    if (taskName) query += `&taskname=${encodeURIComponent(taskName)}`;
     const podInfo = await this._fetch(query);
     return JSON.parse(podInfo);
   }
@@ -166,12 +173,39 @@ export class Apis {
   /**
    * Get pod events
    */
-  public static async getPodEvents(podName: string, podNamespace: string): Promise<JSONObject> {
-    const query = `k8s/pod/events?podname=${encodeURIComponent(
+  public static async getPodEvents(
+    podName: string,
+    podNamespace: string,
+    runId?: string,
+    taskName?: string,
+  ): Promise<JSONObject> {
+    let query = `k8s/pod/events?podname=${encodeURIComponent(
       podName,
     )}&podnamespace=${encodeURIComponent(podNamespace)}`;
+    if (runId) query += `&runid=${encodeURIComponent(runId)}`;
+    if (taskName) query += `&taskname=${encodeURIComponent(taskName)}`;
     const eventList = await this._fetch(query);
     return JSON.parse(eventList);
+  }
+
+  /**
+   * Get pods by run ID label.
+   * This is useful for finding pods that failed early (e.g., ImagePullBackOff)
+   * before the pod name could be recorded in MLMD.
+   */
+  public static async getPodsByRunId(
+    runId: string,
+    podNamespace: string,
+    taskName?: string,
+  ): Promise<JSONObject[]> {
+    let query = `k8s/pods/byRunId?runid=${encodeURIComponent(
+      runId,
+    )}&podnamespace=${encodeURIComponent(podNamespace)}`;
+    if (taskName) {
+      query += `&taskname=${encodeURIComponent(taskName)}`;
+    }
+    const pods = await this._fetch(query);
+    return JSON.parse(pods);
   }
 
   public static get basePath(): string {

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -12,8 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { MouseEvent as ReactMouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  MouseEvent as ReactMouseEvent,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { NamespaceContext } from 'src/lib/KubeflowClient';
 import { V2beta1Experiment } from 'src/apisv2beta1/experiment';
 import { queryKeys } from 'src/hooks/queryKeys';
 import { V2beta1Run, V2beta1RuntimeState, V2beta1RunStorageState } from 'src/apisv2beta1/run';
@@ -51,8 +59,8 @@ import { RunDetailsProps } from './RunDetails';
 import { statusToIcon } from './StatusV2';
 import DagCanvas from './v2/DagCanvas';
 
-const QUERY_STALE_TIME = 10000; // 10000 milliseconds == 10 seconds.
-const QUERY_REFETCH_INTERVAL = 10000; // 10000 milliseconds == 10 seconds.
+const QUERY_STALE_TIME = 30000; // 30000 milliseconds == 30 seconds.
+const QUERY_REFETCH_INTERVAL = 60000; // 60000 milliseconds == 60 seconds (was 10s, increased for performance).
 const TAB_NAMES = ['Graph', 'Detail', 'Pipeline Spec'];
 
 interface MlmdPackage {
@@ -123,7 +131,6 @@ export function RunDetailsV2(props: RunDetailsV2Props) {
     queryKey: queryKeys.runDetailsV2Experiment(runId, experimentId),
     queryFn: () => getExperiment(experimentId),
   });
-  const namespace = experiment?.namespace;
 
   // Single banner effect with clear precedence: MLMD error > experiment error > clear on success.
   useEffect(() => {
@@ -178,6 +185,22 @@ export function RunDetailsV2(props: RunDetailsV2Props) {
       );
     }
   };
+
+  // Get namespace from multiple sources (in order of preference):
+  // 1. Experiment namespace
+  // 2. Kubeflow Central Dashboard context
+  // 3. URL query params (ns or namespace)
+  const contextNamespace = useContext(NamespaceContext);
+  const getNamespaceFromUrl = (): string | undefined => {
+    try {
+      const urlParams = new URLSearchParams(window.location.search);
+      return urlParams.get('ns') || urlParams.get('namespace') || undefined;
+    } catch {
+      return undefined;
+    }
+  };
+  const urlNamespace = getNamespaceFromUrl();
+  const namespace = experiment?.namespace || contextNamespace || urlNamespace;
 
   // Update page title and experiment information.
   useEffect(() => {

--- a/manifests/kustomize/base/installs/multi-user/pipelines-ui/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/pipelines-ui/cluster-role.yaml
@@ -10,6 +10,7 @@ rules:
   - pods/log
   verbs:
   - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-role.yaml
@@ -12,6 +12,7 @@ rules:
   - pods/log
   verbs:
   - get
+  - list
 - apiGroups:
   - ""
   resources:

--- a/test_data/compiled-workflows/add_numbers.yaml
+++ b/test_data/compiled-workflows/add_numbers.yaml
@@ -112,12 +112,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -144,6 +150,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -152,6 +162,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -224,7 +238,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -260,6 +282,8 @@ spec:
             value: add-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add-numbers
         name: add-numbers-driver
         template: system-container-driver
       - arguments:
@@ -269,6 +293,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-numbers-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-numbers
+          - name: task-path
+            value: add-numbers
         depends: add-numbers-driver.Succeeded
         name: add-numbers
         template: system-container-executor
@@ -350,13 +378,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/arguments_parameters.yaml
+++ b/test_data/compiled-workflows/arguments_parameters.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: echo
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo
         name: echo-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo
+          - name: task-path
+            value: echo
         depends: echo-driver.Succeeded
         name: echo
         template: system-container-executor
@@ -341,13 +369,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/artifact_cache.yaml
+++ b/test_data/compiled-workflows/artifact_cache.yaml
@@ -131,12 +131,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -163,6 +169,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -171,6 +181,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -243,7 +257,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -279,6 +301,8 @@ spec:
             value: core-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-core.core-comp
         name: core-comp-driver
         template: system-container-driver
       - arguments:
@@ -288,6 +312,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.core-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: core-comp
+          - name: task-path
+            value: root.comp-core.core-comp
         depends: core-comp-driver.Succeeded
         name: core-comp
         template: system-container-executor
@@ -369,13 +397,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -406,6 +440,8 @@ spec:
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-core"},"taskInfo":{"name":"core"}}'
           - name: task-name
             value: core
+          - name: task-path
+            value: root.comp-mantle.core
         name: core-driver
         template: system-dag-driver
       - arguments:
@@ -437,6 +473,8 @@ spec:
             value: crust-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: crust-comp
         depends: mantle.Succeeded
         name: crust-comp-driver
         template: system-container-driver
@@ -447,6 +485,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.crust-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: crust-comp
+          - name: task-path
+            value: crust-comp
         depends: crust-comp-driver.Succeeded
         name: crust-comp
         template: system-container-executor
@@ -459,6 +501,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-mantle"},"taskInfo":{"name":"mantle"}}'
           - name: task-name
+            value: mantle
+          - name: task-path
             value: mantle
         name: mantle-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/artifact_crust.yaml
+++ b/test_data/compiled-workflows/artifact_crust.yaml
@@ -131,12 +131,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -163,6 +169,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -171,6 +181,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -243,7 +257,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -279,6 +301,8 @@ spec:
             value: core-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-core.core-comp
         name: core-comp-driver
         template: system-container-driver
       - arguments:
@@ -288,6 +312,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.core-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: core-comp
+          - name: task-path
+            value: root.comp-core.core-comp
         depends: core-comp-driver.Succeeded
         name: core-comp
         template: system-container-executor
@@ -369,13 +397,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -406,6 +440,8 @@ spec:
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-core"},"taskInfo":{"name":"core"}}'
           - name: task-name
             value: core
+          - name: task-path
+            value: root.comp-mantle.core
         name: core-driver
         template: system-dag-driver
       - arguments:
@@ -437,6 +473,8 @@ spec:
             value: crust-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: crust-comp
         depends: mantle.Succeeded
         name: crust-comp-driver
         template: system-container-driver
@@ -447,6 +485,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.crust-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: crust-comp
+          - name: task-path
+            value: crust-comp
         depends: crust-comp-driver.Succeeded
         name: crust-comp
         template: system-container-executor
@@ -459,6 +501,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-mantle"},"taskInfo":{"name":"mantle"}}'
           - name: task-name
+            value: mantle
+          - name: task-path
             value: mantle
         name: mantle-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/artifacts_complex.yaml
+++ b/test_data/compiled-workflows/artifacts_complex.yaml
@@ -157,12 +157,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -189,6 +195,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -197,6 +207,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -269,7 +283,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -305,6 +327,8 @@ spec:
             value: add
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-add-two-lists-of-datasets.add
         name: add-driver
         template: system-container-driver
       - arguments:
@@ -314,6 +338,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add
+          - name: task-path
+            value: root.comp-add-two-lists-of-datasets.add
         depends: add-driver.Succeeded
         name: add
         template: system-container-executor
@@ -329,6 +357,8 @@ spec:
             value: add-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-add-two-lists-of-datasets.add-2
         name: add-2-driver
         template: system-container-driver
       - arguments:
@@ -338,6 +368,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-2
+          - name: task-path
+            value: root.comp-add-two-lists-of-datasets.add-2
         depends: add-2-driver.Succeeded
         name: add-2
         template: system-container-executor
@@ -353,6 +387,8 @@ spec:
             value: add-two-ints
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-add-two-lists-of-datasets.add-two-ints
         depends: add.Succeeded && add-2.Succeeded
         name: add-two-ints-driver
         template: system-container-driver
@@ -363,6 +399,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-two-ints-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-two-ints
+          - name: task-path
+            value: root.comp-add-two-lists-of-datasets.add-two-ints
         depends: add-two-ints-driver.Succeeded
         name: add-two-ints
         template: system-container-executor
@@ -386,6 +426,8 @@ spec:
             value: double-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-5.double-2
         name: double-2-driver
         template: system-container-driver
       - arguments:
@@ -395,6 +437,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.double-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: double-2
+          - name: task-path
+            value: root.comp-condition-5.double-2
         depends: double-2-driver.Succeeded
         name: double-2
         template: system-container-executor
@@ -476,13 +522,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -514,6 +566,8 @@ spec:
               \u003e= int(inputs.parameter_values[''pipelinechannel--threshold''])"}}'
           - name: task-name
             value: condition-5
+          - name: task-path
+            value: root.comp-for-loop-4.condition-5
         name: condition-5-driver
         template: system-dag-driver
       - arguments:
@@ -547,6 +601,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
+          - name: task-path
+            value: root.comp-for-loop-2.for-loop-4.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -611,6 +667,8 @@ spec:
             value: double
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.double
         name: double-driver
         template: system-container-driver
       - arguments:
@@ -620,6 +678,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.double-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: double
+          - name: task-path
+            value: root.comp-for-loop-2.double
         depends: double-driver.Succeeded
         name: double
         template: system-container-executor
@@ -650,6 +712,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -711,6 +775,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-add-two-lists-of-datasets"},"dependentTasks":["for-loop-2"],"inputs":{"artifacts":{"in_datasets1":{"taskOutputArtifact":{"outputArtifactKey":"pipelinechannel--double-out_dataset","producerTask":"for-loop-2"}},"in_datasets2":{"taskOutputArtifact":{"outputArtifactKey":"pipelinechannel--double-2-out_dataset","producerTask":"for-loop-2"}}}},"taskInfo":{"name":"add-two-lists-of-datasets"}}'
           - name: task-name
+            value: add-two-lists-of-datasets
+          - name: task-path
             value: add-two-lists-of-datasets
         depends: for-loop-2.Succeeded
         name: add-two-lists-of-datasets-driver

--- a/test_data/compiled-workflows/artifacts_simple.yaml
+++ b/test_data/compiled-workflows/artifacts_simple.yaml
@@ -142,12 +142,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -174,6 +180,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -182,6 +192,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -254,7 +268,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -290,6 +312,8 @@ spec:
             value: double
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.double
         name: double-driver
         template: system-container-driver
       - arguments:
@@ -299,6 +323,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.double-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: double
+          - name: task-path
+            value: root.comp-for-loop-2.double
         depends: double-driver.Succeeded
         name: double
         template: system-container-executor
@@ -380,13 +408,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -420,6 +454,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -484,6 +520,8 @@ spec:
             value: add
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add
         depends: for-loop-2.Succeeded
         name: add-driver
         template: system-container-driver
@@ -494,6 +532,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add
+          - name: task-path
+            value: add
         depends: add-driver.Succeeded
         name: add
         template: system-container-executor
@@ -509,6 +551,8 @@ spec:
             value: add-container
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add-container
         depends: for-loop-2.Succeeded
         name: add-container-driver
         template: system-container-driver
@@ -519,6 +563,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-container-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-container
+          - name: task-path
+            value: add-container
         depends: add-container-driver.Succeeded
         name: add-container
         template: system-container-executor

--- a/test_data/compiled-workflows/collected_artifacts.yaml
+++ b/test_data/compiled-workflows/collected_artifacts.yaml
@@ -223,12 +223,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -255,6 +261,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -263,6 +273,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -335,7 +349,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -371,6 +393,8 @@ spec:
             value: create-dataset
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-single-node-dag.create-dataset
         name: create-dataset-driver
         template: system-container-driver
       - arguments:
@@ -380,6 +404,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.create-dataset-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: create-dataset
+          - name: task-path
+            value: root.comp-single-node-dag.create-dataset
         depends: create-dataset-driver.Succeeded
         name: create-dataset
         template: system-container-executor
@@ -461,13 +489,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -500,6 +534,8 @@ spec:
             value: read-single-dataset-generate-model
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.read-single-dataset-generate-model
         depends: single-node-dag.Succeeded
         name: read-single-dataset-generate-model-driver
         template: system-container-driver
@@ -510,6 +546,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-single-dataset-generate-model-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-single-dataset-generate-model
+          - name: task-path
+            value: root.comp-for-loop-2.read-single-dataset-generate-model
         depends: read-single-dataset-generate-model-driver.Succeeded
         name: read-single-dataset-generate-model
         template: system-container-executor
@@ -523,6 +563,8 @@ spec:
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-single-node-dag"},"inputs":{"parameters":{"char":{"componentInputParameter":"pipelinechannel--split-chars-Output-loop-item"}}},"taskInfo":{"name":"single-node-dag"}}'
           - name: task-name
             value: single-node-dag
+          - name: task-path
+            value: root.comp-for-loop-2.single-node-dag
         name: single-node-dag-driver
         template: system-dag-driver
       - arguments:
@@ -554,6 +596,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-2"},"inputs":{"parameters":{"pipelinechannel--split-chars-Output":{"componentInputParameter":"pipelinechannel--split-chars-Output"},"pipelinechannel--split-ids-Output-loop-item":{"componentInputParameter":"pipelinechannel--split-ids-Output-loop-item"}}},"parameterIterator":{"itemInput":"pipelinechannel--split-chars-Output-loop-item","items":{"inputParameter":"pipelinechannel--split-chars-Output"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.comp-for-loop-1.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -617,6 +661,8 @@ spec:
             value: create-file
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.create-file
         name: create-file-driver
         template: system-container-driver
       - arguments:
@@ -626,6 +672,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.create-file-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: create-file
+          - name: task-path
+            value: root.comp-for-loop-1.create-file
         depends: create-file-driver.Succeeded
         name: create-file
         template: system-container-executor
@@ -647,6 +697,8 @@ spec:
             value: read-datasets
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.read-datasets
         depends: for-loop-2.Succeeded
         name: read-datasets-driver
         template: system-container-driver
@@ -657,6 +709,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-datasets-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-datasets
+          - name: task-path
+            value: root.comp-for-loop-1.read-datasets
         depends: read-datasets-driver.Succeeded
         name: read-datasets
         template: system-container-executor
@@ -672,6 +728,8 @@ spec:
             value: read-models
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.read-models
         depends: for-loop-2.Succeeded
         name: read-models-driver
         template: system-container-driver
@@ -682,6 +740,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-models-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-models
+          - name: task-path
+            value: root.comp-for-loop-1.read-models
         depends: read-models-driver.Succeeded
         name: read-models
         template: system-container-executor
@@ -697,6 +759,8 @@ spec:
             value: read-single-file
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.read-single-file
         depends: create-file.Succeeded
         name: read-single-file-driver
         template: system-container-driver
@@ -707,6 +771,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-single-file-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-single-file
+          - name: task-path
+            value: root.comp-for-loop-1.read-single-file
         depends: read-single-file-driver.Succeeded
         name: read-single-file
         template: system-container-executor
@@ -730,6 +798,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-1"},"dependentTasks":["split-chars","split-ids"],"inputs":{"parameters":{"pipelinechannel--split-chars-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"split-chars"}},"pipelinechannel--split-ids-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"split-ids"}}}},"parameterIterator":{"itemInput":"pipelinechannel--split-ids-Output-loop-item","items":{"inputParameter":"pipelinechannel--split-ids-Output"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
+          - name: task-path
+            value: root.comp-collecting-artifacts.for-loop-1.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -800,6 +870,8 @@ spec:
             value: split-chars
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-collecting-artifacts.split-chars
         name: split-chars-driver
         template: system-container-driver
       - arguments:
@@ -809,6 +881,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.split-chars-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: split-chars
+          - name: task-path
+            value: root.comp-collecting-artifacts.split-chars
         depends: split-chars-driver.Succeeded
         name: split-chars
         template: system-container-executor
@@ -824,6 +900,8 @@ spec:
             value: split-ids
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-collecting-artifacts.split-ids
         name: split-ids-driver
         template: system-container-driver
       - arguments:
@@ -833,6 +911,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.split-ids-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: split-ids
+          - name: task-path
+            value: root.comp-collecting-artifacts.split-ids
         depends: split-ids-driver.Succeeded
         name: split-ids
         template: system-container-executor
@@ -853,6 +935,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-collecting-artifacts"},"inputs":{"parameters":{"model_chars":{"runtimeValue":{"constant":"x,y,z"}},"model_ids":{"runtimeValue":{"constant":"s1,s2,s3"}}}},"taskInfo":{"name":"collecting-artifacts"}}'
           - name: task-name
+            value: collecting-artifacts
+          - name: task-path
             value: collecting-artifacts
         name: collecting-artifacts-driver
         template: system-dag-driver
@@ -877,6 +961,8 @@ spec:
             value: read-models
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: read-models
         depends: collecting-artifacts.Succeeded
         name: read-models-driver
         template: system-container-driver
@@ -887,6 +973,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-models-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-models
+          - name: task-path
+            value: read-models
         depends: read-models-driver.Succeeded
         name: read-models
         template: system-container-executor

--- a/test_data/compiled-workflows/collected_parameters.yaml
+++ b/test_data/compiled-workflows/collected_parameters.yaml
@@ -158,12 +158,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -190,6 +196,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -198,6 +208,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -270,7 +284,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -306,6 +328,8 @@ spec:
             value: consume-single-id
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.consume-single-id
         depends: prepend-id.Succeeded
         name: consume-single-id-driver
         template: system-container-driver
@@ -316,6 +340,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.consume-single-id-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: consume-single-id
+          - name: task-path
+            value: root.comp-for-loop-1.consume-single-id
         depends: consume-single-id-driver.Succeeded
         name: consume-single-id
         template: system-container-executor
@@ -331,6 +359,8 @@ spec:
             value: prepend-id
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.prepend-id
         name: prepend-id-driver
         template: system-container-driver
       - arguments:
@@ -340,6 +370,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.prepend-id-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: prepend-id
+          - name: task-path
+            value: root.comp-for-loop-1.prepend-id
         depends: prepend-id-driver.Succeeded
         name: prepend-id
         template: system-container-executor
@@ -421,13 +455,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -460,6 +500,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-1"},"dependentTasks":["split-ids"],"inputs":{"parameters":{"pipelinechannel--split-ids-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"split-ids"}}}},"parameterIterator":{"itemInput":"pipelinechannel--split-ids-Output-loop-item","items":{"inputParameter":"pipelinechannel--split-ids-Output"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
+          - name: task-path
+            value: root.comp-collecting-parameters.for-loop-1.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -523,6 +565,8 @@ spec:
             value: consume-ids
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-collecting-parameters.consume-ids
         depends: for-loop-1.Succeeded
         name: consume-ids-driver
         template: system-container-driver
@@ -533,6 +577,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.consume-ids-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: consume-ids
+          - name: task-path
+            value: root.comp-collecting-parameters.consume-ids
         depends: consume-ids-driver.Succeeded
         name: consume-ids
         template: system-container-executor
@@ -555,6 +603,8 @@ spec:
             value: split-ids
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-collecting-parameters.split-ids
         name: split-ids-driver
         template: system-container-driver
       - arguments:
@@ -564,6 +614,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.split-ids-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: split-ids
+          - name: task-path
+            value: root.comp-collecting-parameters.split-ids
         depends: split-ids-driver.Succeeded
         name: split-ids
         template: system-container-executor
@@ -584,6 +638,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-collecting-parameters"},"inputs":{"parameters":{"model_ids":{"runtimeValue":{"constant":"s1,s2,s3"}}}},"taskInfo":{"name":"collecting-parameters"}}'
           - name: task-name
+            value: collecting-parameters
+          - name: task-path
             value: collecting-parameters
         name: collecting-parameters-driver
         template: system-dag-driver
@@ -608,6 +664,8 @@ spec:
             value: consume-ids
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: consume-ids
         depends: collecting-parameters.Succeeded
         name: consume-ids-driver
         template: system-container-driver
@@ -618,6 +676,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.consume-ids-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: consume-ids
+          - name: task-path
+            value: consume-ids
         depends: consume-ids-driver.Succeeded
         name: consume-ids
         template: system-container-executor

--- a/test_data/compiled-workflows/component_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/component_with_metadata_fields.yaml
@@ -127,12 +127,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -159,6 +165,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -167,6 +177,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -239,7 +253,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -275,6 +297,8 @@ spec:
             value: dataset-joiner
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: dataset-joiner
         name: dataset-joiner-driver
         template: system-container-driver
       - arguments:
@@ -284,6 +308,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.dataset-joiner-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: dataset-joiner
+          - name: task-path
+            value: dataset-joiner
         depends: dataset-joiner-driver.Succeeded
         name: dataset-joiner
         template: system-container-executor
@@ -365,13 +393,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/component_with_optional_inputs.yaml
+++ b/test_data/compiled-workflows/component_with_optional_inputs.yaml
@@ -116,12 +116,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -148,6 +154,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -156,6 +166,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -228,7 +242,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -264,6 +286,8 @@ spec:
             value: component-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: component-op
         name: component-op-driver
         template: system-container-driver
       - arguments:
@@ -273,6 +297,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-op
+          - name: task-path
+            value: component-op
         depends: component-op-driver.Succeeded
         name: component-op
         template: system-container-executor
@@ -354,13 +382,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/component_with_pip_index_urls.yaml
+++ b/test_data/compiled-workflows/component_with_pip_index_urls.yaml
@@ -114,12 +114,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -146,6 +152,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -154,6 +164,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -226,7 +240,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -262,6 +284,8 @@ spec:
             value: component-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: component-op
         name: component-op-driver
         template: system-container-driver
       - arguments:
@@ -271,6 +295,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-op
+          - name: task-path
+            value: component-op
         depends: component-op-driver.Succeeded
         name: component-op
         template: system-container-executor
@@ -352,13 +380,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/component_with_pip_install.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install.yaml
@@ -114,12 +114,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -146,6 +152,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -154,6 +164,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -226,7 +240,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -262,6 +284,8 @@ spec:
             value: component-with-pip-install
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: component-with-pip-install
         name: component-with-pip-install-driver
         template: system-container-driver
       - arguments:
@@ -271,6 +295,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-with-pip-install-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-with-pip-install
+          - name: task-path
+            value: component-with-pip-install
         depends: component-with-pip-install-driver.Succeeded
         name: component-with-pip-install
         template: system-container-executor
@@ -352,13 +380,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
@@ -115,12 +115,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -147,6 +153,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -155,6 +165,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -227,7 +241,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -263,6 +285,8 @@ spec:
             value: component-with-pip-install
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: component-with-pip-install
         name: component-with-pip-install-driver
         template: system-container-driver
       - arguments:
@@ -272,6 +296,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-with-pip-install-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-with-pip-install
+          - name: task-path
+            value: component-with-pip-install
         depends: component-with-pip-install-driver.Succeeded
         name: component-with-pip-install
         template: system-container-executor
@@ -353,13 +381,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/components_with_optional_artifacts.yaml
+++ b/test_data/compiled-workflows/components_with_optional_artifacts.yaml
@@ -128,12 +128,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -160,6 +166,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -168,6 +178,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -240,7 +254,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -276,6 +298,8 @@ spec:
             value: python-artifact-printer
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-inner-pipeline.python-artifact-printer
         name: python-artifact-printer-driver
         template: system-container-driver
       - arguments:
@@ -285,6 +309,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.python-artifact-printer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: python-artifact-printer
+          - name: task-path
+            value: root.comp-inner-pipeline.python-artifact-printer
         depends: python-artifact-printer-driver.Succeeded
         name: python-artifact-printer
         template: system-container-executor
@@ -308,6 +336,8 @@ spec:
             value: python-artifact-printer
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-inner-pipeline-2.python-artifact-printer
         name: python-artifact-printer-driver
         template: system-container-driver
       - arguments:
@@ -317,6 +347,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.python-artifact-printer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: python-artifact-printer
+          - name: task-path
+            value: root.comp-inner-pipeline-2.python-artifact-printer
         depends: python-artifact-printer-driver.Succeeded
         name: python-artifact-printer
         template: system-container-executor
@@ -467,13 +501,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -506,6 +546,8 @@ spec:
             value: custom-artifact-printer
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: custom-artifact-printer
         name: custom-artifact-printer-driver
         template: system-container-driver
       - arguments:
@@ -515,6 +557,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.custom-artifact-printer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: custom-artifact-printer
+          - name: task-path
+            value: custom-artifact-printer
         depends: custom-artifact-printer-driver.Succeeded
         name: custom-artifact-printer
         template: system-container-executor
@@ -530,6 +576,8 @@ spec:
             value: custom-artifact-printer-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: custom-artifact-printer-2
         name: custom-artifact-printer-2-driver
         template: system-container-driver
       - arguments:
@@ -539,6 +587,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.custom-artifact-printer-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: custom-artifact-printer-2
+          - name: task-path
+            value: custom-artifact-printer-2
         depends: custom-artifact-printer-2-driver.Succeeded
         name: custom-artifact-printer-2
         template: system-container-executor
@@ -564,6 +616,8 @@ spec:
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-inner-pipeline"},"dependentTasks":["importer"],"inputs":{"artifacts":{"dataset":{"taskOutputArtifact":{"outputArtifactKey":"artifact","producerTask":"importer"}}}},"taskInfo":{"name":"inner-pipeline"}}'
           - name: task-name
             value: inner-pipeline
+          - name: task-path
+            value: inner-pipeline
         depends: importer.Succeeded
         name: inner-pipeline-driver
         template: system-dag-driver
@@ -585,6 +639,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-inner-pipeline-2"},"taskInfo":{"name":"inner-pipeline-2"}}'
           - name: task-name
+            value: inner-pipeline-2
+          - name: task-path
             value: inner-pipeline-2
         name: inner-pipeline-2-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/concat_message.yaml
+++ b/test_data/compiled-workflows/concat_message.yaml
@@ -113,12 +113,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -145,6 +151,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -153,6 +163,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -225,7 +239,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -261,6 +283,8 @@ spec:
             value: concat-message
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: concat-message
         name: concat-message-driver
         template: system-container-driver
       - arguments:
@@ -270,6 +294,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.concat-message-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: concat-message
+          - name: task-path
+            value: concat-message
         depends: concat-message-driver.Succeeded
         name: concat-message
         template: system-container-executor
@@ -351,13 +379,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
+++ b/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
@@ -134,12 +134,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -166,6 +172,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -174,6 +184,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -246,7 +260,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -282,6 +304,8 @@ spec:
             value: add
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-4.add
         name: add-driver
         template: system-container-driver
       - arguments:
@@ -291,6 +315,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add
+          - name: task-path
+            value: root.comp-condition-4.add
         depends: add-driver.Succeeded
         name: add
         template: system-container-executor
@@ -314,6 +342,8 @@ spec:
             value: double
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-3.double
         name: double-driver
         template: system-container-driver
       - arguments:
@@ -323,6 +353,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.double-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: double
+          - name: task-path
+            value: root.comp-condition-3.double
         depends: double-driver.Succeeded
         name: double
         template: system-container-executor
@@ -404,13 +438,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -442,6 +482,8 @@ spec:
               \u003e= int(inputs.parameter_values[''pipelinechannel--threshold''])"}}'
           - name: task-name
             value: condition-3
+          - name: task-path
+            value: root.comp-for-loop-2.condition-3
         name: condition-3-driver
         template: system-dag-driver
       - arguments:
@@ -475,6 +517,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -537,6 +581,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-4"},"dependentTasks":["for-loop-2"],"inputs":{"parameters":{"pipelinechannel--for-loop-2-pipelinechannel--double-Output":{"taskOutputParameter":{"outputParameterKey":"pipelinechannel--double-Output","producerTask":"for-loop-2"}},"pipelinechannel--threshold":{"componentInputParameter":"threshold"}}},"taskInfo":{"name":"condition-4"},"triggerPolicy":{"condition":"int(inputs.parameter_values[''pipelinechannel--threshold''])
               == 2"}}'
           - name: task-name
+            value: condition-4
+          - name: task-path
             value: condition-4
         depends: for-loop-2.Succeeded
         name: condition-4-driver

--- a/test_data/compiled-workflows/container_component_with_no_inputs.yaml
+++ b/test_data/compiled-workflows/container_component_with_no_inputs.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: hello-world-container
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: hello-world-container
         name: hello-world-container-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.hello-world-container-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: hello-world-container
+          - name: task-path
+            value: hello-world-container
         depends: hello-world-container-driver.Succeeded
         name: hello-world-container
         template: system-container-executor
@@ -341,13 +369,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/container_io.yaml
+++ b/test_data/compiled-workflows/container_io.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: container-io
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: container-io
         name: container-io-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.container-io-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: container-io
+          - name: task-path
+            value: container-io
         depends: container-io-driver.Succeeded
         name: container-io
         template: system-container-executor
@@ -341,13 +369,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/container_no_input.yaml
+++ b/test_data/compiled-workflows/container_no_input.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: container-no-input
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: container-no-input
         name: container-no-input-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.container-no-input-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: container-no-input
+          - name: task-path
+            value: container-no-input
         depends: container-no-input-driver.Succeeded
         name: container-no-input
         template: system-container-executor
@@ -341,13 +369,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/container_with_artifact_output.yaml
+++ b/test_data/compiled-workflows/container_with_artifact_output.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: container-with-artifact-output
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: container-with-artifact-output
         name: container-with-artifact-output-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.container-with-artifact-output-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: container-with-artifact-output
+          - name: task-path
+            value: container-with-artifact-output
         depends: container-with-artifact-output-driver.Succeeded
         name: container-with-artifact-output
         template: system-container-executor
@@ -341,13 +369,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/container_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_concat_placeholder.yaml
@@ -104,12 +104,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -136,6 +142,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -144,6 +154,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -216,7 +230,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -252,6 +274,8 @@ spec:
             value: container-with-concat-placeholder
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: container-with-concat-placeholder
         name: container-with-concat-placeholder-driver
         template: system-container-driver
       - arguments:
@@ -261,6 +285,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.container-with-concat-placeholder-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: container-with-concat-placeholder
+          - name: task-path
+            value: container-with-concat-placeholder
         depends: container-with-concat-placeholder-driver.Succeeded
         name: container-with-concat-placeholder
         template: system-container-executor
@@ -342,13 +370,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/container_with_if_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder.yaml
@@ -106,12 +106,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -138,6 +144,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -146,6 +156,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -218,7 +232,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -254,6 +276,8 @@ spec:
             value: container-with-if-placeholder
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: container-with-if-placeholder
         name: container-with-if-placeholder-driver
         template: system-container-driver
       - arguments:
@@ -263,6 +287,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.container-with-if-placeholder-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: container-with-if-placeholder
+          - name: task-path
+            value: container-with-if-placeholder
         depends: container-with-if-placeholder-driver.Succeeded
         name: container-with-if-placeholder
         template: system-container-executor
@@ -344,13 +372,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
+++ b/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: container-with-placeholder-in-fstring
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: container-with-placeholder-in-fstring
         name: container-with-placeholder-in-fstring-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.container-with-placeholder-in-fstring-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: container-with-placeholder-in-fstring
+          - name: task-path
+            value: container-with-placeholder-in-fstring
         depends: container-with-placeholder-in-fstring-driver.Succeeded
         name: container-with-placeholder-in-fstring
         template: system-container-executor
@@ -341,13 +369,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/containerized_python_component.yaml
+++ b/test_data/compiled-workflows/containerized_python_component.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: concat-message
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: concat-message
         name: concat-message-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.concat-message-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: concat-message
+          - name: task-path
+            value: concat-message
         depends: concat-message-driver.Succeeded
         name: concat-message
         template: system-container-executor
@@ -341,13 +369,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/create_pod_metadata_complex.yaml
+++ b/test_data/compiled-workflows/create_pod_metadata_complex.yaml
@@ -156,12 +156,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -188,6 +194,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -196,6 +206,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -268,7 +282,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -296,6 +318,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
           - name: pod-metadata-annotation-key
             value: '{{inputs.parameters.pod-metadata-annotation-key}}'
           - name: pod-metadata-annotation-val
@@ -316,6 +342,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-annotation-key
       - name: pod-metadata-annotation-val
       - name: pod-metadata-label-key-1
@@ -394,6 +424,10 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-annotation-key
       - name: pod-metadata-annotation-val
       - name: pod-metadata-label-key-1
@@ -403,9 +437,11 @@ spec:
     metadata:
       annotations:
         '{{inputs.parameters.pod-metadata-annotation-key}}': '{{inputs.parameters.pod-metadata-annotation-val}}'
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
       labels:
         '{{inputs.parameters.pod-metadata-label-key-1}}': '{{inputs.parameters.pod-metadata-label-val-1}}'
         '{{inputs.parameters.pod-metadata-label-key-2}}': '{{inputs.parameters.pod-metadata-label-val-2}}'
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: metadata-1-2-system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -433,6 +469,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
           - name: pod-metadata-annotation-key-1
             value: '{{inputs.parameters.pod-metadata-annotation-key-1}}'
           - name: pod-metadata-annotation-val-1
@@ -449,6 +489,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-annotation-key-1
       - name: pod-metadata-annotation-val-1
       - name: pod-metadata-annotation-key-2
@@ -525,6 +569,10 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-annotation-key-1
       - name: pod-metadata-annotation-val-1
       - name: pod-metadata-annotation-key-2
@@ -533,6 +581,9 @@ spec:
       annotations:
         '{{inputs.parameters.pod-metadata-annotation-key-1}}': '{{inputs.parameters.pod-metadata-annotation-val-1}}'
         '{{inputs.parameters.pod-metadata-annotation-key-2}}': '{{inputs.parameters.pod-metadata-annotation-val-2}}'
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: metadata-2-0-system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -568,6 +619,8 @@ spec:
             value: validate-no-pod-metadata
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: validate-no-pod-metadata
         name: validate-no-pod-metadata-driver
         template: system-container-driver
       - arguments:
@@ -577,6 +630,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.validate-no-pod-metadata-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: validate-no-pod-metadata
+          - name: task-path
+            value: validate-no-pod-metadata
         depends: validate-no-pod-metadata-driver.Succeeded
         name: validate-no-pod-metadata
         template: system-container-executor
@@ -594,6 +651,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-validate-pod-metadata}}'
+          - name: task-path
+            value: validate-pod-metadata
         name: validate-pod-metadata-driver
         template: system-container-driver
       - arguments:
@@ -603,6 +662,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.validate-pod-metadata-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: validate-pod-metadata
+          - name: task-path
+            value: validate-pod-metadata
           - name: pod-metadata-annotation-key
             value: task-annotation
           - name: pod-metadata-annotation-val
@@ -632,6 +695,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-validate-pod-metadata-2}}'
+          - name: task-path
+            value: validate-pod-metadata-2
         name: validate-pod-metadata-2-driver
         template: system-container-driver
       - arguments:
@@ -641,6 +706,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.validate-pod-metadata-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: validate-pod-metadata-2
+          - name: task-path
+            value: validate-pod-metadata-2
           - name: pod-metadata-annotation-key-1
             value: task-annotation-1
           - name: pod-metadata-annotation-val-1
@@ -730,13 +799,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/cross_loop_after_topology.yaml
+++ b/test_data/compiled-workflows/cross_loop_after_topology.yaml
@@ -133,12 +133,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -165,6 +171,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -173,6 +183,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -245,7 +259,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -281,6 +303,8 @@ spec:
             value: print-op-5
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-10.print-op-5
         name: print-op-5-driver
         template: system-container-driver
       - arguments:
@@ -290,6 +314,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-5-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-5
+          - name: task-path
+            value: root.comp-for-loop-10.print-op-5
         depends: print-op-5-driver.Succeeded
         name: print-op-5
         template: system-container-executor
@@ -313,6 +341,8 @@ spec:
             value: print-op-7
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-14.print-op-7
         name: print-op-7-driver
         template: system-container-driver
       - arguments:
@@ -322,6 +352,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-7-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-7
+          - name: task-path
+            value: root.comp-for-loop-14.print-op-7
         depends: print-op-7-driver.Succeeded
         name: print-op-7
         template: system-container-executor
@@ -403,13 +437,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -443,6 +483,8 @@ spec:
               2]"}},"taskInfo":{"name":"for-loop-14"}}'
           - name: task-name
             value: for-loop-14
+          - name: task-path
+            value: root.comp-for-loop-12.for-loop-14.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -513,6 +555,8 @@ spec:
             value: print-op-8
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-12.print-op-8
         depends: for-loop-14.Succeeded
         name: print-op-8-driver
         template: system-container-driver
@@ -523,6 +567,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-8-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-8
+          - name: task-path
+            value: root.comp-for-loop-12.print-op-8
         depends: print-op-8-driver.Succeeded
         name: print-op-8
         template: system-container-executor
@@ -546,6 +594,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -555,6 +605,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: root.comp-for-loop-2.print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -578,6 +632,8 @@ spec:
             value: print-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.print-op-2
         name: print-op-2-driver
         template: system-container-driver
       - arguments:
@@ -587,6 +643,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-2
+          - name: task-path
+            value: root.comp-for-loop-4.print-op-2
         depends: print-op-2-driver.Succeeded
         name: print-op-2
         template: system-container-executor
@@ -610,6 +670,8 @@ spec:
             value: print-op-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-8.print-op-4
         name: print-op-4-driver
         template: system-container-driver
       - arguments:
@@ -619,6 +681,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-4
+          - name: task-path
+            value: root.comp-for-loop-8.print-op-4
         depends: print-op-4-driver.Succeeded
         name: print-op-4
         template: system-container-executor
@@ -643,6 +709,8 @@ spec:
               2]"}},"taskInfo":{"name":"for-loop-8"}}'
           - name: task-name
             value: for-loop-8
+          - name: task-path
+            value: root.comp-for-loop-6.for-loop-8.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -714,6 +782,8 @@ spec:
             value: print-op-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-6.print-op-3
         name: print-op-3-driver
         template: system-container-driver
       - arguments:
@@ -723,6 +793,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-3
+          - name: task-path
+            value: root.comp-for-loop-6.print-op-3
         depends: print-op-3-driver.Succeeded
         name: print-op-3
         template: system-container-executor
@@ -747,6 +821,8 @@ spec:
               2]"}},"taskInfo":{"name":"for-loop-10"}}'
           - name: task-name
             value: for-loop-10
+          - name: task-path
+            value: root.for-loop-10.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -812,6 +888,8 @@ spec:
               2]"}},"taskInfo":{"name":"for-loop-12"}}'
           - name: task-name
             value: for-loop-12
+          - name: task-path
+            value: root.for-loop-12.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -877,6 +955,8 @@ spec:
               2]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -942,6 +1022,8 @@ spec:
               2]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
+          - name: task-path
+            value: root.for-loop-4.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1007,6 +1089,8 @@ spec:
               2]"}},"taskInfo":{"name":"for-loop-6"}}'
           - name: task-name
             value: for-loop-6
+          - name: task-path
+            value: root.for-loop-6.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1102,6 +1186,8 @@ spec:
             value: print-op-6
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op-6
         depends: for-loop-10.Succeeded
         name: print-op-6-driver
         template: system-container-driver
@@ -1112,6 +1198,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-6-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-6
+          - name: task-path
+            value: print-op-6
         depends: print-op-6-driver.Succeeded
         name: print-op-6
         template: system-container-executor

--- a/test_data/compiled-workflows/dict_input.yaml
+++ b/test_data/compiled-workflows/dict_input.yaml
@@ -112,12 +112,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -144,6 +150,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -152,6 +162,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -224,7 +238,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -260,6 +282,8 @@ spec:
             value: dict-input
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: dict-input
         name: dict-input-driver
         template: system-container-driver
       - arguments:
@@ -269,6 +293,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.dict-input-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: dict-input
+          - name: task-path
+            value: dict-input
         depends: dict-input-driver.Succeeded
         name: dict-input
         template: system-container-executor
@@ -350,13 +378,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/embedded_artifact.yaml
+++ b/test_data/compiled-workflows/embedded_artifact.yaml
@@ -153,12 +153,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -185,6 +191,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -193,6 +203,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -265,7 +279,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -301,6 +323,8 @@ spec:
             value: read-embedded-artifact-dir
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: read-embedded-artifact-dir
         name: read-embedded-artifact-dir-driver
         template: system-container-driver
       - arguments:
@@ -310,6 +334,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-embedded-artifact-dir-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-embedded-artifact-dir
+          - name: task-path
+            value: read-embedded-artifact-dir
         depends: read-embedded-artifact-dir-driver.Succeeded
         name: read-embedded-artifact-dir
         template: system-container-executor
@@ -325,6 +353,8 @@ spec:
             value: read-embedded-artifact-file
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: read-embedded-artifact-file
         name: read-embedded-artifact-file-driver
         template: system-container-driver
       - arguments:
@@ -334,6 +364,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-embedded-artifact-file-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-embedded-artifact-file
+          - name: task-path
+            value: read-embedded-artifact-file
         depends: read-embedded-artifact-file-driver.Succeeded
         name: read-embedded-artifact-file
         template: system-container-executor
@@ -415,13 +449,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/env-var.yaml
+++ b/test_data/compiled-workflows/env-var.yaml
@@ -114,12 +114,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -146,6 +152,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -154,6 +164,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -226,7 +240,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -262,6 +284,8 @@ spec:
             value: comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: comp
         name: comp-driver
         template: system-container-driver
       - arguments:
@@ -271,6 +295,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: comp
+          - name: task-path
+            value: comp
         depends: comp-driver.Succeeded
         name: comp
         template: system-container-executor
@@ -352,13 +380,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/fail_v2.yaml
+++ b/test_data/compiled-workflows/fail_v2.yaml
@@ -112,12 +112,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -144,6 +150,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -152,6 +162,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -224,7 +238,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -260,6 +282,8 @@ spec:
             value: fail
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: fail
         name: fail-driver
         template: system-container-driver
       - arguments:
@@ -269,6 +293,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.fail-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: fail
+          - name: task-path
+            value: fail
         depends: fail-driver.Succeeded
         name: fail
         template: system-container-executor
@@ -350,13 +378,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/flip_coin.yaml
+++ b/test_data/compiled-workflows/flip_coin.yaml
@@ -169,12 +169,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -201,6 +207,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -209,6 +219,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -281,7 +295,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -319,6 +341,8 @@ spec:
             value: print-msg
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-2.print-msg
         name: print-msg-driver
         template: system-container-driver
       - arguments:
@@ -328,6 +352,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-msg-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-msg
+          - name: task-path
+            value: root.comp-condition-2.print-msg
         depends: print-msg-driver.Succeeded
         name: print-msg
         template: system-container-executor
@@ -353,6 +381,8 @@ spec:
             value: print-msg-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-3.print-msg-2
         name: print-msg-2-driver
         template: system-container-driver
       - arguments:
@@ -362,6 +392,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-msg-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-msg-2
+          - name: task-path
+            value: root.comp-condition-3.print-msg-2
         depends: print-msg-2-driver.Succeeded
         name: print-msg-2
         template: system-container-executor
@@ -443,13 +477,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -481,6 +521,8 @@ spec:
               \u003e 5"}}'
           - name: task-name
             value: condition-2
+          - name: task-path
+            value: root.comp-condition-1.condition-2
         depends: random-num.Succeeded
         name: condition-2-driver
         template: system-dag-driver
@@ -505,6 +547,8 @@ spec:
               \u003c= 5"}}'
           - name: task-name
             value: condition-3
+          - name: task-path
+            value: root.comp-condition-1.condition-3
         depends: random-num.Succeeded
         name: condition-3-driver
         template: system-dag-driver
@@ -530,6 +574,8 @@ spec:
             value: random-num
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.random-num
         name: random-num-driver
         template: system-container-driver
       - arguments:
@@ -539,6 +585,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.random-num-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: random-num
+          - name: task-path
+            value: root.comp-condition-1.random-num
         depends: random-num-driver.Succeeded
         name: random-num
         template: system-container-executor
@@ -564,6 +614,8 @@ spec:
             value: print-msg-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-5.print-msg-3
         name: print-msg-3-driver
         template: system-container-driver
       - arguments:
@@ -573,6 +625,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-msg-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-msg-3
+          - name: task-path
+            value: root.comp-condition-5.print-msg-3
         depends: print-msg-3-driver.Succeeded
         name: print-msg-3
         template: system-container-executor
@@ -598,6 +654,8 @@ spec:
             value: print-msg-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-6.print-msg-4
         name: print-msg-4-driver
         template: system-container-driver
       - arguments:
@@ -607,6 +665,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-msg-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-msg-4
+          - name: task-path
+            value: root.comp-condition-6.print-msg-4
         depends: print-msg-4-driver.Succeeded
         name: print-msg-4
         template: system-container-executor
@@ -629,6 +691,8 @@ spec:
               \u003e 15"}}'
           - name: task-name
             value: condition-5
+          - name: task-path
+            value: root.comp-condition-4.condition-5
         depends: random-num-2.Succeeded
         name: condition-5-driver
         template: system-dag-driver
@@ -653,6 +717,8 @@ spec:
               \u003c= 15"}}'
           - name: task-name
             value: condition-6
+          - name: task-path
+            value: root.comp-condition-4.condition-6
         depends: random-num-2.Succeeded
         name: condition-6-driver
         template: system-dag-driver
@@ -678,6 +744,8 @@ spec:
             value: random-num-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-4.random-num-2
         name: random-num-2-driver
         template: system-container-driver
       - arguments:
@@ -687,6 +755,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.random-num-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: random-num-2
+          - name: task-path
+            value: root.comp-condition-4.random-num-2
         depends: random-num-2-driver.Succeeded
         name: random-num-2
         template: system-container-executor
@@ -708,6 +780,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-1"},"dependentTasks":["flip-coin"],"inputs":{"parameters":{"pipelinechannel--flip-coin-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"flip-coin"}}}},"taskInfo":{"name":"condition-1"},"triggerPolicy":{"condition":"inputs.parameter_values[''pipelinechannel--flip-coin-Output'']
               == ''heads''"}}'
           - name: task-name
+            value: condition-1
+          - name: task-path
             value: condition-1
         depends: flip-coin.Succeeded
         name: condition-1-driver
@@ -732,6 +806,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-4"},"dependentTasks":["flip-coin"],"inputs":{"parameters":{"pipelinechannel--flip-coin-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"flip-coin"}}}},"taskInfo":{"name":"condition-4"},"triggerPolicy":{"condition":"inputs.parameter_values[''pipelinechannel--flip-coin-Output'']
               == ''tails''"}}'
           - name: task-name
+            value: condition-4
+          - name: task-path
             value: condition-4
         depends: flip-coin.Succeeded
         name: condition-4-driver
@@ -758,6 +834,8 @@ spec:
             value: flip-coin
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: flip-coin
         name: flip-coin-driver
         template: system-container-driver
       - arguments:
@@ -767,6 +845,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin
+          - name: task-path
+            value: flip-coin
         depends: flip-coin-driver.Succeeded
         name: flip-coin
         template: system-container-executor

--- a/test_data/compiled-workflows/hello_world.yaml
+++ b/test_data/compiled-workflows/hello_world.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: echo
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo
         name: echo-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo
+          - name: task-path
+            value: echo
         depends: echo-driver.Succeeded
         name: echo
         template: system-container-executor
@@ -341,13 +369,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/identity.yaml
+++ b/test_data/compiled-workflows/identity.yaml
@@ -112,12 +112,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -144,6 +150,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -152,6 +162,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -224,7 +238,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -260,6 +282,8 @@ spec:
             value: identity
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: identity
         name: identity-driver
         template: system-container-driver
       - arguments:
@@ -269,6 +293,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.identity-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: identity
+          - name: task-path
+            value: identity
         depends: identity-driver.Succeeded
         name: identity
         template: system-container-executor
@@ -350,13 +378,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/if_elif_else_complex.yaml
+++ b/test_data/compiled-workflows/if_elif_else_complex.yaml
@@ -203,12 +203,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -235,6 +241,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -243,6 +253,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -315,7 +329,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -352,6 +374,8 @@ spec:
             value: print-and-return
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-3.print-and-return
         name: print-and-return-driver
         template: system-container-driver
       - arguments:
@@ -361,6 +385,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return
+          - name: task-path
+            value: root.comp-condition-3.print-and-return
         depends: print-and-return-driver.Succeeded
         name: print-and-return
         template: system-container-executor
@@ -442,13 +470,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -480,6 +514,8 @@ spec:
               == 3"}}'
           - name: task-name
             value: condition-3
+          - name: task-path
+            value: root.comp-condition-2.condition-3
         name: condition-3-driver
         template: system-dag-driver
       - arguments:
@@ -513,6 +549,8 @@ spec:
             value: print-and-return-9
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-16.print-and-return-9
         name: print-and-return-9-driver
         template: system-container-driver
       - arguments:
@@ -522,6 +560,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-9-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-9
+          - name: task-path
+            value: root.comp-for-loop-16.print-and-return-9
         depends: print-and-return-9-driver.Succeeded
         name: print-and-return-9
         template: system-container-executor
@@ -546,6 +588,8 @@ spec:
               2]"}},"taskInfo":{"name":"for-loop-16"}}'
           - name: task-name
             value: for-loop-16
+          - name: task-path
+            value: root.comp-condition-14.for-loop-16.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -623,6 +667,8 @@ spec:
               == true"}}'
           - name: task-name
             value: condition-14
+          - name: task-path
+            value: root.comp-condition-13.condition-14
         name: condition-14-driver
         template: system-dag-driver
       - arguments:
@@ -648,6 +694,8 @@ spec:
             value: print-and-return-8
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-13.print-and-return-8
         name: print-and-return-8-driver
         template: system-container-driver
       - arguments:
@@ -657,6 +705,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-8-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-8
+          - name: task-path
+            value: root.comp-condition-13.print-and-return-8
         depends: print-and-return-8-driver.Succeeded
         name: print-and-return-8
         template: system-container-executor
@@ -681,6 +733,8 @@ spec:
             value: print-and-return-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-6.print-and-return-2
         name: print-and-return-2-driver
         template: system-container-driver
       - arguments:
@@ -690,6 +744,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-2
+          - name: task-path
+            value: root.comp-condition-6.print-and-return-2
         depends: print-and-return-2-driver.Succeeded
         name: print-and-return-2
         template: system-container-executor
@@ -714,6 +772,8 @@ spec:
             value: print-and-return-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-7.print-and-return-3
         name: print-and-return-3-driver
         template: system-container-driver
       - arguments:
@@ -723,6 +783,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-3
+          - name: task-path
+            value: root.comp-condition-7.print-and-return-3
         depends: print-and-return-3-driver.Succeeded
         name: print-and-return-3
         template: system-container-executor
@@ -745,6 +809,8 @@ spec:
               == ''even''"}}'
           - name: task-name
             value: condition-6
+          - name: task-path
+            value: root.comp-condition-branches-5.condition-6
         name: condition-6-driver
         template: system-dag-driver
       - arguments:
@@ -768,6 +834,8 @@ spec:
               == ''even'')"}}'
           - name: task-name
             value: condition-7
+          - name: task-path
+            value: root.comp-condition-branches-5.condition-7
         name: condition-7-driver
         template: system-dag-driver
       - arguments:
@@ -798,6 +866,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-branches-5"},"dependentTasks":["is-even-or-odd"],"inputs":{"parameters":{"pipelinechannel--int-0-to-9999-Output":{"componentInputParameter":"pipelinechannel--int-0-to-9999-Output"},"pipelinechannel--is-even-or-odd-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"is-even-or-odd"}}}},"taskInfo":{"name":"condition-branches-5"}}'
           - name: task-name
             value: condition-branches-5
+          - name: task-path
+            value: root.comp-condition-8.condition-branches-5
         depends: is-even-or-odd.Succeeded
         name: condition-branches-5-driver
         template: system-dag-driver
@@ -822,6 +892,8 @@ spec:
             value: is-even-or-odd
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-8.is-even-or-odd
         name: is-even-or-odd-driver
         template: system-container-driver
       - arguments:
@@ -831,6 +903,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.is-even-or-odd-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: is-even-or-odd
+          - name: task-path
+            value: root.comp-condition-8.is-even-or-odd
         depends: is-even-or-odd-driver.Succeeded
         name: is-even-or-odd
         template: system-container-executor
@@ -846,6 +922,8 @@ spec:
             value: print-and-return-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-8.print-and-return-4
         depends: condition-branches-5.Succeeded
         name: print-and-return-4-driver
         template: system-container-driver
@@ -856,6 +934,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-4
+          - name: task-path
+            value: root.comp-condition-8.print-and-return-4
         depends: print-and-return-4-driver.Succeeded
         name: print-and-return-4
         template: system-container-executor
@@ -880,6 +962,8 @@ spec:
             value: print-and-return-5
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-11.print-and-return-5
         name: print-and-return-5-driver
         template: system-container-driver
       - arguments:
@@ -889,6 +973,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-5-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-5
+          - name: task-path
+            value: root.comp-condition-11.print-and-return-5
         depends: print-and-return-5-driver.Succeeded
         name: print-and-return-5
         template: system-container-executor
@@ -913,6 +1001,8 @@ spec:
             value: print-and-return-6
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-12.print-and-return-6
         name: print-and-return-6-driver
         template: system-container-driver
       - arguments:
@@ -922,6 +1012,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-6-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-6
+          - name: task-path
+            value: root.comp-condition-12.print-and-return-6
         depends: print-and-return-6-driver.Succeeded
         name: print-and-return-6
         template: system-container-executor
@@ -944,6 +1038,8 @@ spec:
               == ''even''"}}'
           - name: task-name
             value: condition-11
+          - name: task-path
+            value: root.comp-condition-branches-10.condition-11
         name: condition-11-driver
         template: system-dag-driver
       - arguments:
@@ -967,6 +1063,8 @@ spec:
               == ''even'')"}}'
           - name: task-name
             value: condition-12
+          - name: task-path
+            value: root.comp-condition-branches-10.condition-12
         name: condition-12-driver
         template: system-dag-driver
       - arguments:
@@ -997,6 +1095,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-branches-10"},"dependentTasks":["is-even-or-odd-2"],"inputs":{"parameters":{"pipelinechannel--int-0-to-9999-Output":{"componentInputParameter":"pipelinechannel--int-0-to-9999-Output"},"pipelinechannel--is-even-or-odd-2-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"is-even-or-odd-2"}}}},"taskInfo":{"name":"condition-branches-10"}}'
           - name: task-name
             value: condition-branches-10
+          - name: task-path
+            value: root.comp-condition-9.condition-branches-10
         depends: is-even-or-odd-2.Succeeded
         name: condition-branches-10-driver
         template: system-dag-driver
@@ -1021,6 +1121,8 @@ spec:
             value: is-even-or-odd-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-9.is-even-or-odd-2
         name: is-even-or-odd-2-driver
         template: system-container-driver
       - arguments:
@@ -1030,6 +1132,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.is-even-or-odd-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: is-even-or-odd-2
+          - name: task-path
+            value: root.comp-condition-9.is-even-or-odd-2
         depends: is-even-or-odd-2-driver.Succeeded
         name: is-even-or-odd-2
         template: system-container-executor
@@ -1045,6 +1151,8 @@ spec:
             value: print-and-return-7
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-9.print-and-return-7
         depends: condition-branches-10.Succeeded
         name: print-and-return-7-driver
         template: system-container-driver
@@ -1055,6 +1163,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-7-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-7
+          - name: task-path
+            value: root.comp-condition-9.print-and-return-7
         depends: print-and-return-7-driver.Succeeded
         name: print-and-return-7
         template: system-container-executor
@@ -1078,6 +1190,8 @@ spec:
               \u003e 5000)"}}'
           - name: task-name
             value: condition-13
+          - name: task-path
+            value: root.comp-condition-branches-4.condition-13
         name: condition-13-driver
         template: system-dag-driver
       - arguments:
@@ -1101,6 +1215,8 @@ spec:
               \u003c 5000"}}'
           - name: task-name
             value: condition-8
+          - name: task-path
+            value: root.comp-condition-branches-4.condition-8
         name: condition-8-driver
         template: system-dag-driver
       - arguments:
@@ -1125,6 +1241,8 @@ spec:
               \u003e 5000"}}'
           - name: task-name
             value: condition-9
+          - name: task-path
+            value: root.comp-condition-branches-4.condition-9
         name: condition-9-driver
         template: system-dag-driver
       - arguments:
@@ -1156,6 +1274,8 @@ spec:
               == true"}}'
           - name: task-name
             value: condition-2
+          - name: task-path
+            value: root.comp-for-loop-1.condition-2
         name: condition-2-driver
         template: system-dag-driver
       - arguments:
@@ -1178,6 +1298,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-branches-4"},"dependentTasks":["int-0-to-9999"],"inputs":{"parameters":{"pipelinechannel--int-0-to-9999-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"int-0-to-9999"}},"pipelinechannel--repeat_if_lucky_number":{"componentInputParameter":"pipelinechannel--repeat_if_lucky_number"}}},"taskInfo":{"name":"condition-branches-4"}}'
           - name: task-name
             value: condition-branches-4
+          - name: task-path
+            value: root.comp-for-loop-1.condition-branches-4
         depends: int-0-to-9999.Succeeded
         name: condition-branches-4-driver
         template: system-dag-driver
@@ -1202,6 +1324,8 @@ spec:
             value: int-0-to-9999
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.int-0-to-9999
         name: int-0-to-9999-driver
         template: system-container-driver
       - arguments:
@@ -1211,6 +1335,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.int-0-to-9999-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: int-0-to-9999
+          - name: task-path
+            value: root.comp-for-loop-1.int-0-to-9999
         depends: int-0-to-9999-driver.Succeeded
         name: int-0-to-9999
         template: system-container-executor
@@ -1234,6 +1362,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--add_drumroll":{"componentInputParameter":"add_drumroll"},"pipelinechannel--repeat_if_lucky_number":{"componentInputParameter":"repeat_if_lucky_number"},"pipelinechannel--trials":{"componentInputParameter":"trials"}}},"parameterIterator":{"itemInput":"pipelinechannel--trials-loop-item","items":{"inputParameter":"pipelinechannel--trials"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
+          - name: task-path
+            value: root.for-loop-1.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1303,6 +1433,8 @@ spec:
             value: print-ints
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-ints
         depends: for-loop-1.Succeeded
         name: print-ints-driver
         template: system-container-driver
@@ -1313,6 +1445,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-ints-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-ints
+          - name: task-path
+            value: print-ints
         depends: print-ints-driver.Succeeded
         name: print-ints
         template: system-container-executor

--- a/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
@@ -158,12 +158,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -190,6 +196,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -198,6 +208,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -270,7 +284,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -307,6 +329,8 @@ spec:
             value: print-and-return
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-2.print-and-return
         name: print-and-return-driver
         template: system-container-driver
       - arguments:
@@ -316,6 +340,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return
+          - name: task-path
+            value: root.comp-condition-2.print-and-return
         depends: print-and-return-driver.Succeeded
         name: print-and-return
         template: system-container-executor
@@ -340,6 +368,8 @@ spec:
             value: print-and-return-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-3.print-and-return-2
         name: print-and-return-2-driver
         template: system-container-driver
       - arguments:
@@ -349,6 +379,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-2
+          - name: task-path
+            value: root.comp-condition-3.print-and-return-2
         depends: print-and-return-2-driver.Succeeded
         name: print-and-return-2
         template: system-container-executor
@@ -372,6 +406,8 @@ spec:
             value: special-print-and-return
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-4.special-print-and-return
         name: special-print-and-return-driver
         template: system-container-driver
       - arguments:
@@ -381,6 +417,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.special-print-and-return-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: special-print-and-return
+          - name: task-path
+            value: root.comp-condition-4.special-print-and-return
         depends: special-print-and-return-driver.Succeeded
         name: special-print-and-return
         template: system-container-executor
@@ -462,13 +502,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -500,6 +546,8 @@ spec:
               == ''heads''"}}'
           - name: task-name
             value: condition-2
+          - name: task-path
+            value: root.comp-condition-branches-1.condition-2
         name: condition-2-driver
         template: system-dag-driver
       - arguments:
@@ -524,6 +572,8 @@ spec:
               == ''tails''"}}'
           - name: task-name
             value: condition-3
+          - name: task-path
+            value: root.comp-condition-branches-1.condition-3
         name: condition-3-driver
         template: system-dag-driver
       - arguments:
@@ -548,6 +598,8 @@ spec:
               == ''tails'')"}}'
           - name: task-name
             value: condition-4
+          - name: task-path
+            value: root.comp-condition-branches-1.condition-4
         name: condition-4-driver
         template: system-dag-driver
       - arguments:
@@ -578,6 +630,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-branches-1"},"dependentTasks":["flip-three-sided-die"],"inputs":{"parameters":{"pipelinechannel--flip-three-sided-die-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"flip-three-sided-die"}}}},"taskInfo":{"name":"condition-branches-1"}}'
           - name: task-name
             value: condition-branches-1
+          - name: task-path
+            value: root.comp-roll-die-pipeline.condition-branches-1
         depends: flip-three-sided-die.Succeeded
         name: condition-branches-1-driver
         template: system-dag-driver
@@ -602,6 +656,8 @@ spec:
             value: flip-three-sided-die
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-roll-die-pipeline.flip-three-sided-die
         name: flip-three-sided-die-driver
         template: system-container-driver
       - arguments:
@@ -611,6 +667,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-three-sided-die-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-three-sided-die
+          - name: task-path
+            value: root.comp-roll-die-pipeline.flip-three-sided-die
         depends: flip-three-sided-die-driver.Succeeded
         name: flip-three-sided-die
         template: system-container-executor
@@ -634,6 +694,8 @@ spec:
             value: print-and-return
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-and-return
         depends: roll-die-pipeline.Succeeded
         name: print-and-return-driver
         template: system-container-driver
@@ -644,6 +706,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return
+          - name: task-path
+            value: print-and-return
         depends: print-and-return-driver.Succeeded
         name: print-and-return
         template: system-container-executor
@@ -656,6 +722,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-roll-die-pipeline"},"taskInfo":{"name":"roll-die-pipeline"}}'
           - name: task-name
+            value: roll-die-pipeline
+          - name: task-path
             value: roll-die-pipeline
         name: roll-die-pipeline-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
@@ -150,12 +150,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -182,6 +188,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -190,6 +200,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -262,7 +276,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -298,6 +320,8 @@ spec:
             value: param-to-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-2.param-to-artifact
         name: param-to-artifact-driver
         template: system-container-driver
       - arguments:
@@ -307,6 +331,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.param-to-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: param-to-artifact
+          - name: task-path
+            value: root.comp-condition-2.param-to-artifact
         depends: param-to-artifact-driver.Succeeded
         name: param-to-artifact
         template: system-container-executor
@@ -330,6 +358,8 @@ spec:
             value: param-to-artifact-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-3.param-to-artifact-2
         name: param-to-artifact-2-driver
         template: system-container-driver
       - arguments:
@@ -339,6 +369,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.param-to-artifact-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: param-to-artifact-2
+          - name: task-path
+            value: root.comp-condition-3.param-to-artifact-2
         depends: param-to-artifact-2-driver.Succeeded
         name: param-to-artifact-2
         template: system-container-executor
@@ -420,13 +454,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -458,6 +498,8 @@ spec:
               == ''heads''"}}'
           - name: task-name
             value: condition-2
+          - name: task-path
+            value: root.comp-condition-branches-1.condition-2
         name: condition-2-driver
         template: system-dag-driver
       - arguments:
@@ -481,6 +523,8 @@ spec:
               == ''heads'')"}}'
           - name: task-name
             value: condition-3
+          - name: task-path
+            value: root.comp-condition-branches-1.condition-3
         name: condition-3-driver
         template: system-dag-driver
       - arguments:
@@ -511,6 +555,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-branches-1"},"dependentTasks":["flip-coin"],"inputs":{"parameters":{"pipelinechannel--flip-coin-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"flip-coin"}}}},"taskInfo":{"name":"condition-branches-1"}}'
           - name: task-name
             value: condition-branches-1
+          - name: task-path
+            value: root.comp-flip-coin-pipeline.condition-branches-1
         depends: flip-coin.Succeeded
         name: condition-branches-1-driver
         template: system-dag-driver
@@ -535,6 +581,8 @@ spec:
             value: flip-coin
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-flip-coin-pipeline.flip-coin
         name: flip-coin-driver
         template: system-container-driver
       - arguments:
@@ -544,6 +592,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin
+          - name: task-path
+            value: root.comp-flip-coin-pipeline.flip-coin
         depends: flip-coin-driver.Succeeded
         name: flip-coin
         template: system-container-executor
@@ -559,6 +611,8 @@ spec:
             value: print-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-flip-coin-pipeline.print-artifact
         depends: condition-branches-1.Succeeded
         name: print-artifact-driver
         template: system-container-driver
@@ -569,6 +623,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-artifact
+          - name: task-path
+            value: root.comp-flip-coin-pipeline.print-artifact
         depends: print-artifact-driver.Succeeded
         name: print-artifact
         template: system-container-executor
@@ -589,6 +647,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-flip-coin-pipeline"},"taskInfo":{"name":"flip-coin-pipeline"}}'
           - name: task-name
+            value: flip-coin-pipeline
+          - name: task-path
             value: flip-coin-pipeline
         name: flip-coin-pipeline-driver
         template: system-dag-driver
@@ -613,6 +673,8 @@ spec:
             value: print-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-artifact
         depends: flip-coin-pipeline.Succeeded
         name: print-artifact-driver
         template: system-container-driver
@@ -623,6 +685,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-artifact
+          - name: task-path
+            value: print-artifact
         depends: print-artifact-driver.Succeeded
         name: print-artifact
         template: system-container-executor

--- a/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
@@ -136,12 +136,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -168,6 +174,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -176,6 +186,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -248,7 +262,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -285,6 +307,8 @@ spec:
             value: print-and-return
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-2.print-and-return
         name: print-and-return-driver
         template: system-container-driver
       - arguments:
@@ -294,6 +318,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return
+          - name: task-path
+            value: root.comp-condition-2.print-and-return
         depends: print-and-return-driver.Succeeded
         name: print-and-return
         template: system-container-executor
@@ -318,6 +346,8 @@ spec:
             value: print-and-return-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-3.print-and-return-2
         name: print-and-return-2-driver
         template: system-container-driver
       - arguments:
@@ -327,6 +357,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-2
+          - name: task-path
+            value: root.comp-condition-3.print-and-return-2
         depends: print-and-return-2-driver.Succeeded
         name: print-and-return-2
         template: system-container-executor
@@ -408,13 +442,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -446,6 +486,8 @@ spec:
               == ''heads''"}}'
           - name: task-name
             value: condition-2
+          - name: task-path
+            value: root.comp-condition-branches-1.condition-2
         name: condition-2-driver
         template: system-dag-driver
       - arguments:
@@ -469,6 +511,8 @@ spec:
               == ''heads'')"}}'
           - name: task-name
             value: condition-3
+          - name: task-path
+            value: root.comp-condition-branches-1.condition-3
         name: condition-3-driver
         template: system-dag-driver
       - arguments:
@@ -499,6 +543,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-branches-1"},"dependentTasks":["flip-coin"],"inputs":{"parameters":{"pipelinechannel--flip-coin-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"flip-coin"}}}},"taskInfo":{"name":"condition-branches-1"}}'
           - name: task-name
             value: condition-branches-1
+          - name: task-path
+            value: condition-branches-1
         depends: flip-coin.Succeeded
         name: condition-branches-1-driver
         template: system-dag-driver
@@ -523,6 +569,8 @@ spec:
             value: flip-coin
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: flip-coin
         name: flip-coin-driver
         template: system-container-driver
       - arguments:
@@ -532,6 +580,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin
+          - name: task-path
+            value: flip-coin
         depends: flip-coin-driver.Succeeded
         name: flip-coin
         template: system-container-executor
@@ -547,6 +599,8 @@ spec:
             value: print-and-return-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-and-return-3
         depends: condition-branches-1.Succeeded
         name: print-and-return-3-driver
         template: system-container-driver
@@ -557,6 +611,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-and-return-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-and-return-3
+          - name: task-path
+            value: print-and-return-3
         depends: print-and-return-3-driver.Succeeded
         name: print-and-return-3
         template: system-container-executor

--- a/test_data/compiled-workflows/input_artifact.yaml
+++ b/test_data/compiled-workflows/input_artifact.yaml
@@ -112,12 +112,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -144,6 +150,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -152,6 +162,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -224,7 +238,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -260,6 +282,8 @@ spec:
             value: input-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: input-artifact
         name: input-artifact-driver
         template: system-container-driver
       - arguments:
@@ -269,6 +293,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.input-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: input-artifact
+          - name: task-path
+            value: input-artifact
         depends: input-artifact-driver.Succeeded
         name: input-artifact
         template: system-container-executor
@@ -350,13 +378,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/iris_pipeline_compiled.yaml
+++ b/test_data/compiled-workflows/iris_pipeline_compiled.yaml
@@ -165,12 +165,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -197,6 +203,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -205,6 +215,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -277,7 +291,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -313,6 +335,8 @@ spec:
             value: create-dataset
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: create-dataset
         name: create-dataset-driver
         template: system-container-driver
       - arguments:
@@ -322,6 +346,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.create-dataset-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: create-dataset
+          - name: task-path
+            value: create-dataset
         depends: create-dataset-driver.Succeeded
         name: create-dataset
         template: system-container-executor
@@ -337,6 +365,8 @@ spec:
             value: normalize-dataset
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: normalize-dataset
         depends: create-dataset.Succeeded
         name: normalize-dataset-driver
         template: system-container-driver
@@ -347,6 +377,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.normalize-dataset-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: normalize-dataset
+          - name: task-path
+            value: normalize-dataset
         depends: normalize-dataset-driver.Succeeded
         name: normalize-dataset
         template: system-container-executor
@@ -362,6 +396,8 @@ spec:
             value: train-model
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: train-model
         depends: normalize-dataset.Succeeded
         name: train-model-driver
         template: system-container-driver
@@ -372,6 +408,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.train-model-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: train-model
+          - name: task-path
+            value: train-model
         depends: train-model-driver.Succeeded
         name: train-model
         template: system-container-executor
@@ -453,13 +493,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
@@ -167,12 +167,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -199,6 +205,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -207,6 +217,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -279,7 +293,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -315,6 +337,8 @@ spec:
             value: preprocess
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: preprocess
         name: preprocess-driver
         template: system-container-driver
       - arguments:
@@ -324,6 +348,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.preprocess-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: preprocess
+          - name: task-path
+            value: preprocess
         depends: preprocess-driver.Succeeded
         name: preprocess
         template: system-container-executor
@@ -339,6 +367,8 @@ spec:
             value: train
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: train
         depends: preprocess.Succeeded
         name: train-driver
         template: system-container-driver
@@ -349,6 +379,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.train-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: train
+          - name: task-path
+            value: train
         depends: train-driver.Succeeded
         name: train
         template: system-container-executor
@@ -430,13 +464,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
@@ -159,12 +159,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -191,6 +197,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -199,6 +209,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -271,7 +285,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -307,6 +329,8 @@ spec:
             value: add-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add-numbers
         name: add-numbers-driver
         template: system-container-driver
       - arguments:
@@ -316,6 +340,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-numbers-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-numbers
+          - name: task-path
+            value: add-numbers
         depends: add-numbers-driver.Succeeded
         name: add-numbers
         template: system-container-executor
@@ -331,6 +359,8 @@ spec:
             value: concat-message
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: concat-message
         name: concat-message-driver
         template: system-container-driver
       - arguments:
@@ -340,6 +370,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.concat-message-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: concat-message
+          - name: task-path
+            value: concat-message
         depends: concat-message-driver.Succeeded
         name: concat-message
         template: system-container-executor
@@ -355,6 +389,8 @@ spec:
             value: output-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: output-artifact
         depends: add-numbers.Succeeded && concat-message.Succeeded
         name: output-artifact-driver
         template: system-container-driver
@@ -365,6 +401,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.output-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: output-artifact
+          - name: task-path
+            value: output-artifact
         depends: output-artifact-driver.Succeeded
         name: output-artifact
         template: system-container-executor
@@ -380,6 +420,8 @@ spec:
             value: output-named-tuple
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: output-named-tuple
         depends: output-artifact.Succeeded
         name: output-named-tuple-driver
         template: system-container-driver
@@ -390,6 +432,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.output-named-tuple-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: output-named-tuple
+          - name: task-path
+            value: output-named-tuple
         depends: output-named-tuple-driver.Succeeded
         name: output-named-tuple
         template: system-container-executor
@@ -471,13 +517,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/log_streaming_compiled.yaml
+++ b/test_data/compiled-workflows/log_streaming_compiled.yaml
@@ -116,12 +116,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -148,6 +154,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -156,6 +166,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -228,7 +242,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -264,6 +286,8 @@ spec:
             value: print-message
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-message
         name: print-message-driver
         template: system-container-driver
       - arguments:
@@ -273,6 +297,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-message-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-message
+          - name: task-path
+            value: print-message
         depends: print-message-driver.Succeeded
         name: print-message
         template: system-container-executor
@@ -354,13 +382,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/long-running.yaml
+++ b/test_data/compiled-workflows/long-running.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: wait-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: wait-op
         name: wait-op-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.wait-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: wait-op
+          - name: task-path
+            value: wait-op
         depends: wait-op-driver.Succeeded
         name: wait-op
         template: system-container-executor
@@ -275,6 +303,8 @@ spec:
             value: wait-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: wait-op-2
         depends: wait-op.Succeeded
         name: wait-op-2-driver
         template: system-container-driver
@@ -285,6 +315,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.wait-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: wait-op-2
+          - name: task-path
+            value: wait-op-2
         depends: wait-op-2-driver.Succeeded
         name: wait-op-2
         template: system-container-executor
@@ -366,13 +400,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/loop_consume_upstream.yaml
+++ b/test_data/compiled-workflows/loop_consume_upstream.yaml
@@ -160,12 +160,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -192,6 +198,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -200,6 +210,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -272,7 +286,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -309,6 +331,8 @@ spec:
             value: create-file
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.create-file
         name: create-file-driver
         template: system-container-driver
       - arguments:
@@ -318,6 +342,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.create-file-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: create-file
+          - name: task-path
+            value: root.comp-for-loop-1.create-file
         depends: create-file-driver.Succeeded
         name: create-file
         template: system-container-executor
@@ -334,6 +362,8 @@ spec:
             value: read-file
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.read-file
         depends: create-file.Succeeded
         name: read-file-driver
         template: system-container-driver
@@ -344,6 +374,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-file-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-file
+          - name: task-path
+            value: root.comp-for-loop-1.read-file
         depends: read-file-driver.Succeeded
         name: read-file
         template: system-container-executor
@@ -425,13 +459,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -464,6 +504,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-1"},"dependentTasks":["split-input"],"inputs":{"parameters":{"pipelinechannel--split-input-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"split-input"}}}},"parameterIterator":{"itemInput":"pipelinechannel--split-input-Output-loop-item","items":{"inputParameter":"pipelinechannel--split-input-Output"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
+          - name: task-path
+            value: root.for-loop-1.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -535,6 +577,8 @@ spec:
             value: print-input
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-input
         depends: split-input.Succeeded
         name: print-input-driver
         template: system-container-driver
@@ -545,6 +589,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-input-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-input
+          - name: task-path
+            value: print-input
         depends: print-input-driver.Succeeded
         name: print-input
         template: system-container-executor
@@ -561,6 +609,8 @@ spec:
             value: split-input
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: split-input
         name: split-input-driver
         template: system-container-driver
       - arguments:
@@ -570,6 +620,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.split-input-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: split-input
+          - name: task-path
+            value: split-input
         depends: split-input-driver.Succeeded
         name: split-input
         template: system-container-executor

--- a/test_data/compiled-workflows/metrics_visualization_v2.yaml
+++ b/test_data/compiled-workflows/metrics_visualization_v2.yaml
@@ -204,12 +204,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -236,6 +242,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -244,6 +254,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -316,7 +330,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -352,6 +374,8 @@ spec:
             value: digit-classification
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: digit-classification
         name: digit-classification-driver
         template: system-container-driver
       - arguments:
@@ -361,6 +385,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.digit-classification-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: digit-classification
+          - name: task-path
+            value: digit-classification
         depends: digit-classification-driver.Succeeded
         name: digit-classification
         template: system-container-executor
@@ -376,6 +404,8 @@ spec:
             value: html-visualization
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: html-visualization
         name: html-visualization-driver
         template: system-container-driver
       - arguments:
@@ -385,6 +415,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.html-visualization-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: html-visualization
+          - name: task-path
+            value: html-visualization
         depends: html-visualization-driver.Succeeded
         name: html-visualization
         template: system-container-executor
@@ -400,6 +434,8 @@ spec:
             value: iris-sgdclassifier
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: iris-sgdclassifier
         name: iris-sgdclassifier-driver
         template: system-container-driver
       - arguments:
@@ -409,6 +445,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.iris-sgdclassifier-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: iris-sgdclassifier
+          - name: task-path
+            value: iris-sgdclassifier
         depends: iris-sgdclassifier-driver.Succeeded
         name: iris-sgdclassifier
         template: system-container-executor
@@ -424,6 +464,8 @@ spec:
             value: markdown-visualization
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: markdown-visualization
         name: markdown-visualization-driver
         template: system-container-driver
       - arguments:
@@ -433,6 +475,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.markdown-visualization-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: markdown-visualization
+          - name: task-path
+            value: markdown-visualization
         depends: markdown-visualization-driver.Succeeded
         name: markdown-visualization
         template: system-container-executor
@@ -448,6 +494,8 @@ spec:
             value: wine-classification
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: wine-classification
         name: wine-classification-driver
         template: system-container-driver
       - arguments:
@@ -457,6 +505,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.wine-classification-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: wine-classification
+          - name: task-path
+            value: wine-classification
         depends: wine-classification-driver.Succeeded
         name: wine-classification
         template: system-container-executor
@@ -538,13 +590,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
+++ b/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
@@ -115,12 +115,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -147,6 +153,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -155,6 +165,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -227,7 +241,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -266,6 +288,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-log-message}}'
+          - name: task-path
+            value: log-message
         name: log-message-driver
         template: system-container-driver
       - arguments:
@@ -275,6 +299,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.log-message-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: log-message
+          - name: task-path
+            value: log-message
         depends: log-message-driver.Succeeded
         name: log-message
         template: system-container-executor
@@ -356,13 +384,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/mixed_parameters.yaml
+++ b/test_data/compiled-workflows/mixed_parameters.yaml
@@ -129,12 +129,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -161,6 +167,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -169,6 +179,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -241,7 +255,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -277,6 +299,8 @@ spec:
             value: core-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-core.core-comp
         name: core-comp-driver
         template: system-container-driver
       - arguments:
@@ -286,6 +310,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.core-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: core-comp
+          - name: task-path
+            value: root.comp-core.core-comp
         depends: core-comp-driver.Succeeded
         name: core-comp
         template: system-container-executor
@@ -367,13 +395,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -404,6 +438,8 @@ spec:
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-core"},"taskInfo":{"name":"core"}}'
           - name: task-name
             value: core
+          - name: task-path
+            value: root.comp-mantle.core
         name: core-driver
         template: system-dag-driver
       - arguments:
@@ -435,6 +471,8 @@ spec:
             value: crust-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: crust-comp
         depends: mantle.Succeeded
         name: crust-comp-driver
         template: system-container-driver
@@ -445,6 +483,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.crust-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: crust-comp
+          - name: task-path
+            value: crust-comp
         depends: crust-comp-driver.Succeeded
         name: crust-comp
         template: system-container-executor
@@ -457,6 +499,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-mantle"},"taskInfo":{"name":"mantle"}}'
           - name: task-name
+            value: mantle
+          - name: task-path
             value: mantle
         name: mantle-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/modelcar.yaml
+++ b/test_data/compiled-workflows/modelcar.yaml
@@ -137,12 +137,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -169,6 +175,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -177,6 +187,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -249,7 +263,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -354,6 +376,8 @@ spec:
             value: build-model-car
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: build-model-car
         name: build-model-car-driver
         template: system-container-driver
       - arguments:
@@ -363,6 +387,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.build-model-car-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: build-model-car
+          - name: task-path
+            value: build-model-car
         depends: build-model-car-driver.Succeeded
         name: build-model-car
         template: system-container-executor
@@ -378,6 +406,8 @@ spec:
             value: get-model-files-list
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: get-model-files-list
         depends: importer.Succeeded
         name: get-model-files-list-driver
         template: system-container-driver
@@ -388,6 +418,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.get-model-files-list-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: get-model-files-list
+          - name: task-path
+            value: get-model-files-list
         depends: get-model-files-list-driver.Succeeded
         name: get-model-files-list
         template: system-container-executor
@@ -481,13 +515,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
@@ -108,12 +108,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -147,6 +153,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -155,6 +165,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -229,7 +243,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -271,6 +293,8 @@ spec:
             value: echo
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo
         name: echo-driver
         template: system-container-driver
       - arguments:
@@ -280,6 +304,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo
+          - name: task-path
+            value: echo
         depends: echo-driver.Succeeded
         name: echo
         template: system-container-executor
@@ -366,13 +394,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/mounted_cabundle_secret.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_secret.yaml
@@ -108,12 +108,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -147,6 +153,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -155,6 +165,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -229,7 +243,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -271,6 +293,8 @@ spec:
             value: echo
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo
         name: echo-driver
         template: system-container-driver
       - arguments:
@@ -280,6 +304,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo
+          - name: task-path
+            value: echo
         depends: echo-driver.Succeeded
         name: echo
         template: system-container-executor
@@ -366,13 +394,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
@@ -133,12 +133,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -165,6 +171,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -173,6 +183,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -245,7 +259,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -281,6 +303,8 @@ spec:
             value: core-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-core.core-comp
         name: core-comp-driver
         template: system-container-driver
       - arguments:
@@ -290,6 +314,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.core-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: core-comp
+          - name: task-path
+            value: root.comp-core.core-comp
         depends: core-comp-driver.Succeeded
         name: core-comp
         template: system-container-executor
@@ -371,13 +399,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -408,6 +442,8 @@ spec:
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-core"},"taskInfo":{"name":"core"}}'
           - name: task-name
             value: core
+          - name: task-path
+            value: root.comp-mantle.core
         name: core-driver
         template: system-dag-driver
       - arguments:
@@ -439,6 +475,8 @@ spec:
             value: crust-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: crust-comp
         depends: mantle.Succeeded
         name: crust-comp-driver
         template: system-container-driver
@@ -449,6 +487,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.crust-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: crust-comp
+          - name: task-path
+            value: crust-comp
         depends: crust-comp-driver.Succeeded
         name: crust-comp
         template: system-container-executor
@@ -461,6 +503,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-mantle"},"taskInfo":{"name":"mantle"}}'
           - name: task-name
+            value: mantle
+          - name: task-path
             value: mantle
         name: mantle-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
@@ -132,12 +132,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -164,6 +170,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -172,6 +182,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -244,7 +258,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -280,6 +302,8 @@ spec:
             value: core-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-core.core-comp
         name: core-comp-driver
         template: system-container-driver
       - arguments:
@@ -289,6 +313,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.core-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: core-comp
+          - name: task-path
+            value: root.comp-core.core-comp
         depends: core-comp-driver.Succeeded
         name: core-comp
         template: system-container-executor
@@ -370,13 +398,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -407,6 +441,8 @@ spec:
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-core"},"taskInfo":{"name":"core"}}'
           - name: task-name
             value: core
+          - name: task-path
+            value: root.comp-mantle.core
         name: core-driver
         template: system-dag-driver
       - arguments:
@@ -438,6 +474,8 @@ spec:
             value: crust-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: crust-comp
         depends: mantle.Succeeded
         name: crust-comp-driver
         template: system-container-driver
@@ -448,6 +486,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.crust-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: crust-comp
+          - name: task-path
+            value: crust-comp
         depends: crust-comp-driver.Succeeded
         name: crust-comp
         template: system-container-executor
@@ -460,6 +502,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-mantle"},"taskInfo":{"name":"mantle"}}'
           - name: task-name
+            value: mantle
+          - name: task-path
             value: mantle
         name: mantle-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/nested_parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/nested_parallel_for_secret.yaml
@@ -133,12 +133,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -165,6 +171,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -173,6 +183,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -245,7 +259,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -283,6 +305,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-worker-component}}'
+          - name: task-path
+            value: root.comp-for-loop-2.worker-component
         name: worker-component-driver
         template: system-container-driver
       - arguments:
@@ -292,6 +316,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.worker-component-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: worker-component
+          - name: task-path
+            value: root.comp-for-loop-2.worker-component
         depends: worker-component-driver.Succeeded
         name: worker-component
         template: system-container-executor
@@ -373,13 +401,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -413,6 +447,8 @@ spec:
               \"y\"]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -478,6 +514,8 @@ spec:
             value: emit-secret-name
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: emit-secret-name
         name: emit-secret-name-driver
         template: system-container-driver
       - arguments:
@@ -487,6 +525,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.emit-secret-name-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: emit-secret-name
+          - name: task-path
+            value: emit-secret-name
         depends: emit-secret-name-driver.Succeeded
         name: emit-secret-name
         template: system-container-executor

--- a/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
@@ -192,12 +192,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -224,6 +230,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -232,6 +242,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -304,7 +318,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -340,6 +362,8 @@ spec:
             value: component-a-bool
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline.component-a-bool
         name: component-a-bool-driver
         template: system-container-driver
       - arguments:
@@ -349,6 +373,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-a-bool-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-a-bool
+          - name: task-path
+            value: root.comp-nested-pipeline.component-a-bool
         depends: component-a-bool-driver.Succeeded
         name: component-a-bool
         template: system-container-executor
@@ -364,6 +392,8 @@ spec:
             value: component-a-int
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline.component-a-int
         name: component-a-int-driver
         template: system-container-driver
       - arguments:
@@ -373,6 +403,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-a-int-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-a-int
+          - name: task-path
+            value: root.comp-nested-pipeline.component-a-int
         depends: component-a-int-driver.Succeeded
         name: component-a-int
         template: system-container-executor
@@ -388,6 +422,8 @@ spec:
             value: component-a-str
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline.component-a-str
         name: component-a-str-driver
         template: system-container-driver
       - arguments:
@@ -397,6 +433,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-a-str-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-a-str
+          - name: task-path
+            value: root.comp-nested-pipeline.component-a-str
         depends: component-a-str-driver.Succeeded
         name: component-a-str
         template: system-container-executor
@@ -412,6 +452,8 @@ spec:
             value: component-b-bool
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline.component-b-bool
         name: component-b-bool-driver
         template: system-container-driver
       - arguments:
@@ -421,6 +463,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-b-bool-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-b-bool
+          - name: task-path
+            value: root.comp-nested-pipeline.component-b-bool
         depends: component-b-bool-driver.Succeeded
         name: component-b-bool
         template: system-container-executor
@@ -436,6 +482,8 @@ spec:
             value: component-b-int
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline.component-b-int
         name: component-b-int-driver
         template: system-container-driver
       - arguments:
@@ -445,6 +493,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-b-int-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-b-int
+          - name: task-path
+            value: root.comp-nested-pipeline.component-b-int
         depends: component-b-int-driver.Succeeded
         name: component-b-int
         template: system-container-executor
@@ -460,6 +512,8 @@ spec:
             value: component-b-str
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline.component-b-str
         name: component-b-str-driver
         template: system-container-driver
       - arguments:
@@ -469,6 +523,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-b-str-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-b-str
+          - name: task-path
+            value: root.comp-nested-pipeline.component-b-str
         depends: component-b-str-driver.Succeeded
         name: component-b-str
         template: system-container-executor
@@ -550,13 +608,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -587,6 +651,8 @@ spec:
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-nested-pipeline"},"inputs":{"parameters":{"nestedInputBool1":{"runtimeValue":{"constant":true}},"nestedInputInt1":{"runtimeValue":{"constant":1}},"nestedInputStr1":{"runtimeValue":{"constant":"Input
               - pipeline"}}}},"taskInfo":{"name":"nested-pipeline"}}'
           - name: task-name
+            value: nested-pipeline
+          - name: task-path
             value: nested-pipeline
         name: nested-pipeline-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
@@ -143,12 +143,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -175,6 +181,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -183,6 +193,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -255,7 +269,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -291,6 +313,8 @@ spec:
             value: component-bool
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline.component-bool
         name: component-bool-driver
         template: system-container-driver
       - arguments:
@@ -300,6 +324,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-bool-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-bool
+          - name: task-path
+            value: root.comp-nested-pipeline.component-bool
         depends: component-bool-driver.Succeeded
         name: component-bool
         template: system-container-executor
@@ -315,6 +343,8 @@ spec:
             value: component-int
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline.component-int
         name: component-int-driver
         template: system-container-driver
       - arguments:
@@ -324,6 +354,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-int-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-int
+          - name: task-path
+            value: root.comp-nested-pipeline.component-int
         depends: component-int-driver.Succeeded
         name: component-int
         template: system-container-executor
@@ -339,6 +373,8 @@ spec:
             value: component-str
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline.component-str
         name: component-str-driver
         template: system-container-driver
       - arguments:
@@ -348,6 +384,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-str-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-str
+          - name: task-path
+            value: root.comp-nested-pipeline.component-str
         depends: component-str-driver.Succeeded
         name: component-str
         template: system-container-executor
@@ -429,13 +469,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -465,6 +511,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-nested-pipeline"},"taskInfo":{"name":"nested-pipeline"}}'
           - name: task-name
+            value: nested-pipeline
+          - name: task-path
             value: nested-pipeline
         name: nested-pipeline-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
@@ -195,12 +195,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -227,6 +233,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -235,6 +245,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -307,7 +321,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -343,6 +365,8 @@ spec:
             value: component-nil-bool-default
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline-nil-defaults.component-nil-bool-default
         name: component-nil-bool-default-driver
         template: system-container-driver
       - arguments:
@@ -352,6 +376,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-nil-bool-default-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-nil-bool-default
+          - name: task-path
+            value: root.comp-nested-pipeline-nil-defaults.component-nil-bool-default
         depends: component-nil-bool-default-driver.Succeeded
         name: component-nil-bool-default
         template: system-container-executor
@@ -367,6 +395,8 @@ spec:
             value: component-nil-int-default
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline-nil-defaults.component-nil-int-default
         name: component-nil-int-default-driver
         template: system-container-driver
       - arguments:
@@ -376,6 +406,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-nil-int-default-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-nil-int-default
+          - name: task-path
+            value: root.comp-nested-pipeline-nil-defaults.component-nil-int-default
         depends: component-nil-int-default-driver.Succeeded
         name: component-nil-int-default
         template: system-container-executor
@@ -391,6 +425,8 @@ spec:
             value: component-nil-str-default
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline-nil-defaults.component-nil-str-default
         name: component-nil-str-default-driver
         template: system-container-driver
       - arguments:
@@ -400,6 +436,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-nil-str-default-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-nil-str-default
+          - name: task-path
+            value: root.comp-nested-pipeline-nil-defaults.component-nil-str-default
         depends: component-nil-str-default-driver.Succeeded
         name: component-nil-str-default
         template: system-container-executor
@@ -423,6 +463,8 @@ spec:
             value: component-bool-default
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline-non-nil-defaults.component-bool-default
         name: component-bool-default-driver
         template: system-container-driver
       - arguments:
@@ -432,6 +474,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-bool-default-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-bool-default
+          - name: task-path
+            value: root.comp-nested-pipeline-non-nil-defaults.component-bool-default
         depends: component-bool-default-driver.Succeeded
         name: component-bool-default
         template: system-container-executor
@@ -447,6 +493,8 @@ spec:
             value: component-int-default
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline-non-nil-defaults.component-int-default
         name: component-int-default-driver
         template: system-container-driver
       - arguments:
@@ -456,6 +504,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-int-default-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-int-default
+          - name: task-path
+            value: root.comp-nested-pipeline-non-nil-defaults.component-int-default
         depends: component-int-default-driver.Succeeded
         name: component-int-default
         template: system-container-executor
@@ -471,6 +523,8 @@ spec:
             value: component-str-default
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-nested-pipeline-non-nil-defaults.component-str-default
         name: component-str-default-driver
         template: system-container-driver
       - arguments:
@@ -480,6 +534,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-str-default-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-str-default
+          - name: task-path
+            value: root.comp-nested-pipeline-non-nil-defaults.component-str-default
         depends: component-str-default-driver.Succeeded
         name: component-str-default
         template: system-container-executor
@@ -561,13 +619,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -598,6 +662,8 @@ spec:
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-nested-pipeline-nil-defaults"},"inputs":{"parameters":{"nestedInputBool":{"componentInputParameter":"inputBool"},"nestedInputInt":{"componentInputParameter":"inputInt"},"nestedInputStr":{"componentInputParameter":"inputStr"}}},"taskInfo":{"name":"nested-pipeline-nil-defaults"}}'
           - name: task-name
             value: nested-pipeline-nil-defaults
+          - name: task-path
+            value: nested-pipeline-nil-defaults
         name: nested-pipeline-nil-defaults-driver
         template: system-dag-driver
       - arguments:
@@ -618,6 +684,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-nested-pipeline-non-nil-defaults"},"inputs":{"parameters":{"nestedInputBool":{"componentInputParameter":"inputBool"},"nestedInputInt":{"componentInputParameter":"inputInt"},"nestedInputStr":{"componentInputParameter":"inputStr"}}},"taskInfo":{"name":"nested-pipeline-non-nil-defaults"}}'
           - name: task-name
+            value: nested-pipeline-non-nil-defaults
+          - name: task-path
             value: nested-pipeline-non-nil-defaults
         name: nested-pipeline-non-nil-defaults-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/nested_return.yaml
+++ b/test_data/compiled-workflows/nested_return.yaml
@@ -113,12 +113,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -145,6 +151,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -153,6 +163,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -225,7 +239,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -261,6 +283,8 @@ spec:
             value: nested-return
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: nested-return
         name: nested-return-driver
         template: system-container-driver
       - arguments:
@@ -270,6 +294,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.nested-return-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: nested-return
+          - name: task-path
+            value: nested-return
         depends: nested-return-driver.Succeeded
         name: nested-return
         template: system-container-executor
@@ -351,13 +379,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/nested_with_parameters.yaml
+++ b/test_data/compiled-workflows/nested_with_parameters.yaml
@@ -145,12 +145,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -177,6 +183,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -185,6 +195,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -257,7 +271,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -293,6 +315,8 @@ spec:
             value: add-two-nums
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.add-two-nums
         depends: double.Succeeded && double-2.Succeeded
         name: add-two-nums-driver
         template: system-container-driver
@@ -303,6 +327,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-two-nums-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-two-nums
+          - name: task-path
+            value: root.comp-for-loop-4.add-two-nums
         depends: add-two-nums-driver.Succeeded
         name: add-two-nums
         template: system-container-executor
@@ -318,6 +346,8 @@ spec:
             value: double
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.double
         name: double-driver
         template: system-container-driver
       - arguments:
@@ -327,6 +357,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.double-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: double
+          - name: task-path
+            value: root.comp-for-loop-4.double
         depends: double-driver.Succeeded
         name: double
         template: system-container-executor
@@ -342,6 +376,8 @@ spec:
             value: double-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.double-2
         name: double-2-driver
         template: system-container-driver
       - arguments:
@@ -351,6 +387,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.double-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: double-2
+          - name: task-path
+            value: root.comp-for-loop-4.double-2
         depends: double-2-driver.Succeeded
         name: double-2
         template: system-container-executor
@@ -432,13 +472,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -472,6 +518,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
+          - name: task-path
+            value: root.comp-for-loop-2.for-loop-4.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -551,6 +599,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -615,6 +665,8 @@ spec:
             value: add
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add
         depends: for-loop-2.Succeeded
         name: add-driver
         template: system-container-driver
@@ -625,6 +677,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add
+          - name: task-path
+            value: add
         depends: add-driver.Succeeded
         name: add
         template: system-container-executor

--- a/test_data/compiled-workflows/notebook_component_mixed.yaml
+++ b/test_data/compiled-workflows/notebook_component_mixed.yaml
@@ -341,12 +341,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -373,6 +379,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -381,6 +391,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -453,7 +467,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -489,6 +511,8 @@ spec:
             value: evaluate-model
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: evaluate-model
         depends: train-model.Succeeded
         name: evaluate-model-driver
         template: system-container-driver
@@ -499,6 +523,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.evaluate-model-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: evaluate-model
+          - name: task-path
+            value: evaluate-model
         depends: evaluate-model-driver.Succeeded
         name: evaluate-model
         template: system-container-executor
@@ -514,6 +542,8 @@ spec:
             value: preprocess
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: preprocess
         name: preprocess-driver
         template: system-container-driver
       - arguments:
@@ -523,6 +553,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.preprocess-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: preprocess
+          - name: task-path
+            value: preprocess
         depends: preprocess-driver.Succeeded
         name: preprocess
         template: system-container-executor
@@ -538,6 +572,8 @@ spec:
             value: train-model
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: train-model
         depends: preprocess.Succeeded
         name: train-model-driver
         template: system-container-driver
@@ -548,6 +584,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.train-model-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: train-model
+          - name: task-path
+            value: train-model
         depends: train-model-driver.Succeeded
         name: train-model
         template: system-container-executor
@@ -629,13 +669,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/notebook_component_simple.yaml
+++ b/test_data/compiled-workflows/notebook_component_simple.yaml
@@ -210,12 +210,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -242,6 +248,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -250,6 +260,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -322,7 +336,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -358,6 +380,8 @@ spec:
             value: run-train-notebook
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: run-train-notebook
         name: run-train-notebook-driver
         template: system-container-driver
       - arguments:
@@ -367,6 +391,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.run-train-notebook-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: run-train-notebook
+          - name: task-path
+            value: run-train-notebook
         depends: run-train-notebook-driver.Succeeded
         name: run-train-notebook
         template: system-container-executor
@@ -448,13 +476,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/output_metrics.yaml
+++ b/test_data/compiled-workflows/output_metrics.yaml
@@ -114,12 +114,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -146,6 +152,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -154,6 +164,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -226,7 +240,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -262,6 +284,8 @@ spec:
             value: output-metrics
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: output-metrics
         name: output-metrics-driver
         template: system-container-driver
       - arguments:
@@ -271,6 +295,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.output-metrics-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: output-metrics
+          - name: task-path
+            value: output-metrics
         depends: output-metrics-driver.Succeeded
         name: output-metrics
         template: system-container-executor
@@ -352,13 +380,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/parallel_for_after_dependency.yaml
+++ b/test_data/compiled-workflows/parallel_for_after_dependency.yaml
@@ -115,12 +115,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -147,6 +153,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -155,6 +165,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -227,7 +241,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -263,6 +285,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -272,6 +296,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: root.comp-for-loop-2.print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -353,13 +381,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -393,6 +427,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -463,6 +499,8 @@ spec:
             value: print-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op-2
         depends: for-loop-2.Succeeded
         name: print-op-2-driver
         template: system-container-driver
@@ -473,6 +511,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-2
+          - name: task-path
+            value: print-op-2
         depends: print-op-2-driver.Succeeded
         name: print-op-2
         template: system-container-executor
@@ -488,6 +530,8 @@ spec:
             value: print-op-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op-3
         depends: for-loop-2.Succeeded
         name: print-op-3-driver
         template: system-container-driver
@@ -498,6 +542,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-3
+          - name: task-path
+            value: print-op-3
         depends: print-op-3-driver.Succeeded
         name: print-op-3
         template: system-container-executor

--- a/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
+++ b/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
@@ -139,12 +139,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -171,6 +177,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -179,6 +189,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -251,7 +265,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -289,6 +311,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-example-component}}'
+          - name: task-path
+            value: root.comp-for-loop-2.example-component
         name: example-component-driver
         template: system-container-driver
       - arguments:
@@ -298,6 +322,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.example-component-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: example-component
+          - name: task-path
+            value: root.comp-for-loop-2.example-component
         depends: example-component-driver.Succeeded
         name: example-component
         template: system-container-executor
@@ -379,13 +407,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -418,6 +452,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-2"},"dependentTasks":["createpvc"],"inputs":{"parameters":{"pipelinechannel--createpvc-name":{"taskOutputParameter":{"outputParameterKey":"name","producerTask":"createpvc"}}}},"parameterIterator":{"itemInput":"pipelinechannel--loop-item-param-1","items":{"raw":"[\"a\"]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -481,6 +517,8 @@ spec:
             value: createpvc
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: createpvc
         name: createpvc
         template: system-container-driver
       - arguments:

--- a/test_data/compiled-workflows/parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/parallel_for_secret.yaml
@@ -119,12 +119,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -151,6 +157,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -159,6 +169,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -231,7 +245,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -269,6 +291,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-example-component}}'
+          - name: task-path
+            value: root.comp-for-loop-2.example-component
         name: example-component-driver
         template: system-container-driver
       - arguments:
@@ -278,6 +302,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.example-component-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: example-component
+          - name: task-path
+            value: root.comp-for-loop-2.example-component
         depends: example-component-driver.Succeeded
         name: example-component
         template: system-container-executor
@@ -359,13 +387,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -399,6 +433,8 @@ spec:
               \"b\", \"c\"]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:

--- a/test_data/compiled-workflows/parameter_cache.yaml
+++ b/test_data/compiled-workflows/parameter_cache.yaml
@@ -129,12 +129,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -161,6 +167,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -169,6 +179,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -241,7 +255,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -277,6 +299,8 @@ spec:
             value: core-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-core.core-comp
         name: core-comp-driver
         template: system-container-driver
       - arguments:
@@ -286,6 +310,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.core-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: core-comp
+          - name: task-path
+            value: root.comp-core.core-comp
         depends: core-comp-driver.Succeeded
         name: core-comp
         template: system-container-executor
@@ -367,13 +395,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -404,6 +438,8 @@ spec:
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-core"},"taskInfo":{"name":"core"}}'
           - name: task-name
             value: core
+          - name: task-path
+            value: root.comp-mantle.core
         name: core-driver
         template: system-dag-driver
       - arguments:
@@ -435,6 +471,8 @@ spec:
             value: crust-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: crust-comp
         depends: mantle.Succeeded
         name: crust-comp-driver
         template: system-container-driver
@@ -445,6 +483,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.crust-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: crust-comp
+          - name: task-path
+            value: crust-comp
         depends: crust-comp-driver.Succeeded
         name: crust-comp
         template: system-container-executor
@@ -457,6 +499,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-mantle"},"taskInfo":{"name":"mantle"}}'
           - name: task-name
+            value: mantle
+          - name: task-path
             value: mantle
         name: mantle-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/parameter_oneof.yaml
+++ b/test_data/compiled-workflows/parameter_oneof.yaml
@@ -168,12 +168,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -200,6 +206,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -208,6 +218,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -280,7 +294,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -317,6 +339,8 @@ spec:
             value: core-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-2.core-comp
         name: core-comp-driver
         template: system-container-driver
       - arguments:
@@ -326,6 +350,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.core-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: core-comp
+          - name: task-path
+            value: root.comp-condition-2.core-comp
         depends: core-comp-driver.Succeeded
         name: core-comp
         template: system-container-executor
@@ -350,6 +378,8 @@ spec:
             value: core-output-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-3.core-output-comp
         name: core-output-comp-driver
         template: system-container-driver
       - arguments:
@@ -359,6 +389,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.core-output-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: core-output-comp
+          - name: task-path
+            value: root.comp-condition-3.core-output-comp
         depends: core-output-comp-driver.Succeeded
         name: core-output-comp
         template: system-container-executor
@@ -440,13 +474,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -478,6 +518,8 @@ spec:
               == ''heads''"}}'
           - name: task-name
             value: condition-2
+          - name: task-path
+            value: root.comp-condition-branches-1.condition-2
         name: condition-2-driver
         template: system-dag-driver
       - arguments:
@@ -501,6 +543,8 @@ spec:
               == ''heads'')"}}'
           - name: task-name
             value: condition-3
+          - name: task-path
+            value: root.comp-condition-branches-1.condition-3
         name: condition-3-driver
         template: system-dag-driver
       - arguments:
@@ -531,6 +575,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-branches-1"},"dependentTasks":["flip-coin"],"inputs":{"parameters":{"pipelinechannel--flip-coin-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"flip-coin"}}}},"taskInfo":{"name":"condition-branches-1"}}'
           - name: task-name
             value: condition-branches-1
+          - name: task-path
+            value: root.comp-core.condition-branches-1
         depends: flip-coin.Succeeded
         name: condition-branches-1-driver
         template: system-dag-driver
@@ -555,6 +601,8 @@ spec:
             value: flip-coin
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-core.flip-coin
         name: flip-coin-driver
         template: system-container-driver
       - arguments:
@@ -564,6 +612,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin
+          - name: task-path
+            value: root.comp-core.flip-coin
         depends: flip-coin-driver.Succeeded
         name: flip-coin
         template: system-container-executor
@@ -585,6 +637,8 @@ spec:
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-core"},"taskInfo":{"name":"core"}}'
           - name: task-name
             value: core
+          - name: task-path
+            value: root.comp-mantle.core
         name: core-driver
         template: system-dag-driver
       - arguments:
@@ -616,6 +670,8 @@ spec:
             value: crust-comp
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: crust-comp
         depends: mantle.Succeeded
         name: crust-comp-driver
         template: system-container-driver
@@ -626,6 +682,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.crust-comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: crust-comp
+          - name: task-path
+            value: crust-comp
         depends: crust-comp-driver.Succeeded
         name: crust-comp
         template: system-container-executor
@@ -638,6 +698,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{},"componentRef":{"name":"comp-mantle"},"taskInfo":{"name":"mantle"}}'
           - name: task-name
+            value: mantle
+          - name: task-path
             value: mantle
         name: mantle-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/parameters_complex.yaml
+++ b/test_data/compiled-workflows/parameters_complex.yaml
@@ -162,12 +162,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -194,6 +200,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -202,6 +212,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -274,7 +288,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -310,6 +332,8 @@ spec:
             value: double-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.double-2
         name: double-2-driver
         template: system-container-driver
       - arguments:
@@ -319,6 +343,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.double-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: double-2
+          - name: task-path
+            value: root.comp-for-loop-4.double-2
         depends: double-2-driver.Succeeded
         name: double-2
         template: system-container-executor
@@ -400,13 +428,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -440,6 +474,8 @@ spec:
               5, 6]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
+          - name: task-path
+            value: root.comp-for-loop-2.for-loop-4.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -504,6 +540,8 @@ spec:
             value: double
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.double
         name: double-driver
         template: system-container-driver
       - arguments:
@@ -513,6 +551,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.double-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: double
+          - name: task-path
+            value: root.comp-for-loop-2.double
         depends: double-driver.Succeeded
         name: double
         template: system-container-executor
@@ -534,6 +576,8 @@ spec:
             value: simple-add
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.simple-add
         depends: for-loop-4.Succeeded
         name: simple-add-driver
         template: system-container-driver
@@ -544,6 +588,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.simple-add-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: simple-add
+          - name: task-path
+            value: root.comp-for-loop-2.simple-add
         depends: simple-add-driver.Succeeded
         name: simple-add
         template: system-container-executor
@@ -567,6 +615,8 @@ spec:
             value: nested-add-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-6.nested-add-2
         name: nested-add-2-driver
         template: system-container-driver
       - arguments:
@@ -576,6 +626,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.nested-add-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: nested-add-2
+          - name: task-path
+            value: root.comp-for-loop-6.nested-add-2
         depends: nested-add-2-driver.Succeeded
         name: nested-add-2
         template: system-container-executor
@@ -591,6 +645,8 @@ spec:
             value: simple-add-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-6.simple-add-2
         name: simple-add-2-driver
         template: system-container-driver
       - arguments:
@@ -600,6 +656,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.simple-add-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: simple-add-2
+          - name: task-path
+            value: root.comp-for-loop-6.simple-add-2
         depends: simple-add-2-driver.Succeeded
         name: simple-add-2
         template: system-container-executor
@@ -624,6 +684,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -689,6 +751,8 @@ spec:
               0, 0]"}},"taskInfo":{"name":"for-loop-6"}}'
           - name: task-name
             value: for-loop-6
+          - name: task-path
+            value: root.for-loop-6.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -753,6 +817,8 @@ spec:
             value: add-two-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add-two-numbers
         depends: for-loop-6.Succeeded
         name: add-two-numbers-driver
         template: system-container-driver
@@ -763,6 +829,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-two-numbers-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-two-numbers
+          - name: task-path
+            value: add-two-numbers
         depends: add-two-numbers-driver.Succeeded
         name: add-two-numbers
         template: system-container-executor
@@ -791,6 +861,8 @@ spec:
             value: nested-add
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: nested-add
         depends: for-loop-2.Succeeded
         name: nested-add-driver
         template: system-container-driver
@@ -801,6 +873,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.nested-add-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: nested-add
+          - name: task-path
+            value: nested-add
         depends: nested-add-driver.Succeeded
         name: nested-add
         template: system-container-executor

--- a/test_data/compiled-workflows/parameters_simple.yaml
+++ b/test_data/compiled-workflows/parameters_simple.yaml
@@ -133,12 +133,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -165,6 +171,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -173,6 +183,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -245,7 +259,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -281,6 +303,8 @@ spec:
             value: double
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.double
         name: double-driver
         template: system-container-driver
       - arguments:
@@ -290,6 +314,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.double-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: double
+          - name: task-path
+            value: root.comp-for-loop-2.double
         depends: double-driver.Succeeded
         name: double
         template: system-container-executor
@@ -371,13 +399,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -411,6 +445,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -475,6 +511,8 @@ spec:
             value: add
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add
         depends: for-loop-2.Succeeded
         name: add-driver
         template: system-container-driver
@@ -485,6 +523,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add
+          - name: task-path
+            value: add
         depends: add-driver.Succeeded
         name: add
         template: system-container-executor
@@ -500,6 +542,8 @@ spec:
             value: add-container
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add-container
         depends: for-loop-2.Succeeded
         name: add-container-driver
         template: system-container-driver
@@ -510,6 +554,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-container-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-container
+          - name: task-path
+            value: add-container
         depends: add-container-driver.Succeeded
         name: add-container
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_as_exit_task.yaml
+++ b/test_data/compiled-workflows/pipeline_as_exit_task.yaml
@@ -149,12 +149,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -181,6 +187,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -189,6 +199,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -261,7 +275,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -298,6 +320,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -307,6 +331,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: root.comp-condition-1.print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -388,13 +416,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -426,6 +460,8 @@ spec:
               == ''FAILED''"}}'
           - name: task-name
             value: condition-1
+          - name: task-path
+            value: root.comp-conditional-notification.condition-1
         depends: get-run-state.Succeeded
         name: condition-1-driver
         template: system-dag-driver
@@ -451,6 +487,8 @@ spec:
             value: get-run-state
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-conditional-notification.get-run-state
         name: get-run-state-driver
         template: system-container-driver
       - arguments:
@@ -460,6 +498,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.get-run-state-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: get-run-state
+          - name: task-path
+            value: root.comp-conditional-notification.get-run-state
         depends: get-run-state-driver.Succeeded
         name: get-run-state
         template: system-container-executor
@@ -484,6 +526,8 @@ spec:
             value: fail-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-1.fail-op
         name: fail-op-driver
         template: system-container-driver
       - arguments:
@@ -493,6 +537,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.fail-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: fail-op
+          - name: task-path
+            value: root.comp-exit-handler-1.fail-op
         depends: fail-op-driver.Succeeded
         name: fail-op
         template: system-container-executor
@@ -508,6 +556,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-1.print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -517,6 +567,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: root.comp-exit-handler-1.print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -537,6 +591,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-conditional-notification"},"dependentTasks":["exit-handler-1"],"inputs":{"parameters":{"status":{"taskFinalStatus":{"producerTask":"exit-handler-1"}}}},"taskInfo":{"name":"conditional-notification"},"triggerPolicy":{"strategy":"ALL_UPSTREAM_TASKS_COMPLETED"}}'
           - name: task-name
+            value: conditional-notification
+          - name: task-path
             value: conditional-notification
         name: conditional-notification-driver
         template: system-dag-driver
@@ -566,6 +622,8 @@ spec:
           - name: task
             value: '{"componentRef":{"name":"comp-exit-handler-1"},"inputs":{"parameters":{"pipelinechannel--message":{"componentInputParameter":"message"}}},"taskInfo":{"name":"my-pipeline"}}'
           - name: task-name
+            value: exit-handler-1
+          - name: task-path
             value: exit-handler-1
         name: exit-handler-1-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/pipeline_in_pipeline.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline.yaml
@@ -118,12 +118,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -150,6 +156,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -158,6 +168,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -230,7 +244,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -266,6 +288,8 @@ spec:
             value: print-op1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op1
         name: print-op1-driver
         template: system-container-driver
       - arguments:
@@ -275,6 +299,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op1
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op1
         depends: print-op1-driver.Succeeded
         name: print-op1
         template: system-container-executor
@@ -290,6 +318,8 @@ spec:
             value: print-op2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op2
         depends: print-op1.Succeeded
         name: print-op2-driver
         template: system-container-driver
@@ -300,6 +330,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op2
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op2
         depends: print-op2-driver.Succeeded
         name: print-op2
         template: system-container-executor
@@ -381,13 +415,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -418,6 +458,8 @@ spec:
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-inner-pipeline"},"inputs":{"parameters":{"msg":{"runtimeValue":{"constant":"world"}}}},"taskInfo":{"name":"inner-pipeline"}}'
           - name: task-name
             value: inner-pipeline
+          - name: task-path
+            value: inner-pipeline
         name: inner-pipeline-driver
         template: system-dag-driver
       - arguments:
@@ -441,6 +483,8 @@ spec:
             value: print-op1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op1
         name: print-op1-driver
         template: system-container-driver
       - arguments:
@@ -450,6 +494,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op1
+          - name: task-path
+            value: print-op1
         depends: print-op1-driver.Succeeded
         name: print-op1
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
@@ -127,12 +127,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -159,6 +165,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -167,6 +177,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -239,7 +253,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -275,6 +297,8 @@ spec:
             value: print-op2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.print-op2
         name: print-op2-driver
         template: system-container-driver
       - arguments:
@@ -284,6 +308,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op2
+          - name: task-path
+            value: root.comp-condition-1.print-op2
         depends: print-op2-driver.Succeeded
         name: print-op2
         template: system-container-executor
@@ -307,6 +335,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-2.print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -316,6 +346,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: root.comp-condition-2.print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -397,13 +431,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -435,6 +475,8 @@ spec:
               == ''Hello''"}}'
           - name: task-name
             value: condition-1
+          - name: task-path
+            value: root.comp-inner-pipeline.condition-1
         depends: print-op1.Succeeded
         name: condition-1-driver
         template: system-dag-driver
@@ -459,6 +501,8 @@ spec:
               != ''Hello''"}}'
           - name: task-name
             value: condition-2
+          - name: task-path
+            value: root.comp-inner-pipeline.condition-2
         depends: print-op1.Succeeded
         name: condition-2-driver
         template: system-dag-driver
@@ -484,6 +528,8 @@ spec:
             value: print-op1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op1
         name: print-op1-driver
         template: system-container-driver
       - arguments:
@@ -493,6 +539,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op1
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op1
         depends: print-op1-driver.Succeeded
         name: print-op1
         template: system-container-executor
@@ -514,6 +564,8 @@ spec:
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-inner-pipeline"},"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--loop-item-param-1"}}},"taskInfo":{"name":"inner-pipeline"}}'
           - name: task-name
             value: inner-pipeline
+          - name: task-path
+            value: root.comp-for-loop-2.inner-pipeline
         name: inner-pipeline-driver
         template: system-dag-driver
       - arguments:
@@ -546,6 +598,8 @@ spec:
               \"world!\"]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -616,6 +670,8 @@ spec:
             value: print-op1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op1
         name: print-op1-driver
         template: system-container-driver
       - arguments:
@@ -625,6 +681,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op1
+          - name: task-path
+            value: print-op1
         depends: print-op1-driver.Succeeded
         name: print-op1
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
@@ -134,12 +134,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -166,6 +172,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -174,6 +184,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -246,7 +260,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -282,6 +304,8 @@ spec:
             value: print-op1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op1
         name: print-op1-driver
         template: system-container-driver
       - arguments:
@@ -291,6 +315,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op1
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op1
         depends: print-op1-driver.Succeeded
         name: print-op1
         template: system-container-executor
@@ -306,6 +334,8 @@ spec:
             value: print-op2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op2
         depends: print-op1.Succeeded
         name: print-op2-driver
         template: system-container-driver
@@ -316,6 +346,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op2
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op2
         depends: print-op2-driver.Succeeded
         name: print-op2
         template: system-container-executor
@@ -397,13 +431,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -434,6 +474,8 @@ spec:
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-inner-pipeline"},"inputs":{"parameters":{"msg":{"runtimeValue":{"constant":"world"}}}},"taskInfo":{"name":"inner-pipeline"}}'
           - name: task-name
             value: inner-pipeline
+          - name: task-path
+            value: root.comp-pipeline-in-pipeline.inner-pipeline
         name: inner-pipeline-driver
         template: system-dag-driver
       - arguments:
@@ -457,6 +499,8 @@ spec:
             value: print-op1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-pipeline-in-pipeline.print-op1
         name: print-op1-driver
         template: system-container-driver
       - arguments:
@@ -466,6 +510,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op1
+          - name: task-path
+            value: root.comp-pipeline-in-pipeline.print-op1
         depends: print-op1-driver.Succeeded
         name: print-op1
         template: system-container-executor
@@ -486,6 +534,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-pipeline-in-pipeline"},"inputs":{"parameters":{"msg":{"runtimeValue":{"constant":"Hello"}}}},"taskInfo":{"name":"pipeline-in-pipeline"}}'
           - name: task-name
+            value: pipeline-in-pipeline
+          - name: task-path
             value: pipeline-in-pipeline
         name: pipeline-in-pipeline-driver
         template: system-dag-driver
@@ -510,6 +560,8 @@ spec:
             value: print-op1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op1
         depends: pipeline-in-pipeline.Succeeded
         name: print-op1-driver
         template: system-container-driver
@@ -520,6 +572,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op1
+          - name: task-path
+            value: print-op1
         depends: print-op1-driver.Succeeded
         name: print-op1
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_producer_consumer.yaml
+++ b/test_data/compiled-workflows/pipeline_producer_consumer.yaml
@@ -165,12 +165,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -197,6 +203,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -205,6 +215,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -277,7 +291,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -313,6 +335,8 @@ spec:
             value: echo-and-return
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2-2.echo-and-return
         name: echo-and-return-driver
         template: system-container-driver
       - arguments:
@@ -322,6 +346,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-and-return-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo-and-return
+          - name: task-path
+            value: root.comp-for-loop-2-2.echo-and-return
         depends: echo-and-return-driver.Succeeded
         name: echo-and-return
         template: system-container-executor
@@ -403,13 +431,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -443,6 +477,8 @@ spec:
               \"a\", \"t\", \"h\"]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.comp-add-pipeline.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -507,6 +543,8 @@ spec:
             value: add
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-add-pipeline.add
         name: add-driver
         template: system-container-driver
       - arguments:
@@ -516,6 +554,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add
+          - name: task-path
+            value: root.comp-add-pipeline.add
         depends: add-driver.Succeeded
         name: add
         template: system-container-executor
@@ -545,6 +587,8 @@ spec:
             value: double
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-double-pipeline.double
         name: double-driver
         template: system-container-driver
       - arguments:
@@ -554,6 +598,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.double-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: double
+          - name: task-path
+            value: root.comp-double-pipeline.double
         depends: double-driver.Succeeded
         name: double
         template: system-container-executor
@@ -575,6 +623,8 @@ spec:
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-double-pipeline"},"inputs":{"parameters":{"num":{"componentInputParameter":"pipelinechannel--loop-item-param-3"}}},"taskInfo":{"name":"double-pipeline"}}'
           - name: task-name
             value: double-pipeline
+          - name: task-path
+            value: root.comp-for-loop-4.double-pipeline
         name: double-pipeline-driver
         template: system-dag-driver
       - arguments:
@@ -607,6 +657,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
+          - name: task-path
+            value: root.comp-for-loop-2.for-loop-4.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -686,6 +738,8 @@ spec:
               2, 3]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -748,6 +802,8 @@ spec:
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-add-pipeline"},"dependentTasks":["for-loop-2"],"inputs":{"parameters":{"nums":{"taskOutputParameter":{"outputParameterKey":"pipelinechannel--double-pipeline-Output","producerTask":"for-loop-2"}}}},"taskInfo":{"name":"add-pipeline"}}'
           - name: task-name
             value: add-pipeline
+          - name: task-path
+            value: add-pipeline
         depends: for-loop-2.Succeeded
         name: add-pipeline-driver
         template: system-dag-driver
@@ -778,6 +834,8 @@ spec:
             value: join-and-print
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: join-and-print
         depends: add-pipeline.Succeeded
         name: join-and-print-driver
         template: system-container-driver
@@ -788,6 +846,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.join-and-print-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: join-and-print
+          - name: task-path
+            value: join-and-print
         depends: join-and-print-driver.Succeeded
         name: join-and-print
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_after.yaml
+++ b/test_data/compiled-workflows/pipeline_with_after.yaml
@@ -106,12 +106,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -138,6 +144,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -146,6 +156,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -218,7 +232,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -255,6 +277,8 @@ spec:
             value: print-text
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-text
         name: print-text-driver
         template: system-container-driver
       - arguments:
@@ -264,6 +288,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text
+          - name: task-path
+            value: print-text
         depends: print-text-driver.Succeeded
         name: print-text
         template: system-container-executor
@@ -280,6 +308,8 @@ spec:
             value: print-text-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-text-2
         depends: print-text.Succeeded
         name: print-text-2-driver
         template: system-container-driver
@@ -290,6 +320,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-2
+          - name: task-path
+            value: print-text-2
         depends: print-text-2-driver.Succeeded
         name: print-text-2
         template: system-container-executor
@@ -306,6 +340,8 @@ spec:
             value: print-text-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-text-3
         depends: print-text.Succeeded && print-text-2.Succeeded
         name: print-text-3-driver
         template: system-container-driver
@@ -316,6 +352,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-3
+          - name: task-path
+            value: print-text-3
         depends: print-text-3-driver.Succeeded
         name: print-text-3
         template: system-container-executor
@@ -397,13 +437,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
@@ -134,12 +134,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -166,6 +172,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -174,6 +184,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -246,7 +260,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -282,6 +304,8 @@ spec:
             value: component-output-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: component-output-artifact
         name: component-output-artifact-driver
         template: system-container-driver
       - arguments:
@@ -291,6 +315,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-output-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-output-artifact
+          - name: task-path
+            value: component-output-artifact
         depends: component-output-artifact-driver.Succeeded
         name: component-output-artifact
         template: system-container-executor
@@ -306,6 +334,8 @@ spec:
             value: validate-input-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: validate-input-artifact
         depends: component-output-artifact.Succeeded
         name: validate-input-artifact-driver
         template: system-container-driver
@@ -316,6 +346,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.validate-input-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: validate-input-artifact
+          - name: task-path
+            value: validate-input-artifact
         depends: validate-input-artifact-driver.Succeeded
         name: validate-input-artifact
         template: system-container-executor
@@ -397,13 +431,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
@@ -133,12 +133,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -165,6 +171,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -173,6 +183,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -245,7 +259,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -281,6 +303,8 @@ spec:
             value: download-dataset-and-upload-as-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: download-dataset-and-upload-as-artifact
         name: download-dataset-and-upload-as-artifact-driver
         template: system-container-driver
       - arguments:
@@ -290,6 +314,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.download-dataset-and-upload-as-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: download-dataset-and-upload-as-artifact
+          - name: task-path
+            value: download-dataset-and-upload-as-artifact
         depends: download-dataset-and-upload-as-artifact-driver.Succeeded
         name: download-dataset-and-upload-as-artifact
         template: system-container-executor
@@ -305,6 +333,8 @@ spec:
             value: print-dataset-info
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-dataset-info
         depends: download-dataset-and-upload-as-artifact.Succeeded
         name: print-dataset-info-driver
         template: system-container-driver
@@ -315,6 +345,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-dataset-info-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-dataset-info
+          - name: task-path
+            value: print-dataset-info
         depends: print-dataset-info-driver.Succeeded
         name: print-dataset-info
         template: system-container-executor
@@ -396,13 +430,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
@@ -105,12 +105,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -137,6 +143,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -145,6 +155,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -217,7 +231,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -253,6 +275,8 @@ spec:
             value: component-with-concat-placeholder
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: component-with-concat-placeholder
         name: component-with-concat-placeholder-driver
         template: system-container-driver
       - arguments:
@@ -262,6 +286,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-with-concat-placeholder-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-with-concat-placeholder
+          - name: task-path
+            value: component-with-concat-placeholder
         depends: component-with-concat-placeholder-driver.Succeeded
         name: component-with-concat-placeholder
         template: system-container-executor
@@ -343,13 +371,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_condition.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition.yaml
@@ -131,12 +131,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -163,6 +169,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -171,6 +181,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -243,7 +257,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -279,6 +301,8 @@ spec:
             value: flip-coin-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.flip-coin-op-2
         name: flip-coin-op-2-driver
         template: system-container-driver
       - arguments:
@@ -288,6 +312,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin-op-2
+          - name: task-path
+            value: root.comp-condition-1.flip-coin-op-2
         depends: flip-coin-op-2-driver.Succeeded
         name: flip-coin-op-2
         template: system-container-executor
@@ -303,6 +331,8 @@ spec:
             value: print-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.print-op-2
         depends: flip-coin-op-2.Succeeded
         name: print-op-2-driver
         template: system-container-driver
@@ -313,6 +343,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-2
+          - name: task-path
+            value: root.comp-condition-1.print-op-2
         depends: print-op-2-driver.Succeeded
         name: print-op-2
         template: system-container-executor
@@ -328,6 +362,8 @@ spec:
             value: print-op-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.print-op-3
         name: print-op-3-driver
         template: system-container-driver
       - arguments:
@@ -337,6 +373,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-3
+          - name: task-path
+            value: root.comp-condition-1.print-op-3
         depends: print-op-3-driver.Succeeded
         name: print-op-3
         template: system-container-executor
@@ -418,13 +458,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -456,6 +502,8 @@ spec:
               == ''heads''"}}'
           - name: task-name
             value: condition-1
+          - name: task-path
+            value: condition-1
         depends: flip-coin-op.Succeeded
         name: condition-1-driver
         template: system-dag-driver
@@ -481,6 +529,8 @@ spec:
             value: flip-coin-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: flip-coin-op
         name: flip-coin-op-driver
         template: system-container-driver
       - arguments:
@@ -490,6 +540,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin-op
+          - name: task-path
+            value: flip-coin-op
         depends: flip-coin-op-driver.Succeeded
         name: flip-coin-op
         template: system-container-executor
@@ -505,6 +559,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op
         depends: flip-coin-op.Succeeded
         name: print-op-driver
         template: system-container-driver
@@ -515,6 +571,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
@@ -228,12 +228,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -260,6 +266,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -268,6 +278,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -340,7 +354,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -376,6 +398,8 @@ spec:
             value: custom-training-job
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.custom-training-job
         name: custom-training-job-driver
         template: system-container-driver
       - arguments:
@@ -385,6 +409,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.custom-training-job-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: custom-training-job
+          - name: task-path
+            value: root.comp-condition-1.custom-training-job
         depends: custom-training-job-driver.Succeeded
         name: custom-training-job
         template: system-container-executor
@@ -466,13 +494,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -505,6 +539,8 @@ spec:
             value: accelerator-count
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: accelerator-count
         name: accelerator-count-driver
         template: system-container-driver
       - arguments:
@@ -514,6 +550,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.accelerator-count-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: accelerator-count
+          - name: task-path
+            value: accelerator-count
         depends: accelerator-count-driver.Succeeded
         name: accelerator-count
         template: system-container-executor
@@ -529,6 +569,8 @@ spec:
             value: accelerator-type
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: accelerator-type
         name: accelerator-type-driver
         template: system-container-driver
       - arguments:
@@ -538,6 +580,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.accelerator-type-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: accelerator-type
+          - name: task-path
+            value: accelerator-type
         depends: accelerator-type-driver.Succeeded
         name: accelerator-type
         template: system-container-executor
@@ -551,6 +597,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-1"},"dependentTasks":["accelerator-count","accelerator-type","flip-biased-coin-op","machine-type"],"inputs":{"parameters":{"pipelinechannel--accelerator-count-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-count"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--encryption_spec_key_name":{"componentInputParameter":"encryption_spec_key_name"},"pipelinechannel--flip-biased-coin-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"flip-biased-coin-op"}},"pipelinechannel--location":{"componentInputParameter":"location"},"pipelinechannel--machine-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"machine-type"}},"pipelinechannel--project":{"componentInputParameter":"project"}}},"taskInfo":{"name":"condition-1"},"triggerPolicy":{"condition":"inputs.parameter_values[''pipelinechannel--flip-biased-coin-op-Output'']
               == ''heads''"}}'
           - name: task-name
+            value: condition-1
+          - name: task-path
             value: condition-1
         depends: accelerator-count.Succeeded && accelerator-type.Succeeded && flip-biased-coin-op.Succeeded
           && machine-type.Succeeded
@@ -578,6 +626,8 @@ spec:
             value: flip-biased-coin-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: flip-biased-coin-op
         name: flip-biased-coin-op-driver
         template: system-container-driver
       - arguments:
@@ -587,6 +637,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-biased-coin-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-biased-coin-op
+          - name: task-path
+            value: flip-biased-coin-op
         depends: flip-biased-coin-op-driver.Succeeded
         name: flip-biased-coin-op
         template: system-container-executor
@@ -602,6 +656,8 @@ spec:
             value: machine-type
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: machine-type
         name: machine-type-driver
         template: system-container-driver
       - arguments:
@@ -611,6 +667,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.machine-type-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: machine-type
+          - name: task-path
+            value: machine-type
         depends: machine-type-driver.Succeeded
         name: machine-type
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
@@ -189,12 +189,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -221,6 +227,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -229,6 +239,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -301,7 +315,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -361,6 +383,8 @@ spec:
             value: make-name
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: make-name
         name: make-name-driver
         template: system-container-driver
       - arguments:
@@ -370,6 +394,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.make-name-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: make-name
+          - name: task-path
+            value: make-name
         depends: make-name-driver.Succeeded
         name: make-name
         template: system-container-executor
@@ -451,13 +479,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
@@ -190,12 +190,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -222,6 +228,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -230,6 +240,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -302,7 +316,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -338,6 +360,8 @@ spec:
             value: accelerator-count
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: accelerator-count
         name: accelerator-count-driver
         template: system-container-driver
       - arguments:
@@ -347,6 +371,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.accelerator-count-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: accelerator-count
+          - name: task-path
+            value: accelerator-count
         depends: accelerator-count-driver.Succeeded
         name: accelerator-count
         template: system-container-executor
@@ -362,6 +390,8 @@ spec:
             value: accelerator-type
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: accelerator-type
         name: accelerator-type-driver
         template: system-container-driver
       - arguments:
@@ -371,6 +401,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.accelerator-type-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: accelerator-type
+          - name: task-path
+            value: accelerator-type
         depends: accelerator-type-driver.Succeeded
         name: accelerator-type
         template: system-container-executor
@@ -386,6 +420,8 @@ spec:
             value: custom-training-job
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: custom-training-job
         depends: accelerator-count.Succeeded && accelerator-type.Succeeded && machine-type.Succeeded
         name: custom-training-job-driver
         template: system-container-driver
@@ -396,6 +432,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.custom-training-job-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: custom-training-job
+          - name: task-path
+            value: custom-training-job
         depends: custom-training-job-driver.Succeeded
         name: custom-training-job
         template: system-container-executor
@@ -411,6 +451,8 @@ spec:
             value: machine-type
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: machine-type
         name: machine-type-driver
         template: system-container-driver
       - arguments:
@@ -420,6 +462,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.machine-type-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: machine-type
+          - name: task-path
+            value: machine-type
         depends: machine-type-driver.Succeeded
         name: machine-type
         template: system-container-executor
@@ -501,13 +547,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_env.yaml
@@ -118,12 +118,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -150,6 +156,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -158,6 +168,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -230,7 +244,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -266,6 +288,8 @@ spec:
             value: print-env
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-env
         name: print-env-driver
         template: system-container-driver
       - arguments:
@@ -275,6 +299,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-env-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-env
+          - name: task-path
+            value: print-env
         depends: print-env-driver.Succeeded
         name: print-env
         template: system-container-executor
@@ -290,6 +318,8 @@ spec:
             value: print-env-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-env-op
         name: print-env-op-driver
         template: system-container-driver
       - arguments:
@@ -299,6 +329,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-env-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-env-op
+          - name: task-path
+            value: print-env-op
         depends: print-env-op-driver.Succeeded
         name: print-env-op
         template: system-container-executor
@@ -380,13 +414,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
@@ -130,12 +130,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -162,6 +168,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -170,6 +180,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -242,7 +256,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -279,6 +301,8 @@ spec:
             value: fail-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-1.fail-op
         name: fail-op-driver
         template: system-container-driver
       - arguments:
@@ -288,6 +312,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.fail-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: fail-op
+          - name: task-path
+            value: root.comp-exit-handler-1.fail-op
         depends: fail-op-driver.Succeeded
         name: fail-op
         template: system-container-executor
@@ -303,6 +331,8 @@ spec:
             value: print-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-1.print-op-2
         name: print-op-2-driver
         template: system-container-driver
       - arguments:
@@ -312,6 +342,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-2
+          - name: task-path
+            value: root.comp-exit-handler-1.print-op-2
         depends: print-op-2-driver.Succeeded
         name: print-op-2
         template: system-container-executor
@@ -336,6 +370,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -345,6 +381,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -426,13 +466,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -462,6 +508,8 @@ spec:
           - name: task
             value: '{"componentRef":{"name":"comp-exit-handler-1"},"inputs":{"parameters":{"pipelinechannel--message":{"componentInputParameter":"message"}}},"taskInfo":{"name":"exit-handler-1"}}'
           - name: task-name
+            value: exit-handler-1
+          - name: task-path
             value: exit-handler-1
         name: exit-handler-1-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
+++ b/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
@@ -207,12 +207,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -239,6 +245,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -247,6 +257,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -319,7 +333,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -367,6 +389,8 @@ spec:
             value: model-consumer
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: model-consumer
         depends: importer.Succeeded && model-producer.Succeeded
         name: model-consumer-driver
         template: system-container-driver
@@ -377,6 +401,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.model-consumer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: model-consumer
+          - name: task-path
+            value: model-consumer
         depends: model-consumer-driver.Succeeded
         name: model-consumer
         template: system-container-executor
@@ -392,6 +420,8 @@ spec:
             value: model-producer
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: model-producer
         name: model-producer-driver
         template: system-container-driver
       - arguments:
@@ -401,6 +431,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.model-producer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: model-producer
+          - name: task-path
+            value: model-producer
         depends: model-producer-driver.Succeeded
         name: model-producer
         template: system-container-executor
@@ -482,13 +516,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_importer.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer.yaml
@@ -197,12 +197,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -229,6 +235,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -237,6 +247,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -309,7 +323,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -357,6 +379,8 @@ spec:
             value: train-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.train-2
         depends: importer-2.Succeeded
         name: train-2-driver
         template: system-container-driver
@@ -367,6 +391,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.train-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: train-2
+          - name: task-path
+            value: root.comp-condition-1.train-2
         depends: train-2-driver.Succeeded
         name: train-2
         template: system-container-executor
@@ -448,13 +476,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -485,6 +519,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-1"},"dependentTasks":["train"],"inputs":{"parameters":{"pipelinechannel--dataset2":{"componentInputParameter":"dataset2"},"pipelinechannel--train-scalar":{"taskOutputParameter":{"outputParameterKey":"scalar","producerTask":"train"}}}},"taskInfo":{"name":"condition-1"},"triggerPolicy":{"condition":"inputs.parameter_values[''pipelinechannel--train-scalar'']
               == ''123''"}}'
           - name: task-name
+            value: condition-1
+          - name: task-path
             value: condition-1
         depends: train.Succeeded
         name: condition-1-driver
@@ -523,6 +559,8 @@ spec:
             value: train
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: train
         depends: importer.Succeeded
         name: train-driver
         template: system-container-driver
@@ -533,6 +571,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.train-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: train
+          - name: task-path
+            value: train
         depends: train-driver.Succeeded
         name: train
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
@@ -107,12 +107,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -139,6 +145,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -147,6 +157,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -219,7 +233,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -324,6 +346,8 @@ spec:
             value: consumer-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: consumer-op
         depends: importer.Succeeded
         name: consumer-op-driver
         template: system-container-driver
@@ -334,6 +358,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.consumer-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: consumer-op
+          - name: task-path
+            value: consumer-op
         depends: consumer-op-driver.Succeeded
         name: consumer-op
         template: system-container-executor
@@ -427,13 +455,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
@@ -271,12 +271,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -303,6 +309,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -311,6 +321,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -383,7 +397,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -443,6 +465,8 @@ spec:
             value: read-dir
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-import-stage.read-dir
         depends: importer-2.Succeeded
         name: read-dir-driver
         template: system-container-driver
@@ -453,6 +477,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-dir-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-dir
+          - name: task-path
+            value: root.comp-import-stage.read-dir
         depends: read-dir-driver.Succeeded
         name: read-dir
         template: system-container-executor
@@ -468,6 +496,8 @@ spec:
             value: train
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-import-stage.train
         depends: importer.Succeeded
         name: train-driver
         template: system-container-driver
@@ -478,6 +508,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.train-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: train
+          - name: task-path
+            value: root.comp-import-stage.train
         depends: train-driver.Succeeded
         name: train
         template: system-container-executor
@@ -559,13 +593,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -598,6 +638,8 @@ spec:
             value: get-uri
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: get-uri
         depends: write-file-artifact.Succeeded
         name: get-uri-driver
         template: system-container-driver
@@ -608,6 +650,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.get-uri-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: get-uri
+          - name: task-path
+            value: get-uri
         depends: get-uri-driver.Succeeded
         name: get-uri
         template: system-container-executor
@@ -623,6 +669,8 @@ spec:
             value: get-uri-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: get-uri-2
         depends: write-dir-artifact.Succeeded
         name: get-uri-2-driver
         template: system-container-driver
@@ -633,6 +681,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.get-uri-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: get-uri-2
+          - name: task-path
+            value: get-uri-2
         depends: get-uri-2-driver.Succeeded
         name: get-uri-2
         template: system-container-executor
@@ -645,6 +697,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-import-stage"},"dependentTasks":["get-uri","get-uri-2"],"inputs":{"parameters":{"dir_uri":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"get-uri-2"}},"file_uri":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"get-uri"}}}},"taskInfo":{"name":"import-stage"}}'
           - name: task-name
+            value: import-stage
+          - name: task-path
             value: import-stage
         depends: get-uri.Succeeded && get-uri-2.Succeeded
         name: import-stage-driver
@@ -670,6 +724,8 @@ spec:
             value: write-dir-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: write-dir-artifact
         name: write-dir-artifact-driver
         template: system-container-driver
       - arguments:
@@ -679,6 +735,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.write-dir-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: write-dir-artifact
+          - name: task-path
+            value: write-dir-artifact
         depends: write-dir-artifact-driver.Succeeded
         name: write-dir-artifact
         template: system-container-executor
@@ -694,6 +754,8 @@ spec:
             value: write-file-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: write-file-artifact
         name: write-file-artifact-driver
         template: system-container-driver
       - arguments:
@@ -703,6 +765,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.write-file-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: write-file-artifact
+          - name: task-path
+            value: write-file-artifact
         depends: write-file-artifact-driver.Succeeded
         name: write-file-artifact
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
+++ b/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
@@ -130,12 +130,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -162,6 +168,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -170,6 +180,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -242,7 +256,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -278,6 +300,8 @@ spec:
             value: some-task
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-1.some-task
         name: some-task-driver
         template: system-container-driver
       - arguments:
@@ -287,6 +311,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.some-task-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: some-task
+          - name: task-path
+            value: root.comp-exit-handler-1.some-task
         depends: some-task-driver.Succeeded
         name: some-task
         template: system-container-executor
@@ -310,6 +338,8 @@ spec:
             value: echo-state
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo-state
         name: echo-state-driver
         template: system-container-driver
       - arguments:
@@ -319,6 +349,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-state-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo-state
+          - name: task-path
+            value: echo-state
         depends: echo-state-driver.Succeeded
         name: echo-state
         template: system-container-executor
@@ -400,13 +434,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -436,6 +476,8 @@ spec:
           - name: task
             value: '{"componentRef":{"name":"comp-exit-handler-1"},"taskInfo":{"name":"exit-handler-1"}}'
           - name: task-name
+            value: exit-handler-1
+          - name: task-path
             value: exit-handler-1
         name: exit-handler-1-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/pipeline_with_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops.yaml
@@ -146,12 +146,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -178,6 +184,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -186,6 +196,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -258,7 +272,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -294,6 +316,8 @@ spec:
             value: print-text
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.print-text
         name: print-text-driver
         template: system-container-driver
       - arguments:
@@ -303,6 +327,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text
+          - name: task-path
+            value: root.comp-for-loop-1.print-text
         depends: print-text-driver.Succeeded
         name: print-text
         template: system-container-executor
@@ -326,6 +354,8 @@ spec:
             value: print-struct
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.print-struct
         name: print-struct-driver
         template: system-container-driver
       - arguments:
@@ -335,6 +365,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-struct-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-struct
+          - name: task-path
+            value: root.comp-for-loop-2.print-struct
         depends: print-struct-driver.Succeeded
         name: print-struct
         template: system-container-executor
@@ -350,6 +384,8 @@ spec:
             value: print-text-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.print-text-2
         name: print-text-2-driver
         template: system-container-driver
       - arguments:
@@ -359,6 +395,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-2
+          - name: task-path
+            value: root.comp-for-loop-2.print-text-2
         depends: print-text-2-driver.Succeeded
         name: print-text-2
         template: system-container-executor
@@ -374,6 +414,8 @@ spec:
             value: print-text-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.print-text-3
         name: print-text-3-driver
         template: system-container-driver
       - arguments:
@@ -383,6 +425,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-3
+          - name: task-path
+            value: root.comp-for-loop-2.print-text-3
         depends: print-text-3-driver.Succeeded
         name: print-text-3
         template: system-container-executor
@@ -406,6 +452,8 @@ spec:
             value: print-struct-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.print-struct-2
         name: print-struct-2-driver
         template: system-container-driver
       - arguments:
@@ -415,6 +463,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-struct-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-struct-2
+          - name: task-path
+            value: root.comp-for-loop-4.print-struct-2
         depends: print-struct-2-driver.Succeeded
         name: print-struct-2
         template: system-container-executor
@@ -430,6 +482,8 @@ spec:
             value: print-text-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.print-text-4
         name: print-text-4-driver
         template: system-container-driver
       - arguments:
@@ -439,6 +493,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-4
+          - name: task-path
+            value: root.comp-for-loop-4.print-text-4
         depends: print-text-4-driver.Succeeded
         name: print-text-4
         template: system-container-executor
@@ -454,6 +512,8 @@ spec:
             value: print-text-5
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.print-text-5
         name: print-text-5-driver
         template: system-container-driver
       - arguments:
@@ -463,6 +523,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-5-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-5
+          - name: task-path
+            value: root.comp-for-loop-4.print-text-5
         depends: print-text-5-driver.Succeeded
         name: print-text-5
         template: system-container-executor
@@ -544,13 +608,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -583,6 +653,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
+          - name: task-path
+            value: root.for-loop-1.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -646,6 +718,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-2"},"dependentTasks":["args-generator-op"],"inputs":{"parameters":{"pipelinechannel--args-generator-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"args-generator-op"}}}},"parameterIterator":{"itemInput":"pipelinechannel--args-generator-op-Output-loop-item","items":{"inputParameter":"pipelinechannel--args-generator-op-Output"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -710,6 +784,8 @@ spec:
               \"1\", \"B_b\": \"2\"}, {\"A_a\": \"10\", \"B_b\": \"20\"}]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
+          - name: task-path
+            value: root.for-loop-4.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -774,6 +850,8 @@ spec:
             value: args-generator-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: args-generator-op
         name: args-generator-op-driver
         template: system-container-driver
       - arguments:
@@ -783,6 +861,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.args-generator-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: args-generator-op
+          - name: task-path
+            value: args-generator-op
         depends: args-generator-op-driver.Succeeded
         name: args-generator-op
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
@@ -192,12 +192,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -224,6 +230,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -232,6 +242,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -304,7 +318,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -340,6 +362,8 @@ spec:
             value: print-text-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-3.print-text-2
         name: print-text-2-driver
         template: system-container-driver
       - arguments:
@@ -349,6 +373,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-2
+          - name: task-path
+            value: root.comp-condition-3.print-text-2
         depends: print-text-2-driver.Succeeded
         name: print-text-2
         template: system-container-executor
@@ -372,6 +400,8 @@ spec:
             value: print-text-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-4.print-text-3
         name: print-text-3-driver
         template: system-container-driver
       - arguments:
@@ -381,6 +411,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-3
+          - name: task-path
+            value: root.comp-condition-4.print-text-3
         depends: print-text-3-driver.Succeeded
         name: print-text-3
         template: system-container-executor
@@ -404,6 +438,8 @@ spec:
             value: print-struct
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-7.print-struct
         name: print-struct-driver
         template: system-container-driver
       - arguments:
@@ -413,6 +449,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-struct-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-struct
+          - name: task-path
+            value: root.comp-for-loop-7.print-struct
         depends: print-struct-driver.Succeeded
         name: print-struct
         template: system-container-executor
@@ -494,13 +534,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -534,6 +580,8 @@ spec:
               \"-1\"}, {\"a\": \"-2\"}]"}},"taskInfo":{"name":"for-loop-7"}}'
           - name: task-name
             value: for-loop-7
+          - name: task-path
+            value: root.comp-condition-5.for-loop-7.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -612,6 +660,8 @@ spec:
             value: print-text-8
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-13.print-text-8
         name: print-text-8-driver
         template: system-container-driver
       - arguments:
@@ -621,6 +671,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-8-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-8
+          - name: task-path
+            value: root.comp-condition-13.print-text-8
         depends: print-text-8-driver.Succeeded
         name: print-text-8
         template: system-container-executor
@@ -643,6 +697,8 @@ spec:
               == ''1''"}}'
           - name: task-name
             value: condition-13
+          - name: task-path
+            value: root.comp-for-loop-12.condition-13
         name: condition-13-driver
         template: system-dag-driver
       - arguments:
@@ -667,6 +723,8 @@ spec:
             value: print-text-7
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-12.print-text-7
         name: print-text-7-driver
         template: system-container-driver
       - arguments:
@@ -676,6 +734,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-7-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-7
+          - name: task-path
+            value: root.comp-for-loop-12.print-text-7
         depends: print-text-7-driver.Succeeded
         name: print-text-7
         template: system-container-executor
@@ -699,6 +761,8 @@ spec:
             value: print-text-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-8.print-text-4
         name: print-text-4-driver
         template: system-container-driver
       - arguments:
@@ -708,6 +772,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-4
+          - name: task-path
+            value: root.comp-for-loop-8.print-text-4
         depends: print-text-4-driver.Succeeded
         name: print-text-4
         template: system-container-executor
@@ -731,6 +799,8 @@ spec:
             value: print-text-6
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-10.print-text-6
         name: print-text-6-driver
         template: system-container-driver
       - arguments:
@@ -740,6 +810,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-6-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-6
+          - name: task-path
+            value: root.comp-for-loop-10.print-text-6
         depends: print-text-6-driver.Succeeded
         name: print-text-6
         template: system-container-executor
@@ -763,6 +837,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-10"},"inputs":{"parameters":{"pipelinechannel--args-generator-op-2-Output":{"componentInputParameter":"pipelinechannel--args-generator-op-2-Output"},"pipelinechannel--flip-coin-op-Output":{"componentInputParameter":"pipelinechannel--flip-coin-op-Output"},"pipelinechannel--loop_parameter-loop-item":{"componentInputParameter":"pipelinechannel--loop_parameter-loop-item"}}},"parameterIterator":{"itemInput":"pipelinechannel--args-generator-op-2-Output-loop-item","items":{"inputParameter":"pipelinechannel--args-generator-op-2-Output"}},"taskInfo":{"name":"for-loop-10"}}'
           - name: task-name
             value: for-loop-10
+          - name: task-path
+            value: root.comp-for-loop-9.for-loop-10.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -832,6 +908,8 @@ spec:
             value: print-text-5
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-9.print-text-5
         name: print-text-5-driver
         template: system-container-driver
       - arguments:
@@ -841,6 +919,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-5-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-5
+          - name: task-path
+            value: root.comp-for-loop-9.print-text-5
         depends: print-text-5-driver.Succeeded
         name: print-text-5
         template: system-container-executor
@@ -865,6 +947,8 @@ spec:
               \"2\"]"}},"taskInfo":{"name":"for-loop-12"}}'
           - name: task-name
             value: for-loop-12
+          - name: task-path
+            value: root.comp-for-loop-2.for-loop-12.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -929,6 +1013,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-8"},"inputs":{"parameters":{"pipelinechannel--args-generator-op-Output-loop-item":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item"},"pipelinechannel--args-generator-op-Output-loop-item-subvar-B_b":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"B_b\"]"},"pipelinechannel--flip-coin-op-Output":{"componentInputParameter":"pipelinechannel--flip-coin-op-Output"}}},"parameterIterator":{"itemInput":"pipelinechannel--args-generator-op-Output-loop-item-subvar-B_b-loop-item","items":{"inputParameter":"pipelinechannel--args-generator-op-Output-loop-item-subvar-B_b"}},"taskInfo":{"name":"for-loop-8"}}'
           - name: task-name
             value: for-loop-8
+          - name: task-path
+            value: root.comp-for-loop-2.for-loop-8.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -992,6 +1078,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-9"},"inputs":{"parameters":{"pipelinechannel--args-generator-op-2-Output":{"componentInputParameter":"pipelinechannel--args-generator-op-2-Output"},"pipelinechannel--flip-coin-op-Output":{"componentInputParameter":"pipelinechannel--flip-coin-op-Output"},"pipelinechannel--loop_parameter":{"componentInputParameter":"pipelinechannel--loop_parameter"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-9"}}'
           - name: task-name
             value: for-loop-9
+          - name: task-path
+            value: root.comp-for-loop-2.for-loop-9.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1054,6 +1142,8 @@ spec:
               == ''heads''"}}'
           - name: task-name
             value: condition-3
+          - name: task-path
+            value: root.comp-for-loop-2.condition-3
         name: condition-3-driver
         template: system-dag-driver
       - arguments:
@@ -1077,6 +1167,8 @@ spec:
               == ''heads''"}}'
           - name: task-name
             value: condition-4
+          - name: task-path
+            value: root.comp-for-loop-2.condition-4
         name: condition-4-driver
         template: system-dag-driver
       - arguments:
@@ -1100,6 +1192,8 @@ spec:
               == ''tails''"}}'
           - name: task-name
             value: condition-5
+          - name: task-path
+            value: root.comp-for-loop-2.condition-5
         name: condition-5-driver
         template: system-dag-driver
       - arguments:
@@ -1142,6 +1236,8 @@ spec:
             value: print-text
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.print-text
         name: print-text-driver
         template: system-container-driver
       - arguments:
@@ -1151,6 +1247,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text
+          - name: task-path
+            value: root.comp-for-loop-2.print-text
         depends: print-text-driver.Succeeded
         name: print-text
         template: system-container-executor
@@ -1174,6 +1274,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-2"},"dependentTasks":["args-generator-op-2"],"inputs":{"parameters":{"pipelinechannel--args-generator-op-2-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"args-generator-op-2"}},"pipelinechannel--args-generator-op-Output":{"componentInputParameter":"pipelinechannel--args-generator-op-Output"},"pipelinechannel--flip-coin-op-Output":{"componentInputParameter":"pipelinechannel--flip-coin-op-Output"},"pipelinechannel--loop_parameter":{"componentInputParameter":"pipelinechannel--loop_parameter"},"pipelinechannel--msg":{"componentInputParameter":"pipelinechannel--msg"}}},"parameterIterator":{"itemInput":"pipelinechannel--args-generator-op-Output-loop-item","items":{"inputParameter":"pipelinechannel--args-generator-op-Output"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.comp-condition-1.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1237,6 +1339,8 @@ spec:
             value: args-generator-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.args-generator-op-2
         name: args-generator-op-2-driver
         template: system-container-driver
       - arguments:
@@ -1246,6 +1350,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.args-generator-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: args-generator-op-2
+          - name: task-path
+            value: root.comp-condition-1.args-generator-op-2
         depends: args-generator-op-2-driver.Succeeded
         name: args-generator-op-2
         template: system-container-executor
@@ -1276,6 +1384,8 @@ spec:
             value: print-text-9
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-16.print-text-9
         name: print-text-9-driver
         template: system-container-driver
       - arguments:
@@ -1285,6 +1395,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-9-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-9
+          - name: task-path
+            value: root.comp-for-loop-16.print-text-9
         depends: print-text-9-driver.Succeeded
         name: print-text-9
         template: system-container-executor
@@ -1308,6 +1422,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-16"},"inputs":{"parameters":{"pipelinechannel--loop_parameter-loop-item":{"componentInputParameter":"pipelinechannel--loop_parameter-loop-item"},"pipelinechannel--loop_parameter-loop-item-subvar-B_b":{"componentInputParameter":"pipelinechannel--loop_parameter-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"B_b\"]"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item-subvar-B_b-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter-loop-item-subvar-B_b"}},"taskInfo":{"name":"for-loop-16"}}'
           - name: task-name
             value: for-loop-16
+          - name: task-path
+            value: root.comp-condition-15.for-loop-16.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1384,6 +1500,8 @@ spec:
               == ''heads''"}}'
           - name: task-name
             value: condition-15
+          - name: task-path
+            value: root.comp-for-loop-14.condition-15
         name: condition-15-driver
         template: system-dag-driver
       - arguments:
@@ -1416,6 +1534,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-14"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-14"}}'
           - name: task-name
             value: for-loop-14
+          - name: task-path
+            value: root.for-loop-14.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1479,6 +1599,8 @@ spec:
             value: args-generator-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: args-generator-op
         name: args-generator-op-driver
         template: system-container-driver
       - arguments:
@@ -1488,6 +1610,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.args-generator-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: args-generator-op
+          - name: task-path
+            value: args-generator-op
         depends: args-generator-op-driver.Succeeded
         name: args-generator-op
         template: system-container-executor
@@ -1501,6 +1627,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-1"},"dependentTasks":["args-generator-op","flip-coin-op"],"inputs":{"parameters":{"pipelinechannel--args-generator-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"args-generator-op"}},"pipelinechannel--flip-coin-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"flip-coin-op"}},"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"},"pipelinechannel--msg":{"componentInputParameter":"msg"}}},"taskInfo":{"name":"condition-1"},"triggerPolicy":{"condition":"inputs.parameter_values[''pipelinechannel--flip-coin-op-Output'']
               != ''no-such-result''"}}'
           - name: task-name
+            value: condition-1
+          - name: task-path
             value: condition-1
         depends: args-generator-op.Succeeded && flip-coin-op.Succeeded
         name: condition-1-driver
@@ -1527,6 +1655,8 @@ spec:
             value: flip-coin-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: flip-coin-op
         name: flip-coin-op-driver
         template: system-container-driver
       - arguments:
@@ -1536,6 +1666,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin-op
+          - name: task-path
+            value: flip-coin-op
         depends: flip-coin-op-driver.Succeeded
         name: flip-coin-op
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
@@ -143,12 +143,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -175,6 +181,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -183,6 +193,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -255,7 +269,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -291,6 +313,8 @@ spec:
             value: dataset-joiner
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: dataset-joiner
         depends: str-to-dataset.Succeeded
         name: dataset-joiner-driver
         template: system-container-driver
@@ -301,6 +325,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.dataset-joiner-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: dataset-joiner
+          - name: task-path
+            value: dataset-joiner
         depends: dataset-joiner-driver.Succeeded
         name: dataset-joiner
         template: system-container-executor
@@ -316,6 +344,8 @@ spec:
             value: str-to-dataset
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: str-to-dataset
         name: str-to-dataset-driver
         template: system-container-driver
       - arguments:
@@ -325,6 +355,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.str-to-dataset-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: str-to-dataset
+          - name: task-path
+            value: str-to-dataset
         depends: str-to-dataset-driver.Succeeded
         name: str-to-dataset
         template: system-container-executor
@@ -406,13 +440,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
@@ -117,12 +117,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -149,6 +155,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -157,6 +167,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -229,7 +243,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -265,6 +287,8 @@ spec:
             value: output-metrics-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.output-metrics-2
         name: output-metrics-2-driver
         template: system-container-driver
       - arguments:
@@ -274,6 +298,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.output-metrics-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: output-metrics-2
+          - name: task-path
+            value: root.comp-for-loop-2.output-metrics-2
         depends: output-metrics-2-driver.Succeeded
         name: output-metrics-2
         template: system-container-executor
@@ -355,13 +383,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -395,6 +429,8 @@ spec:
               2]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -465,6 +501,8 @@ spec:
             value: output-metrics
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: output-metrics
         name: output-metrics-driver
         template: system-container-driver
       - arguments:
@@ -474,6 +512,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.output-metrics-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: output-metrics
+          - name: task-path
+            value: output-metrics
         depends: output-metrics-driver.Succeeded
         name: output-metrics
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
+++ b/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
@@ -136,12 +136,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -168,6 +174,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -176,6 +186,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -248,7 +262,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -285,6 +307,8 @@ spec:
             value: fail-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-1.fail-op
         name: fail-op-driver
         template: system-container-driver
       - arguments:
@@ -294,6 +318,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.fail-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: fail-op
+          - name: task-path
+            value: root.comp-exit-handler-1.fail-op
         depends: fail-op-driver.Succeeded
         name: fail-op
         template: system-container-executor
@@ -309,6 +337,8 @@ spec:
             value: print-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-1.print-op-2
         name: print-op-2-driver
         template: system-container-driver
       - arguments:
@@ -318,6 +348,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-2
+          - name: task-path
+            value: root.comp-exit-handler-1.print-op-2
         depends: print-op-2-driver.Succeeded
         name: print-op-2
         template: system-container-executor
@@ -341,6 +375,8 @@ spec:
             value: print-op-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-2.print-op-4
         name: print-op-4-driver
         template: system-container-driver
       - arguments:
@@ -350,6 +386,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-4
+          - name: task-path
+            value: root.comp-exit-handler-2.print-op-4
         depends: print-op-4-driver.Succeeded
         name: print-op-4
         template: system-container-executor
@@ -373,6 +413,8 @@ spec:
             value: print-op-6
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-3.print-op-6
         name: print-op-6-driver
         template: system-container-driver
       - arguments:
@@ -382,6 +424,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-6-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-6
+          - name: task-path
+            value: root.comp-exit-handler-3.print-op-6
         depends: print-op-6-driver.Succeeded
         name: print-op-6
         template: system-container-executor
@@ -406,6 +452,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -415,6 +463,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -439,6 +491,8 @@ spec:
             value: print-op-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op-3
         name: print-op-3-driver
         template: system-container-driver
       - arguments:
@@ -448,6 +502,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-3
+          - name: task-path
+            value: print-op-3
         depends: print-op-3-driver.Succeeded
         name: print-op-3
         template: system-container-executor
@@ -472,6 +530,8 @@ spec:
             value: print-op-5
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op-5
         name: print-op-5-driver
         template: system-container-driver
       - arguments:
@@ -481,6 +541,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-5-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-5
+          - name: task-path
+            value: print-op-5
         depends: print-op-5-driver.Succeeded
         name: print-op-5
         template: system-container-executor
@@ -562,13 +626,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -599,6 +669,8 @@ spec:
             value: '{"componentRef":{"name":"comp-exit-handler-1"},"inputs":{"parameters":{"pipelinechannel--message":{"componentInputParameter":"message"}}},"taskInfo":{"name":"exit-handler-1"}}'
           - name: task-name
             value: exit-handler-1
+          - name: task-path
+            value: exit-handler-1
         name: exit-handler-1-driver
         template: system-dag-driver
       - arguments:
@@ -627,6 +699,8 @@ spec:
             value: '{"componentRef":{"name":"comp-exit-handler-2"},"inputs":{"parameters":{"pipelinechannel--message":{"componentInputParameter":"message"}}},"taskInfo":{"name":"exit-handler-2"}}'
           - name: task-name
             value: exit-handler-2
+          - name: task-path
+            value: exit-handler-2
         name: exit-handler-2-driver
         template: system-dag-driver
       - arguments:
@@ -654,6 +728,8 @@ spec:
           - name: task
             value: '{"componentRef":{"name":"comp-exit-handler-3"},"inputs":{"parameters":{"pipelinechannel--message":{"componentInputParameter":"message"}}},"taskInfo":{"name":"exit-handler-3"}}'
           - name: task-name
+            value: exit-handler-3
+          - name: task-path
             value: exit-handler-3
         name: exit-handler-3-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
@@ -133,12 +133,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -165,6 +171,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -173,6 +183,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -245,7 +259,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -281,6 +303,8 @@ spec:
             value: flip-coin-op-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-2.flip-coin-op-4
         name: flip-coin-op-4-driver
         template: system-container-driver
       - arguments:
@@ -290,6 +314,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-op-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin-op-4
+          - name: task-path
+            value: root.comp-condition-2.flip-coin-op-4
         depends: flip-coin-op-4-driver.Succeeded
         name: flip-coin-op-4
         template: system-container-executor
@@ -305,6 +333,8 @@ spec:
             value: print-op-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-2.print-op-4
         depends: flip-coin-op-4.Succeeded
         name: print-op-4-driver
         template: system-container-driver
@@ -315,6 +345,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-4
+          - name: task-path
+            value: root.comp-condition-2.print-op-4
         depends: print-op-4-driver.Succeeded
         name: print-op-4
         template: system-container-executor
@@ -396,13 +430,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -434,6 +474,8 @@ spec:
               == inputs.parameter_values[''pipelinechannel--flip-coin-op-3-Output'']"}}'
           - name: task-name
             value: condition-2
+          - name: task-path
+            value: root.comp-condition-1.condition-2
         depends: flip-coin-op-3.Succeeded
         name: condition-2-driver
         template: system-dag-driver
@@ -459,6 +501,8 @@ spec:
             value: flip-coin-op-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.flip-coin-op-3
         name: flip-coin-op-3-driver
         template: system-container-driver
       - arguments:
@@ -468,6 +512,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-op-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin-op-3
+          - name: task-path
+            value: root.comp-condition-1.flip-coin-op-3
         depends: flip-coin-op-3-driver.Succeeded
         name: flip-coin-op-3
         template: system-container-executor
@@ -483,6 +531,8 @@ spec:
             value: print-op-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.print-op-3
         depends: flip-coin-op-3.Succeeded
         name: print-op-3-driver
         template: system-container-driver
@@ -493,6 +543,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-3
+          - name: task-path
+            value: root.comp-condition-1.print-op-3
         depends: print-op-3-driver.Succeeded
         name: print-op-3
         template: system-container-executor
@@ -514,6 +568,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-1"},"dependentTasks":["flip-coin-op","flip-coin-op-2"],"inputs":{"parameters":{"pipelinechannel--flip-coin-op-2-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"flip-coin-op-2"}},"pipelinechannel--flip-coin-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"flip-coin-op"}}}},"taskInfo":{"name":"condition-1"},"triggerPolicy":{"condition":"inputs.parameter_values[''pipelinechannel--flip-coin-op-Output'']
               != ''no-such-result''"}}'
           - name: task-name
+            value: condition-1
+          - name: task-path
             value: condition-1
         depends: flip-coin-op.Succeeded && flip-coin-op-2.Succeeded
         name: condition-1-driver
@@ -540,6 +596,8 @@ spec:
             value: flip-coin-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: flip-coin-op
         name: flip-coin-op-driver
         template: system-container-driver
       - arguments:
@@ -549,6 +607,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin-op
+          - name: task-path
+            value: flip-coin-op
         depends: flip-coin-op-driver.Succeeded
         name: flip-coin-op
         template: system-container-executor
@@ -564,6 +626,8 @@ spec:
             value: flip-coin-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: flip-coin-op-2
         name: flip-coin-op-2-driver
         template: system-container-driver
       - arguments:
@@ -573,6 +637,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin-op-2
+          - name: task-path
+            value: flip-coin-op-2
         depends: flip-coin-op-2-driver.Succeeded
         name: flip-coin-op-2
         template: system-container-executor
@@ -588,6 +656,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op
         depends: flip-coin-op.Succeeded
         name: print-op-driver
         template: system-container-driver
@@ -598,6 +668,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -613,6 +687,8 @@ spec:
             value: print-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op-2
         depends: flip-coin-op-2.Succeeded
         name: print-op-2-driver
         template: system-container-driver
@@ -623,6 +699,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-2
+          - name: task-path
+            value: print-op-2
         depends: print-op-2-driver.Succeeded
         name: print-op-2
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
@@ -145,12 +145,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -177,6 +183,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -185,6 +195,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -257,7 +271,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -295,6 +317,8 @@ spec:
             value: print
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-2.print
         name: print-driver
         template: system-container-driver
       - arguments:
@@ -304,6 +328,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print
+          - name: task-path
+            value: root.comp-condition-2.print
         depends: print-driver.Succeeded
         name: print
         template: system-container-executor
@@ -329,6 +357,8 @@ spec:
             value: print-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-3.print-2
         name: print-2-driver
         template: system-container-driver
       - arguments:
@@ -338,6 +368,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-2
+          - name: task-path
+            value: root.comp-condition-3.print-2
         depends: print-2-driver.Succeeded
         name: print-2
         template: system-container-executor
@@ -419,13 +453,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -457,6 +497,8 @@ spec:
               \u003e 5"}}'
           - name: task-name
             value: condition-2
+          - name: task-path
+            value: root.comp-condition-1.condition-2
         depends: generate-random-number.Succeeded
         name: condition-2-driver
         template: system-dag-driver
@@ -481,6 +523,8 @@ spec:
               \u003c= 5"}}'
           - name: task-name
             value: condition-3
+          - name: task-path
+            value: root.comp-condition-1.condition-3
         depends: generate-random-number.Succeeded
         name: condition-3-driver
         template: system-dag-driver
@@ -506,6 +550,8 @@ spec:
             value: generate-random-number
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-1.generate-random-number
         name: generate-random-number-driver
         template: system-container-driver
       - arguments:
@@ -515,6 +561,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.generate-random-number-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: generate-random-number
+          - name: task-path
+            value: root.comp-condition-1.generate-random-number
         depends: generate-random-number-driver.Succeeded
         name: generate-random-number
         template: system-container-executor
@@ -540,6 +590,8 @@ spec:
             value: print-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-5.print-3
         name: print-3-driver
         template: system-container-driver
       - arguments:
@@ -549,6 +601,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-3
+          - name: task-path
+            value: root.comp-condition-5.print-3
         depends: print-3-driver.Succeeded
         name: print-3
         template: system-container-executor
@@ -574,6 +630,8 @@ spec:
             value: print-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-6.print-4
         name: print-4-driver
         template: system-container-driver
       - arguments:
@@ -583,6 +641,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-4
+          - name: task-path
+            value: root.comp-condition-6.print-4
         depends: print-4-driver.Succeeded
         name: print-4
         template: system-container-executor
@@ -605,6 +667,8 @@ spec:
               \u003e 15"}}'
           - name: task-name
             value: condition-5
+          - name: task-path
+            value: root.comp-condition-4.condition-5
         depends: generate-random-number-2.Succeeded
         name: condition-5-driver
         template: system-dag-driver
@@ -629,6 +693,8 @@ spec:
               \u003c= 15"}}'
           - name: task-name
             value: condition-6
+          - name: task-path
+            value: root.comp-condition-4.condition-6
         depends: generate-random-number-2.Succeeded
         name: condition-6-driver
         template: system-dag-driver
@@ -654,6 +720,8 @@ spec:
             value: generate-random-number-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-condition-4.generate-random-number-2
         name: generate-random-number-2-driver
         template: system-container-driver
       - arguments:
@@ -663,6 +731,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.generate-random-number-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: generate-random-number-2
+          - name: task-path
+            value: root.comp-condition-4.generate-random-number-2
         depends: generate-random-number-2-driver.Succeeded
         name: generate-random-number-2
         template: system-container-executor
@@ -684,6 +756,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-1"},"dependentTasks":["flip-coin"],"inputs":{"parameters":{"pipelinechannel--flip-coin-output":{"taskOutputParameter":{"outputParameterKey":"output","producerTask":"flip-coin"}}}},"taskInfo":{"name":"condition-1"},"triggerPolicy":{"condition":"inputs.parameter_values[''pipelinechannel--flip-coin-output'']
               == ''heads''"}}'
           - name: task-name
+            value: condition-1
+          - name: task-path
             value: condition-1
         depends: flip-coin.Succeeded
         name: condition-1-driver
@@ -708,6 +782,8 @@ spec:
             value: '{"componentRef":{"name":"comp-condition-4"},"dependentTasks":["flip-coin"],"inputs":{"parameters":{"pipelinechannel--flip-coin-output":{"taskOutputParameter":{"outputParameterKey":"output","producerTask":"flip-coin"}}}},"taskInfo":{"name":"condition-4"},"triggerPolicy":{"condition":"inputs.parameter_values[''pipelinechannel--flip-coin-output'']
               == ''tails''"}}'
           - name: task-name
+            value: condition-4
+          - name: task-path
             value: condition-4
         depends: flip-coin.Succeeded
         name: condition-4-driver
@@ -734,6 +810,8 @@ spec:
             value: flip-coin
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: flip-coin
         name: flip-coin-driver
         template: system-container-driver
       - arguments:
@@ -743,6 +821,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.flip-coin-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: flip-coin
+          - name: task-path
+            value: flip-coin
         depends: flip-coin-driver.Succeeded
         name: flip-coin
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
@@ -123,12 +123,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -155,6 +161,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -163,6 +173,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -235,7 +249,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -271,6 +293,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -280,6 +304,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: root.comp-for-loop-2.print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -361,13 +389,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -400,6 +434,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-2"},"inputs":{"parameters":{"pipelinechannel--loop_parameter-loop-item":{"componentInputParameter":"pipelinechannel--loop_parameter-loop-item"},"pipelinechannel--loop_parameter-loop-item-subvar-p_a":{"componentInputParameter":"pipelinechannel--loop_parameter-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"p_a\"]"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item-subvar-p_a-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter-loop-item-subvar-p_a"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.comp-for-loop-1.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -477,6 +513,8 @@ spec:
             value: print-op-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-6.print-op-3
         name: print-op-3-driver
         template: system-container-driver
       - arguments:
@@ -486,6 +524,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-3
+          - name: task-path
+            value: root.comp-for-loop-6.print-op-3
         depends: print-op-3-driver.Succeeded
         name: print-op-3
         template: system-container-executor
@@ -510,6 +552,8 @@ spec:
               \"200\", \"300\"]"}},"taskInfo":{"name":"for-loop-6"}}'
           - name: task-name
             value: for-loop-6
+          - name: task-path
+            value: root.comp-for-loop-4.for-loop-6.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -580,6 +624,8 @@ spec:
             value: print-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.print-op-2
         name: print-op-2-driver
         template: system-container-driver
       - arguments:
@@ -589,6 +635,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-2
+          - name: task-path
+            value: root.comp-for-loop-4.print-op-2
         depends: print-op-2-driver.Succeeded
         name: print-op-2
         template: system-container-executor
@@ -612,6 +662,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
+          - name: task-path
+            value: root.for-loop-1.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -676,6 +728,8 @@ spec:
               \"2\"]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
+          - name: task-path
+            value: root.for-loop-4.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:

--- a/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: echo
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo
         name: echo-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo
+          - name: task-path
+            value: echo
         depends: echo-driver.Succeeded
         name: echo
         template: system-container-executor
@@ -341,13 +369,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_outputs.yaml
@@ -119,12 +119,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -151,6 +157,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -159,6 +169,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -231,7 +245,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -267,6 +289,8 @@ spec:
             value: print-op1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op1
         name: print-op1-driver
         template: system-container-driver
       - arguments:
@@ -276,6 +300,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op1
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op1
         depends: print-op1-driver.Succeeded
         name: print-op1
         template: system-container-executor
@@ -291,6 +319,8 @@ spec:
             value: print-op2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op2
         depends: print-op1.Succeeded
         name: print-op2-driver
         template: system-container-driver
@@ -301,6 +331,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op2
+          - name: task-path
+            value: root.comp-inner-pipeline.print-op2
         depends: print-op2-driver.Succeeded
         name: print-op2
         template: system-container-executor
@@ -382,13 +416,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -419,6 +459,8 @@ spec:
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-inner-pipeline"},"inputs":{"parameters":{"msg":{"runtimeValue":{"constant":"world"}}}},"taskInfo":{"name":"inner-pipeline"}}'
           - name: task-name
             value: inner-pipeline
+          - name: task-path
+            value: inner-pipeline
         name: inner-pipeline-driver
         template: system-dag-driver
       - arguments:
@@ -442,6 +484,8 @@ spec:
             value: print-op1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op1
         name: print-op1-driver
         template: system-container-driver
       - arguments:
@@ -451,6 +495,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op1
+          - name: task-path
+            value: print-op1
         depends: print-op1-driver.Succeeded
         name: print-op1
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
@@ -210,12 +210,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -242,6 +248,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -250,6 +260,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -322,7 +336,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -358,6 +380,8 @@ spec:
             value: print-text-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.print-text-2
         name: print-text-2-driver
         template: system-container-driver
       - arguments:
@@ -367,6 +391,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-2
+          - name: task-path
+            value: root.comp-for-loop-2.print-text-2
         depends: print-text-2-driver.Succeeded
         name: print-text-2
         template: system-container-executor
@@ -448,13 +476,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -487,6 +521,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-2"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"pipelinechannel--loop_parameter"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.comp-for-loop-1.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -556,6 +592,8 @@ spec:
             value: print-text
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.print-text
         name: print-text-driver
         template: system-container-driver
       - arguments:
@@ -565,6 +603,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text
+          - name: task-path
+            value: root.comp-for-loop-1.print-text
         depends: print-text-driver.Succeeded
         name: print-text
         template: system-container-executor
@@ -588,6 +630,8 @@ spec:
             value: print-int-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-10.print-int-3
         name: print-int-3-driver
         template: system-container-driver
       - arguments:
@@ -597,6 +641,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-int-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-int-3
+          - name: task-path
+            value: root.comp-for-loop-10.print-int-3
         depends: print-int-3-driver.Succeeded
         name: print-int-3
         template: system-container-executor
@@ -620,6 +668,8 @@ spec:
             value: print-int-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-11.print-int-4
         name: print-int-4-driver
         template: system-container-driver
       - arguments:
@@ -629,6 +679,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-int-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-int-4
+          - name: task-path
+            value: root.comp-for-loop-11.print-int-4
         depends: print-int-4-driver.Succeeded
         name: print-int-4
         template: system-container-executor
@@ -652,6 +706,8 @@ spec:
             value: print-int-5
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-12.print-int-5
         name: print-int-5-driver
         template: system-container-driver
       - arguments:
@@ -661,6 +717,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-int-5-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-int-5
+          - name: task-path
+            value: root.comp-for-loop-12.print-int-5
         depends: print-int-5-driver.Succeeded
         name: print-int-5
         template: system-container-executor
@@ -684,6 +744,8 @@ spec:
             value: print-int-6
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-13.print-int-6
         name: print-int-6-driver
         template: system-container-driver
       - arguments:
@@ -693,6 +755,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-int-6-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-int-6
+          - name: task-path
+            value: root.comp-for-loop-13.print-int-6
         depends: print-int-6-driver.Succeeded
         name: print-int-6
         template: system-container-executor
@@ -716,6 +782,8 @@ spec:
             value: print-text-5
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-6.print-text-5
         name: print-text-5-driver
         template: system-container-driver
       - arguments:
@@ -725,6 +793,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-5-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-5
+          - name: task-path
+            value: root.comp-for-loop-6.print-text-5
         depends: print-text-5-driver.Succeeded
         name: print-text-5
         template: system-container-executor
@@ -740,6 +812,8 @@ spec:
             value: print-text-6
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-6.print-text-6
         name: print-text-6-driver
         template: system-container-driver
       - arguments:
@@ -749,6 +823,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-6-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-6
+          - name: task-path
+            value: root.comp-for-loop-6.print-text-6
         depends: print-text-6-driver.Succeeded
         name: print-text-6
         template: system-container-executor
@@ -773,6 +851,8 @@ spec:
               \"10\", \"B_b\": \"20\"}, {\"A_a\": \"100\", \"B_b\": \"200\"}]"}},"taskInfo":{"name":"for-loop-6"}}'
           - name: task-name
             value: for-loop-6
+          - name: task-path
+            value: root.comp-for-loop-4.for-loop-6.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -844,6 +924,8 @@ spec:
             value: print-text-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.print-text-3
         name: print-text-3-driver
         template: system-container-driver
       - arguments:
@@ -853,6 +935,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-3
+          - name: task-path
+            value: root.comp-for-loop-4.print-text-3
         depends: print-text-3-driver.Succeeded
         name: print-text-3
         template: system-container-executor
@@ -868,6 +954,8 @@ spec:
             value: print-text-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-4.print-text-4
         name: print-text-4-driver
         template: system-container-driver
       - arguments:
@@ -877,6 +965,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-text-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-text-4
+          - name: task-path
+            value: root.comp-for-loop-4.print-text-4
         depends: print-text-4-driver.Succeeded
         name: print-text-4
         template: system-container-executor
@@ -900,6 +992,8 @@ spec:
             value: print-int
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-8.print-int
         name: print-int-driver
         template: system-container-driver
       - arguments:
@@ -909,6 +1003,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-int-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-int
+          - name: task-path
+            value: root.comp-for-loop-8.print-int
         depends: print-int-driver.Succeeded
         name: print-int
         template: system-container-executor
@@ -932,6 +1030,8 @@ spec:
             value: print-int-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-9.print-int-2
         name: print-int-2-driver
         template: system-container-driver
       - arguments:
@@ -941,6 +1041,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-int-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-int-2
+          - name: task-path
+            value: root.comp-for-loop-9.print-int-2
         depends: print-int-2-driver.Succeeded
         name: print-int-2
         template: system-container-executor
@@ -964,6 +1068,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"}}},"iteratorPolicy":{"parallelismLimit":2},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
+          - name: task-path
+            value: root.for-loop-1.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1028,6 +1134,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-10"},"dependentTasks":["list-dict-maker-1"],"inputs":{"parameters":{"pipelinechannel--list-dict-maker-1-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"list-dict-maker-1"}}}},"parameterIterator":{"itemInput":"pipelinechannel--list-dict-maker-1-Output-loop-item","items":{"inputParameter":"pipelinechannel--list-dict-maker-1-Output"}},"taskInfo":{"name":"for-loop-10"}}'
           - name: task-name
             value: for-loop-10
+          - name: task-path
+            value: root.for-loop-10.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1091,6 +1199,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-11"},"dependentTasks":["list-dict-maker-2"],"inputs":{"parameters":{"pipelinechannel--list-dict-maker-2-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"list-dict-maker-2"}}}},"parameterIterator":{"itemInput":"pipelinechannel--list-dict-maker-2-Output-loop-item","items":{"inputParameter":"pipelinechannel--list-dict-maker-2-Output"}},"taskInfo":{"name":"for-loop-11"}}'
           - name: task-name
             value: for-loop-11
+          - name: task-path
+            value: root.for-loop-11.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1154,6 +1264,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-12"},"dependentTasks":["list-dict-maker-3"],"inputs":{"parameters":{"pipelinechannel--list-dict-maker-3-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"list-dict-maker-3"}}}},"parameterIterator":{"itemInput":"pipelinechannel--list-dict-maker-3-Output-loop-item","items":{"inputParameter":"pipelinechannel--list-dict-maker-3-Output"}},"taskInfo":{"name":"for-loop-12"}}'
           - name: task-name
             value: for-loop-12
+          - name: task-path
+            value: root.for-loop-12.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1217,6 +1329,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-13"},"dependentTasks":["list-dict-maker-1-2"],"inputs":{"parameters":{"pipelinechannel--list-dict-maker-1-2-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"list-dict-maker-1-2"}}}},"parameterIterator":{"itemInput":"pipelinechannel--list-dict-maker-1-2-Output-loop-item","items":{"inputParameter":"pipelinechannel--list-dict-maker-1-2-Output"}},"taskInfo":{"name":"for-loop-13"}}'
           - name: task-name
             value: for-loop-13
+          - name: task-path
+            value: root.for-loop-13.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1281,6 +1395,8 @@ spec:
               \"1\", \"B_b\": \"2\"}, {\"A_a\": \"10\", \"B_b\": \"20\"}]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
+          - name: task-path
+            value: root.for-loop-4.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1346,6 +1462,8 @@ spec:
               1, \"b\": 2}, {\"a\": 2, \"b\": 3}, {\"a\": 3, \"b\": 4}]"}},"taskInfo":{"name":"for-loop-8"}}'
           - name: task-name
             value: for-loop-8
+          - name: task-path
+            value: root.for-loop-8.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1411,6 +1529,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-9"},"dependentTasks":["list-dict-maker-0"],"inputs":{"parameters":{"pipelinechannel--list-dict-maker-0-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"list-dict-maker-0"}}}},"parameterIterator":{"itemInput":"pipelinechannel--list-dict-maker-0-Output-loop-item","items":{"inputParameter":"pipelinechannel--list-dict-maker-0-Output"}},"taskInfo":{"name":"for-loop-9"}}'
           - name: task-name
             value: for-loop-9
+          - name: task-path
+            value: root.for-loop-9.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -1527,6 +1647,8 @@ spec:
             value: list-dict-maker-0
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: list-dict-maker-0
         name: list-dict-maker-0-driver
         template: system-container-driver
       - arguments:
@@ -1536,6 +1658,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.list-dict-maker-0-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: list-dict-maker-0
+          - name: task-path
+            value: list-dict-maker-0
         depends: list-dict-maker-0-driver.Succeeded
         name: list-dict-maker-0
         template: system-container-executor
@@ -1551,6 +1677,8 @@ spec:
             value: list-dict-maker-1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: list-dict-maker-1
         name: list-dict-maker-1-driver
         template: system-container-driver
       - arguments:
@@ -1560,6 +1688,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.list-dict-maker-1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: list-dict-maker-1
+          - name: task-path
+            value: list-dict-maker-1
         depends: list-dict-maker-1-driver.Succeeded
         name: list-dict-maker-1
         template: system-container-executor
@@ -1575,6 +1707,8 @@ spec:
             value: list-dict-maker-1-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: list-dict-maker-1-2
         name: list-dict-maker-1-2-driver
         template: system-container-driver
       - arguments:
@@ -1584,6 +1718,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.list-dict-maker-1-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: list-dict-maker-1-2
+          - name: task-path
+            value: list-dict-maker-1-2
         depends: list-dict-maker-1-2-driver.Succeeded
         name: list-dict-maker-1-2
         template: system-container-executor
@@ -1599,6 +1737,8 @@ spec:
             value: list-dict-maker-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: list-dict-maker-2
         name: list-dict-maker-2-driver
         template: system-container-driver
       - arguments:
@@ -1608,6 +1748,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.list-dict-maker-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: list-dict-maker-2
+          - name: task-path
+            value: list-dict-maker-2
         depends: list-dict-maker-2-driver.Succeeded
         name: list-dict-maker-2
         template: system-container-executor
@@ -1623,6 +1767,8 @@ spec:
             value: list-dict-maker-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: list-dict-maker-3
         name: list-dict-maker-3-driver
         template: system-container-driver
       - arguments:
@@ -1632,6 +1778,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.list-dict-maker-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: list-dict-maker-3
+          - name: task-path
+            value: list-dict-maker-3
         depends: list-dict-maker-3-driver.Succeeded
         name: list-dict-maker-3
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
@@ -135,12 +135,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -167,6 +173,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -175,6 +185,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -247,7 +261,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -283,6 +305,8 @@ spec:
             value: print-with-prefix
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.print-with-prefix
         name: print-with-prefix-driver
         template: system-container-driver
       - arguments:
@@ -292,6 +316,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-with-prefix-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-with-prefix
+          - name: task-path
+            value: root.comp-for-loop-1.print-with-prefix
         depends: print-with-prefix-driver.Succeeded
         name: print-with-prefix
         template: system-container-executor
@@ -315,6 +343,8 @@ spec:
             value: print-with-prefix-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.print-with-prefix-2
         name: print-with-prefix-2-driver
         template: system-container-driver
       - arguments:
@@ -324,6 +354,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-with-prefix-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-with-prefix-2
+          - name: task-path
+            value: root.comp-for-loop-2.print-with-prefix-2
         depends: print-with-prefix-2-driver.Succeeded
         name: print-with-prefix-2
         template: system-container-executor
@@ -347,6 +381,8 @@ spec:
             value: print-with-prefix-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-5.print-with-prefix-3
         name: print-with-prefix-3-driver
         template: system-container-driver
       - arguments:
@@ -356,6 +392,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-with-prefix-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-with-prefix-3
+          - name: task-path
+            value: root.comp-for-loop-5.print-with-prefix-3
         depends: print-with-prefix-3-driver.Succeeded
         name: print-with-prefix-3
         template: system-container-executor
@@ -437,13 +477,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -476,6 +522,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-5"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"pipelinechannel--loop_parameter"},"pipelinechannel--prefix":{"componentInputParameter":"pipelinechannel--prefix"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-5"}}'
           - name: task-name
             value: for-loop-5
+          - name: task-path
+            value: root.comp-for-loop-4.for-loop-5.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -553,6 +601,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"},"pipelinechannel--prefix":{"componentInputParameter":"prefix"}}},"iteratorPolicy":{"parallelismLimit":1},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
+          - name: task-path
+            value: root.for-loop-1.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -617,6 +667,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-2"},"dependentTasks":["make-prefix"],"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"},"pipelinechannel--make-prefix-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"make-prefix"}}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -681,6 +733,8 @@ spec:
               \"y\"]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
+          - name: task-path
+            value: root.for-loop-4.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -765,6 +819,8 @@ spec:
             value: make-prefix
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: make-prefix
         name: make-prefix-driver
         template: system-container-driver
       - arguments:
@@ -774,6 +830,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.make-prefix-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: make-prefix
+          - name: task-path
+            value: make-prefix
         depends: make-prefix-driver.Succeeded
         name: make-prefix
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
+++ b/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
@@ -132,12 +132,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -164,6 +170,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -172,6 +182,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -244,7 +258,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -281,6 +303,8 @@ spec:
             value: print-op2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-2.print-op2
         name: print-op2-driver
         template: system-container-driver
       - arguments:
@@ -290,6 +314,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op2
+          - name: task-path
+            value: root.comp-for-loop-2.print-op2
         depends: print-op2-driver.Succeeded
         name: print-op2
         template: system-container-executor
@@ -371,13 +399,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -411,6 +445,8 @@ spec:
               \"2\"]"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
+          - name: task-path
+            value: root.for-loop-2.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -482,6 +518,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -491,6 +529,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -507,6 +549,8 @@ spec:
             value: print-op-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op-2
         depends: print-op.Succeeded
         name: print-op-2-driver
         template: system-container-driver
@@ -517,6 +561,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op-2
+          - name: task-path
+            value: print-op-2
         depends: print-op-2-driver.Succeeded
         name: print-op-2
         template: system-container-executor

--- a/test_data/compiled-workflows/pipeline_with_placeholders.yaml
+++ b/test_data/compiled-workflows/pipeline_with_placeholders.yaml
@@ -119,12 +119,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -151,6 +157,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -159,6 +169,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -231,7 +245,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -267,6 +289,8 @@ spec:
             value: print-all-placeholders
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-all-placeholders
         name: print-all-placeholders-driver
         template: system-container-driver
       - arguments:
@@ -276,6 +300,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-all-placeholders-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-all-placeholders
+          - name: task-path
+            value: print-all-placeholders
         depends: print-all-placeholders-driver.Succeeded
         name: print-all-placeholders
         template: system-container-executor
@@ -357,13 +385,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
@@ -234,12 +234,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -266,6 +272,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -274,6 +284,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -346,7 +360,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -374,6 +396,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
           - name: pod-metadata-annotation-key
             value: '{{inputs.parameters.pod-metadata-annotation-key}}'
           - name: pod-metadata-annotation-val
@@ -394,6 +420,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-annotation-key
       - name: pod-metadata-annotation-val
       - name: pod-metadata-label-key-1
@@ -472,6 +502,10 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-annotation-key
       - name: pod-metadata-annotation-val
       - name: pod-metadata-label-key-1
@@ -481,9 +515,11 @@ spec:
     metadata:
       annotations:
         '{{inputs.parameters.pod-metadata-annotation-key}}': '{{inputs.parameters.pod-metadata-annotation-val}}'
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
       labels:
         '{{inputs.parameters.pod-metadata-label-key-1}}': '{{inputs.parameters.pod-metadata-label-val-1}}'
         '{{inputs.parameters.pod-metadata-label-key-2}}': '{{inputs.parameters.pod-metadata-label-val-2}}'
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: metadata-1-2-system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -511,6 +547,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
           - name: pod-metadata-annotation-key-1
             value: '{{inputs.parameters.pod-metadata-annotation-key-1}}'
           - name: pod-metadata-annotation-val-1
@@ -547,6 +587,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-annotation-key-1
       - name: pod-metadata-annotation-val-1
       - name: pod-metadata-annotation-key-2
@@ -633,6 +677,10 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-annotation-key-1
       - name: pod-metadata-annotation-val-1
       - name: pod-metadata-annotation-key-2
@@ -653,10 +701,12 @@ spec:
         '{{inputs.parameters.pod-metadata-annotation-key-2}}': '{{inputs.parameters.pod-metadata-annotation-val-2}}'
         '{{inputs.parameters.pod-metadata-annotation-key-3}}': '{{inputs.parameters.pod-metadata-annotation-val-3}}'
         '{{inputs.parameters.pod-metadata-annotation-key-4}}': '{{inputs.parameters.pod-metadata-annotation-val-4}}'
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
       labels:
         '{{inputs.parameters.pod-metadata-label-key-1}}': '{{inputs.parameters.pod-metadata-label-val-1}}'
         '{{inputs.parameters.pod-metadata-label-key-2}}': '{{inputs.parameters.pod-metadata-label-val-2}}'
         '{{inputs.parameters.pod-metadata-label-key-3}}': '{{inputs.parameters.pod-metadata-label-val-3}}'
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: metadata-4-3-system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -684,6 +734,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
           - name: pod-metadata-annotation-key-1
             value: '{{inputs.parameters.pod-metadata-annotation-key-1}}'
           - name: pod-metadata-annotation-val-1
@@ -700,6 +754,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-annotation-key-1
       - name: pod-metadata-annotation-val-1
       - name: pod-metadata-annotation-key-2
@@ -776,6 +834,10 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-annotation-key-1
       - name: pod-metadata-annotation-val-1
       - name: pod-metadata-annotation-key-2
@@ -784,6 +846,9 @@ spec:
       annotations:
         '{{inputs.parameters.pod-metadata-annotation-key-1}}': '{{inputs.parameters.pod-metadata-annotation-val-1}}'
         '{{inputs.parameters.pod-metadata-annotation-key-2}}': '{{inputs.parameters.pod-metadata-annotation-val-2}}'
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: metadata-2-0-system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -811,6 +876,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
           - name: pod-metadata-label-key-1
             value: '{{inputs.parameters.pod-metadata-label-key-1}}'
           - name: pod-metadata-label-val-1
@@ -831,6 +900,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-label-key-1
       - name: pod-metadata-label-val-1
       - name: pod-metadata-label-key-2
@@ -909,6 +982,10 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: pod-metadata-label-key-1
       - name: pod-metadata-label-val-1
       - name: pod-metadata-label-key-2
@@ -916,10 +993,13 @@ spec:
       - name: pod-metadata-label-key-3
       - name: pod-metadata-label-val-3
     metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
       labels:
         '{{inputs.parameters.pod-metadata-label-key-1}}': '{{inputs.parameters.pod-metadata-label-val-1}}'
         '{{inputs.parameters.pod-metadata-label-key-2}}': '{{inputs.parameters.pod-metadata-label-val-2}}'
         '{{inputs.parameters.pod-metadata-label-key-3}}': '{{inputs.parameters.pod-metadata-label-val-3}}'
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: metadata-0-3-system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -957,6 +1037,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-validate-no-pod-metadata}}'
+          - name: task-path
+            value: validate-no-pod-metadata
         name: validate-no-pod-metadata-driver
         template: system-container-driver
       - arguments:
@@ -966,6 +1048,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.validate-no-pod-metadata-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: validate-no-pod-metadata
+          - name: task-path
+            value: validate-no-pod-metadata
         depends: validate-no-pod-metadata-driver.Succeeded
         name: validate-no-pod-metadata
         template: system-container-executor
@@ -983,6 +1069,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-validate-pod-metadata-task-a}}'
+          - name: task-path
+            value: validate-pod-metadata-task-a
         name: validate-pod-metadata-task-a-driver
         template: system-container-driver
       - arguments:
@@ -992,6 +1080,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.validate-pod-metadata-task-a-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: validate-pod-metadata-task-a
+          - name: task-path
+            value: validate-pod-metadata-task-a
           - name: pod-metadata-annotation-key
             value: task-annotation
           - name: pod-metadata-annotation-val
@@ -1021,6 +1113,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-validate-pod-metadata-task-b}}'
+          - name: task-path
+            value: validate-pod-metadata-task-b
         name: validate-pod-metadata-task-b-driver
         template: system-container-driver
       - arguments:
@@ -1030,6 +1124,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.validate-pod-metadata-task-b-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: validate-pod-metadata-task-b
+          - name: task-path
+            value: validate-pod-metadata-task-b
           - name: pod-metadata-annotation-key-1
             value: task-annotation-1
           - name: pod-metadata-annotation-val-1
@@ -1075,6 +1173,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-validate-pod-metadata-task-c}}'
+          - name: task-path
+            value: validate-pod-metadata-task-c
         name: validate-pod-metadata-task-c-driver
         template: system-container-driver
       - arguments:
@@ -1084,6 +1184,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.validate-pod-metadata-task-c-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: validate-pod-metadata-task-c
+          - name: task-path
+            value: validate-pod-metadata-task-c
           - name: pod-metadata-annotation-key-1
             value: task-annotation-1
           - name: pod-metadata-annotation-val-1
@@ -1109,6 +1213,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-validate-pod-metadata-task-d}}'
+          - name: task-path
+            value: validate-pod-metadata-task-d
         name: validate-pod-metadata-task-d-driver
         template: system-container-driver
       - arguments:
@@ -1118,6 +1224,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.validate-pod-metadata-task-d-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: validate-pod-metadata-task-d
+          - name: task-path
+            value: validate-pod-metadata-task-d
           - name: pod-metadata-label-key-1
             value: task-label-1
           - name: pod-metadata-label-val-1
@@ -1211,13 +1321,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry.yaml
@@ -112,12 +112,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -144,6 +150,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
           - name: retry-max-count
             value: '{{inputs.parameters.retry-max-count}}'
           - name: retry-backoff-duration
@@ -160,6 +170,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: retry-max-count
       - default: "0"
@@ -242,11 +256,19 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
       - name: retry-max-count
       - name: retry-backoff-duration
       - name: retry-backoff-factor
       - name: retry-backoff-max-duration
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: retry-system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -288,6 +310,8 @@ spec:
             value: add
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add
         name: add-driver
         template: system-container-driver
       - arguments:
@@ -297,6 +321,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add
+          - name: task-path
+            value: add
           - name: retry-max-count
             value: "3"
           - name: retry-backoff-duration
@@ -386,13 +414,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_reused_component.yaml
+++ b/test_data/compiled-workflows/pipeline_with_reused_component.yaml
@@ -112,12 +112,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -144,6 +150,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -152,6 +162,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -224,7 +238,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -260,6 +282,8 @@ spec:
             value: add-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add-numbers
         name: add-numbers-driver
         template: system-container-driver
       - arguments:
@@ -269,6 +293,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-numbers-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-numbers
+          - name: task-path
+            value: add-numbers
         depends: add-numbers-driver.Succeeded
         name: add-numbers
         template: system-container-executor
@@ -284,6 +312,8 @@ spec:
             value: add-numbers-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add-numbers-2
         depends: add-numbers.Succeeded
         name: add-numbers-2-driver
         template: system-container-driver
@@ -294,6 +324,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-numbers-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-numbers-2
+          - name: task-path
+            value: add-numbers-2
         depends: add-numbers-2-driver.Succeeded
         name: add-numbers-2
         template: system-container-executor
@@ -309,6 +343,8 @@ spec:
             value: add-numbers-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: add-numbers-3
         depends: add-numbers-2.Succeeded
         name: add-numbers-3-driver
         template: system-container-driver
@@ -319,6 +355,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.add-numbers-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: add-numbers-3
+          - name: task-path
+            value: add-numbers-3
         depends: add-numbers-3-driver.Succeeded
         name: add-numbers-3
         template: system-container-executor
@@ -400,13 +440,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
@@ -131,12 +131,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -163,6 +169,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -171,6 +181,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -243,7 +257,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -281,6 +303,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-comp}}'
+          - name: task-path
+            value: comp
         depends: generate-secret-name.Succeeded
         name: comp-driver
         template: system-container-driver
@@ -291,6 +315,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: comp
+          - name: task-path
+            value: comp
         depends: comp-driver.Succeeded
         name: comp
         template: system-container-executor
@@ -306,6 +334,8 @@ spec:
             value: generate-secret-name
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: generate-secret-name
         name: generate-secret-name-driver
         template: system-container-driver
       - arguments:
@@ -315,6 +345,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.generate-secret-name-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: generate-secret-name
+          - name: task-path
+            value: generate-secret-name
         depends: generate-secret-name-driver.Succeeded
         name: generate-secret-name
         template: system-container-executor
@@ -396,13 +430,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
@@ -119,12 +119,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -151,6 +157,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -159,6 +169,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -231,7 +245,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -269,6 +291,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-comp}}'
+          - name: task-path
+            value: comp
         name: comp-driver
         template: system-container-driver
       - arguments:
@@ -278,6 +302,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.comp-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: comp
+          - name: task-path
+            value: comp
         depends: comp-driver.Succeeded
         name: comp
         template: system-container-executor
@@ -359,13 +387,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
@@ -112,12 +112,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -144,6 +150,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -152,6 +162,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -224,7 +238,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -260,6 +282,8 @@ spec:
             value: sum-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: sum-numbers
         name: sum-numbers-driver
         template: system-container-driver
       - arguments:
@@ -269,6 +293,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.sum-numbers-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: sum-numbers
+          - name: task-path
+            value: sum-numbers
         depends: sum-numbers-driver.Succeeded
         name: sum-numbers
         template: system-container-executor
@@ -350,13 +378,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
@@ -71,7 +71,7 @@ spec:
         kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
         sum_numbers(a: int, b: int) -\u003e int:\n    return a + b\n\n"],"image":"python:3.11","resources":{"accelerator":{"resourceCount":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}","resourceType":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"},"resourceCpuLimit":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}","resourceMemoryLimit":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}}'
     - name: components-root
-      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["cpu-limit","memory-limit","accelerator-limit","accelerator-type"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
+      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-limit","memory-limit","accelerator-type","cpu-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
   entrypoint: entrypoint
   podMetadata:
     annotations:
@@ -164,12 +164,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -196,6 +202,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -204,6 +214,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -276,7 +290,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -312,6 +334,8 @@ spec:
             value: accelerator-limit
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: accelerator-limit
         name: accelerator-limit-driver
         template: system-container-driver
       - arguments:
@@ -321,6 +345,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.accelerator-limit-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: accelerator-limit
+          - name: task-path
+            value: accelerator-limit
         depends: accelerator-limit-driver.Succeeded
         name: accelerator-limit
         template: system-container-executor
@@ -336,6 +364,8 @@ spec:
             value: accelerator-type
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: accelerator-type
         name: accelerator-type-driver
         template: system-container-driver
       - arguments:
@@ -345,6 +375,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.accelerator-type-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: accelerator-type
+          - name: task-path
+            value: accelerator-type
         depends: accelerator-type-driver.Succeeded
         name: accelerator-type
         template: system-container-executor
@@ -360,6 +394,8 @@ spec:
             value: cpu-limit
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: cpu-limit
         name: cpu-limit-driver
         template: system-container-driver
       - arguments:
@@ -369,6 +405,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.cpu-limit-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: cpu-limit
+          - name: task-path
+            value: cpu-limit
         depends: cpu-limit-driver.Succeeded
         name: cpu-limit
         template: system-container-executor
@@ -384,6 +424,8 @@ spec:
             value: memory-limit
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: memory-limit
         name: memory-limit-driver
         template: system-container-driver
       - arguments:
@@ -393,6 +435,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.memory-limit-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: memory-limit
+          - name: task-path
+            value: memory-limit
         depends: memory-limit-driver.Succeeded
         name: memory-limit
         template: system-container-executor
@@ -401,15 +447,17 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["cpu-limit","memory-limit","accelerator-limit","accelerator-type"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-limit","memory-limit","accelerator-type","cpu-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
           - name: container
             value: '{{workflow.parameters.implementations-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task-name
             value: sum-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
-        depends: cpu-limit.Succeeded && memory-limit.Succeeded && accelerator-limit.Succeeded
-          && accelerator-type.Succeeded
+          - name: task-path
+            value: sum-numbers
+        depends: accelerator-limit.Succeeded && memory-limit.Succeeded && accelerator-type.Succeeded
+          && cpu-limit.Succeeded
         name: sum-numbers-driver
         template: system-container-driver
       - arguments:
@@ -419,6 +467,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.sum-numbers-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: sum-numbers
+          - name: task-path
+            value: sum-numbers
         depends: sum-numbers-driver.Succeeded
         name: sum-numbers
         template: system-container-executor
@@ -500,13 +552,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_submit_request.yaml
+++ b/test_data/compiled-workflows/pipeline_with_submit_request.yaml
@@ -123,12 +123,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -155,6 +161,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -163,6 +173,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -235,7 +249,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -271,6 +293,8 @@ spec:
             value: submit-request
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: submit-request
         name: submit-request-driver
         template: system-container-driver
       - arguments:
@@ -280,6 +304,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.submit-request-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: submit-request
+          - name: task-path
+            value: submit-request
         depends: submit-request-driver.Succeeded
         name: submit-request
         template: system-container-executor
@@ -295,6 +323,8 @@ spec:
             value: submit-request-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: submit-request-2
         name: submit-request-2-driver
         template: system-container-driver
       - arguments:
@@ -304,6 +334,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.submit-request-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: submit-request-2
+          - name: task-path
+            value: submit-request-2
         depends: submit-request-2-driver.Succeeded
         name: submit-request-2
         template: system-container-executor
@@ -385,13 +419,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
@@ -146,12 +146,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -178,6 +184,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -186,6 +196,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -258,7 +272,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -295,6 +317,8 @@ spec:
             value: fail-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-1.fail-op
         name: fail-op-driver
         template: system-container-driver
       - arguments:
@@ -304,6 +328,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.fail-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: fail-op
+          - name: task-path
+            value: root.comp-exit-handler-1.fail-op
         depends: fail-op-driver.Succeeded
         name: fail-op
         template: system-container-executor
@@ -319,6 +347,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-1.print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -328,6 +358,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: root.comp-exit-handler-1.print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -351,6 +385,8 @@ spec:
             value: exit-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: exit-op
         name: exit-op-driver
         template: system-container-driver
       - arguments:
@@ -360,6 +396,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.exit-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: exit-op
+          - name: task-path
+            value: exit-op
         depends: exit-op-driver.Succeeded
         name: exit-op
         template: system-container-executor
@@ -441,13 +481,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -477,6 +523,8 @@ spec:
           - name: task
             value: '{"componentRef":{"name":"comp-exit-handler-1"},"inputs":{"parameters":{"pipelinechannel--message":{"componentInputParameter":"message"}}},"taskInfo":{"name":"my-pipeline"}}'
           - name: task-name
+            value: exit-handler-1
+          - name: task-path
             value: exit-handler-1
         name: exit-handler-1-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
@@ -111,12 +111,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -143,6 +149,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -151,6 +161,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -223,7 +237,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -259,6 +281,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-exit-handler-1.print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -268,6 +292,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: root.comp-exit-handler-1.print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -291,6 +319,8 @@ spec:
             value: exit-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: exit-op
         name: exit-op-driver
         template: system-container-driver
       - arguments:
@@ -300,6 +330,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.exit-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: exit-op
+          - name: task-path
+            value: exit-op
         depends: exit-op-driver.Succeeded
         name: exit-op
         template: system-container-executor
@@ -381,13 +415,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -417,6 +457,8 @@ spec:
           - name: task
             value: '{"componentRef":{"name":"comp-exit-handler-1"},"inputs":{"parameters":{"pipelinechannel--message":{"componentInputParameter":"message"}}},"taskInfo":{"name":"my-pipeline"}}'
           - name: task-name
+            value: exit-handler-1
+          - name: task-path
             value: exit-handler-1
         name: exit-handler-1-driver
         template: system-dag-driver

--- a/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -126,12 +126,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -158,6 +164,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -166,6 +176,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -238,7 +252,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -274,6 +296,8 @@ spec:
             value: print-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: print-op
         name: print-op-driver
         template: system-container-driver
       - arguments:
@@ -283,6 +307,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.print-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: print-op
+          - name: task-path
+            value: print-op
         depends: print-op-driver.Succeeded
         name: print-op
         template: system-container-executor
@@ -306,6 +334,8 @@ spec:
             value: fail-op
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: fail-op
         name: fail-op-driver
         template: system-container-driver
       - arguments:
@@ -315,6 +345,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.fail-op-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: fail-op
+          - name: task-path
+            value: fail-op
         depends: fail-op-driver.Succeeded
         hooks:
           exit:
@@ -403,13 +437,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_utils.yaml
+++ b/test_data/compiled-workflows/pipeline_with_utils.yaml
@@ -116,12 +116,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -148,6 +154,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -156,6 +166,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -228,7 +242,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -264,6 +286,8 @@ spec:
             value: echo
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo
         name: echo-driver
         template: system-container-driver
       - arguments:
@@ -273,6 +297,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo
+          - name: task-path
+            value: echo
         depends: echo-driver.Succeeded
         name: echo
         template: system-container-executor
@@ -354,13 +382,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
@@ -107,12 +107,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -139,6 +145,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -147,6 +157,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -219,7 +233,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -255,6 +277,8 @@ spec:
             value: downstream
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: downstream
         depends: upstream.Succeeded
         name: downstream-driver
         template: system-container-driver
@@ -265,6 +289,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.downstream-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: downstream
+          - name: task-path
+            value: downstream
         depends: downstream-driver.Succeeded
         name: downstream
         template: system-container-executor
@@ -280,6 +308,8 @@ spec:
             value: upstream
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: upstream
         name: upstream-driver
         template: system-container-driver
       - arguments:
@@ -289,6 +319,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.upstream-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: upstream
+          - name: task-path
+            value: upstream
         depends: upstream-driver.Succeeded
         name: upstream
         template: system-container-executor
@@ -370,13 +404,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume.yaml
@@ -160,12 +160,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -192,6 +198,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -200,6 +210,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -272,7 +286,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -310,6 +332,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-consumer}}'
+          - name: task-path
+            value: consumer
         depends: createpvc.Succeeded && producer.Succeeded
         name: consumer-driver
         template: system-container-driver
@@ -320,6 +344,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.consumer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: consumer
+          - name: task-path
+            value: consumer
         depends: consumer-driver.Succeeded
         name: consumer
         template: system-container-executor
@@ -335,6 +363,8 @@ spec:
             value: createpvc
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: createpvc
         name: createpvc
         template: system-container-driver
       - arguments:
@@ -349,6 +379,8 @@ spec:
             value: deletepvc
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: deletepvc
         depends: consumer.Succeeded && createpvc.Succeeded
         name: deletepvc
         template: system-container-driver
@@ -366,6 +398,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-producer}}'
+          - name: task-path
+            value: producer
         depends: createpvc.Succeeded
         name: producer-driver
         template: system-container-driver
@@ -376,6 +410,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.producer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: producer
+          - name: task-path
+            value: producer
         depends: producer-driver.Succeeded
         name: producer
         template: system-container-executor
@@ -457,13 +495,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
@@ -134,12 +134,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -166,6 +172,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -174,6 +184,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -246,7 +260,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -282,6 +304,8 @@ spec:
             value: createpvc
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: createpvc
         name: createpvc
         template: system-container-driver
       - arguments:
@@ -296,6 +320,8 @@ spec:
             value: dummy-task
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: dummy-task
         name: dummy-task-driver
         template: system-container-driver
       - arguments:
@@ -305,6 +331,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.dummy-task-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: dummy-task
+          - name: task-path
+            value: dummy-task
         depends: dummy-task-driver.Succeeded
         name: dummy-task
         template: system-container-executor
@@ -386,13 +416,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
@@ -160,12 +160,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -192,6 +198,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -200,6 +210,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -272,7 +286,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -310,6 +332,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-consumer}}'
+          - name: task-path
+            value: consumer
         depends: createpvc.Succeeded && producer.Succeeded
         name: consumer-driver
         template: system-container-driver
@@ -320,6 +344,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.consumer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: consumer
+          - name: task-path
+            value: consumer
         depends: consumer-driver.Succeeded
         name: consumer
         template: system-container-executor
@@ -335,6 +363,8 @@ spec:
             value: createpvc
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: createpvc
         name: createpvc
         template: system-container-driver
       - arguments:
@@ -349,6 +379,8 @@ spec:
             value: deletepvc
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: deletepvc
         depends: consumer.Succeeded && createpvc.Succeeded
         name: deletepvc
         template: system-container-driver
@@ -366,6 +398,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-producer}}'
+          - name: task-path
+            value: producer
         depends: createpvc.Succeeded
         name: producer-driver
         template: system-container-driver
@@ -376,6 +410,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.producer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: producer
+          - name: task-path
+            value: producer
         depends: producer-driver.Succeeded
         name: producer
         template: system-container-executor
@@ -457,13 +495,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pipeline_with_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_workspace.yaml
@@ -136,12 +136,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -168,6 +174,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -176,6 +186,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -248,7 +262,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -284,6 +306,8 @@ spec:
             value: read-from-workspace
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: read-from-workspace
         depends: write-to-workspace.Succeeded
         name: read-from-workspace-driver
         template: system-container-driver
@@ -294,6 +318,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-from-workspace-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-from-workspace
+          - name: task-path
+            value: read-from-workspace
         depends: read-from-workspace-driver.Succeeded
         name: read-from-workspace
         template: system-container-executor
@@ -309,6 +337,8 @@ spec:
             value: write-to-workspace
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: write-to-workspace
         name: write-to-workspace-driver
         template: system-container-driver
       - arguments:
@@ -318,6 +348,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.write-to-workspace-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: write-to-workspace
+          - name: task-path
+            value: write-to-workspace
         depends: write-to-workspace-driver.Succeeded
         name: write-to-workspace
         template: system-container-executor
@@ -399,13 +433,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
+++ b/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
@@ -106,12 +106,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -138,6 +144,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -146,6 +156,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -218,7 +232,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -254,6 +276,8 @@ spec:
             value: component-with-optional-inputs
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: component-with-optional-inputs
         name: component-with-optional-inputs-driver
         template: system-container-driver
       - arguments:
@@ -263,6 +287,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component-with-optional-inputs-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component-with-optional-inputs
+          - name: task-path
+            value: component-with-optional-inputs
         depends: component-with-optional-inputs-driver.Succeeded
         name: component-with-optional-inputs
         template: system-container-executor
@@ -344,13 +372,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/preprocess.yaml
+++ b/test_data/compiled-workflows/preprocess.yaml
@@ -134,12 +134,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -166,6 +172,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -174,6 +184,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -246,7 +260,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -282,6 +304,8 @@ spec:
             value: preprocess
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: preprocess
         name: preprocess-driver
         template: system-container-driver
       - arguments:
@@ -291,6 +315,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.preprocess-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: preprocess
+          - name: task-path
+            value: preprocess
         depends: preprocess-driver.Succeeded
         name: preprocess
         template: system-container-executor
@@ -372,13 +400,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
+++ b/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
@@ -110,12 +110,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -142,6 +148,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -150,6 +160,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -222,7 +236,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -258,6 +280,8 @@ spec:
             value: consumer
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: consumer
         depends: producer.Succeeded
         name: consumer-driver
         template: system-container-driver
@@ -268,6 +292,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.consumer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: consumer
+          - name: task-path
+            value: consumer
         depends: consumer-driver.Succeeded
         name: consumer
         template: system-container-executor
@@ -283,6 +311,8 @@ spec:
             value: producer
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: producer
         name: producer-driver
         template: system-container-driver
       - arguments:
@@ -292,6 +322,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.producer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: producer
+          - name: task-path
+            value: producer
         depends: producer-driver.Succeeded
         name: producer
         template: system-container-executor
@@ -373,13 +407,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pvc_mount.yaml
+++ b/test_data/compiled-workflows/pvc_mount.yaml
@@ -130,12 +130,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -162,6 +168,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -170,6 +180,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -242,7 +256,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -280,6 +302,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-consumer}}'
+          - name: task-path
+            value: consumer
         depends: producer.Succeeded
         name: consumer-driver
         template: system-container-driver
@@ -290,6 +314,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.consumer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: consumer
+          - name: task-path
+            value: consumer
         depends: consumer-driver.Succeeded
         name: consumer
         template: system-container-executor
@@ -307,6 +335,8 @@ spec:
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: kubernetes-config
             value: '{{workflow.parameters.kubernetes-comp-producer}}'
+          - name: task-path
+            value: producer
         name: producer-driver
         template: system-container-driver
       - arguments:
@@ -316,6 +346,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.producer-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: producer
+          - name: task-path
+            value: producer
         depends: producer-driver.Succeeded
         name: producer
         template: system-container-executor
@@ -397,13 +431,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
+++ b/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
@@ -192,12 +192,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -224,6 +230,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -232,6 +242,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -304,7 +318,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -352,6 +374,8 @@ spec:
             value: make-language-model
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: make-language-model
         depends: importer.Succeeded
         name: make-language-model-driver
         template: system-container-driver
@@ -362,6 +386,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.make-language-model-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: make-language-model
+          - name: task-path
+            value: make-language-model
         depends: make-language-model-driver.Succeeded
         name: make-language-model
         template: system-container-executor
@@ -443,13 +471,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
@@ -131,12 +131,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -163,6 +169,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -171,6 +181,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -243,7 +257,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -279,6 +301,8 @@ spec:
             value: gen-data
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: gen-data
         name: gen-data-driver
         template: system-container-driver
       - arguments:
@@ -288,6 +312,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.gen-data-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: gen-data
+          - name: task-path
+            value: gen-data
         depends: gen-data-driver.Succeeded
         name: gen-data
         template: system-container-executor
@@ -303,6 +331,8 @@ spec:
             value: train-model
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: train-model
         depends: gen-data.Succeeded
         name: train-model-driver
         template: system-container-driver
@@ -313,6 +343,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.train-model-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: train-model
+          - name: task-path
+            value: train-model
         depends: train-model-driver.Succeeded
         name: train-model
         template: system-container-executor
@@ -394,13 +428,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
@@ -132,12 +132,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -164,6 +170,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -172,6 +182,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -244,7 +258,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -280,6 +302,8 @@ spec:
             value: make-dataset
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-for-loop-1.make-dataset
         name: make-dataset-driver
         template: system-container-driver
       - arguments:
@@ -289,6 +313,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.make-dataset-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: make-dataset
+          - name: task-path
+            value: root.comp-for-loop-1.make-dataset
         depends: make-dataset-driver.Succeeded
         name: make-dataset
         template: system-container-executor
@@ -370,13 +398,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -409,6 +443,8 @@ spec:
             value: '{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--texts":{"componentInputParameter":"texts"}}},"parameterIterator":{"itemInput":"pipelinechannel--texts-loop-item","items":{"inputParameter":"pipelinechannel--texts"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
+          - name: task-path
+            value: root.for-loop-1.iteration-item
         name: iteration-item-driver
         template: system-dag-driver
       - arguments:
@@ -478,6 +514,8 @@ spec:
             value: join-datasets
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: join-datasets
         depends: for-loop-1.Succeeded
         name: join-datasets-driver
         template: system-container-driver
@@ -488,6 +526,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.join-datasets-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: join-datasets
+          - name: task-path
+            value: join-datasets
         depends: join-datasets-driver.Succeeded
         name: join-datasets
         template: system-container-executor

--- a/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
@@ -137,12 +137,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -169,6 +175,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -177,6 +187,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -249,7 +263,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -285,6 +307,8 @@ spec:
             value: dataset-splitter
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: root.comp-splitter-pipeline.dataset-splitter
         name: dataset-splitter-driver
         template: system-container-driver
       - arguments:
@@ -294,6 +318,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.dataset-splitter-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: dataset-splitter
+          - name: task-path
+            value: root.comp-splitter-pipeline.dataset-splitter
         depends: dataset-splitter-driver.Succeeded
         name: dataset-splitter
         template: system-container-executor
@@ -375,13 +403,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:
@@ -414,6 +448,8 @@ spec:
             value: make-dataset
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: make-dataset
         name: make-dataset-driver
         template: system-container-driver
       - arguments:
@@ -423,6 +459,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.make-dataset-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: make-dataset
+          - name: task-path
+            value: make-dataset
         depends: make-dataset-driver.Succeeded
         name: make-dataset
         template: system-container-executor
@@ -435,6 +475,8 @@ spec:
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-splitter-pipeline"},"dependentTasks":["make-dataset"],"inputs":{"artifacts":{"in_dataset":{"taskOutputArtifact":{"outputArtifactKey":"Output","producerTask":"make-dataset"}}}},"taskInfo":{"name":"splitter-pipeline"}}'
           - name: task-name
+            value: splitter-pipeline
+          - name: task-path
             value: splitter-pipeline
         depends: make-dataset.Succeeded
         name: splitter-pipeline-driver

--- a/test_data/compiled-workflows/ray_integration_compiled.yaml
+++ b/test_data/compiled-workflows/ray_integration_compiled.yaml
@@ -177,12 +177,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -209,6 +215,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -217,6 +227,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -289,7 +303,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -325,6 +347,8 @@ spec:
             value: ray-fn
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: ray-fn
         name: ray-fn-driver
         template: system-container-driver
       - arguments:
@@ -334,6 +358,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.ray-fn-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: ray-fn
+          - name: task-path
+            value: ray-fn
         depends: ray-fn-driver.Succeeded
         name: ray-fn
         template: system-container-executor
@@ -415,13 +443,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
@@ -106,12 +106,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -138,6 +144,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -146,6 +156,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -220,7 +234,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -256,6 +278,8 @@ spec:
             value: echo
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo
         name: echo-driver
         template: system-container-driver
       - arguments:
@@ -265,6 +289,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo
+          - name: task-path
+            value: echo
         depends: echo-driver.Succeeded
         name: echo
         template: system-container-executor
@@ -348,13 +376,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
@@ -106,12 +106,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -138,6 +144,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -146,6 +156,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -220,7 +234,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -256,6 +278,8 @@ spec:
             value: echo
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo
         name: echo-driver
         template: system-container-driver
       - arguments:
@@ -265,6 +289,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo
+          - name: task-path
+            value: echo
         depends: echo-driver.Succeeded
         name: echo
         template: system-container-executor
@@ -348,13 +376,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/sequential_v1.yaml
+++ b/test_data/compiled-workflows/sequential_v1.yaml
@@ -103,12 +103,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -135,6 +141,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -143,6 +153,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -215,7 +229,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -251,6 +273,8 @@ spec:
             value: echo
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo
         name: echo-driver
         template: system-container-driver
       - arguments:
@@ -260,6 +284,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo
+          - name: task-path
+            value: echo
         depends: echo-driver.Succeeded
         name: echo
         template: system-container-executor
@@ -275,6 +303,8 @@ spec:
             value: echo-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo-2
         name: echo-2-driver
         template: system-container-driver
       - arguments:
@@ -284,6 +314,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo-2
+          - name: task-path
+            value: echo-2
         depends: echo-2-driver.Succeeded
         name: echo-2
         template: system-container-executor
@@ -365,13 +399,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/sequential_v2.yaml
+++ b/test_data/compiled-workflows/sequential_v2.yaml
@@ -107,12 +107,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -139,6 +145,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -147,6 +157,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -219,7 +233,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -255,6 +277,8 @@ spec:
             value: download
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: download
         name: download-driver
         template: system-container-driver
       - arguments:
@@ -264,6 +288,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.download-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: download
+          - name: task-path
+            value: download
         depends: download-driver.Succeeded
         name: download
         template: system-container-executor
@@ -279,6 +307,8 @@ spec:
             value: echo
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: echo
         depends: download.Succeeded
         name: echo-driver
         template: system-container-driver
@@ -289,6 +319,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.echo-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: echo
+          - name: task-path
+            value: echo
         depends: echo-driver.Succeeded
         name: echo
         template: system-container-executor
@@ -370,13 +404,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/take_nap_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_compiled.yaml
@@ -128,12 +128,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -160,6 +166,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -168,6 +178,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -240,7 +254,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -276,6 +298,8 @@ spec:
             value: take-nap
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: take-nap
         name: take-nap-driver
         template: system-container-driver
       - arguments:
@@ -285,6 +309,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.take-nap-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: take-nap
+          - name: task-path
+            value: take-nap
         depends: take-nap-driver.Succeeded
         name: take-nap
         template: system-container-executor
@@ -300,6 +328,8 @@ spec:
             value: wake-up
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: wake-up
         depends: take-nap.Succeeded
         name: wake-up-driver
         template: system-container-driver
@@ -310,6 +340,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.wake-up-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: wake-up
+          - name: task-path
+            value: wake-up
         depends: wake-up-driver.Succeeded
         name: wake-up
         template: system-container-executor
@@ -391,13 +425,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
@@ -128,12 +128,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -160,6 +166,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -168,6 +178,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -240,7 +254,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -276,6 +298,8 @@ spec:
             value: take-nap
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: take-nap
         name: take-nap-driver
         template: system-container-driver
       - arguments:
@@ -285,6 +309,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.take-nap-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: take-nap
+          - name: task-path
+            value: take-nap
         depends: take-nap-driver.Succeeded
         name: take-nap
         template: system-container-executor
@@ -300,6 +328,8 @@ spec:
             value: wake-up
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: wake-up
         depends: take-nap.Succeeded
         name: wake-up-driver
         template: system-container-driver
@@ -310,6 +340,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.wake-up-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: wake-up
+          - name: task-path
+            value: wake-up
         depends: wake-up-driver.Succeeded
         name: wake-up
         template: system-container-executor
@@ -391,13 +425,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/two_step_pipeline.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline.yaml
@@ -108,12 +108,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -140,6 +146,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -148,6 +158,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -220,7 +234,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -256,6 +278,8 @@ spec:
             value: read-from-gcs
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: read-from-gcs
         depends: write-to-gcs.Succeeded
         name: read-from-gcs-driver
         template: system-container-driver
@@ -266,6 +290,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.read-from-gcs-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: read-from-gcs
+          - name: task-path
+            value: read-from-gcs
         depends: read-from-gcs-driver.Succeeded
         name: read-from-gcs
         template: system-container-executor
@@ -281,6 +309,8 @@ spec:
             value: write-to-gcs
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: write-to-gcs
         name: write-to-gcs-driver
         template: system-container-driver
       - arguments:
@@ -290,6 +320,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.write-to-gcs-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: write-to-gcs
+          - name: task-path
+            value: write-to-gcs
         depends: write-to-gcs-driver.Succeeded
         name: write-to-gcs
         template: system-container-executor
@@ -371,13 +405,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
@@ -109,12 +109,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -141,6 +147,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -149,6 +159,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -221,7 +235,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -257,6 +279,8 @@ spec:
             value: component1
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: component1
         name: component1-driver
         template: system-container-driver
       - arguments:
@@ -266,6 +290,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component1-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component1
+          - name: task-path
+            value: component1
         depends: component1-driver.Succeeded
         name: component1
         template: system-container-executor
@@ -281,6 +309,8 @@ spec:
             value: component2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: component2
         depends: component1.Succeeded
         name: component2-driver
         template: system-container-driver
@@ -291,6 +321,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.component2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: component2
+          - name: task-path
+            value: component2
         depends: component2-driver.Succeeded
         name: component2
         template: system-container-executor
@@ -372,13 +406,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/upload_download_compiled.yaml
+++ b/test_data/compiled-workflows/upload_download_compiled.yaml
@@ -167,12 +167,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -199,6 +205,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -207,6 +217,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -279,7 +293,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -315,6 +337,8 @@ spec:
             value: receive-file
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: receive-file
         depends: send-file.Succeeded
         name: receive-file-driver
         template: system-container-driver
@@ -325,6 +349,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.receive-file-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: receive-file
+          - name: task-path
+            value: receive-file
         depends: receive-file-driver.Succeeded
         name: receive-file
         template: system-container-executor
@@ -340,6 +368,8 @@ spec:
             value: send-file
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: send-file
         name: send-file-driver
         template: system-container-driver
       - arguments:
@@ -349,6 +379,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.send-file-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: send-file
+          - name: task-path
+            value: send-file
         depends: send-file-driver.Succeeded
         name: send-file
         template: system-container-executor
@@ -364,6 +398,8 @@ spec:
             value: test-uploaded-artifact
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: test-uploaded-artifact
         depends: receive-file.Succeeded
         name: test-uploaded-artifact-driver
         template: system-container-driver
@@ -374,6 +410,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.test-uploaded-artifact-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: test-uploaded-artifact
+          - name: task-path
+            value: test-uploaded-artifact
         depends: test-uploaded-artifact-driver.Succeeded
         name: test-uploaded-artifact
         template: system-container-executor
@@ -455,13 +495,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:

--- a/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
+++ b/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
@@ -371,12 +371,18 @@ spec:
       - name: task
       - name: container
       - name: task-name
+      - default: ""
+        name: task-path
       - name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: ""
         name: kubernetes-config
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-driver
     outputs:
       parameters:
@@ -403,6 +409,10 @@ spec:
           parameters:
           - name: pod-spec-patch
             value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: task-name
+            value: '{{inputs.parameters.task-name}}'
+          - name: task-path
+            value: '{{inputs.parameters.task-path}}'
         name: executor
         template: system-container-impl
         when: '{{inputs.parameters.cached-decision}} != true'
@@ -411,6 +421,10 @@ spec:
       - name: pod-spec-patch
       - default: "false"
         name: cached-decision
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
     metadata: {}
     name: system-container-executor
     outputs: {}
@@ -483,7 +497,15 @@ spec:
     inputs:
       parameters:
       - name: pod-spec-patch
-    metadata: {}
+      - default: ""
+        name: task-name
+      - default: ""
+        name: task-path
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-container-impl
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
@@ -520,6 +542,8 @@ spec:
             value: chicago-taxi-trips-dataset
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: chicago-taxi-trips-dataset
         name: chicago-taxi-trips-dataset-driver
         template: system-container-driver
       - arguments:
@@ -529,6 +553,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.chicago-taxi-trips-dataset-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: chicago-taxi-trips-dataset
+          - name: task-path
+            value: chicago-taxi-trips-dataset
         depends: chicago-taxi-trips-dataset-driver.Succeeded
         name: chicago-taxi-trips-dataset
         template: system-container-executor
@@ -544,6 +572,8 @@ spec:
             value: convert-csv-to-apache-parquet
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: convert-csv-to-apache-parquet
         depends: chicago-taxi-trips-dataset.Succeeded
         name: convert-csv-to-apache-parquet-driver
         template: system-container-driver
@@ -554,6 +584,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.convert-csv-to-apache-parquet-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: convert-csv-to-apache-parquet
+          - name: task-path
+            value: convert-csv-to-apache-parquet
         depends: convert-csv-to-apache-parquet-driver.Succeeded
         name: convert-csv-to-apache-parquet
         template: system-container-executor
@@ -569,6 +603,8 @@ spec:
             value: xgboost-predict
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: xgboost-predict
         depends: chicago-taxi-trips-dataset.Succeeded && xgboost-train.Succeeded
         name: xgboost-predict-driver
         template: system-container-driver
@@ -579,6 +615,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.xgboost-predict-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: xgboost-predict
+          - name: task-path
+            value: xgboost-predict
         depends: xgboost-predict-driver.Succeeded
         name: xgboost-predict
         template: system-container-executor
@@ -594,6 +634,8 @@ spec:
             value: xgboost-predict-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: xgboost-predict-2
         depends: convert-csv-to-apache-parquet.Succeeded && xgboost-train-2.Succeeded
         name: xgboost-predict-2-driver
         template: system-container-driver
@@ -604,6 +646,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.xgboost-predict-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: xgboost-predict-2
+          - name: task-path
+            value: xgboost-predict-2
         depends: xgboost-predict-2-driver.Succeeded
         name: xgboost-predict-2
         template: system-container-executor
@@ -619,6 +665,8 @@ spec:
             value: xgboost-predict-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: xgboost-predict-3
         depends: convert-csv-to-apache-parquet.Succeeded && xgboost-train.Succeeded
         name: xgboost-predict-3-driver
         template: system-container-driver
@@ -629,6 +677,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.xgboost-predict-3-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: xgboost-predict-3
+          - name: task-path
+            value: xgboost-predict-3
         depends: xgboost-predict-3-driver.Succeeded
         name: xgboost-predict-3
         template: system-container-executor
@@ -644,6 +696,8 @@ spec:
             value: xgboost-predict-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: xgboost-predict-4
         depends: chicago-taxi-trips-dataset.Succeeded && xgboost-train-2.Succeeded
         name: xgboost-predict-4-driver
         template: system-container-driver
@@ -654,6 +708,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.xgboost-predict-4-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: xgboost-predict-4
+          - name: task-path
+            value: xgboost-predict-4
         depends: xgboost-predict-4-driver.Succeeded
         name: xgboost-predict-4
         template: system-container-executor
@@ -669,6 +727,8 @@ spec:
             value: xgboost-train
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: xgboost-train
         depends: chicago-taxi-trips-dataset.Succeeded
         name: xgboost-train-driver
         template: system-container-driver
@@ -679,6 +739,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.xgboost-train-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: xgboost-train
+          - name: task-path
+            value: xgboost-train
         depends: xgboost-train-driver.Succeeded
         name: xgboost-train
         template: system-container-executor
@@ -694,6 +758,8 @@ spec:
             value: xgboost-train-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+          - name: task-path
+            value: xgboost-train-2
         depends: convert-csv-to-apache-parquet.Succeeded
         name: xgboost-train-2-driver
         template: system-container-driver
@@ -704,6 +770,10 @@ spec:
           - default: "false"
             name: cached-decision
             value: '{{tasks.xgboost-train-2-driver.outputs.parameters.cached-decision}}'
+          - name: task-name
+            value: xgboost-train-2
+          - name: task-path
+            value: xgboost-train-2
         depends: xgboost-train-2-driver.Succeeded
         name: xgboost-train-2
         template: system-container-executor
@@ -785,13 +855,19 @@ spec:
         name: task
       - default: ""
         name: task-name
+      - default: ""
+        name: task-path
       - default: "0"
         name: parent-dag-id
       - default: "-1"
         name: iteration-index
       - default: DAG
         name: driver-type
-    metadata: {}
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/task_path: '{{inputs.parameters.task-path}}'
+      labels:
+        pipelines.kubeflow.org/task_name: '{{inputs.parameters.task-name}}'
     name: system-dag-driver
     outputs:
       parameters:


### PR DESCRIPTION
## Summary

- Adds a **Pod Status** tab to each pipeline component in the KFP v2 run details page, showing current pod phase, container status, Kubernetes events, and full pod lifecycle timeline
- Implements server-side caching (file-based) so pod status, events, and state history survive pod deletion and K8s event expiration (~1hr TTL)
- Adds `pipelines.kubeflow.org/task_name` label and `pipelines.kubeflow.org/task_path` annotation to pod templates via the Argo compiler for reliable pod-to-component association
- Adds a pod watcher for real-time status updates

## Database schema change

> **⚠️ This PR adds two new columns to the `tasks` table:**
> - `PodStatus` (`LONGTEXT`, nullable) — stores the last known pod status as JSON
> - `PodEvents` (`LONGTEXT`, nullable) — stores pod events as JSON
>
> These columns are added **automatically** by GORM `AutoMigrate` on API server startup (`client_manager.go`). No manual migration is required. The columns are nullable with `default:null`, so existing rows are unaffected and the migration is non-breaking.
>
> **Rollback note:** If this feature is reverted, the columns will remain in the database but will be unused. They can be dropped manually if desired.

## Changes

### Frontend Server (`frontend/server/`)
- **`pod-events-cache.ts`** (new) — File-based cache for pod events, status, and state history with automatic cleanup. Scheduler uses `.unref()` and is disabled under `NODE_ENV=test`
- **`pod-watcher.ts`** (new) — Watches pod status changes in real-time
- **`handlers/pod-info.ts`** — New endpoints: `GET /pod/info`, `GET /pod/events`, `GET /pod/list_by_run`, `GET /pod/cached_info`. All endpoints wrapped with authorization checks
- **`k8s-helper.ts`** — New K8s API helpers: `getPod()`, `listPodEvents()`, `listPodsByRunId()` with full pagination support (continuation tokens)

### Frontend Client (`frontend/src/`)
- **`hooks/usePodStatus.ts`** (new) — Dedicated hook module for pod status fetching, pod scoring/selection, and state derivation. Extracted from RuntimeNodeDetailsV2 for testability
- **`components/tabs/RuntimeNodeDetailsV2.tsx`** — Pod Status tab with current status, events, and lifecycle timeline sections. Uses full task path (from `layers`) for nested DAG disambiguation
- **`lib/Apis.ts`** — New API client methods for pod status endpoints

### Backend (`backend/src/v2/compiler/argocompiler/`)
- **`container.go`** — Adds `pipelines.kubeflow.org/task_name` label and `pipelines.kubeflow.org/task_path` annotation to container pod templates
- **`dag.go`** — Adds task path annotations and `task_name` label to DAG driver templates

### Backend (`backend/src/apiserver/`)
- **`model/task.go`** — Adds `PodStatus` and `PodEvents` fields to the Task model (with `PodStatus`, `PodEvent`, and `ContainerStatus` structs)
- **`storage/task_store.go`** — Persists/loads pod status and events; pod events are merged/deduplicated (by type+reason+message+timestamp) instead of replaced, so events accumulate over time

## Review feedback addressed

### First round
- Removed unused imports in `app.ts`
- Added `.trim()` to namespace file read in `pod-watcher.ts`
- Removed all debug `console.log` statements from frontend code
- Added `.unref()` and `NODE_ENV=test` guard to cleanup scheduler in `pod-events-cache.ts`
- Wrapped `/k8s/pods/byRunId` and `/k8s/pod/cached` endpoints with authorization
- Merged/deduplicated pod events in `task_store.go` `patchTask` instead of replacing
- Removed internal tracking docs (`PERFORMANCE_OPTIMIZATION_ROLLBACK.md`, `POD_STATUS_CHANGES.md`)

### Second round
- Added pagination (continuation tokens) to `listPodsByRunId` for large ParallelFor runs exceeding 100 pods
- Used full task path (`layers` + leaf key → `root.sub-dag.task-name`) for nested DAG disambiguation via `task_path` annotation
- Dropped `run.proto` schema additions (PodStatus/PodEvent messages) since generated API clients were not regenerated
- Extracted `getPodStatusAndEvents` into dedicated `usePodStatus` hook module with smaller decomposed helpers (`findBestPod`, `buildTaskPath`, `parseContainerStatus`)
- Added tests for `/k8s/pods/byRunId` and `/k8s/pod/cached` endpoints (param validation + auth rejection)
- Fixed K8s client API calls to use object parameter style (matching master branch)
- Fixed ESM import extensions in `pod-watcher.ts`

### Third round
- Fixed `buildTaskPath` to resolve the parent DAG's **componentRef name** from the pipeline spec (matching the compiler's `task_path` annotation format from `dag.go:247-249`)
- Added `layers` to the React Query key to prevent stale cache hits for same-named tasks in different sub-DAGs

## Test plan
- [ ] Verify Pod Status tab renders correctly for running and completed pipeline components
- [ ] Verify pod events are displayed and cached beyond K8s event TTL
- [ ] Verify pod lifecycle timeline shows state transitions including transient error states
- [ ] Verify cache survives frontend pod restart (with PVC)
- [ ] Verify no regressions in existing tabs (Input/Output, Logs, Visualizations)
- [ ] Verify new endpoints reject unauthorized requests (authz tests added)
- [ ] Verify nested DAG tasks show correct pod status (task_path disambiguation)
- [ ] Verify large ParallelFor runs (>100 pods) correctly paginate pod listing
- [ ] Verify API server starts successfully with existing database (AutoMigrate adds new columns)

---

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).