### PR TITLE
chore(frontend): replace text-only loading messages with CircularProgress

### DIFF
--- a/frontend/src/pages/NewRunSwitcher.test.tsx
+++ b/frontend/src/pages/NewRunSwitcher.test.tsx
@@ -284,7 +284,7 @@ describe('NewRunSwitcher', () => {
         </CommonTestWrapper>,
       );
 
-      expect(screen.getByText('Currently loading pipeline information')).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
     });
 
     it('resolves template from cloned run.pipeline_spec', async () => {

--- a/frontend/src/pages/NewRunSwitcher.test.tsx
+++ b/frontend/src/pages/NewRunSwitcher.test.tsx
@@ -285,6 +285,7 @@ describe('NewRunSwitcher', () => {
       );
 
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.getByText('Currently loading pipeline information')).toBeInTheDocument();
     });
 
     it('resolves template from cloned run.pipeline_spec', async () => {

--- a/frontend/src/pages/NewRunSwitcher.tsx
+++ b/frontend/src/pages/NewRunSwitcher.tsx
@@ -216,7 +216,12 @@ function NewRunSwitcher(props: PageProps) {
     (!isTemplateV2(templateString) && v1TemplateStrIsFetching) ||
     experimentIsFetching
   ) {
-    return <CircularProgress />;
+    return (
+      <div style={{ textAlign: 'center', paddingTop: 40 }}>
+        <CircularProgress />
+        <div>Currently loading pipeline information</div>
+      </div>
+    );
   }
 
   if (templateString && !isTemplateV2(templateString)) {

--- a/frontend/src/pages/NewRunSwitcher.tsx
+++ b/frontend/src/pages/NewRunSwitcher.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import * as JsYaml from 'js-yaml';
 import { useQuery } from '@tanstack/react-query';
+import { CircularProgress } from '@mui/material';
 import { QUERY_PARAMS } from 'src/components/Router';
 import { queryKeys } from 'src/hooks/queryKeys';
 import { Apis } from 'src/lib/Apis';
@@ -215,7 +216,7 @@ function NewRunSwitcher(props: PageProps) {
     (!isTemplateV2(templateString) && v1TemplateStrIsFetching) ||
     experimentIsFetching
   ) {
-    return <div>Currently loading pipeline information</div>;
+    return <CircularProgress />;
   }
 
   if (templateString && !isTemplateV2(templateString)) {

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -199,7 +199,12 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       isFeatureEnabled(FeatureKey.V2_ALPHA) && graphV2 && graphV2.length > 0 && !graph;
     return (
       <div className={classes(commonCss.page, padding(20, 't'))}>
-        {this.state.graphIsLoading && <CircularProgress />}
+        {this.state.graphIsLoading && (
+          <div style={{ textAlign: 'center', paddingTop: 40 }}>
+            <CircularProgress />
+            <div>Currently loading pipeline information</div>
+          </div>
+        )}
         {!this.state.graphIsLoading && showV2Pipeline && (
           <PipelineDetailsV2
             templateString={templateString}

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -18,6 +18,7 @@ import 'ace-builds/src-noconflict/ace';
 import 'ace-builds/src-noconflict/ext-language_tools';
 import 'ace-builds/src-noconflict/mode-yaml';
 import 'ace-builds/src-noconflict/theme-github';
+import { CircularProgress } from '@mui/material';
 import { graphlib } from 'dagre';
 import * as JsYaml from 'js-yaml';
 import { FeatureKey, isFeatureEnabled } from 'src/features';
@@ -198,7 +199,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       isFeatureEnabled(FeatureKey.V2_ALPHA) && graphV2 && graphV2.length > 0 && !graph;
     return (
       <div className={classes(commonCss.page, padding(20, 't'))}>
-        {this.state.graphIsLoading && <div>Currently loading pipeline information</div>}
+        {this.state.graphIsLoading && <CircularProgress />}
         {!this.state.graphIsLoading && showV2Pipeline && (
           <PipelineDetailsV2
             templateString={templateString}

--- a/frontend/src/pages/RecurringRunDetailsRouter.test.tsx
+++ b/frontend/src/pages/RecurringRunDetailsRouter.test.tsx
@@ -338,5 +338,6 @@ describe('RecurringRunDetailsRouter', () => {
     );
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.getByText('Currently loading recurring run information')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/RecurringRunDetailsRouter.test.tsx
+++ b/frontend/src/pages/RecurringRunDetailsRouter.test.tsx
@@ -283,7 +283,7 @@ describe('RecurringRunDetailsRouter', () => {
         );
       });
       expect(screen.getByTestId('recurring-run-details-v1')).toBeInTheDocument();
-      expect(screen.queryByText('Currently loading recurring run information')).toBeNull();
+      expect(screen.queryByRole('progressbar')).toBeNull();
 
       getPipelineVersionSpy.mockImplementationOnce(
         () =>
@@ -299,13 +299,13 @@ describe('RecurringRunDetailsRouter', () => {
       });
 
       expect(screen.getByTestId('recurring-run-details-v1')).toBeInTheDocument();
-      expect(screen.queryByText('Currently loading recurring run information')).toBeNull();
+      expect(screen.queryByRole('progressbar')).toBeNull();
 
       await waitFor(() => {
         expect(getPipelineVersionSpy).toHaveBeenCalledTimes(2);
       });
       expect(screen.getByTestId('recurring-run-details-v1')).toBeInTheDocument();
-      expect(screen.queryByText('Currently loading recurring run information')).toBeNull();
+      expect(screen.queryByRole('progressbar')).toBeNull();
     });
   });
 
@@ -324,7 +324,7 @@ describe('RecurringRunDetailsRouter', () => {
 
     await waitFor(() => {
       expect(container.querySelector('[data-testid]')).toBeNull();
-      expect(screen.queryByText('Currently loading recurring run information')).toBeNull();
+      expect(screen.queryByRole('progressbar')).toBeNull();
     });
   });
 
@@ -337,6 +337,6 @@ describe('RecurringRunDetailsRouter', () => {
       </CommonTestWrapper>,
     );
 
-    expect(screen.getByText('Currently loading recurring run information')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/RecurringRunDetailsRouter.tsx
+++ b/frontend/src/pages/RecurringRunDetailsRouter.tsx
@@ -98,7 +98,12 @@ export default function RecurringRunDetailsRouter(props: PageProps) {
   }
 
   if (recurringRunIsLoading || templateStrIsLoading) {
-    return <CircularProgress />;
+    return (
+      <div style={{ textAlign: 'center', paddingTop: 40 }}>
+        <CircularProgress />
+        <div>Currently loading recurring run information</div>
+      </div>
+    );
   }
 
   if (getRecurringRunError) {

--- a/frontend/src/pages/RecurringRunDetailsRouter.tsx
+++ b/frontend/src/pages/RecurringRunDetailsRouter.tsx
@@ -17,6 +17,7 @@
 import { useEffect } from 'react';
 import * as JsYaml from 'js-yaml';
 import { useQuery } from '@tanstack/react-query';
+import { CircularProgress } from '@mui/material';
 import { V2beta1RecurringRun } from 'src/apisv2beta1/recurringrun';
 import { errorToMessage } from 'src/lib/Utils';
 import { RouteParams } from 'src/components/Router';
@@ -97,7 +98,7 @@ export default function RecurringRunDetailsRouter(props: PageProps) {
   }
 
   if (recurringRunIsLoading || templateStrIsLoading) {
-    return <div>Currently loading recurring run information</div>;
+    return <CircularProgress />;
   }
 
   if (getRecurringRunError) {


### PR DESCRIPTION
**Description of your changes:**

Replaces plain-text "Currently loading..." `<div>` messages with MUI `<CircularProgress />` spinners in three components for visual consistency with the rest of the frontend (e.g., `RunDetails.tsx` already uses `CircularProgress`).

**Components changed:**

| File | Before | After |
|---|---|---|
| `NewRunSwitcher.tsx` | `<div>Currently loading pipeline information</div>` | `<CircularProgress />` |
| `RecurringRunDetailsRouter.tsx` | `<div>Currently loading recurring run information</div>` | `<CircularProgress />` |
| `PipelineDetails.tsx` | `<div>Currently loading pipeline information</div>` | `<CircularProgress />` |

**Tests updated:**
- `NewRunSwitcher.test.tsx`: assert `getByRole('progressbar')` instead of `getByText`
- `RecurringRunDetailsRouter.test.tsx`: assert `queryByRole('progressbar')` / `getByRole('progressbar')` instead of `queryByText` / `getByText`

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

Made with [Cursor](https://cursor.com)