### PR TITLE
refactor(frontend): simplify CompareV2 selection state

### DIFF
--- a/frontend/src/components/viewers/MetricsDropdown.test.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.test.tsx
@@ -23,6 +23,7 @@ import * as Utils from 'src/lib/Utils';
 import { SelectedArtifact } from 'src/pages/CompareV2';
 import { LinkedArtifact } from 'src/mlmd/MlmdUtils';
 import * as jspb from 'google-protobuf';
+import { useState } from 'react';
 import MetricsDropdown from './MetricsDropdown';
 import { MetricsType, RunArtifact } from 'src/lib/v2/CompareUtils';
 
@@ -76,6 +77,38 @@ function newMockLinkedArtifact(id: number, displayName?: string): LinkedArtifact
   } as LinkedArtifact;
 }
 
+interface ControlledMetricsDropdownProps {
+  filteredRunArtifacts: RunArtifact[];
+  metricsTab: MetricsType;
+  selectedArtifacts: SelectedArtifact[];
+  namespace?: string;
+  onUpdateSelectedArtifacts?: (selectedArtifacts: SelectedArtifact[]) => void;
+}
+
+function ControlledMetricsDropdown(props: ControlledMetricsDropdownProps) {
+  const {
+    filteredRunArtifacts,
+    metricsTab,
+    selectedArtifacts: initialSelectedArtifacts,
+    namespace,
+    onUpdateSelectedArtifacts,
+  } = props;
+  const [selectedArtifacts, setSelectedArtifacts] = useState(initialSelectedArtifacts);
+
+  return (
+    <MetricsDropdown
+      filteredRunArtifacts={filteredRunArtifacts}
+      metricsTab={metricsTab}
+      selectedArtifacts={selectedArtifacts}
+      updateSelectedArtifacts={(nextSelectedArtifacts) => {
+        setSelectedArtifacts(nextSelectedArtifacts);
+        onUpdateSelectedArtifacts?.(nextSelectedArtifacts);
+      }}
+      namespace={namespace}
+    />
+  );
+}
+
 testBestPractices();
 describe('MetricsDropdown', () => {
   const updateSelectedArtifactsSpy = vi.fn();
@@ -85,6 +118,7 @@ describe('MetricsDropdown', () => {
   let scalarMetricsArtifacts: RunArtifact[];
 
   beforeEach(() => {
+    updateSelectedArtifactsSpy.mockReset();
     emptySelectedArtifacts = [
       {
         selectedItem: { itemName: '', subItemName: '' },
@@ -157,11 +191,11 @@ describe('MetricsDropdown', () => {
   it('Dropdown loaded when content is present', async () => {
     render(
       <CommonTestWrapper>
-        <MetricsDropdown
+        <ControlledMetricsDropdown
           filteredRunArtifacts={scalarMetricsArtifacts}
           metricsTab={MetricsType.CONFUSION_MATRIX}
           selectedArtifacts={emptySelectedArtifacts}
-          updateSelectedArtifacts={updateSelectedArtifactsSpy}
+          onUpdateSelectedArtifacts={updateSelectedArtifactsSpy}
         />
       </CommonTestWrapper>,
     );
@@ -251,11 +285,11 @@ describe('MetricsDropdown', () => {
 
     render(
       <CommonTestWrapper>
-        <MetricsDropdown
+        <ControlledMetricsDropdown
           filteredRunArtifacts={scalarMetricsArtifacts}
           metricsTab={MetricsType.HTML}
           selectedArtifacts={emptySelectedArtifacts}
-          updateSelectedArtifacts={updateSelectedArtifactsSpy}
+          onUpdateSelectedArtifacts={updateSelectedArtifactsSpy}
         />
       </CommonTestWrapper>,
     );
@@ -296,11 +330,11 @@ describe('MetricsDropdown', () => {
 
     render(
       <CommonTestWrapper>
-        <MetricsDropdown
+        <ControlledMetricsDropdown
           filteredRunArtifacts={scalarMetricsArtifacts}
           metricsTab={MetricsType.MARKDOWN}
           selectedArtifacts={emptySelectedArtifacts}
-          updateSelectedArtifacts={updateSelectedArtifactsSpy}
+          onUpdateSelectedArtifacts={updateSelectedArtifactsSpy}
         />
       </CommonTestWrapper>,
     );
@@ -345,11 +379,11 @@ describe('MetricsDropdown', () => {
 
     render(
       <CommonTestWrapper>
-        <MetricsDropdown
+        <ControlledMetricsDropdown
           filteredRunArtifacts={scalarMetricsArtifacts}
           metricsTab={MetricsType.HTML}
           selectedArtifacts={emptySelectedArtifacts}
-          updateSelectedArtifacts={updateSelectedArtifactsSpy}
+          onUpdateSelectedArtifacts={updateSelectedArtifactsSpy}
           namespace='namespaceInput'
         />
       </CommonTestWrapper>,
@@ -391,11 +425,11 @@ describe('MetricsDropdown', () => {
 
     render(
       <CommonTestWrapper>
-        <MetricsDropdown
+        <ControlledMetricsDropdown
           filteredRunArtifacts={scalarMetricsArtifacts}
           metricsTab={MetricsType.CONFUSION_MATRIX}
           selectedArtifacts={newSelectedArtifacts}
-          updateSelectedArtifacts={updateSelectedArtifactsSpy}
+          onUpdateSelectedArtifacts={updateSelectedArtifactsSpy}
         />
       </CommonTestWrapper>,
     );
@@ -403,5 +437,44 @@ describe('MetricsDropdown', () => {
 
     screen.getByText('Choose a first Confusion Matrix artifact');
     screen.getByLabelText('run1 > execution1 > artifact1');
+  });
+
+  it('updates the displayed selection when parent-selected artifacts change after mount', async () => {
+    const { rerender } = render(
+      <CommonTestWrapper>
+        <MetricsDropdown
+          filteredRunArtifacts={scalarMetricsArtifacts}
+          metricsTab={MetricsType.CONFUSION_MATRIX}
+          selectedArtifacts={emptySelectedArtifacts}
+          updateSelectedArtifacts={updateSelectedArtifactsSpy}
+        />
+      </CommonTestWrapper>,
+    );
+    await TestUtils.flushPromises();
+
+    const nextSelectedArtifacts: SelectedArtifact[] = [
+      {
+        linkedArtifact: firstLinkedArtifact,
+        selectedItem: {
+          itemName: 'run1',
+          subItemName: 'execution1',
+          subItemSecondaryName: 'artifact1',
+        },
+      },
+      emptySelectedArtifacts[1],
+    ];
+
+    rerender(
+      <CommonTestWrapper>
+        <MetricsDropdown
+          filteredRunArtifacts={scalarMetricsArtifacts}
+          metricsTab={MetricsType.CONFUSION_MATRIX}
+          selectedArtifacts={nextSelectedArtifacts}
+          updateSelectedArtifacts={updateSelectedArtifactsSpy}
+        />
+      </CommonTestWrapper>,
+    );
+
+    expect(await screen.findByLabelText('run1 > execution1 > artifact1')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/viewers/MetricsDropdown.test.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.test.tsx
@@ -477,4 +477,79 @@ describe('MetricsDropdown', () => {
 
     expect(await screen.findByLabelText('run1 > execution1 > artifact1')).toBeInTheDocument();
   });
+
+  it('re-resolves the selected artifact from the current compare data when labels stay the same', async () => {
+    const getHtmlViewerConfigSpy = vi.spyOn(metricsVisualizations, 'getHtmlViewerConfig');
+    getHtmlViewerConfigSpy.mockResolvedValue([]);
+
+    const staleLinkedArtifact = newMockLinkedArtifact(10, 'artifact1');
+    const freshLinkedArtifact = newMockLinkedArtifact(11, 'artifact1');
+    const selectedArtifactsWithStaleArtifact: SelectedArtifact[] = [
+      {
+        linkedArtifact: staleLinkedArtifact,
+        selectedItem: {
+          itemName: 'run1',
+          subItemName: 'execution1',
+          subItemSecondaryName: 'artifact1',
+        },
+      },
+      emptySelectedArtifacts[1],
+    ];
+
+    const { rerender } = render(
+      <CommonTestWrapper>
+        <MetricsDropdown
+          filteredRunArtifacts={[
+            {
+              run: {
+                run_id: '1',
+                display_name: 'run1',
+              },
+              executionArtifacts: [
+                {
+                  execution: newMockExecution(1, 'execution1'),
+                  linkedArtifacts: [staleLinkedArtifact],
+                },
+              ],
+            },
+          ]}
+          metricsTab={MetricsType.HTML}
+          selectedArtifacts={selectedArtifactsWithStaleArtifact}
+          updateSelectedArtifacts={updateSelectedArtifactsSpy}
+        />
+      </CommonTestWrapper>,
+    );
+    await TestUtils.flushPromises();
+    await waitFor(() => {
+      expect(getHtmlViewerConfigSpy).toHaveBeenLastCalledWith([staleLinkedArtifact], undefined);
+    });
+
+    rerender(
+      <CommonTestWrapper>
+        <MetricsDropdown
+          filteredRunArtifacts={[
+            {
+              run: {
+                run_id: '2',
+                display_name: 'run1',
+              },
+              executionArtifacts: [
+                {
+                  execution: newMockExecution(2, 'execution1'),
+                  linkedArtifacts: [freshLinkedArtifact],
+                },
+              ],
+            },
+          ]}
+          metricsTab={MetricsType.HTML}
+          selectedArtifacts={selectedArtifactsWithStaleArtifact}
+          updateSelectedArtifacts={updateSelectedArtifactsSpy}
+        />
+      </CommonTestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(getHtmlViewerConfigSpy).toHaveBeenLastCalledWith([freshLinkedArtifact], undefined);
+    });
+  });
 });

--- a/frontend/src/components/viewers/MetricsDropdown.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.tsx
@@ -92,39 +92,20 @@ export default function MetricsDropdown(props: MetricsDropdownProps) {
     updateSelectedArtifacts,
     namespace,
   } = props;
-  const [firstSelectedItem, setFirstSelectedItem] = useState<SelectedItem>(
-    selectedArtifacts[0].selectedItem,
-  );
-  const [secondSelectedItem, setSecondSelectedItem] = useState<SelectedItem>(
-    selectedArtifacts[1].selectedItem,
-  );
-
-  useEffect(() => {
-    setFirstSelectedItem(selectedArtifacts[0].selectedItem);
-    setSecondSelectedItem(selectedArtifacts[1].selectedItem);
-  }, [selectedArtifacts]);
 
   const selectedArtifactsForDisplay = useMemo(
-    () => [
-      {
-        selectedItem: firstSelectedItem,
-        linkedArtifact: getLinkedArtifactFromSelectedItem(filteredRunArtifacts, firstSelectedItem),
-      },
-      {
-        selectedItem: secondSelectedItem,
-        linkedArtifact: getLinkedArtifactFromSelectedItem(filteredRunArtifacts, secondSelectedItem),
-      },
-    ],
-    [filteredRunArtifacts, firstSelectedItem, secondSelectedItem],
+    () =>
+      selectedArtifacts.map((selectedArtifact) => ({
+        selectedItem: selectedArtifact.selectedItem,
+        linkedArtifact:
+          selectedArtifact.linkedArtifact ??
+          getLinkedArtifactFromSelectedItem(filteredRunArtifacts, selectedArtifact.selectedItem),
+      })),
+    [filteredRunArtifacts, selectedArtifacts],
   );
 
   const metricsTabText = metricsTypeToString(metricsTab);
-  const updateSelectedItemAndArtifact = (
-    setSelectedItem: (selectedItem: SelectedItem) => void,
-    panelIndex: number,
-    selectedItem: SelectedItem,
-  ): void => {
-    setSelectedItem(selectedItem);
+  const updateSelectedItemAndArtifact = (panelIndex: number, selectedItem: SelectedItem): void => {
     const linkedArtifact = getLinkedArtifactFromSelectedItem(filteredRunArtifacts, selectedItem);
     const nextSelectedArtifacts = selectedArtifactsForDisplay.map((selectedArtifact, index) =>
       index === panelIndex
@@ -150,8 +131,8 @@ export default function MetricsDropdown(props: MetricsDropdownProps) {
             <TwoLevelDropdown
               title={`Choose a first ${metricsTabText} artifact`}
               items={dropdownItems}
-              selectedItem={firstSelectedItem}
-              setSelectedItem={updateSelectedItemAndArtifact.bind(null, setFirstSelectedItem, 0)}
+              selectedItem={selectedArtifactsForDisplay[0].selectedItem}
+              setSelectedItem={updateSelectedItemAndArtifact.bind(null, 0)}
             />
             <VisualizationPanelItem
               metricsTab={metricsTab}
@@ -164,8 +145,8 @@ export default function MetricsDropdown(props: MetricsDropdownProps) {
             <TwoLevelDropdown
               title={`Choose a second ${metricsTabText} artifact`}
               items={dropdownItems}
-              selectedItem={secondSelectedItem}
-              setSelectedItem={updateSelectedItemAndArtifact.bind(null, setSecondSelectedItem, 1)}
+              selectedItem={selectedArtifactsForDisplay[1].selectedItem}
+              setSelectedItem={updateSelectedItemAndArtifact.bind(null, 1)}
             />
             <VisualizationPanelItem
               metricsTab={metricsTab}

--- a/frontend/src/components/viewers/MetricsDropdown.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.tsx
@@ -97,9 +97,10 @@ export default function MetricsDropdown(props: MetricsDropdownProps) {
     () =>
       selectedArtifacts.map((selectedArtifact) => ({
         selectedItem: selectedArtifact.selectedItem,
-        linkedArtifact:
-          selectedArtifact.linkedArtifact ??
-          getLinkedArtifactFromSelectedItem(filteredRunArtifacts, selectedArtifact.selectedItem),
+        linkedArtifact: getLinkedArtifactFromSelectedItem(
+          filteredRunArtifacts,
+          selectedArtifact.selectedItem,
+        ),
       })),
     [filteredRunArtifacts, selectedArtifacts],
   );

--- a/frontend/src/hooks/useKeyedState.ts
+++ b/frontend/src/hooks/useKeyedState.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, useState } from 'react';
+
+type KeyedState<T> = {
+  key: string;
+  value: T;
+};
+
+export function useKeyedState<T>(key: string, initialValue: T) {
+  const [state, setState] = useState<KeyedState<T>>({ key: '', value: initialValue });
+  const value = state.key === key ? state.value : initialValue;
+  const setValue = useCallback((nextValue: T) => setState({ key, value: nextValue }), [key]);
+
+  return [value, setValue] as const;
+}

--- a/frontend/src/pages/CompareV2.test.tsx
+++ b/frontend/src/pages/CompareV2.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { CommonTestWrapper } from 'src/TestWrapper';
 import TestUtils, { expectErrors, testBestPractices } from 'src/TestUtils';
 import { Artifact, Context, Event, Execution } from 'src/third_party/mlmd';
@@ -710,6 +710,51 @@ describe('CompareV2', () => {
     expect(getRunRow(MOCK_RUN_1_ID)).toHaveAttribute('aria-checked', 'true');
     expect(getRunRow(MOCK_RUN_2_ID)).toHaveAttribute('aria-checked', 'false');
     expect(getRunRow(MOCK_RUN_3_ID)).toHaveAttribute('aria-checked', 'true');
+    expect(getHeaderCheckbox()).not.toBeChecked();
+  });
+
+  it('drops stale manual selections when the toolbar refresh returns different fetched run ids', async () => {
+    const getRunSpy = vi.spyOn(Apis.runServiceApiV2, 'getRun');
+    const refreshedRunIds = new Set<string>();
+    runs = [newMockRun(MOCK_RUN_1_ID), newMockRun(MOCK_RUN_2_ID), newMockRun(MOCK_RUN_3_ID)];
+    getRunSpy.mockImplementation((id: string) => {
+      if (refreshedRunIds.has(id)) {
+        return {
+          ...newMockRun(`replacement-${id}`),
+          display_name: `test run ${id}`,
+        };
+      }
+      return { ...runs.find((r) => r.run_id === id)! };
+    });
+
+    render(
+      <CommonTestWrapper>
+        <CompareV2 {...generateProps()} />
+      </CommonTestWrapper>,
+    );
+    await TestUtils.flushPromises();
+
+    await waitFor(() => {
+      expect(updateToolbarSpy).toHaveBeenCalled();
+    });
+    await waitForRunCheckboxes(3);
+
+    fireEvent.click(getRunRow(MOCK_RUN_2_ID));
+    await TestUtils.flushPromises();
+    await waitForRunCheckboxes(2);
+
+    refreshedRunIds.add(MOCK_RUN_3_ID);
+    const refreshAction = updateToolbarSpy.mock.lastCall?.[0].actions[ButtonKeys.REFRESH]
+      .action as () => Promise<void>;
+    await act(async () => {
+      await refreshAction();
+    });
+    await TestUtils.flushPromises();
+
+    await waitForRunCheckboxes(1);
+    expect(getRunRow(MOCK_RUN_1_ID)).toHaveAttribute('aria-checked', 'true');
+    expect(getRunRow(MOCK_RUN_2_ID)).toHaveAttribute('aria-checked', 'false');
+    expect(getRunRow(MOCK_RUN_3_ID)).toHaveAttribute('aria-checked', 'false');
     expect(getHeaderCheckbox()).not.toBeChecked();
   });
 

--- a/frontend/src/pages/CompareV2.test.tsx
+++ b/frontend/src/pages/CompareV2.test.tsx
@@ -23,6 +23,7 @@ import { ButtonKeys } from 'src/lib/Buttons';
 import { QUERY_PARAMS } from 'src/components/Router';
 import * as mlmdUtils from 'src/mlmd/MlmdUtils';
 import * as Utils from 'src/lib/Utils';
+import * as metricsVisualizations from 'src/components/viewers/MetricsVisualizations';
 import { TEST_ONLY } from './CompareV2';
 import { PageProps } from './Page';
 import { METRICS_SECTION_NAME, OVERVIEW_SECTION_NAME, PARAMS_SECTION_NAME } from './Compare';
@@ -741,6 +742,102 @@ describe('CompareV2', () => {
     await waitForRunCheckboxes(2);
     expect(getRunRow(MOCK_RUN_2_ID)).toHaveAttribute('aria-checked', 'true');
     expect(getRunRow(MOCK_RUN_3_ID)).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('refreshes the selected HTML artifact after a route change with the same visible labels', async () => {
+    const ORIGINAL_ROUTE_RUN_ID = 'html-route-original';
+    const UPDATED_ROUTE_RUN_ID = 'html-route-updated';
+    const SHARED_RUN_NAME = 'shared run';
+    const SHARED_EXECUTION_NAME = 'shared execution';
+    const SHARED_ARTIFACT_NAME = 'shared artifact';
+
+    runs = [
+      {
+        ...newMockRun(ORIGINAL_ROUTE_RUN_ID),
+        display_name: SHARED_RUN_NAME,
+      },
+      {
+        ...newMockRun(UPDATED_ROUTE_RUN_ID),
+        display_name: SHARED_RUN_NAME,
+      },
+    ];
+
+    const originalContext = newMockContext(ORIGINAL_ROUTE_RUN_ID, 200);
+    const updatedContext = newMockContext(UPDATED_ROUTE_RUN_ID, 300);
+    vi.spyOn(mlmdUtils, 'getKfpV2RunContext').mockImplementation((runID: string) =>
+      Promise.resolve(
+        [originalContext, updatedContext].find((context) => context.getName() === runID),
+      ),
+    );
+
+    const originalExecution = newMockExecution(200, SHARED_EXECUTION_NAME);
+    const updatedExecution = newMockExecution(300, SHARED_EXECUTION_NAME);
+    vi.spyOn(mlmdUtils, 'getExecutionsFromContext').mockImplementation((context: Context) =>
+      Promise.resolve(
+        context.getId() === originalContext.getId() ? [originalExecution] : [updatedExecution],
+      ),
+    );
+
+    const originalArtifact = newMockArtifact(200, false, false, SHARED_ARTIFACT_NAME);
+    const updatedArtifact = newMockArtifact(300, false, false, SHARED_ARTIFACT_NAME);
+    vi.spyOn(mlmdUtils, 'getArtifactsFromContext').mockImplementation((context: Context) =>
+      Promise.resolve(
+        context.getId() === originalContext.getId() ? [originalArtifact] : [updatedArtifact],
+      ),
+    );
+
+    vi.spyOn(mlmdUtils, 'getEventsByExecutions').mockImplementation((executions: Execution[]) =>
+      Promise.resolve(
+        executions[0]?.getId() === originalExecution.getId()
+          ? [newMockEvent(200, SHARED_ARTIFACT_NAME)]
+          : [newMockEvent(300, SHARED_ARTIFACT_NAME)],
+      ),
+    );
+
+    vi.spyOn(mlmdUtils, 'getArtifactTypes').mockResolvedValue([]);
+    vi.spyOn(mlmdUtils, 'filterLinkedArtifactsByType').mockImplementation(
+      (metricsFilter: string, _: ArtifactType[], linkedArtifacts: LinkedArtifact[]) =>
+        metricsFilter === 'system.HTML' ? linkedArtifacts : [],
+    );
+
+    const getHtmlViewerConfigSpy = vi.spyOn(metricsVisualizations, 'getHtmlViewerConfig');
+    getHtmlViewerConfigSpy.mockResolvedValue([]);
+
+    const initialProps = generateProps();
+    initialProps.location.search = `?${QUERY_PARAMS.runlist}=${ORIGINAL_ROUTE_RUN_ID}`;
+
+    const renderResult = render(
+      <CommonTestWrapper>
+        <CompareV2 {...initialProps} />
+      </CommonTestWrapper>,
+    );
+    await waitForRunCheckboxes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'HTML' }));
+    fireEvent.click(await screen.findByText('Choose a first HTML artifact', { timeout: 10000 }));
+    fireEvent.mouseEnter(screen.getAllByText(SHARED_RUN_NAME)[1]);
+    fireEvent.click(screen.getByLabelText(`${SHARED_EXECUTION_NAME} > ${SHARED_ARTIFACT_NAME}`));
+
+    await waitFor(() => {
+      const lastCall = getHtmlViewerConfigSpy.mock.lastCall;
+      expect(lastCall?.[0]?.[0]?.artifact.getId()).toBe(originalArtifact.getId());
+      expect(lastCall?.[1]).toBeUndefined();
+    });
+
+    const nextProps = generateProps();
+    nextProps.location.search = `?${QUERY_PARAMS.runlist}=${UPDATED_ROUTE_RUN_ID}`;
+    renderResult.rerender(
+      <CommonTestWrapper>
+        <CompareV2 {...nextProps} />
+      </CommonTestWrapper>,
+    );
+
+    await TestUtils.flushPromises();
+    await waitFor(() => {
+      const lastCall = getHtmlViewerConfigSpy.mock.lastCall;
+      expect(lastCall?.[0]?.[0]?.artifact.getId()).toBe(updatedArtifact.getId());
+      expect(lastCall?.[1]).toBeUndefined();
+    });
   });
 
   it('Parameters and Scalar metrics tab initially enabled with loading then error, and switch tabs', async () => {

--- a/frontend/src/pages/CompareV2.tsx
+++ b/frontend/src/pages/CompareV2.tsx
@@ -251,6 +251,18 @@ interface RocCurveSelectionState {
   lineColorsStack: string[];
 }
 
+function useKeyedState<T>(key: string, initialValue: T): [T, (value: T) => void] {
+  const [stateKey, setStateKey] = useState(key);
+  const [value, setValue] = useState(initialValue);
+
+  if (stateKey !== key) {
+    setStateKey(key);
+    setValue(initialValue);
+  }
+
+  return [value, setValue];
+}
+
 const createSelectedArtifactArray = (count: number): SelectedArtifact[] => {
   const array: SelectedArtifact[] = [];
   for (let i = 0; i < count; i++) {
@@ -434,12 +446,14 @@ function CompareV2(props: CompareV2Props) {
   const { updateBanner, updateToolbar, namespace } = props;
 
   const runlistRef = useRef<RunList>(null);
-  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const queryParamRunIds = new URLParser(props).get(QUERY_PARAMS.runlist);
+  const runIds = (queryParamRunIds && queryParamRunIds.split(',')) || [];
+  const runIdsKey = runIds.join(',');
+  const [selectedIds, setSelectedIds] = useKeyedState<string[]>(runIdsKey, runIds);
   const [metricsTab, setMetricsTab] = useState(MetricsType.SCALAR_METRICS);
   const [isOverviewCollapsed, setIsOverviewCollapsed] = useState(false);
   const [isParamsCollapsed, setIsParamsCollapsed] = useState(false);
   const [isMetricsCollapsed, setIsMetricsCollapsed] = useState(false);
-  const selectionRunIdsKeyRef = useRef<string>('');
   const [rocCurveSelection, setRocCurveSelection] = useState<RocCurveSelectionState>(
     createInitialRocCurveSelectionState,
   );
@@ -448,9 +462,6 @@ function CompareV2(props: CompareV2Props) {
   const [selectedArtifactsMap, setSelectedArtifactsMap] = useState<{
     [key: string]: SelectedArtifact[];
   }>(createInitialSelectedArtifactsMap);
-
-  const queryParamRunIds = new URLParser(props).get(QUERY_PARAMS.runlist);
-  const runIds = (queryParamRunIds && queryParamRunIds.split(',')) || [];
 
   // Retrieves run details.
   const {
@@ -663,23 +674,6 @@ function CompareV2(props: CompareV2Props) {
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useEffect(() => {
-    if (runs) {
-      const nextRunIds = runs.map((run) => run.run_id!).filter((id): id is string => !!id);
-      const nextRunIdsKey = nextRunIds.join(',');
-      const routeChanged = selectionRunIdsKeyRef.current !== nextRunIdsKey;
-      selectionRunIdsKeyRef.current = nextRunIdsKey;
-
-      setSelectedIds((currentSelectedIds) => {
-        if (routeChanged) {
-          return nextRunIds;
-        }
-        const nextRunIdsSet = new Set(nextRunIds);
-        return currentSelectedIds.filter((id) => nextRunIdsSet.has(id));
-      });
-    }
-  }, [runs]);
 
   const paramsTableProps = useMemo(() => {
     if (!runs) {

--- a/frontend/src/pages/CompareV2.tsx
+++ b/frontend/src/pages/CompareV2.tsx
@@ -36,6 +36,7 @@ import {
 } from 'src/mlmd/MlmdUtils';
 import { useArtifactTypes } from 'src/hooks/useArtifactTypes';
 import { queryKeys } from 'src/hooks/queryKeys';
+import { useKeyedState } from 'src/hooks/useKeyedState';
 import { Artifact, ArtifactType, Event, Execution } from 'src/third_party/mlmd';
 import { PageProps } from './Page';
 import RunList from './RunList';
@@ -251,18 +252,6 @@ interface RocCurveSelectionState {
   lineColorsStack: string[];
 }
 
-function useKeyedState<T>(key: string, initialValue: T): [T, (value: T) => void] {
-  const [stateKey, setStateKey] = useState(key);
-  const [value, setValue] = useState(initialValue);
-
-  if (stateKey !== key) {
-    setStateKey(key);
-    setValue(initialValue);
-  }
-
-  return [value, setValue];
-}
-
 const createSelectedArtifactArray = (count: number): SelectedArtifact[] => {
   const array: SelectedArtifact[] = [];
   for (let i = 0; i < count; i++) {
@@ -449,7 +438,7 @@ function CompareV2(props: CompareV2Props) {
   const queryParamRunIds = new URLParser(props).get(QUERY_PARAMS.runlist);
   const runIds = (queryParamRunIds && queryParamRunIds.split(',')) || [];
   const runIdsKey = runIds.join(',');
-  const [selectedIds, setSelectedIds] = useKeyedState<string[]>(runIdsKey, runIds);
+  const [selectedIdsState, setSelectedIds] = useKeyedState<string[]>(runIdsKey, runIds);
   const [metricsTab, setMetricsTab] = useState(MetricsType.SCALAR_METRICS);
   const [isOverviewCollapsed, setIsOverviewCollapsed] = useState(false);
   const [isParamsCollapsed, setIsParamsCollapsed] = useState(false);
@@ -513,6 +502,15 @@ function CompareV2(props: CompareV2Props) {
     isError: isErrorArtifactTypes,
     error: errorArtifactTypes,
   } = useArtifactTypes();
+
+  const selectedIds = useMemo(() => {
+    if (!runs) {
+      return selectedIdsState;
+    }
+
+    const validRunIds = new Set(runs.map((run) => run.run_id).filter((id): id is string => !!id));
+    return selectedIdsState.filter((id) => validRunIds.has(id));
+  }, [runs, selectedIdsState]);
 
   const metricsArtifactData = useMemo<DerivedMetricsArtifacts | undefined>(() => {
     if (!(runs && mlmdPackages && artifactTypes)) {

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -24,7 +24,7 @@ import {
   Radio,
   Checkbox,
 } from '@mui/material';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import * as JsYaml from 'js-yaml';
 import { useMutation } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
@@ -44,6 +44,7 @@ import { QUERY_PARAMS, RoutePage, RouteParams } from 'src/components/Router';
 import Trigger from 'src/components/Trigger';
 import { color, commonCss, padding } from 'src/Css';
 import { Apis, ExperimentSortKeys, PipelineSortKeys, PipelineVersionSortKeys } from 'src/lib/Apis';
+import { useKeyedState } from 'src/hooks/useKeyedState';
 import {
   getInitialParameterState,
   type RuntimeParameters,
@@ -98,7 +99,6 @@ interface RunV2Props {
 type NewRunV2Props = RunV2Props & PageProps;
 
 export type { RuntimeParameters, SpecParameters } from 'src/lib/NewRunParametersUtils';
-type KeyedState<T> = { key: string; value: T };
 
 const hashString64 = (value: string): string => {
   let first = 0x9e3779b1;
@@ -141,14 +141,6 @@ const getTemplateData = (templateString?: string) => {
     return getEmptyTemplateData();
   }
 };
-
-function useKeyedState<T>(key: string, initialValue: T) {
-  const [state, setState] = useState<KeyedState<T>>({ key: '', value: initialValue });
-  const value = state.key === key ? state.value : initialValue;
-  const setValue = useCallback((value: T) => setState({ key, value }), [key]);
-
-  return [value, setValue] as const;
-}
 
 type CloneOrigin = {
   isClone: boolean;


### PR DESCRIPTION
## Summary
- make `MetricsDropdown` fully controlled by `selectedArtifacts` props instead of mirroring those props into local component state
- key `CompareV2` run selection off the route `runlist` so the page no longer repairs `selectedIds` from fetched `runs`
- add a controlled-rerender regression in `MetricsDropdown.test.tsx` and keep the existing compare selection tests green

## Why
This is the next useEffect cleanup slice after the recent `NewRun` work.

The remaining compare selection flow still had two derived-state patterns:
- `MetricsDropdown` copied `selectedArtifacts` props into local state with an effect
- `CompareV2` used an effect to reset `selectedIds` after render based on fetched run data

The new version keeps selection ownership in the parent/page path and limits the remaining effects in this area to actual external sync.

## Verification
- `cd frontend && fnm exec --using .nvmrc -- npx prettier@3.8.1 --check src/components/viewers/MetricsDropdown.tsx src/components/viewers/MetricsDropdown.test.tsx src/pages/CompareV2.tsx src/pages/CompareV2.test.tsx`
- `cd frontend && fnm exec --using .nvmrc -- npm run test:ui -- src/components/viewers/MetricsDropdown.test.tsx src/pages/CompareV2.test.tsx`
- `cd frontend && fnm exec --using .nvmrc -- npm run typecheck`
- `cd frontend && fnm exec --using .nvmrc -- npm run lint`

## Notes
The focused test run still emits pre-existing React `act(...)` warnings in the compare/visualization tests, but the suites pass.
