### PR TITLE
refactor(frontend): derive CompareV2 artifact selection

### DIFF
--- a/frontend/src/components/viewers/MetricsDropdown.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { color, commonCss, fontsize, zIndex } from 'src/Css';
 import { queryKeys } from 'src/hooks/queryKeys';
 import { classes, stylesheet } from 'typestyle';
@@ -104,6 +104,20 @@ export default function MetricsDropdown(props: MetricsDropdownProps) {
     setSecondSelectedItem(selectedArtifacts[1].selectedItem);
   }, [selectedArtifacts]);
 
+  const selectedArtifactsForDisplay = useMemo(
+    () => [
+      {
+        selectedItem: firstSelectedItem,
+        linkedArtifact: getLinkedArtifactFromSelectedItem(filteredRunArtifacts, firstSelectedItem),
+      },
+      {
+        selectedItem: secondSelectedItem,
+        linkedArtifact: getLinkedArtifactFromSelectedItem(filteredRunArtifacts, secondSelectedItem),
+      },
+    ],
+    [filteredRunArtifacts, firstSelectedItem, secondSelectedItem],
+  );
+
   const metricsTabText = metricsTypeToString(metricsTab);
   const updateSelectedItemAndArtifact = (
     setSelectedItem: (selectedItem: SelectedItem) => void,
@@ -112,7 +126,7 @@ export default function MetricsDropdown(props: MetricsDropdownProps) {
   ): void => {
     setSelectedItem(selectedItem);
     const linkedArtifact = getLinkedArtifactFromSelectedItem(filteredRunArtifacts, selectedItem);
-    const nextSelectedArtifacts = selectedArtifacts.map((selectedArtifact, index) =>
+    const nextSelectedArtifacts = selectedArtifactsForDisplay.map((selectedArtifact, index) =>
       index === panelIndex
         ? {
             selectedItem,
@@ -142,7 +156,7 @@ export default function MetricsDropdown(props: MetricsDropdownProps) {
             <VisualizationPanelItem
               metricsTab={metricsTab}
               metricsTabText={metricsTabText}
-              linkedArtifact={selectedArtifacts[0].linkedArtifact}
+              linkedArtifact={selectedArtifactsForDisplay[0].linkedArtifact}
               namespace={namespace}
             />
           </td>
@@ -156,7 +170,7 @@ export default function MetricsDropdown(props: MetricsDropdownProps) {
             <VisualizationPanelItem
               metricsTab={metricsTab}
               metricsTabText={metricsTabText}
-              linkedArtifact={selectedArtifacts[1].linkedArtifact}
+              linkedArtifact={selectedArtifactsForDisplay[1].linkedArtifact}
               namespace={namespace}
             />
           </td>

--- a/frontend/src/pages/CompareV2.test.tsx
+++ b/frontend/src/pages/CompareV2.test.tsx
@@ -308,6 +308,80 @@ describe('CompareV2', () => {
       itemName: `test run ${MOCK_RUN_1_ID}`,
       subItemName: 'firstHtmlArtifact',
     });
+    expect(reconciledArtifactsMap[MetricsType.MARKDOWN][0].selectedItem).toEqual({
+      itemName: '',
+      subItemName: '',
+    });
+    expect(reconciledArtifactsMap[MetricsType.MARKDOWN][1].selectedItem).toEqual({
+      itemName: '',
+      subItemName: '',
+    });
+  });
+
+  it('keeps both two-panel selections when they reference the same run', () => {
+    const selectedArtifactsMap = {
+      [MetricsType.CONFUSION_MATRIX]: [
+        {
+          selectedItem: {
+            itemName: `test run ${MOCK_RUN_2_ID}`,
+            subItemName: 'firstArtifact',
+          },
+        },
+        {
+          selectedItem: {
+            itemName: `test run ${MOCK_RUN_2_ID}`,
+            subItemName: 'secondArtifact',
+          },
+        },
+      ],
+      [MetricsType.HTML]: [
+        {
+          selectedItem: {
+            itemName: '',
+            subItemName: '',
+          },
+        },
+        {
+          selectedItem: {
+            itemName: '',
+            subItemName: '',
+          },
+        },
+      ],
+      [MetricsType.MARKDOWN]: [
+        {
+          selectedItem: {
+            itemName: '',
+            subItemName: '',
+          },
+        },
+        {
+          selectedItem: {
+            itemName: '',
+            subItemName: '',
+          },
+        },
+      ],
+    };
+
+    const reconciledArtifactsMap = TEST_ONLY.reconcileSelectedArtifactsMap(selectedArtifactsMap, {
+      scalarMetricsTableData: undefined,
+      confusionMatrixRunArtifacts: [
+        { run: newMockRun(MOCK_RUN_2_ID), executionArtifacts: [] as any },
+      ],
+      htmlRunArtifacts: [],
+      markdownRunArtifacts: [],
+      rocCurveRunArtifacts: [],
+    });
+
+    expect(reconciledArtifactsMap[MetricsType.CONFUSION_MATRIX][0].selectedItem).toEqual({
+      itemName: `test run ${MOCK_RUN_2_ID}`,
+      subItemName: 'firstArtifact',
+    });
+    expect(reconciledArtifactsMap[MetricsType.CONFUSION_MATRIX][1].selectedItem).toEqual({
+      itemName: `test run ${MOCK_RUN_2_ID}`,
+      subItemName: 'secondArtifact',
+    });
   });
 
   it('getRun is called with query param IDs', async () => {

--- a/frontend/src/pages/CompareV2.tsx
+++ b/frontend/src/pages/CompareV2.tsx
@@ -299,7 +299,8 @@ const getVerifiedTwoPanelSelection = (
     const runName = runArtifact.run.display_name;
     if (runName === selectedArtifacts[0].selectedItem.itemName) {
       artifactsPresent[0] = true;
-    } else if (runName === selectedArtifacts[1].selectedItem.itemName) {
+    }
+    if (runName === selectedArtifacts[1].selectedItem.itemName) {
       artifactsPresent[1] = true;
     }
   }


### PR DESCRIPTION
## Summary
- move two-panel artifact selection cleanup in `CompareV2` from a post-render effect into memoized derived state
- stop `MetricsDropdown` from mutating the `selectedArtifacts` array in place
- add focused regression coverage for stale artifact selection reconciliation

## Why
This is the next narrow slice of the frontend `useEffect` cleanup. `CompareV2` was still repairing selected confusion-matrix / HTML / markdown artifacts in an effect after render even though the valid artifact set is already derivable from current runs and MLMD data. Keeping that repair in render-time derivation removes one more state-orchestration effect without changing the page's user-visible behavior.

I kept ROC selection reconciliation in the remaining effect for this PR so the change stays small and reviewable.

## Testing
- `cd frontend && fnm exec --using .nvmrc -- npx prettier@3.8.1 --check src/pages/CompareV2.tsx src/pages/CompareV2.test.tsx src/components/viewers/MetricsDropdown.tsx`
- `cd frontend && fnm exec --using .nvmrc -- npm run test:ui -- src/pages/CompareV2.test.tsx`
- `cd frontend && fnm exec --using .nvmrc -- npm run typecheck`