### PR TITLE
test(backend): Add MLFlow Integrations tests with KFP

### DIFF
--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -96,6 +96,10 @@ inputs:
     description: "Skip API access configuration and token generation (for tests that do not need a cluster)"
     required: false
     default: 'false'
+  mlflow_enabled:
+    description: "Whether MLflow is deployed and available for integration tests"
+    required: false
+    default: 'false'
 
 
 runs:
@@ -264,7 +268,7 @@ runs:
           DISABLE_TLS_CHECK='false'
         fi
 
-        go run github.com/onsi/ginkgo/v2/ginkgo -r -v --cover -p --keep-going --github-output=true --nodes=${{ inputs.num_parallel_nodes }} --label-filter=${{ inputs.test_label }} --silence-skips=true -- -namespace=${{ inputs.default_namespace }} -multiUserMode=$MULTI_USER -useProxy=$USE_PROXY -userNamespace=${{ inputs.user_namespace }} -uploadPipelinesWithKubernetes=${{ inputs.upload_pipelines_with_kubernetes_client}} -pipelineStoreKubernetes=$pipelineStoreKubernetes -disableTlsCheck=$DISABLE_TLS_CHECK -apiScheme=$API_SCHEME -tlsEnabled=$TLS_ENABLED -caCertPath=$CA_CERT_PATH -pullNumber=$PULL_NUMBER -repoName=$REPO_NAME -apiUrl="$API_URL" -authToken="$AUTH_TOKEN" -serviceAccountName="$SERVICE_ACCOUNT_NAME" $BASE_IMAGE_FLAG
+        go run github.com/onsi/ginkgo/v2/ginkgo -r -v --cover -p --keep-going --github-output=true --nodes=${{ inputs.num_parallel_nodes }} --label-filter=${{ inputs.test_label }} --silence-skips=true -- -namespace=${{ inputs.default_namespace }} -multiUserMode=$MULTI_USER -useProxy=$USE_PROXY -userNamespace=${{ inputs.user_namespace }} -uploadPipelinesWithKubernetes=${{ inputs.upload_pipelines_with_kubernetes_client}} -pipelineStoreKubernetes=$pipelineStoreKubernetes -disableTlsCheck=$DISABLE_TLS_CHECK -apiScheme=$API_SCHEME -tlsEnabled=$TLS_ENABLED -caCertPath=$CA_CERT_PATH -pullNumber=$PULL_NUMBER -repoName=$REPO_NAME -apiUrl="$API_URL" -authToken="$AUTH_TOKEN" -serviceAccountName="$SERVICE_ACCOUNT_NAME" -mlflowEnabled=${{ inputs.mlflow_enabled }} $BASE_IMAGE_FLAG
       continue-on-error: true
 
     - name: Collect Pod logs in case of Test Failures

--- a/.github/resources/scripts/configure-mlflow.sh
+++ b/.github/resources/scripts/configure-mlflow.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Purpose:
+# This script configures KFP to use an already-deployed MLflow instance for
+# MLflow E2E tests.
+#
+# CI helper: patch the KFP API server with plugins.mlflow, roll it out, and
+# port-forward the API server and MLflow so E2E tests can reach both.
+# It also exports workspace/auth variables used by MLflow test helpers.
+#
+# Usage: configure-mlflow.sh <KFP_NAMESPACE> <MLFLOW_NAMESPACE> <CONFIG_JSON_PATH>
+
+set -e
+
+KFP_NAMESPACE="${1:?KFP namespace required}"
+MLFLOW_NAMESPACE="${2:?MLflow namespace required}"
+CONFIG_JSON_PATH="${3:?Path to source config.json required}"
+
+echo "Services in ${MLFLOW_NAMESPACE} namespace:"
+kubectl get svc -n "$MLFLOW_NAMESPACE" --no-headers
+MLFLOW_SVC=$(kubectl get svc -n "$MLFLOW_NAMESPACE" --no-headers -o custom-columns=":metadata.name" | grep -i mlflow | head -1)
+if [ -z "$MLFLOW_SVC" ]; then
+  echo "ERROR: No service matching 'mlflow' found in namespace $MLFLOW_NAMESPACE"
+  exit 1
+fi
+MLFLOW_PORT=$(kubectl get svc -n "$MLFLOW_NAMESPACE" "$MLFLOW_SVC" -o jsonpath='{.spec.ports[0].port}')
+MLFLOW_HOST="${MLFLOW_SVC}.${MLFLOW_NAMESPACE}.svc.cluster.local"
+MLFLOW_ENDPOINT="https://${MLFLOW_HOST}:${MLFLOW_PORT}"
+echo "MLflow service: $MLFLOW_SVC port=$MLFLOW_PORT endpoint=$MLFLOW_ENDPOINT"
+
+MLFLOW_PATCH=$(jq -n --arg endpoint "$MLFLOW_ENDPOINT" '{
+  endpoint: $endpoint,
+  tls: { insecureSkipVerify: true },
+  settings: { workspacesEnabled: true }
+}')
+
+jq --argjson mlflow "$MLFLOW_PATCH" '. + { plugins: { mlflow: $mlflow } }' \
+  "$CONFIG_JSON_PATH" > /tmp/kfp-config.json
+
+echo "Patched config.json plugins.mlflow:"
+jq '.plugins.mlflow' /tmp/kfp-config.json
+
+kubectl create configmap kfp-mlflow-config -n "$KFP_NAMESPACE" \
+  --from-file=config.json=/tmp/kfp-config.json --dry-run=client -o yaml | kubectl apply -f -
+kubectl patch deployment ml-pipeline -n "$KFP_NAMESPACE" --type=strategic -p \
+  '{"spec":{"template":{"spec":{"volumes":[{"name":"mlflow-cfg","configMap":{"name":"kfp-mlflow-config"}}],"containers":[{"name":"ml-pipeline-api-server","volumeMounts":[{"name":"mlflow-cfg","mountPath":"/config/config.json","subPath":"config.json"}]}]}}}}'
+kubectl rollout status deployment/ml-pipeline -n "$KFP_NAMESPACE" --timeout=180s
+
+pkill -f "kubectl port-forward.*ml-pipeline.*8888" || true
+sleep 2
+
+C_DIR="${BASH_SOURCE%/*}"
+"${C_DIR}/forward-port.sh" "$KFP_NAMESPACE" ml-pipeline 8888 8888
+
+for i in $(seq 1 12); do
+  if curl -sf http://localhost:8888/apis/v1beta1/healthz > /dev/null 2>&1; then
+    echo "API server is healthy on localhost:8888"
+    break
+  fi
+  echo "Waiting for API server to become healthy... ($i/12)"
+  sleep 5
+done
+curl -sf http://localhost:8888/apis/v1beta1/healthz > /dev/null 2>&1 || {
+  echo "ERROR: API server not reachable at localhost:8888"
+  exit 1
+}
+
+SA_TOKEN=$(kubectl create token ml-pipeline -n "$KFP_NAMESPACE" --duration=1h 2>/dev/null || true)
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "MLFLOW_WORKSPACE=$KFP_NAMESPACE" >> "$GITHUB_ENV"
+  # Later workflow steps need these to re-establish port-forward: background jobs from this step
+  # are terminated when the step exits, so test-and-report starts kubectl port-forward again.
+  echo "MLFLOW_PORT_FORWARD_NS=$MLFLOW_NAMESPACE" >> "$GITHUB_ENV"
+  echo "MLFLOW_PORT_FORWARD_SVC=$MLFLOW_SVC" >> "$GITHUB_ENV"
+  echo "MLFLOW_PORT_FORWARD_REMOTE_PORT=$MLFLOW_PORT" >> "$GITHUB_ENV"
+  if [ -n "$SA_TOKEN" ]; then
+    echo "MLFLOW_BEARER_TOKEN=$SA_TOKEN" >> "$GITHUB_ENV"
+    echo "Exported MLFLOW_BEARER_TOKEN and MLFLOW_WORKSPACE for test helpers"
+  else
+    echo "WARNING: Could not create SA token; MLflow requests may be unauthenticated"
+    echo "Exported MLFLOW_WORKSPACE only"
+  fi
+fi
+
+kubectl port-forward -n "$MLFLOW_NAMESPACE" "svc/$MLFLOW_SVC" "8080:$MLFLOW_PORT" &
+sleep 3
+
+HEALTH_URL="https://localhost:8080/api/2.0/mlflow/experiments/search"
+CURL_HEADERS=(-H "X-MLflow-Workspace: $KFP_NAMESPACE")
+[ -n "$SA_TOKEN" ] && CURL_HEADERS+=(-H "Authorization: Bearer $SA_TOKEN")
+
+STATUS=000
+for i in $(seq 1 30); do
+  STATUS=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 \
+    "${CURL_HEADERS[@]}" "$HEALTH_URL" 2>/dev/null || echo "000")
+  if [ "$STATUS" != "000" ] && [ "$STATUS" -lt 500 ] 2>/dev/null; then
+    echo "MLflow backend is healthy on localhost:8080 (HTTPS, status=$STATUS)"
+    break
+  fi
+  echo "Waiting for MLflow backend... ($i/30, status=$STATUS)"
+  sleep 5
+done
+if [ "$STATUS" = "000" ] || { [ "$STATUS" -ge 500 ] 2>/dev/null; }; then
+  echo "ERROR: MLflow backend not healthy after 30 attempts (last status=$STATUS)"
+  exit 1
+fi

--- a/.github/resources/scripts/configure-mlflow.sh
+++ b/.github/resources/scripts/configure-mlflow.sh
@@ -38,7 +38,8 @@ if [ -z "$MLFLOW_SVC" ]; then
 fi
 MLFLOW_PORT=$(kubectl get svc -n "$MLFLOW_NAMESPACE" "$MLFLOW_SVC" -o jsonpath='{.spec.ports[0].port}')
 MLFLOW_HOST="${MLFLOW_SVC}.${MLFLOW_NAMESPACE}.svc.cluster.local"
