### PR TITLE
refactor(frontend): centralize flushPromisesInAct and invokeAndFlush in TestUtils

### DIFF
--- a/frontend/src/TestUtils.ts
+++ b/frontend/src/TestUtils.ts
@@ -18,6 +18,7 @@
 // Because this is test utils.
 
 import 'src/build/tailwind.output.css';
+import { act } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import { match } from 'react-router';
 import { beforeEach, expect, MockInstance } from 'vitest';
@@ -125,6 +126,27 @@ function getTestApi() {
     throw new Error('Vitest API (vi) not found');
   }
   return testApi;
+}
+
+/**
+ * Wraps {@link TestUtils.flushPromises} inside `act()` so React state
+ * updates triggered by resolved promises are applied without warnings.
+ */
+export async function flushPromisesInAct(): Promise<void> {
+  await act(async () => {
+    await TestUtils.flushPromises();
+  });
+}
+
+/**
+ * Runs `callback` and then flushes pending promises, all inside a
+ * single `act()` boundary.
+ */
+export async function invokeAndFlush(callback: () => void | Promise<void>): Promise<void> {
+  await act(async () => {
+    await callback();
+    await TestUtils.flushPromises();
+  });
 }
 
 export function expectWarnings() {

--- a/frontend/src/components/CustomTable.test.tsx
+++ b/frontend/src/components/CustomTable.test.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import CustomTable, { Column, ExpandState, Row } from './CustomTable';
-import TestUtils from '../TestUtils';
+import TestUtils, { flushPromisesInAct, invokeAndFlush } from '../TestUtils';
 import { V2beta1PredicateOperation } from '../apisv2beta1/filter';
 import { logger } from 'src/lib/Utils';
 
@@ -130,19 +130,6 @@ function getRowsPerPageCombobox(): HTMLElement {
     throw new Error('Unable to locate table footer containing the rows-per-page selector');
   }
   return within(footer).getByRole('combobox');
-}
-
-async function flushPromisesInAct(): Promise<void> {
-  await act(async () => {
-    await TestUtils.flushPromises();
-  });
-}
-
-async function invokeAndFlush(callback: () => void | Promise<void>): Promise<void> {
-  await act(async () => {
-    await callback();
-    await TestUtils.flushPromises();
-  });
 }
 
 async function selectRowsPerPage(pageSize: number): Promise<void> {
@@ -590,7 +577,7 @@ describe('CustomTable', () => {
     wrapper.unmount();
   });
 
-  it('calls reload with a different page size, resets page token list when rows/page changes', async () => {
+  it('reloads with new page size and appends next-page token when rows/page changes', async () => {
     const reloadResult = Promise.resolve('some token');
     const spy = vi.fn(() => reloadResult);
     const wrapper = renderTable({ rows: [], columns, reload: spy });
@@ -606,7 +593,7 @@ describe('CustomTable', () => {
     wrapper.unmount();
   });
 
-  it('calls reload with a different page size, resets page token list when rows/page changes', async () => {
+  it('reloads with new page size and resets token list when no next page exists', async () => {
     const reloadResult = Promise.resolve('');
     const spy = vi.fn(() => reloadResult);
     const wrapper = renderTable({ rows: [], columns, reload: spy });

--- a/frontend/src/pages/ExperimentDetails.test.tsx
+++ b/frontend/src/pages/ExperimentDetails.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import EnhancedExperimentDetails, { ExperimentDetails } from './ExperimentDetails';
-import TestUtils from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct, invokeAndFlush } from 'src/TestUtils';
 import { V2beta1Experiment, V2beta1ExperimentStorageState } from 'src/apisv2beta1/experiment';
 import { Apis } from 'src/lib/Apis';
 import { PageProps } from './Page';
@@ -23,7 +23,7 @@ import { RoutePage, RouteParams, QUERY_PARAMS } from 'src/components/Router';
 import { range } from 'lodash';
 import { ButtonKeys } from 'src/lib/Buttons';
 import { CommonTestWrapper } from 'src/TestWrapper';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { NamespaceContext } from 'src/lib/KubeflowClient';
 import { Router } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
@@ -92,19 +92,6 @@ describe('ExperimentDetails', () => {
     );
     await flushPromisesInAct();
     return utils;
-  }
-
-  async function flushPromisesInAct(): Promise<void> {
-    await act(async () => {
-      await TestUtils.flushPromises();
-    });
-  }
-
-  async function invokeAndFlush(callback: () => void | Promise<void>): Promise<void> {
-    await act(async () => {
-      await callback();
-      await TestUtils.flushPromises();
-    });
   }
 
   async function waitForExperimentLoad(): Promise<void> {

--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { ImportMethod, NewPipelineVersion } from './NewPipelineVersion';
-import TestUtils from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct } from 'src/TestUtils';
 import { PageProps } from './Page';
 import { Apis } from 'src/lib/Apis';
 import { RoutePage, QUERY_PARAMS } from 'src/components/Router';
@@ -124,12 +124,6 @@ describe('NewPipelineVersion', () => {
     const props = { ...generateProps(search), ...propsPatch } as PageProps;
     renderResult = render(<TestNewPipelineVersion ref={pipelineVersionRef} {...props} />);
     await flushPromisesInAct();
-  }
-
-  async function flushPromisesInAct(): Promise<void> {
-    await act(async () => {
-      await TestUtils.flushPromises();
-    });
   }
 
   beforeEach(() => {

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -17,7 +17,7 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { NewRun } from 'src/pages/NewRun';
-import TestUtils from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct, invokeAndFlush } from 'src/TestUtils';
 import { PageProps } from 'src/pages/Page';
 import { Apis } from 'src/lib/Apis';
 import { RoutePage, RouteParams, QUERY_PARAMS } from 'src/components/Router';
@@ -183,19 +183,6 @@ async function renderNewRunElement(
     throw new Error('NewRun instance is not available');
   }
   return new NewRunWrapper(newRunRef.current, result);
-}
-
-async function flushPromisesInAct(): Promise<void> {
-  await act(async () => {
-    await TestUtils.flushPromises();
-  });
-}
-
-async function invokeAndFlush(callback: () => void): Promise<void> {
-  await act(async () => {
-    callback();
-    await TestUtils.flushPromises();
-  });
 }
 
 async function clickAndFlush(element: HTMLElement): Promise<void> {

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -31,7 +31,7 @@ import { OutputArtifactLoader } from 'src/lib/OutputArtifactLoader';
 import { NodePhase } from 'src/lib/StatusUtils';
 import * as Utils from 'src/lib/Utils';
 import WorkflowParser from 'src/lib/WorkflowParser';
-import TestUtils, { testBestPractices } from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct, testBestPractices } from 'src/TestUtils';
 import { PageProps } from './Page';
 import EnhancedRunDetails, { RunDetailsInternalProps, SidePanelTab, TEST_ONLY } from './RunDetails';
 import { Context, Execution, GetArtifactTypesResponse, Value } from 'src/third_party/mlmd';
@@ -1618,9 +1618,7 @@ describe('RunDetails', () => {
           </NamespaceContext.Provider>
         </Router>,
       );
-      await act(async () => {
-        await TestUtils.flushPromises();
-      });
+      await flushPromisesInAct();
       expect(history.location.pathname).toEqual('/initial-path');
       await act(async () => {
         rerender(
@@ -1646,9 +1644,7 @@ describe('RunDetails', () => {
           </NamespaceContext.Provider>
         </Router>,
       );
-      await act(async () => {
-        await TestUtils.flushPromises();
-      });
+      await flushPromisesInAct();
       expect(history.location.pathname).toEqual('/initial-path');
       await act(async () => {
         rerender(


### PR DESCRIPTION
**Description of your changes:**

The `flushPromisesInAct` and `invokeAndFlush` test helpers were independently
copy-pasted into five test files during the React 18/19 upgrade (#13075, #13077,
#13266). This PR moves both helpers into the shared `TestUtils` module and
replaces every local definition with an import.

Additionally, two `CustomTable` tests that shared the identical description
*"calls reload with a different page size, resets page token list when rows/page
changes"* are renamed so each test name is unique and reflects its specific
scenario (non-empty next-page token vs. empty token).

**Changes:**

| File | What changed |
|------|-------------|
| `frontend/src/TestUtils.ts` | Added `flushPromisesInAct` and `invokeAndFlush` as shared exports |
| `frontend/src/components/CustomTable.test.tsx` | Removed local helper definitions, imported from `TestUtils`; renamed duplicate test descriptions |
| `frontend/src/pages/ExperimentDetails.test.tsx` | Removed local helper definitions, imported from `TestUtils`; removed unused `act` import |
| `frontend/src/pages/NewPipelineVersion.test.tsx` | Removed local `flushPromisesInAct`, imported from `TestUtils` |
| `frontend/src/pages/NewRun.test.tsx` | Removed local `flushPromisesInAct` and `invokeAndFlush`, imported from `TestUtils` |
| `frontend/src/pages/RunDetails.test.tsx` | Replaced 2 inline `act(async () => { await TestUtils.flushPromises() })` calls with imported `flushPromisesInAct` |

**Net effect:** −59 lines, +32 lines (−27 net).

**Verification:**

All affected test suites pass locally:
- `npx vitest run src/components/CustomTable.test.tsx` — 47 passed
- `npx vitest run src/pages/ExperimentDetails.test.tsx` — 30 passed
- `npx vitest run src/pages/NewPipelineVersion.test.tsx` — 23 passed
- `npx vitest run src/pages/NewRun.test.tsx` — 80 passed
- `npx vitest run src/pages/RunDetails.test.tsx` — 86 passed
- `npx prettier --check` on all changed files — clean

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

Made with [Cursor](https://cursor.com)