### PR TITLE
refactor(frontend): narrow compare metrics effect cleanup

### DIFF
--- a/frontend/src/components/viewers/MetricsDropdown.test.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.test.tsx
@@ -373,7 +373,6 @@ describe('MetricsDropdown', () => {
   });
 
   it('HTML file loading and error display with namespace input', async () => {
-    const assertErrors = expectErrors();
     const getHtmlViewerConfigSpy = vi.spyOn(metricsVisualizations, 'getHtmlViewerConfig');
     getHtmlViewerConfigSpy.mockRejectedValue(new Error('HTML file not found.'));
 
@@ -402,7 +401,6 @@ describe('MetricsDropdown', () => {
       );
       screen.getByText('Error: failed loading HTML file. Click Details for more information.');
     });
-    assertErrors();
   });
 
   it('Dropdown initially loaded with selected artifact', async () => {

--- a/frontend/src/components/viewers/MetricsDropdown.test.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.test.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { CommonTestWrapper } from 'src/TestWrapper';
-import TestUtils, { expectErrors, testBestPractices } from 'src/TestUtils';
+import TestUtils, { testBestPractices } from 'src/TestUtils';
 import { Artifact, Event, Execution, Value } from 'src/third_party/mlmd';
 import * as metricsVisualizations from 'src/components/viewers/MetricsVisualizations';
 import * as Utils from 'src/lib/Utils';

--- a/frontend/src/components/viewers/MetricsDropdown.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { color, commonCss, fontsize, zIndex } from 'src/Css';
 import { queryKeys } from 'src/hooks/queryKeys';
 import { classes, stylesheet } from 'typestyle';
@@ -186,8 +186,8 @@ interface VisualizationPanelItemProps {
 
 function VisualizationPanelItem(props: VisualizationPanelItemProps) {
   const { metricsTab, metricsTabText, linkedArtifact, namespace } = props;
-  const [errorMessage, setErrorMessage] = useState<string>('');
-  const [showError, setShowError] = useState<boolean>(false);
+  const shouldLoadViewerConfig =
+    !!linkedArtifact && (metricsTab === MetricsType.HTML || metricsTab === MetricsType.MARKDOWN);
 
   const {
     isLoading,
@@ -198,38 +198,22 @@ function VisualizationPanelItem(props: VisualizationPanelItemProps) {
     queryKey: queryKeys.visualizationPanelViewerConfig(linkedArtifact?.artifact.getId(), namespace),
 
     queryFn: async () => {
-      let viewerConfigs: ViewerConfig[] = [];
-      if (linkedArtifact) {
+      try {
         if (metricsTab === MetricsType.HTML) {
-          viewerConfigs = await getHtmlViewerConfig([linkedArtifact], namespace);
-        } else if (metricsTab === MetricsType.MARKDOWN) {
-          viewerConfigs = await getMarkdownViewerConfig([linkedArtifact], namespace);
+          return await getHtmlViewerConfig([linkedArtifact!], namespace);
         }
+        if (metricsTab === MetricsType.MARKDOWN) {
+          return await getMarkdownViewerConfig([linkedArtifact!], namespace);
+        }
+        return [];
+      } catch (queryError) {
+        throw new Error(await errorToMessage(queryError));
       }
-      return viewerConfigs;
     },
 
+    enabled: shouldLoadViewerConfig,
     staleTime: Infinity,
   });
-
-  useEffect(() => {
-    if (isError) {
-      let cancelled = false;
-      errorToMessage(error).then((msg) => {
-        if (!cancelled) {
-          setErrorMessage(msg);
-          setShowError(true);
-        }
-      });
-      return () => {
-        cancelled = true;
-      };
-    }
-    if (!isLoading) {
-      setShowError(false);
-    }
-    return undefined;
-  }, [isLoading, isError, error, setErrorMessage, setShowError]);
 
   if (!linkedArtifact) {
     return <VisualizationPlaceholder metricsTabText={metricsTabText} />;
@@ -243,17 +227,17 @@ function VisualizationPanelItem(props: VisualizationPanelItemProps) {
     );
   }
 
-  if (showError || isLoading) {
+  if (isError || isLoading) {
     return (
       <React.Fragment>
-        {showError && (
+        {isError && (
           <div className={css.errorBanner}>
             <Banner
               message={`Error: failed loading ${metricsTabText} file.${
-                errorMessage && ' Click Details for more information.'
+                error?.message && ' Click Details for more information.'
               }`}
               mode='error'
-              additionalInfo={errorMessage}
+              additionalInfo={error?.message || undefined}
               isLeftAlign
             />
           </div>

--- a/frontend/src/components/viewers/MetricsDropdown.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.tsx
@@ -234,7 +234,7 @@ function VisualizationPanelItem(props: VisualizationPanelItemProps) {
           <div className={css.errorBanner}>
             <Banner
               message={`Error: failed loading ${metricsTabText} file.${
-                error?.message && ' Click Details for more information.'
+                error?.message ? ' Click Details for more information.' : ''
               }`}
               mode='error'
               additionalInfo={error?.message || undefined}

--- a/frontend/src/components/viewers/MetricsVisualizations.test.tsx
+++ b/frontend/src/components/viewers/MetricsVisualizations.test.tsx
@@ -106,17 +106,18 @@ describe('ConfidenceMetricsSection', () => {
     selectedIds: string[];
   }
 
-  function generateRocCurveDataByCount(count: number): RocCurveData {
+  function generateRocCurveDataByCount(count: number, offset = 0): RocCurveData {
     const linkedArtifacts: LinkedArtifact[] = [];
     const fullArtifactPathMap: FullArtifactPathMap = {};
     const selectedIds: string[] = [];
     for (let i = 0; i < count; i++) {
-      const rocCurveId: string = `${i}-${i}`;
-      linkedArtifacts.push(newMockLinkedArtifact(i, i, `artifact${i}`));
-      fullArtifactPathMap[`${i}-${i}`] = {
-        run: { name: `run${i}`, id: `${i}` },
-        execution: { name: `execution${i}`, id: `${i}` },
-        artifact: { name: `artifact${i}`, id: `${i}` },
+      const artifactId = i + offset;
+      const rocCurveId: string = `${artifactId}-${artifactId}`;
+      linkedArtifacts.push(newMockLinkedArtifact(artifactId, artifactId, `artifact${artifactId}`));
+      fullArtifactPathMap[rocCurveId] = {
+        run: { name: `run${artifactId}`, id: `${artifactId}` },
+        execution: { name: `execution${artifactId}`, id: `${artifactId}` },
+        artifact: { name: `artifact${artifactId}`, id: `${artifactId}` },
       };
       if (i < 10) {
         selectedIds.push(rocCurveId);
@@ -342,6 +343,49 @@ describe('ConfidenceMetricsSection', () => {
     // Selecting a disabled checkbox has no change.
     fireEvent.click(checkboxes[1]);
     expect(setSelectedIdsSpy).toHaveBeenLastCalledWith(rocCurveData.selectedIds);
+  });
+
+  it('resets the ROC filter page when linked artifacts change', async () => {
+    const initialRocCurveData = generateRocCurveDataByCount(15);
+    const renderResult = render(
+      <CommonTestWrapper>
+        <ConfidenceMetricsSection
+          {...generateProps(
+            initialRocCurveData.selectedIds,
+            initialRocCurveData.linkedArtifacts,
+            initialRocCurveData.fullArtifactPathMap,
+          )}
+        />
+      </CommonTestWrapper>,
+    );
+    await TestUtils.flushPromises();
+
+    const buttons = screen.queryAllByRole('button');
+    const nextPage = buttons[buttons.length - 1];
+    fireEvent.click(nextPage);
+
+    await waitFor(() => {
+      expect(screen.getByText('execution10 > artifact10')).toBeInTheDocument();
+    });
+
+    const updatedRocCurveData = generateRocCurveDataByCount(3, 100);
+    renderResult.rerender(
+      <CommonTestWrapper>
+        <ConfidenceMetricsSection
+          {...generateProps(
+            updatedRocCurveData.selectedIds,
+            updatedRocCurveData.linkedArtifacts,
+            updatedRocCurveData.fullArtifactPathMap,
+          )}
+        />
+      </CommonTestWrapper>,
+    );
+    await TestUtils.flushPromises();
+
+    await waitFor(() => {
+      expect(screen.getByText('execution100 > artifact100')).toBeInTheDocument();
+      expect(screen.queryByText('execution10 > artifact10')).toBeNull();
+    });
   });
 
   it('Filter table is present with relevant rows', async () => {

--- a/frontend/src/components/viewers/MetricsVisualizations.tsx
+++ b/frontend/src/components/viewers/MetricsVisualizations.tsx
@@ -15,11 +15,12 @@
  */
 
 import HelpIcon from '@mui/icons-material/Help';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Array as ArrayRunType, Failure, Number, Record, String, ValidationError } from 'runtypes';
 import IconWithTooltip from 'src/atoms/IconWithTooltip';
 import { color, commonCss, padding } from 'src/Css';
+import { useKeyedState } from 'src/hooks/useKeyedState';
 import { queryKeys } from 'src/hooks/queryKeys';
 import { Apis, ListRequest } from 'src/lib/Apis';
 import { OutputArtifactLoader } from 'src/lib/OutputArtifactLoader';
@@ -62,7 +63,6 @@ import {
 import { logger } from 'src/lib/Utils';
 import { stylesheet } from 'typestyle';
 import { buildRocCurveConfig, validateConfidenceMetrics } from './ROCCurveHelper';
-import { isEqual } from 'lodash';
 import { Tooltip } from '@mui/material';
 
 const css = stylesheet({
@@ -496,15 +496,17 @@ const updateRocCurveSelection = (
   setSelectedIds(sharedIds.concat(limitedAddedIds));
 
   // Update the color stack and mapping to match the new selected ROC Curves.
+  const nextLineColorsStack = [...lineColorsStack];
+  const nextSelectedIdColorMap = { ...selectedIdColorMap };
   removedIds.forEach((removedId) => {
-    lineColorsStack.push(selectedIdColorMap[removedId]);
-    delete selectedIdColorMap[removedId];
+    nextLineColorsStack.push(selectedIdColorMap[removedId]);
+    delete nextSelectedIdColorMap[removedId];
   });
   limitedAddedIds.forEach((addedId) => {
-    selectedIdColorMap[addedId] = lineColorsStack.pop()!;
+    nextSelectedIdColorMap[addedId] = nextLineColorsStack.pop()!;
   });
-  setSelectedIdColorMap(selectedIdColorMap);
-  setLineColorsStack(lineColorsStack);
+  setSelectedIdColorMap(nextSelectedIdColorMap);
+  setLineColorsStack(nextLineColorsStack);
 };
 
 function reloadRocCurve(
@@ -561,23 +563,14 @@ export function ConfidenceMetricsSection({
   filter,
 }: ConfidenceMetricsSectionProps) {
   const maxSelectedRocCurves: number = 10;
-  const [allLinkedArtifacts, setAllLinkedArtifacts] = useState<LinkedArtifact[]>(linkedArtifacts);
-  const [linkedArtifactsPage, setLinkedArtifactsPage] = useState<LinkedArtifact[]>(linkedArtifacts);
+  const linkedArtifactsKey = linkedArtifacts
+    .map((linkedArtifact) => getRocCurveId(linkedArtifact))
+    .join(',');
+  const [linkedArtifactsPage, setLinkedArtifactsPage] = useKeyedState<LinkedArtifact[]>(
+    linkedArtifactsKey,
+    linkedArtifacts,
+  );
   const [filterString, setFilterString] = useState<string>('');
-
-  // Reload the page on linked artifacts refresh or re-selection.
-  useEffect(() => {
-    if (filter && !isEqual(linkedArtifacts, allLinkedArtifacts)) {
-      setLinkedArtifactsPage(linkedArtifacts);
-      setAllLinkedArtifacts(linkedArtifacts);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [linkedArtifacts]);
-
-  // Verify that the existing linked artifacts are correct; otherwise, wait for refresh.
-  if (filter && !isEqual(linkedArtifacts, allLinkedArtifacts)) {
-    return null;
-  }
 
   let confidenceMetricsDataList: ConfidenceMetricsData[] = linkedArtifacts
     .map((linkedArtifact) => {

--- a/frontend/src/pages/CompareV2.test.tsx
+++ b/frontend/src/pages/CompareV2.test.tsx
@@ -15,12 +15,15 @@
  */
 
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useEffect, useState } from 'react';
 import { CommonTestWrapper } from 'src/TestWrapper';
 import TestUtils, { expectErrors, testBestPractices } from 'src/TestUtils';
 import { Artifact, Context, Event, Execution } from 'src/third_party/mlmd';
 import { Apis } from 'src/lib/Apis';
 import { ButtonKeys } from 'src/lib/Buttons';
 import { QUERY_PARAMS } from 'src/components/Router';
+import { ArtifactType } from 'src/mlmd';
+import { LinkedArtifact } from 'src/mlmd/MlmdUtils';
 import * as mlmdUtils from 'src/mlmd/MlmdUtils';
 import * as Utils from 'src/lib/Utils';
 import * as metricsVisualizations from 'src/components/viewers/MetricsVisualizations';
@@ -239,6 +242,73 @@ describe('CompareV2', () => {
     expect(TEST_ONLY.reconcileRocCurveSelectionState(initialSelection, [], new Set())).toBe(
       initialSelection,
     );
+  });
+
+  it('initializes ROC selection once and only prunes invalid ids on later refreshes', async () => {
+    const initialLinkedArtifacts: LinkedArtifact[] = [
+      {
+        artifact: newMockArtifact(100, false, true, 'artifact-100'),
+        event: newMockEvent(100, 'artifact-100'),
+      },
+      {
+        artifact: newMockArtifact(200, false, true, 'artifact-200'),
+        event: newMockEvent(200, 'artifact-200'),
+      },
+      {
+        artifact: newMockArtifact(300, false, true, 'artifact-300'),
+        event: newMockEvent(300, 'artifact-300'),
+      },
+    ];
+    const refreshedLinkedArtifacts: LinkedArtifact[] = [
+      {
+        artifact: newMockArtifact(50, false, true, 'artifact-50'),
+        event: newMockEvent(50, 'artifact-50'),
+      },
+      ...initialLinkedArtifacts,
+    ];
+
+    function RocCurveSelectionHarness() {
+      const [linkedArtifacts, setLinkedArtifacts] = useState(initialLinkedArtifacts);
+      const [selection, setSelection] = useState(TEST_ONLY.createInitialRocCurveSelectionState);
+
+      useEffect(() => {
+        setSelection((currentSelection) =>
+          TEST_ONLY.reconcileRocCurveSelectionState(
+            currentSelection,
+            linkedArtifacts,
+            new Set(
+              linkedArtifacts.map(
+                (linkedArtifact) =>
+                  `${linkedArtifact.event.getExecutionId()}-${linkedArtifact.artifact.getId()}`,
+              ),
+            ),
+          ),
+        );
+      }, [linkedArtifacts]);
+
+      return (
+        <>
+          <div data-testid='roc-selected-ids'>{selection.selectedIds.join(',')}</div>
+          <button onClick={() => setLinkedArtifacts(refreshedLinkedArtifacts)}>refresh ROC</button>
+        </>
+      );
+    }
+
+    render(
+      <CommonTestWrapper>
+        <RocCurveSelectionHarness />
+      </CommonTestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('roc-selected-ids')).toHaveTextContent('100-100,200-200,300-300');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'refresh ROC' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('roc-selected-ids')).toHaveTextContent('100-100,200-200,300-300');
+    });
   });
 
   it('reconciles invalid two-panel artifact selections against the available run artifacts', () => {

--- a/frontend/src/pages/CompareV2.tsx
+++ b/frontend/src/pages/CompareV2.tsx
@@ -443,7 +443,7 @@ function CompareV2(props: CompareV2Props) {
   const [isOverviewCollapsed, setIsOverviewCollapsed] = useState(false);
   const [isParamsCollapsed, setIsParamsCollapsed] = useState(false);
   const [isMetricsCollapsed, setIsMetricsCollapsed] = useState(false);
-  const [rocCurveSelectionState, setRocCurveSelectionState] = useState<RocCurveSelectionState>(
+  const [rocCurveSelection, setRocCurveSelection] = useState<RocCurveSelectionState>(
     createInitialRocCurveSelectionState,
   );
 
@@ -582,15 +582,15 @@ function CompareV2(props: CompareV2Props) {
     [selectedArtifactsMap, metricsArtifactData],
   );
 
-  const visibleRocCurveSelection = useMemo(
-    () =>
+  useEffect(() => {
+    setRocCurveSelection((currentSelection) =>
       reconcileRocCurveSelectionState(
-        rocCurveSelectionState,
+        currentSelection,
         rocCurveData.rocCurveLinkedArtifacts,
         rocCurveData.validRocCurveIdSet,
       ),
-    [rocCurveSelectionState, rocCurveData],
-  );
+    );
+  }, [rocCurveData]);
 
   const scalarMetricsTableData = metricsArtifactData?.scalarMetricsTableData;
   const confusionMatrixRunArtifacts = metricsArtifactData?.confusionMatrixRunArtifacts || [];
@@ -792,37 +792,25 @@ function CompareV2(props: CompareV2Props) {
                   <RocCurveMetrics
                     linkedArtifacts={rocCurveLinkedArtifacts}
                     filter={{
-                      selectedIds: visibleRocCurveSelection.selectedIds,
+                      selectedIds: rocCurveSelection.selectedIds,
                       setSelectedIds: (selectedIds) =>
-                        setRocCurveSelectionState((currentSelection) => ({
-                          ...reconcileRocCurveSelectionState(
-                            currentSelection,
-                            rocCurveData.rocCurveLinkedArtifacts,
-                            rocCurveData.validRocCurveIdSet,
-                          ),
+                        setRocCurveSelection((currentSelection) => ({
+                          ...currentSelection,
                           hasInitialized: true,
                           selectedIds,
                         })),
                       fullArtifactPathMap,
-                      selectedIdColorMap: visibleRocCurveSelection.selectedIdColorMap,
+                      selectedIdColorMap: rocCurveSelection.selectedIdColorMap,
                       setSelectedIdColorMap: (selectedIdColorMap) =>
-                        setRocCurveSelectionState((currentSelection) => ({
-                          ...reconcileRocCurveSelectionState(
-                            currentSelection,
-                            rocCurveData.rocCurveLinkedArtifacts,
-                            rocCurveData.validRocCurveIdSet,
-                          ),
+                        setRocCurveSelection((currentSelection) => ({
+                          ...currentSelection,
                           hasInitialized: true,
                           selectedIdColorMap,
                         })),
-                      lineColorsStack: visibleRocCurveSelection.lineColorsStack,
+                      lineColorsStack: rocCurveSelection.lineColorsStack,
                       setLineColorsStack: (lineColorsStack) =>
-                        setRocCurveSelectionState((currentSelection) => ({
-                          ...reconcileRocCurveSelectionState(
-                            currentSelection,
-                            rocCurveData.rocCurveLinkedArtifacts,
-                            rocCurveData.validRocCurveIdSet,
-                          ),
+                        setRocCurveSelection((currentSelection) => ({
+                          ...currentSelection,
                           hasInitialized: true,
                           lineColorsStack,
                         })),

--- a/frontend/src/pages/CompareV2.tsx
+++ b/frontend/src/pages/CompareV2.tsx
@@ -443,7 +443,7 @@ function CompareV2(props: CompareV2Props) {
   const [isOverviewCollapsed, setIsOverviewCollapsed] = useState(false);
   const [isParamsCollapsed, setIsParamsCollapsed] = useState(false);
   const [isMetricsCollapsed, setIsMetricsCollapsed] = useState(false);
-  const [rocCurveSelection, setRocCurveSelection] = useState<RocCurveSelectionState>(
+  const [rocCurveSelectionState, setRocCurveSelectionState] = useState<RocCurveSelectionState>(
     createInitialRocCurveSelectionState,
   );
 
@@ -582,15 +582,15 @@ function CompareV2(props: CompareV2Props) {
     [selectedArtifactsMap, metricsArtifactData],
   );
 
-  useEffect(() => {
-    setRocCurveSelection((currentSelection) =>
+  const visibleRocCurveSelection = useMemo(
+    () =>
       reconcileRocCurveSelectionState(
-        currentSelection,
+        rocCurveSelectionState,
         rocCurveData.rocCurveLinkedArtifacts,
         rocCurveData.validRocCurveIdSet,
       ),
-    );
-  }, [rocCurveData]);
+    [rocCurveSelectionState, rocCurveData],
+  );
 
   const scalarMetricsTableData = metricsArtifactData?.scalarMetricsTableData;
   const confusionMatrixRunArtifacts = metricsArtifactData?.confusionMatrixRunArtifacts || [];
@@ -792,23 +792,38 @@ function CompareV2(props: CompareV2Props) {
                   <RocCurveMetrics
                     linkedArtifacts={rocCurveLinkedArtifacts}
                     filter={{
-                      selectedIds: rocCurveSelection.selectedIds,
+                      selectedIds: visibleRocCurveSelection.selectedIds,
                       setSelectedIds: (selectedIds) =>
-                        setRocCurveSelection((currentSelection) => ({
-                          ...currentSelection,
+                        setRocCurveSelectionState((currentSelection) => ({
+                          ...reconcileRocCurveSelectionState(
+                            currentSelection,
+                            rocCurveData.rocCurveLinkedArtifacts,
+                            rocCurveData.validRocCurveIdSet,
+                          ),
+                          hasInitialized: true,
                           selectedIds,
                         })),
                       fullArtifactPathMap,
-                      selectedIdColorMap: rocCurveSelection.selectedIdColorMap,
+                      selectedIdColorMap: visibleRocCurveSelection.selectedIdColorMap,
                       setSelectedIdColorMap: (selectedIdColorMap) =>
-                        setRocCurveSelection((currentSelection) => ({
-                          ...currentSelection,
+                        setRocCurveSelectionState((currentSelection) => ({
+                          ...reconcileRocCurveSelectionState(
+                            currentSelection,
+                            rocCurveData.rocCurveLinkedArtifacts,
+                            rocCurveData.validRocCurveIdSet,
+                          ),
+                          hasInitialized: true,
                           selectedIdColorMap,
                         })),
-                      lineColorsStack: rocCurveSelection.lineColorsStack,
+                      lineColorsStack: visibleRocCurveSelection.lineColorsStack,
                       setLineColorsStack: (lineColorsStack) =>
-                        setRocCurveSelection((currentSelection) => ({
-                          ...currentSelection,
+                        setRocCurveSelectionState((currentSelection) => ({
+                          ...reconcileRocCurveSelectionState(
+                            currentSelection,
+                            rocCurveData.rocCurveLinkedArtifacts,
+                            rocCurveData.validRocCurveIdSet,
+                          ),
+                          hasInitialized: true,
                           lineColorsStack,
                         })),
                     }}


### PR DESCRIPTION
## Summary
- keep the `CompareV2` ROC reconciliation effect because it persists the one-time automatic ROC selection contract
- replace the ROC filter page reset effect in `MetricsVisualizations` with keyed state
- remove the `MetricsDropdown` query-error effect and render its banner directly from query state
- add regressions for ROC page reset and ROC initialize-once behavior

## Why
This follow-up is still worthwhile, but it is narrower than the original pitch.

The review on the ROC path was correct: the `CompareV2` ROC effect was not just redundant derivation. It persists the first automatic selection exactly once and then only prunes invalid ids on later refreshes. Removing it changed behavior, so this PR now keeps that effect and limits the cleanup to the places where the state was genuinely being mirrored or reset after render.

## Verification
- `cd frontend && fnm exec --using .nvmrc -- npx prettier@3.8.1 --check src/pages/CompareV2.tsx src/pages/CompareV2.test.tsx src/components/viewers/MetricsDropdown.tsx src/components/viewers/MetricsDropdown.test.tsx src/components/viewers/MetricsVisualizations.tsx src/components/viewers/MetricsVisualizations.test.tsx`
- `cd frontend && fnm exec --using .nvmrc -- npm run test:ui -- src/components/viewers/MetricsDropdown.test.tsx src/components/viewers/MetricsVisualizations.test.tsx src/pages/CompareV2.test.tsx`
- `cd frontend && fnm exec --using .nvmrc -- npm run typecheck`
- `cd frontend && fnm exec --using .nvmrc -- npm run lint`

Focused test result: 3 files passed, 45 tests passed.

Note: the compare/visualization area still emits the same pre-existing React `act(...)` warnings during the targeted Vitest run, but the suites pass.
