### PR TITLE
Fix: Handle missing PipelineVersion in Kubernetes API mode

### DIFF
--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -219,15 +219,18 @@ func toApiPipelineV1(pipeline *model.Pipeline, pipelineVersion *model.PipelineVe
 		}
 	}
 
-	params := toApiParametersV1(string(pipelineVersion.Parameters))
-	if params == nil {
-		return &apiv1beta1.Pipeline{
-			Id:    pipeline.UUID,
-			Error: util.NewInternalServerError(util.NewInvalidInputError("%s", fmt.Sprintf("Failed to convert parameters: %s", pipelineVersion.Parameters)), "Failed to convert a model pipeline to v1beta1 API pipeline").Error(),
+	var params []*apiv1beta1.Parameter
+	if pipelineVersion != nil {
+		params = toApiParametersV1(string(pipelineVersion.Parameters))
+		if params == nil {
+			return &apiv1beta1.Pipeline{
+				Id:    pipeline.UUID,
+				Error: util.NewInternalServerError(util.NewInvalidInputError("%s", fmt.Sprintf("Failed to convert parameters: %s", pipelineVersion.Parameters)), "Failed to convert a model pipeline to v1beta1 API pipeline").Error(),
+			}
 		}
-	}
-	if len(params) == 0 {
-		params = nil
+		if len(params) == 0 {
+			params = nil
+		}
 	}
 
 	defaultVersion := toApiPipelineVersionV1(pipelineVersion)

--- a/backend/src/apiserver/server/pipeline_server.go
+++ b/backend/src/apiserver/server/pipeline_server.go
@@ -327,7 +327,11 @@ func (s *PipelineServerV1) GetPipelineV1(ctx context.Context, request *apiv1beta
 
 	pipelineVersion, err := s.getLatestPipelineVersion(ctx, pipelineId)
 	if err != nil {
-		return nil, util.Wrapf(err, "Failed to get a pipeline (v1beta1) %s due to error fetching the latest pipeline version", pipelineId)
+		if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			pipelineVersion = nil
+		} else {
+			return nil, util.Wrapf(err, "Failed to get a pipeline (v1beta1) %s due to error fetching the latest pipeline version", pipelineId)
+		}
 	}
 
 	return toApiPipelineV1(pipeline, pipelineVersion), nil


### PR DESCRIPTION
Fixes an issue where GetPipelineV1 fails if a PipelineVersion is not found.

The current implementation assumes that a "latest" PipelineVersion always exists and returns an error if it is missing ("PipelineVersion: Latest not found"). This causes the Kubeflow UI to fail when accessing pipelines created in Kubernetes API mode.

This PR updates the behavior to:
- Gracefully handle missing PipelineVersion
- Return the pipeline without failing when the version is not found
- Preserve existing behavior for other error cases

This ensures compatibility between v1beta1 API expectations and v2beta1 CRD-based pipelines.

Fixes #13216