### PR TITLE
test(e2e): reduce pipeline_with_loops fanout

### DIFF
--- a/test_data/compiled-workflows/pipeline_with_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops.yaml
@@ -48,11 +48,11 @@ spec:
         kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
         print_struct(struct: Dict):\n    print(struct)\n\n"],"image":"python:3.11"}'
     - name: components-comp-for-loop-2
-      value: '{"dag":{"tasks":{"print-struct":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-struct"},"inputs":{"parameters":{"struct":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item"}}},"taskInfo":{"name":"print-struct"}},"print-text-2":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-2"},"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"A_a\"]"}}},"taskInfo":{"name":"print-text-2"}},"print-text-3":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-3"},"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"B_b\"]"}}},"taskInfo":{"name":"print-text-3"}}}},"inputDefinitions":{"parameters":{"pipelinechannel--args-generator-op-Output":{"parameterType":"LIST"},"pipelinechannel--args-generator-op-Output-loop-item":{"parameterType":"STRUCT"}}}}'
+      value: '{"dag":{"tasks":{"print-struct":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-struct"},"inputs":{"parameters":{"struct":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item"}}},"taskInfo":{"name":"print-struct"}},"print-text-2":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-2"},"dependentTasks":["print-struct"],"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"A_a\"]"}}},"taskInfo":{"name":"print-text-2"}},"print-text-3":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-3"},"dependentTasks":["print-text-2"],"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"B_b\"]"}}},"taskInfo":{"name":"print-text-3"}}}},"inputDefinitions":{"parameters":{"pipelinechannel--args-generator-op-Output":{"parameterType":"LIST"},"pipelinechannel--args-generator-op-Output-loop-item":{"parameterType":"STRUCT"}}}}'
     - name: components-comp-for-loop-4
-      value: '{"dag":{"tasks":{"print-struct-2":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-struct-2"},"inputs":{"parameters":{"struct":{"componentInputParameter":"pipelinechannel--loop-item-param-3"}}},"taskInfo":{"name":"print-struct-2"}},"print-text-4":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-4"},"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--loop-item-param-3","parameterExpressionSelector":"parseJson(string_value)[\"A_a\"]"}}},"taskInfo":{"name":"print-text-4"}},"print-text-5":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-5"},"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--loop-item-param-3","parameterExpressionSelector":"parseJson(string_value)[\"B_b\"]"}}},"taskInfo":{"name":"print-text-5"}}}},"inputDefinitions":{"parameters":{"pipelinechannel--loop-item-param-3":{"parameterType":"STRUCT"}}}}'
+      value: '{"dag":{"tasks":{"print-struct-2":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-struct-2"},"inputs":{"parameters":{"struct":{"componentInputParameter":"pipelinechannel--loop-item-param-3"}}},"taskInfo":{"name":"print-struct-2"}},"print-text-4":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-4"},"dependentTasks":["print-struct-2"],"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--loop-item-param-3","parameterExpressionSelector":"parseJson(string_value)[\"A_a\"]"}}},"taskInfo":{"name":"print-text-4"}},"print-text-5":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-5"},"dependentTasks":["print-text-4"],"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--loop-item-param-3","parameterExpressionSelector":"parseJson(string_value)[\"B_b\"]"}}},"taskInfo":{"name":"print-text-5"}}}},"inputDefinitions":{"parameters":{"pipelinechannel--loop-item-param-3":{"parameterType":"STRUCT"}}}}'
     - name: components-root
