### PR TITLE
fix(test): Add `Eventually` for informer cache sync in pipeline version tests (#13312)

### DIFF
--- a/backend/test/v2/api/pipeline_api_test.go
+++ b/backend/test/v2/api/pipeline_api_test.go
@@ -59,6 +59,38 @@ func newListPipelinesParams() *pipeline_params.PipelineServiceListPipelinesParam
 	}
 }
 
+const (
+	informerSyncTimeout  = 30 * time.Second
+	informerSyncInterval = 2 * time.Second
+)
+
+type pipelineVersionListResult struct {
+	Versions      []*pipeline_model.V2beta1PipelineVersion
+	TotalSize     int
+	NextPageToken string
+}
+
+// eventuallyListPipelineVersions returns a poll function for Gomega's Eventually
+// that lists pipeline versions and yields totalSize. The last successful response
+// is stored in the returned result pointer so callers can inspect Versions,
+// TotalSize, and NextPageToken after Eventually succeeds.
+func eventuallyListPipelineVersions(
+	params *pipeline_params.PipelineServiceListPipelineVersionsParams,
+) (*pipelineVersionListResult, func() int) {
+	result := &pipelineVersionListResult{}
+	pollFn := func() int {
+		versions, totalSize, nextPageToken, err := pipelineClient.ListPipelineVersions(params)
+		if err != nil {
+			return 0
+		}
+		result.Versions = versions
+		result.TotalSize = totalSize
+		result.NextPageToken = nextPageToken
+		return totalSize
+	}
+	return result, pollFn
+}
+
 // ###########################################
 // ################## TESTS ##################
 // ###########################################
@@ -88,7 +120,7 @@ var _ = Describe("List Pipelines API Tests >", Label(constants.POSITIVE, constan
 					}
 				}
 				return false
-			}, 30*time.Second, 2*time.Second).Should(BeTrue(), "Created pipeline should appear in list results")
+			}, informerSyncTimeout, informerSyncInterval).Should(BeTrue(), "Created pipeline should appear in list results")
 		})
 
 		It("After creating multiple pipelines", func() {
@@ -568,21 +600,11 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err = uploadPipelineVersion(pipelineSpecFilePath, uploadParams3)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
-			var versions []*pipeline_model.V2beta1PipelineVersion
-			var totalSize int
-			Eventually(func() int {
-				versions, totalSize, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-					PipelineID: createdPipeline.PipelineID,
-				})
-				if err != nil {
-					return 0
-				}
-				return totalSize
-			}, 30*time.Second, 2*time.Second).Should(Equal(3), "Expected 3 pipeline versions after uploading two additional versions")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(versions).To(HaveLen(3))
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: createdPipeline.PipelineID,
+			})
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(Equal(3), "Expected 3 pipeline versions after uploading two additional versions")
+			Expect(result.Versions).To(HaveLen(3))
 		})
 
 		It("By pipeline ID - only returns versions for that pipeline", func() {
@@ -626,25 +648,14 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err := uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
 			pageSize := int32(1)
-			var versions []*pipeline_model.V2beta1PipelineVersion
-			var totalSize int
-			var nextPageToken string
-			Eventually(func() int {
-				versions, totalSize, nextPageToken, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-					PipelineID: createdPipeline.PipelineID,
-					PageSize:   &pageSize,
-				})
-				if err != nil {
-					return 0
-				}
-				return totalSize
-			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(versions).To(HaveLen(1))
-			Expect(nextPageToken).NotTo(BeEmpty(), "Next page token should be set when more results exist")
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: createdPipeline.PipelineID,
+				PageSize:   &pageSize,
+			})
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
+			Expect(result.Versions).To(HaveLen(1))
+			Expect(result.NextPageToken).NotTo(BeEmpty(), "Next page token should be set when more results exist")
 		})
 
 		It("List pipeline versions with pagination - iterate through all pages (at least 2)", func() {
@@ -662,8 +673,6 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
 			pageSize := int32(2)
 			var allVersions []*pipeline_model.V2beta1PipelineVersion
 			var pagesVisited int
@@ -687,7 +696,7 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 					params.PageToken = &nextPageToken
 				}
 				return len(allVersions)
-			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 3), "Expected at least 3 pipeline versions across all pages")
+			}, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 3), "Expected at least 3 pipeline versions across all pages")
 			Expect(pagesVisited).To(BeNumerically(">=", 2), "Should visit at least 2 pages")
 		})
 	})
@@ -706,27 +715,18 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err := uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
 			sortBy := "name asc"
