### PR TITLE
fix(frontend): add root ErrorBoundary and loading indicators

### DIFF
--- a/frontend/src/atoms/ErrorBoundary.test.tsx
+++ b/frontend/src/atoms/ErrorBoundary.test.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { testBestPractices } from 'src/TestUtils';
+import { ErrorBoundary } from './ErrorBoundary';
+
+function ThrowingChild(): JSX.Element {
+  throw new Error('test render crash');
+}
+
+testBestPractices();
+describe('ErrorBoundary', () => {
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <div>child content</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('child content')).toBeInTheDocument();
+  });
+
+  it('renders a Banner with error details when a child throws', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+    expect(screen.getByText('Details')).toBeInTheDocument();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/frontend/src/atoms/ErrorBoundary.test.tsx
+++ b/frontend/src/atoms/ErrorBoundary.test.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
 import { testBestPractices } from 'src/TestUtils';
 import { ErrorBoundary } from './ErrorBoundary';
 
@@ -44,6 +45,31 @@ describe('ErrorBoundary', () => {
 
     expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
     expect(screen.getByText('Details')).toBeInTheDocument();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('recovers when the key prop changes (simulates navigation)', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    function Harness() {
+      const [locationKey, setLocationKey] = useState('page-a');
+      return (
+        <>
+          <ErrorBoundary key={locationKey}>
+            {locationKey === 'page-a' ? <ThrowingChild /> : <div>recovered content</div>}
+          </ErrorBoundary>
+          <button onClick={() => setLocationKey('page-b')}>navigate</button>
+        </>
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.getByText('Something went wrong.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'navigate' }));
+    expect(screen.queryByText('Something went wrong.')).not.toBeInTheDocument();
+    expect(screen.getByText('recovered content')).toBeInTheDocument();
 
     consoleSpy.mockRestore();
   });

--- a/frontend/src/atoms/ErrorBoundary.tsx
+++ b/frontend/src/atoms/ErrorBoundary.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import Banner from 'src/components/Banner';
 
 interface ErrorBoundaryState {
   error: any;
@@ -36,19 +37,20 @@ export class ErrorBoundary extends React.Component<React.PropsWithChildren, Erro
 
   render() {
     if (this.state.errorInfo) {
-      // Error path
       return (
-        <div>
-          <h2>Something went wrong.</h2>
-          <details style={{ whiteSpace: 'pre-wrap' }}>
-            {this.state.error && this.state.error.toString()}
-            <br />
-            {this.state.errorInfo.componentStack}
-          </details>
+        <div style={{ padding: 20 }}>
+          <Banner
+            message='Something went wrong.'
+            mode='error'
+            additionalInfo={
+              this.state.error
+                ? `${this.state.error.toString()}\n${this.state.errorInfo.componentStack}`
+                : this.state.errorInfo.componentStack
+            }
+          />
         </div>
       );
     }
-    // Normally, just render children
     return this.props.children;
   }
 }

--- a/frontend/src/components/tabs/InputOutputTab.test.tsx
+++ b/frontend/src/components/tabs/InputOutputTab.test.tsx
@@ -45,6 +45,20 @@ describe('InoutOutputTab', () => {
     vi.spyOn(mlmdUtils, 'getArtifactTypes').mockResolvedValue([]);
   });
 
+  it('shows a loading spinner while artifacts are being fetched', () => {
+    vi.spyOn(Api.getInstance().metadataStoreService, 'getEventsByExecutionIDs').mockReturnValue(
+      new Promise(() => {}),
+    );
+
+    render(
+      <CommonTestWrapper>
+        <InputOutputTab execution={buildBasicExecution()} namespace={namespace} />
+      </CommonTestWrapper>,
+    );
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
   it('shows execution title', () => {
     vi.spyOn(Api.getInstance().metadataStoreService, 'getEventsByExecutionIDs').mockResolvedValue(
       new GetEventsByExecutionIDsResponse(),

--- a/frontend/src/components/tabs/InputOutputTab.tsx
+++ b/frontend/src/components/tabs/InputOutputTab.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { CircularProgress } from '@mui/material';
 import { Link } from 'react-router-dom';
 import { ErrorBoundary } from 'src/atoms/ErrorBoundary';
 import { commonCss, padding } from 'src/Css';
@@ -63,6 +64,7 @@ export function InputOutputTab({ execution, namespace }: IOTabProps) {
 
   // Retrieves input and output artifacts from Metadata store.
   const {
+    isLoading,
     isSuccess,
     error,
     data: linkedArtifacts,
@@ -119,6 +121,8 @@ export function InputOutputTab({ execution, namespace }: IOTabProps) {
       <div className={commonCss.page}>
         <div className={padding(20)}>
           <ExecutionTitle execution={execution} />
+
+          {isLoading && <CircularProgress />}
 
           {error && (
             <Banner

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -17,11 +17,11 @@
 // import './CSSReset';
 import 'src/build/tailwind.output.css';
 import '@xyflow/react/dist/style.css';
-import { StrictMode } from 'react';
+import React, { StrictMode } from 'react';
 import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { HashRouter } from 'react-router-dom';
+import { HashRouter, useLocation } from 'react-router-dom';
 import { cssRule } from 'typestyle';
 import { ErrorBoundary } from './atoms/ErrorBoundary';
 import Router from './components/Router';
@@ -36,6 +36,11 @@ import {
 } from './lib/KubeflowClient';
 import { BuildInfoProvider } from './lib/BuildInfo';
 // TODO: license headers
+
+function LocationKeyedErrorBoundary({ children }: React.PropsWithChildren) {
+  const location = useLocation();
+  return <ErrorBoundary key={location.key}>{children}</ErrorBoundary>;
+}
 
 if (KFP_FLAGS.DEPLOYMENT === Deployments.KUBEFLOW) {
   initKfClient();
@@ -61,9 +66,9 @@ const app = (
         <BuildInfoProvider>
           <GkeMetadataProvider>
             <HashRouter>
-              <ErrorBoundary>
+              <LocationKeyedErrorBoundary>
                 <Router />
-              </ErrorBoundary>
+              </LocationKeyedErrorBoundary>
             </HashRouter>
           </GkeMetadataProvider>
         </BuildInfoProvider>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -23,6 +23,7 @@ import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { HashRouter } from 'react-router-dom';
 import { cssRule } from 'typestyle';
+import { ErrorBoundary } from './atoms/ErrorBoundary';
 import Router from './components/Router';
 import { fonts, theme } from './Css';
 import { initFeatures } from './features';
@@ -60,7 +61,9 @@ const app = (
         <BuildInfoProvider>
           <GkeMetadataProvider>
             <HashRouter>
-              <Router />
+              <ErrorBoundary>
+                <Router />
+              </ErrorBoundary>
             </HashRouter>
           </GkeMetadataProvider>
         </BuildInfoProvider>

--- a/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.test.tsx
+++ b/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.test.tsx
@@ -125,9 +125,13 @@ describe('RecurringRunDetailsV2FC', () => {
       </CommonTestWrapper>,
     );
 
+    // Wait for Router to resolve past its own loading state before
+    // asserting V2FC's spinner — the Router also renders a CircularProgress
+    // while loading, so we must confirm it has finished first.
     await waitFor(() => {
-      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.queryByText('Currently loading recurring run information')).toBeNull();
     });
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 
   it('renders a recurring run with periodic schedule', async () => {

--- a/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.test.tsx
+++ b/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.test.tsx
@@ -97,6 +97,9 @@ describe('RecurringRunDetailsV2FC', () => {
     // mock both v2_alpha and functional feature keys are enable.
     vi.spyOn(features, 'isFeatureEnabled').mockReturnValue(true);
 
+    // mockReset clears the mockOnce queue that vi.clearAllMocks leaves behind,
+    // preventing unconsumed one-time mocks from leaking between tests.
+    getRecurringRunSpy.mockReset();
     getRecurringRunSpy.mockImplementation(() => fullTestV2RecurringRun);
     getPipelineVersionSpy.mockImplementation(() => testPipelineVersion);
 

--- a/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.test.tsx
+++ b/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.test.tsx
@@ -112,6 +112,24 @@ describe('RecurringRunDetailsV2FC', () => {
     });
   });
 
+  it('shows a loading spinner while the recurring run is being fetched', async () => {
+    // First call from the Router succeeds so V2FC can mount;
+    // second call from V2FC hangs to show the loading spinner.
+    getRecurringRunSpy
+      .mockImplementationOnce(() => fullTestV2RecurringRun)
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    render(
+      <CommonTestWrapper>
+        <RecurringRunDetailsRouter {...generateProps()} />
+      </CommonTestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+
   it('renders a recurring run with periodic schedule', async () => {
     render(
       <CommonTestWrapper>

--- a/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.tsx
+++ b/frontend/src/pages/functional_components/RecurringRunDetailsV2FC.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { CircularProgress } from '@mui/material';
 import Buttons, { ButtonKeys } from 'src/lib/Buttons';
 import { queryKeys } from 'src/hooks/queryKeys';
 import DetailsTable from 'src/components/DetailsTable';
@@ -37,6 +38,7 @@ export function RecurringRunDetailsV2FC(props: PageProps) {
   const recurringRunId = props.match.params[RouteParams.recurringRunId];
 
   const {
+    isLoading: isRecurringRunLoading,
     data: recurringRun,
     error: getRecurringRunError,
     refetch: refetchRecurringRun,
@@ -166,6 +168,10 @@ export function RecurringRunDetailsV2FC(props: PageProps) {
       pageTitle: '',
     };
   };
+
+  if (isRecurringRunLoading) {
+    return <CircularProgress />;
+  }
 
   return (
     <div className={classes(commonCss.page, padding(20, 'lr'))}>


### PR DESCRIPTION
**Description of your changes:**

Users can hit a white screen when a render-time error occurs because there is no root-level error boundary. Additionally, two components (`RecurringRunDetailsV2FC` and `InputOutputTab`) show blank content while their data queries are in flight, with no loading feedback.

### Changes

**`index.tsx`**
- Wrap `<Router />` with `<ErrorBoundary>` so unhandled render-time throws display a styled error Banner instead of a blank white page.

**`ErrorBoundary.tsx`**
- Upgrade the fallback from raw `<div>/<h2>/<details>` HTML to the existing `<Banner>` component with `mode='error'`, matching the visual style used throughout the application.

**`RecurringRunDetailsV2FC.tsx`**
- Destructure `isLoading` from the recurring run `useQuery`.
- Return `<CircularProgress />` while the query is in flight, consistent with the pattern used in `ExecutionDetails` and other pages.

**`InputOutputTab.tsx`**
- Destructure `isLoading` from the artifact `useQuery`.
- Render `<CircularProgress />` below the execution title while artifacts are being fetched.

### Tests added

- **`ErrorBoundary.test.tsx`** (new): verifies children render normally, and verifies the Banner fallback appears with error details when a child throws.
- **`RecurringRunDetailsV2FC.test.tsx`**: added test for loading spinner while recurring run is being fetched.
- **`InputOutputTab.test.tsx`**: added test for loading spinner while artifacts are being fetched.

**Checklist:**

- [x] You have signed off your commits
- [x] The title for your pull request (PR) follows the title convention

Made with [Cursor](https://cursor.com)