### PR TITLE
fix(backend): make runtime status errors JSON-safe

### DIFF
--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -15,7 +15,10 @@
 package model
 
 import (
+	"fmt"
 	"strings"
+
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 )
 
 type (
@@ -342,24 +345,28 @@ type RunMetric struct {
 }
 
 type RuntimeError struct {
+	Code    int32  `json:"code,omitempty"`
 	Message string `json:"message,omitempty"`
 	Type    string `json:"type,omitempty"`
-}
-
-type RuntimeStatus struct {
-	UpdateTimeInSec int64         `json:"UpdateTimeInSec,omitempty"`
-	State           RuntimeState  `json:"State,omitempty"`
-	Error           *RuntimeError `json:"Error,omitempty"`
 }
 
 func NewRuntimeError(err error) *RuntimeError {
 	if err == nil {
 		return nil
 	}
+
+	rpcStatus := util.ToRpcStatus(err)
 	return &RuntimeError{
-		Message: err.Error(),
-		Type:    "*util.UserError",
+		Code:    rpcStatus.GetCode(),
+		Message: rpcStatus.GetMessage(),
+		Type:    fmt.Sprintf("%T", err),
 	}
+}
+
+type RuntimeStatus struct {
+	UpdateTimeInSec int64         `json:"UpdateTimeInSec,omitempty"`
+	State           RuntimeState  `json:"State,omitempty"`
+	Error           *RuntimeError `json:"Error,omitempty"`
 }
 
 func NewRuntimeStatus(state RuntimeState, err error, now int64) *RuntimeStatus {

--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -341,10 +341,33 @@ type RunMetric struct {
 	Payload     LargeText `gorm:"column:Payload; not null;"`
 }
 
+type RuntimeError struct {
+	Message string `json:"message,omitempty"`
+	Type    string `json:"type,omitempty"`
+}
+
 type RuntimeStatus struct {
-	UpdateTimeInSec int64        `json:"UpdateTimeInSec,omitempty"`
-	State           RuntimeState `json:"State,omitempty"`
-	Error           error        `json:"Error,omitempty"`
+	UpdateTimeInSec int64         `json:"UpdateTimeInSec,omitempty"`
+	State           RuntimeState  `json:"State,omitempty"`
+	Error           *RuntimeError `json:"Error,omitempty"`
+}
+
+func NewRuntimeError(err error) *RuntimeError {
+	if err == nil {
+		return nil
+	}
+	return &RuntimeError{
+		Message: err.Error(),
+		Type:    "*util.UserError",
+	}
+}
+
+func NewRuntimeStatus(state RuntimeState, err error, now int64) *RuntimeStatus {
+	return &RuntimeStatus{
+		UpdateTimeInSec: now,
+		State:           state,
+		Error:           NewRuntimeError(err),
+	}
 }
 
 func (r Run) GetValueOfPrimaryKey() string {

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -32,6 +32,7 @@ import (
 	swapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/pkg/errors"
 	"github.com/robfig/cron"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -2444,7 +2445,6 @@ func toApiRuntimeStateV1(s *model.RuntimeState) string {
 
 // Converts API runtime status to its internal representation.
 // Supports v2beta1 API.
-// Supports v2beta1 API.
 func toModelRuntimeStatus(s *apiv2beta1.RuntimeStatus) (*model.RuntimeStatus, error) {
 	if s == nil {
 		return &model.RuntimeStatus{}, nil
@@ -2457,6 +2457,7 @@ func toModelRuntimeStatus(s *apiv2beta1.RuntimeStatus) (*model.RuntimeStatus, er
 	var runtimeErr *model.RuntimeError
 	if s.GetError() != nil {
 		runtimeErr = &model.RuntimeError{
+			Code:    s.GetError().GetCode(),
 			Message: s.GetError().GetMessage(),
 			Type:    "*util.UserError",
 		}
@@ -2504,9 +2505,29 @@ func toApiRuntimeStatus(s *model.RuntimeStatus) *apiv2beta1.RuntimeStatus {
 	}
 
 	if s.Error != nil {
-		msg := strings.TrimPrefix(s.Error.Message, "Invalid input error: ")
-		userErr := util.NewInvalidInputError("%s", msg)
-		apiStatus.Error = util.ToRpcStatus(userErr)
+		switch s.Error.Code {
+		case 3:
+			msg := strings.TrimPrefix(s.Error.Message, "Invalid input error: ")
+			apiStatus.Error = util.ToRpcStatus(util.NewInvalidInputError("%s", msg))
+		case 13:
+			msg := strings.TrimPrefix(s.Error.Message, "InternalServerError: ")
+			parts := strings.SplitN(msg, ": ", 2)
+			if len(parts) == 2 {
+				apiStatus.Error = util.ToRpcStatus(
+					util.NewInternalServerError(errors.New(parts[1]), "%s", parts[0]),
+				)
+			} else {
+				apiStatus.Error = &statuspb.Status{
+					Code:    s.Error.Code,
+					Message: s.Error.Message,
+				}
+			}
+		default:
+			apiStatus.Error = &statuspb.Status{
+				Code:    s.Error.Code,
+				Message: s.Error.Message,
+			}
+		}
 	}
 
 	return apiStatus

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
@@ -2443,6 +2444,7 @@ func toApiRuntimeStateV1(s *model.RuntimeState) string {
 
 // Converts API runtime status to its internal representation.
 // Supports v2beta1 API.
+// Supports v2beta1 API.
 func toModelRuntimeStatus(s *apiv2beta1.RuntimeStatus) (*model.RuntimeStatus, error) {
 	if s == nil {
 		return &model.RuntimeStatus{}, nil
@@ -2451,13 +2453,21 @@ func toModelRuntimeStatus(s *apiv2beta1.RuntimeStatus) (*model.RuntimeStatus, er
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to convert runtime status to its internal representation")
 	}
+
+	var runtimeErr *model.RuntimeError
+	if s.GetError() != nil {
+		runtimeErr = &model.RuntimeError{
+			Message: s.GetError().GetMessage(),
+			Type:    "*util.UserError",
+		}
+	}
+
 	modelStatus := &model.RuntimeStatus{
 		UpdateTimeInSec: s.GetUpdateTime().GetSeconds(),
 		State:           state.ToV2(),
+		Error:           runtimeErr,
 	}
-	if s.GetError() != nil {
-		modelStatus.Error = util.ToError(s.GetError())
-	}
+
 	return modelStatus, nil
 }
 
@@ -2484,15 +2494,21 @@ func toApiRuntimeStatus(s *model.RuntimeStatus) *apiv2beta1.RuntimeStatus {
 	if s == nil {
 		return nil
 	}
+
 	apiStatus := &apiv2beta1.RuntimeStatus{
 		State: toApiRuntimeState(&s.State),
 	}
+
 	if s.UpdateTimeInSec > 0 {
 		apiStatus.UpdateTime = &timestamppb.Timestamp{Seconds: s.UpdateTimeInSec}
 	}
+
 	if s.Error != nil {
-		apiStatus.Error = util.ToRpcStatus(s.Error)
+		msg := strings.TrimPrefix(s.Error.Message, "Invalid input error: ")
+		userErr := util.NewInvalidInputError("%s", msg)
+		apiStatus.Error = util.ToRpcStatus(userErr)
 	}
+
 	return apiStatus
 }
 

--- a/backend/src/apiserver/server/api_converter_test.go
+++ b/backend/src/apiserver/server/api_converter_test.go
@@ -2815,7 +2815,7 @@ func Test_toModelRuntimeStatus(t *testing.T) {
 			&model.RuntimeStatus{
 				UpdateTimeInSec: 0,
 				State:           model.RuntimeStateUnspecified,
-				Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Invalid input: %s", "sample value"))),
+				Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 			},
 			false,
 			"",
@@ -2856,7 +2856,7 @@ func Test_toModelRuntimeStatus(t *testing.T) {
 			&model.RuntimeStatus{
 				UpdateTimeInSec: 100,
 				State:           model.RuntimeStateCancelling,
-				Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Invalid input: %s", "sample value"))),
+				Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 			},
 			false,
 			"",
@@ -2910,7 +2910,7 @@ func Test_toModelRuntimeStatuses(t *testing.T) {
 		{
 			UpdateTimeInSec: 0,
 			State:           model.RuntimeStateUnspecified,
-			Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Invalid input: %s", "sample value"))),
+			Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 		},
 		{
 			UpdateTimeInSec: 100,
@@ -2925,7 +2925,7 @@ func Test_toModelRuntimeStatuses(t *testing.T) {
 		{
 			UpdateTimeInSec: 100,
 			State:           model.RuntimeStateCancelling,
-			Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Invalid input: %s", "sample value"))),
+			Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 		},
 	}
 	got, err := toModelRuntimeStatuses(arg)
@@ -2949,7 +2949,7 @@ func Test_toApiRuntimeStatus(t *testing.T) {
 			&model.RuntimeStatus{
 				UpdateTimeInSec: 100,
 				State:           model.RuntimeStateCancelling,
-				Error:           util.NewInvalidInputError("Invalid input: %s", "sample value"),
+				Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 			},
 			&apiv2beta1.RuntimeStatus{
 				UpdateTime: &timestamppb.Timestamp{Seconds: 100},
@@ -2969,7 +2969,7 @@ func Test_toApiRuntimeStatus(t *testing.T) {
 		{
 			"error",
 			&model.RuntimeStatus{
-				Error: util.NewInvalidInputError("Invalid input: %s", "sample value"),
+				Error: model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 			},
 			&apiv2beta1.RuntimeStatus{
 				Error: util.ToRpcStatus(util.NewInvalidInputError("Invalid input: %s", "sample value")),
@@ -2989,7 +2989,7 @@ func Test_toApiRuntimeStatus(t *testing.T) {
 			&model.RuntimeStatus{
 				UpdateTimeInSec: 100,
 				State:           model.RuntimeStateErrorV1,
-				Error:           util.NewInvalidInputError("Invalid input: %s", "sample value"),
+				Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 			},
 			&apiv2beta1.RuntimeStatus{
 				UpdateTime: &timestamppb.Timestamp{Seconds: 100},
@@ -3002,7 +3002,7 @@ func Test_toApiRuntimeStatus(t *testing.T) {
 			&model.RuntimeStatus{
 				UpdateTimeInSec: 100,
 				State:           model.RuntimeStateUnknownV1,
-				Error:           util.NewInvalidInputError("Invalid input: %s", "sample value"),
+				Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 			},
 			&apiv2beta1.RuntimeStatus{
 				UpdateTime: &timestamppb.Timestamp{Seconds: 100},
@@ -3015,7 +3015,7 @@ func Test_toApiRuntimeStatus(t *testing.T) {
 			&model.RuntimeStatus{
 				UpdateTimeInSec: 100,
 				State:           model.RuntimeState("WRONG STATE"),
-				Error:           util.NewInvalidInputError("Invalid input: %s", "sample value"),
+				Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 			},
 			&apiv2beta1.RuntimeStatus{
 				UpdateTime: &timestamppb.Timestamp{Seconds: 100},
@@ -3028,7 +3028,7 @@ func Test_toApiRuntimeStatus(t *testing.T) {
 			&model.RuntimeStatus{
 				UpdateTimeInSec: 100,
 				State:           model.RuntimeState(""),
-				Error:           util.NewInvalidInputError("Invalid input: %s", "sample value"),
+				Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 			},
 			&apiv2beta1.RuntimeStatus{
 				UpdateTime: &timestamppb.Timestamp{Seconds: 100},
@@ -3051,27 +3051,27 @@ func Test_toApiRuntimeStatuses(t *testing.T) {
 		{
 			UpdateTimeInSec: 100,
 			State:           model.RuntimeStateCancelling,
-			Error:           util.NewInvalidInputError("Invalid input: %s", "sample value"),
+			Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 		},
 		{
 			UpdateTimeInSec: 100,
 			State:           model.RuntimeStateErrorV1,
-			Error:           util.NewInvalidInputError("Invalid input: %s", "sample value"),
+			Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 		},
 		{
 			UpdateTimeInSec: 100,
 			State:           model.RuntimeStateUnknownV1,
-			Error:           util.NewInvalidInputError("Invalid input: %s", "sample value"),
+			Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 		},
 		{
 			UpdateTimeInSec: 100,
 			State:           model.RuntimeState("WRONG STATE"),
-			Error:           util.NewInvalidInputError("Invalid input: %s", "sample value"),
+			Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 		},
 		{
 			UpdateTimeInSec: 100,
 			State:           model.RuntimeState(""),
-			Error:           util.NewInvalidInputError("Invalid input: %s", "sample value"),
+			Error:           model.NewRuntimeError(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 		},
 	}
 	expected := []*apiv2beta1.RuntimeStatus{
@@ -3313,7 +3313,7 @@ func Test_toModelTasks_v2(t *testing.T) {
 				{
 					UpdateTimeInSec: 9,
 					State:           model.RuntimeStateFailed,
-					Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Input argument is invalid"))),
+					Error:           model.NewRuntimeError(util.NewInvalidInputError("Input argument is invalid")),
 				},
 			},
 			MLMDInputs:   `{"a1":{"artifact_ids":[1,2,3]}}`,
@@ -3416,7 +3416,7 @@ func Test_toApiTaskV1(t *testing.T) {
 					{
 						UpdateTimeInSec: 9,
 						State:           model.RuntimeStatePaused,
-						Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Sample error2"))),
+						Error:           model.NewRuntimeError(util.NewInvalidInputError("Sample error2")),
 					},
 				},
 				MLMDInputs:   `{"a1":{"artifact_ids":[1,2,3]}}`,
@@ -3480,7 +3480,7 @@ func Test_toApiTasksV1(t *testing.T) {
 				{
 					UpdateTimeInSec: 9,
 					State:           model.RuntimeStatePaused,
-					Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Sample error2"))),
+					Error:           model.NewRuntimeError(util.NewInvalidInputError("Sample error2")),
 				},
 			},
 			MLMDInputs:   `{"a1":{"artifact_ids":[1,2,3]}}`,
@@ -3568,7 +3568,7 @@ func Test_toApiPipelineTaskDetail(t *testing.T) {
 					{
 						UpdateTimeInSec: 9,
 						State:           model.RuntimeStatePaused,
-						Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Sample error2"))),
+						Error:           model.NewRuntimeError(util.NewInvalidInputError("Sample error2")),
 					},
 				},
 				MLMDInputs:   `{"a1":{"artifact_ids":[1,2,3]}}`,
@@ -3633,7 +3633,7 @@ func Test_toApiPipelineTaskDetail(t *testing.T) {
 					{
 						UpdateTimeInSec: 9,
 						State:           model.RuntimeStatePaused,
-						Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Sample error2"))),
+						Error:           model.NewRuntimeError(util.NewInvalidInputError("Sample error2")),
 					},
 				},
 				MLMDInputs:   `{"a1":{"artifact_ids":[1,2,3]}`,
@@ -3666,7 +3666,7 @@ func Test_toApiPipelineTaskDetail(t *testing.T) {
 					{
 						UpdateTimeInSec: 9,
 						State:           model.RuntimeStatePaused,
-						Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Sample error2"))),
+						Error:           model.NewRuntimeError(util.NewInvalidInputError("Sample error2")),
 					},
 				},
 				MLMDInputs:   `{"a1":{"artifact_ids":[1,2,3]}}`,
@@ -3726,7 +3726,7 @@ func Test_toApiPipelineTaskDetails(t *testing.T) {
 				{
 					UpdateTimeInSec: 9,
 					State:           model.RuntimeStatePaused,
-					Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Sample error2"))),
+					Error:           model.NewRuntimeError(util.NewInvalidInputError("Sample error2")),
 				},
 			},
 			MLMDInputs:   `{"a1":{"artifact_ids":[1,2,3]}}`,
@@ -3803,7 +3803,7 @@ func Test_toApiPipelineTaskDetails(t *testing.T) {
 				{
 					UpdateTimeInSec: 9,
 					State:           model.RuntimeStatePaused,
-					Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Sample error2"))),
+					Error:           model.NewRuntimeError(util.NewInvalidInputError("Sample error2")),
 				},
 			},
 			MLMDInputs:   `{"a1":{"artifact_ids":[1,2,3]}`,
@@ -3827,7 +3827,7 @@ func Test_toApiPipelineTaskDetails(t *testing.T) {
 				{
 					UpdateTimeInSec: 9,
 					State:           model.RuntimeStatePaused,
-					Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Sample error2"))),
+					Error:           model.NewRuntimeError(util.NewInvalidInputError("Sample error2")),
 				},
 			},
 			MLMDInputs:   `{"a1":{"artifact_ids":[1,2,3]}}`,
@@ -3971,7 +3971,7 @@ func TestToModelRun(t *testing.T) {
 						{
 							UpdateTimeInSec: 9,
 							State:           model.RuntimeStateFailed,
-							Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Input argument is invalid"))),
+							Error:           model.NewRuntimeError(util.NewInvalidInputError("Input argument is invalid")),
 						},
 					},
 					CreatedAtInSec:       1,
@@ -3998,7 +3998,7 @@ func TestToModelRun(t *testing.T) {
 								{
 									UpdateTimeInSec: 15,
 									State:           model.RuntimeStateFailed,
-									Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Input argument is invalid"))),
+									Error:           model.NewRuntimeError(util.NewInvalidInputError("Input argument is invalid")),
 								},
 							},
 							ChildrenPods: []string{"task2"},
@@ -4438,7 +4438,7 @@ func Test_toApiRun(t *testing.T) {
 						{
 							UpdateTimeInSec: 9,
 							State:           model.RuntimeStateFailed,
-							Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Input argument is invalid"))),
+							Error:           model.NewRuntimeError(util.NewInvalidInputError("Input argument is invalid")),
 						},
 					},
 					CreatedAtInSec:       1,
@@ -4465,7 +4465,7 @@ func Test_toApiRun(t *testing.T) {
 								{
 									UpdateTimeInSec: 15,
 									State:           model.RuntimeStateFailed,
-									Error:           util.ToError(util.ToRpcStatus(util.NewInvalidInputError("Input argument is invalid"))),
+									Error:           model.NewRuntimeError(util.NewInvalidInputError("Input argument is invalid")),
 								},
 							},
 						},

--- a/backend/src/apiserver/server/api_converter_test.go
+++ b/backend/src/apiserver/server/api_converter_test.go
@@ -3036,7 +3036,21 @@ func Test_toApiRuntimeStatus(t *testing.T) {
 				Error:      util.ToRpcStatus(util.NewInvalidInputError("Invalid input: %s", "sample value")),
 			},
 		},
+		{
+			"internal error",
+			&model.RuntimeStatus{
+				Error: model.NewRuntimeError(
+					util.NewInternalServerError(errors.New("boom"), "internal failure"),
+				),
+			},
+			&apiv2beta1.RuntimeStatus{
+				Error: util.ToRpcStatus(
+					util.NewInternalServerError(errors.New("boom"), "internal failure"),
+				),
+			},
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := toApiRuntimeStatus(tt.modelStatus)

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -477,10 +477,12 @@ func (s *RunStore) CreateRun(r *model.Run) (*model.Run, error) {
 	}
 
 	if len(r.RunDetails.StateHistory) == 0 || r.RunDetails.StateHistory[len(r.RunDetails.StateHistory)-1].State != r.RunDetails.State {
-		r.RunDetails.StateHistory = append(r.RunDetails.StateHistory, &model.RuntimeStatus{
-			UpdateTimeInSec: s.time.Now().Unix(),
-			State:           r.RunDetails.State,
-		})
+		r.RunDetails.StateHistory = append(r.RunDetails.StateHistory, model.NewRuntimeStatus(
+			r.RunDetails.State,
+			nil,
+			s.time.Now().Unix(),
+		),
+		)
 	}
 
 	stateHistoryString := ""
@@ -556,10 +558,12 @@ func (s *RunStore) UpdateRun(run *model.Run) error {
 		return util.NewInternalServerError(err, "transaction creation failed")
 	}
 	if len(run.RunDetails.StateHistory) == 0 || run.RunDetails.StateHistory[len(run.RunDetails.StateHistory)-1].State != run.RunDetails.State {
-		run.RunDetails.StateHistory = append(run.RunDetails.StateHistory, &model.RuntimeStatus{
-			UpdateTimeInSec: s.time.Now().Unix(),
-			State:           run.RunDetails.State,
-		})
+		run.RunDetails.StateHistory = append(run.RunDetails.StateHistory, model.NewRuntimeStatus(
+			run.RunDetails.State,
+			nil,
+			s.time.Now().Unix(),
+		),
+		)
 	}
 	stateHistoryString := ""
 	if historyString, err := json.Marshal(run.RunDetails.StateHistory); err == nil {


### PR DESCRIPTION
## Summary

Fixes the `RuntimeStatus.Error` serialization issue that prevents runtime errors from being safely persisted in `state_history`.

## Problem

`RuntimeStatus.Error` was typed as Go's `error` interface, which does not serialize/deserialize properly through JSON. This caused:

- `"Error": {}` during marshaling
- unmarshal failures for `state_history`
- inability to persist runtime errors (blocking TODO(#1426))

## Changes

- Replaced `error` with a concrete `*model.RuntimeError`
- Added JSON-safe error struct with exported fields
- Added helper constructors for runtime error/status
- Updated `run_store.go` to use new constructor
- Fixed model ↔ API conversion in `api_converter.go`
- Updated tests to use new runtime error structure

## Why no migration is needed

`StateHistory` is already stored as JSON and existing rows do not rely on serialized Go error types.

## Testing

```bash
go test ./backend/src/apiserver/server/... ./backend/src/apiserver/storage/...