-			var versions []*pipeline_model.V2beta1PipelineVersion
-			Eventually(func() int {
-				versions, _, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-					PipelineID: createdPipeline.PipelineID,
-					SortBy:     &sortBy,
-				})
-				if err != nil {
-					return 0
-				}
-				return len(versions)
-			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
-			Expect(err).NotTo(HaveOccurred())
-			for i := 1; i < len(versions); i++ {
-				cur := strings.ToLower(versions[i].Name)
-				prev := strings.ToLower(versions[i-1].Name)
-				logger.Log("Version name ascending sort check [%d]: %q >= %q => %v", i, versions[i].Name, versions[i-1].Name, cur >= prev)
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: createdPipeline.PipelineID,
+				SortBy:     &sortBy,
+			})
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
+			for i := 1; i < len(result.Versions); i++ {
+				cur := strings.ToLower(result.Versions[i].Name)
+				prev := strings.ToLower(result.Versions[i-1].Name)
+				logger.Log("Version name ascending sort check [%d]: %q >= %q => %v", i, result.Versions[i].Name, result.Versions[i-1].Name, cur >= prev)
 				Expect(cur >= prev).To(BeTrue(),
-					fmt.Sprintf("Versions should be sorted by name ascending: [%d] %q should be >= [%d] %q", i, versions[i].Name, i-1, versions[i-1].Name))
+					fmt.Sprintf("Versions should be sorted by name ascending: [%d] %q should be >= [%d] %q", i, result.Versions[i].Name, i-1, result.Versions[i-1].Name))
 			}
 		})
 
@@ -742,27 +742,18 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err := uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
 			sortBy := "name desc"
-			var versions []*pipeline_model.V2beta1PipelineVersion
-			Eventually(func() int {
-				versions, _, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-					PipelineID: createdPipeline.PipelineID,
-					SortBy:     &sortBy,
-				})
-				if err != nil {
-					return 0
-				}
-				return len(versions)
-			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
-			Expect(err).NotTo(HaveOccurred())
-			for i := 1; i < len(versions); i++ {
-				cur := strings.ToLower(versions[i].Name)
-				prev := strings.ToLower(versions[i-1].Name)
-				logger.Log("Version name descending sort check [%d]: %q <= %q => %v", i, versions[i].Name, versions[i-1].Name, cur <= prev)
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: createdPipeline.PipelineID,
+				SortBy:     &sortBy,
+			})
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
+			for i := 1; i < len(result.Versions); i++ {
+				cur := strings.ToLower(result.Versions[i].Name)
+				prev := strings.ToLower(result.Versions[i-1].Name)
+				logger.Log("Version name descending sort check [%d]: %q <= %q => %v", i, result.Versions[i].Name, result.Versions[i-1].Name, cur <= prev)
 				Expect(cur <= prev).To(BeTrue(),
-					fmt.Sprintf("Versions should be sorted by name descending: [%d] %q should be <= [%d] %q", i, versions[i].Name, i-1, versions[i-1].Name))
+					fmt.Sprintf("Versions should be sorted by name descending: [%d] %q should be <= [%d] %q", i, result.Versions[i].Name, i-1, result.Versions[i-1].Name))
 			}
 		})
 
@@ -865,23 +856,13 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err := uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
 			filter := fmt.Sprintf(`{"predicates":[{"key":"name","operation":"EQUALS","string_value":"%s"}]}`, v2Name)
-			var filteredVersions []*pipeline_model.V2beta1PipelineVersion
-			var totalSize int
-			Eventually(func() int {
-				filteredVersions, totalSize, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-					PipelineID: createdPipeline.PipelineID,
-					Filter:     &filter,
-				})
-				if err != nil {
-					return 0
-				}
-				return totalSize
-			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 1), "Expected the filtered version to appear in results")
-			Expect(err).NotTo(HaveOccurred())
-			for _, v := range filteredVersions {
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: createdPipeline.PipelineID,
+				Filter:     &filter,
+			})
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 1), "Expected the filtered version to appear in results")
+			for _, v := range result.Versions {
 				Expect(v.Name).To(Equal(v2Name))
 			}
 		})
@@ -917,23 +898,13 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err := uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
 			filter := fmt.Sprintf(`{"predicates":[{"key":"description","operation":"EQUALS","string_value":"%s"}]}`, v2Desc)