-      value: '{"dag":{"tasks":{"args-generator-op":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-args-generator-op"},"taskInfo":{"name":"args-generator-op"}},"for-loop-1":{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-1"}},"for-loop-2":{"componentRef":{"name":"comp-for-loop-2"},"dependentTasks":["args-generator-op"],"inputs":{"parameters":{"pipelinechannel--args-generator-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"args-generator-op"}}}},"parameterIterator":{"itemInput":"pipelinechannel--args-generator-op-Output-loop-item","items":{"inputParameter":"pipelinechannel--args-generator-op-Output"}},"taskInfo":{"name":"for-loop-2"}},"for-loop-4":{"componentRef":{"name":"comp-for-loop-4"},"parameterIterator":{"itemInput":"pipelinechannel--loop-item-param-3","items":{"raw":"[{\"A_a\":
+      value: '{"dag":{"tasks":{"args-generator-op":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-args-generator-op"},"taskInfo":{"name":"args-generator-op"}},"for-loop-1":{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"}}},"iteratorPolicy":{"parallelismLimit":1},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-1"}},"for-loop-2":{"componentRef":{"name":"comp-for-loop-2"},"dependentTasks":["args-generator-op"],"inputs":{"parameters":{"pipelinechannel--args-generator-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"args-generator-op"}}}},"iteratorPolicy":{"parallelismLimit":1},"parameterIterator":{"itemInput":"pipelinechannel--args-generator-op-Output-loop-item","items":{"inputParameter":"pipelinechannel--args-generator-op-Output"}},"taskInfo":{"name":"for-loop-2"}},"for-loop-4":{"componentRef":{"name":"comp-for-loop-4"},"iteratorPolicy":{"parallelismLimit":1},"parameterIterator":{"itemInput":"pipelinechannel--loop-item-param-3","items":{"raw":"[{\"A_a\":
         \"1\", \"B_b\": \"2\"}, {\"A_a\": \"10\", \"B_b\": \"20\"}]"}},"taskInfo":{"name":"for-loop-4"}}}},"inputDefinitions":{"parameters":{"loop_parameter":{"defaultValue":["a","b"],"isOptional":true,"parameterType":"LIST"}}}}'
   entrypoint: entrypoint
   podMetadata:
@@ -343,13 +343,14 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-317c58411818b2658547854882ddd2335912f90f03549c22a3ed7031bb45a11d}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-2"},"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"A_a\"]"}}},"taskInfo":{"name":"print-text-2"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-2"},"dependentTasks":["print-struct"],"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"A_a\"]"}}},"taskInfo":{"name":"print-text-2"}}'
           - name: container
             value: '{{workflow.parameters.implementations-317c58411818b2658547854882ddd2335912f90f03549c22a3ed7031bb45a11d}}'
           - name: task-name
             value: print-text-2
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+        depends: print-struct.Succeeded
         name: print-text-2-driver
         template: system-container-driver
       - arguments:
@@ -367,13 +368,14 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-317c58411818b2658547854882ddd2335912f90f03549c22a3ed7031bb45a11d}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-3"},"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"B_b\"]"}}},"taskInfo":{"name":"print-text-3"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-3"},"dependentTasks":["print-text-2"],"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--args-generator-op-Output-loop-item","parameterExpressionSelector":"parseJson(string_value)[\"B_b\"]"}}},"taskInfo":{"name":"print-text-3"}}'
           - name: container
             value: '{{workflow.parameters.implementations-317c58411818b2658547854882ddd2335912f90f03549c22a3ed7031bb45a11d}}'
           - name: task-name
             value: print-text-3
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+        depends: print-text-2.Succeeded
         name: print-text-3-driver
         template: system-container-driver
       - arguments:
@@ -423,13 +425,14 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-317c58411818b2658547854882ddd2335912f90f03549c22a3ed7031bb45a11d}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-4"},"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--loop-item-param-3","parameterExpressionSelector":"parseJson(string_value)[\"A_a\"]"}}},"taskInfo":{"name":"print-text-4"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-4"},"dependentTasks":["print-struct-2"],"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--loop-item-param-3","parameterExpressionSelector":"parseJson(string_value)[\"A_a\"]"}}},"taskInfo":{"name":"print-text-4"}}'
           - name: container
             value: '{{workflow.parameters.implementations-317c58411818b2658547854882ddd2335912f90f03549c22a3ed7031bb45a11d}}'
           - name: task-name
             value: print-text-4
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+        depends: print-struct-2.Succeeded
         name: print-text-4-driver
         template: system-container-driver
       - arguments:
