### PR TITLE
fix(sagemaker): correct 'occured' -> 'occurred' in ERROR_UPDATE_MESSAGE

### DIFF
--- a/components/aws/sagemaker/commonv2/sagemaker_component.py
+++ b/components/aws/sagemaker/commonv2/sagemaker_component.py
@@ -284,7 +284,7 @@ class SageMakerComponent:
         """
         submission_ack_printed = False
         ERROR_NOT_CREATED_MESSAGE = "An error occurred while getting resource arn, ACK CR created but Sagemaker resource not created."
-        ERROR_UPDATE_MESSAGE = "An error occured when getting the resource arn. Check the ACK Sagemaker Controller logs."
+        ERROR_UPDATE_MESSAGE = "An error occurred when getting the resource arn. Check the ACK Sagemaker Controller logs."
 
         try:
             while True:


### PR DESCRIPTION
`components/aws/sagemaker/commonv2/sagemaker_component.py:287` defined `ERROR_UPDATE_MESSAGE` with the wrong spelling:

```python
ERROR_NOT_CREATED_MESSAGE = "An error occurred while getting resource arn, ACK CR created but Sagemaker resource not created."
ERROR_UPDATE_MESSAGE = "An error occured when getting the resource arn. Check the ACK Sagemaker Controller logs."
```

The sibling constant on the line above (`ERROR_NOT_CREATED_MESSAGE`) already uses the correct `occurred`; align them. Both messages are surfaced when the SageMaker ACK controller fails to provision a CR, so the spelling reaches end users in pipeline error output. `ast.parse` clean against current `master`.