### PR TITLE
fix(ci): keep Tide-required contexts green on label churn

### DIFF
--- a/.github/workflows/add-ci-passed-label.yml
+++ b/.github/workflows/add-ci-passed-label.yml
@@ -23,22 +23,34 @@ jobs:
   fetch_data:
     name: Fetch PR eligibility
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.conclusion == 'success'
     outputs:
       pr_number: ${{ steps.pr.outputs.pr_number }}
       eligible: ${{ steps.pr.outputs.eligible }}
+      should_add_label: ${{ steps.pr.outputs.should_add_label }}
     steps:
       - name: Check PR label eligibility
         id: pr
         uses: actions/github-script@v8
         with:
           script: |
+            core.setOutput("eligible", "false");
+            core.setOutput("should_add_label", "false");
+
+            if (context.eventName !== "workflow_run") {
+              core.info(`No ci-passed eligibility lookup needed for ${context.eventName}.`);
+              return;
+            }
+
+            if (context.payload.workflow_run.conclusion !== "success") {
+              core.info(
+                `CI Check concluded with ${context.payload.workflow_run.conclusion}; not adding ci-passed.`
+              );
+              return;
+            }
+
             const workflowEvent = context.payload.workflow_run.event;
             if (workflowEvent !== "pull_request" && workflowEvent !== "pull_request_target") {
               core.info(`Skipping workflow_run event ${workflowEvent}`);
-              core.setOutput("eligible", "false");
               return;
             }
 
@@ -47,7 +59,6 @@ jobs:
             const runHeadSha = context.payload.workflow_run.head_sha;
             if (!headRepositoryOwner || !headBranch || !runHeadSha) {
               core.info("workflow_run is missing head repository, branch, or SHA metadata.");
-              core.setOutput("eligible", "false");
               return;
             }
 
@@ -63,7 +74,6 @@ jobs:
               core.info(
                 `No open pull request matched ${headRepositoryOwner}:${headBranch} at ${runHeadSha}.`
               );
-              core.setOutput("eligible", "false");
               return;
             }
 
@@ -73,26 +83,32 @@ jobs:
             core.info(`PR #${pullRequest.number} labels: ${Array.from(labels).join(", ")}`);
             core.setOutput("pr_number", String(pullRequest.number));
             core.setOutput("eligible", eligible ? "true" : "false");
+            core.setOutput("should_add_label", eligible ? "true" : "false");
 
   reset_ci_passed_label:
     name: Reset stale 'ci-passed' label
     runs-on: ubuntu-latest
-    # Only run on pull_request_target events that can actually affect ci-passed:
-    #   - synchronize/reopened: new commits invalidate previous CI results
-    #   - labeled with 'needs-ok-to-test': PR became ineligible
-    #   - unlabeled with 'ok-to-test': PR became ineligible
-    # This avoids spinning up a runner for unrelated label changes.
-    if: >
-      github.event_name == 'pull_request_target' &&
-      (
-        github.event.action == 'synchronize' ||
-        github.event.action == 'reopened' ||
-        (github.event.action == 'labeled' && github.event.label.name == 'needs-ok-to-test') ||
-        (github.event.action == 'unlabeled' && github.event.label.name == 'ok-to-test')
-      )
     steps:
       - name: Remove existing 'ci-passed' label
+        shell: bash
         run: |