@@ -447,13 +450,14 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-317c58411818b2658547854882ddd2335912f90f03549c22a3ed7031bb45a11d}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-5"},"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--loop-item-param-3","parameterExpressionSelector":"parseJson(string_value)[\"B_b\"]"}}},"taskInfo":{"name":"print-text-5"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-print-text-5"},"dependentTasks":["print-text-4"],"inputs":{"parameters":{"msg":{"componentInputParameter":"pipelinechannel--loop-item-param-3","parameterExpressionSelector":"parseJson(string_value)[\"B_b\"]"}}},"taskInfo":{"name":"print-text-5"}}'
           - name: container
             value: '{{workflow.parameters.implementations-317c58411818b2658547854882ddd2335912f90f03549c22a3ed7031bb45a11d}}'
           - name: task-name
             value: print-text-5
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
+        depends: print-text-4.Succeeded
         name: print-text-5-driver
         template: system-container-driver
       - arguments:
@@ -580,7 +584,7 @@ spec:
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: task
-            value: '{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-1"}}'
+            value: '{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"}}},"iteratorPolicy":{"parallelismLimit":1},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
         name: iteration-item-driver
@@ -610,7 +614,7 @@ spec:
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: task
-            value: '{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"}}},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-1"}}'
+            value: '{"componentRef":{"name":"comp-for-loop-1"},"inputs":{"parameters":{"pipelinechannel--loop_parameter":{"componentInputParameter":"loop_parameter"}}},"iteratorPolicy":{"parallelismLimit":1},"parameterIterator":{"itemInput":"pipelinechannel--loop_parameter-loop-item","items":{"inputParameter":"pipelinechannel--loop_parameter"}},"taskInfo":{"name":"for-loop-1"}}'
           - name: task-name
             value: for-loop-1
         name: iteration-driver
@@ -632,6 +636,7 @@ spec:
     metadata: {}
     name: comp-for-loop-1-for-loop-1-iterator
     outputs: {}
+    parallelism: 1
   - dag:
       tasks:
       - arguments:
@@ -643,7 +648,7 @@ spec:
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: task
-            value: '{"componentRef":{"name":"comp-for-loop-2"},"dependentTasks":["args-generator-op"],"inputs":{"parameters":{"pipelinechannel--args-generator-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"args-generator-op"}}}},"parameterIterator":{"itemInput":"pipelinechannel--args-generator-op-Output-loop-item","items":{"inputParameter":"pipelinechannel--args-generator-op-Output"}},"taskInfo":{"name":"for-loop-2"}}'
+            value: '{"componentRef":{"name":"comp-for-loop-2"},"dependentTasks":["args-generator-op"],"inputs":{"parameters":{"pipelinechannel--args-generator-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"args-generator-op"}}}},"iteratorPolicy":{"parallelismLimit":1},"parameterIterator":{"itemInput":"pipelinechannel--args-generator-op-Output-loop-item","items":{"inputParameter":"pipelinechannel--args-generator-op-Output"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
         name: iteration-item-driver
@@ -673,7 +678,7 @@ spec:
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: task
-            value: '{"componentRef":{"name":"comp-for-loop-2"},"dependentTasks":["args-generator-op"],"inputs":{"parameters":{"pipelinechannel--args-generator-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"args-generator-op"}}}},"parameterIterator":{"itemInput":"pipelinechannel--args-generator-op-Output-loop-item","items":{"inputParameter":"pipelinechannel--args-generator-op-Output"}},"taskInfo":{"name":"for-loop-2"}}'
+            value: '{"componentRef":{"name":"comp-for-loop-2"},"dependentTasks":["args-generator-op"],"inputs":{"parameters":{"pipelinechannel--args-generator-op-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"args-generator-op"}}}},"iteratorPolicy":{"parallelismLimit":1},"parameterIterator":{"itemInput":"pipelinechannel--args-generator-op-Output-loop-item","items":{"inputParameter":"pipelinechannel--args-generator-op-Output"}},"taskInfo":{"name":"for-loop-2"}}'
           - name: task-name
             value: for-loop-2
         name: iteration-driver
