### PR TITLE
ci: preload Kind images instead of pushing via local registry

### DIFF
--- a/.github/actions/create-cluster/action.yml
+++ b/.github/actions/create-cluster/action.yml
@@ -43,7 +43,6 @@ runs:
         kubectl_version: ${{ inputs.k8s_version }}
         version: v0.31.0
         node_image: kindest/node:${{ inputs.k8s_version }}
-        registry: true
 
     - name: Retry Create k8s Kind Cluster
       uses: helm/kind-action@v1.13.0
@@ -53,4 +52,3 @@ runs:
         kubectl_version: ${{ inputs.k8s_version }}
         version: v0.31.0
         node_image: kindest/node:${{ inputs.k8s_version }}
-        registry: true

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -62,18 +62,37 @@ runs:
         path: "images_${{ github.run_id }}"
         pattern: "!*.dockerbuild"
 
-    - name: Load Docker Images
+    - name: Load Control Plane Images Into Kind
       shell: bash
       run: |
-        APPS=("apiserver" "driver" "launcher" "scheduledworkflow" "persistenceagent" "frontend" "metadata-writer" "viewer-crd-controller" "visualization-server" "cache-deployer" "cache-server" "metadata-envoy"  )
+        # These images are deployed directly by the CI manifests and use
+        # IfNotPresent in the CI install path, so loading the image archive
+        # into the Kind node is sufficient.
+        APPS=("apiserver" "scheduledworkflow" "persistenceagent" "frontend" "metadata-writer" "viewer-crd-controller" "visualization-server" "cache-deployer" "cache-server" "metadata-envoy")
         for app in "${APPS[@]}"; do
-          docker image load -i ${{ inputs.image_path }}/$app/$app.tar
-          docker tag ${{ inputs.image_registry }}/$app:${{ inputs.image_tag }} localhost:5000/$app:${{ inputs.image_tag }}
-          docker push localhost:5000/$app:${{ inputs.image_tag }}
+          kind --name "${{ inputs.cluster_name }}" load image-archive "${{ inputs.image_path }}/$app/$app.tar"
           rm ${{ inputs.image_path }}/$app/$app.tar
-          docker image rm ${{ inputs.image_registry }}/$app:${{ inputs.image_tag }}
-          docker image rm localhost:5000/$app:${{ inputs.image_tag }}
         done
+
+    - name: Load Driver and Launcher Images Into Kind
+      shell: bash
+      run: |
+        # Runtime-generated workflow pods inherit these refs from the API server
+        # environment. Tagging them away from `latest` makes Kubernetes default
+        # them to IfNotPresent, so they can also be loaded directly into Kind.
+        APPS=("driver" "launcher")
+        for app in "${APPS[@]}"; do
+          docker image load -i "${{ inputs.image_path }}/$app/$app.tar"
+          docker tag "${{ inputs.image_registry }}/$app:${{ inputs.image_tag }}" "${{ inputs.image_registry }}/$app:ci"
+          kind --name "${{ inputs.cluster_name }}" load docker-image "${{ inputs.image_registry }}/$app:ci"
+          rm "${{ inputs.image_path }}/$app/$app.tar"
+          docker image rm "${{ inputs.image_registry }}/$app:${{ inputs.image_tag }}"
+          docker image rm "${{ inputs.image_registry }}/$app:ci"
+        done
+
+    - name: Load Runtime Base Images Into Kind
+      shell: bash
+      run: |
         docker pull python:3.11
         docker pull registry.access.redhat.com/ubi9/python-311:latest
         kind load docker-image python:3.11 --name ${{ inputs.cluster_name }}

--- a/.github/resources/manifests/base/apiserver-env.yaml
+++ b/.github/resources/manifests/base/apiserver-env.yaml
@@ -22,9 +22,9 @@ spec:
         - name: ml-pipeline-api-server
           env:
             - name: V2_DRIVER_IMAGE
-              value: kind-registry:5000/driver
+              value: kind-registry:5000/driver:ci
             - name: V2_LAUNCHER_IMAGE
-              value: kind-registry:5000/launcher
+              value: kind-registry:5000/launcher:ci
             - name: LOG_LEVEL
               value: "debug"
             - name: DBCONFIG_HOST_NAME

--- a/.github/resources/manifests/base/cache-deployer-pull-policy.yaml
+++ b/.github/resources/manifests/base/cache-deployer-pull-policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-deployer-deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: main
+          imagePullPolicy: IfNotPresent