-MLFLOW_ENDPOINT="https://${MLFLOW_HOST}:${MLFLOW_PORT}"
+MLFLOW_STATIC_PREFIX="/mlflow"
+MLFLOW_ENDPOINT="https://${MLFLOW_HOST}:${MLFLOW_PORT}${MLFLOW_STATIC_PREFIX}"
 echo "MLflow service: $MLFLOW_SVC port=$MLFLOW_PORT endpoint=$MLFLOW_ENDPOINT"
 
 MLFLOW_PATCH=$(jq -n --arg endpoint "$MLFLOW_ENDPOINT" '{
@@ -98,7 +99,7 @@ fi
 kubectl port-forward -n "$MLFLOW_NAMESPACE" "svc/$MLFLOW_SVC" "8080:$MLFLOW_PORT" &
 sleep 3
 
-HEALTH_URL="https://localhost:8080/api/2.0/mlflow/experiments/search"
+HEALTH_URL="https://localhost:8080${MLFLOW_STATIC_PREFIX}/health"
 CURL_HEADERS=(-H "X-MLflow-Workspace: $KFP_NAMESPACE")
 [ -n "$SA_TOKEN" ] && CURL_HEADERS+=(-H "Authorization: Bearer $SA_TOKEN")
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -10,7 +10,7 @@ env:
   AWS_ACCESS_KEY_ID: 'minio'
   AWS_SECRET_ACCESS_KEY: 'minio123'
   AWS_S3_BUCKET: 'mlpipeline'
-  MLFLOW_TRACKING_URI: "https://localhost:8080"
+  MLFLOW_TRACKING_URI: "https://localhost:8080/mlflow"
   MLFLOW_TRACKING_INSECURE_TLS: "true"
 
 on:
@@ -307,9 +307,8 @@ jobs:
           image_registry: ${{ needs.build.outputs.IMAGE_REGISTRY }}
 
       - name: Deploy MLflow
-        id: deploy-mlflow
-        # TEMP: pin pre-migration-init regression in upstream @main.
-        uses: opendatahub-io/mlflow-operator/.github/actions/deploy@daa0c1a28be532563ca6c0f1925ddecd0d0290f1
+        id: deploy-mlflow        
+        uses: opendatahub-io/mlflow-operator/.github/actions/deploy@8ab07a89d6d2d6bc2ffa0c8601f4a856a4cb1b18
         if: ${{ steps.create-cluster.outcome == 'success' }}
         with:
           namespace: 'opendatahub'

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -7,6 +7,11 @@ env:
   PYTHON_VERSION: "3.9"
   USER_NAMESPACE: "kubeflow-user-example-com"
   CA_CERT_PATH: ""
+  AWS_ACCESS_KEY_ID: 'minio'
+  AWS_SECRET_ACCESS_KEY: 'minio123'
+  AWS_S3_BUCKET: 'mlpipeline'
+  MLFLOW_TRACKING_URI: "https://localhost:8080"
+  MLFLOW_TRACKING_INSECURE_TLS: "true"
 
 on:
   push:
@@ -256,3 +261,119 @@ jobs:
           python_version: ${{ env.PYTHON_VERSION }}
           user_namespace: ${{ env.USER_NAMESPACE }}
           report_name: "E2EMultiUserTests_K8s=${{ matrix.k8s_version }}_cacheEnabled=${{ matrix.cache_enabled }}_multiUser=${{ matrix.multi_user }}"
+
+
+  end-to-end-critical-mlflow-tests:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        k8s_version: [ "v1.34.0" ]
+        cache_enabled: [ "true", "false" ]
+        argo_version: [ "v3.7.3" ]
+        proxy: [ "false" ]
+        test_label: [ "MLflow" ]
+        pod_to_pod_tls_enabled: [ "false" ]
+        multi_user: [ "false" ]
+        artifact_proxy: [ "false" ]
+        artifact_storage: [ "file", "s3" ]
+        backend_store: [ "postgres" ]
+        registry_store: [ "postgres" ]
+      fail-fast: false
+    name: End to End Critical Scenario MLflow Tests - K8s ${{ matrix.k8s_version }} cacheEnabled=${{ matrix.cache_enabled }} multiUser=${{ matrix.multi_user }} artifactProxy=${{ matrix.artifact_proxy }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Create cluster
+        uses: ./.github/actions/create-cluster
+        id: create-cluster
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
+          cluster_name: ${{ env.CLUSTER_NAME }}
+
+      - name: Deploy KFP
+        uses: ./.github/actions/deploy
+        if: ${{ steps.create-cluster.outcome == 'success' }}
+        id: deploy
+        with:
+          cache_enabled: ${{ matrix.cache_enabled }}
+          argo_version: ${{ matrix.argo_version }}
+          pod_to_pod_tls_enabled: ${{ matrix.pod_to_pod_tls_enabled }}
+          multi_user: ${{ matrix.multi_user }}
+          artifact_proxy: ${{ matrix.artifact_proxy }}
+          image_path: ${{ needs.build.outputs.IMAGE_PATH }}
+          image_tag: ${{ needs.build.outputs.IMAGE_TAG }}
+          image_registry: ${{ needs.build.outputs.IMAGE_REGISTRY }}
+
+      - name: Deploy MLflow
+        id: deploy-mlflow
+        # TEMP: pin pre-migration-init regression in upstream @main.
+        uses: opendatahub-io/mlflow-operator/.github/actions/deploy@daa0c1a28be532563ca6c0f1925ddecd0d0290f1
+        if: ${{ steps.create-cluster.outcome == 'success' }}
+        with:
+          namespace: 'opendatahub'
+          mlflow_image: quay.io/${{ github.repository_owner == 'red-hat-data-services' && 'rhoai' || 'opendatahub' }}/mlflow:odh-stable
+          mlflow_operator_image: quay.io/${{ github.repository_owner == 'red-hat-data-services' && 'rhoai' || 'opendatahub' }}/mlflow-operator:odh-stable
+          backend_store: ${{ matrix.backend_store }}
+          artifact_storage: ${{ matrix.artifact_storage }}
+          registry_store: ${{ matrix.registry_store }}
+          s3_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
+          s3_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Wait for MLflow stack readiness
+        shell: bash
+        if: ${{ steps.deploy-mlflow.outcome == 'success' }}
+        run: |
+          kubectl wait --for=condition=Ready pods --field-selector=status.phase=Running -n opendatahub --timeout=180s
+          echo "All running pods in opendatahub are Ready"
+
+      - name: Configure MLflow Plugin and Forward Ports
+        shell: bash
+        id: configure-mlflow-plugin
+        if: ${{ steps.deploy.outcome == 'success' && steps.deploy-mlflow.outcome == 'success' }}
+        run: ./.github/resources/scripts/configure-mlflow.sh kubeflow opendatahub backend/src/apiserver/config/config.json
+
+      - name: Configure Input Variables
+        shell: bash
+        id: configure
+        if: ${{ steps.deploy.outcome == 'success' }}
+        run: |
+          NUMBER_OF_NODES=${{ env.NUMBER_OF_PARALLEL_NODES }}
+          TEST_LABEL=${{ matrix.test_label }}
+          NAMESPACE=${{ env.NAMESPACE }}
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            NUMBER_OF_NODES=${{ inputs.number_of_parallel_tests }}
+            TEST_LABEL=${{ inputs.test_label }}
+            NAMESPACE=${{ inputs.namespace }}
+          fi
+
+          {
+            echo "NUMBER_OF_NODES=$NUMBER_OF_NODES"
+            echo "TEST_LABEL=$TEST_LABEL"
+            echo "NAMESPACE=$NAMESPACE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and upload the sample Modelcar image to Kind
+        id: build-sample-modelcar-image
+        if: ${{ steps.deploy.outcome == 'success' }}
+        run: |
+          docker build -f ./test_data/sdk_compiled_pipelines/valid/critical/modelcar/Dockerfile -t registry.domain.local/modelcar:test .
+          kind --name kfp load docker-image registry.domain.local/modelcar:test
+        continue-on-error: true
+
+      - name: Run Tests
+        uses: ./.github/actions/test-and-report
+        id: test-run
+        if: ${{ steps.configure.outcome == 'success' && steps.deploy-mlflow.outcome == 'success' && steps.configure-mlflow-plugin.outcome == 'success'}}
+        with:
+          cache_enabled: ${{ matrix.cache_enabled }}
+          test_directory: ${{ env.E2E_TESTS_DIR }}
+          test_label: ${{ steps.configure.outputs.TEST_LABEL }}
+          num_parallel_nodes: ${{ steps.configure.outputs.NUMBER_OF_NODES }}
+          default_namespace: ${{ steps.configure.outputs.NAMESPACE }}
+          python_version: ${{ env.PYTHON_VERSION }}
+          report_name: "MLflowTests_K8s=${{ matrix.k8s_version }}_cacheEnabled=${{ matrix.cache_enabled }}_artifactStorage=${{ matrix.artifact_storage }}"
+          tls_enabled: ${{ matrix.pod_to_pod_tls_enabled }}
+          ca_cert_path: ${{ env.CA_CERT_PATH }}
+          mlflow_enabled: 'true'

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -280,7 +280,7 @@ jobs:
         backend_store: [ "postgres" ]
         registry_store: [ "postgres" ]
       fail-fast: false
-    name: End to End Critical Scenario MLflow Tests - K8s ${{ matrix.k8s_version }} cacheEnabled=${{ matrix.cache_enabled }} multiUser=${{ matrix.multi_user }} artifactProxy=${{ matrix.artifact_proxy }}
+    name: End to End Critical Scenario MLflow Tests - K8s ${{ matrix.k8s_version }} cacheEnabled=${{ matrix.cache_enabled }} artifactStorage=${{ matrix.artifact_storage }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/backend/src/apiserver/config/config.json
+++ b/backend/src/apiserver/config/config.json
@@ -24,5 +24,18 @@
   "CacheEnabled": "true",
   "CRON_SCHEDULE_TIMEZONE": "UTC",
   "CACHE_IMAGE": "ghcr.io/containerd/busybox",
-  "CACHE_NODE_RESTRICTIONS": "false"
+  "CACHE_NODE_RESTRICTIONS": "false",
+  "plugins": {
+    "mlflow": {
+      "endpoint": "https://mlflow.opendatahub.svc.cluster.local:8443",
+      "timeout": "60s",
+      "tls": {
+        "insecureSkipVerify": false,
+        "caBundlePath": "/etc/mlflow-tracking-ca/ca.crt"
+      },
+      "settings": {
+        "workspacesEnabled": true
+      }
+    }
+  }
 }

--- a/backend/src/common/client/api_server/v2/run_client.go
+++ b/backend/src/common/client/api_server/v2/run_client.go
@@ -36,6 +36,7 @@ type RunInterface interface {
 	Get(params *params.RunServiceGetRunParams) (*model.V2beta1Run, error)
 	List(params *params.RunServiceListRunsParams) ([]*model.V2beta1Run, int, string, error)
 	ListAll(params *params.RunServiceListRunsParams, maxResultSize int) ([]*model.V2beta1Run, error)
+	Retry(params *params.RunServiceRetryRunParams) error
 	Unarchive(params *params.RunServiceUnarchiveRunParams) error
 	Terminate(params *params.RunServiceTerminateRunParams) error
 }
@@ -263,6 +264,25 @@ func listAllForRun(client RunInterface, parameters *params.RunServiceListRunsPar
 	}
 
 	return allResults, nil
+}
+
+func (c *RunClient) Retry(parameters *params.RunServiceRetryRunParams) error {
+	ctx, cancel := context.WithTimeout(context.Background(), api_server.APIServerDefaultTimeout)
+	defer cancel()
+
+	parameters.Context = ctx
+	_, err := c.apiClient.RunService.RunServiceRetryRun(parameters, c.authInfoWriter)
+	if err != nil {
+		if defaultError, ok := err.(*params.RunServiceRetryRunDefault); ok {
+			err = api_server.CreateErrorFromAPIStatus(defaultError.Payload.Message, defaultError.Payload.Code)
+		} else {
+			err = api_server.CreateErrorCouldNotRecoverAPIStatus(err)
+		}
+		return util.NewUserError(err,
+			fmt.Sprintf("Failed to retry run. Params: '%+v'", parameters),
+			fmt.Sprintf("Failed to retry run %v", parameters.RunID))
+	}
+	return nil
 }
 
 func (c *RunClient) Terminate(parameters *params.RunServiceTerminateRunParams) error {

--- a/backend/src/common/client/api_server/v2/run_client_fake.go
+++ b/backend/src/common/client/api_server/v2/run_client_fake.go
@@ -15,8 +15,6 @@
 package api_server_v2
 
 import (
-	"fmt"
-
 	"github.com/go-openapi/strfmt"
 	params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_client/run_service"
 	model "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_model"
@@ -65,7 +63,11 @@ func (c *RunClientFake) Unarchive(params *params.RunServiceUnarchiveRunParams) e
 	return nil
 }
 
+func (c *RunClientFake) Retry(params *params.RunServiceRetryRunParams) error {
+	return nil
+}
+
 func (c *RunClientFake) Terminate(params *params.RunServiceTerminateRunParams) error {
-	return fmt.Errorf(InvalidFakeRequest, params.RunID)
+	return nil
 
 }

--- a/backend/test/config/flags.go
+++ b/backend/test/config/flags.go
@@ -59,3 +59,7 @@ var (
 	MinioEndpoint      = flag.String("minioEndpoint", "localhost:9000", "MinIO endpoint (host:port)")
 	MinioLogsPrefixFmt = flag.String("minioLogsPrefixFmt", "private-artifacts/%s", "Format string for logs prefix (use %s for workflow namespace)")
 )
+
+var (
+	MLflowEnabled = flag.Bool("mlflowEnabled", false, "Whether MLflow is deployed and available for integration tests")
+)

--- a/backend/test/constants/test_features.go
+++ b/backend/test/constants/test_features.go
@@ -47,4 +47,7 @@ const (
 
 	UpgradePreparation  string = "UpgradePreparation"
 	UpgradeVerification string = "UpgradeVerification"
+
+	// MLflow - quality gate tag for MLflow integration testing
+	MLflow string = "MLflow"
 )

--- a/backend/test/constants/test_features.go
+++ b/backend/test/constants/test_features.go
@@ -50,4 +50,10 @@ const (
 
 	// MLflow - quality gate tag for MLflow integration testing
 	MLflow string = "MLflow"
+	// MLflowCore — primary MLflow E2E paths
+	MLflowCore string = "MLflowCore"
+	// MLflowParallelLoop — parallel-for pipeline and multi-level nested MLflow run assertions.
+	MLflowParallelLoop string = "MLflowParallelLoop"
+	// MLflowFailure — failed pipelines and RetryRun semantics with MLflow tracking.
+	MLflowFailure string = "MLflowFailure"
 )

--- a/backend/test/end2end/mlflow_e2e_test.go
+++ b/backend/test/end2end/mlflow_e2e_test.go
@@ -1,0 +1,676 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package end2end
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	upload_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service"
+	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_model"
+	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_model"
+	. "github.com/kubeflow/pipelines/backend/test/constants"
+	e2e_utils "github.com/kubeflow/pipelines/backend/test/end2end/utils"
+	"github.com/kubeflow/pipelines/backend/test/logger"
+	"github.com/kubeflow/pipelines/backend/test/testutil"
+	apitests "github.com/kubeflow/pipelines/backend/test/v2/api"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
+	var testContext *apitests.TestContext
+	var mlflowEndpoint string
+
+	const singleTaskPipelineFile = "add_numbers.yaml"
+	const singleTaskPipelineDir = "valid/critical"
+
+	const multiTaskPipelineFile = "producer_consumer_param_pipeline.yaml"
+	const multiTaskPipelineDir = "valid/critical"
+
+	// ################## SETUP AND TEARDOWN ##################
+
+	BeforeEach(func() {
+		e2e_utils.SkipIfMLflowDisabled()
+		mlflowEndpoint = e2e_utils.GetMLflowEndpoint()
+
+		logger.Log("################### Setup before each MLflow test #####################")
+		testContext = &apitests.TestContext{
+			TestStartTimeUTC: time.Now(),
+		}
+		randomName = strconv.FormatInt(time.Now().UnixNano(), 10)
+		testContext.Pipeline.UploadParams = upload_params.NewUploadPipelineParams()
+		testContext.Pipeline.PipelineGeneratedName = "mlflow-e2e-" + randomName
+		testContext.Pipeline.CreatedPipelines = make([]*pipeline_upload_model.V2beta1Pipeline, 0)
+		testContext.PipelineRun.CreatedRunIds = make([]string, 0)
+	})
+
+	ReportAfterEach(func(specReport types.SpecReport) {
+		if testContext == nil {
+			return
+		}
+		if specReport.Failed() && len(testContext.PipelineRun.CreatedRunIds) > 0 {
+			report, _ := testutil.BuildArchivedWorkflowLogsReport(k8Client, testContext.PipelineRun.CreatedRunIds)
+			AddReportEntry(testutil.ArchivedWorkflowLogsReportTitle, report)
+		}
+
+		logger.Log("Deleting %d run(s)", len(testContext.PipelineRun.CreatedRunIds))
+		for _, runID := range testContext.PipelineRun.CreatedRunIds {
+			runID := runID
+			testutil.TerminatePipelineRun(runClient, runID)
+			testutil.ArchivePipelineRun(runClient, runID)
+			testutil.DeletePipelineRun(runClient, runID)
+		}
+		logger.Log("Deleting %d experiment(s)", len(testContext.Experiment.CreatedExperimentIds))
+		for _, expID := range testContext.Experiment.CreatedExperimentIds {
+			expID := expID
+			testutil.DeleteExperiment(experimentClient, expID)
+		}
+		logger.Log("Deleting %d pipeline(s)", len(testContext.Pipeline.CreatedPipelines))
+		for _, pipeline := range testContext.Pipeline.CreatedPipelines {
+			testutil.DeletePipeline(pipelineClient, pipeline.PipelineID, true)
+		}
+	})
+
+	// ################## HELPER ##################
+
+	// uploadPipeline uploads a pipeline from the given dir/file and returns
+	// the pipeline ID and version ID.
+	uploadPipeline := func(dir, file string) (string, string) {
+		pipelineFilePath := filepath.Join(testutil.GetPipelineFilesDir(), dir, file)
+		uploadedPipeline, err := testutil.UploadPipeline(pipelineUploadClient, pipelineFilePath, &testContext.Pipeline.PipelineGeneratedName, nil)
+		Expect(err).To(BeNil(), "Failed to upload pipeline %s", file)
+		testContext.Pipeline.CreatedPipelines = append(testContext.Pipeline.CreatedPipelines, uploadedPipeline)
+		version := testutil.GetLatestPipelineVersion(pipelineClient, &uploadedPipeline.PipelineID)
+		return uploadedPipeline.PipelineID, version.PipelineVersionID
+	}
+
+	uploadSingleTaskPipeline := func() (string, string) {
+		return uploadPipeline(singleTaskPipelineDir, singleTaskPipelineFile)
+	}
+
+	uploadMultiTaskPipeline := func() (string, string) {
+		return uploadPipeline(multiTaskPipelineDir, multiTaskPipelineFile)
+	}
+
+	// ################## TESTS ##################
+
+	Context("Single task pipeline with MLflow enabled >", func() {
+		It("Should populate plugins_output.mlflow with experiment_id, root_run_id, and state=PLUGIN_SUCCEEDED", func() {
+			pipelineID, versionID := uploadSingleTaskPipeline()
+			experimentName := fmt.Sprintf("mlflow-test-%s", randomName)
+			pluginsInput := e2e_utils.BuildMLflowPluginsInput(experimentName)
+			pipelineRuntimeInputs := testutil.GetPipelineRunTimeInputs(
+				filepath.Join(testutil.GetPipelineFilesDir(), singleTaskPipelineDir, singleTaskPipelineFile),
+			)
+
+			createdRun := e2e_utils.CreatePipelineRunWithPluginsInput(
+				runClient, testContext, &pipelineID, &versionID, experimentID, pipelineRuntimeInputs, pluginsInput,
+			)
+
+			timeout := time.Duration(maxPipelineWaitTime)
+			testutil.WaitForRunToBeInState(runClient, &createdRun.RunID, []run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateSUCCEEDED,
+				run_model.V2beta1RuntimeStateFAILED,
+			}, &timeout)
+
+			updatedRun := testutil.GetPipelineRun(runClient, &createdRun.RunID)
+			Expect(updatedRun.State).NotTo(BeNil())
+			Expect(*updatedRun.State).To(Equal(run_model.V2beta1RuntimeStateSUCCEEDED),
+				"Pipeline run should succeed")
+
+			// Verify KFP plugins_output
+			err := e2e_utils.VerifyPluginsOutput(updatedRun, run_model.V2beta1PluginStatePLUGINSUCCEEDED)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify MLflow side
+			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rootRunID).NotTo(BeEmpty(), "root_run_id should not be empty")
+
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mlflowExperimentID).NotTo(BeEmpty(), "experiment_id should not be empty")
+
+			// Verify the MLflow experiment was created with the correct name
+			mlflowExp, err := e2e_utils.QueryMLflowExperimentByName(mlflowEndpoint, experimentName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mlflowExp.ID).To(Equal(mlflowExperimentID))
+
+			// Verify parent run status
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FINISHED")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify KFP tags on parent run
+			err = e2e_utils.VerifyMLflowRunTags(mlflowEndpoint, rootRunID, map[string]string{
+				"kfp.pipeline_run_id": updatedRun.RunID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should have nested MLflow run(s) with FINISHED status", func() {
+			pipelineID, versionID := uploadSingleTaskPipeline()
+			experimentName := fmt.Sprintf("mlflow-nested-%s", randomName)
+			pluginsInput := e2e_utils.BuildMLflowPluginsInput(experimentName)
+			pipelineRuntimeInputs := testutil.GetPipelineRunTimeInputs(
+				filepath.Join(testutil.GetPipelineFilesDir(), singleTaskPipelineDir, singleTaskPipelineFile),
+			)
+
+			createdRun := e2e_utils.CreatePipelineRunWithPluginsInput(
+				runClient, testContext, &pipelineID, &versionID, experimentID, pipelineRuntimeInputs, pluginsInput,
+			)
+
+			timeout := time.Duration(maxPipelineWaitTime)
+			testutil.WaitForRunToBeInState(runClient, &createdRun.RunID, []run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateSUCCEEDED,
+			}, &timeout)
+
+			updatedRun := testutil.GetPipelineRun(runClient, &createdRun.RunID)
+			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
+			Expect(err).NotTo(HaveOccurred())
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Single-task pipeline should have exactly 1 nested run directly under the root
+			nestedRuns, err := e2e_utils.QueryNestedRuns(mlflowEndpoint, rootRunID, mlflowExperimentID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(nestedRuns)).To(Equal(1),
+				"Should have exactly 1 nested MLflow run for a single-task pipeline")
+
+			// Verify the nested run is FINISHED
+			nestedRun := nestedRuns[0]
+			Expect(nestedRun.Info.Status).To(Equal("FINISHED"),
+				"Nested MLflow run should be FINISHED")
+
+			// Verify kfp.task_name tag is present on the nested run
+			var hasTaskNameTag bool
+			for _, tag := range nestedRun.Data.Tags {
+				if tag.Key == "kfp.task_name" {
+					hasTaskNameTag = true
+					Expect(tag.Value).NotTo(BeEmpty(),
+						"kfp.task_name tag should have a non-empty value")
+					break
+				}
+			}
+			Expect(hasTaskNameTag).To(BeTrue(),
+				"Nested MLflow run should have a kfp.task_name tag")
+		})
+	})
+
+	Context("Multi-task pipeline with MLflow >", func() {
+		// producer_consumer_param_pipeline.yaml has 2 executor tasks: producer → consumer
+		const expectedTaskCount = 2
+
+		It("Should create one parent run and one nested run per task, all FINISHED", func() {
+			pipelineID, versionID := uploadMultiTaskPipeline()
+			experimentName := fmt.Sprintf("mlflow-multi-%s", randomName)
+			pluginsInput := e2e_utils.BuildMLflowPluginsInput(experimentName)
+			pipelineRuntimeInputs := testutil.GetPipelineRunTimeInputs(
+				filepath.Join(testutil.GetPipelineFilesDir(), multiTaskPipelineDir, multiTaskPipelineFile),
+			)
+
+			createdRun := e2e_utils.CreatePipelineRunWithPluginsInput(
+				runClient, testContext, &pipelineID, &versionID, experimentID, pipelineRuntimeInputs, pluginsInput,
+			)
+
+			timeout := time.Duration(maxPipelineWaitTime)
+			testutil.WaitForRunToBeInState(runClient, &createdRun.RunID, []run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateSUCCEEDED,
+				run_model.V2beta1RuntimeStateFAILED,
+			}, &timeout)
+
+			updatedRun := testutil.GetPipelineRun(runClient, &createdRun.RunID)
+			Expect(updatedRun.State).NotTo(BeNil())
+			Expect(*updatedRun.State).To(Equal(run_model.V2beta1RuntimeStateSUCCEEDED),
+				"Multi-task pipeline run should succeed")
+
+			// Verify KFP plugins_output
+			err := e2e_utils.VerifyPluginsOutput(updatedRun, run_model.V2beta1PluginStatePLUGINSUCCEEDED)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify parent MLflow run
+			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
+			Expect(err).NotTo(HaveOccurred())
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FINISHED")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify there is one nested run per task
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
+			nestedCount, err := e2e_utils.CountNestedRuns(mlflowEndpoint, rootRunID, mlflowExperimentID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nestedCount).To(Equal(expectedTaskCount),
+				fmt.Sprintf("Should have exactly %d nested MLflow runs (one per task)", expectedTaskCount))
+
+			// Verify all nested runs are FINISHED
+			allRuns, err := e2e_utils.QueryMLflowRuns(mlflowEndpoint, mlflowExperimentID)
+			Expect(err).NotTo(HaveOccurred())
+			for _, run := range allRuns {
+				Expect(run.Info.Status).To(Equal("FINISHED"),
+					fmt.Sprintf("MLflow run %s should be FINISHED", run.Info.RunID))
+			}
+		})
+	})
+
+	Context("Backward compatibility — no plugins_input >", func() {
+		It("Should succeed and populate plugins_output with defaults when no plugins_input is provided", func() {
+			pipelineID, versionID := uploadSingleTaskPipeline()
+			pipelineRuntimeInputs := testutil.GetPipelineRunTimeInputs(
+				filepath.Join(testutil.GetPipelineFilesDir(), singleTaskPipelineDir, singleTaskPipelineFile),
+			)
+
+			// Create run without plugins_input
+			createdRun := e2e_utils.CreatePipelineRun(
+				runClient, testContext, &pipelineID, &versionID, experimentID, pipelineRuntimeInputs,
+			)
+
+			timeout := time.Duration(maxPipelineWaitTime)
+			testutil.WaitForRunToBeInState(runClient, &createdRun.RunID, []run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateSUCCEEDED,
+				run_model.V2beta1RuntimeStateFAILED,
+			}, &timeout)
+
+			updatedRun := testutil.GetPipelineRun(runClient, &createdRun.RunID)
+			Expect(updatedRun.State).NotTo(BeNil())
+			Expect(*updatedRun.State).To(Equal(run_model.V2beta1RuntimeStateSUCCEEDED),
+				"Pipeline run should succeed even without plugins_input")
+
+			err := e2e_utils.VerifyPluginsOutput(updatedRun, run_model.V2beta1PluginStatePLUGINSUCCEEDED)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the default MLflow experiment and parent run exist
+			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rootRunID).NotTo(BeEmpty(), "root_run_id should be present even without plugins_input")
+
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FINISHED")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("MLflow opt-out via disabled flag >", func() {
+		It("Should succeed with no MLflow output when plugins_input.mlflow.disabled=true", func() {
+			pipelineID, versionID := uploadSingleTaskPipeline()
+			pluginsInput := e2e_utils.BuildMLflowPluginsInputDisabled()
+			pipelineRuntimeInputs := testutil.GetPipelineRunTimeInputs(
+				filepath.Join(testutil.GetPipelineFilesDir(), singleTaskPipelineDir, singleTaskPipelineFile),
+			)
+
+			createdRun := e2e_utils.CreatePipelineRunWithPluginsInput(
+				runClient, testContext, &pipelineID, &versionID, experimentID, pipelineRuntimeInputs, pluginsInput,
+			)
+
+			timeout := time.Duration(maxPipelineWaitTime)
+			testutil.WaitForRunToBeInState(runClient, &createdRun.RunID, []run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateSUCCEEDED,
+				run_model.V2beta1RuntimeStateFAILED,
+			}, &timeout)
+
+			updatedRun := testutil.GetPipelineRun(runClient, &createdRun.RunID)
+			Expect(updatedRun.State).NotTo(BeNil())
+			Expect(*updatedRun.State).To(Equal(run_model.V2beta1RuntimeStateSUCCEEDED),
+				"Pipeline run should succeed when MLflow is disabled via plugins_input")
+
+			// No MLflow output should be present
+			err := e2e_utils.VerifyNoPluginsOutput(updatedRun)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("Parallel-for pipeline with MLflow >", func() {
+		// parallel_for_after_dependency.yaml has a parallel-for loop with 3 iterations
+		// and 2 dependent tasks.
+		const parallelForPipelineFile = "parallel_for_after_dependency.yaml"
+		const parallelForPipelineDir = "valid/critical"
+
+		It("Should create parent run with correct 2-level nesting hierarchy", func() {
+			pipelineID, versionID := uploadPipeline(parallelForPipelineDir, parallelForPipelineFile)
+			experimentName := fmt.Sprintf("mlflow-loop-%s", randomName)
+			pluginsInput := e2e_utils.BuildMLflowPluginsInput(experimentName)
+			pipelineRuntimeInputs := testutil.GetPipelineRunTimeInputs(
+				filepath.Join(testutil.GetPipelineFilesDir(), parallelForPipelineDir, parallelForPipelineFile),
+			)
+
+			createdRun := e2e_utils.CreatePipelineRunWithPluginsInput(
+				runClient, testContext, &pipelineID, &versionID, experimentID, pipelineRuntimeInputs, pluginsInput,
+			)
+
+			timeout := time.Duration(maxPipelineWaitTime)
+			testutil.WaitForRunToBeInState(runClient, &createdRun.RunID, []run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateSUCCEEDED,
+				run_model.V2beta1RuntimeStateFAILED,
+			}, &timeout)
+
+			updatedRun := testutil.GetPipelineRun(runClient, &createdRun.RunID)
+			Expect(updatedRun.State).NotTo(BeNil())
+			Expect(*updatedRun.State).To(Equal(run_model.V2beta1RuntimeStateSUCCEEDED),
+				"Parallel-for pipeline run should succeed")
+
+			// Verify KFP plugins_output
+			err := e2e_utils.VerifyPluginsOutput(updatedRun, run_model.V2beta1PluginStatePLUGINSUCCEEDED)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify parent MLflow run is FINISHED
+			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
+			Expect(err).NotTo(HaveOccurred())
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FINISHED")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Direct children of root: 1 loop run + 2 dependent tasks = 3
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
+			const expectedDirectChildren = 3
+			directChildCount, err := e2e_utils.CountNestedRuns(mlflowEndpoint, rootRunID, mlflowExperimentID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(directChildCount).To(Equal(expectedDirectChildren),
+				"Should have exactly 3 direct children of root (1 loop run + 2 dependent tasks)")
+
+			// Find the loop nested run (has iterations as children).
+			// It's the one direct child that itself has nested runs.
+			allRuns, err := e2e_utils.QueryMLflowRuns(mlflowEndpoint, mlflowExperimentID)
+			Expect(err).NotTo(HaveOccurred())
+
+			var loopRunID string
+			for _, run := range allRuns {
+				if run.Info.RunID == rootRunID {
+					continue // skip parent
+				}
+				childCount, err := e2e_utils.CountNestedRuns(mlflowEndpoint, run.Info.RunID, mlflowExperimentID)
+				Expect(err).NotTo(HaveOccurred())
+				if childCount > 0 {
+					loopRunID = run.Info.RunID
+					// The loop run should have exactly 3 iteration children
+					Expect(childCount).To(Equal(3),
+						"Loop nested run should have exactly 3 iteration children")
+					break
+				}
+			}
+			Expect(loopRunID).NotTo(BeEmpty(),
+				"Should find a loop nested run with iteration children")
+
+			// Verify all MLflow runs in the experiment are FINISHED
+			for _, run := range allRuns {
+				Expect(run.Info.Status).To(Equal("FINISHED"),
+					fmt.Sprintf("MLflow run %s should be FINISHED", run.Info.RunID))
+			}
+
+			// Total runs in experiment: 1 parent + 3 direct + 3 iterations = 7
+			Expect(len(allRuns)).To(Equal(7),
+				"Should have exactly 7 MLflow runs in the experiment")
+		})
+	})
+
+	Context("Failed pipeline with MLflow >", func() {
+		const failPipelineFile = "fail_v2.yaml"
+		const failPipelineDir = "valid/failing"
+
+		It("Should mark parent and nested MLflow runs as FAILED", func() {
+			pipelineID, versionID := uploadPipeline(failPipelineDir, failPipelineFile)
+			experimentName := fmt.Sprintf("mlflow-fail-%s", randomName)
+			pluginsInput := e2e_utils.BuildMLflowPluginsInput(experimentName)
+			pipelineRuntimeInputs := testutil.GetPipelineRunTimeInputs(
+				filepath.Join(testutil.GetPipelineFilesDir(), failPipelineDir, failPipelineFile),
+			)
+
+			createdRun := e2e_utils.CreatePipelineRunWithPluginsInput(
+				runClient, testContext, &pipelineID, &versionID, experimentID, pipelineRuntimeInputs, pluginsInput,
+			)
+
+			timeout := time.Duration(maxPipelineWaitTime)
+			testutil.WaitForRunToBeInState(runClient, &createdRun.RunID, []run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateFAILED,
+			}, &timeout)
+
+			updatedRun := testutil.GetPipelineRun(runClient, &createdRun.RunID)
+			Expect(updatedRun.State).NotTo(BeNil())
+			Expect(*updatedRun.State).To(Equal(run_model.V2beta1RuntimeStateFAILED),
+				"Pipeline run should be FAILED")
+
+			// Verify MLflow plugins_output still records the run
+			err := e2e_utils.VerifyPluginsOutput(updatedRun, run_model.V2beta1PluginStatePLUGINSUCCEEDED)
+			Expect(err).NotTo(HaveOccurred())
+
+			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rootRunID).NotTo(BeEmpty(), "root_run_id should not be empty")
+
+			// The parent MLflow run should be FAILED because the KFP run failed
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FAILED")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify any nested runs are also in a terminal state (FAILED)
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
+			allRuns, err := e2e_utils.QueryMLflowRuns(mlflowEndpoint, mlflowExperimentID)
+			Expect(err).NotTo(HaveOccurred())
+			for _, run := range allRuns {
+				if run.Info.RunID != rootRunID {
+					// Nested runs for failed tasks should be FAILED
+					Expect(run.Info.Status).To(Equal("FAILED"),
+						fmt.Sprintf("Nested MLflow run %s should be FAILED", run.Info.RunID))
+				}
+			}
+		})
+	})
+
+	Context("Failed pipeline + RetryRun with MLflow >", func() {
+		const failPipelineFile = "fail_v2.yaml"
+		const failPipelineDir = "valid/failing"
+
+		It("Should reopen MLflow runs on retry and then reflect the retried status", func() {
+			pipelineID, versionID := uploadPipeline(failPipelineDir, failPipelineFile)
+			experimentName := fmt.Sprintf("mlflow-retry-%s", randomName)
+			pluginsInput := e2e_utils.BuildMLflowPluginsInput(experimentName)
+			pipelineRuntimeInputs := testutil.GetPipelineRunTimeInputs(
+				filepath.Join(testutil.GetPipelineFilesDir(), failPipelineDir, failPipelineFile),
+			)
+
+			// Create the run and wait for it to FAIL
+			createdRun := e2e_utils.CreatePipelineRunWithPluginsInput(
+				runClient, testContext, &pipelineID, &versionID, experimentID, pipelineRuntimeInputs, pluginsInput,
+			)
+
+			timeout := time.Duration(maxPipelineWaitTime)
+			testutil.WaitForRunToBeInState(runClient, &createdRun.RunID, []run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateFAILED,
+			}, &timeout)
+
+			updatedRun := testutil.GetPipelineRun(runClient, &createdRun.RunID)
+			Expect(updatedRun.State).NotTo(BeNil())
+			Expect(*updatedRun.State).To(Equal(run_model.V2beta1RuntimeStateFAILED),
+				"Pipeline run should initially be FAILED")
+
+			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rootRunID).NotTo(BeEmpty(), "root_run_id should not be empty")
+
+			// Retry the run
+			e2e_utils.RetryPipelineRun(runClient, createdRun.RunID)
+
+			// Wait for the retried run to reach terminal state
+			testutil.WaitForRunToBeInState(runClient, &createdRun.RunID, []run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateFAILED,
+			}, &timeout)
+
+			retriedRun := testutil.GetPipelineRun(runClient, &createdRun.RunID)
+			Expect(retriedRun.State).NotTo(BeNil())
+			Expect(*retriedRun.State).To(Equal(run_model.V2beta1RuntimeStateFAILED),
+				"Retried pipeline run should still be FAILED (fail_v2 always fails)")
+
+			// Verify the MLflow parent run reflects the retry
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FAILED")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify plugins_output is still populated after retry
+			err = e2e_utils.VerifyPluginsOutput(retriedRun, run_model.V2beta1PluginStatePLUGINSUCCEEDED)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify retry reused the existing parent run
+			retriedRootRunID, err := e2e_utils.GetPluginsOutputEntryValue(retriedRun, "root_run_id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(retriedRootRunID).To(Equal(rootRunID),
+				"OnRunRetry should reopen the existing parent MLflow run, not create a new one")
+		})
+	})
+
+	Context("Custom experiment name >", func() {
+		It("Should create MLflow experiment with the user-specified name", func() {
+			pipelineID, versionID := uploadSingleTaskPipeline()
+			customExpName := fmt.Sprintf("custom-exp-%s", randomName)
+			pluginsInput := e2e_utils.BuildMLflowPluginsInput(customExpName)
+			pipelineRuntimeInputs := testutil.GetPipelineRunTimeInputs(
+				filepath.Join(testutil.GetPipelineFilesDir(), singleTaskPipelineDir, singleTaskPipelineFile),
+			)
+
+			createdRun := e2e_utils.CreatePipelineRunWithPluginsInput(
+				runClient, testContext, &pipelineID, &versionID, experimentID, pipelineRuntimeInputs, pluginsInput,
+			)
+
+			timeout := time.Duration(maxPipelineWaitTime)
+			testutil.WaitForRunToBeInState(runClient, &createdRun.RunID, []run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateSUCCEEDED,
+			}, &timeout)
+
+			updatedRun := testutil.GetPipelineRun(runClient, &createdRun.RunID)
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify the MLflow experiment name matches
+			mlflowExp, err := e2e_utils.QueryMLflowExperimentByName(mlflowEndpoint, customExpName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mlflowExp.ID).To(Equal(mlflowExperimentID),
+				"MLflow experiment ID should match the one in plugins_output")
+			Expect(mlflowExp.Name).To(Equal(customExpName),
+				"MLflow experiment name should match the user-specified name")
+		})
+	})
+})
+
+// Additional scenarios from proposals/12862-mlflow-integration/MLflow-KFP-Integration-TestPlan*.md.
+// Uses PDescribe the same way as pipeline_api_test.go.
+
+var _ = PDescribe("MLflow Integration > CreateRun and validation >", Label(MLflow, FullRegression), func() {
+	Context("Experiment and plugins_input >", func() {
+		It("Should use default admin experiment name when no plugins_input and assert run_url in plugins_output", func() {
+		})
+		It("Should prefer experiment_id over experiment_name when both are set", func() {
+		})
+		It("Should create two separate MLflow experiments and parent runs for two runs with different experiment_name (same pipeline)", func() {
+		})
+		It("Should recover when concurrent creates race and MLflow reports experiment already exists", func() {
+		})
+	})
+	Context("API and workflow semantics >", func() {
+		It("Should reject CreateRun when client supplies plugins_output", func() {
+		})
+		It("Should expose MLflow runtime JSON env on driver and launcher templates only after compile", func() {
+		})
+		It("Should update MLflow parent to Failed when MLflow parent exists then workflow create or DB write fails", func() {
+		})
+	})
+	Context("Tags and deep links >", func() {
+		It("Should set MLflow tags for pipeline_id and pipeline_version_id when present", func() {
+		})
+		It("Should produce usable KFP and MLflow deep links in tags and plugins_output", func() {
+		})
+		It("Should honor experiment description omit, empty string, and custom values per defaults", func() {
+		})
+	})
+})
+
+var _ = PDescribe("MLflow Integration > Terminal state and sync >", Label(MLflow, FullRegression), func() {
+	Context("Pipeline outcomes >", func() {
+		It("Should map MLflow parent and nested runs when pipeline is Canceled", func() {
+		})
+	})
+	Context("Reliability >", func() {
+		It("Should update straggler nested runs with pagination for large fan-out", func() {
+		})
+		It("Should persist latest plugins_output on the KFP run after terminal handling", func() {
+		})
+		It("Should record KFP terminal state when MLflow sync returns errors", func() {
+		})
+		It("Should handle terminal sync with corrupt or missing stored MLflow ids in plugin output", func() {
+		})
+		It("Should retry MLflow HTTP only where appropriate", func() {
+		})
+	})
+})
+
+var _ = PDescribe("MLflow Integration > RetryRun >", Label(MLflow, FullRegression), func() {
+	Context("Edge cases >", func() {
+		It("Should have no MLflow side effects when retrying a failed run with no MLflow plugin output", func() {
+		})
+	})
+})
+
+var _ = PDescribe("MLflow Integration > CloneRun >", Label(MLflow, FullRegression), func() {
+	Context("Clone behavior >", func() {
+		It("Should inherit plugins_input.mlflow on clone and create a new MLflow parent for the cloned run", func() {
+		})
+		It("Should use distinct MLflow run ids for clone vs original when both complete", func() {
+		})
+	})
+})
+
+var _ = PDescribe("MLflow Integration > Recurring runs >", Label(MLflow, FullRegression), func() {
+	Context("Scheduled jobs >", func() {
+		It("Should store plugins_input on recurring job and surface it on the scheduled workflow", func() {
+		})
+		It("Should propagate plugins_input to runs created by each schedule trigger", func() {
+		})
+		It("Should accept recurring job referencing pipeline version with plugins without inline workflow spec", func() {
+		})
+		It("Should create one MLflow parent per schedule trigger", func() {
+		})
+	})
+})
+
+var _ = PDescribe("MLflow Integration > Negative and edge cases >", Label(MLflow, FullRegression), func() {
+	Context("Configuration and validation >", func() {
+		It("Should allow or clearly fail CreateRun when MLflow endpoint is unreachable at create", func() {
+		})
+		It("Should reject malformed plugins_input.mlflow JSON or unknown fields with validation error", func() {
+		})
+	})
+})
+
+var _ = PDescribe("MLflow Integration > Compiled workflow injection >", Label(MLflow, FullRegression), func() {
+	Context("Templates and env >", func() {
+		It("Should inject MLflow env only on driver and launcher templates", func() {
+		})
+		It("Should replace duplicate env keys consistently when template predefines the same name", func() {
+		})
+		It("Should omit MLflow env when plugins.mlflow is not configured", func() {
+		})
+	})
+})
+
+var _ = PDescribe("MLflow Integration > Cluster and deployment >", Label(MLflow, FullRegression), func() {
+	Context("Lifecycle and platform >", func() {
+		It("Should leave existing behavior unchanged with no plugins.mlflow (upgrade path)", func() {
+		})
+		It("Should respect per-namespace kfp-launcher overrides for MLflow in multi-tenant setups", func() {
+		})
+		It("Should allow deleting KFP run while MLflow runs may remain", func() {
+		})
+		It("Should succeed against MLflow served over HTTPS", func() {
+		})
+	})
+})