@@ -695,6 +700,7 @@ spec:
     metadata: {}
     name: comp-for-loop-2-for-loop-2-iterator
     outputs: {}
+    parallelism: 1
   - dag:
       tasks:
       - arguments:
@@ -706,7 +712,7 @@ spec:
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: task
-            value: '{"componentRef":{"name":"comp-for-loop-4"},"parameterIterator":{"itemInput":"pipelinechannel--loop-item-param-3","items":{"raw":"[{\"A_a\":
+            value: '{"componentRef":{"name":"comp-for-loop-4"},"iteratorPolicy":{"parallelismLimit":1},"parameterIterator":{"itemInput":"pipelinechannel--loop-item-param-3","items":{"raw":"[{\"A_a\":
               \"1\", \"B_b\": \"2\"}, {\"A_a\": \"10\", \"B_b\": \"20\"}]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
@@ -737,7 +743,7 @@ spec:
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
           - name: task
-            value: '{"componentRef":{"name":"comp-for-loop-4"},"parameterIterator":{"itemInput":"pipelinechannel--loop-item-param-3","items":{"raw":"[{\"A_a\":
+            value: '{"componentRef":{"name":"comp-for-loop-4"},"iteratorPolicy":{"parallelismLimit":1},"parameterIterator":{"itemInput":"pipelinechannel--loop-item-param-3","items":{"raw":"[{\"A_a\":
               \"1\", \"B_b\": \"2\"}, {\"A_a\": \"10\", \"B_b\": \"20\"}]"}},"taskInfo":{"name":"for-loop-4"}}'
           - name: task-name
             value: for-loop-4
@@ -760,6 +766,7 @@ spec:
     metadata: {}
     name: comp-for-loop-4-for-loop-4-iterator
     outputs: {}
+    parallelism: 1
   - dag:
       tasks:
       - arguments:

--- a/test_data/sdk_compiled_pipelines/valid/parallel_and_nested/pipeline_with_loops.py
+++ b/test_data/sdk_compiled_pipelines/valid/parallel_and_nested/pipeline_with_loops.py
@@ -38,22 +38,26 @@ def print_struct(struct: Dict):
 def my_pipeline(loop_parameter: List[str] = ["a", "b"]):
 
     # Loop argument is from a pipeline input
-    with dsl.ParallelFor(loop_parameter) as item:
+    with dsl.ParallelFor(loop_parameter, parallelism=1) as item:
         print_text(msg=item)
 
     # Loop argument is from a component output
     args_generator = args_generator_op()
-    with dsl.ParallelFor(args_generator.output) as item:
-        print_struct(struct=item)
-        print_text(msg=item.A_a)
-        print_text(msg=item.B_b)
+    with dsl.ParallelFor(args_generator.output, parallelism=1) as item:
+        print_struct_task = print_struct(struct=item)
+        print_text_a_task = print_text(msg=item.A_a)
+        print_text_a_task.after(print_struct_task)
+        print_text_b_task = print_text(msg=item.B_b)
+        print_text_b_task.after(print_text_a_task)
 
     # Loop argument is a static value known at compile time
     loop_args = [{'A_a': '1', 'B_b': '2'}, {'A_a': '10', 'B_b': '20'}]
-    with dsl.ParallelFor(loop_args) as item:
-        print_struct(struct=item)
-        print_text(msg=item.A_a)
-        print_text(msg=item.B_b)
+    with dsl.ParallelFor(loop_args, parallelism=1) as item:
+        print_struct_task = print_struct(struct=item)
+        print_text_a_task = print_text(msg=item.A_a)
+        print_text_a_task.after(print_struct_task)
+        print_text_b_task = print_text(msg=item.B_b)
+        print_text_b_task.after(print_text_a_task)
 
 
 if __name__ == '__main__':

--- a/test_data/sdk_compiled_pipelines/valid/parallel_and_nested/pipeline_with_loops.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/parallel_and_nested/pipeline_with_loops.yaml
@@ -48,6 +48,8 @@ components:
             enableCache: true
           componentRef:
             name: comp-print-text-2