--- a/.github/resources/manifests/base/cache-server-pull-policy.yaml
+++ b/.github/resources/manifests/base/cache-server-pull-policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cache-server
+spec:
+  template:
+    spec:
+      containers:
+        - name: server
+          imagePullPolicy: IfNotPresent

--- a/.github/resources/manifests/base/metadata-envoy-pull-policy.yaml
+++ b/.github/resources/manifests/base/metadata-envoy-pull-policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metadata-envoy-deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: container
+          imagePullPolicy: IfNotPresent

--- a/.github/resources/manifests/base/metadata-writer-pull-policy.yaml
+++ b/.github/resources/manifests/base/metadata-writer-pull-policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metadata-writer
+spec:
+  template:
+    spec:
+      containers:
+        - name: main
+          imagePullPolicy: IfNotPresent

--- a/.github/resources/manifests/base/viewer-crd-pull-policy.yaml
+++ b/.github/resources/manifests/base/viewer-crd-pull-policy.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ml-pipeline-viewer-crd
+spec:
+  template:
+    spec:
+      containers:
+        - name: ml-pipeline-viewer-crd
+          imagePullPolicy: IfNotPresent

--- a/.github/resources/manifests/kubernetes-native/default/kustomization.yaml
+++ b/.github/resources/manifests/kubernetes-native/default/kustomization.yaml
@@ -50,6 +50,26 @@ patches:
     target:
       kind: Deployment
       name: cache-server
+  - path: ../../base/metadata-writer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-writer
+  - path: ../../base/viewer-crd-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: ml-pipeline-viewer-crd
+  - path: ../../base/cache-deployer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-deployer-deployment
+  - path: ../../base/cache-server-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-server
+  - path: ../../base/metadata-envoy-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-envoy-deployment
 
 replacements:
   - source:

--- a/.github/resources/manifests/multiuser/artifact-proxy/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/artifact-proxy/kustomization.yaml
@@ -54,6 +54,26 @@ patches:
     target:
       kind: Deployment
       name: cache-server
+  - path: ../../base/metadata-writer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-writer
+  - path: ../../base/viewer-crd-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: ml-pipeline-viewer-crd
+  - path: ../../base/cache-deployer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-deployer-deployment
+  - path: ../../base/cache-server-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-server
+  - path: ../../base/metadata-envoy-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-envoy-deployment
   - path: env.yaml
     target:
       kind: Deployment
@@ -96,4 +116,3 @@ replacements:
           name: cache-server
         fieldPaths:
           - spec.template.spec.dnsConfig.searches.[=NAMESPACE.svc.cluster.local]
-

--- a/.github/resources/manifests/multiuser/cache-disabled/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/cache-disabled/kustomization.yaml
@@ -58,6 +58,26 @@ patches:
     target:
       kind: Deployment
       name: cache-server
+  - path: ../../base/metadata-writer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-writer
+  - path: ../../base/viewer-crd-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: ml-pipeline-viewer-crd
+  - path: ../../base/cache-deployer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-deployer-deployment
+  - path: ../../base/cache-server-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-server
+  - path: ../../base/metadata-envoy-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-envoy-deployment
 
 replacements:
   - source:

--- a/.github/resources/manifests/multiuser/default/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/default/kustomization.yaml
@@ -54,6 +54,26 @@ patches:
     target:
       kind: Deployment
       name: cache-server
+  - path: ../../base/metadata-writer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-writer
+  - path: ../../base/viewer-crd-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: ml-pipeline-viewer-crd
+  - path: ../../base/cache-deployer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-deployer-deployment
+  - path: ../../base/cache-server-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-server
+  - path: ../../base/metadata-envoy-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-envoy-deployment
 
 replacements:
   - source:

--- a/.github/resources/manifests/standalone/cache-disabled/kustomization.yaml
+++ b/.github/resources/manifests/standalone/cache-disabled/kustomization.yaml
@@ -54,6 +54,26 @@ patches:
     target:
       kind: Deployment
       name: cache-server
+  - path: ../../base/metadata-writer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-writer
+  - path: ../../base/viewer-crd-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: ml-pipeline-viewer-crd
+  - path: ../../base/cache-deployer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-deployer-deployment
+  - path: ../../base/cache-server-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-server
+  - path: ../../base/metadata-envoy-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-envoy-deployment
 
 replacements:
   - source:

--- a/.github/resources/manifests/standalone/default/kustomization.yaml
+++ b/.github/resources/manifests/standalone/default/kustomization.yaml
@@ -50,6 +50,26 @@ patches:
     target:
       kind: Deployment
       name: cache-server
