### PR TITLE
fix(backend): stop requiring workspace PVC storageClassName

### DIFF
--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -653,8 +653,12 @@ func GetWorkspacePVC(
 		return k8score.PersistentVolumeClaim{}, fmt.Errorf("workspace PVC spec must specify accessModes")
 	}
 
-	if pvcSpec.StorageClassName == nil || *pvcSpec.StorageClassName == "" {
-		return k8score.PersistentVolumeClaim{}, fmt.Errorf("workspace PVC spec must specify storageClassName")
+	// Allow nil storageClassName so Kubernetes can apply the cluster default.
+	// Explicit empty string requests "no storage class" behavior and is rejected.
+	if pvcSpec.StorageClassName != nil && *pvcSpec.StorageClassName == "" {
+		return k8score.PersistentVolumeClaim{}, fmt.Errorf(
+			"workspace PVC spec storageClassName must be omitted or set to a non-empty value",
+		)
 	}
 
 	quantity, err := k8sres.ParseQuantity(sizeStr)

--- a/backend/src/v2/compiler/argocompiler/argo_workspace_test.go
+++ b/backend/src/v2/compiler/argocompiler/argo_workspace_test.go
@@ -209,6 +209,56 @@ func TestGetWorkspacePVC(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "workspace with nil storageClassName should succeed",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "8Gi",
+				Kubernetes: &pipelinespec.KubernetesWorkspaceConfig{
+					PvcSpecPatch: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"accessModes": structpb.NewListValue(&structpb.ListValue{
+								Values: []*structpb.Value{
+									structpb.NewStringValue("ReadWriteOnce"),
+								},
+							}),
+						},
+					},
+				},
+			},
+			opts: nil,
+			expectedPVC: k8score.PersistentVolumeClaim{
+				ObjectMeta: k8smeta.ObjectMeta{
+					Name: "kfp-workspace",
+				},
+				Spec: k8score.PersistentVolumeClaimSpec{
+					AccessModes: []k8score.PersistentVolumeAccessMode{
+						k8score.ReadWriteOnce,
+					},
+					Resources: k8score.VolumeResourceRequirements{
+						Requests: map[k8score.ResourceName]resource.Quantity{
+							k8score.ResourceStorage: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "workspace with explicit empty storageClassName should fail",
+			workspace: &pipelinespec.WorkspaceConfig{
+				Size: "8Gi",
+			},
+			opts: &argocompiler.Options{
+				DefaultWorkspace: &k8score.PersistentVolumeClaimSpec{
+					AccessModes: []k8score.PersistentVolumeAccessMode{
+						k8score.ReadWriteOnce,
+					},
+					StorageClassName: stringPtr(""),
+				},
+			},
+			expectedPVC: k8score.PersistentVolumeClaim{},
+			expectError: true,
+		},
+		{
 			name: "workspace with invalid PVC spec patch",
 			workspace: &pipelinespec.WorkspaceConfig{
 				Size: "10Gi",


### PR DESCRIPTION
## Summary

Fixes a regression from #12369.

- remove the compiler validation that required `workspace.pvcSpec.storageClassName` in `GetWorkspacePVC`
- keep `accessModes` as the only required PVC spec field in this code path
- allow clusters to rely on their default storage class when none is specified

## Test plan
- [x] `go test ./backend/src/v2/compiler/argocompiler -run TestGetWorkspacePVC -count=1`