### PR TITLE
fix(ci): reduce flaky E2E workflow parallelism

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,7 +1,8 @@
 name: KFP E2E Pipeline tests
 env:
   E2E_TESTS_DIR: "./backend/test/end2end"
-  NUMBER_OF_PARALLEL_NODES: 10
+  # Keep per-job load below the current Kind/GitHub runner saturation point.
+  NUMBER_OF_PARALLEL_NODES: 6
   CLUSTER_NAME: "kfp"
   NAMESPACE: "kubeflow"
   PYTHON_VERSION: "3.9"
@@ -39,7 +40,7 @@ on:
         type: string
       number_of_parallel_tests:
         description: "Number of ginkgo nodes that you want run in parallel, it essentially is equivalent to number of parallel tests with some caveats"
-        default: 10
+        default: 6
         required: true
         type: number
       namespace:

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -3,7 +3,8 @@ name: KFP upgrade tests
 env:
   TESTS_DIR: "./backend/test/v2/api"
   TESTS_LABEL: "ApiServerTests"
-  NUMBER_OF_PARALLEL_NODES: 15
+  # Upgrade jobs share the same Kind runner constraints as E2E and need more headroom.
+  NUMBER_OF_PARALLEL_NODES: 8
   CLUSTER_NAME: "kfp"
   NAMESPACE: "kubeflow"
   PYTHON_VERSION: "3.9"


### PR DESCRIPTION
## Summary

- reduce `KFP E2E Pipeline tests` default Ginkgo parallelism from `10` to `6`
- reduce `KFP upgrade tests` default Ginkgo parallelism from `15` to `8`

## Context

This is a mitigation for the current `master` E2E / upgrade flake, not a claim that a single product-code PR introduced the full failure mode.

The last green `master` E2E workflow before the current flaky period was run [`23638070877`](https://github.com/kubeflow/pipelines/actions/runs/23638070877) on March 27, 2026.

The first bad `master` E2E workflow after that was run [`23651967509`](https://github.com/kubeflow/pipelines/actions/runs/23651967509) on March 27, 2026, and the same family of failures keeps showing up in later `master` runs such as [`23726985949`](https://github.com/kubeflow/pipelines/actions/runs/23726985949) on March 30, 2026 and [`23805886050`](https://github.com/kubeflow/pipelines/actions/runs/23805886050) on March 31, 2026.

The recurring signature in those runs is:

- early deploy instability in core services, especially `metadata-grpc-deployment`
- later workflow-controller errors like `Ignoring 137 exit code of container 'kfp-launcher'`
- task failures reported as `Pod failed before main container starts due to PodInitializing`
- affected lanes spanning `E2ECritical`, `E2EEssential`, multi-user, and upgrade coverage

In the first bad `master` run, `metadata-grpc-deployment` was already flapping during deploy and later E2E tasks were failing with the `PodInitializing` / exit `137` pattern.

## Attribution

I do **not** think the underlying startup flake can be honestly attributed to a single repo PR based on the current evidence.

Between the last green `master` E2E run and the first bad one, the repo diff only included:

- `refactor(frontend): reduce NewRunV2 effect state handling (#13140)`
- `fix(sdk): support .after() dependencies on ExitHandler groups (#13112)`

Those diffs did not touch CI manifests, cluster deployment scripts, metadata manifests, or E2E workflow orchestration.

There was a separate nil `ReadPodLogs` panic in the E2E harness, but that has already been fixed on current `master`; this PR is not about that secondary issue.

## Why this change

Given the current evidence, the safest repo-side fix is to lower per-job Ginkgo parallelism so the Kind cluster on GitHub-hosted runners has more headroom for metadata, MySQL, launcher, and workflow-controller startup/reconciliation.

This trades CI runtime for stability.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/e2e-test.yml .github/workflows/upgrade-test.yml`
