### PR TITLE
fix(backend, frontend): Infer FAILED state for pods stuck in CreateContainerConfigError

### DIFF
--- a/backend/src/apiserver/server/api_converter_test.go
+++ b/backend/src/apiserver/server/api_converter_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -3358,6 +3359,53 @@ func Test_toModelTasks_wf(t *testing.T) {
 	if !cmp.Equal(expectedWf, gotWf) {
 		t.Errorf("toModelTasks() diff: %v", cmp.Diff(gotWf, expectedWf))
 	}
+}
+
+// Test_toModelTasks_wf_pending_pod_create_container_config_error ensures v2 run task details derived
+// from an Argo Workflow surface FAILED when the pod is still Pending but the node Message contains
+// CreateContainerConfigError (e.g. missing Secret for secretAsEnv), matching frontend expectations.
+func Test_toModelTasks_wf_pending_pod_create_container_config_error(t *testing.T) {
+	startedAt := v1.NewTime(time.Date(2023, 2, 7, 1, 56, 55, 0, time.UTC))
+	createdAt := v1.NewTime(time.Date(2023, 2, 7, 1, 55, 19, 0, time.UTC))
+
+	argWf := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "wf1",
+			Namespace:         "kubeflow",
+			UID:               "wf1_uid",
+			CreationTimestamp: createdAt,
+			Labels:            map[string]string{"pipeline/runid": "wf1_run_id"},
+		},
+		Status: v1alpha1.WorkflowStatus{
+			Phase: v1alpha1.WorkflowRunning,
+			Nodes: map[string]v1alpha1.NodeStatus{
+				"wf1-print-envvar-0": {
+					ID:           "wf1-print-envvar-0",
+					Name:         "wf1.print-envvar",
+					DisplayName:  "print-envvar",
+					Type:         v1alpha1.NodeTypePod,
+					TemplateName: "print-envvar",
+					Phase:        v1alpha1.NodePending,
+					Message:      `containers with unready status: [main] (Message: secret "my-secret-that-doesnt-exist" not found: CreateContainerConfigError)`,
+					StartedAt:    startedAt,
+				},
+			},
+		},
+	})
+
+	tasks, err := toModelTasks(argWf)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+
+	printTask := tasks[0]
+	assert.Equal(t, "print-envvar", printTask.Name)
+	assert.Equal(t, model.RuntimeStateFailed, printTask.State)
+	assert.Equal(t, "kubeflow", printTask.Namespace)
+	assert.Equal(t, "wf1_run_id", printTask.RunID)
+	assert.Equal(t, "wf1-print-envvar-0", printTask.PodName)
+	assert.Equal(t, startedAt.Unix(), printTask.StartedTimestamp)
+	assert.Equal(t, startedAt.Unix(), printTask.FinishedTimestamp, "inferred failure uses StartedAt when FinishedAt is unset")
+	assert.Equal(t, createdAt.Unix(), printTask.CreatedTimestamp)
 }
 
 func Test_toApiTaskV1(t *testing.T) {

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -816,16 +816,59 @@ func (w *Workflow) PatchTemplateOutputArtifacts() {
 	}
 }
 
