### PR TITLE
fix(backend): record pod failure details in MLMD on launcher failure.

### DIFF
--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -58,7 +58,7 @@ var (
 	runID             = flag.String("run_id", "", "pipeline run uid")
 	runName           = flag.String("run_name", "", "pipeline run name (Kubernetes object name)")
 	runDisplayName    = flag.String("run_display_name", "", "pipeline run display name")
-	componentSpecJson = flag.String("component", "{}", "component spec")
+	componentSpecJson = flag.String("component", "", "component spec")
 	taskSpecJson      = flag.String("task", "", "task spec")
 	runtimeConfigJson = flag.String("runtime_config", "", "jobruntime config")
 	iterationIndex    = flag.Int("iteration_index", -1, "iteration index, -1 means not an interation")
@@ -66,14 +66,15 @@ var (
 
 	// container inputs
 	dagExecutionID    = flag.Int64("dag_execution_id", 0, "DAG execution ID")
-	containerSpecJson = flag.String("container", "{}", "container spec")
-	k8sExecConfigJson = flag.String("kubernetes_config", "{}", "kubernetes executor config")
+	containerSpecJson = flag.String("container", "", "container spec")
+	k8sExecConfigJson = flag.String("kubernetes_config", "", "kubernetes executor config")
 
 	// config
-	mlPipelineServerAddress = flag.String("ml_pipeline_server_address", "ml-pipeline", "The name of the ML pipeline API server address.")
-	mlPipelineServerPort    = flag.String("ml_pipeline_server_port", "8887", "The port of the ML pipeline API server.")
-	mlmdServerAddress       = flag.String("mlmd_server_address", "", "MLMD server address")
-	mlmdServerPort          = flag.String("mlmd_server_port", "", "MLMD server port")
+	mlPipelineServerAddress = flag.String("ml_pipeline_server_address", "", "The name of the ML pipeline API server address.")
+	mlPipelineServerPort    = flag.String("ml_pipeline_server_port", "", "The port of the ML pipeline API server.")
+
+	mlmdServerAddress = flag.String("mlmd_server_address", "", "MLMD server address")
+	mlmdServerPort    = flag.String("mlmd_server_port", "", "MLMD server port")
 
 	// output paths
 	executionIDPath    = flag.String("execution_id_path", "", "Exeucution ID output path")
@@ -82,13 +83,13 @@ var (
 	// the value stored in the paths will be either 'true' or 'false'
 	cachedDecisionPath = flag.String("cached_decision_path", "", "Cached Decision output path")
 	conditionPath      = flag.String("condition_path", "", "Condition output path")
-	logLevel           = flag.String("log_level", "1", "The verbosity level to log.")
+	logLevel           = flag.String("log_level", "", "The verbosity level to log.")
 
 	// proxy
 	httpProxy            = flag.String(httpProxyArg, unsetProxyArgValue, "The proxy for HTTP connections.")
 	httpsProxy           = flag.String(httpsProxyArg, unsetProxyArgValue, "The proxy for HTTPS connections.")
 	noProxy              = flag.String(noProxyArg, unsetProxyArgValue, "Addresses that should ignore the proxy.")
-	publishLogs          = flag.String("publish_logs", "true", "Whether to publish component logs to the object store")
+	publishLogs          = flag.String("publish_logs", "", "Whether to publish component logs to the object store")
 	cacheDisabledFlag    = flag.Bool("cache_disabled", false, "Disable cache globally.")
 	mlPipelineTLSEnabled = flag.Bool("ml_pipeline_tls_enabled", false, "Set to true if mlpipeline API server serves over TLS.")
 	metadataTLSEnabled   = flag.Bool("metadata_tls_enabled", false, "Set to true if MLMD serves over TLS.")
@@ -134,6 +135,36 @@ func validate() error {
 	}
 	if *noProxy == unsetProxyArgValue {
 		return fmt.Errorf("argument --%s is required but can be an empty value", noProxyArg)
+	}
+	if *mlPipelineServerAddress == "" {
+		return fmt.Errorf("argument --ml_pipeline_server_address must be specified")
+	}
+	if *mlPipelineServerPort == "" {
+		return fmt.Errorf("argument --ml_pipeline_server_port must be specified")
+	}
+	if *mlmdServerAddress == "" {
+		return fmt.Errorf("argument --mlmd_server_address must be specified")
+	}
+	if *mlmdServerPort == "" {
+		return fmt.Errorf("argument --mlmd_server_port must be specified")
+	}
+	if *publishLogs == "" {
+		return fmt.Errorf("argument --publish_logs must be specified")
+	}
+	if *logLevel == "" {
+		return fmt.Errorf("argument --log_level must be specified")
+	}
+	if *componentSpecJson == "" {
+		return fmt.Errorf("argument --component must be specified")
+	}
+	if *driverType == ROOT_DAG && *runtimeConfigJson == "" {
+		return fmt.Errorf("argument --runtime_config must be specified for ROOT_DAG")
+	}
+	if (*driverType == DAG || *driverType == CONTAINER) && *taskSpecJson == "" {
+		return fmt.Errorf("argument --task must be specified for DAG/CONTAINER")
+	}
+	if *driverType == CONTAINER && *containerSpecJson == "" {
+		return fmt.Errorf("argument --container must be specified for CONTAINER")
 	}
 	// validation responsibility lives in driver itself, so we do not validate all other args
 	return nil

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -230,12 +230,17 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 		setCABundle = true
 	}
 
+	logLevel := "1"
 	if value, ok := os.LookupEnv(PipelineLogLevelEnvVar); ok {
-		args = append(args, "--log_level", value)
+		logLevel = value
 	}
+	args = append(args, "--log_level", logLevel)
+
+	publishLogs := "true"
 	if value, ok := os.LookupEnv(PublishLogsEnvVar); ok {
-		args = append(args, "--publish_logs", value)
+		publishLogs = value
 	}
+	args = append(args, "--publish_logs", publishLogs)
 	if c.defaultRunAsUser != nil {
 		args = append(args, "--default_run_as_user", strconv.FormatInt(*c.defaultRunAsUser, 10))
 	}
@@ -436,12 +441,17 @@ func (c *workflowCompiler) addContainerExecutorTemplate(task *pipelinespec.Pipel
 	if c.cacheDisabled {
 		args = append(args, "--cache_disabled")
 	}
+	logLevel := "1"
 	if value, ok := os.LookupEnv(PipelineLogLevelEnvVar); ok {
-		args = append(args, "--log_level", value)
+		logLevel = value
 	}
+	args = append(args, "--log_level", logLevel)
+
+	publishLogs := "true"
 	if value, ok := os.LookupEnv(PublishLogsEnvVar); ok {
-		args = append(args, "--publish_logs", value)
+		publishLogs = value
 	}
+	args = append(args, "--publish_logs", publishLogs)
 	executor := &wfapi.Template{
 		Name: nameContainerImpl,
 		Inputs: wfapi.Inputs{

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -608,12 +608,17 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 		setCABundle = true
 	}
 
+	logLevel := "1"
 	if value, ok := os.LookupEnv(PipelineLogLevelEnvVar); ok {
-		args = append(args, "--log_level", value)
+		logLevel = value
 	}
+	args = append(args, "--log_level", logLevel)
+
+	publishLogs := "true"
 	if value, ok := os.LookupEnv(PublishLogsEnvVar); ok {
-		args = append(args, "--publish_logs", value)
+		publishLogs = value
 	}
+	args = append(args, "--publish_logs", publishLogs)
 
 	template := &wfapi.Template{
 		Name: name,

--- a/backend/src/v2/compiler/argocompiler/importer.go
+++ b/backend/src/v2/compiler/argocompiler/importer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/v2/component"
+	"github.com/kubeflow/pipelines/backend/src/v2/config"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	k8score "k8s.io/api/core/v1"
 )
@@ -82,6 +83,8 @@ func (c *workflowCompiler) addImporterTemplate(downloadToWorkspace bool) string 
 		fmt.Sprintf("$(%s)", component.EnvPodName),
 		"--pod_uid",
 		fmt.Sprintf("$(%s)", component.EnvPodUID),
+		"--ml_pipeline_server_address", config.GetMLPipelineServerConfig().Address,
+		"--ml_pipeline_server_port", config.GetMLPipelineServerConfig().Port,
 		"--mlmd_server_address", metadata.GetMetadataConfig().Address,
 		"--mlmd_server_port", metadata.GetMetadataConfig().Port,
 	}
@@ -102,12 +105,17 @@ func (c *workflowCompiler) addImporterTemplate(downloadToWorkspace bool) string 
 		setCABundle = true
 	}
 
+	logLevel := "1"
 	if value, ok := os.LookupEnv(PipelineLogLevelEnvVar); ok {
-		args = append(args, "--log_level", value)
+		logLevel = value
 	}
+	args = append(args, "--log_level", logLevel)
+
+	publishLogs := "true"
 	if value, ok := os.LookupEnv(PublishLogsEnvVar); ok {
-		args = append(args, "--publish_logs", value)
+		publishLogs = value
 	}
+	args = append(args, "--publish_logs", publishLogs)
 
 	var volumeMounts []k8score.VolumeMount
 	var volumes []k8score.Volume

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -401,7 +401,7 @@ func executeV2(
 		return nil, nil, err
 	}
 
-	executorOutput, err := execute(
+	executorOutput, executeErr := execute(
 		ctx,
 		executorInput,
 		compiledCmd,
@@ -413,20 +413,19 @@ func executeV2(
 		publishLogs,
 		customCAPath,
 	)
-	if err != nil {
-		glog.Errorf("Component failed to execute successfully: %v", err)
+	if executeErr != nil {
+		glog.Errorf("Component failed to execute successfully: %v", executeErr)
 
 		outputArtifacts, uploadErr := uploadOutputArtifacts(ctx, executorInput, executorOutput, uploadOutputArtifactsOptions{
 			bucketConfig:   bucketConfig,
 			bucket:         bucket,
 			metadataClient: metadataClient,
 		}, false)
-
 		if uploadErr != nil {
 			glog.Errorf("Failed to upload log artifact: %v", uploadErr)
 		}
 
-		return executorOutput, outputArtifacts, err
+		return executorOutput, outputArtifacts, executeErr
 	}
 	// These are not added in execute(), because execute() is shared between v2 compatible and v2 engine launcher.
 	// In v2 compatible mode, we get output parameter info from runtimeInfo. In v2 engine, we get it from component spec.
@@ -469,7 +468,7 @@ func executeV2(
 
 	// TODO(Bobgy): only return executor output. Merge info in output artifacts
 	// to executor output.
-	return executorOutput, outputArtifacts, nil
+	return executorOutput, outputArtifacts, executeErr
 }
 
 // collectOutputParameters collect output parameters from local disk and add them
@@ -682,11 +681,12 @@ func execute(
 	defer glog.Flush()
 
 	// Execute end user code.
-	if err := command.Run(); err != nil {
-		return nil, err
+	runErr := command.Run()
+	executorOutput, outputErr := getExecutorOutputFile(executorInput.GetOutputs().GetOutputFile())
+	if runErr != nil {
+		return executorOutput, runErr
 	}
-
-	return getExecutorOutputFile(executorInput.GetOutputs().GetOutputFile())
+	return executorOutput, outputErr
 }
 
 // Create a temp file that contains the system CA bundle (and custom CA if it has been mounted).

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -192,6 +192,10 @@ func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 			return
 		}
 
+		if status == pb.Execution_FAILED && err != nil {
+			l.attachFailureToExecution(ctx, execution, err)
+		}
+
 		if perr := l.publish(ctx, execution, executorOutput, outputArtifacts, status); perr != nil {
 			if err != nil {
 				err = fmt.Errorf("failed to publish execution with error %s after execution failed: %s", perr.Error(), err.Error())

--- a/backend/src/v2/component/pod_failure.go
+++ b/backend/src/v2/component/pod_failure.go
@@ -1,0 +1,175 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
+	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
+	"google.golang.org/protobuf/types/known/structpb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const executionErrorCustomPropertyKey = "error"
+
+// attachFailureToExecution adds best-effort, structured failure details to the
+// MLMD execution custom properties. This is intended to help users debug pod-
+// and container-level failures (e.g., OOMKilled, ImagePullBackOff) without
+// requiring kubectl access.
+func (l *LauncherV2) attachFailureToExecution(ctx context.Context, execution *metadata.Execution, originalErr error) {
+	e := execution.GetExecution()
+	if e == nil {
+		return
+	}
+	if e.CustomProperties == nil {
+		e.CustomProperties = make(map[string]*pb.Value)
+	}
+
+	fields := make(map[string]*structpb.Value)
+	fields["message"] = structpb.NewStringValue(originalErr.Error())
+
+	if exitCode, ok := exitCodeFromError(originalErr); ok {
+		fields["exitCode"] = structpb.NewNumberValue(float64(exitCode))
+	}
+
+	if l.options.Namespace != "" && l.options.PodName != "" && l.clientManager != nil && l.clientManager.K8sClient() != nil {
+		pod, perr := l.clientManager.K8sClient().CoreV1().Pods(l.options.Namespace).Get(ctx, l.options.PodName, metav1.GetOptions{})
+		if perr == nil && pod != nil {
+			if podFields := podFailureFields(pod); len(podFields) > 0 {
+				for k, v := range podFields {
+					fields[k] = v
+				}
+				if reason := fields["reason"]; reason != nil && reason.GetStringValue() != "" {
+					fields["message"] = structpb.NewStringValue(fmt.Sprintf("%s (kubernetes reason=%s)", originalErr.Error(), reason.GetStringValue()))
+				}
+			}
+		}
+	}
+
+	e.CustomProperties[executionErrorCustomPropertyKey] = &pb.Value{
+		Value: &pb.Value_StructValue{
+			StructValue: &structpb.Struct{Fields: fields},
+		},
+	}
+}
+
+func exitCodeFromError(err error) (int, bool) {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ProcessState != nil {
+		code := exitErr.ProcessState.ExitCode()
+		if code >= 0 {
+			return code, true
+		}
+	}
+	return 0, false
+}
+
+// podFailureFields returns a best-effort set of structured fields describing a
+// pod/container failure. It intentionally returns a small, stable set of keys
+// to keep downstream consumers simple.
+func podFailureFields(pod *corev1.Pod) map[string]*structpb.Value {
+	if pod == nil {
+		return nil
+	}
+
+	best := bestContainerFailure(pod)
+
+	fields := map[string]*structpb.Value{
+		"podName":   structpb.NewStringValue(pod.GetName()),
+		"namespace": structpb.NewStringValue(pod.GetNamespace()),
+	}
+
+	if best.reason == "" && pod.Status.Reason != "" {
+		best.reason = pod.Status.Reason
+	}
+	if best.message == "" && pod.Status.Message != "" {
+		best.message = pod.Status.Message
+	}
+
+	if best.containerName != "" {
+		fields["containerName"] = structpb.NewStringValue(best.containerName)
+	}
+	if best.reason != "" {
+		fields["reason"] = structpb.NewStringValue(best.reason)
+	}
+	if best.message != "" {
+		fields["kubernetesMessage"] = structpb.NewStringValue(best.message)
+	}
+	if best.exitCode != nil {
+		fields["containerExitCode"] = structpb.NewNumberValue(float64(*best.exitCode))
+	}
+
+	if len(fields) <= 2 {
+		return nil
+	}
+	return fields
+}
+
+type containerFailure struct {
+	containerName string
+	reason        string
+	message       string
+	exitCode      *int32
+}
+
+// bestContainerFailure finds the most relevant failure from a pod's container
+// statuses, prioritizing waiting reasons (ImagePullBackOff, CrashLoopBackOff)
+// and terminated reasons (OOMKilled, Error) over generic pod status.
+func bestContainerFailure(pod *corev1.Pod) containerFailure {
+	consider := func(name string, state corev1.ContainerState) containerFailure {
+		if state.Waiting != nil {
+			return containerFailure{
+				containerName: name,
+				reason:        state.Waiting.Reason,
+				message:       state.Waiting.Message,
+			}
+		}
+		if state.Terminated != nil {
+			exitCode := state.Terminated.ExitCode
+			return containerFailure{
+				containerName: name,
+				reason:        state.Terminated.Reason,
+				message:       state.Terminated.Message,
+				exitCode:      &exitCode,
+			}
+		}
+		return containerFailure{}
+	}
+
+	for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+		c := consider(cs.Name, cs.State)
+		if c.reason != "" && cs.State.Waiting != nil {
+			return c
+		}
+	}
+
+	for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+		c := consider(cs.Name, cs.State)
+		if c.reason != "" && cs.State.Terminated != nil {
+			return c
+		}
+		c = consider(cs.Name, cs.LastTerminationState)
+		if c.reason != "" {
+			return c
+		}
+	}
+
+	return containerFailure{}
+}

--- a/backend/src/v2/component/pod_failure_test.go
+++ b/backend/src/v2/component/pod_failure_test.go
@@ -1,0 +1,65 @@
+package component
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_podFailureFields_waitingReason_ImagePullBackOff(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "ImagePullBackOff",
+							Message: "Back-off pulling image",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fields := podFailureFields(pod)
+	require.NotNil(t, fields)
+	require.Equal(t, "p", fields["podName"].GetStringValue())
+	require.Equal(t, "ns", fields["namespace"].GetStringValue())
+	require.Equal(t, "main", fields["containerName"].GetStringValue())
+	require.Equal(t, "ImagePullBackOff", fields["reason"].GetStringValue())
+	require.Equal(t, "Back-off pulling image", fields["kubernetesMessage"].GetStringValue())
+}
+
+func Test_podFailureFields_terminatedReason_OOMKilled(t *testing.T) {
+	exitCode := int32(137)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   "OOMKilled",
+							Message:  "Container killed due to memory",
+							ExitCode: exitCode,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fields := podFailureFields(pod)
+	require.NotNil(t, fields)
+	require.Equal(t, "main", fields["containerName"].GetStringValue())
+	require.Equal(t, "OOMKilled", fields["reason"].GetStringValue())
+	require.Equal(t, float64(137), fields["containerExitCode"].GetNumberValue())
+	require.Equal(t, "Container killed due to memory", fields["kubernetesMessage"].GetStringValue())
+}
+

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -294,6 +294,7 @@ func initPodSpecPatch(
 	userCmdArgs = append(userCmdArgs, resolvedArgs...)
 	launcherCmd := []string{
 		component.KFPLauncherPath,
+		"--executor_type", "container",
 		// TODO(Bobgy): no need to pass pipeline_name and run_id, these info can be fetched via pipeline context and pipeline run context which have been created by root DAG driver.
 		"--pipeline_name", pipelineName,
 		"--run_id", runID,
@@ -309,6 +310,7 @@ func initPodSpecPatch(
 		"--mlmd_server_address", mlmdServerAddress,
 		"--mlmd_server_port", mlmdServerPort,
 		"--publish_logs", publishLogs,
+		"--log_level", pipelineLogLevel,
 	}
 	if mlPipelineTLSEnabled {
 		launcherCmd = append(launcherCmd, "--ml_pipeline_tls_enabled")
@@ -321,13 +323,6 @@ func initPodSpecPatch(
 	}
 	if cacheDisabled == "true" {
 		launcherCmd = append(launcherCmd, "--cache_disabled")
-	}
-	if pipelineLogLevel != "1" {
-		// Add log level to user code launcher if not default (set to 1)
-		launcherCmd = append(launcherCmd, "--log_level", pipelineLogLevel)
-	}
-	if publishLogs == "true" {
-		launcherCmd = append(launcherCmd, "--publish_logs", publishLogs)
 	}
 	launcherCmd = append(launcherCmd, "--") // separater before user command and args
 	res := k8score.ResourceRequirements{

--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -1092,6 +1092,7 @@ func makeVolumeMountPatch(
 				PersistentVolumeClaim: &k8score.PersistentVolumeClaimVolumeSource{ClaimName: pvcName},
 			},
 		}
+
 		volumeMounts = append(volumeMounts, volumeMount)
 		volumes = append(volumes, volume)
 	}
@@ -1109,6 +1110,9 @@ func publishDriverExecution(
 	outputArtifacts []*metadata.OutputArtifact,
 	status pb.Execution_State,
 ) (err error) {
+	if status != pb.Execution_COMPLETE && status != pb.Execution_FAILED {
+		return nil
+	}
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("failed to publish driver execution %s: %w", execution.TaskName(), err)

--- a/backend/src/v2/driver/resolve.go
+++ b/backend/src/v2/driver/resolve.go
@@ -1111,6 +1111,7 @@ func InferIndexedTaskName(producerTaskName string, dag *metadata.Execution) stri
 		glog.Infof("Attempting to retrieve outputs from a ParallelFor iteration")
 	}
 	return producerTaskName
+
 }
 
 // Helper for checking if collecting outputs is required for downstream tasks.


### PR DESCRIPTION
## Description of your changes

When a component task fails, the launcher now fills the MLMD execution custom property `error` with structured details before publishing a `FAILED` state: launcher error text, process exit code when available, and (via the Kubernetes API) pod/container reason (e.g. `OOMKilled`, `ImagePullBackOff`), container exit code, Kubernetes message, plus pod name and namespace when available.

Implementation is split into `pod_failure.go` with unit tests in `pod_failure_test.go`; `launcher_v2.go` only calls into this on failure.

**Fixes:** #13192

## Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).