### PR TITLE
feat(backend): serve artifacts via presigned URLs when available

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -44,6 +44,7 @@ const (
 	DefaultSecurityContextRunAsUser         string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_USER"
 	DefaultSecurityContextRunAsGroup        string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_GROUP"
 	DefaultSecurityContextRunAsNonRoot      string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_NON_ROOT"
+	ArtifactPresignedURLEnabled             string = "ARTIFACT_PRESIGNED_URL_ENABLED"
 )
 
 func IsPipelineVersionUpdatedByDefault() bool {
@@ -114,6 +115,9 @@ func IsMultiUserMode() bool {
 
 func IsMultiUserSharedReadMode() bool {
 	return GetBoolConfigWithDefault(MultiUserModeSharedReadAccess, false)
+}
+func IsArtifactPresignedURLEnabled() bool {
+	return GetBoolConfigWithDefault(ArtifactPresignedURLEnabled, false)
 }
 
 func GetPodNamespace() string {

--- a/backend/src/apiserver/common/config_test.go
+++ b/backend/src/apiserver/common/config_test.go
@@ -322,6 +322,11 @@ func TestConfigWrapperDefaults(t *testing.T) {
 			expected: false,
 		},
 		{
+			name:     "IsArtifactPresignedURLEnabled defaults to false",
+			getter:   func() interface{} { return IsArtifactPresignedURLEnabled() },
+			expected: false,
+		},
+		{
 			name:     "GetPodNamespace defaults to kubeflow",
 			getter:   func() interface{} { return GetPodNamespace() },
 			expected: DefaultPodNamespace,
@@ -432,6 +437,13 @@ func TestConfigWrapperCustomValues(t *testing.T) {
 			envKey:   MultiUserModeSharedReadAccess,
 			envValue: "true",
 			getter:   func() interface{} { return IsMultiUserSharedReadMode() },
+			expected: true,
+		},
+		{
+			name:     "IsArtifactPresignedURLEnabled with custom true",
+			envKey:   ArtifactPresignedURLEnabled,
+			envValue: "true",
+			getter:   func() interface{} { return IsArtifactPresignedURLEnabled() },
 			expected: true,
 		},
 		{

--- a/backend/src/apiserver/resource/client_manager_fake.go
+++ b/backend/src/apiserver/resource/client_manager_fake.go
@@ -122,6 +122,10 @@ func (f *FakeClientManager) ObjectStore() storage.ObjectStore {
 	return f.objectStore
 }
 
+func (f *FakeClientManager) UpdateObjectStore(store storage.ObjectStore) {
+	f.objectStore = store
+}
+
 func (f *FakeClientManager) LogArchive() archive.LogArchiveInterface {
 	return f.logArchive
 }

--- a/backend/src/apiserver/server/run_artifact_server.go
+++ b/backend/src/apiserver/server/run_artifact_server.go
@@ -88,15 +88,6 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 		return
 	}
 
-	artifactFileExists, err := s.artifactFileExists(r.Context(), runID, nodeID, artifactName)
-	if err != nil {
-		s.writeErrorToResponse(response, http.StatusInternalServerError, err)
-		return
-	} else if !artifactFileExists {
-		s.writeErrorToResponse(response, http.StatusNotFound, fmt.Errorf("artifact not found: %v", err))
-		return
-	}
-
 	artifactPath, err := s.resourceManager.ResolveArtifactPath(runID, nodeID, artifactName)
 	if err != nil {
 		s.writeErrorToResponse(response, http.StatusInternalServerError, err)
@@ -120,7 +111,14 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 			}
 		}
 	}
-
+	artifactFileExists, err := s.artifactFileExists(r.Context(), runID, nodeID, artifactName)
+	if err != nil {
+		s.writeErrorToResponse(response, http.StatusInternalServerError, err)
+		return
+	} else if !artifactFileExists {
+		s.writeErrorToResponse(response, http.StatusNotFound, fmt.Errorf("artifact not found: %v", err))
+		return
+	}
 	reader, err := objectStore.GetFileReader(r.Context(), artifactPath)
 	if err != nil {
 		s.writeErrorToResponse(response, http.StatusInternalServerError, fmt.Errorf("failed to get file reader: %v", err))

--- a/backend/src/apiserver/server/run_artifact_server.go
+++ b/backend/src/apiserver/server/run_artifact_server.go
@@ -52,8 +52,9 @@ type RunArtifactServer struct {
 //     HTTP 200 with body: {"data": "<base64-encoded content>"}
 //
 //   - Flag on + backend supports presigned URLs (S3, GCS): returns HTTP 307 with
-//     a Location header pointing directly to the object in storage. The response
-//     body is empty — there is no JSON wrapper. Clients must follow the redirect.
+//     a Location header pointing directly to the object in storage. No JSON wrapper
+//     is returned in this mode; clients must follow the redirect and should ignore
+//     the response body content.
 //
 //   - Flag on + backend does not support presigned URLs (e.g. local FS):
 //     falls back to the proxied JSON response above.

--- a/backend/src/apiserver/server/run_artifact_server.go
+++ b/backend/src/apiserver/server/run_artifact_server.go
@@ -100,6 +100,10 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 				return
 			}
 			if url != "" {
+				// Prevent caching of redirect responses that contain time-limited bearer URLs
+				response.Header().Set("Cache-Control", "no-store, private")
+				response.Header().Set("Pragma", "no-cache")
+				response.Header().Set("Expires", "0")
 				http.Redirect(response, r, url, http.StatusTemporaryRedirect)
 				return
 			}

--- a/backend/src/apiserver/server/run_artifact_server.go
+++ b/backend/src/apiserver/server/run_artifact_server.go
@@ -44,9 +44,19 @@ type RunArtifactServer struct {
 	*BaseRunServer
 }
 
-// ReadArtifact is an artifact reading endpoint that streams artifacts from object storage,
-// encodes them to base64 on-the-fly, and returns them as JSON.
-// The streaming approach allows handling large artifacts without buffering everything in memory.
+// ReadArtifact retrieves a pipeline artifact by run, node, and artifact name.
+//
+// Response format depends on the ARTIFACT_PRESIGNED_URL_ENABLED flag:
+//
+//   - Default (flag off): proxies the artifact through the API server and returns
+//     HTTP 200 with body: {"data": "<base64-encoded content>"}
+//
+//   - Flag on + backend supports presigned URLs (S3, GCS): returns HTTP 307 with
+//     a Location header pointing directly to the object in storage. The response
+//     body is empty — there is no JSON wrapper. Clients must follow the redirect.
+//
+//   - Flag on + backend does not support presigned URLs (e.g. local FS):
+//     falls back to the proxied JSON response above.
 func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.Request) {
 	glog.Infof("Read artifact v2 called")
 

--- a/backend/src/apiserver/server/run_artifact_server.go
+++ b/backend/src/apiserver/server/run_artifact_server.go
@@ -22,12 +22,14 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/storage"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	authorizationv1 "k8s.io/api/authorization/v1"
 )
@@ -35,6 +37,7 @@ import (
 const (
 	ArtifactNameKey          = "artifact_name"
 	missingParamErrorMessage = "missing path parameter: '%s'"
+	ArtifactURLDuration      = 15 * time.Minute
 )
 
 type RunArtifactServer struct {
@@ -88,8 +91,22 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 		s.writeErrorToResponse(response, http.StatusInternalServerError, err)
 		return
 	}
+	objectStore := s.resourceManager.ObjectStore()
+	if common.IsArtifactPresignedURLEnabled() {
+		if ps, ok := objectStore.(storage.PresignableStore); ok {
+			url, err := ps.SignedURL(r.Context(), artifactPath, ArtifactURLDuration)
+			if err != nil {
+				s.writeErrorToResponse(response, http.StatusInternalServerError, err)
+				return
+			}
+			if url != "" {
+				http.Redirect(response, r, url, http.StatusTemporaryRedirect)
+				return
+			}
+		}
+	}
 
-	reader, err := s.resourceManager.ObjectStore().GetFileReader(r.Context(), artifactPath)
+	reader, err := objectStore.GetFileReader(r.Context(), artifactPath)
 	if err != nil {
 		s.writeErrorToResponse(response, http.StatusInternalServerError, fmt.Errorf("failed to get file reader: %v", err))
 		return

--- a/backend/src/apiserver/server/run_artifact_server_test.go
+++ b/backend/src/apiserver/server/run_artifact_server_test.go
@@ -456,7 +456,7 @@ func TestReadArtifact_PresignedURLRedirect(t *testing.T) {
 
 	assert.Equal(t, http.StatusTemporaryRedirect, rr.Code)
 	assert.Equal(t, presignedURL, rr.Header().Get("Location"))
-	// check empty data filed in the body
+	// check empty data field in the body
 	assert.NotContains(t, rr.Body.String(), `"data"`)
 }
 

--- a/backend/src/apiserver/server/run_artifact_server_test.go
+++ b/backend/src/apiserver/server/run_artifact_server_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/storage"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -409,4 +410,94 @@ func TestReadArtifactV1_Unauthorized(t *testing.T) {
 
 	require.Contains(t, errorResponse.ErrorMessage, "User 'user@google.com' is not authorized")
 	require.Contains(t, errorResponse.ErrorMessage, "this is not allowed")
+}
+
+type fakePresignableStore struct {
+	storage.ObjectStore
+	url string
+}
+
+func (f *fakePresignableStore) SignedURL(_ context.Context, _ string, _ time.Duration) (string, error) {
+	return f.url, nil
+}
+
+func TestReadArtifact_PresignedURLRedirect(t *testing.T) {
+	viper.Set(common.ArtifactPresignedURLEnabled, "true")
+	defer viper.Set(common.ArtifactPresignedURLEnabled, "false")
+
+	filePath := "test/artifact.txt"
+	presignedURL := "https://storage.example.com/bucket/test/artifact.txt?sig=abc123"
+
+	clientManager, manager, run := initWithOneTimeRun(t)
+	defer clientManager.Close()
+
+	err := clientManager.ObjectStore().AddFile(context.TODO(), []byte("content"), filePath)
+	require.NoError(t, err)
+
+	clientManager.UpdateObjectStore(&fakePresignableStore{
+		ObjectStore: clientManager.ObjectStore(),
+		url:         presignedURL,
+	})
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+
+	workflow := createWorkflowWithArtifact(run.UUID, "node-1", "artifact-1", filePath)
+	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req = mux.SetURLVars(req, map[string]string{
+		"run_id":        run.UUID,
+		"node_id":       "node-1",
+		"artifact_name": "artifact-1",
+	})
+	rr := httptest.NewRecorder()
+
+	NewRunArtifactServer(resourceManager).ReadArtifact(rr, req)
+
+	assert.Equal(t, http.StatusTemporaryRedirect, rr.Code)
+	assert.Equal(t, presignedURL, rr.Header().Get("Location"))
+	// check empty data filed in the body
+	assert.NotContains(t, rr.Body.String(), `"data"`)
+}
+
+func TestReadArtifact_PresignedURLFallback_WhenUnsupported(t *testing.T) {
+	viper.Set(common.ArtifactPresignedURLEnabled, "true")
+	defer viper.Set(common.ArtifactPresignedURLEnabled, "false")
+
+	expectedContent := "test artifact content"
+	filePath := "test/artifact.txt"
+
+	// fakePresignableStore returning empty string simulates a backend that doesn't support presigned URLs
+	clientManager, manager, run := initWithOneTimeRun(t)
+	defer clientManager.Close()
+
+	err := clientManager.ObjectStore().AddFile(context.TODO(), []byte(expectedContent), filePath)
+	require.NoError(t, err)
+
+	clientManager.UpdateObjectStore(&fakePresignableStore{
+		ObjectStore: clientManager.ObjectStore(),
+		url:         "",
+	})
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+
+	workflow := createWorkflowWithArtifact(run.UUID, "node-1", "artifact-1", filePath)
+	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req = mux.SetURLVars(req, map[string]string{
+		"run_id":        run.UUID,
+		"node_id":       "node-1",
+		"artifact_name": "artifact-1",
+	})
+	rr := httptest.NewRecorder()
+
+	NewRunArtifactServer(resourceManager).ReadArtifact(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var jsonResponse map[string]string
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &jsonResponse))
+	decoded, err := base64.StdEncoding.DecodeString(jsonResponse["data"])
+	require.NoError(t, err)
+	assert.Equal(t, expectedContent, string(decoded))
 }

--- a/backend/src/apiserver/storage/blob_object_store.go
+++ b/backend/src/apiserver/storage/blob_object_store.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"io"
 	"path"
+	"time"
 
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"gocloud.dev/blob"
+	"gocloud.dev/gcerrors"
 	"sigs.k8s.io/yaml"
 )
 
@@ -117,6 +119,17 @@ func (b *BlobObjectStore) GetFromYamlFile(ctx context.Context, o interface{}, fi
 		return util.NewInternalServerError(err, "Failed to unmarshal file %v: %v", filePath, err.Error())
 	}
 	return nil
+}
+
+func (b *BlobObjectStore) SignedURL(ctx context.Context, filePath string, ttl time.Duration) (string, error) {
+	url, err := b.bucket.SignedURL(ctx, filePath, &blob.SignedURLOptions{Expiry: ttl})
+	if err != nil {
+		if gcerrors.Code(err) == gcerrors.Unimplemented {
+			return "", nil
+		}
+		return "", util.NewInternalServerError(err, "Failed to get signed URL for file %v", filePath)
+	}
+	return url, nil
 }
 
 func NewBlobObjectStore(bucket *blob.Bucket, baseFolder string) *BlobObjectStore {

--- a/backend/src/apiserver/storage/blob_object_store.go
+++ b/backend/src/apiserver/storage/blob_object_store.go
@@ -122,6 +122,9 @@ func (b *BlobObjectStore) GetFromYamlFile(ctx context.Context, o interface{}, fi
 }
 
 func (b *BlobObjectStore) SignedURL(ctx context.Context, filePath string, ttl time.Duration) (string, error) {
+	if b.bucket == nil {
+		return "", util.NewInternalServerError(nil, "Bucket is not configured")
+	}
 	url, err := b.bucket.SignedURL(ctx, filePath, &blob.SignedURLOptions{Expiry: ttl})
 	if err != nil {
 		if gcerrors.Code(err) == gcerrors.Unimplemented {

--- a/backend/src/apiserver/storage/object_store.go
+++ b/backend/src/apiserver/storage/object_store.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"context"
 	"io"
+	"time"
 )
 
 // ObjectStore is the interface for object store operations.
@@ -30,4 +31,11 @@ type ObjectStore interface {
 	AddAsYamlFile(ctx context.Context, o interface{}, filePath string) error
 	GetFromYamlFile(ctx context.Context, o interface{}, filePath string) error
 	GetPipelineKey(pipelineId string) string
+}
+
+// PresignableStore is an optional capability interface implemented by
+// ObjectStore backends that support time-limited pre-signed URLs (e.g. S3, GCS).
+// Returns an empty string (no error) if the backend does not support presigned URLs.
+type PresignableStore interface {
+	SignedURL(ctx context.Context, filePath string, ttl time.Duration) (string, error)
 }


### PR DESCRIPTION
 Add a config flag (ARTIFACT_PRESIGNED_URL_ENABLED) to trigger the artifact server attempts a presigned URL via the new PresignableStore
  optional interface and returns a 307 redirect instead of proxying the
  full file through the API server
  Fixes #12459

**Description of your changes:**


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
