### PR TITLE
refactor: replace deprecated kustomize vars with replacements #12615

### DIFF
--- a/manifests/kustomize/base/installs/generic/kustomization.yaml
+++ b/manifests/kustomize/base/installs/generic/kustomization.yaml
@@ -48,7 +48,10 @@ replacements:
     fieldPath: data.defaultPipelineRoot
   targets:
   - select:
-      name: kfp-default-pipeline-root
+      kind: ConfigMap
+      name: kfp-launcher
+    fieldPaths:
+    - data.defaultPipelineRoot
 
 configurations:
 - params.yaml

--- a/manifests/kustomize/base/installs/generic/kustomization.yaml
+++ b/manifests/kustomize/base/installs/generic/kustomization.yaml
@@ -1,47 +1,54 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: kubeflow
+
 resources:
 - ../../pipeline
 - ../../cache
 - ../../cache-deployer
 - pipeline-install-config.yaml
 - mysql-secret.yaml
-vars:
-- fieldref:
-    fieldPath: metadata.namespace
-  name: kfp-namespace
-  objref:
-    apiVersion: apps/v1
+
+replacements:
+- source:
     kind: Deployment
     name: ml-pipeline
-- fieldref:
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      name: kfp-namespace
+
+- source:
+    kind: ConfigMap
+    name: pipeline-install-config
     fieldPath: data.appName
-  name: kfp-app-name
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      name: kfp-app-name
+
+- source:
     kind: ConfigMap
     name: pipeline-install-config
-- fieldref:
     fieldPath: data.appVersion
-  name: kfp-app-version
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      name: kfp-app-version
+
+- source:
     kind: ConfigMap
     name: pipeline-install-config
-- fieldref:
     fieldPath: data.bucketName
-  name: kfp-artifact-bucket-name
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      name: kfp-artifact-bucket-name
+
+- source:
     kind: ConfigMap
     name: pipeline-install-config
-- fieldref:
     fieldPath: data.defaultPipelineRoot
-  name: kfp-default-pipeline-root
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: pipeline-install-config
+  targets:
+  - select:
+      name: kfp-default-pipeline-root
+
 configurations:
 - params.yaml


### PR DESCRIPTION

## Changes

- Converted all `vars` entries to `replacements`
- Removed usage of `fieldref` and `objref`
- Ensured compatibility with modern Kustomize versions

## Result

After this change, `kustomize build .` runs successfully without errors.

## Before and After

**Before (error):**  
<img width="893" height="1027" alt="Screenshot 2026-03-27 at 10 18 41 AM" src="https://github.com/user-attachments/assets/d3c61abf-d10e-42dc-8934-09d337f56ab8" />


**After (working):**  
<img width="877" height="1026" alt="Screenshot 2026-03-27 at 10 15 56 AM" src="https://github.com/user-attachments/assets/463a94a8-080a-4c7d-b45e-2e6dd1c0a4c1" />

Closes #12615