### PR TITLE
refactor(frontend): reduce NewRun prop syncing

### DIFF
--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -407,6 +407,24 @@ describe('NewRunV2', () => {
     ).toBeInTheDocument();
   });
 
+  it('updates the displayed pipeline name when the selected pipeline prop changes', async () => {
+    const { rerender } = renderNewRunV2({ chosenExperiment: DEFAULT_EXPERIMENT });
+
+    expect(await screen.findByDisplayValue(ORIGINAL_TEST_PIPELINE_NAME)).toBeInTheDocument();
+
+    rerender(
+      buildNewRunV2Element({
+        ...generatePropsNewRun(NEW_TEST_PIPELINE_ID, NEW_TEST_PIPELINE_VERSION_ID),
+        existingPipeline: NEW_TEST_PIPELINE,
+        existingPipelineVersion: NEW_TEST_PIPELINE_VERSION,
+        templateString: v2LWYamlTemplateString,
+        chosenExperiment: DEFAULT_EXPERIMENT,
+      }),
+    );
+
+    expect(await screen.findByDisplayValue(NEW_TEST_PIPELINE_NAME)).toBeInTheDocument();
+  });
+
   it('preserves a custom run name when the selected pipeline version changes', async () => {
     const { rerender } = renderNewRunV2();
 
@@ -423,6 +441,20 @@ describe('NewRunV2', () => {
     );
 
     expect(await screen.findByDisplayValue('Run with custom name')).toBeInTheDocument();
+  });
+
+  it('updates the displayed experiment name when the chosen experiment prop changes', async () => {
+    const { rerender } = renderNewRunV2({ chosenExperiment: DEFAULT_EXPERIMENT });
+
+    expect(await screen.findByDisplayValue(DEFAULT_EXPERIMENT.display_name!)).toBeInTheDocument();
+
+    rerender(
+      buildNewRunV2Element({
+        chosenExperiment: NEW_EXPERIMENT,
+      }),
+    );
+
+    expect(await screen.findByDisplayValue(NEW_EXPERIMENT.display_name!)).toBeInTheDocument();
   });
 
   it('resets parameter inputs when the selected template changes', async () => {

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -259,11 +259,6 @@ function NewRunV2(props: NewRunV2Props) {
   const urlParser = new URLParser(props);
   const [customRunName, setCustomRunName] = useState<string | null>(null);
   const [runDescription, setRunDescription] = useState('');
-  const [pipelineName, setPipelineName] = useState('');
-  const [pipelineVersionName, setPipelineVersionName] = useState('');
-  const [experimentId, setExperimentId] = useState('');
-  const [experiment, setExperiment] = useState(chosenExperiment);
-  const [experimentName, setExperimentName] = useState('');
   const [serviceAccount, setServiceAccount] = useState('');
   const [isStartingNewRun, setIsStartingNewRun] = useState(false);
   const [openNewExperiment, setOpenNewExperiment] = useState(false);
@@ -289,6 +284,23 @@ function NewRunV2(props: NewRunV2Props) {
   const existingRunDisplayName = existingRun?.display_name;
   const existingRecurringRunDisplayName = existingRecurringRun?.display_name;
   const existingPipelineVersionDisplayName = existingPipelineVersion?.display_name;
+  const [pipelineName, setPipelineName] = useKeyedState<string>(
+    existingPipeline?.pipeline_id ?? '',
+    existingPipeline?.display_name ?? '',
+  );
+  const [selectedExperiment, setSelectedExperiment] = useKeyedState<V2beta1Experiment | undefined>(
+    chosenExperiment?.experiment_id ?? '',
+    chosenExperiment,
+  );
+  const experimentId = selectedExperiment?.experiment_id ?? '';
+  const experimentName = selectedExperiment?.display_name ?? '';
+  // Prefix the "latest version" mode key so toggling the checkbox cannot reuse a concrete version id.
+  const [pipelineVersionName, setPipelineVersionName] = useKeyedState<string>(
+    useLatestVersion
+      ? `latest:${existingPipeline?.pipeline_id ?? ''}`
+      : (existingPipelineVersion?.pipeline_version_id ?? ''),
+    useLatestVersion ? '' : (existingPipelineVersion?.display_name ?? ''),
+  );
   const defaultRunName = useMemo(
     () =>
       getDefaultRunName(
@@ -383,27 +395,6 @@ function NewRunV2(props: NewRunV2Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRecurringRun]);
 
-  // Pre-fill names for pipeline, pipeline version and experiment.
-  useEffect(() => {
-    if (existingPipeline?.display_name) {
-      setPipelineName(existingPipeline.display_name);
-    }
-    if (experiment?.display_name) {
-      setExperimentName(experiment.display_name);
-    }
-    if (experiment?.experiment_id) {
-      setExperimentId(experiment.experiment_id);
-    }
-  }, [existingPipeline, experiment]);
-
-  useEffect(() => {
-    if (useLatestVersion) {
-      setPipelineVersionName('');
-    } else if (existingPipelineVersion?.display_name) {
-      setPipelineVersionName(existingPipelineVersion.display_name);
-    }
-  }, [existingPipelineVersion, useLatestVersion]);
-
   // Defines the behavior when user clicks `Start` button.
   const newRunMutation = useMutation({
     mutationFn: (run: V2beta1Run) => {
@@ -422,7 +413,7 @@ function NewRunV2(props: NewRunV2Props) {
     let newRun: V2beta1Run = {
       description: runDescription,
       display_name: runName,
-      experiment_id: experiment?.experiment_id,
+      experiment_id: selectedExperiment?.experiment_id,
       // pipeline_spec and pipeline_version_reference is exclusive.
       pipeline_spec: !(pipelineVersionRefClone || pipelineVersionRefNew)
         ? JsYaml.safeLoad(templateString || '')
@@ -562,11 +553,7 @@ function NewRunV2(props: NewRunV2Props) {
                   <Checkbox
                     checked={useLatestVersion}
                     onChange={(e) => {
-                      const isChecked = e.target.checked;
-                      setUseLatestVersion(isChecked);
-                      if (isChecked) {
-                        setPipelineVersionName('');
-                      }
+                      setUseLatestVersion(e.target.checked);
                     }}
                     color='primary'
                     disabled={!existingPipeline}
@@ -630,12 +617,8 @@ function NewRunV2(props: NewRunV2Props) {
           toolbarActionMap={createNewExperiment}
           experimentName={experimentName}
           handleExperimentChange={(experiment) => {
-            setExperiment(experiment);
-            if (experiment.display_name) {
-              setExperimentName(experiment.display_name);
-            }
+            setSelectedExperiment(experiment);
             if (experiment.experiment_id) {
-              setExperimentId(experiment.experiment_id);
               let searchString;
               if (existingPipeline?.pipeline_id && existingPipelineVersion?.pipeline_version_id) {
                 searchString = urlParser.build({


### PR DESCRIPTION
## Summary
- remove the remaining page-side prop-mirroring effects in `NewRunV2`
- switch pipeline, experiment, and displayed pipeline-version state to keyed initialization instead of effect-driven syncing
- add rerender coverage for pipeline-name and experiment-name prop changes

## Why
`NewRunV2` still had two non-toolbar `useEffect` blocks whose only job was to copy pipeline, experiment, and version display data from props into local state after render. That pattern is the same effect misuse this cleanup series has been removing elsewhere: it adds post-render repair work, makes rerender behavior harder to reason about, and encourages `react-hooks/exhaustive-deps` suppressions.

This PR keeps the slice narrow:
- the toolbar effect stays, because it is legitimate external synchronization
- `NewRunParametersV2` is intentionally unchanged here, because its remaining mount-time propagation behavior still has a broader standalone-test contract and should be handled in its own follow-up if we keep going

## What changed
- `NewRunV2` now initializes `pipelineName`, `selectedExperiment`, and `pipelineVersionName` with `useKeyedState(...)` keyed from the corresponding prop identity instead of syncing them in effects
- the latest-version checkbox now only toggles `useLatestVersion`; blanking the displayed version name is derived from the keyed state initialization rather than an effect or imperative checkbox handler reset
- run submission now reads the selected experiment directly from `selectedExperiment`
- `NewRunV2.test.tsx` now verifies that rerendering with a different pipeline prop updates the displayed pipeline name, and rerendering with a different chosen experiment prop updates the displayed experiment name

## Verification
- `cd frontend && fnm exec --using .nvmrc -- npx prettier@3.8.1 --check src/pages/NewRunV2.tsx src/pages/NewRunV2.test.tsx`
- `cd frontend && fnm exec --using .nvmrc -- npm run test:ui -- src/pages/NewRunV2.test.tsx`
- `cd frontend && fnm exec --using .nvmrc -- npm run typecheck`

Result: formatter passed, `src/pages/NewRunV2.test.tsx` passed with `34` tests, and typecheck passed.
