### PR TITLE
refactor(frontend): derive CompareV2 artifact state

### DIFF
--- a/frontend/src/pages/CompareV2.test.tsx
+++ b/frontend/src/pages/CompareV2.test.tsx
@@ -231,6 +231,14 @@ describe('CompareV2', () => {
     screen.getByText(OVERVIEW_SECTION_NAME);
   });
 
+  it('does not mark ROC selection initialized before ROC artifacts are available', () => {
+    const initialSelection = TEST_ONLY.createInitialRocCurveSelectionState();
+
+    expect(TEST_ONLY.reconcileRocCurveSelectionState(initialSelection, [], new Set())).toBe(
+      initialSelection,
+    );
+  });
+
   it('getRun is called with query param IDs', async () => {
     const getRunSpy = vi.spyOn(Apis.runServiceApiV2, 'getRun');
     runs = [newMockRun(MOCK_RUN_1_ID), newMockRun(MOCK_RUN_2_ID), newMockRun(MOCK_RUN_3_ID)];

--- a/frontend/src/pages/CompareV2.tsx
+++ b/frontend/src/pages/CompareV2.tsx
@@ -295,6 +295,10 @@ const reconcileRocCurveSelectionState = (
   validRocCurveIdSet: Set<string>,
 ): RocCurveSelectionState => {
   if (!currentSelection.hasInitialized) {
+    if (linkedArtifacts.length === 0) {
+      return currentSelection;
+    }
+
     const nextLineColorsStack = [...currentSelection.lineColorsStack];
     const nextSelectedIdColorMap = { ...currentSelection.selectedIdColorMap };
     const nextSelectedIds = linkedArtifacts
@@ -854,4 +858,6 @@ export default EnhancedCompareV2;
 
 export const TEST_ONLY = {
   CompareV2,
+  createInitialRocCurveSelectionState,
+  reconcileRocCurveSelectionState,
 };


### PR DESCRIPTION
## Summary

This is the next frontend `useEffect` cleanup slice, focused on `CompareV2`.

It removes the stored derived artifact state that the page was mirroring through a large effect:

- scalar metrics table props
- filtered run artifacts for confusion matrix, HTML, and Markdown tabs
- ROC linked-artifact metadata (`rocCurveLinkedArtifacts`, `fullArtifactPathMap`)

Those values are now derived with `useMemo` from the current run selection and MLMD query results.

## Why

`CompareV2` still had one large effect that was acting as a mini state machine for derived data. That effect:

- recomputed filtered artifact data from query results
- mirrored that derived data into local state
- reconciled selected two-panel artifacts
- updated ROC curve display state

This made the page harder to reason about and required dependency suppression.

This PR narrows that flow so that:

- pure artifact derivation happens during render with `useMemo`
- only user-controlled selection state stays in `useState`
- a smaller reconciliation effect keeps the selected artifacts and ROC selection valid when the available artifact set changes
- `selectedArtifactsMap` updates are immutable instead of mutating the existing state object in place

## Scope boundary

This PR is intentionally limited to `CompareV2`.

The follow-up `NewRunV2` / `NewRunParametersV2` effect cleanup will stay in a separate PR because the remaining work there crosses component state ownership boundaries.

## Verification

```bash
cd frontend
fnm exec --using .nvmrc -- npm ci
fnm exec --using .nvmrc -- npm run test:ui -- src/pages/CompareV2.test.tsx
fnm exec --using .nvmrc -- npm run typecheck
```

Result:
- `CompareV2.test.tsx`: `18` tests passed
- `typecheck`: passed

Note: the existing `CompareV2` suite still emits pre-existing `act(...)` warnings, but the run passes.
