### PR TITLE
fix: use is/is not None in sagemaker spec_input_parsers (E711)

### DIFF
--- a/components/aws/sagemaker/commonv2/spec_input_parsers.py
+++ b/components/aws/sagemaker/commonv2/spec_input_parsers.py
@@ -25,7 +25,7 @@ class SpecInputParsers:
 
     @staticmethod
     def _yaml_or_json_str(value):
-        if value == "" or value == None:
+        if value == "" or value is None:
             return None
         try:
             return json.loads(value)


### PR DESCRIPTION
## Summary

PEP 8 recommends using `is None` / `is not None` rather than `== None` / `!= None` for `None` comparisons. Using `is` compares identity (the correct semantics for the `None` singleton) and avoids an unnecessary `__eq__` dispatch. This is also flagged by flake8 rule E711.

**Change:**
```python
# Before
if x == None:
    ...

# After
if x is None:
    ...
```

## Testing
No behavior change — `None` is a singleton, so `x is None` and `x == None` are equivalent; the `is` form is the PEP 8 / E711 idiom.
