### PR TITLE
fix(frontend): surface usePipelineVersionTemplate errors in run detail routers

### DIFF
--- a/frontend/src/pages/RecurringRunDetailsRouter.test.tsx
+++ b/frontend/src/pages/RecurringRunDetailsRouter.test.tsx
@@ -127,19 +127,8 @@ describe('RecurringRunDetailsRouter', () => {
         pipeline_version_id: TEST_PIPELINE_VERSION_ID,
       },
     };
-    const pipelineVersion: V2beta1PipelineVersion = {
-      pipeline_id: TEST_PIPELINE_ID,
-      pipeline_version_id: TEST_PIPELINE_VERSION_ID,
-      pipeline_spec: {
-        apiVersion: 'argoproj.io/v1alpha1',
-        kind: 'Workflow',
-        metadata: { name: 'from-version' },
-        spec: { arguments: { parameters: [{ name: 'output' }] } },
-      },
-    };
 
     getRecurringRunSpy.mockResolvedValue(recurringRun);
-    getPipelineVersionSpy.mockResolvedValue(pipelineVersion);
 
     render(
       <CommonTestWrapper>
@@ -148,12 +137,9 @@ describe('RecurringRunDetailsRouter', () => {
     );
 
     await waitFor(() => {
-      expect(getPipelineVersionSpy).toHaveBeenCalledWith(
-        TEST_PIPELINE_ID,
-        TEST_PIPELINE_VERSION_ID,
-      );
       expect(screen.getByTestId('recurring-run-details-v2')).toBeInTheDocument();
     });
+    expect(getPipelineVersionSpy).not.toHaveBeenCalled();
   });
 
   it('renders RecurringRunDetailsV2FC when FUNCTIONAL_COMPONENT flag is enabled', async () => {
@@ -328,6 +314,62 @@ describe('RecurringRunDetailsRouter', () => {
       expect(screen.queryByTestId('recurring-run-details-v2-fc')).toBeNull();
       expect(screen.queryByRole('progressbar')).toBeNull();
     });
+  });
+
+  it('shows error banner when pipeline version template fetch fails', async () => {
+    const recurringRun: V2beta1RecurringRun = {
+      recurring_run_id: TEST_RECURRING_RUN_ID,
+      pipeline_version_reference: {
+        pipeline_id: TEST_PIPELINE_ID,
+        pipeline_version_id: TEST_PIPELINE_VERSION_ID,
+      },
+    };
+    getRecurringRunSpy.mockResolvedValue(recurringRun);
+    getPipelineVersionSpy.mockRejectedValue(new Error('Version not found'));
+
+    const props = generateProps();
+    render(
+      <CommonTestWrapper>
+        <RecurringRunDetailsRouter {...props} />
+      </CommonTestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(props.updateBanner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('failed to retrieve pipeline version template'),
+          mode: 'error',
+        }),
+      );
+    });
+  });
+
+  it('does not show error banner when inline pipeline_spec is present and getPipelineVersion rejects', async () => {
+    vi.spyOn(features, 'isFeatureEnabled').mockImplementation(
+      (featureKey) => featureKey === features.FeatureKey.V2_ALPHA,
+    );
+    const recurringRun: V2beta1RecurringRun = {
+      recurring_run_id: TEST_RECURRING_RUN_ID,
+      pipeline_spec: v2PipelineSpec,
+      pipeline_version_reference: {
+        pipeline_id: TEST_PIPELINE_ID,
+        pipeline_version_id: TEST_PIPELINE_VERSION_ID,
+      },
+    };
+    getRecurringRunSpy.mockResolvedValue(recurringRun);
+    getPipelineVersionSpy.mockRejectedValue(new Error('Version not found'));
+
+    const props = generateProps();
+    render(
+      <CommonTestWrapper>
+        <RecurringRunDetailsRouter {...props} />
+      </CommonTestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('recurring-run-details-v2')).toBeInTheDocument();
+    });
+    expect(props.updateBanner).not.toHaveBeenCalled();
   });
 
   it('shows loading message while recurring run data is being fetched', () => {

--- a/frontend/src/pages/RecurringRunDetailsRouter.tsx
+++ b/frontend/src/pages/RecurringRunDetailsRouter.tsx
@@ -62,8 +62,15 @@ export default function RecurringRunDetailsRouter(props: PageProps) {
   const pipelineId = v2RecurringRun?.pipeline_version_reference?.pipeline_id;
   const pipelineVersionId = v2RecurringRun?.pipeline_version_reference?.pipeline_version_id;
 
-  const { isLoading: templateStrIsLoading, data: templateStrFromPipelineVersion } =
-    usePipelineVersionTemplate(pipelineId, pipelineVersionId);
+  const {
+    isLoading: templateStrIsLoading,
+    isError: templateStrIsError,
+    error: templateStrError,
+    data: templateStrFromPipelineVersion,
+  } = usePipelineVersionTemplate(
+    pipelineManifest ? undefined : pipelineId,
+    pipelineManifest ? undefined : pipelineVersionId,
+  );
 
   const templateString = pipelineManifest ?? templateStrFromPipelineVersion;
 
@@ -85,6 +92,26 @@ export default function RecurringRunDetailsRouter(props: PageProps) {
     }
     return undefined;
   }, [getRecurringRunError, recurringRunError, recurringRunId, updateBanner]);
+
+  useEffect(() => {
+    if (templateStrIsError && templateStrError && !getRecurringRunError) {
+      let cancelled = false;
+      errorToMessage(templateStrError).then((msg) => {
+        if (!cancelled) {
+          updateBanner({
+            message:
+              'Error: failed to retrieve pipeline version template. Click Details for more information.',
+            mode: 'error',
+            additionalInfo: msg,
+          });
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    return undefined;
+  }, [templateStrIsError, templateStrError, getRecurringRunError, updateBanner]);
 
   if (getRecurringRunSuccess && v2RecurringRun && templateString) {
     const isV2Pipeline = WorkflowUtils.isPipelineSpec(templateString);

--- a/frontend/src/pages/RunDetailsRouter.test.tsx
+++ b/frontend/src/pages/RunDetailsRouter.test.tsx
@@ -264,28 +264,16 @@ describe('RunDetailsRouter', () => {
       },
     };
     getRunSpy.mockResolvedValue(v2Run);
-    getPipelineVersionSpy.mockResolvedValue({
-      pipeline_id: TEST_PIPELINE_ID,
-      pipeline_version_id: TEST_PIPELINE_VERSION_ID,
-      pipeline_spec: {
-        apiVersion: 'argoproj.io/v1alpha1',
-        kind: 'Workflow',
-        metadata: { name: 'from-version' },
-        spec: { arguments: { parameters: [{ name: 'output' }] } },
-      },
-    } as V2beta1PipelineVersion);
+
     render(
       <CommonTestWrapper>
         <RunDetailsRouter {...generateProps()} />
       </CommonTestWrapper>,
     );
     await waitFor(() => {
-      expect(getPipelineVersionSpy).toHaveBeenCalledWith(
-        TEST_PIPELINE_ID,
-        TEST_PIPELINE_VERSION_ID,
-      );
       expect(screen.getByTestId('run-details-v2')).toBeInTheDocument();
     });
+    expect(getPipelineVersionSpy).not.toHaveBeenCalled();
   });
 
   it('renders EnhancedRunDetails when getRun fails', async () => {
@@ -306,6 +294,59 @@ describe('RunDetailsRouter', () => {
       expect(element).toBeInTheDocument();
       expect(element.dataset.isLoading).toBe('false');
     });
+  });
+
+  it('shows error banner when pipeline version template fetch fails', async () => {
+    const runWithVersionRef: V2beta1Run = {
+      run_id: TEST_RUN_ID,
+      pipeline_version_reference: {
+        pipeline_id: TEST_PIPELINE_ID,
+        pipeline_version_id: TEST_PIPELINE_VERSION_ID,
+      },
+    };
+    getRunSpy.mockResolvedValue(runWithVersionRef);
+    getPipelineVersionSpy.mockRejectedValue(new Error('Version not found'));
+
+    const props = generateProps();
+    render(
+      <CommonTestWrapper>
+        <RunDetailsRouter {...props} />
+      </CommonTestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(props.updateBanner).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('failed to retrieve pipeline version template'),
+          mode: 'error',
+        }),
+      );
+    });
+  });
+
+  it('does not show error banner when inline pipeline_spec is present and getPipelineVersion rejects', async () => {
+    const v2Run: V2beta1Run = {
+      run_id: TEST_RUN_ID,
+      pipeline_spec: v2PipelineSpec,
+      pipeline_version_reference: {
+        pipeline_id: TEST_PIPELINE_ID,
+        pipeline_version_id: TEST_PIPELINE_VERSION_ID,
+      },
+    };
+    getRunSpy.mockResolvedValue(v2Run);
+    getPipelineVersionSpy.mockRejectedValue(new Error('Version not found'));
+
+    const props = generateProps();
+    render(
+      <CommonTestWrapper>
+        <RunDetailsRouter {...props} />
+      </CommonTestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('run-details-v2')).toBeInTheDocument();
+    });
+    expect(props.updateBanner).not.toHaveBeenCalled();
   });
 
   it('fetches template from pipeline version when run has no inline spec', async () => {

--- a/frontend/src/pages/RunDetailsRouter.tsx
+++ b/frontend/src/pages/RunDetailsRouter.tsx
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+import { useEffect } from 'react';
 import * as JsYaml from 'js-yaml';
 import { useQuery } from '@tanstack/react-query';
 import { V2beta1Run } from 'src/apisv2beta1/run';
 import { RouteParams } from 'src/components/Router';
 import { Apis } from 'src/lib/Apis';
+import { errorToMessage } from 'src/lib/Utils';
 import * as WorkflowUtils from 'src/lib/v2/WorkflowUtils';
 import { RouteComponentProps } from 'react-router-dom';
 import EnhancedRunDetails, { RunDetailsProps } from 'src/pages/RunDetails';
@@ -30,6 +32,7 @@ import { queryKeys } from 'src/hooks/queryKeys';
 export default function RunDetailsRouter(
   props: RunDetailsProps & RouteComponentProps<RunDetailsV2Params>,
 ) {
+  const { updateBanner } = props;
   const runId = props.match.params[RouteParams.runId];
   let pipelineManifest: string | undefined;
 
@@ -50,8 +53,35 @@ export default function RunDetailsRouter(
   const pipelineId = v2Run?.pipeline_version_reference?.pipeline_id;
   const pipelineVersionId = v2Run?.pipeline_version_reference?.pipeline_version_id;
 
-  const { isLoading: templateStrIsLoading, data: templateStrFromPipelineVersion } =
-    usePipelineVersionTemplate(pipelineId, pipelineVersionId);
+  const {
+    isLoading: templateStrIsLoading,
+    isError: templateStrIsError,
+    error: templateStrError,
+    data: templateStrFromPipelineVersion,
+  } = usePipelineVersionTemplate(
+    pipelineManifest ? undefined : pipelineId,
+    pipelineManifest ? undefined : pipelineVersionId,
+  );
+
+  useEffect(() => {
+    if (templateStrIsError && templateStrError) {
+      let cancelled = false;
+      errorToMessage(templateStrError).then((msg) => {
+        if (!cancelled) {
+          updateBanner({
+            message:
+              'Error: failed to retrieve pipeline version template. Click Details for more information.',
+            mode: 'error',
+            additionalInfo: msg,
+          });
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
+    }
+    return undefined;
+  }, [templateStrIsError, templateStrError, updateBanner]);
 
   const templateString = pipelineManifest ?? templateStrFromPipelineVersion;
 


### PR DESCRIPTION
**Description of your changes:**

`RunDetailsRouter` and `RecurringRunDetailsRouter` both call `usePipelineVersionTemplate()` but only destructure `isLoading` and `data`, silently dropping query failures. When the pipeline version fetch fails, the user sees no error feedback and falls through to a legacy or broken view.

### Changes

**`RunDetailsRouter.tsx`**
- Destructure `isError`/`error` from `usePipelineVersionTemplate`.
- Add a `useEffect` that calls `updateBanner` on template fetch failure with an error message and details.

**`RecurringRunDetailsRouter.tsx`**
- Destructure `isError`/`error` from `usePipelineVersionTemplate`.
- Add a `useEffect` that calls `updateBanner` on template fetch failure, gated behind `!getRecurringRunError` to avoid overwriting a more critical recurring run error.

### Tests added

- **`RunDetailsRouter.test.tsx`**: verifies `updateBanner` is called with the template error message when `getPipelineVersion` rejects.
- **`RecurringRunDetailsRouter.test.tsx`**: verifies `updateBanner` is called with the template error message when `getPipelineVersion` rejects.

This follows the same error-surfacing pattern established in PR #13217 for other `useQuery` consumers (`NewRunSwitcher`, `RuntimeNodeDetailsV2`, `RunDetailsV2`, `ExecutionReference`).

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

Made with [Cursor](https://cursor.com)