### PR TITLE
fix: use identity check for None and catch specific exception

### DIFF
--- a/components/aws/sagemaker/commonv2/spec_input_parsers.py
+++ b/components/aws/sagemaker/commonv2/spec_input_parsers.py
@@ -25,11 +25,11 @@ class SpecInputParsers:
 
     @staticmethod
     def _yaml_or_json_str(value):
-        if value == "" or value == None:
+        if value == "" or value is None:
             return None
         try:
             return json.loads(value)
-        except:
+        except Exception:
             return yaml.safe_load(value)
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fix PEP 8 style issues in `components/aws/sagemaker/commonv2/spec_input_parsers.py`:

- Replace `== None` with `is None` (PEP 8 E711)
- Replace bare `except:` with `except Exception:` (PEP 8 E722)

**Changes:**
```python
# Before
if value == "" or value == None:
    ...
except:

# After
if value == "" or value is None:
    ...
except Exception:
```

## Testing
No behavior change — style/correctness fix only. Identity checks with `is None` are recommended by PEP 8 since `None` is a singleton. Catching `Exception` instead of bare `except` avoids accidentally catching `SystemExit`, `KeyboardInterrupt`, etc.