--- a/backend/test/end2end/mlflow_e2e_test.go
+++ b/backend/test/end2end/mlflow_e2e_test.go
@@ -111,7 +111,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 
 	// ################## TESTS ##################
 
-	Context("Single task pipeline with MLflow enabled >", func() {
+	Context("Single task pipeline with MLflow enabled >", Label(MLflowCore), func() {
 		It("Should populate plugins_output.mlflow with experiment_id, root_run_id, and state=PLUGIN_SUCCEEDED", func() {
 			pipelineID, versionID := uploadSingleTaskPipeline()
 			experimentName := fmt.Sprintf("mlflow-test-%s", randomName)
@@ -154,11 +154,11 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(mlflowExp.ID).To(Equal(mlflowExperimentID))
 
 			// Verify parent run status
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FINISHED")
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify KFP tags on parent run
-			err = e2e_utils.VerifyMLflowRunTags(mlflowEndpoint, rootRunID, map[string]string{
+			err = e2e_utils.VerifyMLflowRunTags(mlflowEndpoint, rootRunID, mlflowExperimentID, map[string]string{
 				"kfp.pipeline_run_id": updatedRun.RunID,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -198,22 +198,23 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(nestedRun.Info.Status).To(Equal("FINISHED"),
 				"Nested MLflow run should be FINISHED")
 
-			// Verify kfp.task_name tag is present on the nested run
-			var hasTaskNameTag bool
+			// Verify parent linkage tag is present on the nested run.
+			// Task-level run naming/tagging may vary by launcher/runtime path.
+			var hasParentRunTag bool
 			for _, tag := range nestedRun.Data.Tags {
-				if tag.Key == "kfp.task_name" {
-					hasTaskNameTag = true
-					Expect(tag.Value).NotTo(BeEmpty(),
-						"kfp.task_name tag should have a non-empty value")
+				if tag.Key == "mlflow.parentRunId" {
+					hasParentRunTag = true
+					Expect(tag.Value).To(Equal(rootRunID),
+						"Nested MLflow run should reference the parent root run")
 					break
 				}
 			}
-			Expect(hasTaskNameTag).To(BeTrue(),
-				"Nested MLflow run should have a kfp.task_name tag")
+			Expect(hasParentRunTag).To(BeTrue(),
+				"Nested MLflow run should have an mlflow.parentRunId tag")
 		})
 	})
 
-	Context("Multi-task pipeline with MLflow >", func() {
+	Context("Multi-task pipeline with MLflow >", Label(MLflowCore), func() {
 		// producer_consumer_param_pipeline.yaml has 2 executor tasks: producer → consumer
 		const expectedTaskCount = 2
 
@@ -247,12 +248,12 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			// Verify parent MLflow run
 			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
 			Expect(err).NotTo(HaveOccurred())
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FINISHED")
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify there is one nested run per task
-			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
-			Expect(err).NotTo(HaveOccurred())
 			nestedCount, err := e2e_utils.CountNestedRuns(mlflowEndpoint, rootRunID, mlflowExperimentID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(nestedCount).To(Equal(expectedTaskCount),
@@ -268,7 +269,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 		})
 	})
 
-	Context("Backward compatibility — no plugins_input >", func() {
+	Context("Backward compatibility — no plugins_input >", Label(MLflowCore), func() {
 		It("Should succeed and populate plugins_output with defaults when no plugins_input is provided", func() {
 			pipelineID, versionID := uploadSingleTaskPipeline()
 			pipelineRuntimeInputs := testutil.GetPipelineRunTimeInputs(
@@ -298,13 +299,15 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rootRunID).NotTo(BeEmpty(), "root_run_id should be present even without plugins_input")
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
 
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FINISHED")
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
-	Context("MLflow opt-out via disabled flag >", func() {
+	Context("MLflow opt-out via disabled flag >", Label(MLflowCore), func() {
 		It("Should succeed with no MLflow output when plugins_input.mlflow.disabled=true", func() {
 			pipelineID, versionID := uploadSingleTaskPipeline()
 			pluginsInput := e2e_utils.BuildMLflowPluginsInputDisabled()
@@ -333,7 +336,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 		})
 	})
 
-	Context("Parallel-for pipeline with MLflow >", func() {
+	Context("Parallel-for pipeline with MLflow >", Label(MLflowParallelLoop), func() {
 		// parallel_for_after_dependency.yaml has a parallel-for loop with 3 iterations
 		// and 2 dependent tasks.
 		const parallelForPipelineFile = "parallel_for_after_dependency.yaml"
@@ -369,12 +372,12 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			// Verify parent MLflow run is FINISHED
 			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
 			Expect(err).NotTo(HaveOccurred())
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FINISHED")
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Direct children of root: 1 loop run + 2 dependent tasks = 3
-			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
-			Expect(err).NotTo(HaveOccurred())
 			const expectedDirectChildren = 3
 			directChildCount, err := e2e_utils.CountNestedRuns(mlflowEndpoint, rootRunID, mlflowExperimentID)
 			Expect(err).NotTo(HaveOccurred())
@@ -416,7 +419,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 		})
 	})
 
-	Context("Failed pipeline with MLflow >", func() {
+	Context("Failed pipeline with MLflow >", Label(MLflowFailure), func() {
 		const failPipelineFile = "fail_v2.yaml"
 		const failPipelineDir = "valid/failing"
 
@@ -449,14 +452,13 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rootRunID).NotTo(BeEmpty(), "root_run_id should not be empty")
-
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
 			// The parent MLflow run should be FAILED because the KFP run failed
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FAILED")
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FAILED")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify any nested runs are also in a terminal state (FAILED)
-			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
-			Expect(err).NotTo(HaveOccurred())
 			allRuns, err := e2e_utils.QueryMLflowRuns(mlflowEndpoint, mlflowExperimentID)
 			Expect(err).NotTo(HaveOccurred())
 			for _, run := range allRuns {
@@ -469,7 +471,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 		})
 	})
 
-	Context("Failed pipeline + RetryRun with MLflow >", func() {
+	Context("Failed pipeline + RetryRun with MLflow >", Label(MLflowFailure), func() {
 		const failPipelineFile = "fail_v2.yaml"
 		const failPipelineDir = "valid/failing"
 
@@ -499,6 +501,8 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			rootRunID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "root_run_id")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rootRunID).NotTo(BeEmpty(), "root_run_id should not be empty")
+			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
+			Expect(err).NotTo(HaveOccurred())
 
 			// Retry the run
 			e2e_utils.RetryPipelineRun(runClient, createdRun.RunID)
@@ -514,7 +518,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 				"Retried pipeline run should still be FAILED (fail_v2 always fails)")
 
 			// Verify the MLflow parent run reflects the retry
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, "FAILED")
+			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FAILED")
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify plugins_output is still populated after retry
@@ -529,7 +533,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 		})
 	})
 
-	Context("Custom experiment name >", func() {
+	Context("Custom experiment name >", Label(MLflowCore), func() {
 		It("Should create MLflow experiment with the user-specified name", func() {
 			pipelineID, versionID := uploadSingleTaskPipeline()
 			customExpName := fmt.Sprintf("custom-exp-%s", randomName)

--- a/backend/test/end2end/utils/mlflow_utils.go
+++ b/backend/test/end2end/utils/mlflow_utils.go
@@ -294,22 +294,26 @@ func QueryMLflowRuns(endpoint, experimentID string) ([]MLflowRun, error) {
 	return searchMLflowRuns(endpoint, []string{experimentID}, "", 1000)
 }
 
-func QueryMLflowRunByID(endpoint, runID string) (*MLflowRun, error) {
+func QueryMLflowRunByID(endpoint, runID, experimentID string) (*MLflowRun, error) {
 	ginkgo.GinkgoHelper()
-	filter := fmt.Sprintf("attributes.run_id = '%s'", runID)
-	runs, err := searchMLflowRuns(endpoint, nil, filter, 1)
+	if experimentID == "" {
+		return nil, fmt.Errorf("experimentID is required to query MLflow run %q", runID)
+	}
+	runs, err := searchMLflowRuns(endpoint, []string{experimentID}, "", 1000)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query MLflow run %q: %w", runID, err)
 	}
-	if len(runs) == 0 {
-		return nil, fmt.Errorf("MLflow run %q not found", runID)
+	for _, run := range runs {
+		if run.Info.RunID == runID {
+			return &run, nil
+		}
 	}
-	return &runs[0], nil
+	return nil, fmt.Errorf("MLflow run %q not found in experiment %q", runID, experimentID)
 }
 
-func VerifyMLflowRunStatus(endpoint, runID, expectedStatus string) error {
+func VerifyMLflowRunStatus(endpoint, runID, experimentID, expectedStatus string) error {
 	ginkgo.GinkgoHelper()
-	mlflowRun, err := QueryMLflowRunByID(endpoint, runID)
+	mlflowRun, err := QueryMLflowRunByID(endpoint, runID, experimentID)
 	if err != nil {
 		return err
 	}
@@ -319,9 +323,9 @@ func VerifyMLflowRunStatus(endpoint, runID, expectedStatus string) error {
 	return nil
 }
 
-func VerifyMLflowRunTags(endpoint, runID string, expectedTags map[string]string) error {
+func VerifyMLflowRunTags(endpoint, runID, experimentID string, expectedTags map[string]string) error {
 	ginkgo.GinkgoHelper()
-	mlflowRun, err := QueryMLflowRunByID(endpoint, runID)
+	mlflowRun, err := QueryMLflowRunByID(endpoint, runID, experimentID)
 	if err != nil {
 		return err
 	}

--- a/backend/test/end2end/utils/mlflow_utils.go
+++ b/backend/test/end2end/utils/mlflow_utils.go
@@ -1,0 +1,395 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Package utils provides helpers shared across end-to-end tests.
+package utils
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	runparams "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_client/run_service"
+	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_model"
+	apiserver "github.com/kubeflow/pipelines/backend/src/common/client/api_server/v2"
+	mlflowclient "github.com/kubeflow/pipelines/backend/src/common/plugins/mlflow"
+	"github.com/kubeflow/pipelines/backend/test/config"
+	"github.com/kubeflow/pipelines/backend/test/logger"
+	apitests "github.com/kubeflow/pipelines/backend/test/v2/api"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+const (
+	mlflowEndpointEnv    = "MLFLOW_TRACKING_URI"
+	mlflowInsecureTLSEnv = "MLFLOW_TRACKING_INSECURE_TLS"
+	mlflowBearerTokenEnv = "MLFLOW_BEARER_TOKEN"
+	mlflowWorkspaceEnv   = "MLFLOW_WORKSPACE"
+	mlflowPluginKey      = "mlflow"
+)
+
+func getMLflowClient(endpoint string) (*mlflowclient.Client, error) {
+	insecure := strings.EqualFold(os.Getenv(mlflowInsecureTLSEnv), "true")
+	workspace := os.Getenv(mlflowWorkspaceEnv)
+	bearerToken := os.Getenv(mlflowBearerTokenEnv)
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: insecure, //nolint:gosec
+			},
+		},
+	}
+	client, err := mlflowclient.NewClient(mlflowclient.Config{
+		Endpoint:          endpoint,
+		HTTPClient:        httpClient,
+		BearerToken:       bearerToken,
+		WorkspacesEnabled: workspace != "",
+		Workspace:         workspace,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MLflow client: %w", err)
+	}
+	if bearerToken != "" {
+		logger.Log("MLflow client initialized with bearer token auth")
+	}
+	if workspace != "" {
+		logger.Log("MLflow client initialized with workspace header: %s", workspace)
+	}
+	if insecure {
+		logger.Log("MLflow client initialized with InsecureSkipVerify=true")
+	}
+	return client, nil
+}
+
+// RetryPipelineRun retries a failed/terminated KFP pipeline run.
+func RetryPipelineRun(runClient *apiserver.RunClient, runID string) {
+	ginkgo.GinkgoHelper()
+	retryParams := runparams.NewRunServiceRetryRunParams()
+	retryParams.RunID = runID
+	err := runClient.Retry(retryParams)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+		fmt.Sprintf("Failed to retry run %s", runID))
+	logger.Log("Retried Pipeline Run, runId=%s", runID)
+}
+
+// SkipIfMLflowDisabled skips the current test if the mlflowEnabled flag is false.
+func SkipIfMLflowDisabled() {
+	ginkgo.GinkgoHelper()
+	if !*config.MLflowEnabled {
+		ginkgo.Skip("MLflow is not enabled; skipping MLflow integration test")
+	}
+}
+
+// GetMLflowEndpoint returns the MLflow tracking server endpoint from the
+// MLFLOW_TRACKING_URI environment variable.
+func GetMLflowEndpoint() string {
+	ginkgo.GinkgoHelper()
+	endpoint := os.Getenv(mlflowEndpointEnv)
+	gomega.Expect(endpoint).NotTo(gomega.BeEmpty(),
+		fmt.Sprintf("%s environment variable must be set for MLflow tests", mlflowEndpointEnv))
+	return strings.TrimRight(endpoint, "/")
+}
+
+// --- KFP Run helpers with plugins_input ---
+
+// CreatePipelineRunWithPluginsInput - Create a pipeline run with plugins_input.
+func CreatePipelineRunWithPluginsInput(
+	runClient *apiserver.RunClient,
+	testContext *apitests.TestContext,
+	pipelineID *string,
+	pipelineVersionID *string,
+	experimentID *string,
+	inputParams map[string]interface{},
+	pluginsInput map[string]interface{},
+) *run_model.V2beta1Run {
+	ginkgo.GinkgoHelper()
+	runName := fmt.Sprintf("MLflow E2e Test Run-%v", testContext.TestStartTimeUTC)
+	runDescription := fmt.Sprintf("MLflow run for %s", runName)
+	logger.Log("Create a pipeline run with plugins_input for pipeline id=%s versionId=%s",
+		*pipelineID, *pipelineVersionID)
+
+	createRunRequest := &runparams.RunServiceCreateRunParams{
+		ExperimentID: experimentID,
+		Run: CreatePipelineRunWithPluginsInputPayload(
+			runName,
+			runDescription,
+			pipelineID,
+			pipelineVersionID,
+			experimentID,
+			inputParams,
+			pluginsInput,
+		),
+	}
+	createdRun, createRunError := runClient.Create(createRunRequest)
+	gomega.Expect(createRunError).NotTo(gomega.HaveOccurred(),
+		"Failed to create run with plugins_input for pipeline id="+*pipelineID)
+	testContext.PipelineRun.CreatedRunIds = append(testContext.PipelineRun.CreatedRunIds, createdRun.RunID)
+	logger.Log("Created Pipeline Run with plugins_input, runId=%s", createdRun.RunID)
+	return createdRun
+}
+
+// CreatePipelineRunWithPluginsInputPayload - Create a pipeline run payload with plugins_input.
+func CreatePipelineRunWithPluginsInputPayload(
+	runName string,
+	runDescription string,
+	pipelineID *string,
+	pipelineVersionID *string,
+	experimentID *string,
+	inputParams map[string]interface{},
+	pluginsInput map[string]interface{},
+) *run_model.V2beta1Run {
+	run := CreatePipelineRunPayload(
+		runName,
+		runDescription,
+		pipelineID,
+		pipelineVersionID,
+		experimentID,
+		inputParams,
+	)
+	run.PluginsInput = pluginsInput
+	return run
+}
+
+func BuildMLflowPluginsInput(experimentName string) map[string]interface{} {
+	mlflowCfg := map[string]interface{}{}
+	if experimentName != "" {
+		mlflowCfg["experiment_name"] = experimentName
+	}
+	return map[string]interface{}{
+		mlflowPluginKey: mlflowCfg,
+	}
+}
+
+func BuildMLflowPluginsInputDisabled() map[string]interface{} {
+	return map[string]interface{}{
+		mlflowPluginKey: map[string]interface{}{
+			"disabled": true,
+		},
+	}
+}
+
+// --- KFP plugins_output verification ---
+
+// VerifyPluginsOutput asserts that the run's plugins_output contains a valid
+// MLflow entry with experiment_id, root_run_id, and the expected plugin state.
+func VerifyPluginsOutput(run *run_model.V2beta1Run, expectedState run_model.V2beta1PluginState) error {
+	ginkgo.GinkgoHelper()
+	if run.PluginsOutput == nil {
+		return fmt.Errorf("plugins_output should not be nil")
+	}
+	mlflowOutput, ok := run.PluginsOutput[mlflowPluginKey]
+	if !ok {
+		return fmt.Errorf("plugins_output should contain %q key", mlflowPluginKey)
+	}
+	if mlflowOutput.State == nil {
+		return fmt.Errorf("plugins_output.%s.state should not be nil", mlflowPluginKey)
+	}
+
+	if *mlflowOutput.State != expectedState {
+		return fmt.Errorf(
+			"plugins_output.%s.state should be %s, got %s",
+			mlflowPluginKey, expectedState, *mlflowOutput.State,
+		)
+	}
+
+	if mlflowOutput.Entries == nil {
+		return fmt.Errorf("plugins_output.%s.entries should not be nil", mlflowPluginKey)
+	}
+	if _, ok := mlflowOutput.Entries["experiment_id"]; !ok {
+		return fmt.Errorf("plugins_output.%s.entries should have %q", mlflowPluginKey, "experiment_id")
+	}
+	if _, ok := mlflowOutput.Entries["root_run_id"]; !ok {
+		return fmt.Errorf("plugins_output.%s.entries should have %q", mlflowPluginKey, "root_run_id")
+	}
+	return nil
+}
+
+func GetPluginsOutputEntryValue(run *run_model.V2beta1Run, entryKey string) (string, error) {
+	ginkgo.GinkgoHelper()
+	if run.PluginsOutput == nil {
+		return "", fmt.Errorf("plugins_output should not be nil")
+	}
+	mlflowOutput, ok := run.PluginsOutput[mlflowPluginKey]
+	if !ok {
+		return "", fmt.Errorf("plugins_output should contain %q key", mlflowPluginKey)
+	}
+	entry, ok := mlflowOutput.Entries[entryKey]
+	if !ok {
+		return "", fmt.Errorf("plugins_output.%s.entries should have %q", mlflowPluginKey, entryKey)
+	}
+	strVal, ok := entry.Value.(string)
+	if !ok {
+		return "", fmt.Errorf(
+			"plugins_output.%s.entries[%q].value should be a string",
+			mlflowPluginKey, entryKey,
+		)
+	}
+	return strVal, nil
+}
+
+func VerifyNoPluginsOutput(run *run_model.V2beta1Run) error {
+	ginkgo.GinkgoHelper()
+	if run.PluginsOutput == nil {
+		return nil
+	}
+	_, ok := run.PluginsOutput[mlflowPluginKey]
+	if ok {
+		return fmt.Errorf("plugins_output should not contain %q key when MLflow is disabled", mlflowPluginKey)
+	}
+	return nil
+}
+
+type MLflowRun struct {
+	Info MLflowRunInfo `json:"info"`
+	Data MLflowRunData `json:"data"`
+}
+
+type MLflowRunInfo struct {
+	RunID        string `json:"run_id"`
+	ExperimentID string `json:"experiment_id"`
+	Status       string `json:"status"`
+}
+
+type MLflowRunData struct {
+	Tags []MLflowTag `json:"tags"`
+}
+
+type MLflowTag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func QueryMLflowExperimentByName(endpoint, experimentName string) (*mlflowclient.MLflowExperiment, error) {
+	ginkgo.GinkgoHelper()
+	client, err := getMLflowClient(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	experiment, err := client.GetExperimentByName(context.Background(), experimentName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query MLflow experiment by name %q: %w", experimentName, err)
+	}
+	return experiment, nil
+}
+
+func QueryMLflowRuns(endpoint, experimentID string) ([]MLflowRun, error) {
+	return searchMLflowRuns(endpoint, []string{experimentID}, "", 1000)
+}
+
+func QueryMLflowRunByID(endpoint, runID string) (*MLflowRun, error) {
+	ginkgo.GinkgoHelper()
+	filter := fmt.Sprintf("attributes.run_id = '%s'", runID)
+	runs, err := searchMLflowRuns(endpoint, nil, filter, 1)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query MLflow run %q: %w", runID, err)
+	}
+	if len(runs) == 0 {
+		return nil, fmt.Errorf("MLflow run %q not found", runID)
+	}
+	return &runs[0], nil
+}
+
+func VerifyMLflowRunStatus(endpoint, runID, expectedStatus string) error {
+	ginkgo.GinkgoHelper()
+	mlflowRun, err := QueryMLflowRunByID(endpoint, runID)
+	if err != nil {
+		return err
+	}
+	if mlflowRun.Info.Status != expectedStatus {
+		return fmt.Errorf("MLflow run %s should have status %s", runID, expectedStatus)
+	}
+	return nil
+}
+
+func VerifyMLflowRunTags(endpoint, runID string, expectedTags map[string]string) error {
+	ginkgo.GinkgoHelper()
+	mlflowRun, err := QueryMLflowRunByID(endpoint, runID)
+	if err != nil {
+		return err
+	}
+	tagMap := make(map[string]string)
+	for _, tag := range mlflowRun.Data.Tags {
+		tagMap[tag.Key] = tag.Value
+	}
+	for key, expectedValue := range expectedTags {
+		actualValue, ok := tagMap[key]
+		if !ok || actualValue != expectedValue {
+			return fmt.Errorf("MLflow run %s should have tag %s=%s", runID, key, expectedValue)
+		}
+	}
+	return nil
+}
+
+// QueryNestedRuns returns the MLflow runs whose mlflow.parentRunId tag matches
+// the given parent run ID.
+func QueryNestedRuns(endpoint, parentRunID string, experimentID ...string) ([]MLflowRun, error) {
+	ginkgo.GinkgoHelper()
+	filter := fmt.Sprintf(`tags.mlflow.parentRunId = '%s'`, parentRunID)
+	if len(experimentID) > 0 && experimentID[0] != "" {
+		return searchMLflowRuns(endpoint, []string{experimentID[0]}, filter, 1000)
+	}
+	return searchMLflowRuns(endpoint, nil, filter, 1000)
+}
+
+// CountNestedRuns counts the number of MLflow runs that have a
+// mlflow.parentRunId tag matching the given parent run ID.
+func CountNestedRuns(endpoint, parentRunID string, experimentID ...string) (int, error) {
+	nestedRuns, err := QueryNestedRuns(endpoint, parentRunID, experimentID...)
+	if err != nil {
+		return 0, err
+	}
+	return len(nestedRuns), nil
+}
+
+func searchMLflowRuns(endpoint string, experimentIDs []string, filter string, maxResults int) ([]MLflowRun, error) {
+	ginkgo.GinkgoHelper()
+	client, err := getMLflowClient(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	pageToken := ""
+	var allRuns []MLflowRun
+	for {
+		response, err := client.SearchRuns(
+			context.Background(),
+			experimentIDs,
+			filter,
+			maxResults,
+			pageToken,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to search MLflow runs: %w", err)
+		}
+		for _, rawRun := range response.Runs {
+			var parsedRun MLflowRun
+			unmarshalErr := json.Unmarshal(rawRun, &parsedRun)
+			if unmarshalErr != nil {
+				return nil, fmt.Errorf("failed to unmarshal MLflow runs/search response: %w", unmarshalErr)
+			}
+			allRuns = append(allRuns, parsedRun)
+		}
+		if response.NextPageToken == "" {
+			break
+		}
+		pageToken = response.NextPageToken
+	}
+	return allRuns, nil
+}

--- a/backend/test/v2/integration/run_api_test.go
+++ b/backend/test/v2/integration/run_api_test.go
@@ -359,6 +359,8 @@ func (s *RunAPITestSuite) checkTerminatedRunDetail(t *testing.T, run *run_model.
 		StorageState:   run.StorageState,
 		ServiceAccount: test.GetDefaultPipelineRunnerServiceAccount(*isKubeflowMode),
 		PipelineSpec:   run.PipelineSpec,
+		PluginsInput:   run.PluginsInput,
+		PluginsOutput:  run.PluginsOutput,
 		ExperimentID:   experimentID,
 		PipelineVersionReference: &run_model.V2beta1PipelineVersionReference{
 			PipelineID:        pipelineID,
@@ -383,6 +385,8 @@ func (s *RunAPITestSuite) checkHelloWorldRunDetail(t *testing.T, run *run_model.
 		StorageState:   run.StorageState,
 		ServiceAccount: test.GetDefaultPipelineRunnerServiceAccount(*isKubeflowMode),
 		PipelineSpec:   run.PipelineSpec,
+		PluginsInput:   run.PluginsInput,
+		PluginsOutput:  run.PluginsOutput,
 		ExperimentID:   experimentID,
 		PipelineVersionReference: &run_model.V2beta1PipelineVersionReference{
 			PipelineID:        pipelineID,
@@ -419,6 +423,8 @@ func (s *RunAPITestSuite) checkArgParamsRunDetail(t *testing.T, run *run_model.V
 		StorageState:   run.StorageState,
 		ServiceAccount: test.GetDefaultPipelineRunnerServiceAccount(*isKubeflowMode),
 		PipelineSpec:   run.PipelineSpec,
+		PluginsInput:   run.PluginsInput,
+		PluginsOutput:  run.PluginsOutput,
 		RuntimeConfig: &run_model.V2beta1RuntimeConfig{
 			Parameters: map[string]interface{}{
 				"param1": "goodbye",

--- a/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
+++ b/manifests/gcp_marketplace/chart/kubeflow-pipelines/templates/pipeline.yaml
@@ -323,6 +323,23 @@ rules:
       - update
       - patch
       - delete
+  - apiGroups:
+      - mlflow.kubeflow.org
+    resources:
+      - experiments
+    verbs:
+      - get
+      - list
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - kfp-launcher
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -400,6 +417,15 @@ rules:
       - jobs
     verbs:
       - '*'
+  - apiGroups:
+      - mlflow.kubeflow.org
+    resources:
+      - experiments
+    verbs:
+      - get
+      - list
+      - create
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/manifests/kustomize/base/installs/multi-user/api-service/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/api-service/cluster-role.yaml
@@ -61,3 +61,11 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - kfp-launcher
+  verbs:
+  - get

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -297,4 +297,14 @@ spec:
             requests:
               cpu: 250m
               memory: 500Mi
+          # Trust bundle for plugins.mlflow.tls.caBundlePath (create ConfigMap mlflow-tracking-ca in the same namespace).
+          volumeMounts:
+            - name: mlflow-tracking-ca
+              mountPath: /etc/mlflow-tracking-ca
+              readOnly: true
+      volumes:
+        - name: mlflow-tracking-ca
+          configMap:
+            name: mlflow-tracking-ca
+            optional: true
       serviceAccountName: ml-pipeline

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-role.yaml
@@ -63,3 +63,20 @@ rules:
   - tokenreviews
   verbs:
   - create
+- apiGroups:
+  - mlflow.kubeflow.org
+  resources:
+  - experiments
+  verbs:
+  - get
+  - list
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - kfp-launcher
+  verbs:
+  - get

--- a/manifests/kustomize/base/pipeline/pipeline-runner-role.yaml
+++ b/manifests/kustomize/base/pipeline/pipeline-runner-role.yaml
@@ -85,3 +85,12 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - mlflow.kubeflow.org
+  resources:
+  - experiments
+  verbs:
+  - get
+  - list
+  - create
+  - update


### PR DESCRIPTION
**Description of your changes:**

**Summary**
Adds automated end-to-end tests that run KFP against a real MLflow tracking server, and wires a CI job so those tests run on Kind with MLflow deployed and the API server configured for the plugin.

**What’s changed**

- New E2E tests — Ginkgo specs that create pipeline runs with MLflow-related plugins_input, verify plugins_output.mlflow, and call the MLflow REST API to check parent/nested runs, tags, and status (including multi-task, parallel-for, failure, retry, opt-out, and default-plugin behavior).
- Test helpers — Shared utilities for MLflow HTTP calls (tracking URI, TLS, bearer token, workspace header), run creation with plugins_input, and assertions on plugin output and nested runs.
- CI workflow — New E2E job that deploys MLflow, runs the configure script (API server plugin + port forwards + env for tests), and executes the suite with the MLflow label and -mlflowEnabled=true.
- Configure script — Script used by CI to patch the API server with MLflow settings and grant the pipeline service account access to MLflow.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