-			var filteredVersions []*pipeline_model.V2beta1PipelineVersion
-			var totalSize int
-			Eventually(func() int {
-				filteredVersions, totalSize, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-					PipelineID: createdPipeline.PipelineID,
-					Filter:     &filter,
-				})
-				if err != nil {
-					return 0
-				}
-				return totalSize
-			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 1), "Expected the filtered version to appear in results")
-			Expect(err).NotTo(HaveOccurred())
-			for _, v := range filteredVersions {
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: createdPipeline.PipelineID,
+				Filter:     &filter,
+			})
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 1), "Expected the filtered version to appear in results")
+			for _, v := range result.Versions {
 				Expect(v.Description).To(Equal(v2Desc))
 			}
 		})
@@ -1071,22 +1042,13 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err = uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
-			var versions []*pipeline_model.V2beta1PipelineVersion
-			Eventually(func() int {
-				versions, _, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-					PipelineID: createdPipeline.PipelineID,
-				})
-				if err != nil {
-					return 0
-				}
-				return len(versions)
-			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
-			Expect(err).NotTo(HaveOccurred())
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: createdPipeline.PipelineID,
+			})
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
 
 			var foundTaggedVersion bool
-			for _, v := range versions {
+			for _, v := range result.Versions {
 				if v.DisplayName == vName {
 					Expect(v.Tags).To(Equal(versionTags), "Tagged version should include tags in list response")
 					foundTaggedVersion = true
@@ -1127,24 +1089,14 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err = uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
 			filter := `{"predicates":[{"key":"tags.env","operation":"EQUALS","string_value":"prod"}]}`
-			var versions []*pipeline_model.V2beta1PipelineVersion
-			var totalSize int
-			Eventually(func() int {
-				versions, totalSize, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-					PipelineID: createdPipeline.PipelineID,
-					Filter:     &filter,
-				})
-				if err != nil {
-					return 0
-				}
-				return totalSize
-			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 1), "Expected the tagged version to appear in filtered results")
-			Expect(err).NotTo(HaveOccurred())
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: createdPipeline.PipelineID,
+				Filter:     &filter,
+			})
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 1), "Expected the tagged version to appear in filtered results")
 
-			for _, v := range versions {
+			for _, v := range result.Versions {
 				Expect(v.Tags).To(HaveKeyWithValue("env", "prod"))
 			}
 		})
@@ -1166,25 +1118,15 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err = uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
 			filter := `{"predicates":[{"key":"tags.env","operation":"EQUALS","string_value":"staging"},{"key":"tags.team","operation":"EQUALS","string_value":"data"}]}`
-			var versions []*pipeline_model.V2beta1PipelineVersion
-			var totalSize int
-			Eventually(func() int {
-				versions, totalSize, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-					PipelineID: createdPipeline.PipelineID,
-					Filter:     &filter,
-				})
-				if err != nil {
-					return 0
-				}
-				return totalSize
-			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 1), "Expected the tagged version to appear in filtered results")
-			Expect(err).NotTo(HaveOccurred())
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: createdPipeline.PipelineID,
+				Filter:     &filter,
+			})
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 1), "Expected the tagged version to appear in filtered results")
 
 			found := false
-			for _, v := range versions {
+			for _, v := range result.Versions {
 				if v.DisplayName == vName {
 					found = true
 					break
@@ -1660,13 +1602,11 @@ var _ = Describe("Get Pipeline Version API Tests >", Label(constants.POSITIVE, c
 			_, err = uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
 			var versions []*pipeline_model.V2beta1PipelineVersion
 			Eventually(func() int {
 				versions = utils.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil)
 				return len(versions)
-			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
+			}, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
 
 			// Find the tagged version and verify tags
 			var foundTaggedVersion bool
@@ -1778,13 +1718,11 @@ var _ = Describe("Create Pipeline Version API Tests >", Label(constants.POSITIVE
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			// Use Eventually to allow the informer cache to sync (applies to K8s store;
-			// SQL store returns immediately on first attempt).
 			var versions []*pipeline_model.V2beta1PipelineVersion
 			Eventually(func() int {
 				versions = utils.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil)
 				return len(versions)
-			}, 30*time.Second, 2*time.Second).Should(Equal(4), "Should have 4 versions total")
+			}, informerSyncTimeout, informerSyncInterval).Should(Equal(4), "Should have 4 versions total")
 		})
 	})
 })