+  - path: ../../base/metadata-writer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-writer
+  - path: ../../base/viewer-crd-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: ml-pipeline-viewer-crd
+  - path: ../../base/cache-deployer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-deployer-deployment
+  - path: ../../base/cache-server-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-server
+  - path: ../../base/metadata-envoy-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-envoy-deployment
 
 replacements:
   - source:

--- a/.github/resources/manifests/standalone/proxy/kustomization.yaml
+++ b/.github/resources/manifests/standalone/proxy/kustomization.yaml
@@ -54,6 +54,26 @@ patches:
     target:
       kind: Deployment
       name: cache-server
+  - path: ../../base/metadata-writer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-writer
+  - path: ../../base/viewer-crd-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: ml-pipeline-viewer-crd
+  - path: ../../base/cache-deployer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-deployer-deployment
+  - path: ../../base/cache-server-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-server
+  - path: ../../base/metadata-envoy-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-envoy-deployment
 
 replacements:
   - source:

--- a/.github/resources/manifests/standalone/tls-enabled/kustomization.yaml
+++ b/.github/resources/manifests/standalone/tls-enabled/kustomization.yaml
@@ -54,6 +54,26 @@ patches:
     target:
       kind: Deployment
       name: cache-server
+  - path: ../../base/metadata-writer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-writer
+  - path: ../../base/viewer-crd-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: ml-pipeline-viewer-crd
+  - path: ../../base/cache-deployer-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-deployer-deployment
+  - path: ../../base/cache-server-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: cache-server
+  - path: ../../base/metadata-envoy-pull-policy.yaml
+    target:
+      kind: Deployment
+      name: metadata-envoy-deployment
 
 replacements:
   - source:


### PR DESCRIPTION
## Summary
- preload CI images directly into the Kind node instead of pushing them through the local registry
- retag `driver` and `launcher` to `:ci` and point the API server at those refs so runtime-created pods also use preloaded images
- remove the now-unused local registry startup from the shared `create-cluster` action

## Why
The current deploy path spends a large chunk of `Deploy KFP` moving already-built tarball artifacts through a temporary local registry:
- `docker load`
- retag to `localhost:5000/...`
- `docker push`
- remove the temporary tags

The image-build workflow already produces tarballs tagged as `kind-registry:5000/<image>:latest`, so the control-plane images can be loaded directly into the Kind node with `kind load image-archive`.

The only extra compatibility work needed is for runtime-created `driver` and `launcher` pods. Those refs came from the API server env vars and previously used untagged `kind-registry:5000/driver` / `launcher`, which fall back to `latest` pull semantics. This PR changes them to `:ci`, loads those images directly into Kind, and adds CI-only `IfNotPresent` patches for the remaining control-plane deployments that previously relied on `Always`.

This keeps the image names used by CI manifests and runtime pods consistent while removing the registry push path.

## Expected impact
From recent green E2E timing analysis, the first safe slice of direct Kind loading removed about 91 seconds of registry-push / cleanup time per affected lane. This PR removes the remaining push path as well, so the main expected win is a faster `Deploy KFP` step across the Kind-based CI workflows.

## What changed
- `.github/actions/deploy/action.yml`
  - replace the shared `docker load -> tag -> push localhost:5000` path with:
    - `kind load image-archive` for control-plane images
    - `docker load` + retag to `:ci` + `kind load docker-image` for `driver` and `launcher`
  - keep preloading the runtime base images used by E2E tasks (`python:3.11`, `registry.access.redhat.com/ubi9/python-311:latest`)
- `.github/actions/create-cluster/action.yml`
  - stop starting the local registry in the shared Kind cluster setup
- `.github/resources/manifests/base/apiserver-env.yaml`
  - point `V2_DRIVER_IMAGE` and `V2_LAUNCHER_IMAGE` at `kind-registry:5000/<name>:ci`
- `.github/resources/manifests/.../kustomization.yaml`
  - add CI-only `IfNotPresent` pull-policy patches for `metadata-writer`, `viewer-crd-controller`, `cache-deployer`, `cache-server`, and `metadata-envoy`

## Verification
- `ruby -e "require 'yaml'; ..."` on the edited actions and manifests
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest` across the workflows that use `create-cluster` / `deploy`
- `kubectl kustomize --load-restrictor LoadRestrictionsNone .github/resources/manifests/standalone/default`
- `kubectl kustomize --load-restrictor LoadRestrictionsNone .github/resources/manifests/multiuser/artifact-proxy`
- `git diff --check`

I did not run a live Docker-backed Kind deploy locally because Docker is not available in this environment right now.
