### PR TITLE
fix(ci): gate ci-passed on real CI poll completion

### DIFF
--- a/.github/workflows/add-ci-passed-label.yml
+++ b/.github/workflows/add-ci-passed-label.yml
@@ -35,8 +35,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            core.setOutput("eligible", "false");
-            core.setOutput("should_add_label", "false");
+            core.setOutput("artifact_found", "false");
 
             if (context.eventName !== "workflow_run") {
               core.info(`No ci-passed eligibility lookup needed for ${context.eventName}.`);
@@ -60,9 +59,10 @@ jobs:
             });
 
             if (!resultArtifact) {
-              throw new Error(
-                `Required artifact "ci-check-result" was not found for workflow run ID ${context.payload.workflow_run.id}.`
+              core.warning(
+                `Required artifact "ci-check-result" was not found for workflow run ID ${context.payload.workflow_run.id}; skipping ci-passed update.`
               );
+              return;
             }
 
             const download = await github.rest.actions.downloadArtifact({
@@ -74,18 +74,23 @@ jobs:
 
             const fs = require("fs");
             fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/ci-check-result.zip`, Buffer.from(download.data));
+            core.setOutput("artifact_found", "true");
 
       - name: Unzip CI check result
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+        if: steps.download_result.outputs.artifact_found == 'true'
         shell: bash
         run: unzip -o ci-check-result.zip -d ci-check-result
 
       - name: Parse CI check result and confirm current PR state
         id: ci_result
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+        if: steps.download_result.outputs.artifact_found == 'true'
         uses: actions/github-script@v8
         with:
           script: |
+            core.setOutput("pr_number", "");
+            core.setOutput("eligible", "false");
+            core.setOutput("should_add_label", "false");
+
             const fs = require("fs");
             const result = JSON.parse(
               fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/ci-check-result/result.json`, "utf8")

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -67,6 +67,10 @@ jobs:
           poll_outcome="${{ steps.poll.outcome }}"
           should_add_label=false
 
+          if [[ -z "${should_poll}" ]]; then
+            should_poll=false
+          fi
+
           if [[ -z "${poll_outcome}" ]]; then
             poll_outcome=skipped
           fi
@@ -75,15 +79,19 @@ jobs:
             should_add_label=true
           fi
 
-          cat > ci-check-result/result.json <<EOF
-          {
-            "pr_number": "${{ github.event.pull_request.number }}",
-            "head_sha": "${{ github.event.pull_request.head.sha }}",
-            "should_poll": ${should_poll},
-            "poll_outcome": "${poll_outcome}",
-            "should_add_label": ${should_add_label}
-          }
-          EOF
+          jq -n \
+            --arg pr_number "${{ github.event.pull_request.number }}" \
+            --arg head_sha "${{ github.event.pull_request.head.sha }}" \
+            --arg poll_outcome "${poll_outcome}" \
+            --argjson should_poll "${should_poll}" \
+            --argjson should_add_label "${should_add_label}" \
+            '{
+              pr_number: $pr_number,
+              head_sha: $head_sha,
+              should_poll: $should_poll,
+              poll_outcome: $poll_outcome,
+              should_add_label: $should_add_label
+            }' > ci-check-result/result.json
 
       - name: Upload CI check result
         if: always()


### PR DESCRIPTION
## Summary
- make `CI Check` publish an explicit `ci-check-result` artifact for every run, including no-op success cases
- make `Add CI Passed Label` consume that artifact so it only adds `ci-passed` when the triggering run actually completed the CI polling gate successfully
- preserve the existing stale-label guards by re-checking the current PR head SHA and eligibility labels before any label add

## Root cause
- #13095 changed `Add CI Passed Label` to infer add eligibility from the PR's current labels during `workflow_run`
- #13172 changed irrelevant label events from skipped jobs to no-op successful jobs so Tide would keep the helper contexts green
- together, that let older no-op-success `CI Check` runs re-evaluate as eligible after `ok-to-test` was added and incorrectly add `ci-passed` before real CI finished

## Validation
- `ruby -e 'require "yaml"; [".github/workflows/ci-checks.yml", ".github/workflows/add-ci-passed-label.yml"].each { |path| YAML.load_file(path); puts "YAML OK: #{path}" }'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci-checks.yml .github/workflows/add-ci-passed-label.yml`
- `git diff --check`

## Note
- This PR itself will still show the current helper-workflow behavior until the fix lands, because `pull_request_target` and downstream `workflow_run` executions use the workflow files from the base branch, not from this PR branch.