--- a/backend/test/v2/api/pipeline_api_test.go
+++ b/backend/test/v2/api/pipeline_api_test.go
@@ -74,19 +74,22 @@ type pipelineVersionListResult struct {
 // that lists pipeline versions and yields totalSize. The last successful response
 // is stored in the returned result pointer so callers can inspect Versions,
 // TotalSize, and NextPageToken after Eventually succeeds.
+//
+// The poll function returns (int, error) so that Eventually surfaces the real
+// API error on timeout instead of silently retrying with a zero value.
 func eventuallyListPipelineVersions(
 	params *pipeline_params.PipelineServiceListPipelineVersionsParams,
-) (*pipelineVersionListResult, func() int) {
+) (*pipelineVersionListResult, func() (int, error)) {
 	result := &pipelineVersionListResult{}
-	pollFn := func() int {
+	pollFn := func() (int, error) {
 		versions, totalSize, nextPageToken, err := pipelineClient.ListPipelineVersions(params)
 		if err != nil {
-			return 0
+			return 0, err
 		}
 		result.Versions = versions
 		result.TotalSize = totalSize
 		result.NextPageToken = nextPageToken
-		return totalSize
+		return totalSize, nil
 	}
 	return result, pollFn
 }
@@ -676,7 +679,7 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			pageSize := int32(2)
 			var allVersions []*pipeline_model.V2beta1PipelineVersion
 			var pagesVisited int
-			Eventually(func() int {
+			Eventually(func() (int, error) {
 				allVersions = make([]*pipeline_model.V2beta1PipelineVersion, 0)
 				pagesVisited = 0
 				params := &pipeline_params.PipelineServiceListPipelineVersionsParams{
@@ -686,7 +689,7 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 				for {
 					versions, _, nextPageToken, err := pipelineClient.ListPipelineVersions(params)
 					if err != nil {
-						return 0
+						return 0, err
 					}
 					allVersions = append(allVersions, versions...)
 					pagesVisited++
@@ -695,7 +698,7 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 					}
 					params.PageToken = &nextPageToken
 				}
-				return len(allVersions)
+				return len(allVersions), nil
 			}, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 3), "Expected at least 3 pipeline versions across all pages")
 			Expect(pagesVisited).To(BeNumerically(">=", 2), "Should visit at least 2 pages")
 		})
@@ -1603,9 +1606,15 @@ var _ = Describe("Get Pipeline Version API Tests >", Label(constants.POSITIVE, c
 			Expect(err).NotTo(HaveOccurred())
 
 			var versions []*pipeline_model.V2beta1PipelineVersion
-			Eventually(func() int {
-				versions = utils.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil)
-				return len(versions)
+			Eventually(func() (int, error) {
+				v, _, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+				})
+				if err != nil {
+					return 0, err
+				}
+				versions = v
+				return len(versions), nil
 			}, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
 
 			// Find the tagged version and verify tags
@@ -1719,9 +1728,15 @@ var _ = Describe("Create Pipeline Version API Tests >", Label(constants.POSITIVE
 			}
 
 			var versions []*pipeline_model.V2beta1PipelineVersion
-			Eventually(func() int {
-				versions = utils.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil)
-				return len(versions)
+			Eventually(func() (int, error) {
+				v, _, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+				})
+				if err != nil {
+					return 0, err
+				}
+				versions = v
+				return len(versions), nil
 			}, informerSyncTimeout, informerSyncInterval).Should(Equal(4), "Should have 4 versions total")
 		})
 	})

--- a/backend/test/v2/api/pipeline_api_test.go
+++ b/backend/test/v2/api/pipeline_api_test.go
@@ -568,11 +568,20 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err = uploadPipelineVersion(pipelineSpecFilePath, uploadParams3)
 			Expect(err).NotTo(HaveOccurred())
 
-			versions, totalSize, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-				PipelineID: createdPipeline.PipelineID,
-			})
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
+			var versions []*pipeline_model.V2beta1PipelineVersion
+			var totalSize int
+			Eventually(func() int {
+				versions, totalSize, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+				})
+				if err != nil {
+					return 0
+				}
+				return totalSize
+			}, 30*time.Second, 2*time.Second).Should(Equal(3), "Expected 3 pipeline versions after uploading two additional versions")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(totalSize).To(Equal(3))
 			Expect(versions).To(HaveLen(3))
 		})
 
@@ -617,14 +626,24 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err := uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
 			pageSize := int32(1)