+          should_reset=false
+
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            if [[ "${{ github.event.action }}" == "synchronize" || "${{ github.event.action }}" == "reopened" ]]; then
+              should_reset=true
+            elif [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.label.name }}" == "needs-ok-to-test" ]]; then
+              should_reset=true
+            elif [[ "${{ github.event.action }}" == "unlabeled" && "${{ github.event.label.name }}" == "ok-to-test" ]]; then
+              should_reset=true
+            fi
+          fi
+
+          if [[ "${should_reset}" != "true" ]]; then
+            echo "No stale ci-passed reset needed for ${GITHUB_EVENT_NAME} ${GITHUB_EVENT_ACTION:-}."
+            exit 0
+          fi
+
           pr_number=${{ github.event.pull_request.number }}
           echo "Checking for stale 'ci-passed' label on PR #${pr_number} after ${{ github.event.action }}"
           labels=$(gh pr view "${pr_number}" --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name')
@@ -110,10 +126,15 @@ jobs:
     name: Add 'ci-passed' label
     runs-on: ubuntu-latest
     needs: fetch_data
-    if: needs.fetch_data.outputs.eligible == 'true'
     steps:
       - name: Add 'ci-passed' label
+        shell: bash
         run: |
+          if [[ "${{ needs.fetch_data.outputs.should_add_label }}" != "true" ]]; then
+            echo "No ci-passed label update needed for this event."
+            exit 0
+          fi
+
           echo "Adding 'ci-passed' label to PR #${{ needs.fetch_data.outputs.pr_number }}"
           gh pr edit ${{ needs.fetch_data.outputs.pr_number }} --add-label "ci-passed" --repo "$GITHUB_REPOSITORY"
         env:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -8,22 +8,35 @@ on:
 jobs:
   check_ci_status:
     runs-on: ubuntu-latest
-    # Only run for eligible PRs: must have 'ok-to-test' and not 'needs-ok-to-test'.
-    # For 'labeled' events, only react when 'ok-to-test' is added.
-    # For 'unlabeled' events, only react when 'needs-ok-to-test' is removed.
-    # These are the only label changes that can change eligibility, avoiding
-    # restarting the 50-min polling loop on unrelated labels like 'size/L' or 'lgtm'.
-    # Using a job-level condition so ineligible PRs are 'skipped' rather than 'success',
-    # which prevents a wasted downstream workflow_run trigger.
-    if: >
-      (github.event.action != 'labeled' || github.event.label.name == 'ok-to-test') &&
-      (github.event.action != 'unlabeled' || github.event.label.name == 'needs-ok-to-test') &&
-      contains(github.event.pull_request.labels.*.name, 'ok-to-test') &&
-      !contains(github.event.pull_request.labels.*.name, 'needs-ok-to-test')
     permissions:
       checks: read
     steps:
+      - name: Determine whether CI polling is needed
+        id: eligibility
+        shell: bash
+        run: |
+          should_poll=false
+          reason="CI polling is not needed for this pull request event."
+
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}" != "true" ]]; then
+            reason="PR is not yet labeled ok-to-test."
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'needs-ok-to-test') }}" == "true" ]]; then
+            reason="PR still has the needs-ok-to-test label."
+          elif [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.label.name }}" != "ok-to-test" ]]; then
+            reason="Added label '${{ github.event.label.name }}' does not change CI eligibility."
+          elif [[ "${{ github.event.action }}" == "unlabeled" && "${{ github.event.label.name }}" != "needs-ok-to-test" ]]; then
+            reason="Removed label '${{ github.event.label.name }}' does not change CI eligibility."
+          else
+            should_poll=true
+            reason="PR is eligible; running CI status polling."
+          fi
+
+          echo "should_poll=${should_poll}" >> "$GITHUB_OUTPUT"
+          echo "reason=${reason}" >> "$GITHUB_OUTPUT"
+          echo "${reason}"
+
       - name: Check if all CI checks passed
+        if: steps.eligibility.outputs.should_poll == 'true'
         uses: wechuli/allcheckspassed@0b68b3b7d92e595bcbdea0c860d05605720cf479
         with:
           delay: '5'
@@ -36,3 +49,7 @@ jobs:
           checks_exclude: '^Cleanup artifacts$,^Upload results$,^Agent$,^Prepare$'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Skip CI polling with success
+        if: steps.eligibility.outputs.should_poll != 'true'
+        run: echo "${{ steps.eligibility.outputs.reason }}"


### PR DESCRIPTION
## Summary
- keep CI Check green on irrelevant pull_request_target label events by turning them into explicit no-op successes
- keep Fetch PR eligibility, Reset stale ci-passed label, and Add ci-passed label green when the current event does not require work
- preserve the existing stale ci-passed reset and ci-passed re-add behavior for relevant eligibility transitions

## Root cause
PR #13095 moved eligibility gating to job-level if conditions. On later label events like /lgtm and /approve, GitHub created fresh CI helper check contexts on the PR head that ended as skipped, and Tide treated those latest contexts as not succeeded.

This fixes the merge blocker seen on #13126 without changing the actual ci-passed label semantics.

## Validation
- ruby -e 'require "yaml"; [".github/workflows/ci-checks.yml", ".github/workflows/add-ci-passed-label.yml"].each { |path| YAML.load_file(path); puts "YAML OK: #{path}" }'
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci-checks.yml .github/workflows/add-ci-passed-label.yml

## Note
This PR itself will still show the current skipped helper contexts until the fix lands, because pull_request_target and downstream workflow_run executions use the workflow files from the base branch, not from this PR branch.