### PR TITLE
chore(frontend): clean up NewRunV2 test boilerplate, validation contract, memo dependencies

### DIFF
--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -248,6 +248,35 @@ describe('NewRunV2', () => {
     return render(buildNewRunV2Element(overrides));
   }
 
+  // Clone-mode helpers: use generatePropsClonedRun() as the PageProps base and
+  // default existingPipeline/existingPipelineVersion to undefined, matching how
+  // clone runs work (pipeline info comes from the original run, not the URL).
+  function buildClonedRunV2Element(overrides: Partial<ComponentProps<typeof NewRunV2>> = {}) {
+    const props: ComponentProps<typeof NewRunV2> = {
+      ...generatePropsClonedRun(),
+      existingRunId: null,
+      existingRun: undefined,
+      existingRecurringRunId: null,
+      existingRecurringRun: undefined,
+      existingPipeline: undefined,
+      handlePipelineIdChange: vi.fn(),
+      existingPipelineVersion: undefined,
+      handlePipelineVersionIdChange: vi.fn(),
+      templateString: v2XGYamlTemplateString,
+      chosenExperiment: undefined,
+      ...overrides,
+    };
+    return (
+      <CommonTestWrapper>
+        <NewRunV2 {...props} />
+      </CommonTestWrapper>
+    );
+  }
+
+  function renderClonedRunV2(overrides: Partial<ComponentProps<typeof NewRunV2>> = {}) {
+    return render(buildClonedRunV2Element(overrides));
+  }
+
   // For creating new run with no pipeline is selected (enter from run list)
   function generatePropsNoPipelineDef(eid: string | null): PageProps {
     return {
@@ -421,26 +450,22 @@ describe('NewRunV2', () => {
     expect(await screen.findByText('This pipeline has no parameters')).toBeInTheDocument();
   });
 
-  it('shows a loading message when pipeline version is selected but template has not arrived', async () => {
+  it('disables start button when pipeline version is selected but template is unavailable', async () => {
     renderNewRunV2({ templateString: undefined });
-
-    expect(await screen.findByText('Loading pipeline template...')).toBeInTheDocument();
 
     const startButton = screen.getByText('Start');
     expect(startButton.closest('button')?.disabled).toEqual(true);
   });
 
-  it('shows a loading spinner when template is loading for a new run', async () => {
-    renderNewRunV2({ templateString: undefined });
-
-    expect(screen.getByRole('progressbar')).toBeInTheDocument();
-  });
-
-  it('does not show the loading spinner once the template has arrived', async () => {
-    renderNewRunV2();
+  it('does not show a loading spinner when cloning a run with an undefined template', async () => {
+    renderClonedRunV2({
+      existingRunId: TEST_RUN_ID,
+      existingRun: API_UI_CREATED_NEW_RUN_DETAILS,
+      existingPipelineVersion: ORIGINAL_TEST_PIPELINE_VERSION,
+      templateString: undefined,
+    });
 
     expect(screen.queryByRole('progressbar')).toBeNull();
-    expect(screen.queryByText('Loading pipeline template...')).toBeNull();
   });
 
   it('shows the cloned pipeline root after rerendering into clone mode', async () => {
@@ -786,12 +811,9 @@ describe('NewRunV2', () => {
 
   describe('cloning an existing run', () => {
     it('only shows clone run name from original run', () => {
-      renderNewRunV2({
-        ...generatePropsClonedRun(),
+      renderClonedRunV2({
         existingRunId: TEST_RUN_ID,
         existingRun: API_UI_CREATED_NEW_RUN_DETAILS,
-        existingPipeline: undefined,
-        existingPipelineVersion: undefined,
       });
       screen.findByDisplayValue(`Clone of ${API_UI_CREATED_NEW_RUN_DETAILS.display_name}`);
     });
@@ -800,12 +822,9 @@ describe('NewRunV2', () => {
       const createRunSpy = vi.spyOn(Apis.runServiceApiV2, 'createRun');
       createRunSpy.mockResolvedValue(API_UI_CREATED_CLONING_RUN_DETAILS);
 
-      renderNewRunV2({
-        ...generatePropsClonedRun(),
+      renderClonedRunV2({
         existingRunId: TEST_RUN_ID,
         existingRun: API_UI_CREATED_NEW_RUN_DETAILS,
-        existingPipeline: undefined,
-        existingPipelineVersion: undefined,
       });
 
       const startButton = await screen.findByText('Start');
@@ -838,12 +857,9 @@ describe('NewRunV2', () => {
       const createRunSpy = vi.spyOn(Apis.runServiceApiV2, 'createRun');
       createRunSpy.mockResolvedValue(API_SDK_CREATED_CLONING_RUN_DETAILS);
 
-      renderNewRunV2({
-        ...generatePropsClonedRun(),
+      renderClonedRunV2({
         existingRunId: TEST_RUN_ID,
         existingRun: API_SDK_CREATED_NEW_RUN_DETAILS,
-        existingPipeline: undefined,
-        existingPipelineVersion: undefined,
       });
 
       const startButton = await screen.findByText('Start');
@@ -875,12 +891,9 @@ describe('NewRunV2', () => {
       const createRecurringRunSpy = vi.spyOn(Apis.recurringRunServiceApi, 'createRecurringRun');
       createRecurringRunSpy.mockResolvedValue(API_UI_CREATED_CLONING_RECURRING_RUN_DETAILS);
 
-      renderNewRunV2({
-        ...generatePropsClonedRun(),
+      renderClonedRunV2({
         existingRecurringRunId: TEST_RECURRING_RUN_ID,
         existingRecurringRun: API_UI_CREATED_NEW_RECURRING_RUN_DETAILS,
-        existingPipeline: undefined,
-        existingPipelineVersion: undefined,
       });
 
       const startButton = await screen.findByText('Start');
@@ -923,12 +936,9 @@ describe('NewRunV2', () => {
       const createRecurringRunSpy = vi.spyOn(Apis.recurringRunServiceApi, 'createRecurringRun');
       createRecurringRunSpy.mockResolvedValue(API_SDK_CREATED_CLONING_RECURRING_RUN_DETAILS);
 
-      renderNewRunV2({
-        ...generatePropsClonedRun(),
+      renderClonedRunV2({
         existingRecurringRunId: TEST_RECURRING_RUN_ID,
         existingRecurringRun: API_SDK_CREATED_NEW_RECURRING_RUN_DETAILS,
-        existingPipeline: undefined,
-        existingPipelineVersion: undefined,
       });
 
       const startButton = await screen.findByText('Start');

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -16,7 +16,6 @@
 
 import {
   Button,
-  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
@@ -222,7 +221,7 @@ function getRunValidationErrorMessage(
   if (!existingPipelineVersion) {
     return 'A pipeline version must be selected';
   }
-  return 'Loading pipeline template...';
+  return '';
 }
 
 function getDefaultRunName(
@@ -336,7 +335,6 @@ function NewRunV2(props: NewRunV2Props) {
   const usePipelineFromRunLabel = `Using pipeline from existing ${labelTextAdjective} run.`;
 
   const isTemplatePullSuccess = templateString ? true : false;
-  const isTemplateLoading = !templateString && !!existingPipelineVersion && !cloneOrigin.isClone;
   const validationErrorMessage = getRunValidationErrorMessage(
     runName,
     existingPipeline,
@@ -774,9 +772,6 @@ function NewRunV2(props: NewRunV2Props) {
           >
             {'Cancel'}
           </Button>
-          {isTemplateLoading && (
-            <CircularProgress size={24} style={{ marginLeft: 12, alignSelf: 'center' }} />
-          )}
           <div className={classes(padding(20, 'r'))} style={{ color: 'red' }}>
             {validationErrorMessage}
           </div>


### PR DESCRIPTION
**Description of your changes:**

Addresses items from #13146 with refinements based on review feedback:

1. **Extract test helpers** — `buildNewRunV2Element`/`renderNewRunV2` eliminate ~30 repeated 15-line render blocks in `NewRunV2.test.tsx`.
2. **Add clone-mode test helpers** — `buildClonedRunV2Element`/`renderClonedRunV2` use `generatePropsClonedRun()` as the PageProps base directly, making the override chain explicit instead of silently clobbering the `generatePropsNewRun()` base from `buildNewRunV2Element`. All 5 existing clone tests migrated.
3. **Clean up validation contract** — `getRunValidationErrorMessage` returns `''` (not a loading message) when the template is unavailable; the Start button stays disabled via the existing `!!templateString` guard in `isStartButtonEnabled`. This keeps the validation function's contract clean: empty = valid, non-empty = actual validation error.
4. **Remove misleading loading UX** — Removed `isTemplateLoading`, `CircularProgress` spinner, and "Loading pipeline template..." message. `NewRunSwitcher` already blocks rendering with "Currently loading pipeline information" while fetching, so `NewRunV2` never sees a true template-loading state — showing a spinner for what is actually a post-fetch-failure state would mislead users indefinitely.
5. **Narrow memo/effect dependencies** — `useMemo`/`useEffect` dependency arrays use specific fields (e.g. `?.display_name`) instead of full object references to avoid unnecessary re-fires when the parent recreates objects.
6. **Add clone-mode spinner test** — Verifies no spinner appears when cloning a run with `templateString: undefined`.

Closes #13146

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).