-			versions, totalSize, nextPageToken, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-				PipelineID: createdPipeline.PipelineID,
-				PageSize:   &pageSize,
-			})
+			var versions []*pipeline_model.V2beta1PipelineVersion
+			var totalSize int
+			var nextPageToken string
+			Eventually(func() int {
+				versions, totalSize, nextPageToken, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+					PageSize:   &pageSize,
+				})
+				if err != nil {
+					return 0
+				}
+				return totalSize
+			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(versions).To(HaveLen(1))
-			Expect(totalSize).To(BeNumerically(">=", 2))
 			Expect(nextPageToken).NotTo(BeEmpty(), "Next page token should be set when more results exist")
 		})
 
@@ -643,29 +662,33 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 				Expect(err).NotTo(HaveOccurred())
 			}
 
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
 			pageSize := int32(2)
-			params := &pipeline_params.PipelineServiceListPipelineVersionsParams{
-				PipelineID: createdPipeline.PipelineID,
-				PageSize:   &pageSize,
-			}
-
-			allVersions := make([]*pipeline_model.V2beta1PipelineVersion, 0)
-			pagesVisited := 0
-
-			for {
-				versions, _, nextPageToken, err := pipelineClient.ListPipelineVersions(params)
-				Expect(err).NotTo(HaveOccurred())
-				allVersions = append(allVersions, versions...)
-				pagesVisited++
-
-				if nextPageToken == "" {
-					break
+			var allVersions []*pipeline_model.V2beta1PipelineVersion
+			var pagesVisited int
+			Eventually(func() int {
+				allVersions = make([]*pipeline_model.V2beta1PipelineVersion, 0)
+				pagesVisited = 0
+				params := &pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+					PageSize:   &pageSize,
 				}
-				params.PageToken = &nextPageToken
-			}
-
+				for {
+					versions, _, nextPageToken, err := pipelineClient.ListPipelineVersions(params)
+					if err != nil {
+						return 0
+					}
+					allVersions = append(allVersions, versions...)
+					pagesVisited++
+					if nextPageToken == "" {
+						break
+					}
+					params.PageToken = &nextPageToken
+				}
+				return len(allVersions)
+			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 3), "Expected at least 3 pipeline versions across all pages")
 			Expect(pagesVisited).To(BeNumerically(">=", 2), "Should visit at least 2 pages")
-			Expect(len(allVersions)).To(BeNumerically(">=", 3))
 		})
 	})
 
@@ -683,13 +706,21 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err := uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
 			sortBy := "name asc"
-			versions, _, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-				PipelineID: createdPipeline.PipelineID,
-				SortBy:     &sortBy,
-			})
+			var versions []*pipeline_model.V2beta1PipelineVersion
+			Eventually(func() int {
+				versions, _, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+					SortBy:     &sortBy,
+				})
+				if err != nil {
+					return 0
+				}
+				return len(versions)
+			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(versions)).To(BeNumerically(">=", 2))
 			for i := 1; i < len(versions); i++ {
 				cur := strings.ToLower(versions[i].Name)
 				prev := strings.ToLower(versions[i-1].Name)
@@ -711,11 +742,20 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err := uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
 			sortBy := "name desc"
-			versions, _, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-				PipelineID: createdPipeline.PipelineID,
-				SortBy:     &sortBy,
-			})
+			var versions []*pipeline_model.V2beta1PipelineVersion
+			Eventually(func() int {
+				versions, _, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+					SortBy:     &sortBy,
+				})
+				if err != nil {
+					return 0
+				}
+				return len(versions)
+			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
 			Expect(err).NotTo(HaveOccurred())
 			for i := 1; i < len(versions); i++ {
 				cur := strings.ToLower(versions[i].Name)
@@ -825,13 +865,22 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err := uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
 			filter := fmt.Sprintf(`{"predicates":[{"key":"name","operation":"EQUALS","string_value":"%s"}]}`, v2Name)
-			filteredVersions, totalSize, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-				PipelineID: createdPipeline.PipelineID,
-				Filter:     &filter,
-			})
+			var filteredVersions []*pipeline_model.V2beta1PipelineVersion
+			var totalSize int
+			Eventually(func() int {
+				filteredVersions, totalSize, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+					Filter:     &filter,
+				})
+				if err != nil {
+					return 0
+				}
+				return totalSize
+			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 1), "Expected the filtered version to appear in results")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(totalSize).To(BeNumerically(">=", 1))
 			for _, v := range filteredVersions {
 				Expect(v.Name).To(Equal(v2Name))
 			}
@@ -868,13 +917,22 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err := uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
 			filter := fmt.Sprintf(`{"predicates":[{"key":"description","operation":"EQUALS","string_value":"%s"}]}`, v2Desc)
