### PR TITLE
docs: clarify host URL usage in SDK README

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -35,13 +35,14 @@ def add_pipeline(
 ):
     first_add_task = add(a=a, b=4.0)
     second_add_task = add(a=first_add_task.output, b=b)
+```
 
+Before running the pipeline, replace `<my-host-url>` with your Kubeflow Pipelines endpoint (for example, the URL of your deployed Kubeflow instance).
 
+```python
 client = kfp.Client(host='<my-host-url>')
 client.create_run_from_pipeline_func(
     add_pipeline, arguments={
         'a': 7.0,
         'b': 8.0
     })
-
-```


### PR DESCRIPTION
This PR improves the SDK README by clarifying how to set the `<my-host-url>` parameter when creating a Kubeflow Pipelines client.

This helps new users better understand how to configure the client correctly.