+// fatalPodStartupReasonSubstrings matches Argo/Kubernetes node Message text when the workload
+// is failing to run correctly while Phase may stay Pending or Running (substring heuristic; only
+// applied to NodeTypePod in Pending/Running to limit false positives on DAG aggregate messages).
+var fatalPodStartupReasonSubstrings = []string{
+	"CreateContainerConfigError",
+	"CreateContainerError",
+	"ImagePullBackOff",
+	"ErrImagePull",
+	"InvalidImageName",
+	"CrashLoopBackOff",
+	"RunContainerError",
+}
+
+// taskStateFromNodeStatus maps an Argo node to the task state string stored by the API server.
+// Pod nodes may report kubelet errors only in Message while Phase is still non-terminal.
+// Non-Pod nodes keep Phase as State (Argo sets Type for workflow nodes; empty Type is not treated as Pod).
+func taskStateFromNodeStatus(node workflowapi.NodeStatus) string {
+	if node.Type == workflowapi.NodeTypePod &&
+		(node.Phase == workflowapi.NodePending || node.Phase == workflowapi.NodeRunning) {
+		for _, sub := range fatalPodStartupReasonSubstrings {
+			if strings.Contains(node.Message, sub) {
+				return string(workflowapi.NodeFailed)
+			}
+		}
+	}
+	return string(node.Phase)
+}
+
+// taskFinishTimeUnix returns Unix finish time for persisted task details. When we infer Failed from
+// Message while Phase is still non-terminal, FinishedAt is often unset; use StartedAt so UIs can show duration.
+// Zero metav1.Time encodes as Unix -62135596800, not 0; treat IsZero as unset.
+func taskFinishTimeUnix(node workflowapi.NodeStatus, state string) int64 {
+	if !node.FinishedAt.IsZero() {
+		return node.FinishedAt.Unix()
+	}
+	if state == string(workflowapi.NodeFailed) && node.Phase != workflowapi.NodeFailed &&
+		!node.StartedAt.IsZero() {
+		return node.StartedAt.Unix()
+	}
+	return 0
+}
+
 func (w *Workflow) NodeStatuses() map[string]NodeStatus {
 	rev := make(map[string]NodeStatus, len(w.Status.Nodes))
 	for id, node := range w.Status.Nodes {
+		state := taskStateFromNodeStatus(node)
 		rev[id] = NodeStatus{
 			ID:          RetrievePodName(*w.Workflow, node),
 			DisplayName: node.DisplayName,
-			State:       string(node.Phase),
+			State:       state,
 			StartTime:   node.StartedAt.Unix(),
 			CreateTime:  node.StartedAt.Unix(),
-			FinishTime:  node.FinishedAt.Unix(),
+			FinishTime:  taskFinishTimeUnix(node, state),
 			Children:    node.Children,
 		}
 	}

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -1336,6 +1336,172 @@ func TestWorkflow_NodeStatuses(t *testing.T) {
 	assert.Empty(t, statuses)
 }
 
+func TestWorkflow_NodeStatuses_PodMessageInfersFailed(t *testing.T) {
+	startTime := metav1.NewTime(time.Unix(100, 0).UTC())
+	tests := []struct {
+		name      string
+		node      workflowapi.NodeStatus
+		wantState string
+	}{
+		{
+			// Typical v2 Kubernetes secretAsEnv + missing Secret: task stays Pending while Message
+			// carries CreateContainerConfigError (frontend must not treat this as success).
+			name: "pending pod CreateContainerConfigError",
+			node: workflowapi.NodeStatus{
+				ID:          "n1",
+				DisplayName: "print-envvar",
+				Type:        workflowapi.NodeTypePod,
+				Phase:       workflowapi.NodePending,
+				Message:     `containers with unready status: [main] (Message: secret "my-secret-that-doesnt-exist" not found: CreateContainerConfigError)`,
+				StartedAt:   startTime,
+			},
+			wantState: string(workflowapi.NodeFailed),
+		},
+		{
+			name: "running pod CreateContainerError",
+			node: workflowapi.NodeStatus{
+				ID:          "n2",
+				DisplayName: "step",
+				Type:        workflowapi.NodeTypePod,
+				Phase:       workflowapi.NodeRunning,
+				Message:     "failed to create container: CreateContainerError",
+				StartedAt:   startTime,
+			},
+			wantState: string(workflowapi.NodeFailed),
+		},
+		{
+			name: "pending pod ImagePullBackOff",
+			node: workflowapi.NodeStatus{
+				ID:          "n2b",
+				DisplayName: "pull",
+				Type:        workflowapi.NodeTypePod,
+				Phase:       workflowapi.NodePending,
+				Message:     "Back-off pulling image \"x\": ImagePullBackOff",
+				StartedAt:   startTime,
+			},
+			wantState: string(workflowapi.NodeFailed),
+		},
+		{
+			name: "running pod ErrImagePull",
+			node: workflowapi.NodeStatus{
+				ID:          "n2c",
+				DisplayName: "pull2",
+				Type:        workflowapi.NodeTypePod,
+				Phase:       workflowapi.NodeRunning,
+				Message:     "Failed to pull image: ErrImagePull",
+				StartedAt:   startTime,
+			},
+			wantState: string(workflowapi.NodeFailed),
+		},
+		{
+			name: "pending pod InvalidImageName",
+			node: workflowapi.NodeStatus{
+				ID:          "n2d",
+				DisplayName: "badimg",
+				Type:        workflowapi.NodeTypePod,
+				Phase:       workflowapi.NodePending,
+				Message:     "InvalidImageName: invalid reference format",
+				StartedAt:   startTime,
+			},
+			wantState: string(workflowapi.NodeFailed),
+		},
+		{
+			name: "running pod CrashLoopBackOff",
+			node: workflowapi.NodeStatus{
+				ID:          "n2e",
+				DisplayName: "crash",
+				Type:        workflowapi.NodeTypePod,
+				Phase:       workflowapi.NodeRunning,
+				Message:     "Back-off restarting failed container: CrashLoopBackOff",
+				StartedAt:   startTime,
+			},
+			wantState: string(workflowapi.NodeFailed),
+		},
+		{
+			name: "pending pod RunContainerError",
+			node: workflowapi.NodeStatus{
+				ID:          "n2f",
+				DisplayName: "runerr",
+				Type:        workflowapi.NodeTypePod,
+				Phase:       workflowapi.NodePending,
+				Message:     "failed to start container: RunContainerError",
+				StartedAt:   startTime,
+			},
+			wantState: string(workflowapi.NodeFailed),
+		},
+		{
+			name: "pending pod without fatal message",
+			node: workflowapi.NodeStatus{
+				ID:          "n3",
+				DisplayName: "ok",
+				Type:        workflowapi.NodeTypePod,
+				Phase:       workflowapi.NodePending,
+				Message:     "ContainerCreating",
+				StartedAt:   startTime,
+			},
+			wantState: string(workflowapi.NodePending),
+		},
+		{
+			name: "dag node with CreateContainerConfigError text ignored",
+			node: workflowapi.NodeStatus{
+				ID:          "n4",
+				DisplayName: "root",
+				Type:        workflowapi.NodeTypeDAG,
+				Phase:       workflowapi.NodeRunning,
+				Message:     "child has CreateContainerConfigError",
+				StartedAt:   startTime,
+			},
+			wantState: string(workflowapi.NodeRunning),
+		},
+		{
+			name: "pod already failed unchanged",
+			node: workflowapi.NodeStatus{
+				ID:          "n5",
+				DisplayName: "x",
+				Type:        workflowapi.NodeTypePod,
+				Phase:       workflowapi.NodeFailed,
+				Message:     "CreateContainerConfigError: ...",
+				StartedAt:   startTime,
+			},
+			wantState: string(workflowapi.NodeFailed),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wf := NewWorkflow(&workflowapi.Workflow{
+				ObjectMeta: metav1.ObjectMeta{Name: "wf"},
+				Status: workflowapi.WorkflowStatus{
+					Nodes: map[string]workflowapi.NodeStatus{"x": tt.node},
+				},
+			})
+			ns := wf.NodeStatuses()["x"]
+			assert.Equal(t, tt.wantState, ns.State)
+		})
+	}
+}
+
+func TestWorkflow_NodeStatuses_InferredFailureFinishTimeUsesStartedAt(t *testing.T) {
+	startTime := metav1.NewTime(time.Unix(100, 0).UTC())
+	node := workflowapi.NodeStatus{
+		ID:          "p1",
+		DisplayName: "task",
+		Type:        workflowapi.NodeTypePod,
+		Phase:       workflowapi.NodePending,
+		Message:     "CreateContainerConfigError: mount failed",
+		StartedAt:   startTime,
+		// FinishedAt zero
+	}
+	wf := NewWorkflow(&workflowapi.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "wf"},
+		Status: workflowapi.WorkflowStatus{
+			Nodes: map[string]workflowapi.NodeStatus{"x": node},
+		},
+	})
+	ns := wf.NodeStatuses()["x"]
+	assert.Equal(t, string(workflowapi.NodeFailed), ns.State)
+	assert.Equal(t, startTime.Unix(), ns.FinishTime)
+}
+
 func TestWorkflow_Compare(t *testing.T) {
 	client := &WorkflowClient{}
 

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -521,9 +521,9 @@ const OutputMetadataFilepath = "/tmp/kfp_outputs/output_metadata.json"
 // We overwrite this as a DI mechanism for testing getLogWriter.
 var osCreateFunc = os.Create
 
-// qualifyExecutorLogsURI appends the retry index to the executor-logs artifact
-// URI so that each Argo retry attempt writes to and registers a distinct,
-// human-readable path in the object store and MLMD (e.g. executor-logs-0,
+// qualifyExecutorLogsURI mutates the executor-logs artifact URI in-place,
+// appending the retry index so that each Argo retry attempt writes to a
+// distinct path in the object store and MLMD (e.g. executor-logs-0,
 // executor-logs-1, …). Without this, all retry pods share the single URI that
 // the driver provisioned before any attempt ran, causing every retry to
 // overwrite the same S3 key and register duplicate MLMD artifacts pointing at
@@ -543,12 +543,20 @@ func qualifyExecutorLogsURI(artifacts map[string]*pipelinespec.ArtifactList, ret
 	art.Uri = art.Uri + "-" + retryIndex
 }
 
+// errNoRetrySuffix is returned by retryIndexFromPodAnnotation when the Argo
+// node-name annotation exists but has no "(N)" retry suffix. This is the
+// expected case for non-retry (single-attempt) pods and should not be logged
+// as a warning.
+var errNoRetrySuffix = errors.New("argo node-name has no retry index suffix")
+
 // retryIndexFromPodAnnotation reads the Argo node-name annotation on the current
 // pod and parses the 0-based retry index from it. Argo encodes the index as a
 // parenthesised suffix on the node name, e.g. "…executor(3)". This provides a
 // fallback when the KFP_RETRY_INDEX env var (set via {{retries}} in the Argo
 // template) is unavailable, which is the case when an older API server that
 // does not yet inject KFP_RETRY_INDEX is in use.
+//
+// Returns errNoRetrySuffix for non-retry pods (expected, not an error condition).
 func retryIndexFromPodAnnotation(ctx context.Context, k8sClient kubernetes.Interface, namespace, podName string) (string, error) {
 	pod, err := k8sClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
@@ -562,7 +570,7 @@ func retryIndexFromPodAnnotation(ctx context.Context, k8sClient kubernetes.Inter
 	open := strings.LastIndex(nodeName, "(")
 	close := strings.LastIndex(nodeName, ")")
 	if open < 0 || close <= open {
-		return "", fmt.Errorf("argo node-name %q has no retry index suffix", nodeName)
+		return "", fmt.Errorf("%w: %q", errNoRetrySuffix, nodeName)
 	}
 	index := nodeName[open+1 : close]
 	if _, err := strconv.Atoi(index); err != nil {
@@ -651,7 +659,7 @@ func execute(
 			if podName != "" && k8sClient != nil && namespace != "" {
 				if idx, err := retryIndexFromPodAnnotation(ctx, k8sClient, namespace, podName); err == nil {
 					retryIndex = idx
-				} else {
+				} else if !errors.Is(err, errNoRetrySuffix) {
 					glog.Warningf("Could not determine retry index from pod annotation, defaulting to 0: %v", err)
 				}
 			}

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -499,10 +499,11 @@ func Test_qualifyExecutorLogsURI(t *testing.T) {
 
 func Test_retryIndexFromPodAnnotation(t *testing.T) {
 	tests := []struct {
-		name       string
-		annotation string
-		wantIndex  string
-		wantErr    bool
+		name           string
+		annotation     string
+		wantIndex      string
+		wantErr        bool
+		wantNoRetrySuf bool
 	}{
 		{
 			name:       "parses first attempt (0)",
@@ -520,9 +521,10 @@ func Test_retryIndexFromPodAnnotation(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "annotation without parenthesised suffix",
-			annotation: "my-pipeline-abc.root.always-fail.executor",
-			wantErr:    true,
+			name:           "annotation without parenthesised suffix returns errNoRetrySuffix",
+			annotation:     "my-pipeline-abc.root.always-fail.executor",
+			wantErr:        true,
+			wantNoRetrySuf: true,
 		},
 		{
 			name:       "annotation with non-integer index",
@@ -548,6 +550,10 @@ func Test_retryIndexFromPodAnnotation(t *testing.T) {
 			idx, err := retryIndexFromPodAnnotation(context.Background(), clientset, "test-ns", "test-pod")
 			if tc.wantErr {
 				assert.Error(t, err)
+				if tc.wantNoRetrySuf {
+					assert.True(t, errors.Is(err, errNoRetrySuffix),
+						"expected errNoRetrySuffix sentinel for non-retry pods, got: %v", err)
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.wantIndex, idx)

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -60,6 +60,11 @@ const (
 	// than a typical RPC retry budget because MySQL deadlocks (codes.Aborted) on
 	// the MLMD server are transient and require time to resolve under sustained
 	// parallel execution.
+	//
+	// Worst-case total retry latency with these settings is approximately
+	// 4–5 minutes (sum of capped exponential backoff intervals across 10
+	// attempts). During a sustained MLMD outage, launcher pods will stall
+	// for this duration before failing.
 	mlmdClientSideMaxRetries    = 10
 	mlmdClientSideBackoffBase   = 1 * time.Second
 	mlmdClientSideBackoffJitter = 0.25

--- a/backend/test/v2/integration/run_api_test.go
+++ b/backend/test/v2/integration/run_api_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -432,6 +434,77 @@ func (s *RunAPITestSuite) checkArgParamsRunDetail(t *testing.T, run *run_model.V
 	}
 
 	assert.Equal(t, expectedRun, run)
+}
+
+// TestRunAPIx_MissingSecretEnvReportsFailedTaskDetail polls the cluster until
+// run_details.task_details reports at least one FAILED task caused by a missing Secret
+// (CreateContainerConfigError). In v2, the failing node is the "executor" pod, not the KFP task itself.
+func (s *RunAPITestSuite) TestRunAPIx_MissingSecretEnvReportsFailedTaskDetail() {
+	t := s.T()
+	const pipelinePath = "../resources/missing-secret-env.yaml"
+	pl, err := s.pipelineUploadClient.UploadFile(pipelinePath, upload_params.NewUploadPipelineParams())
+	require.NoError(t, err)
+	require.NotNil(t, pl)
+	time.Sleep(1 * time.Second)
+	pv, err := s.pipelineUploadClient.UploadPipelineVersion(
+		pipelinePath,
+		&upload_params.UploadPipelineVersionParams{
+			Name:       util.StringPointer("e2e-missing-secret-env"),
+			Pipelineid: util.StringPointer(pl.PipelineID),
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, pv)
+
+	exp := test.MakeExperiment("e2e missing secret env", "", s.resourceNamespace)
+	ex, err := s.experimentClient.Create(&experiment_params.ExperimentServiceCreateExperimentParams{Experiment: exp})
+	require.NoError(t, err)
+
+	runDetail, err := s.runClient.Create(&run_params.RunServiceCreateRunParams{Run: &run_model.V2beta1Run{
+		DisplayName:  "e2e-missing-secret-env-run",
+		Description:  "Expect FAILED task_details when Secret is missing (CreateContainerConfigError)",
+		ExperimentID: ex.ExperimentID,
+		PipelineVersionReference: &run_model.V2beta1PipelineVersionReference{
+			PipelineID:        pv.PipelineID,
+			PipelineVersionID: pv.PipelineVersionID,
+		},
+	}})
+	require.NoError(t, err)
+	require.NotEmpty(t, runDetail.RunID)
+
+	deadline := time.Now().Add(8 * time.Minute)
+	var failedDisplayName string
+	var lastDebug string
+	for time.Now().Before(deadline) {
+		time.Sleep(5 * time.Second)
+		run, err := s.runClient.Get(&run_params.RunServiceGetRunParams{RunID: runDetail.RunID})
+		if err != nil {
+			lastDebug = fmt.Sprintf("get error (will retry): %v", err)
+			continue
+		}
+		if run.RunDetails == nil {
+			lastDebug = "run_details=nil"
+			continue
+		}
+		var parts []string
+		for _, td := range run.RunDetails.TaskDetails {
+			st := "<nil>"
+			if td.State != nil {
+				st = string(*td.State)
+			}
+			parts = append(parts, fmt.Sprintf("%q:%s", td.DisplayName, st))
+			if td.State != nil && *td.State == run_model.V2beta1RuntimeStateFAILED {
+				failedDisplayName = td.DisplayName
+			}
+		}
+		lastDebug = fmt.Sprintf("task_details[%s]", strings.Join(parts, ", "))
+		if failedDisplayName != "" {
+			break
+		}
+	}
+	require.NotEmpty(t, failedDisplayName,
+		"expected at least one FAILED task in run_details.task_details (missing Secret / CreateContainerConfigError); last poll: %s", lastDebug)
+	t.Logf("FAILED task display_name=%q (v2 executor pod); last poll: %s", failedDisplayName, lastDebug)
 }
 
 func TestRunAPI(t *testing.T) {

--- a/backend/test/v2/resources/missing-secret-env.yaml
+++ b/backend/test/v2/resources/missing-secret-env.yaml
@@ -1,0 +1,69 @@
+# PIPELINE DEFINITION
+# Name: e2e-missing-secret-env
+components:
+  comp-missing-secret-task:
+    executorLabel: exec-missing-secret-task
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-missing-secret-task:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - missing_secret_task
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef missing_secret_task() -> str:\n    import os\n    return os.getenv('KFP_E2E_MISSING_SECRET_ENV_MARKER',\
+          \ '')\n\n"
+        image: public.ecr.aws/docker/library/python:3.12
+pipelineInfo:
+  name: e2e-missing-secret-env
+root:
+  dag:
+    tasks:
+      missing-secret-task:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-missing-secret-task
+        taskInfo:
+          name: missing-secret-task
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.15.2
+---
+platforms:
+  kubernetes:
+    deploymentSpec:
+      executors:
+        exec-missing-secret-task:
+          secretAsEnv:
+          - keyToEnv:
+            - envVar: KFP_E2E_MISSING_SECRET_ENV_MARKER
+              secretKey: placeholder-key
+            optional: false
+            secretName: kfp-e2e-missing-secret-not-found
+            secretNameParameter:
+              runtimeValue:
+                constant: kfp-e2e-missing-secret-not-found

--- a/backend/test/v2/resources/missing_secret_env_e2e_pipeline.py
+++ b/backend/test/v2/resources/missing_secret_env_e2e_pipeline.py
@@ -1,0 +1,56 @@
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pipeline IR source for v2 integration: missing Secret → CreateContainerConfigError.
+
+Regenerate the checked-in YAML (KFP pipeline spec IR, not an Argo Workflow):
+
+  cd backend/test/v2/resources
+  kfp dsl compile --py missing_secret_env_e2e_pipeline.py --output missing-secret-env.yaml
+
+Requires editable installs: kfp, kfp-kubernetes (see repo AGENTS.md).
+The compiled YAML embeds the SDK version at compilation time (sdkVersion field).
+
+Cluster E2E: RunAPITestSuite.TestRunAPIx_MissingSecretEnvReportsFailedTaskDetail in
+backend/test/v2/integration (requires -runIntegrationTests=true).
+"""
+from kfp import dsl
+from kfp import kubernetes
+
+# Intentionally does not exist in the cluster; kubelet surfaces CreateContainerConfigError.
+_MISSING_SECRET_NAME = 'kfp-e2e-missing-secret-not-found'
+
+
+@dsl.component(base_image='public.ecr.aws/docker/library/python:3.12')
+def missing_secret_task() -> str:
+    import os
+    return os.getenv('KFP_E2E_MISSING_SECRET_ENV_MARKER', '')
+
+
+@dsl.pipeline(name='e2e-missing-secret-env')
+def e2e_missing_secret_env_pipeline():
+    task = missing_secret_task()
+    kubernetes.use_secret_as_env(
+        task,
+        secret_name=_MISSING_SECRET_NAME,
+        secret_key_to_env={'placeholder-key': 'KFP_E2E_MISSING_SECRET_ENV_MARKER'},
+    )
+
+
+if __name__ == '__main__':
+    from kfp import compiler
+
+    compiler.Compiler().compile(
+        e2e_missing_secret_env_pipeline,
+        package_path='missing-secret-env.yaml',
+    )

--- a/frontend/src/lib/v2/DynamicFlow.test.ts
+++ b/frontend/src/lib/v2/DynamicFlow.test.ts
@@ -15,14 +15,23 @@
 import { Node } from '@xyflow/react';
 import { FlowElementDataBase } from 'src/components/graph/Constants';
 import { PipelineSpec } from 'src/generated/pipeline_spec';
+import { V2beta1RuntimeState } from 'src/apisv2beta1/run/models/V2beta1RuntimeState';
 import { Artifact, Event, Execution, Value } from 'src/third_party/mlmd';
 import {
   getNodeMlmdInfo,
+  ITERATION_COUNT_KEY,
+  ITERATION_INDEX_KEY,
   PARENT_DAG_ID_KEY,
   TASK_NAME_KEY,
   updateFlowElementsState,
 } from './DynamicFlow';
-import { convertFlowElements, getTaskKeyFromNodeKey, NodeTypeNames } from './StaticFlow';
+import {
+  convertFlowElements,
+  getTaskKeyFromNodeKey,
+  getTaskNodeKey,
+  NodeTypeNames,
+  TaskType,
+} from './StaticFlow';
 import v2YamlTemplateString from 'src/data/test/lightweight_python_functions_v2_pipeline_rev.yaml?raw';
 import jsyaml from 'js-yaml';
 
@@ -142,6 +151,202 @@ describe('DynamicFlow', () => {
       expect(updatedPreprocessNode.hidden).toBeUndefined();
       expect(updatedPreprocessNode.measured).toEqual({ width: 123, height: 45 });
       expect(updatedPreprocessNode.data?.state).toEqual(preprocessExecution.getLastKnownState());
+    });
+
+    it('overlays FAILED from run task_details when MLMD is still RUNNING', () => {
+      const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
+      EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
+      const EXECUTION_TRAIN = new Execution()
+        .setId(4)
+        .setLastKnownState(Execution.State.RUNNING);
+      EXECUTION_TRAIN.getCustomPropertiesMap()
+        .set(TASK_NAME_KEY, new Value().setStringValue('train'))
+        .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));
+
+      const yamlObject = jsyaml.safeLoad(v2YamlTemplateString);
+      const pipelineSpec = PipelineSpec.fromJSON(yamlObject);
+      const graph = convertFlowElements(pipelineSpec);
+
+      const runtimeGraph = updateFlowElementsState(
+        ['root'],
+        graph,
+        [EXECUTION_ROOT, EXECUTION_TRAIN],
+        [],
+        [],
+        [{ display_name: 'train', state: V2beta1RuntimeState.FAILED }],
+      );
+      const trainNode = runtimeGraph.find((e) => e.id === 'task.train');
+      expect(trainNode?.data?.state).toEqual(Execution.State.FAILED);
+    });
+
+    it('overlays FAILED for hyphenated executor task when MLMD is RUNNING (secretAsEnv / print-envvar shape)', () => {
+      const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
+      EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
+      const EXECUTION_PRINT = new Execution()
+        .setId(11)
+        .setLastKnownState(Execution.State.RUNNING);
+      EXECUTION_PRINT.getCustomPropertiesMap()
+        .set(TASK_NAME_KEY, new Value().setStringValue('print-envvar'))
+        .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));
+
+      const singleTaskGraph: Node<FlowElementDataBase>[] = [
+        {
+          id: 'task.print-envvar',
+          type: NodeTypeNames.EXECUTION,
+          position: { x: 0, y: 0 },
+          data: { label: 'print-envvar', taskType: TaskType.EXECUTOR },
+        },
+      ];
+
+      const runtimeGraph = updateFlowElementsState(
+        ['root'],
+        singleTaskGraph,
+        [EXECUTION_ROOT, EXECUTION_PRINT],
+        [],
+        [],
+        [{ display_name: 'print-envvar', state: V2beta1RuntimeState.FAILED }],
+      );
+      const printNode = runtimeGraph.find((e) => e.id === 'task.print-envvar');
+      expect(printNode?.data?.state).toEqual(Execution.State.FAILED);
+    });
+
+    it('overlays FAILED from execution_id when display_name does not match task key', () => {
+      const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
+      EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
+      const EXECUTION_TRAIN = new Execution()
+        .setId(4)
+        .setLastKnownState(Execution.State.RUNNING);
+      EXECUTION_TRAIN.getCustomPropertiesMap()
+        .set(TASK_NAME_KEY, new Value().setStringValue('train'))
+        .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));
+
+      const yamlObject = jsyaml.safeLoad(v2YamlTemplateString);
+      const pipelineSpec = PipelineSpec.fromJSON(yamlObject);
+      const graph = convertFlowElements(pipelineSpec);
+
+      const runtimeGraph = updateFlowElementsState(
+        ['root'],
+        graph,
+        [EXECUTION_ROOT, EXECUTION_TRAIN],
+        [],
+        [],
+        [{ display_name: 'different-ui-label', execution_id: '4', state: V2beta1RuntimeState.FAILED }],
+      );
+      const trainNode = runtimeGraph.find((e) => e.id === 'task.train');
+      expect(trainNode?.data?.state).toEqual(Execution.State.FAILED);
+    });
+
+    it('overlays FAILED on parallel-for iteration node via execution_id when display_name mismatches', () => {
+      const expandNoop = (): void => {};
+      const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
+      EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
+
+      const EXECUTION_PAR = new Execution().setId(10).setLastKnownState(Execution.State.RUNNING);
+      EXECUTION_PAR.getCustomPropertiesMap()
+        .set(TASK_NAME_KEY, new Value().setStringValue('par'))
+        .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2))
+        .set(ITERATION_COUNT_KEY, new Value().setIntValue(2));
+
+      const EXECUTION_PAR_ITER0 = new Execution().setId(99).setLastKnownState(Execution.State.RUNNING);
+      EXECUTION_PAR_ITER0.getCustomPropertiesMap()
+        .set(TASK_NAME_KEY, new Value().setStringValue('par'))
+        .set(PARENT_DAG_ID_KEY, new Value().setIntValue(10))
+        .set(ITERATION_INDEX_KEY, new Value().setIntValue(0));
+
+      const parallelForElems: Node<FlowElementDataBase>[] = [
+        {
+          id: getTaskNodeKey('par.0'),
+          type: NodeTypeNames.SUB_DAG,
+          position: { x: 0, y: 0 },
+          data: { label: 'par.0', taskType: TaskType.DAG, expand: expandNoop },
+        },
+      ];
+
+      const runtimeGraph = updateFlowElementsState(
+        ['root', 'par'],
+        parallelForElems,
+        [EXECUTION_ROOT, EXECUTION_PAR, EXECUTION_PAR_ITER0],
+        [],
+        [],
+        [
+          {
+            display_name: 'iteration-0-api-label',
+            execution_id: '99',
+            state: V2beta1RuntimeState.FAILED,
+          },
+        ],
+      );
+      const iterNode = runtimeGraph.find((e) => e.id === getTaskNodeKey('par.0'));
+      expect(iterNode?.data?.state).toEqual(Execution.State.FAILED);
+    });
+
+    it('overlays FAILED from execution_id only (no display_name)', () => {
+      const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
+      EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
+      const EXECUTION_TRAIN = new Execution()
+        .setId(4)
+        .setLastKnownState(Execution.State.RUNNING);
+      EXECUTION_TRAIN.getCustomPropertiesMap()
+        .set(TASK_NAME_KEY, new Value().setStringValue('train'))
+        .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));
+
+      const yamlObject = jsyaml.safeLoad(v2YamlTemplateString);
+      const pipelineSpec = PipelineSpec.fromJSON(yamlObject);
+      const graph = convertFlowElements(pipelineSpec);
+
+      const runtimeGraph = updateFlowElementsState(
+        ['root'],
+        graph,
+        [EXECUTION_ROOT, EXECUTION_TRAIN],
+        [],
+        [],
+        [{ execution_id: '4', state: V2beta1RuntimeState.FAILED }],
+      );
+      const trainNode = runtimeGraph.find((e) => e.id === 'task.train');
+      expect(trainNode?.data?.state).toEqual(Execution.State.FAILED);
+    });
+
+    it('accepts numeric execution_id from JSON-shaped task details', () => {
+      const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
+      EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
+      const EXECUTION_TRAIN = new Execution()
+        .setId(4)
+        .setLastKnownState(Execution.State.RUNNING);
+      EXECUTION_TRAIN.getCustomPropertiesMap()
+        .set(TASK_NAME_KEY, new Value().setStringValue('train'))
+        .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));
+
+      const yamlObject = jsyaml.safeLoad(v2YamlTemplateString);
+      const pipelineSpec = PipelineSpec.fromJSON(yamlObject);
+      const graph = convertFlowElements(pipelineSpec);
+
+      const runtimeGraph = updateFlowElementsState(
+        ['root'],
+        graph,
+        [EXECUTION_ROOT, EXECUTION_TRAIN],
+        [],
+        [],
+        [{ execution_id: 4 as unknown as string, state: V2beta1RuntimeState.FAILED }],
+      );
+      const trainNode = runtimeGraph.find((e) => e.id === 'task.train');
+      expect(trainNode?.data?.state).toEqual(Execution.State.FAILED);
+    });
+
+    it('applies task_details FAILED when MLMD execution layers are incomplete', () => {
+      const yamlObject = jsyaml.safeLoad(v2YamlTemplateString);
+      const pipelineSpec = PipelineSpec.fromJSON(yamlObject);
+      const graph = convertFlowElements(pipelineSpec);
+
+      const runtimeGraph = updateFlowElementsState(
+        ['root'],
+        graph,
+        [],
+        [],
+        [],
+        [{ display_name: 'train', state: V2beta1RuntimeState.FAILED }],
+      );
+      const trainNode = runtimeGraph.find((e) => e.id === 'task.train');
+      expect(trainNode?.data?.state).toEqual(Execution.State.FAILED);
     });
   });
 

--- a/frontend/src/lib/v2/DynamicFlow.test.ts
+++ b/frontend/src/lib/v2/DynamicFlow.test.ts
@@ -346,6 +346,39 @@ describe('DynamicFlow', () => {
       const trainNode = runtimeGraph.find((e) => e.id === 'task.train');
       expect(trainNode?.data?.state).toEqual(Execution.State.FAILED);
     });
+
+    it('skips display_name fallback in nested sub-DAG layers to avoid cross-DAG collisions', () => {
+      const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
+      EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
+      const EXECUTION_SUBDAG = new Execution()
+        .setId(10)
+        .setLastKnownState(Execution.State.RUNNING);
+      EXECUTION_SUBDAG.getCustomPropertiesMap()
+        .set(TASK_NAME_KEY, new Value().setStringValue('inner'))
+        .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));
+
+      const innerTaskElems: Node<FlowElementDataBase>[] = [
+        {
+          id: 'task.inner-step',
+          type: NodeTypeNames.EXECUTION,
+          position: { x: 0, y: 0 },
+          data: { label: 'inner-step', taskType: TaskType.EXECUTOR },
+        },
+      ];
+
+      const runtimeGraph = updateFlowElementsState(
+        ['root', 'inner'],
+        innerTaskElems,
+        [EXECUTION_ROOT, EXECUTION_SUBDAG],
+        [],
+        [],
+        [{ display_name: 'inner-step', state: V2beta1RuntimeState.FAILED }],
+      );
+      const innerNode = runtimeGraph.find((e) => e.id === 'task.inner-step');
+      // display_name fallback is disabled in nested layers; without execution_id
+      // or mlmdId match, the node should NOT be marked FAILED.
+      expect(innerNode?.data?.state).not.toEqual(Execution.State.FAILED);
+    });
   });
 
   describe('getNodeMlmdInfo', () => {

--- a/frontend/src/lib/v2/DynamicFlow.test.ts
+++ b/frontend/src/lib/v2/DynamicFlow.test.ts
@@ -156,9 +156,7 @@ describe('DynamicFlow', () => {
     it('overlays FAILED from run task_details when MLMD is still RUNNING', () => {
       const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
       EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
-      const EXECUTION_TRAIN = new Execution()
-        .setId(4)
-        .setLastKnownState(Execution.State.RUNNING);
+      const EXECUTION_TRAIN = new Execution().setId(4).setLastKnownState(Execution.State.RUNNING);
       EXECUTION_TRAIN.getCustomPropertiesMap()
         .set(TASK_NAME_KEY, new Value().setStringValue('train'))
         .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));
@@ -182,9 +180,7 @@ describe('DynamicFlow', () => {
     it('overlays FAILED for hyphenated executor task when MLMD is RUNNING (secretAsEnv / print-envvar shape)', () => {
       const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
       EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
-      const EXECUTION_PRINT = new Execution()
-        .setId(11)
-        .setLastKnownState(Execution.State.RUNNING);
+      const EXECUTION_PRINT = new Execution().setId(11).setLastKnownState(Execution.State.RUNNING);
       EXECUTION_PRINT.getCustomPropertiesMap()
         .set(TASK_NAME_KEY, new Value().setStringValue('print-envvar'))
         .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));
@@ -213,9 +209,7 @@ describe('DynamicFlow', () => {
     it('overlays FAILED from execution_id when display_name does not match task key', () => {
       const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
       EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
-      const EXECUTION_TRAIN = new Execution()
-        .setId(4)
-        .setLastKnownState(Execution.State.RUNNING);
+      const EXECUTION_TRAIN = new Execution().setId(4).setLastKnownState(Execution.State.RUNNING);
       EXECUTION_TRAIN.getCustomPropertiesMap()
         .set(TASK_NAME_KEY, new Value().setStringValue('train'))
         .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));
@@ -230,7 +224,13 @@ describe('DynamicFlow', () => {
         [EXECUTION_ROOT, EXECUTION_TRAIN],
         [],
         [],
-        [{ display_name: 'different-ui-label', execution_id: '4', state: V2beta1RuntimeState.FAILED }],
+        [
+          {
+            display_name: 'different-ui-label',
+            execution_id: '4',
+            state: V2beta1RuntimeState.FAILED,
+          },
+        ],
       );
       const trainNode = runtimeGraph.find((e) => e.id === 'task.train');
       expect(trainNode?.data?.state).toEqual(Execution.State.FAILED);
@@ -247,7 +247,9 @@ describe('DynamicFlow', () => {
         .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2))
         .set(ITERATION_COUNT_KEY, new Value().setIntValue(2));
 
-      const EXECUTION_PAR_ITER0 = new Execution().setId(99).setLastKnownState(Execution.State.RUNNING);
+      const EXECUTION_PAR_ITER0 = new Execution()
+        .setId(99)
+        .setLastKnownState(Execution.State.RUNNING);
       EXECUTION_PAR_ITER0.getCustomPropertiesMap()
         .set(TASK_NAME_KEY, new Value().setStringValue('par'))
         .set(PARENT_DAG_ID_KEY, new Value().setIntValue(10))
@@ -283,9 +285,7 @@ describe('DynamicFlow', () => {
     it('overlays FAILED from execution_id only (no display_name)', () => {
       const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
       EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
-      const EXECUTION_TRAIN = new Execution()
-        .setId(4)
-        .setLastKnownState(Execution.State.RUNNING);
+      const EXECUTION_TRAIN = new Execution().setId(4).setLastKnownState(Execution.State.RUNNING);
       EXECUTION_TRAIN.getCustomPropertiesMap()
         .set(TASK_NAME_KEY, new Value().setStringValue('train'))
         .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));
@@ -309,9 +309,7 @@ describe('DynamicFlow', () => {
     it('accepts numeric execution_id from JSON-shaped task details', () => {
       const EXECUTION_ROOT = new Execution().setId(2).setLastKnownState(Execution.State.COMPLETE);
       EXECUTION_ROOT.getCustomPropertiesMap().set(TASK_NAME_KEY, new Value().setStringValue(''));
-      const EXECUTION_TRAIN = new Execution()
-        .setId(4)
-        .setLastKnownState(Execution.State.RUNNING);
+      const EXECUTION_TRAIN = new Execution().setId(4).setLastKnownState(Execution.State.RUNNING);
       EXECUTION_TRAIN.getCustomPropertiesMap()
         .set(TASK_NAME_KEY, new Value().setStringValue('train'))
         .set(PARENT_DAG_ID_KEY, new Value().setIntValue(2));

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -116,10 +116,7 @@ function applyFailedOverlayFromTaskDetails(
     return;
   }
   const label = data?.label;
-  if (
-    !overlay.displayNames.has(taskKey) &&
-    !(label && overlay.displayNames.has(label))
-  ) {
+  if (!overlay.displayNames.has(taskKey) && !(label && overlay.displayNames.has(label))) {
     return;
   }
   if (elem.type === NodeTypeNames.EXECUTION) {

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -21,6 +21,8 @@ import {
   SubDagFlowElementData,
 } from 'src/components/graph/Constants';
 import { PipelineSpec, PipelineTaskSpec } from 'src/generated/pipeline_spec';
+import type { V2beta1PipelineTaskDetail } from 'src/apisv2beta1/run/models/V2beta1PipelineTaskDetail';
+import { V2beta1RuntimeState } from 'src/apisv2beta1/run/models/V2beta1RuntimeState';
 import {
   buildDag,
   buildGraphLayout,
@@ -41,6 +43,91 @@ export const TASK_NAME_KEY = 'task_name';
 export const PARENT_DAG_ID_KEY = 'parent_dag_id';
 export const ITERATION_COUNT_KEY = 'iteration_count';
 export const ITERATION_INDEX_KEY = 'iteration_index';
+
+type TaskDetailsFailedOverlay = {
+  displayNames: Set<string>;
+  /** MLMD execution ids from the API, stored as decimal strings (avoids Number precision loss). */
+  executionIds: Set<string>;
+};
+
+function isTaskDetailsFailedOverlayEmpty(overlay: TaskDetailsFailedOverlay): boolean {
+  return overlay.displayNames.size === 0 && overlay.executionIds.size === 0;
+}
+
+// JSON may send execution_id as string or number; normalize without floating-point coercion.
+function normalizeTaskDetailExecutionId(raw: unknown): string | undefined {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+  const s = String(raw).trim();
+  return s === '' ? undefined : s;
+}
+
+function buildTaskDetailsFailedOverlay(
+  taskDetails: V2beta1PipelineTaskDetail[] | undefined,
+): TaskDetailsFailedOverlay {
+  const displayNames = new Set<string>();
+  const executionIds = new Set<string>();
+  if (!taskDetails?.length) {
+    return { displayNames, executionIds };
+  }
+  for (const detail of taskDetails) {
+    if (detail.state !== V2beta1RuntimeState.FAILED) {
+      continue;
+    }
+    if (detail.display_name) {
+      displayNames.add(detail.display_name);
+    }
+    const idStr = normalizeTaskDetailExecutionId(detail.execution_id);
+    if (idStr !== undefined) {
+      executionIds.add(idStr);
+    }
+  }
+  return { displayNames, executionIds };
+}
+
+function applyFailedOverlayFromTaskDetails(
+  elem: PipelineFlowElement,
+  overlay: TaskDetailsFailedOverlay,
+): void {
+  if (
+    isTaskDetailsFailedOverlayEmpty(overlay) ||
+    (elem.type !== NodeTypeNames.EXECUTION && elem.type !== NodeTypeNames.SUB_DAG)
+  ) {
+    return;
+  }
+  const data = elem.data as ExecutionFlowElementData | SubDagFlowElementData;
+  const mlmdId = data?.mlmdId;
+  if (mlmdId !== undefined && overlay.executionIds.has(String(mlmdId))) {
+    if (elem.type === NodeTypeNames.EXECUTION) {
+      (elem.data as ExecutionFlowElementData).state = Execution.State.FAILED;
+    } else {
+      (elem.data as SubDagFlowElementData).state = Execution.State.FAILED;
+    }
+    return;
+  }
+  let taskKey: string;
+  try {
+    taskKey = getTaskKeyFromNodeKey(elem.id);
+  } catch (err) {
+    if (process.env.NODE_ENV === 'development') {
+      console.warn('applyFailedOverlayFromTaskDetails: skip node', elem.id, err);
+    }
+    return;
+  }
+  const label = data?.label;
+  if (
+    !overlay.displayNames.has(taskKey) &&
+    !(label && overlay.displayNames.has(label))
+  ) {
+    return;
+  }
+  if (elem.type === NodeTypeNames.EXECUTION) {
+    (elem.data as ExecutionFlowElementData).state = Execution.State.FAILED;
+  } else {
+    (elem.data as SubDagFlowElementData).state = Execution.State.FAILED;
+  }
+}
 
 export function convertSubDagToRuntimeFlowElements(
   spec: PipelineSpec,
@@ -221,11 +308,23 @@ export function updateFlowElementsState(
   executions: Execution[],
   events: Event[],
   artifacts: Artifact[],
+  taskDetails?: V2beta1PipelineTaskDetail[],
 ): PipelineFlowElement[] {
   const executionLayers = getExecutionLayers(layers, executions);
+  const failedFromApi = buildTaskDetailsFailedOverlay(taskDetails);
+
   if (executionLayers.length < layers.length) {
-    // This Sub DAG is not executed yet. There is no runtime information to update.
-    return elems;
+    // Sub-DAG layer not fully matched in MLMD yet; still apply API task_details overlay for failures.
+    if (isTaskDetailsFailedOverlayEmpty(failedFromApi)) {
+      return elems;
+    }
+    const overlayGraph: PipelineFlowElement[] = [];
+    for (const elem of elems) {
+      const updatedElem = cloneFlowElement(elem);
+      applyFailedOverlayFromTaskDetails(updatedElem, failedFromApi);
+      overlayGraph.push(updatedElem);
+    }
+    return overlayGraph;
   }
 
   const taskNameToExecution = getTaskNameToExecution(executions);
@@ -257,7 +356,9 @@ export function updateFlowElementsState(
       });
       if (matchedExecs && matchedExecs.length > 0) {
         (updatedElem.data as SubDagFlowElementData).state = matchedExecs[0].getLastKnownState();
+        (updatedElem.data as SubDagFlowElementData).mlmdId = matchedExecs[0].getId();
       }
+      applyFailedOverlayFromTaskDetails(updatedElem, failedFromApi);
       flowGraph.push(updatedElem);
     }
     return flowGraph;
@@ -306,6 +407,7 @@ export function updateFlowElementsState(
         (updatedElem.data as SubDagFlowElementData).mlmdId = executions[0]?.getId();
       }
     }
+    applyFailedOverlayFromTaskDetails(updatedElem, failedFromApi);
     flowGraph.push(updatedElem);
   }
   return flowGraph;

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -86,9 +86,16 @@ function buildTaskDetailsFailedOverlay(
   return { displayNames, executionIds };
 }
 
+// applyFailedOverlayFromTaskDetails marks an element as FAILED when the API's
+// task_details reports it so. Matching uses execution_id first (precise). When
+// useDisplayNameFallback is true, falls back to display_name matching by task
+// key or label. The display_name fallback should only be enabled at the root
+// layer because task_details are flat (no parent DAG info) and display_name
+// can collide across different sub-DAGs.
 function applyFailedOverlayFromTaskDetails(
   elem: PipelineFlowElement,
   overlay: TaskDetailsFailedOverlay,
+  useDisplayNameFallback: boolean = true,
 ): void {
   if (
     isTaskDetailsFailedOverlayEmpty(overlay) ||
@@ -104,6 +111,9 @@ function applyFailedOverlayFromTaskDetails(
     } else {
       (elem.data as SubDagFlowElementData).state = Execution.State.FAILED;
     }
+    return;
+  }
+  if (!useDisplayNameFallback) {
     return;
   }
   let taskKey: string;
@@ -309,6 +319,9 @@ export function updateFlowElementsState(
 ): PipelineFlowElement[] {
   const executionLayers = getExecutionLayers(layers, executions);
   const failedFromApi = buildTaskDetailsFailedOverlay(taskDetails);
+  // display_name fallback is only safe at the root layer because task_details
+  // are flat and display_name can collide across different sub-DAGs.
+  const isRootLayer = layers.length === 1;
 
   if (executionLayers.length < layers.length) {
     // Sub-DAG layer not fully matched in MLMD yet; still apply API task_details overlay for failures.
@@ -318,7 +331,7 @@ export function updateFlowElementsState(
     const overlayGraph: PipelineFlowElement[] = [];
     for (const elem of elems) {
       const updatedElem = cloneFlowElement(elem);
-      applyFailedOverlayFromTaskDetails(updatedElem, failedFromApi);
+      applyFailedOverlayFromTaskDetails(updatedElem, failedFromApi, isRootLayer);
       overlayGraph.push(updatedElem);
     }
     return overlayGraph;
@@ -355,7 +368,7 @@ export function updateFlowElementsState(
         (updatedElem.data as SubDagFlowElementData).state = matchedExecs[0].getLastKnownState();
         (updatedElem.data as SubDagFlowElementData).mlmdId = matchedExecs[0].getId();
       }
-      applyFailedOverlayFromTaskDetails(updatedElem, failedFromApi);
+      applyFailedOverlayFromTaskDetails(updatedElem, failedFromApi, isRootLayer);
       flowGraph.push(updatedElem);
     }
     return flowGraph;
@@ -404,7 +417,7 @@ export function updateFlowElementsState(
         (updatedElem.data as SubDagFlowElementData).mlmdId = executions[0]?.getId();
       }
     }
-    applyFailedOverlayFromTaskDetails(updatedElem, failedFromApi);
+    applyFailedOverlayFromTaskDetails(updatedElem, failedFromApi, isRootLayer);
     flowGraph.push(updatedElem);
   }
   return flowGraph;

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -167,8 +167,9 @@ export function RunDetailsV2(props: RunDetailsV2Props) {
       data.executions,
       data.events,
       data.artifacts,
+      run.run_details?.task_details,
     );
-  }, [data, flowElements, isSuccess, layers]);
+  }, [data, flowElements, isSuccess, layers, run.run_details?.task_details]);
 
   const onElementSelection = (event: ReactMouseEvent, element: PipelineFlowElement) => {
     setSelectedNode(element);


### PR DESCRIPTION
### Problem

When a pipeline task pod hits a fatal startup error like `CreateContainerConfigError` (e.g. missing Secret referenced by `secretAsEnv`), the pod stays in `Pending` phase indefinitely. Argo never transitions the node to `Failed` — it only reports the error in `NodeStatus.Message`. The API server persists the task as `Pending`/`Running`, so the frontend shows the task as still running while the pipeline is stuck.

### Fix

**Backend:** `NodeStatuses()` now infers `Failed` when a Pod-type node is `Pending`/`Running` and its message contains a known fatal substring (`CreateContainerConfigError`, `ImagePullBackOff`, `CrashLoopBackOff`, etc.). `FinishedAt` is normalized to `StartedAt` when unset for inferred failures, and to `0` (instead of `-62135596800`) for unset times generally.

**Frontend:** `updateFlowElementsState` accepts `task_details` from the API and overlays `FAILED` onto graph nodes, matching by MLMD `execution_id` (preferred) or `display_name`. This covers the case where MLMD still reports `RUNNING` but the API already knows the task failed.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
