### PR TITLE
feat(backend): add hostUsers:false default and override guard for customer workloads

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -46,6 +46,7 @@ const (
 	DefaultSecurityContextRunAsUser         string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_USER"
 	DefaultSecurityContextRunAsGroup        string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_GROUP"
 	DefaultSecurityContextRunAsNonRoot      string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_NON_ROOT"
+	DefaultSecurityContextHostUsers         string = "DEFAULT_SECURITY_CONTEXT_HOST_USERS"
 	BlockV1Pipelines                        string = "BLOCK_V1_PIPELINES"
 	V1NamespaceWhitelist                    string = "V1_ALLOWED_NAMESPACES"
 	PipelineURLAllowedDomains               string = "PIPELINE_URL_ALLOWED_DOMAINS"
@@ -226,6 +227,10 @@ func GetDefaultSecurityContextRunAsGroup() string {
 
 func GetDefaultSecurityContextRunAsNonRoot() string {
 	return GetStringConfigWithDefault(DefaultSecurityContextRunAsNonRoot, "")
+}
+
+func GetDefaultSecurityContextHostUsers() string {
+	return GetStringConfigWithDefault(DefaultSecurityContextHostUsers, "")
 }
 
 func GetPluginLimitsConfig() (PluginLimitsConfig, error) {

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -228,6 +228,7 @@ func main() {
 			DefaultRunAsUser:     parseOptionalInt64(common.GetDefaultSecurityContextRunAsUser()),
 			DefaultRunAsGroup:    parseOptionalInt64(common.GetDefaultSecurityContextRunAsGroup()),
 			DefaultRunAsNonRoot:  parseOptionalBool(common.GetDefaultSecurityContextRunAsNonRoot()),
+			DefaultHostUsers:     parseOptionalBool(common.GetDefaultSecurityContextHostUsers()),
 		},
 	)
 	err = config.LoadSamples(resourceManager, *sampleConfigPath)

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -127,6 +127,7 @@ type ResourceManagerOptions struct {
 	DefaultRunAsUser     *int64                            `json:"default_run_as_user,omitempty"`
 	DefaultRunAsGroup    *int64                            `json:"default_run_as_group,omitempty"`
 	DefaultRunAsNonRoot  *bool                             `json:"default_run_as_non_root,omitempty"`
+	DefaultHostUsers     *bool                             `json:"default_host_users,omitempty"`
 }
 
 type ResourceManager struct {
@@ -521,6 +522,7 @@ func (r *ResourceManager) CreatePipelineAndPipelineVersion(p *model.Pipeline, pv
 		DefaultRunAsUser:     r.options.DefaultRunAsUser,
 		DefaultRunAsGroup:    r.options.DefaultRunAsGroup,
 		DefaultRunAsNonRoot:  r.options.DefaultRunAsNonRoot,
+		DefaultHostUsers:     r.options.DefaultHostUsers,
 	}
 	tmpl, err := template.New(pipelineSpecBytes, templateOptions)
 	if err != nil {
@@ -1358,6 +1360,7 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			DefaultRunAsUser:     r.options.DefaultRunAsUser,
 			DefaultRunAsGroup:    r.options.DefaultRunAsGroup,
 			DefaultRunAsNonRoot:  r.options.DefaultRunAsNonRoot,
+			DefaultHostUsers:     r.options.DefaultHostUsers,
 		}
 		tmpl, err := template.New(manifest, templateOptions)
 		if err != nil {
@@ -1786,6 +1789,7 @@ func (r *ResourceManager) fetchTemplateFromPipelineSpec(pipelineSpec *model.Pipe
 		DefaultRunAsUser:     r.options.DefaultRunAsUser,
 		DefaultRunAsGroup:    r.options.DefaultRunAsGroup,
 		DefaultRunAsNonRoot:  r.options.DefaultRunAsNonRoot,
+		DefaultHostUsers:     r.options.DefaultHostUsers,
 	}
 	tmpl, err := template.New([]byte(manifest), templateOptions)
 	if err != nil {
@@ -1977,6 +1981,7 @@ func (r *ResourceManager) CreatePipelineVersion(pv *model.PipelineVersion) (*mod
 		DefaultRunAsUser:     r.options.DefaultRunAsUser,
 		DefaultRunAsGroup:    r.options.DefaultRunAsGroup,
 		DefaultRunAsNonRoot:  r.options.DefaultRunAsNonRoot,
+		DefaultHostUsers:     r.options.DefaultHostUsers,
 	}
 	tmpl, err := template.New(pipelineSpecBytes, templateOptions)
 	if err != nil {

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -148,6 +148,7 @@ type TemplateOptions struct {
 	DefaultRunAsUser     *int64
 	DefaultRunAsGroup    *int64
 	DefaultRunAsNonRoot  *bool
+	DefaultHostUsers     *bool
 }
 
 func New(bytes []byte, opts TemplateOptions) (Template, error) {

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -147,6 +147,7 @@ func (t *V2Spec) ScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.Sche
 			DefaultRunAsUser:     t.templateOptions.DefaultRunAsUser,
 			DefaultRunAsGroup:    t.templateOptions.DefaultRunAsGroup,
 			DefaultRunAsNonRoot:  t.templateOptions.DefaultRunAsNonRoot,
+			DefaultHostUsers:     t.templateOptions.DefaultHostUsers,
 		}
 		obj, err = argocompiler.Compile(job, kubernetesSpec, opts)
 	}
@@ -389,6 +390,7 @@ func (t *V2Spec) RunWorkflow(modelRun *model.Run, options RunWorkflowOptions) (u
 			DefaultRunAsUser:     t.templateOptions.DefaultRunAsUser,
 			DefaultRunAsGroup:    t.templateOptions.DefaultRunAsGroup,
 			DefaultRunAsNonRoot:  t.templateOptions.DefaultRunAsNonRoot,
+			DefaultHostUsers:     t.templateOptions.DefaultHostUsers,
 		}
 		obj, err = argocompiler.Compile(job, kubernetesSpec, opts)
 	}

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -100,6 +100,7 @@ var (
 	defaultRunAsUser     = flag.Int64("default_run_as_user", -1, "Admin-configured default runAsUser for user containers. -1 means not set.")
 	defaultRunAsGroup    = flag.Int64("default_run_as_group", -1, "Admin-configured default runAsGroup for user containers. -1 means not set.")
 	defaultRunAsNonRoot  = flag.String("default_run_as_non_root", "", "Admin-configured default runAsNonRoot for user containers. Empty means not set.")
+	defaultHostUsers     = flag.String("default_host_users", "", "Administrator-configured default hostUsers for user workload pods. Empty means not set. Set to false to run pods in a dedicated Linux user namespace.")
 )
 
 // func RootDAG(pipelineName string, runID string, component *pipelinespec.ComponentSpec, task *pipelinespec.PipelineTaskSpec, mlmd *metadata.Client) (*Execution, error) {
@@ -269,6 +270,13 @@ func drive() (err error) {
 			if err == nil {
 				options.DefaultRunAsNonRoot = &v
 			}
+		}
+		if *defaultHostUsers != "" {
+			v, err := strconv.ParseBool(*defaultHostUsers)
+			if err != nil {
+				return fmt.Errorf("invalid --default_host_users value %q: %w", *defaultHostUsers, err)
+			}
+			options.DefaultHostUsers = &v
 		}
 		execution, driverErr = driver.Container(ctx, options, client, cacheClient)
 	default:

--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -57,6 +57,11 @@ type Options struct {
 	// Optional: admin-configured default runAsNonRoot for customer containers.
 	// Nil means not set (feature disabled).
 	DefaultRunAsNonRoot *bool
+	// Optional: administrator-configured default hostUsers for customer workload pods.
+	// Nil means not set (feature disabled). Setting this to false places the pod
+	// in a dedicated Linux user namespace: UID 0 inside the pod maps to an
+	// unprivileged host UID, so root processes in the container are not root on the host.
+	DefaultHostUsers *bool
 }
 
 const (
@@ -213,6 +218,7 @@ func Compile(jobArg *pipelinespec.PipelineJob, kubernetesSpecArg *pipelinespec.S
 		c.defaultRunAsUser = opts.DefaultRunAsUser
 		c.defaultRunAsGroup = opts.DefaultRunAsGroup
 		c.defaultRunAsNonRoot = opts.DefaultRunAsNonRoot
+		c.defaultHostUsers = opts.DefaultHostUsers
 		if opts.DriverImage != "" {
 			c.driverImage = opts.DriverImage
 		}
@@ -318,6 +324,7 @@ type workflowCompiler struct {
 	defaultRunAsUser     *int64
 	defaultRunAsGroup    *int64
 	defaultRunAsNonRoot  *bool
+	defaultHostUsers     *bool
 }
 
 func (c *workflowCompiler) Resolver(name string, component *pipelinespec.ComponentSpec, resolver *pipelinespec.PipelineDeploymentConfig_ResolverSpec) error {

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -246,6 +246,9 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 	if c.defaultRunAsNonRoot != nil {
 		args = append(args, "--default_run_as_non_root", strconv.FormatBool(*c.defaultRunAsNonRoot))
 	}
+	if c.defaultHostUsers != nil {
+		args = append(args, "--default_host_users", strconv.FormatBool(*c.defaultHostUsers))
+	}
 
 	template := &wfapi.Template{
 		Name: name,

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -101,6 +101,11 @@ type Options struct {
 	DefaultRunAsGroup *int64
 	// Admin-configured default runAsNonRoot for user containers. Nil means not set.
 	DefaultRunAsNonRoot *bool
+	// Administrator-configured default hostUsers for user workload pods. Nil means not set.
+	// When set to false the pod runs in a dedicated Linux user namespace:
+	// UID 0 inside the pod maps to an unprivileged host UID, so root processes
+	// in the container are not root on the host.
+	DefaultHostUsers *bool
 }
 
 // TaskConfig needs to stay aligned with the TaskConfig in the SDK.

--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -730,6 +730,17 @@ func extendPodSpecPatch(
 		}
 	}
 
+	// Pre-populate the administrator-configured hostUsers default at the pod level
+	// only when no value is already present. Setting hostUsers to false places the
+	// pod in a dedicated Linux user namespace: UID 0 inside the pod maps to an
+	// unprivileged host UID, so root processes in the container are not root on
+	// the host. We set only when nil so that the post-processing guard below can
+	// detect and warn about user-supplied overrides.
+	if opts.DefaultHostUsers != nil && podSpec.HostUsers == nil {
+		v := *opts.DefaultHostUsers
+		podSpec.HostUsers = &v
+	}
+
 	// Apply container security context (PSS baseline compliant).
 	// User-specified identity fields (runAsUser, runAsGroup) are only applied
 	// when they are not already set by the platform/admin. If the compiler or
@@ -772,6 +783,19 @@ func extendPodSpecPatch(
 		podSpec.Containers[0].SecurityContext.Capabilities = &k8score.Capabilities{
 			Drop: []k8score.Capability{"ALL"},
 		}
+	}
+
+	// Post-processing: enforce administrator hostUsers regardless of any
+	// user override. hostUsers is a pod-level field controlling Linux user
+	// namespace isolation; allowing users to silently flip it to true would
+	// defeat the administrator's security policy.
+	if opts.DefaultHostUsers != nil {
+		if podSpec.HostUsers != nil && *podSpec.HostUsers != *opts.DefaultHostUsers {
+			glog.Warningf("Ignoring user-specified hostUsers=%t: administrator default hostUsers=%t takes precedence",
+				*podSpec.HostUsers, *opts.DefaultHostUsers)
+		}
+		v := *opts.DefaultHostUsers
+		podSpec.HostUsers = &v
 	}
 
 	return nil

--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -2341,7 +2341,7 @@ func Test_extendPodSpecPatch_SecurityContext_AdminSetPreserved(t *testing.T) {
 	)
 	assert.Nil(t, err)
 	assert.NotNil(t, got)
-	// Admin-set values are preserved; user-specified values are ignored.
+	// Administrator-set values are preserved; user-specified values are ignored.
 	assert.Equal(t, int64(1000), *got.Containers[0].SecurityContext.RunAsUser)
 	assert.Equal(t, int64(0), *got.Containers[0].SecurityContext.RunAsGroup)
 	// Capabilities always dropped.
@@ -2366,7 +2366,7 @@ func Test_extendPodSpecPatch_SecurityContext_AdminDefaultsNoUserOverride(t *test
 		nil,
 	)
 	assert.Nil(t, err)
-	// Admin defaults are applied even without user SecurityContext.
+	// Administrator defaults are applied even without user SecurityContext.
 	assert.Equal(t, int64(1000), *got.Containers[0].SecurityContext.RunAsUser)
 }
 
@@ -2440,7 +2440,7 @@ func Test_extendPodSpecPatch_SecurityContext_AdminRunAsNonRoot(t *testing.T) {
 	)
 	assert.Nil(t, err)
 	assert.NotNil(t, got)
-	// Admin-set runAsNonRoot is preserved; user-specified value is ignored.
+	// Administrator-set runAsNonRoot is preserved; user-specified value is ignored.
 	assert.True(t, *got.Containers[0].SecurityContext.RunAsNonRoot)
 	// Capabilities always dropped.
 	assert.Equal(t, &k8score.Capabilities{Drop: []k8score.Capability{"ALL"}}, got.Containers[0].SecurityContext.Capabilities)
@@ -2464,7 +2464,7 @@ func Test_extendPodSpecPatch_SecurityContext_AdminRunAsNonRootNoUserOverride(t *
 		nil,
 	)
 	assert.Nil(t, err)
-	// Admin defaults are applied even without user SecurityContext.
+	// Administrator defaults are applied even without user SecurityContext.
 	assert.True(t, *got.Containers[0].SecurityContext.RunAsNonRoot)
 }
 
@@ -3424,4 +3424,137 @@ func Test_buildPVCDataSource(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_extendPodSpecPatch_DefaultHostUsersFalse(t *testing.T) {
+	hostUsersInDedicatedNamespace := false
+
+	podSpec := &k8score.PodSpec{Containers: []k8score.Container{
+		{Name: "main"},
+	}}
+	err := extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		Options{
+			DefaultHostUsers: &hostUsersInDedicatedNamespace,
+		},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	assert.Nil(t, err)
+	assert.NotNil(t, podSpec.HostUsers)
+	// hostUsers: false places the pod in a dedicated Linux user namespace,
+	// so UID 0 inside the container maps to an unprivileged host UID.
+	assert.False(t, *podSpec.HostUsers)
+}
+
+func Test_extendPodSpecPatch_DefaultHostUsersTrue(t *testing.T) {
+	hostUsersInHostNamespace := true
+
+	podSpec := &k8score.PodSpec{Containers: []k8score.Container{
+		{Name: "main"},
+	}}
+	err := extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		Options{
+			DefaultHostUsers: &hostUsersInHostNamespace,
+		},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	assert.Nil(t, err)
+	assert.NotNil(t, podSpec.HostUsers)
+	assert.True(t, *podSpec.HostUsers)
+}
+
+func Test_extendPodSpecPatch_DefaultHostUsersNil(t *testing.T) {
+	podSpec := &k8score.PodSpec{Containers: []k8score.Container{
+		{Name: "main"},
+	}}
+	err := extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		Options{
+			DefaultHostUsers: nil,
+		},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	assert.Nil(t, err)
+	// When the administrator default is not set, hostUsers is left unspecified so the
+	// Kubernetes default (host user namespace) applies.
+	assert.Nil(t, podSpec.HostUsers)
+}
+
+// Test_extendPodSpecPatch_RootUserWithHostUsersNamespace verifies that a
+// customer workload container configured to run as UID 0 (root) in combination
+// with hostUsers:false is accepted. When the pod runs in a dedicated Linux user
+// namespace, the root identity inside that namespace does not correspond to root
+// on the host, providing defense-in-depth isolation.
+func Test_extendPodSpecPatch_RootUserWithHostUsersNamespace(t *testing.T) {
+	hostUsersInDedicatedNamespace := false
+	rootUserIdentifier := int64(0)
+
+	podSpec := &k8score.PodSpec{Containers: []k8score.Container{
+		{Name: "main"},
+	}}
+	err := extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		Options{
+			DefaultHostUsers: &hostUsersInDedicatedNamespace,
+			KubernetesExecutorConfig: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: &rootUserIdentifier,
+				},
+			},
+		},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	assert.Nil(t, err)
+	// hostUsers: false must be present on the pod spec.
+	assert.NotNil(t, podSpec.HostUsers)
+	assert.False(t, *podSpec.HostUsers)
+	// The root UID requested by the pipeline author must be applied, since there
+	// is no administrator-level runAsUser override in effect.
+	assert.NotNil(t, podSpec.Containers[0].SecurityContext)
+	assert.NotNil(t, podSpec.Containers[0].SecurityContext.RunAsUser)
+	assert.Equal(t, int64(0), *podSpec.Containers[0].SecurityContext.RunAsUser)
+	// Capabilities are always dropped as a defense-in-depth measure.
+	assert.Equal(t, &k8score.Capabilities{Drop: []k8score.Capability{"ALL"}},
+		podSpec.Containers[0].SecurityContext.Capabilities)
+}
+
+// Test_extendPodSpecPatch_HostUsersAdminOverrideProtection verifies that the
+// post-processing guard re-applies the administrator's hostUsers default even
+// when a user-supplied podSpecPatch has set hostUsers to a different value.
+func Test_extendPodSpecPatch_HostUsersAdminOverrideProtection(t *testing.T) {
+	adminFalse := false
+	// Simulate user setting hostUsers=true via podSpecPatch before
+	// the post-processing guard runs.
+	userTrue := true
+	podSpec := &k8score.PodSpec{
+		Containers: []k8score.Container{{Name: "main"}},
+		HostUsers:  &userTrue,
+	}
+	err := extendPodSpecPatch(
+		context.Background(),
+		podSpec,
+		Options{
+			DefaultHostUsers: &adminFalse,
+		},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	assert.Nil(t, err)
+	// The administrator's false must override the user's true.
+	assert.NotNil(t, podSpec.HostUsers)
+	assert.False(t, *podSpec.HostUsers)
 }

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -114,6 +114,10 @@ data:
   defaultSecurityContextRunAsUser: ""
   defaultSecurityContextRunAsGroup: ""
   defaultSecurityContextRunAsNonRoot: ""
+  ## Default pod-level setting (PodSpec.hostUsers) controlling Linux user
+  ## namespace isolation for customer workloads. When "false", UID 0 inside
+  ## the pod maps to an unprivileged host UID. Set "" to disable.
+  defaultSecurityContextHostUsers: "false"
   ## BLOCK_V1_PIPELINES: Controls whether v1 pipelines are allowed to be created and run.
   ## Valid values are 'true' and 'false'. Defaults to 'false'.
   BLOCK_V1_PIPELINES: "false"

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -117,7 +117,7 @@ data:
   ## Default pod-level setting (PodSpec.hostUsers) controlling Linux user
   ## namespace isolation for customer workloads. When "false", UID 0 inside
   ## the pod maps to an unprivileged host UID. Set "" to disable.
-  defaultSecurityContextHostUsers: "false"
+  defaultSecurityContextHostUsers: ""
   ## BLOCK_V1_PIPELINES: Controls whether v1 pipelines are allowed to be created and run.
   ## Valid values are 'true' and 'false'. Defaults to 'false'.
   BLOCK_V1_PIPELINES: "false"

--- a/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
@@ -109,6 +109,10 @@ data:
   defaultSecurityContextRunAsUser: ""
   defaultSecurityContextRunAsGroup: ""
   defaultSecurityContextRunAsNonRoot: ""
+  ## Default pod-level setting (PodSpec.hostUsers) controlling Linux user
+  ## namespace isolation for customer workloads. When "false", UID 0 inside
+  ## the pod maps to an unprivileged host UID. Set "" to disable.
+  defaultSecurityContextHostUsers: "false"
   ## BLOCK_V1_PIPELINES: Controls whether v1 pipelines are allowed to be created and run.
   ## Valid values are 'true' and 'false'. Defaults to 'false'.
   BLOCK_V1_PIPELINES: "false"

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -239,6 +239,12 @@ spec:
                   name: pipeline-install-config
                   key: defaultSecurityContextRunAsNonRoot
                   optional: true
+            - name: DEFAULT_SECURITY_CONTEXT_HOST_USERS
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: defaultSecurityContextHostUsers
+                  optional: true
             - name: BLOCK_V1_PIPELINES
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
## Summary

Adds `hostUsers: false` default for customer workload pods and a defense-in-depth override guard preventing silent user override of administrator-configured `hostUsers`. Supersedes #13211.

Addresses review feedback from @jsonmp-k8 ([silent override concern](https://github.com/kubeflow/pipelines/pull/13211#issuecomment-2782052083)).

## Changes

### ConfigMap → API server → compiler → driver plumbing

| File | Change |
|------|--------|
| `manifests/.../generic/pipeline-install-config.yaml` | Add `defaultSecurityContextHostUsers` field |
| `manifests/.../postgres/pipeline-install-config.yaml` | Same |
| `manifests/.../ml-pipeline-apiserver-deployment.yaml` | `DEFAULT_SECURITY_CONTEXT_HOST_USERS` env var |
| `backend/src/apiserver/common/config.go` | `DefaultSecurityContextHostUsers` config constant |
| `backend/src/apiserver/main.go` | Read config, set env var |
| `backend/src/apiserver/resource/resource_manager.go` | Pass to template |
| `backend/src/apiserver/template/template.go` | Add to `CreateConfig` |
| `backend/src/apiserver/template/v2_template.go` | Thread to compiler |
| `backend/src/v2/compiler/argocompiler/argo.go` | Pass `defaultHostUsers` to compiler options |
| `backend/src/v2/compiler/argocompiler/container.go` | Emit `--default_host_users` driver arg |
| `backend/src/v2/driver/driver.go` | Thread `DefaultHostUsers` through `Options` |
| `backend/src/v2/cmd/driver/main.go` | Wire `--default_host_users` flag, fail-fast on invalid values |

### Driver enforcement

| File | Change |
|------|--------|
| `backend/src/v2/driver/k8s.go` | Pre-populate `hostUsers` default + post-processing override guard |
| `backend/src/v2/driver/k8s_test.go` | 5 tests: `DefaultHostUsers{False,True,Nil}`, `RootUserWithHostUsersNamespace`, `AdminOverrideProtection` |

## Design Decision

Post-processing guard chosen over pre-processing validation because `hostUsers` can be injected via multiple paths (`podSpecPatch` YAML, future `KubernetesExecutorConfig` fields). A single enforcement point after all mutations guarantees the administrator value always wins regardless of injection vector.

## Related

- Supersedes: #13211
- Previous guard-only PR: #13238 (merged into `copilot/add-default-hostusers-false`)
- Review feedback: @jsonmp-k8 (silent override concern)

## Checklist

- [x] DCO sign-off
- [x] Co-authored-by for original author
- [x] Unit tests cover guard logic
- [x] Matches existing `runAsUser`/`runAsGroup`/`runAsNonRoot` guard patterns

Co-authored-by: Julius von Kohout <juliusvonkohout@users.noreply.github.com>
Signed-off-by: Siddhant Jain <siddhantjainofficial26@gmail.com>
