### PR TITLE
chore(backend): Fix MLflow tags,nested run status update

### DIFF
--- a/backend/src/apiserver/plugins/mlflow/config_test.go
+++ b/backend/src/apiserver/plugins/mlflow/config_test.go
@@ -246,11 +246,22 @@ func TestMergePluginConfigAndSettingsDefaults(t *testing.T) {
 	global := commonmlflow.PluginConfig{
 		Endpoint: "https://global-mlflow.example.com",
 		Timeout:  "30s",
-		Settings: &commonmlflow.MLflowPluginSettings{ExperimentDescription: &globalDesc},
+		Settings: &commonmlflow.MLflowPluginSettings{
+			ExperimentDescription: &globalDesc,
+			KFPBaseURL:            "https://global-kfp.example.com",
+			KFPRunURLPathTemplate: "/global/{run_id}",
+			MLflowBaseURL:         "https://global-mlflow-ui.example.com",
+			MLflowUIPathPrefix:    "/global-mlflow",
+		},
 	}
 	namespace := &commonmlflow.PluginConfig{
 		Endpoint: "https://ns-mlflow.example.com",
-		Settings: &commonmlflow.MLflowPluginSettings{WorkspacesEnabled: &wsDisabled},
+		Settings: &commonmlflow.MLflowPluginSettings{
+			WorkspacesEnabled:     &wsDisabled,
+			KFPRunURLPathTemplate: "/ns/{namespace}/runs/{run_id}",
+			MLflowBaseURL:         "https://ns-mlflow-ui.example.com",
+			MLflowUIPathPrefix:    "/ns-mlflow",
+		},
 	}
 
 	merged := commonmlflow.MergePluginConfig(global, namespace)
@@ -263,6 +274,10 @@ func TestMergePluginConfigAndSettingsDefaults(t *testing.T) {
 	assert.False(t, *settings.WorkspacesEnabled)
 	require.NotNil(t, settings.ExperimentDescription)
 	assert.Equal(t, "Global desc", *settings.ExperimentDescription)
+	assert.Equal(t, "https://global-kfp.example.com", settings.KFPBaseURL)
+	assert.Equal(t, "/ns/{namespace}/runs/{run_id}", settings.KFPRunURLPathTemplate)
+	assert.Equal(t, "https://ns-mlflow-ui.example.com", settings.MLflowBaseURL)
+	assert.Equal(t, "/ns-mlflow", settings.MLflowUIPathPrefix)
 }
 
 func TestBuildMLflowRequestContextKubernetesAuth(t *testing.T) {
@@ -344,26 +359,47 @@ func TestEnsureExperimentExists(t *testing.T) {
 func TestBuildKFPTags(t *testing.T) {
 	run := &apiserverPlugins.PendingRun{
 		RunID:             "kfp-run-1",
+		Namespace:         "ns-1",
 		PipelineID:        "pipeline-1",
 		PipelineVersionID: "pipeline-version-1",
 	}
-	tags := BuildKFPTags(run, "")
+	tags := BuildKFPTags(run, "", "")
 	require.Len(t, tags, 4)
 	assert.Contains(t, tags, commonmlflow.Tag{Key: TagKFPRunID, Value: "kfp-run-1"})
-	assert.Contains(t, tags, commonmlflow.Tag{Key: TagKFPRunURL, Value: "/#/runs/details/kfp-run-1"})
+	assert.Contains(t, tags, commonmlflow.Tag{Key: TagKFPRunURL, Value: ""})
 	assert.Contains(t, tags, commonmlflow.Tag{Key: TagKFPPipelineID, Value: "pipeline-1"})
 	assert.Contains(t, tags, commonmlflow.Tag{Key: TagKFPPipelineVersionID, Value: "pipeline-version-1"})
 }
 
 func TestBuildKFPTags_WithBaseURL(t *testing.T) {
-	run := &apiserverPlugins.PendingRun{RunID: "run-1"}
-	tags := BuildKFPTags(run, "https://kfp.example.com")
+	run := &apiserverPlugins.PendingRun{
+		RunID:     "run-1",
+		Namespace: "ns-1",
+	}
+	tags := BuildKFPTags(run, "https://kfp.example.com", "")
 	require.Len(t, tags, 2)
-	assert.Contains(t, tags, commonmlflow.Tag{Key: TagKFPRunURL, Value: "https://kfp.example.com/#/runs/details/run-1"})
+	assert.Contains(t, tags, commonmlflow.Tag{
+		Key:   TagKFPRunURL,
+		Value: "https://kfp.example.com/#/runs/details/run-1",
+	})
+}
+
+func TestBuildKFPTags_WithCustomPathTemplate(t *testing.T) {
+	run := &apiserverPlugins.PendingRun{
+		RunID:     "run-b",
+		Namespace: "proj-1",
+	}
+	tmpl := "/demo/console/pipelines/{namespace}/runs/{run_id}"
+	tags := BuildKFPTags(run, "https://console.example.com", tmpl)
+	require.Len(t, tags, 2)
+	assert.Contains(t, tags, commonmlflow.Tag{
+		Key:   TagKFPRunURL,
+		Value: "https://console.example.com/demo/console/pipelines/proj-1/runs/run-b",
+	})
 }
 
 func TestBuildKFPTags_NilRun(t *testing.T) {
-	assert.Nil(t, BuildKFPTags(nil, ""))
+	assert.Nil(t, BuildKFPTags(nil, "", ""))
 }
 
 func TestCreateRunWithKFPTags(t *testing.T) {
@@ -390,7 +426,7 @@ func TestCreateRunWithKFPTags(t *testing.T) {
 		PipelineID:        "pipeline-1",
 		PipelineVersionID: "pipeline-version-1",
 	}
-	tags := BuildKFPTags(run, "")
+	tags := BuildKFPTags(run, "", "")
 	mlflowRunID, err := mlflowCtx.Client.CreateRun(context.Background(), "exp-1", "sample-run", tags)
 	require.NoError(t, err)
 	assert.Equal(t, "mlflow-parent-run-1", mlflowRunID)

--- a/backend/src/apiserver/plugins/mlflow/dispatcher.go
+++ b/backend/src/apiserver/plugins/mlflow/dispatcher.go
@@ -16,6 +16,7 @@ package mlflow
 
 import (
 	"context"
+	"time"
 
 	"github.com/golang/glog"
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
@@ -25,6 +26,8 @@ import (
 )
 
 var _ apiserverPlugins.PluginDispatcher = (*Dispatcher)(nil)
+
+const preRunMLflowTimeout = 3 * time.Second
 
 // Dispatcher implements PluginDispatcher for MLflow.
 type Dispatcher struct {
@@ -62,14 +65,24 @@ func (d *Dispatcher) OnBeforeRunCreation(ctx context.Context, run *apiserverPlug
 
 	resolvedCfg, err := ResolveMLflowRequestConfig(ctx, d.kubeClients, run.Namespace)
 	if err != nil {
-		return util.NewInternalServerError(err, "MLflow config resolution failed for run %q", run.RunID)
+		message := "MLflow config resolution failed; run creation will continue: " + err.Error()
+		glog.Warningf("MLflow OnBeforeRunCreation failed for run %q (%s)", run.RunID, message)
+		pluginOutput := FailedPluginOutput(selectedID, selectedName, "", "", "", message)
+		if outputErr := SetPendingRunPluginOutput(run, PluginName, pluginOutput); outputErr != nil {
+			glog.Warningf("Failed to persist MLflow plugin output for run %q: %v", run.RunID, outputErr)
+		}
+		return nil
 	}
 	if resolvedCfg == nil {
 		return nil
 	}
 
 	handler := NewHandler(mlflowInput, run.Namespace)
-	pluginOutput, pluginErr := handler.OnBeforeRunCreation(ctx, run, resolvedCfg.Config)
+	// Limit MLflow pre-run calls to a short timeout budget while still
+	// honoring parent request cancellation.
+	mlflowCtx, cancel := context.WithTimeout(ctx, preRunMLflowTimeout)
+	defer cancel()
+	pluginOutput, pluginErr := handler.OnBeforeRunCreation(mlflowCtx, run, resolvedCfg.Config)
 	if pluginErr != nil {
 		glog.Warningf("MLflow OnBeforeRunCreation failed for run %q (run creation will continue): %v", run.RunID, pluginErr)
 	}

--- a/backend/src/apiserver/plugins/mlflow/handler.go
+++ b/backend/src/apiserver/plugins/mlflow/handler.go
@@ -80,7 +80,7 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 		return FailedPluginOutput(experimentID, experimentName, "", "", endpoint, err.Error()), err
 	}
 
-	tags := BuildKFPTags(run, settings.KFPBaseURL)
+	tags := BuildKFPTags(run, settings.KFPBaseURL, settings.KFPRunURLPathTemplate)
 	parentRunID, err := mlflowRequestCtx.Client.CreateRun(ctx, mlflowExperiment.ID, run.DisplayName, tags)
 	if err != nil {
 		return FailedPluginOutput(mlflowExperiment.ID, mlflowExperiment.Name, "", "", endpoint, err.Error()), err
@@ -119,7 +119,7 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 		commonmlflow.EnvMLflowConfig: string(mlflowConfigJSON),
 	}
 
-	runURL := BuildRunURL(mlflowRequestCtx, mlflowExperiment.ID, parentRunID)
+	runURL := BuildRunURL(mlflowRequestCtx, mlflowExperiment.ID, parentRunID, settings)
 	return SuccessfulPluginOutput(mlflowExperiment.ID, mlflowExperiment.Name, parentRunID, runURL, endpoint), nil
 }
 

--- a/backend/src/apiserver/plugins/mlflow/handler_test.go
+++ b/backend/src/apiserver/plugins/mlflow/handler_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -345,10 +346,12 @@ func TestHandleRetry_Success(t *testing.T) {
 
 func TestBuildKFPRunURL(t *testing.T) {
 	tests := []struct {
-		name       string
-		runID      string
-		kfpBaseURL string
-		wantURL    string
+		name         string
+		runID        string
+		namespace    string
+		kfpBaseURL   string
+		pathTemplate string
+		wantURL      string
 	}{
 		{
 			name:    "empty runID returns empty",
@@ -356,29 +359,163 @@ func TestBuildKFPRunURL(t *testing.T) {
 			wantURL: "",
 		},
 		{
-			name:    "no base URL returns relative path",
+			name:    "no base URL returns empty",
 			runID:   "abc",
-			wantURL: "/#/runs/details/abc",
+			wantURL: "",
 		},
 		{
-			name:       "with base URL returns absolute URL",
-			runID:      "abc",
+			name:       "default KFP UI hash route",
+			runID:      "run-xyz",
+			namespace:  "team-a",
 			kfpBaseURL: "https://kfp.example.com",
-			wantURL:    "https://kfp.example.com/#/runs/details/abc",
+			wantURL:    "https://kfp.example.com/#/runs/details/run-xyz",
 		},
 		{
-			name:       "trailing slash on base URL is trimmed",
-			runID:      "abc",
-			kfpBaseURL: "https://kfp.example.com/",
-			wantURL:    "https://kfp.example.com/#/runs/details/abc",
+			name:       "default hash route without namespace segment",
+			runID:      "run-xyz",
+			namespace:  "",
+			kfpBaseURL: "https://kfp.example.com",
+			wantURL:    "https://kfp.example.com/#/runs/details/run-xyz",
+		},
+		{
+			name:         "path template with placeholders",
+			runID:        "run-b",
+			namespace:    "ns-a",
+			kfpBaseURL:   "https://console.example.com",
+			pathTemplate: "/demo/console/pipelines/{namespace}/runs/{run_id}",
+			wantURL:      "https://console.example.com/demo/console/pipelines/ns-a/runs/run-b",
+		},
+		{
+			name:         "path template without leading slash normalized",
+			runID:        "r",
+			namespace:    "n",
+			kfpBaseURL:   "https://x.example",
+			pathTemplate: "clusters/{namespace}/runs/{run_id}",
+			wantURL:      "https://x.example/clusters/n/runs/r",
+		},
+		{
+			name:         "template with namespace placeholder rejects empty ns",
+			runID:        "run-xyz",
+			namespace:    "",
+			kfpBaseURL:   "https://kfp.example.com",
+			pathTemplate: "/demo/console/pipelines/{namespace}/runs/{run_id}",
+			wantURL:      "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := BuildKFPRunURL(tt.runID, tt.kfpBaseURL)
+			got := BuildKFPRunURL(tt.runID, tt.namespace, tt.kfpBaseURL, tt.pathTemplate)
 			assert.Equal(t, tt.wantURL, got)
 		})
 	}
+}
+
+func TestBuildRunURL(t *testing.T) {
+	mustParseURL := func(raw string) *url.URL {
+		t.Helper()
+		u, err := url.Parse(raw)
+		require.NoError(t, err)
+		return u
+	}
+	tests := []struct {
+		name         string
+		requestCtx   *commonmlflow.RequestContext
+		experimentID string
+		runID        string
+		settings     *commonmlflow.MLflowPluginSettings
+		wantURL      string
+	}{
+		{
+			name:         "endpoint base with default hash route",
+			requestCtx:   &commonmlflow.RequestContext{BaseURL: mustParseURL("https://tracking.example:5000")},
+			experimentID: "5",
+			runID:        "abc123",
+			wantURL:      "https://tracking.example:5000/#/experiments/5/runs/abc123",
+		},
+		{
+			name: "mlflowBaseURL overrides browser entry point",
+			requestCtx: &commonmlflow.RequestContext{
+				BaseURL: mustParseURL("http://mlflow.internal.svc.cluster.local:5000"),
+			},
+			experimentID: "9",
+			runID:        "run-z",
+			settings: &commonmlflow.MLflowPluginSettings{
+				MLflowBaseURL: "https://mlflow.example.com",
+			},
+			wantURL: "https://mlflow.example.com/#/experiments/9/runs/run-z",
+		},
+		{
+			name: "optional path prefix before fragment",
+			requestCtx: &commonmlflow.RequestContext{
+				BaseURL: mustParseURL("https://dashboard.example.com"),
+			},
+			experimentID: "1",
+			runID:        "r1",
+			settings:     &commonmlflow.MLflowPluginSettings{MLflowUIPathPrefix: "/mlflow"},
+			wantURL:      "https://dashboard.example.com/mlflow/#/experiments/1/runs/r1",
+		},
+		{
+			name: "workspace query in hash fragment",
+			requestCtx: &commonmlflow.RequestContext{
+				BaseURL:           mustParseURL("https://tracking.example"),
+				WorkspacesEnabled: true,
+				Workspace:         "mlflow-ws-1",
+			},
+			experimentID: "5",
+			runID:        "abc123",
+			wantURL:      "https://tracking.example/#/experiments/5/runs/abc123?workspace=mlflow-ws-1",
+		},
+		{
+			name:         "mlflowBaseURL without requestCtx.BaseURL",
+			requestCtx:   &commonmlflow.RequestContext{},
+			experimentID: "2",
+			runID:        "run-a",
+			settings: &commonmlflow.MLflowPluginSettings{
+				MLflowBaseURL: "https://ml.example",
+			},
+			wantURL: "https://ml.example/#/experiments/2/runs/run-a",
+		},
+		{
+			name:         "no mount base yields empty",
+			requestCtx:   &commonmlflow.RequestContext{},
+			experimentID: "5",
+			runID:        "x",
+			wantURL:      "",
+		},
+		{
+			name:         "missing experiment id yields empty",
+			requestCtx:   &commonmlflow.RequestContext{BaseURL: mustParseURL("https://x")},
+			experimentID: "",
+			runID:        "y",
+			wantURL:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildRunURL(tt.requestCtx, tt.experimentID, tt.runID, tt.settings)
+			assert.Equal(t, tt.wantURL, got)
+		})
+	}
+}
+
+func TestShouldSyncNestedRun(t *testing.T) {
+	t.Run("terminal mode syncs non-terminal statuses", func(t *testing.T) {
+		assert.True(t, shouldSyncNestedRun(RunSyncModeTerminal, "RUNNING"))
+		assert.True(t, shouldSyncNestedRun(RunSyncModeTerminal, "SCHEDULED"))
+		assert.True(t, shouldSyncNestedRun(RunSyncModeTerminal, "PENDING"))
+		assert.True(t, shouldSyncNestedRun(RunSyncModeTerminal, ""))
+		assert.False(t, shouldSyncNestedRun(RunSyncModeTerminal, "FINISHED"))
+		assert.False(t, shouldSyncNestedRun(RunSyncModeTerminal, "FAILED"))
+		assert.False(t, shouldSyncNestedRun(RunSyncModeTerminal, "KILLED"))
+	})
+
+	t.Run("retry mode syncs only failed and killed", func(t *testing.T) {
+		assert.True(t, shouldSyncNestedRun(RunSyncModeRetry, "FAILED"))
+		assert.True(t, shouldSyncNestedRun(RunSyncModeRetry, "KILLED"))
+		assert.False(t, shouldSyncNestedRun(RunSyncModeRetry, "RUNNING"))
+		assert.False(t, shouldSyncNestedRun(RunSyncModeRetry, "FINISHED"))
+	})
 }
 
 // ---- ModelToPersistedRun tests ----

--- a/backend/src/apiserver/plugins/mlflow/run_start.go
+++ b/backend/src/apiserver/plugins/mlflow/run_start.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
@@ -138,26 +139,42 @@ func CreateExperiment(ctx context.Context, requestCtx *commonmlflow.RequestConte
 	return nil, createErr
 }
 
-// BuildKFPRunURL constructs a KFP pipeline run URL.
-func BuildKFPRunURL(runID, kfpBaseURL string) string {
-	if runID == "" {
+// BuildKFPRunURL builds a link from kfpBaseURL to the pipeline run details page.
+func BuildKFPRunURL(runID, namespace, kfpBaseURL, pathTemplate string) string {
+	if runID == "" || kfpBaseURL == "" {
+		glog.V(4).Infof(
+			"BuildKFPRunURL returned empty URL due to missing input(s): runID_empty=%t kfpBaseURL_empty=%t",
+			runID == "",
+			kfpBaseURL == "",
+		)
 		return ""
 	}
-	path := fmt.Sprintf("/#/runs/details/%s", runID)
-	if kfpBaseURL != "" {
-		return strings.TrimRight(kfpBaseURL, "/") + path
+	pathTemplate = strings.TrimSpace(pathTemplate)
+	if pathTemplate == "" {
+		base := strings.TrimRight(kfpBaseURL, "/")
+		return fmt.Sprintf("%s/#/runs/details/%s", base, url.PathEscape(runID))
 	}
-	return path
+	if namespace == "" && strings.Contains(pathTemplate, "{namespace}") {
+		glog.V(4).Infof("BuildKFPRunURL returned empty URL: namespace required when template contains {namespace}")
+		return ""
+	}
+	base := strings.TrimRight(kfpBaseURL, "/")
+	rendered := strings.ReplaceAll(pathTemplate, "{run_id}", url.PathEscape(runID))
+	rendered = strings.ReplaceAll(rendered, "{namespace}", url.PathEscape(namespace))
+	if !(strings.HasPrefix(rendered, "/") || strings.HasPrefix(rendered, "#")) {
+		rendered = "/" + rendered
+	}
+	return base + rendered
 }
 
 // BuildKFPTags builds MLflow tags containing KFP metadata for a pipeline run.
-func BuildKFPTags(run *apiserverPlugins.PendingRun, kfpBaseURL string) []commonmlflow.Tag {
+func BuildKFPTags(run *apiserverPlugins.PendingRun, kfpBaseURL, kfpRunURLPathTemplate string) []commonmlflow.Tag {
 	if run == nil {
 		return nil
 	}
 	tags := []commonmlflow.Tag{
 		{Key: TagKFPRunID, Value: run.RunID},
-		{Key: TagKFPRunURL, Value: BuildKFPRunURL(run.RunID, kfpBaseURL)},
+		{Key: TagKFPRunURL, Value: BuildKFPRunURL(run.RunID, run.Namespace, kfpBaseURL, kfpRunURLPathTemplate)},
 	}
 	if run.PipelineID != "" {
 		tags = append(tags, commonmlflow.Tag{Key: TagKFPPipelineID, Value: run.PipelineID})
@@ -168,19 +185,61 @@ func BuildKFPTags(run *apiserverPlugins.PendingRun, kfpBaseURL string) []commonm
 	return tags
 }
 
-func BuildRunURL(requestCtx *commonmlflow.RequestContext, experimentID, runID string) string {
-	if requestCtx == nil || requestCtx.BaseURL == nil || experimentID == "" || runID == "" {
+// mlflowTrackingUIMountBase resolves the UI link prefix for MLflow Tracking UI links.
+func mlflowTrackingUIMountBase(requestCtx *commonmlflow.RequestContext, settings *commonmlflow.MLflowPluginSettings) string {
+	if settings != nil {
+		if b := strings.TrimSpace(settings.MLflowBaseURL); b != "" {
+			return strings.TrimRight(b, "/")
+		}
+	}
+	if requestCtx != nil && requestCtx.BaseURL != nil {
+		return strings.TrimRight(requestCtx.BaseURL.String(), "/")
+	}
+	return ""
+}
+
+func normalizeMlflowUIPathPrefix(prefix string) string {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
 		return ""
 	}
-	u := *requestCtx.BaseURL
-	basePath := stringsTrimRightSlash(u.Path)
-	u.Path = fmt.Sprintf("%s/experiments/%s/runs/%s", basePath, url.PathEscape(experimentID), url.PathEscape(runID))
-	if requestCtx.WorkspacesEnabled && requestCtx.Workspace != "" {
-		q := u.Query()
-		q.Set("workspace", requestCtx.Workspace)
-		u.RawQuery = q.Encode()
+	if !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
 	}
-	return u.String()
+	return strings.TrimRight(prefix, "/")
+}
+
+// BuildRunURL returns the MLflow Tracking UI URL for a run.
+func BuildRunURL(requestCtx *commonmlflow.RequestContext, experimentID, runID string, settings *commonmlflow.MLflowPluginSettings) string {
+	if experimentID == "" || runID == "" {
+		glog.V(4).Infof(
+			"BuildRunURL returned empty URL due to missing input(s): experimentID_empty=%t runID_empty=%t",
+			experimentID == "",
+			runID == "",
+		)
+		return ""
+	}
+	trackingUIBase := mlflowTrackingUIMountBase(requestCtx, settings)
+	if trackingUIBase == "" {
+		glog.V(4).Infof(
+			"BuildRunURL returned empty URL: no mlflowBaseURL and requestCtx.BaseURL is unavailable",
+		)
+		return ""
+	}
+	uiPathPrefix := ""
+	if settings != nil {
+		uiPathPrefix = normalizeMlflowUIPathPrefix(settings.MLflowUIPathPrefix)
+	}
+
+	trackingMlflowRunPath := fmt.Sprintf(
+		"/experiments/%s/runs/%s",
+		url.PathEscape(experimentID),
+		url.PathEscape(runID),
+	)
+	if requestCtx != nil && requestCtx.WorkspacesEnabled && requestCtx.Workspace != "" {
+		trackingMlflowRunPath = fmt.Sprintf("%s?workspace=%s", trackingMlflowRunPath, url.QueryEscape(requestCtx.Workspace))
+	}
+	return trackingUIBase + uiPathPrefix + "/#" + trackingMlflowRunPath
 }
 
 func SuccessfulPluginOutput(experimentID, experimentName, runID, runURL, endpoint string) *apiv2beta1.PluginOutput {
@@ -368,7 +427,7 @@ func syncNestedRuns(ctx context.Context, requestCtx *commonmlflow.RequestContext
 		action = "reopen nested run"
 	}
 	var syncErrors []string
-	filter := fmt.Sprintf("tags.mlflow.parentRunId = '%s'", parentRunID)
+	filter := fmt.Sprintf(`tags.%q = '%s'`, commonmlflow.TagNestedRunParentRunID, parentRunID)
 	pageToken := ""
 	for page := 0; page < maxSearchPages; page++ {
 		searchResp, err := requestCtx.Client.SearchRuns(ctx, []string{experimentID}, filter, 1000, pageToken)
@@ -389,7 +448,6 @@ func syncNestedRuns(ctx context.Context, requestCtx *commonmlflow.RequestContext
 			if nestedRunID == "" || nestedRunID == parentRunID || !shouldSyncNestedRun(mode, mlflowRun.Info.Status) {
 				continue
 			}
-			// Recurse into children before updating this run .
 			childErrors := syncNestedRuns(ctx, requestCtx, nestedRunID, experimentID, mode, targetStatus, endTimeMs, depth+1)
 			syncErrors = append(syncErrors, childErrors...)
 			if err := requestCtx.Client.UpdateRun(ctx, nestedRunID, targetStatus, endTimeMs); err != nil {
@@ -431,18 +489,11 @@ func buildPluginOutput(experimentID, experimentName, runID, runURL, endpoint str
 	}
 }
 
-func stringsTrimRightSlash(s string) string {
-	for len(s) > 0 && s[len(s)-1] == '/' {
-		s = s[:len(s)-1]
-	}
-	return s
-}
-
 func shouldSyncNestedRun(mode RunSyncMode, status string) bool {
 	upperStatus := strings.ToUpper(status)
 	switch mode {
 	case RunSyncModeTerminal:
-		return upperStatus == "RUNNING" || upperStatus == "SCHEDULED"
+		return upperStatus != "FINISHED" && upperStatus != "FAILED" && upperStatus != "KILLED"
 	case RunSyncModeRetry:
 		return upperStatus == "FAILED" || upperStatus == "KILLED"
 	default:

--- a/backend/src/common/plugins/mlflow/client.go
+++ b/backend/src/common/plugins/mlflow/client.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -441,6 +442,9 @@ func (rt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 
 	var resp *http.Response
 	operation := func() error {
+		if ctxErr := req.Context().Err(); ctxErr != nil {
+			return backoff.Permanent(ctxErr)
+		}
 		// Reset the request body for each attempt.
 		if req.GetBody != nil {
 			body, err := req.GetBody()
@@ -453,6 +457,9 @@ func (rt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 		var err error
 		resp, err = rt.next.RoundTrip(req)
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return backoff.Permanent(err)
+			}
 			glog.Warningf("MLflow request %s %s failed (will retry): %v", req.Method, req.URL.Path, err)
 			return err
 		}
@@ -490,7 +497,8 @@ func (rt *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 		b.Multiplier = rt.retry.Multiplier
 	}
 
-	if err := backoff.Retry(operation, b); err != nil {
+	retryBackoff := backoff.WithContext(b, req.Context())
+	if err := backoff.Retry(operation, retryBackoff); err != nil {
 		// If we have a response (4xx case), return it so the caller can parse the error body.
 		if resp != nil {
 			return resp, nil

--- a/backend/src/common/plugins/mlflow/config.go
+++ b/backend/src/common/plugins/mlflow/config.go
@@ -31,6 +31,9 @@ import (
 // Workflow templates by the API server.
 const EnvMLflowConfig = "KFP_MLFLOW_CONFIG"
 
+// MLflow tag on nested runs (parent linkage).
+const TagNestedRunParentRunID = "mlflow.parentRunId"
+
 // MLflowRuntimeConfig is the JSON payload marshalled into KFP_MLFLOW_CONFIG.
 type MLflowRuntimeConfig struct {
 	Endpoint           string     `json:"endpoint"`
@@ -81,6 +84,9 @@ type MLflowPluginSettings struct {
 	ExperimentDescription *string `json:"experimentDescription,omitempty"`
 	DefaultExperimentName string  `json:"defaultExperimentName,omitempty"`
 	KFPBaseURL            string  `json:"kfpBaseURL,omitempty"`
+	KFPRunURLPathTemplate string  `json:"kfpRunURLPathTemplate,omitempty"`
+	MLflowBaseURL         string  `json:"mlflowBaseURL,omitempty"`
+	MLflowUIPathPrefix    string  `json:"mlflowUIPathPrefix,omitempty"`
 	InjectUserEnvVars     *bool   `json:"injectUserEnvVars,omitempty"`
 }
 
@@ -125,6 +131,15 @@ func mergeSettings(global, namespace *MLflowPluginSettings) *MLflowPluginSetting
 	}
 	if namespace.KFPBaseURL != "" {
 		merged.KFPBaseURL = namespace.KFPBaseURL
+	}
+	if namespace.KFPRunURLPathTemplate != "" {
+		merged.KFPRunURLPathTemplate = namespace.KFPRunURLPathTemplate
+	}
+	if namespace.MLflowBaseURL != "" {
+		merged.MLflowBaseURL = namespace.MLflowBaseURL
+	}
+	if namespace.MLflowUIPathPrefix != "" {
+		merged.MLflowUIPathPrefix = namespace.MLflowUIPathPrefix
 	}
 	if namespace.InjectUserEnvVars != nil {
 		merged.InjectUserEnvVars = namespace.InjectUserEnvVars

--- a/backend/src/v2/driver/container_test.go
+++ b/backend/src/v2/driver/container_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
+	"github.com/kubeflow/pipelines/backend/src/v2/common/plugins"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
 	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
 	"github.com/stretchr/testify/assert"
@@ -253,6 +254,7 @@ func TestContainer_CreateExecutionGeneralFailure(t *testing.T) {
 			Image:   "python:3.11",
 			Command: []string{"python", "main.py"},
 		},
+		PluginDispatcher: plugins.NoOpDispatcher{},
 	}, mlmdClient, &mockCacheClient{})
 
 	require.NotNil(t, execution)
@@ -309,6 +311,7 @@ func TestContainer_CreateExecutionSuccess(t *testing.T) {
 			Image:   "python:3.11",
 			Command: []string{"python", "main.py"},
 		},
+		PluginDispatcher: plugins.NoOpDispatcher{},
 	}, mlmdClient, &mockCacheClient{})
 
 	require.NotNil(t, execution)
@@ -368,6 +371,7 @@ func TestContainer_CreateExecutionAlreadyExistsLookupReturnsNil(t *testing.T) {
 			Image:   "python:3.11",
 			Command: []string{"python", "main.py"},
 		},
+		PluginDispatcher: plugins.NoOpDispatcher{},
 	}, mlmdClient, &mockCacheClient{})
 
 	require.NotNil(t, execution)
@@ -426,6 +430,7 @@ func TestContainer_CreateExecutionDoesNotExistGenericError(t *testing.T) {
 			Image:   "python:3.11",
 			Command: []string{"python", "main.py"},
 		},
+		PluginDispatcher: plugins.NoOpDispatcher{},
 	}, mlmdClient, &mockCacheClient{})
 
 	// In a successful recovery, we expect NO error to be returned from Container


### PR DESCRIPTION
**Description of your changes:**
This PR addressed the following issues identified in MLflow KFP integration:
- KFP run URL tags in MLflow are not accessible.
- plugins_output.mlflow.run_url used internal MLflow service URLs instead of externally accessible UI URLs.
- KFP run creation could still be impacted when MLflow was down.
- MLflow client retry loop continued retrying after context cancellation/deadline.
- Nested MLflow runs could remain open due to narrow terminal-sync status filtering.

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
