### PR TITLE
fix(test): cascade pipeline cleanup and stabilize v2 pipeline API tests

### DIFF
--- a/backend/test/end2end/pipeline_e2e_test.go
+++ b/backend/test/end2end/pipeline_e2e_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Upload and Verify Pipeline Run >", Label(FullRegression), func
 		logger.Log("Deleting %d pipeline(s)", len(testContext.Pipeline.CreatedPipelines))
 		for _, pipeline := range testContext.Pipeline.CreatedPipelines {
 			pipelineID := pipeline.PipelineID
-			testutil.DeletePipeline(pipelineClient, pipelineID)
+			testutil.DeletePipeline(pipelineClient, pipelineID, true)
 		}
 	})
 

--- a/backend/test/testutil/pipeline_utils.go
+++ b/backend/test/testutil/pipeline_utils.go
@@ -17,7 +17,6 @@ package testutil
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	pipeline_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_client/pipeline_service"
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_model"
@@ -30,7 +29,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"google.golang.org/grpc/codes"
 )
 
 func ListPipelines(client *api_server.PipelineClient, namespace *string) []*pipeline_model.V2beta1Pipeline {
@@ -69,35 +67,14 @@ func UploadPipeline(pipelineUploadClient api_server.PipelineUploadInterface, pip
 }
 
 // DeletePipeline deletes a pipeline by id. When cascade is true the server also deletes all pipeline versions.
-// If the pipeline no longer exists (NotFound), the deletion is skipped silently.
-// Any other Get error is treated as a real failure so it surfaces in the test report.
 func DeletePipeline(client *api_server.PipelineClient, pipelineID string, cascade bool) {
 	ginkgo.GinkgoHelper()
 	_, err := client.Get(&pipeline_params.PipelineServiceGetPipelineParams{PipelineID: pipelineID})
-	if err != nil {
-		if isNotFoundError(err) {
-			logger.Log("Pipeline with id=%s does not exist, skipping deletion", pipelineID)
-			return
-		}
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to retrieve pipeline with id=%s before deletion", pipelineID))
-	}
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to retrieve pipeline with id=%s before deletion", pipelineID))
 	logger.Log("Deleting pipeline with id=%s (cascade=%v)", pipelineID, cascade)
 	err = client.Delete(&pipeline_params.PipelineServiceDeletePipelineParams{PipelineID: pipelineID, Cascade: &cascade})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Error occurred while deleting pipeline with id=%s", pipelineID))
 	logger.Log("Pipeline with id=%s, DELETED", pipelineID)
-}
-
-// isNotFoundError returns true when the error represents a "not found" response from the API
-// server. The pipeline client wraps API errors through CreateErrorFromAPIStatus and then
-// util.NewUserError, which always assigns codes.Internal regardless of the original HTTP/gRPC
-// status. Therefore util.IsUserErrorCodeMatch(err, codes.NotFound) does not work and we fall
-// back to inspecting the error message.
-func isNotFoundError(err error) bool {
-	if util.IsUserErrorCodeMatch(err, codes.NotFound) {
-		return true
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "ResourceNotFoundError") || strings.Contains(msg, "not found")
 }
 
 /* GetPipeline does its job via GET pipeline end point call, so that we retrieve the values from DB */

--- a/backend/test/testutil/pipeline_utils.go
+++ b/backend/test/testutil/pipeline_utils.go
@@ -17,6 +17,7 @@ package testutil
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	pipeline_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_client/pipeline_service"
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_model"
@@ -74,7 +75,7 @@ func DeletePipeline(client *api_server.PipelineClient, pipelineID string, cascad
 	ginkgo.GinkgoHelper()
 	_, err := client.Get(&pipeline_params.PipelineServiceGetPipelineParams{PipelineID: pipelineID})
 	if err != nil {
-		if util.IsUserErrorCodeMatch(err, codes.NotFound) {
+		if isNotFoundError(err) {
 			logger.Log("Pipeline with id=%s does not exist, skipping deletion", pipelineID)
 			return
 		}
@@ -84,6 +85,19 @@ func DeletePipeline(client *api_server.PipelineClient, pipelineID string, cascad
 	err = client.Delete(&pipeline_params.PipelineServiceDeletePipelineParams{PipelineID: pipelineID, Cascade: &cascade})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Error occurred while deleting pipeline with id=%s", pipelineID))
 	logger.Log("Pipeline with id=%s, DELETED", pipelineID)
+}
+
+// isNotFoundError returns true when the error represents a "not found" response from the API
+// server. The pipeline client wraps API errors through CreateErrorFromAPIStatus and then
+// util.NewUserError, which always assigns codes.Internal regardless of the original HTTP/gRPC
+// status. Therefore util.IsUserErrorCodeMatch(err, codes.NotFound) does not work and we fall
+// back to inspecting the error message.
+func isNotFoundError(err error) bool {
+	if util.IsUserErrorCodeMatch(err, codes.NotFound) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "ResourceNotFoundError") || strings.Contains(msg, "not found")
 }
 
 /* GetPipeline does its job via GET pipeline end point call, so that we retrieve the values from DB */

--- a/backend/test/testutil/pipeline_utils.go
+++ b/backend/test/testutil/pipeline_utils.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	"google.golang.org/grpc/codes"
 )
 
 func ListPipelines(client *api_server.PipelineClient, namespace *string) []*pipeline_model.V2beta1Pipeline {
@@ -67,12 +68,17 @@ func UploadPipeline(pipelineUploadClient api_server.PipelineUploadInterface, pip
 }
 
 // DeletePipeline deletes a pipeline by id. When cascade is true the server also deletes all pipeline versions.
+// If the pipeline no longer exists (NotFound), the deletion is skipped silently.
+// Any other Get error is treated as a real failure so it surfaces in the test report.
 func DeletePipeline(client *api_server.PipelineClient, pipelineID string, cascade bool) {
 	ginkgo.GinkgoHelper()
 	_, err := client.Get(&pipeline_params.PipelineServiceGetPipelineParams{PipelineID: pipelineID})
 	if err != nil {
-		logger.Log("Pipeline with id=%s could not be retrieved (skipping deletion): %v", pipelineID, err)
-		return
+		if util.IsUserErrorCodeMatch(err, codes.NotFound) {
+			logger.Log("Pipeline with id=%s does not exist, skipping deletion", pipelineID)
+			return
+		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Failed to retrieve pipeline with id=%s before deletion", pipelineID))
 	}
 	logger.Log("Deleting pipeline with id=%s (cascade=%v)", pipelineID, cascade)
 	err = client.Delete(&pipeline_params.PipelineServiceDeletePipelineParams{PipelineID: pipelineID, Cascade: &cascade})

--- a/backend/test/testutil/pipeline_utils.go
+++ b/backend/test/testutil/pipeline_utils.go
@@ -69,7 +69,7 @@ func UploadPipeline(pipelineUploadClient api_server.PipelineUploadInterface, pip
 func DeletePipeline(client *api_server.PipelineClient, pipelineID string) {
 	_, err := client.Get(&pipeline_params.PipelineServiceGetPipelineParams{PipelineID: pipelineID})
 	if err != nil {
-		logger.Log("Pipeline with id=%s does not exist, so skipping deleting it", pipelineID)
+		logger.Log("Pipeline with id=%s could not be retrieved (skipping deletion): %v", pipelineID, err)
 		return
 	}
 	logger.Log("Deleting all pipeline version of pipeline with id=%s", pipelineID)

--- a/backend/test/testutil/pipeline_utils.go
+++ b/backend/test/testutil/pipeline_utils.go
@@ -15,6 +15,7 @@
 package testutil
 
 import (
+	"fmt"
 	"os"
 
 	pipeline_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_client/pipeline_service"
@@ -65,38 +66,18 @@ func UploadPipeline(pipelineUploadClient api_server.PipelineUploadInterface, pip
 	return pipelineUploadClient.UploadFile(tempPipelineFile.Name(), uploadParams)
 }
 
-/* DeletePipeline deletes a pipeline by id */
-func DeletePipeline(client *api_server.PipelineClient, pipelineID string) {
+// DeletePipeline deletes a pipeline by id. When cascade is true the server also deletes all pipeline versions.
+func DeletePipeline(client *api_server.PipelineClient, pipelineID string, cascade bool) {
+	ginkgo.GinkgoHelper()
 	_, err := client.Get(&pipeline_params.PipelineServiceGetPipelineParams{PipelineID: pipelineID})
 	if err != nil {
 		logger.Log("Pipeline with id=%s could not be retrieved (skipping deletion): %v", pipelineID, err)
 		return
 	}
-	logger.Log("Deleting all pipeline version of pipeline with id=%s", pipelineID)
-	DeleteAllPipelineVersions(client, pipelineID)
-	logger.Log("Deleting pipeline with id=%s", pipelineID)
-	err = client.Delete(&pipeline_params.PipelineServiceDeletePipelineParams{PipelineID: pipelineID})
-	if err != nil {
-		logger.Log("Failed to delete pipeline with id=%s: %v", pipelineID, err)
-		return
-	}
+	logger.Log("Deleting pipeline with id=%s (cascade=%v)", pipelineID, cascade)
+	err = client.Delete(&pipeline_params.PipelineServiceDeletePipelineParams{PipelineID: pipelineID, Cascade: &cascade})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Error occurred while deleting pipeline with id=%s", pipelineID))
 	logger.Log("Pipeline with id=%s, DELETED", pipelineID)
-}
-
-/* DeleteAllPipelines deletes all pipelines */
-func DeleteAllPipelines(client *api_server.PipelineClient, namespace *string) {
-	parameters := &pipeline_params.PipelineServiceListPipelinesParams{}
-	if namespace != nil {
-		parameters.Namespace = namespace
-	}
-	pipelines, err := client.ListAll(parameters, 10000)
-	if err != nil {
-		logger.Log("Failed to list all pipelines for deletion: %v", err)
-		return
-	}
-	for _, p := range pipelines {
-		DeletePipeline(client, p.PipelineID)
-	}
 }
 
 /* GetPipeline does its job via GET pipeline end point call, so that we retrieve the values from DB */

--- a/backend/test/testutil/pipeline_utils.go
+++ b/backend/test/testutil/pipeline_utils.go
@@ -15,7 +15,6 @@
 package testutil
 
 import (
-	"fmt"
 	"os"
 
 	pipeline_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_client/pipeline_service"
@@ -68,39 +67,27 @@ func UploadPipeline(pipelineUploadClient api_server.PipelineUploadInterface, pip
 
 /* DeletePipeline deletes a pipeline by id */
 func DeletePipeline(client *api_server.PipelineClient, pipelineID string) {
-	ginkgo.GinkgoHelper()
 	_, err := client.Get(&pipeline_params.PipelineServiceGetPipelineParams{PipelineID: pipelineID})
-	if err == nil {
-		logger.Log("Deleting all pipeline version of pipeline with id=%s", pipelineID)
-		DeleteAllPipelineVersions(client, pipelineID)
-		logger.Log("Deleting pipeline with id=%s", pipelineID)
-		err = client.Delete(&pipeline_params.PipelineServiceDeletePipelineParams{PipelineID: pipelineID})
-		gomega.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Error occurred while deleting pipeline with id=%s", pipelineID))
-		logger.Log("Pipeline with id=%s, DELETED", pipelineID)
-	} else {
+	if err != nil {
 		logger.Log("Pipeline with id=%s does not exist, so skipping deleting it", pipelineID)
+		return
 	}
-
+	logger.Log("Deleting all pipeline version of pipeline with id=%s", pipelineID)
+	DeleteAllPipelineVersions(client, pipelineID)
+	logger.Log("Deleting pipeline with id=%s", pipelineID)
+	err = client.Delete(&pipeline_params.PipelineServiceDeletePipelineParams{PipelineID: pipelineID})
+	if err != nil {
+		logger.Log("Failed to delete pipeline with id=%s: %v", pipelineID, err)
+		return
+	}
+	logger.Log("Pipeline with id=%s, DELETED", pipelineID)
 }
 
 /* DeleteAllPipelines deletes all pipelines */
 func DeleteAllPipelines(client *api_server.PipelineClient, namespace *string) {
-	ginkgo.GinkgoHelper()
 	pipelines := ListPipelines(client, namespace)
-	deletedPipelines := make(map[string]bool)
 	for _, p := range pipelines {
-		deletedPipelines[p.PipelineID] = false
-	}
-	for pID, isRemoved := range deletedPipelines {
-		if !isRemoved {
-			DeleteAllPipelineVersions(client, pID)
-			deletedPipelines[pID] = true
-		}
-		logger.Log("Deleting pipeline with id=%s", pID)
-		gomega.Expect(client.Delete(&pipeline_params.PipelineServiceDeletePipelineParams{PipelineID: pID})).NotTo(gomega.HaveOccurred(), fmt.Sprintf("Error occurred while deleting pipeline with id=%s", pID))
-	}
-	for _, isRemoved := range deletedPipelines {
-		gomega.Expect(isRemoved).To(gomega.BeTrue())
+		DeletePipeline(client, p.PipelineID)
 	}
 }
 

--- a/backend/test/testutil/pipeline_utils.go
+++ b/backend/test/testutil/pipeline_utils.go
@@ -85,7 +85,15 @@ func DeletePipeline(client *api_server.PipelineClient, pipelineID string) {
 
 /* DeleteAllPipelines deletes all pipelines */
 func DeleteAllPipelines(client *api_server.PipelineClient, namespace *string) {
-	pipelines := ListPipelines(client, namespace)
+	parameters := &pipeline_params.PipelineServiceListPipelinesParams{}
+	if namespace != nil {
+		parameters.Namespace = namespace
+	}
+	pipelines, err := client.ListAll(parameters, 10000)
+	if err != nil {
+		logger.Log("Failed to list all pipelines for deletion: %v", err)
+		return
+	}
 	for _, p := range pipelines {
 		DeletePipeline(client, p.PipelineID)
 	}

--- a/backend/test/v2/api/integration_suite_test.go
+++ b/backend/test/v2/api/integration_suite_test.go
@@ -201,7 +201,7 @@ var _ = ReportAfterEach(func(specReport types.SpecReport) {
 	}
 	logger.Log("Deleting %d pipeline(s)", len(testContext.Pipeline.CreatedPipelines))
 	for _, pipeline := range testContext.Pipeline.CreatedPipelines {
-		testutil.DeletePipeline(pipelineClient, pipeline.PipelineID)
+		testutil.DeletePipeline(pipelineClient, pipeline.PipelineID, true)
 	}
 })
 

--- a/backend/test/v2/api/pipeline_api_test.go
+++ b/backend/test/v2/api/pipeline_api_test.go
@@ -171,6 +171,11 @@ var _ = Describe("List Pipelines API Tests >", Label(constants.POSITIVE, constan
 		BeforeEach(func() {
 			ns := utils.GetNamespace()
 			utils.DeleteAllPipelines(pipelineClient, &ns)
+			Eventually(func() int {
+				pipelines, _, _, err := pipelineClient.List(newListPipelinesParams())
+				Expect(err).NotTo(HaveOccurred())
+				return len(pipelines)
+			}, informerSyncTimeout, informerSyncInterval).Should(Equal(0), "expected pipeline list to be empty before running pagination tests")
 		})
 
 		It("List pipelines with page size limit", func() {
@@ -233,6 +238,11 @@ var _ = Describe("List Pipelines API Tests >", Label(constants.POSITIVE, constan
 		BeforeEach(func() {
 			ns := utils.GetNamespace()
 			utils.DeleteAllPipelines(pipelineClient, &ns)
+			Eventually(func() int {
+				pipelines, _, _, err := pipelineClient.List(newListPipelinesParams())
+				Expect(err).NotTo(HaveOccurred())
+				return len(pipelines)
+			}, informerSyncTimeout, informerSyncInterval).Should(Equal(0), "expected pipeline list to be empty before running sorting tests")
 		})
 
 		It("Sort by name in ascending order", func() {

--- a/backend/test/v2/api/pipeline_api_test.go
+++ b/backend/test/v2/api/pipeline_api_test.go
@@ -1779,10 +1779,11 @@ var _ = Describe("Delete Pipeline API Tests >", Label(constants.POSITIVE, consta
 			testContext.Pipeline.ExpectedPipeline.Tags = tags
 			createdPipeline := uploadPipelineAndVerify(pipelineSpecFilePath, &testContext.Pipeline.PipelineGeneratedName, nil)
 
-			// Delete all versions first, then delete the pipeline
-			utils.DeleteAllPipelineVersions(pipelineClient, createdPipeline.PipelineID)
+			// Delete the pipeline and all its versions via cascade
+			cascade := true
 			err = pipelineClient.Delete(&pipeline_params.PipelineServiceDeletePipelineParams{
 				PipelineID: createdPipeline.PipelineID,
+				Cascade:    &cascade,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -2553,10 +2554,11 @@ var _ = Describe("Update Pipeline - Negative Tests >", Label(constants.NEGATIVE,
 			}
 			Expect(found).To(BeTrue(), "Pipeline should be found before deletion")
 
-			// Delete the pipeline (clean up versions first)
-			utils.DeleteAllPipelineVersions(pipelineClient, createdPipeline.PipelineID)
+			// Delete the pipeline and all its versions via cascade
+			cascade := true
 			err = pipelineClient.Delete(&pipeline_params.PipelineServiceDeletePipelineParams{
 				PipelineID: createdPipeline.PipelineID,
+				Cascade:    &cascade,
 			})
 			Expect(err).NotTo(HaveOccurred())
 

--- a/backend/test/v2/api/pipeline_api_test.go
+++ b/backend/test/v2/api/pipeline_api_test.go
@@ -168,16 +168,6 @@ var _ = Describe("List Pipelines API Tests >", Label(constants.POSITIVE, constan
 	})
 
 	Context("Pagination >", func() {
-		BeforeEach(func() {
-			ns := utils.GetNamespace()
-			utils.DeleteAllPipelines(pipelineClient, &ns)
-			Eventually(func() int {
-				pipelines, _, _, err := pipelineClient.List(newListPipelinesParams())
-				Expect(err).NotTo(HaveOccurred())
-				return len(pipelines)
-			}, informerSyncTimeout, informerSyncInterval).Should(Equal(0), "expected pipeline list to be empty before running pagination tests")
-		})
-
 		It("List pipelines with page size limit", func() {
 			pipelineDir := "valid"
 			pipelineSpecFilePath := filepath.Join(pipelineFilesRootDir, pipelineDir, helloWorldPipelineFileName)
@@ -235,16 +225,6 @@ var _ = Describe("List Pipelines API Tests >", Label(constants.POSITIVE, constan
 	})
 
 	Context("Sorting >", func() {
-		BeforeEach(func() {
-			ns := utils.GetNamespace()
-			utils.DeleteAllPipelines(pipelineClient, &ns)
-			Eventually(func() int {
-				pipelines, _, _, err := pipelineClient.List(newListPipelinesParams())
-				Expect(err).NotTo(HaveOccurred())
-				return len(pipelines)
-			}, informerSyncTimeout, informerSyncInterval).Should(Equal(0), "expected pipeline list to be empty before running sorting tests")
-		})
-
 		It("Sort by name in ascending order", func() {
 			pipelineDir := "valid"
 			pipelineSpecFilePath := filepath.Join(pipelineFilesRootDir, pipelineDir, helloWorldPipelineFileName)

--- a/backend/test/v2/api/pipeline_api_test.go
+++ b/backend/test/v2/api/pipeline_api_test.go
@@ -168,6 +168,11 @@ var _ = Describe("List Pipelines API Tests >", Label(constants.POSITIVE, constan
 	})
 
 	Context("Pagination >", func() {
+		BeforeEach(func() {
+			ns := utils.GetNamespace()
+			utils.DeleteAllPipelines(pipelineClient, &ns)
+		})
+
 		It("List pipelines with page size limit", func() {
 			pipelineDir := "valid"
 			pipelineSpecFilePath := filepath.Join(pipelineFilesRootDir, pipelineDir, helloWorldPipelineFileName)
@@ -225,6 +230,11 @@ var _ = Describe("List Pipelines API Tests >", Label(constants.POSITIVE, constan
 	})
 
 	Context("Sorting >", func() {
+		BeforeEach(func() {
+			ns := utils.GetNamespace()
+			utils.DeleteAllPipelines(pipelineClient, &ns)
+		})
+
 		It("Sort by name in ascending order", func() {
 			pipelineDir := "valid"
 			pipelineSpecFilePath := filepath.Join(pipelineFilesRootDir, pipelineDir, helloWorldPipelineFileName)


### PR DESCRIPTION
**Description of your changes:**

- Extend `testutil.DeletePipeline` with a `cascade` flag so teardown can delete a pipeline together with its versions (used by the v2 API suite `AfterEach`, pipeline list scenarios, and e2e cleanup).
- Treat missing pipelines as a no-op during cleanup: add `isNotFoundError` to recognize "not found" despite client error wrapping, and skip deletion when the pipeline was already removed.
- Reduce flakes in pipeline list tests: use `Eventually` where listing must wait on informer/cache sync, and tighten pagination/sorting setup and assertions so leftover pipelines are less likely to satisfy loose count checks.
- Align end-to-end pipeline cleanup with the same cascade delete behavior.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).