### PR TITLE
fix(backend): add hostUsers override guard, improve error handling and comments

### DIFF
--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -262,9 +262,10 @@ func drive() (err error) {
 		}
 		if *defaultHostUsers != "" {
 			v, err := strconv.ParseBool(*defaultHostUsers)
-			if err == nil {
-				options.DefaultHostUsers = &v
+			if err != nil {
+				return fmt.Errorf("invalid --default_host_users value %q: %w", *defaultHostUsers, err)
 			}
+			options.DefaultHostUsers = &v
 		}
 		execution, driverErr = driver.Container(ctx, options, client, cacheClient)
 	default:

--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -769,6 +769,19 @@ func extendPodSpecPatch(
 		}
 	}
 
+	// Post-processing: enforce administrator hostUsers regardless of any
+	// user override. hostUsers is a pod-level field controlling Linux user
+	// namespace isolation; allowing users to silently flip it to true would
+	// defeat the administrator's security policy.
+	if opts.DefaultHostUsers != nil {
+		if podSpec.HostUsers != nil && *podSpec.HostUsers != *opts.DefaultHostUsers {
+			glog.Warningf("Ignoring user-specified hostUsers=%t: administrator default hostUsers=%t takes precedence",
+				*podSpec.HostUsers, *opts.DefaultHostUsers)
+		}
+		v := *opts.DefaultHostUsers
+		podSpec.HostUsers = &v
+	}
+
 	return nil
 }
 

--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -3461,3 +3461,31 @@ func Test_extendPodSpecPatch_RootUserWithHostUsersNamespace(t *testing.T) {
 	assert.Equal(t, &k8score.Capabilities{Drop: []k8score.Capability{"ALL"}},
 		podSpec.Containers[0].SecurityContext.Capabilities)
 }
+
+// Test_extendPodSpecPatch_HostUsersAdminOverrideProtection verifies that the
+// post-processing guard re-applies the administrator's hostUsers default even
+// when a user-supplied podSpecPatch has set hostUsers to a different value.
+func Test_extendPodSpecPatch_HostUsersAdminOverrideProtection(t *testing.T) {
+	adminFalse := false
+	// Simulate user setting hostUsers=true via podSpecPatch before
+	// the post-processing guard runs.
+	userTrue := true
+	podSpec := &k8score.PodSpec{
+		Containers: []k8score.Container{{Name: "main"}},
+		HostUsers:  &userTrue,
+	}
+	err := extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		Options{
+			DefaultHostUsers: &adminFalse,
+		},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	assert.Nil(t, err)
+	// The administrator's false must override the user's true.
+	assert.NotNil(t, podSpec.HostUsers)
+	assert.False(t, *podSpec.HostUsers)
+}


### PR DESCRIPTION
## Summary

Addresses review feedback on #13211: adds defence-in-depth guard preventing silent user override of administrator-configured `hostUsers`, fixes silent error swallowing, and documents the ConfigMap field.

## Root Cause

Original implementation applied `hostUsers` default early but had no post-processing enforcement. A user-supplied `podSpecPatch` setting `hostUsers: true` could silently override the administrator's `false` default. The `ParseBool` error path for `--default_host_users` also silently dropped invalid values instead of failing the driver.

## Changes

| File | Change |
|------|--------|
| [backend/src/v2/driver/k8s.go](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/raakshass-pipelines/backend/src/v2/driver/k8s.go:0:0-0:0) | Post-processing override guard: re-applies administrator `hostUsers` after all user input, logs warning on conflict. Matches `runAsUser`/`runAsGroup`/`runAsNonRoot` pattern. |
| [backend/src/v2/cmd/driver/main.go](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/raakshass-pipelines/backend/src/v2/cmd/driver/main.go:0:0-0:0) | `ParseBool` returns `fmt.Errorf` on invalid `--default_host_users` instead of silent no-op. |
| `manifests/.../generic/pipeline-install-config.yaml` | Comment: clarifies `hostUsers` is pod-level `spec.hostUsers`, defaults `"false"`, set `""` to disable. |
| `manifests/.../postgres/pipeline-install-config.yaml` | Same comment update. |
| [backend/src/v2/driver/k8s_test.go](cci:7://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/raakshass-pipelines/backend/src/v2/driver/k8s_test.go:0:0-0:0) | [Test_extendPodSpecPatch_HostUsersAdminOverrideProtection](cci:1://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/raakshass-pipelines/backend/src/v2/driver/k8s_test.go:3464:0-3488:1): administrator `false` wins over user `true`. |

## Design Decision

Post-processing guard chosen over pre-processing validation because `hostUsers` can be injected via multiple paths (podSpecPatch YAML, future KubernetesExecutorConfig fields). A single enforcement point after all mutations guarantees the administrator value always wins regardless of injection vector.

## Related

- Parent PR: #13211
- Reviewer feedback: @jsonmp-k8 (silent override concern), @copilot-pull-request-reviewer (error handling)

## Checklist

- [x] DCO sign-off on all commits
- [x] Unit test covers new guard logic
- [x] Existing [HostUsers](cci:1://file:///c:/Users/asus%20vivoBook/Desktop/New%20folder%20%282%29/raakshass-pipelines/backend/src/v2/driver/k8s_test.go:3403:0-3421:1) tests unaffected
- [x] Matches `master` guard patterns
- [x] No abbreviated variable names
- [x] All open reviewer comments addressed

Signed-off-by: Siddhant Jain <siddhantjainofficial26@gmail.com>
