### PR TITLE
fix(frontend): guard _loadAllOutputs against unhandled promise rejection

### DIFF
--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -965,18 +965,22 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
       return;
     }
 
-    const outputPathsList = WorkflowParser.loadAllOutputPathsWithStepNames(workflow);
+    try {
+      const outputPathsList = WorkflowParser.loadAllOutputPathsWithStepNames(workflow);
 
-    const configLists = await Promise.all(
-      outputPathsList.map(({ stepName, path }) =>
-        OutputArtifactLoader.load(path, workflow?.metadata?.namespace).then((configs) =>
-          configs.map((config) => ({ config, stepName })),
+      const configLists = await Promise.all(
+        outputPathsList.map(({ stepName, path }) =>
+          OutputArtifactLoader.load(path, workflow?.metadata?.namespace).then((configs) =>
+            configs.map((config) => ({ config, stepName })),
+          ),
         ),
-      ),
-    );
-    const allArtifactConfigs = flatten(configLists);
+      );
+      const allArtifactConfigs = flatten(configLists);
 
-    this.setStateSafe({ allArtifactConfigs });
+      this.setStateSafe({ allArtifactConfigs });
+    } catch (err) {
+      logger.error('Failed to load run outputs:', err);
+    }
   }
 
   private _getDetailsFields(workflow: Workflow, runMetadata?: ApiRun): Array<KeyValue<string>> {


### PR DESCRIPTION
**Description of your changes:**

`RunDetails._loadAllOutputs` uses `Promise.all` to load output artifacts for every step in the workflow. If any single `OutputArtifactLoader.load()` call rejects, the entire `Promise.all` rejects. Because `_loadAllOutputs` is called **outside** the main `try/catch` block in `refresh()`, this rejection propagates as an unhandled promise rejection, which can crash the page in strict environments and provides no user feedback.

### Fix

Wrap the body of `_loadAllOutputs` in a `try/catch` that logs the error via `logger.error()`. This:
- Prevents the unhandled rejection
- Keeps the rest of the page functional (run details, graph, side panel all still render)
- Preserves the error in the console for debugging

### Context

The call site in `refresh()`:

```typescript
} catch (err) {
  // main refresh error handling
}

// These two are outside the try/catch:
await this._loadSidePaneTab(this.state.sidepanelSelectedTab);
await this._loadAllOutputs();  // ← can reject unhandled
```

`_loadSidePaneTab` is already safe because it delegates to `_loadSelectedNodeLogs`, which has its own `try/catch`. `_loadAllOutputs` had no such protection until this fix.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).