+          dependentTasks:
+          - print-struct
           inputs:
             parameters:
               msg:
@@ -60,6 +62,8 @@ components:
             enableCache: true
           componentRef:
             name: comp-print-text-3
+          dependentTasks:
+          - print-text-2
           inputs:
             parameters:
               msg:
@@ -92,6 +96,8 @@ components:
             enableCache: true
           componentRef:
             name: comp-print-text-4
+          dependentTasks:
+          - print-struct-2
           inputs:
             parameters:
               msg:
@@ -104,6 +110,8 @@ components:
             enableCache: true
           componentRef:
             name: comp-print-text-5
+          dependentTasks:
+          - print-text-4
           inputs:
             parameters:
               msg:
@@ -403,6 +411,8 @@ root:
           parameters:
             pipelinechannel--loop_parameter:
               componentInputParameter: loop_parameter
+        iteratorPolicy:
+          parallelismLimit: 1
         parameterIterator:
           itemInput: pipelinechannel--loop_parameter-loop-item
           items:
@@ -420,6 +430,8 @@ root:
               taskOutputParameter:
                 outputParameterKey: Output
                 producerTask: args-generator-op
+        iteratorPolicy:
+          parallelismLimit: 1
         parameterIterator:
           itemInput: pipelinechannel--args-generator-op-Output-loop-item
           items:
@@ -429,6 +441,8 @@ root:
       for-loop-4:
         componentRef:
           name: comp-for-loop-4
+        iteratorPolicy:
+          parallelismLimit: 1
         parameterIterator:
           itemInput: pipelinechannel--loop-item-param-3
           items:


### PR DESCRIPTION
## Summary
- address the remaining genuine saturation case in `E2EParallelNested`
- reduce fanout inside `parallel_and_nested/pipeline_with_loops` instead of changing global E2E parallelism again
- regenerate the matching compiled IR and Argo golden files

## Root Cause
Follow-up from #13191.

On current `master`, `E2EParallelNested` is already forced to a single Ginkgo node in `.github/workflows/e2e-test.yml`, so the remaining flake is not caused by multiple specs running at once.

The latest failing `master` runs still showed `metadata-grpc` `CrashLoopBackOff`, `Init:OOMKilled`, `PodInitializing`, and launcher `exit 137` in the `E2EParallelNested` lane. Parsing those logs narrowed the persistent offender to `test_data/sdk_compiled_pipelines/valid/parallel_and_nested/pipeline_with_loops.yaml`:
- in run `23957264553` (`argo=v3.5.14`), `pipeline_with_loops.yaml` was the only failing fixture in the lane
- in run `23962218937` (`argo=v3.7.3`), `loop_consume_upstream.yaml` failed once, but `pipeline_with_loops.yaml` still failed repeatedly afterward

That fixture creates three independent `ParallelFor` sections, and two of them also fan out multiple sibling tasks per iteration. The resulting workflow can burst into roughly a dozen-plus component pods even though the test only needs to validate that loop handling works end to end.

## Fix
- add `parallelism=1` to each `ParallelFor` in `pipeline_with_loops.py`
- serialize the sibling tasks in the second and third loops with `.after(...)`
- regenerate:
  - `test_data/sdk_compiled_pipelines/valid/parallel_and_nested/pipeline_with_loops.yaml`
  - `test_data/compiled-workflows/pipeline_with_loops.yaml`

This keeps the nested/loop coverage in the lane, but removes the unnecessary burstiness that was saturating the single-node Kind cluster.

## Verification
- `python3 -m py_compile test_data/sdk_compiled_pipelines/valid/parallel_and_nested/pipeline_with_loops.py`
- `go test ./backend/test/compiler -run TestCompilation -args -ginkgo.focus='pipeline_with_loops.yaml' -updateCompiledFiles=true`
- `go test ./backend/test/compiler -run TestCompilation -args -ginkgo.focus='pipeline_with_loops.yaml'`
- `git diff --check`

I did not rerun the full GitHub `E2EParallelNested` workflow locally.
