### PR TITLE
test(frontend): add RunDetails regression test for rejected output artifact loads.

### DIFF
--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -605,6 +605,24 @@ describe('RunDetails', () => {
     expect(renderResult!.asFragment()).toMatchSnapshot();
   });
 
+  it('catches rejected output artifact loads without surfacing an unhandled rejection', async () => {
+    const loggerErrorSpy = vi.spyOn(Utils.logger, 'error').mockImplementation();
+    pathsWithStepsParser.mockImplementation(() => [
+      { stepName: 'step1', path: { source: 'gcs', bucket: 'somebucket', key: 'somekey' } },
+    ]);
+    loaderSpy.mockImplementation(() => Promise.reject(new Error('artifact load failed')));
+
+    await renderRunDetails();
+    await TestUtils.flushPromises();
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith('Failed to load run outputs:', expect.any(Error));
+    expect(getRunDetailsState()?.allArtifactConfigs).toEqual([]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run output' }));
+    await TestUtils.flushPromises();
+    expect(screen.getByText('No output artifacts found for this run.')).toBeInTheDocument();
+  });
+
   it('switches to config tab', async () => {
     await renderRunDetails();
     fireEvent.click(screen.getByRole('button', { name: 'Config' }));


### PR DESCRIPTION
**Description of your changes:**

Adds a regression test to `RunDetails.test.tsx` that verifies the `try/catch` guard in `_loadAllOutputs()` (introduced in PR #13218) correctly handles `OutputArtifactLoader.load()` rejections.

The test:
- Mocks `WorkflowParser.loadAllOutputPathsWithStepNames()` to return an output path
- Mocks `OutputArtifactLoader.load()` to reject
- Asserts the page loads without an unhandled rejection escaping the component
- Asserts `allArtifactConfigs` remains empty and the output tab shows "No output artifacts found for this run."

This prevents future refactors from reintroducing the unhandled rejection fixed in #13218.

Fixes #13226 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

Made with [Cursor](https://cursor.com)