-			filteredVersions, totalSize, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-				PipelineID: createdPipeline.PipelineID,
-				Filter:     &filter,
-			})
+			var filteredVersions []*pipeline_model.V2beta1PipelineVersion
+			var totalSize int
+			Eventually(func() int {
+				filteredVersions, totalSize, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+					Filter:     &filter,
+				})
+				if err != nil {
+					return 0
+				}
+				return totalSize
+			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 1), "Expected the filtered version to appear in results")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(totalSize).To(BeNumerically(">=", 1))
 			for _, v := range filteredVersions {
 				Expect(v.Description).To(Equal(v2Desc))
 			}
@@ -1013,11 +1071,19 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err = uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			versions, _, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-				PipelineID: createdPipeline.PipelineID,
-			})
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
+			var versions []*pipeline_model.V2beta1PipelineVersion
+			Eventually(func() int {
+				versions, _, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+				})
+				if err != nil {
+					return 0
+				}
+				return len(versions)
+			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(versions)).To(BeNumerically(">=", 2))
 
 			var foundTaggedVersion bool
 			for _, v := range versions {
@@ -1061,13 +1127,22 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err = uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
 			filter := `{"predicates":[{"key":"tags.env","operation":"EQUALS","string_value":"prod"}]}`
-			versions, totalSize, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-				PipelineID: createdPipeline.PipelineID,
-				Filter:     &filter,
-			})
+			var versions []*pipeline_model.V2beta1PipelineVersion
+			var totalSize int
+			Eventually(func() int {
+				versions, totalSize, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+					Filter:     &filter,
+				})
+				if err != nil {
+					return 0
+				}
+				return totalSize
+			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 1), "Expected the tagged version to appear in filtered results")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(totalSize).To(BeNumerically(">=", 1))
 
 			for _, v := range versions {
 				Expect(v.Tags).To(HaveKeyWithValue("env", "prod"))
@@ -1091,13 +1166,22 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 			_, err = uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
 			filter := `{"predicates":[{"key":"tags.env","operation":"EQUALS","string_value":"staging"},{"key":"tags.team","operation":"EQUALS","string_value":"data"}]}`
-			versions, totalSize, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
-				PipelineID: createdPipeline.PipelineID,
-				Filter:     &filter,
-			})
+			var versions []*pipeline_model.V2beta1PipelineVersion
+			var totalSize int
+			Eventually(func() int {
+				versions, totalSize, _, err = pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+					PipelineID: createdPipeline.PipelineID,
+					Filter:     &filter,
+				})
+				if err != nil {
+					return 0
+				}
+				return totalSize
+			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 1), "Expected the tagged version to appear in filtered results")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(totalSize).To(BeNumerically(">=", 1))
 
 			found := false
 			for _, v := range versions {
@@ -1576,9 +1660,13 @@ var _ = Describe("Get Pipeline Version API Tests >", Label(constants.POSITIVE, c
 			_, err = uploadPipelineVersion(pipelineSpecFilePath, uploadParams)
 			Expect(err).NotTo(HaveOccurred())
 
-			// List versions
-			versions := utils.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil)
-			Expect(len(versions)).To(BeNumerically(">=", 2))
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
+			var versions []*pipeline_model.V2beta1PipelineVersion
+			Eventually(func() int {
+				versions = utils.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil)
+				return len(versions)
+			}, 30*time.Second, 2*time.Second).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a second version")
 
 			// Find the tagged version and verify tags
 			var foundTaggedVersion bool
@@ -1690,9 +1778,13 @@ var _ = Describe("Create Pipeline Version API Tests >", Label(constants.POSITIVE
 				Expect(err).NotTo(HaveOccurred())
 			}
 
-			// Verify all 4 versions exist (1 from upload + 3 created)
-			versions := utils.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil)
-			Expect(len(versions)).To(Equal(4), "Should have 4 versions total")
+			// Use Eventually to allow the informer cache to sync (applies to K8s store;
+			// SQL store returns immediately on first attempt).
+			var versions []*pipeline_model.V2beta1PipelineVersion
+			Eventually(func() int {
+				versions = utils.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil)
+				return len(versions)
+			}, 30*time.Second, 2*time.Second).Should(Equal(4), "Should have 4 versions total")
 		})
 	})
 })


### PR DESCRIPTION
Resolves https://github.com/kubeflow/pipelines/issues/13252.

**Description of your changes:**
- Updated test cases in `pipeline_api_test.go` to use `Eventually` for handling informer cache synchronization.
- Improved reliability of pipeline version listing and filtering assertions.

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
