### PR TITLE
fix(backend): Wire `MANAGED_PIPELINES_UPLOAD_TAGS` into `LoadSamples`

### DIFF
--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -106,14 +106,6 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 		return nil
 	}
 
-	tags, err := parseManagedPipelinesTags()
-	if err != nil {
-		return err
-	}
-	if len(tags) > 0 {
-		glog.Infof("Parsed %d managed pipeline upload tag(s) from %s", len(tags), managedPipelinesUploadTagsEnv)
-	}
-
 	configBytes, err := os.ReadFile(sampleConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to read sample configurations file. Err: %v", err)
@@ -148,6 +140,14 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 	if !pipelineConfig.LoadSamplesOnRestart && haveSamplesLoaded {
 		glog.Infof("Samples already loaded in the past. Skip loading.")
 		return nil
+	}
+
+	tags, err := parseManagedPipelinesTags()
+	if err != nil {
+		return err
+	}
+	if len(tags) > 0 {
+		glog.Infof("Parsed %d managed pipeline upload tag(s) from %s", len(tags), managedPipelinesUploadTagsEnv)
 	}
 
 	processedPipelines := map[string]bool{}

--- a/backend/src/apiserver/config/config_test.go
+++ b/backend/src/apiserver/config/config_test.go
@@ -444,6 +444,36 @@ func TestLoadSamples_MalformedTagsReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "badentry")
 }
 
+func TestLoadSamples_MalformedTagsIgnoredWhenLoadingSkipped(t *testing.T) {
+	viper.Set("POD_NAMESPACE", "")
+	rm := fakeResourceManager()
+
+	pc := config{
+		LoadSamplesOnRestart: false,
+		Pipelines: []configPipelines{
+			{
+				Name:        "Already Loaded Pipeline",
+				Description: "test",
+				File:        "testdata/sample_pipeline.yaml",
+				VersionName: "Already Loaded Pipeline - Ver 1",
+			},
+		},
+	}
+
+	// First load succeeds (no malformed tags, samples not yet loaded).
+	t.Setenv(managedPipelinesUploadTagsEnv, "")
+	path, err := writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+
+	// Second load: samples already loaded + LoadSamplesOnRestart=false → skip.
+	// A malformed env var must NOT cause an error because loading is skipped.
+	t.Setenv(managedPipelinesUploadTagsEnv, "badentry")
+	path, err = writeSampleConfig(t, pc, "sample.json")
+	require.NoError(t, err)
+	require.NoError(t, LoadSamples(rm, path))
+}
+
 func TestLoadSamples_ExistingPipelineNotRetagged(t *testing.T) {
 	viper.Set("POD_NAMESPACE", "")
 	rm := fakeResourceManager()


### PR DESCRIPTION
**Description of your changes:**

The API server accepts a `MANAGED_PIPELINES_UPLOAD_TAGS` environment variable to convey tags (e.g., `managed=true,platform-version=v2.18.0`) for managed pipelines. However, `LoadSamples` — the function that preloads sample/managed pipelines at startup — never reads this variable, so the pipelines it creates are always untagged.

This PR parses `MANAGED_PIPELINES_UPLOAD_TAGS` and passes the resulting tags to `CreatePipeline` inside `LoadSamples`. Consistent with the convention established in #12999, tags are applied to pipelines only — not to pipeline versions. When the variable is unset or empty, behavior is unchanged.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
