### PR TITLE
test(end2end): add gpu fixtures folder and gpu label

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-04-25
+- Last updated: 2026-05-01
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -243,10 +243,13 @@ ginkgo -v --label-filter="Smoke" ./backend/test/v2/api
 ginkgo -v ./backend/test/end2end -- -namespace=kubeflow -isDebugMode=true
 ```
 
+Without `--label-filter`, `gpu`-labeled E2E tests run as well (they request accelerators) and may pend or fail on CPU-only clusters; pass `--label-filter` to limit what runs (for example `Smoke`, or `gpu` on GPU-capable clusters). NVIDIA vs AMD fixtures: set `KFP_E2E_GPU_VENDOR` to `nvidia` (default if unset), `amd`, or `both` so only matching IRs run (`pytorch_nvidia_gpu_availability.yaml` / `pytorch_amd_gpu_availability.yaml`).
+
 Test data is centralized under:
 
 - `test_data/pipeline_files/valid/` (inputs) with a `valid/critical/` subset for smoke lanes
 - `test_data/compiled-workflows/` (expected compiled Argo Workflows)
+- `test_data/sdk_compiled_pipelines/valid/gpu/` (GPU pipeline IR + `.py` sources vendored from [ods-ci PyTorch GPU samples](https://github.com/red-hat-data-services/ods-ci/tree/master/ods_ci/tests/Resources/Files/pipeline-samples/v2/cache-disabled/gpu/pytorch); checked-in `pytorch_*.yaml` matches upstream `*_compiled.yaml` names expected by this repo’s compiler goldens)
 
 ## Local execution
 
@@ -644,7 +647,7 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 - Run backend unit tests: `go test -v $(go list ./backend/... | grep -v backend/test/)`
 - Run compiler tests: `ginkgo -v ./backend/test/compiler`
 - Run API tests: `ginkgo -v --label-filter="Smoke" ./backend/test/v2/api`
-- Run E2E tests: `ginkgo -v ./backend/test/end2end -- -namespace=kubeflow`
+- Run E2E tests: `ginkgo -v ./backend/test/end2end -- -namespace=kubeflow` (CPU-only: add `--label-filter`, e.g. `Smoke`, to avoid `gpu` tests)
 - Check formatting:
   `yapf --recursive --diff sdk/python/ && pycln --check sdk/python && isort --check --profile google sdk/python`
 - Frontend dev server: `cd frontend && npm start`

--- a/backend/test/constants/test_features.go
+++ b/backend/test/constants/test_features.go
@@ -32,6 +32,8 @@ const (
 	E2eParallelNested string = "E2EParallelNested"
 	// E2eProxy - For pipeline that runs with a proxy
 	E2eProxy string = "E2EProxy"
+	// E2eGpu - For pipelines that require GPU-capable clusters (accelerator workloads)
+	E2eGpu string = "gpu"
 
 	WorkflowCompiler       string = "WorkflowCompiler"
 	WorkflowCompilerVisits string = "WorkflowCompilerVisits"

--- a/backend/test/end2end/pipeline_e2e_test.go
+++ b/backend/test/end2end/pipeline_e2e_test.go
@@ -237,8 +237,8 @@ var _ = Describe("Upload and Verify Pipeline Run >", Label(FullRegression), func
 		}
 	})
 
-	// gpu-labeled specs run even when the package has no --label-filter; see AGENTS.md (Local execution → E2E tests).
-	Context("GPU component test >", Label("gpu"), func() {
+	// E2eGpu-labeled specs run even when the package has no --label-filter; see AGENTS.md (Local execution → E2E tests).
+	Context("GPU component test >", Label(E2eGpu), func() {
 		var pipelineDir = "valid/gpu"
 		pipelineFiles := testutil.GetListOfFilesInADir(filepath.Join(testutil.GetPipelineFilesDir(), pipelineDir))
 		for _, pipelineFile := range pipelineFiles {

--- a/backend/test/end2end/pipeline_e2e_test.go
+++ b/backend/test/end2end/pipeline_e2e_test.go
@@ -16,6 +16,7 @@ package end2end
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -235,7 +236,37 @@ var _ = Describe("Upload and Verify Pipeline Run >", Label(FullRegression), func
 			})
 		}
 	})
+
+	// gpu-labeled specs run even when the package has no --label-filter; see AGENTS.md (Local execution → E2E tests).
+	Context("GPU component test >", Label("gpu"), func() {
+		var pipelineDir = "valid/gpu"
+		pipelineFiles := testutil.GetListOfFilesInADir(filepath.Join(testutil.GetPipelineFilesDir(), pipelineDir))
+		for _, pipelineFile := range pipelineFiles {
+			if !gpuPipelineFixtureSelected(pipelineFile) {
+				continue
+			}
+			It(fmt.Sprintf("Upload %s pipeline", pipelineFile), FlakeAttempts(2), func() {
+				validatePipelineRunSuccess(pipelineFile, pipelineDir, testContext)
+			})
+		}
+	})
 })
+
+// gpuPipelineFixtureSelected returns whether to run an E2E for this IR fixture.
+// Fixtures are vendored from ods-ci (NVIDIA vs AMD); only one vendor typically matches the cluster.
+// KFP_E2E_GPU_VENDOR: unset or "nvidia" → pytorch_nvidia_gpu_availability.yaml only;
+// "amd" → pytorch_amd_gpu_availability.yaml only; "both" → all yaml in valid/gpu.
+func gpuPipelineFixtureSelected(pipelineFile string) bool {
+	vendor := strings.ToLower(strings.TrimSpace(os.Getenv("KFP_E2E_GPU_VENDOR")))
+	switch vendor {
+	case "amd":
+		return strings.Contains(pipelineFile, "amd")
+	case "both", "all":
+		return true
+	default:
+		return strings.Contains(pipelineFile, "nvidia")
+	}
+}
 
 func validatePipelineRunSuccess(pipelineFile string, pipelineDir string, testContext *apitests.TestContext) {
 	testutil.CheckIfSkipping(pipelineFile)

--- a/test_data/compiled-workflows/pytorch_amd_gpu_availability.yaml
+++ b/test_data/compiled-workflows/pytorch_amd_gpu_availability.yaml
@@ -1,0 +1,464 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: pytorch-amd-gpu-availability-
+spec:
+  arguments:
+    parameters:
+    - name: components-6149b670d0a6a870bbd3421507afdd4a17582617eff6e1f394ffd0ae957918d8
+      value: '{"executorLabel":"exec-verify-gpu-availability","inputDefinitions":{"parameters":{"gpu_toleration":{"parameterType":"BOOLEAN"}}}}'
+    - name: implementations-6149b670d0a6a870bbd3421507afdd4a17582617eff6e1f394ffd0ae957918d8
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","verify_gpu_availability"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.13.0'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        verify_gpu_availability(gpu_toleration: bool):\n    import torch  # noqa:
+        PLC0415\n\n    cuda_available = torch.cuda.is_available()\n    device_count
+        = torch.cuda.device_count()\n    print(\"------------------------------\")\n    print(\"GPU
+        availability\")\n    print(\"------------------------------\")\n    print(f\"cuda
+        available: {cuda_available}\")\n    print(f\"device count: {device_count}\")\n    if
+        gpu_toleration:\n        assert torch.cuda.is_available()\n        assert
+        torch.cuda.device_count() \u003e 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64,
+        device=\"cuda\")\n    else:\n        assert not torch.cuda.is_available()\n        assert
+        torch.cuda.device_count() == 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64)\n    print(f\"tensor:
+        {t}\")\n    print(\"GPU availability test: PASS\")\n\n"],"image":"quay.io/modh/odh-pipeline-runtime-pytorch-rocm-py311-ubi9@sha256:d9fb9efa196afd97d8ff9c0bf4c5bd09a9f01bd03d1166bebf974c8bf18958c4"}'
+    - name: kubernetes-comp-verify-gpu-availability-2
+      value: '{"tolerations":[{"effect":"NoSchedule","key":"amd.com/gpu","operator":"Exists"}]}'
+    - name: components-481102a042aeb30a3095b1d88b309e7e848e45ad9e3ecf49839de29a7153c853
+      value: '{"executorLabel":"exec-verify-gpu-availability-2","inputDefinitions":{"parameters":{"gpu_toleration":{"parameterType":"BOOLEAN"}}}}'
+    - name: implementations-481102a042aeb30a3095b1d88b309e7e848e45ad9e3ecf49839de29a7153c853
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","verify_gpu_availability"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.13.0'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        verify_gpu_availability(gpu_toleration: bool):\n    import torch  # noqa:
+        PLC0415\n\n    cuda_available = torch.cuda.is_available()\n    device_count
+        = torch.cuda.device_count()\n    print(\"------------------------------\")\n    print(\"GPU
+        availability\")\n    print(\"------------------------------\")\n    print(f\"cuda
+        available: {cuda_available}\")\n    print(f\"device count: {device_count}\")\n    if
+        gpu_toleration:\n        assert torch.cuda.is_available()\n        assert
+        torch.cuda.device_count() \u003e 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64,
+        device=\"cuda\")\n    else:\n        assert not torch.cuda.is_available()\n        assert
+        torch.cuda.device_count() == 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64)\n    print(f\"tensor:
+        {t}\")\n    print(\"GPU availability test: PASS\")\n\n"],"image":"quay.io/modh/odh-pipeline-runtime-pytorch-rocm-py311-ubi9@sha256:d9fb9efa196afd97d8ff9c0bf4c5bd09a9f01bd03d1166bebf974c8bf18958c4","resources":{"accelerator":{"count":"1","resourceCount":"1","resourceType":"amd.com/gpu","type":"amd.com/gpu"}}}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"verify-gpu-availability":{"cachingOptions":{},"componentRef":{"name":"comp-verify-gpu-availability"},"inputs":{"parameters":{"gpu_toleration":{"runtimeValue":{"constant":false}}}},"taskInfo":{"name":"verify-gpu-availability"}},"verify-gpu-availability-2":{"cachingOptions":{},"componentRef":{"name":"comp-verify-gpu-availability-2"},"inputs":{"parameters":{"gpu_toleration":{"runtimeValue":{"constant":true}}}},"taskInfo":{"name":"verify-gpu-availability-2"}}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - pytorch-amd-gpu-availability
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      command:
+      - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: task-name
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata: {}
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+        name: executor
+        template: system-container-impl
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+    metadata: {}
+    name: system-container-executor
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher:latest
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+    metadata: {}
+    name: system-container-impl
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-6149b670d0a6a870bbd3421507afdd4a17582617eff6e1f394ffd0ae957918d8}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-verify-gpu-availability"},"inputs":{"parameters":{"gpu_toleration":{"runtimeValue":{"constant":false}}}},"taskInfo":{"name":"verify-gpu-availability"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-6149b670d0a6a870bbd3421507afdd4a17582617eff6e1f394ffd0ae957918d8}}'
+          - name: task-name
+            value: verify-gpu-availability
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: verify-gpu-availability-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.verify-gpu-availability-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.verify-gpu-availability-driver.outputs.parameters.cached-decision}}'
+        depends: verify-gpu-availability-driver.Succeeded
+        name: verify-gpu-availability
+        template: system-container-executor
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-481102a042aeb30a3095b1d88b309e7e848e45ad9e3ecf49839de29a7153c853}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-verify-gpu-availability-2"},"inputs":{"parameters":{"gpu_toleration":{"runtimeValue":{"constant":true}}}},"taskInfo":{"name":"verify-gpu-availability-2"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-481102a042aeb30a3095b1d88b309e7e848e45ad9e3ecf49839de29a7153c853}}'
+          - name: task-name
+            value: verify-gpu-availability-2
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+          - name: kubernetes-config
+            value: '{{workflow.parameters.kubernetes-comp-verify-gpu-availability-2}}'
+        name: verify-gpu-availability-2-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.verify-gpu-availability-2-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.verify-gpu-availability-2-driver.outputs.parameters.cached-decision}}'
+        depends: verify-gpu-availability-2-driver.Succeeded
+        name: verify-gpu-availability-2
+        template: system-container-executor
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - pytorch-amd-gpu-availability
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: ""
+        name: task-name
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata: {}
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/test_data/compiled-workflows/pytorch_nvidia_gpu_availability.yaml
+++ b/test_data/compiled-workflows/pytorch_nvidia_gpu_availability.yaml
@@ -1,0 +1,464 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: pytorch-nvidia-gpu-availability-
+spec:
+  arguments:
+    parameters:
+    - name: components-b99207864ea365706de69474d5b81360a07ae5147608481feab23a922e67c3a5
+      value: '{"executorLabel":"exec-verify-gpu-availability","inputDefinitions":{"parameters":{"gpu_toleration":{"parameterType":"BOOLEAN"}}}}'
+    - name: implementations-b99207864ea365706de69474d5b81360a07ae5147608481feab23a922e67c3a5
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","verify_gpu_availability"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.13.0'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        verify_gpu_availability(gpu_toleration: bool):\n    import torch  # noqa:
+        PLC0415\n\n    cuda_available = torch.cuda.is_available()\n    device_count
+        = torch.cuda.device_count()\n    print(\"------------------------------\")\n    print(\"GPU
+        availability\")\n    print(\"------------------------------\")\n    print(f\"cuda
+        available: {cuda_available}\")\n    print(f\"device count: {device_count}\")\n    if
+        gpu_toleration:\n        assert torch.cuda.is_available()\n        assert
+        torch.cuda.device_count() \u003e 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64,
+        device=\"cuda\")\n    else:\n        assert not torch.cuda.is_available()\n        assert
+        torch.cuda.device_count() == 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64)\n    print(f\"tensor:
+        {t}\")\n    print(\"GPU availability test: PASS\")\n\n"],"image":"quay.io/modh/odh-pipeline-runtime-pytorch-cuda-py311-ubi9@sha256:4706be608af3f33c88700ef6ef6a99e716fc95fc7d2e879502e81c0022fd840e"}'
+    - name: kubernetes-comp-verify-gpu-availability-2
+      value: '{"tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]}'
+    - name: components-f7cf7dc5d52074851c1e8b89d7731afd4398b29b02fd8bc71cd73322f0002bbe
+      value: '{"executorLabel":"exec-verify-gpu-availability-2","inputDefinitions":{"parameters":{"gpu_toleration":{"parameterType":"BOOLEAN"}}}}'
+    - name: implementations-f7cf7dc5d52074851c1e8b89d7731afd4398b29b02fd8bc71cd73322f0002bbe
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","verify_gpu_availability"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.13.0'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        verify_gpu_availability(gpu_toleration: bool):\n    import torch  # noqa:
+        PLC0415\n\n    cuda_available = torch.cuda.is_available()\n    device_count
+        = torch.cuda.device_count()\n    print(\"------------------------------\")\n    print(\"GPU
+        availability\")\n    print(\"------------------------------\")\n    print(f\"cuda
+        available: {cuda_available}\")\n    print(f\"device count: {device_count}\")\n    if
+        gpu_toleration:\n        assert torch.cuda.is_available()\n        assert
+        torch.cuda.device_count() \u003e 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64,
+        device=\"cuda\")\n    else:\n        assert not torch.cuda.is_available()\n        assert
+        torch.cuda.device_count() == 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64)\n    print(f\"tensor:
+        {t}\")\n    print(\"GPU availability test: PASS\")\n\n"],"image":"quay.io/modh/odh-pipeline-runtime-pytorch-cuda-py311-ubi9@sha256:4706be608af3f33c88700ef6ef6a99e716fc95fc7d2e879502e81c0022fd840e","resources":{"accelerator":{"count":"1","resourceCount":"1","resourceType":"nvidia.com/gpu","type":"nvidia.com/gpu"}}}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"verify-gpu-availability":{"cachingOptions":{},"componentRef":{"name":"comp-verify-gpu-availability"},"inputs":{"parameters":{"gpu_toleration":{"runtimeValue":{"constant":false}}}},"taskInfo":{"name":"verify-gpu-availability"}},"verify-gpu-availability-2":{"cachingOptions":{},"componentRef":{"name":"comp-verify-gpu-availability-2"},"inputs":{"parameters":{"gpu_toleration":{"runtimeValue":{"constant":true}}}},"taskInfo":{"name":"verify-gpu-availability-2"}}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - pytorch-nvidia-gpu-availability
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      command:
+      - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: task-name
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata: {}
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+        name: executor
+        template: system-container-impl
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+    metadata: {}
+    name: system-container-executor
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher:latest
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+    metadata: {}
+    name: system-container-impl
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-b99207864ea365706de69474d5b81360a07ae5147608481feab23a922e67c3a5}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-verify-gpu-availability"},"inputs":{"parameters":{"gpu_toleration":{"runtimeValue":{"constant":false}}}},"taskInfo":{"name":"verify-gpu-availability"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-b99207864ea365706de69474d5b81360a07ae5147608481feab23a922e67c3a5}}'
+          - name: task-name
+            value: verify-gpu-availability
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: verify-gpu-availability-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.verify-gpu-availability-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.verify-gpu-availability-driver.outputs.parameters.cached-decision}}'
+        depends: verify-gpu-availability-driver.Succeeded
+        name: verify-gpu-availability
+        template: system-container-executor
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-f7cf7dc5d52074851c1e8b89d7731afd4398b29b02fd8bc71cd73322f0002bbe}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-verify-gpu-availability-2"},"inputs":{"parameters":{"gpu_toleration":{"runtimeValue":{"constant":true}}}},"taskInfo":{"name":"verify-gpu-availability-2"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-f7cf7dc5d52074851c1e8b89d7731afd4398b29b02fd8bc71cd73322f0002bbe}}'
+          - name: task-name
+            value: verify-gpu-availability-2
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+          - name: kubernetes-config
+            value: '{{workflow.parameters.kubernetes-comp-verify-gpu-availability-2}}'
+        name: verify-gpu-availability-2-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.verify-gpu-availability-2-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.verify-gpu-availability-2-driver.outputs.parameters.cached-decision}}'
+        depends: verify-gpu-availability-2-driver.Succeeded
+        name: verify-gpu-availability-2
+        template: system-container-executor
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - pytorch-nvidia-gpu-availability
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: ""
+        name: task-name
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata: {}
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/test_data/sdk_compiled_pipelines/valid/gpu/pytorch_amd_gpu_availability.py
+++ b/test_data/sdk_compiled_pipelines/valid/gpu/pytorch_amd_gpu_availability.py
@@ -1,0 +1,78 @@
+# Copyright 2025 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Vendored from red-hat-data-services/ods-ci (Apache-2.0):
+# https://github.com/red-hat-data-services/ods-ci/blob/master/ods_ci/tests/Resources/Files/pipeline-samples/v2/cache-disabled/gpu/pytorch/pytorch_amd_gpu_availability.py
+
+from kfp import compiler, dsl, kubernetes
+from kfp.dsl import PipelineTask
+
+# Runtime: Pytorch with ROCm and Python 3.11 (UBI 9)
+# The images for each release can be found in
+# https://github.com/red-hat-data-services/rhoai-disconnected-install-helper/blob/main/rhoai-2.21.md
+common_base_image = "quay.io/modh/odh-pipeline-runtime-pytorch-rocm-py311-ubi9@sha256:d9fb9efa196afd97d8ff9c0bf4c5bd09a9f01bd03d1166bebf974c8bf18958c4"
+
+
+def add_gpu_toleration(task: PipelineTask, accelerator_type: str,
+                       accelerator_limit: int):
+    print(f"Adding GPU tolerations: {accelerator_type}({accelerator_limit})")
+    task.set_accelerator_type(accelerator=accelerator_type)
+    task.set_accelerator_limit(accelerator_limit)
+    kubernetes.add_toleration(task,
+                              key=accelerator_type,
+                              operator="Exists",
+                              effect="NoSchedule")
+
+
+@dsl.component(base_image=common_base_image)
+def verify_gpu_availability(gpu_toleration: bool):
+    import torch  # noqa: PLC0415
+
+    cuda_available = torch.cuda.is_available()
+    device_count = torch.cuda.device_count()
+    print("------------------------------")
+    print("GPU availability")
+    print("------------------------------")
+    print(f"cuda available: {cuda_available}")
+    print(f"device count: {device_count}")
+    if gpu_toleration:
+        assert torch.cuda.is_available()
+        assert torch.cuda.device_count() > 0
+        t = torch.tensor([5, 5, 5], dtype=torch.int64, device="cuda")
+    else:
+        assert not torch.cuda.is_available()
+        assert torch.cuda.device_count() == 0
+        t = torch.tensor([5, 5, 5], dtype=torch.int64)
+    print(f"tensor: {t}")
+    print("GPU availability test: PASS")
+
+
+@dsl.pipeline(
+    name="pytorch-amd-gpu-availability",
+    description="Verifies pipeline tasks run on GPU nodes only when tolerations are added",
+)
+def pytorch_amd_gpu_availability():
+    verify_gpu_availability(gpu_toleration=False).set_caching_options(False)
+
+    task_with_toleration = verify_gpu_availability(
+        gpu_toleration=True).set_caching_options(False)
+    add_gpu_toleration(task_with_toleration, "amd.com/gpu", 1)
+
+
+if __name__ == "__main__":
+    # Checked-in `.yaml` IR is copied from ods-ci `pytorch_amd_gpu_availability_compiled.yaml`.
+    compiler.Compiler().compile(
+        pytorch_amd_gpu_availability,
+        package_path=__file__.replace(".py", ".yaml"),
+    )

--- a/test_data/sdk_compiled_pipelines/valid/gpu/pytorch_amd_gpu_availability.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/gpu/pytorch_amd_gpu_availability.yaml
@@ -1,0 +1,141 @@
+# PIPELINE DEFINITION
+# Name: pytorch-amd-gpu-availability
+# Description: Verifies pipeline tasks run on GPU nodes only when tolerations are added
+components:
+  comp-verify-gpu-availability:
+    executorLabel: exec-verify-gpu-availability
+    inputDefinitions:
+      parameters:
+        gpu_toleration:
+          parameterType: BOOLEAN
+  comp-verify-gpu-availability-2:
+    executorLabel: exec-verify-gpu-availability-2
+    inputDefinitions:
+      parameters:
+        gpu_toleration:
+          parameterType: BOOLEAN
+deploymentSpec:
+  executors:
+    exec-verify-gpu-availability:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - verify_gpu_availability
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef verify_gpu_availability(gpu_toleration: bool):\n    import torch\
+          \  # noqa: PLC0415\n\n    cuda_available = torch.cuda.is_available()\n \
+          \   device_count = torch.cuda.device_count()\n    print(\"------------------------------\"\
+          )\n    print(\"GPU availability\")\n    print(\"------------------------------\"\
+          )\n    print(f\"cuda available: {cuda_available}\")\n    print(f\"device\
+          \ count: {device_count}\")\n    if gpu_toleration:\n        assert torch.cuda.is_available()\n\
+          \        assert torch.cuda.device_count() > 0\n        t = torch.tensor([5,\
+          \ 5, 5], dtype=torch.int64, device=\"cuda\")\n    else:\n        assert\
+          \ not torch.cuda.is_available()\n        assert torch.cuda.device_count()\
+          \ == 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64)\n    print(f\"\
+          tensor: {t}\")\n    print(\"GPU availability test: PASS\")\n\n"
+        image: quay.io/modh/odh-pipeline-runtime-pytorch-rocm-py311-ubi9@sha256:d9fb9efa196afd97d8ff9c0bf4c5bd09a9f01bd03d1166bebf974c8bf18958c4
+    exec-verify-gpu-availability-2:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - verify_gpu_availability
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef verify_gpu_availability(gpu_toleration: bool):\n    import torch\
+          \  # noqa: PLC0415\n\n    cuda_available = torch.cuda.is_available()\n \
+          \   device_count = torch.cuda.device_count()\n    print(\"------------------------------\"\
+          )\n    print(\"GPU availability\")\n    print(\"------------------------------\"\
+          )\n    print(f\"cuda available: {cuda_available}\")\n    print(f\"device\
+          \ count: {device_count}\")\n    if gpu_toleration:\n        assert torch.cuda.is_available()\n\
+          \        assert torch.cuda.device_count() > 0\n        t = torch.tensor([5,\
+          \ 5, 5], dtype=torch.int64, device=\"cuda\")\n    else:\n        assert\
+          \ not torch.cuda.is_available()\n        assert torch.cuda.device_count()\
+          \ == 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64)\n    print(f\"\
+          tensor: {t}\")\n    print(\"GPU availability test: PASS\")\n\n"
+        image: quay.io/modh/odh-pipeline-runtime-pytorch-rocm-py311-ubi9@sha256:d9fb9efa196afd97d8ff9c0bf4c5bd09a9f01bd03d1166bebf974c8bf18958c4
+        resources:
+          accelerator:
+            count: '1'
+            resourceCount: '1'
+            resourceType: amd.com/gpu
+            type: amd.com/gpu
+pipelineInfo:
+  description: Verifies pipeline tasks run on GPU nodes only when tolerations are
+    added
+  name: pytorch-amd-gpu-availability
+root:
+  dag:
+    tasks:
+      verify-gpu-availability:
+        cachingOptions: {}
+        componentRef:
+          name: comp-verify-gpu-availability
+        inputs:
+          parameters:
+            gpu_toleration:
+              runtimeValue:
+                constant: false
+        taskInfo:
+          name: verify-gpu-availability
+      verify-gpu-availability-2:
+        cachingOptions: {}
+        componentRef:
+          name: comp-verify-gpu-availability-2
+        inputs:
+          parameters:
+            gpu_toleration:
+              runtimeValue:
+                constant: true
+        taskInfo:
+          name: verify-gpu-availability-2
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.13.0
+---
+platforms:
+  kubernetes:
+    deploymentSpec:
+      executors:
+        exec-verify-gpu-availability-2:
+          tolerations:
+          - effect: NoSchedule
+            key: amd.com/gpu
+            operator: Exists

--- a/test_data/sdk_compiled_pipelines/valid/gpu/pytorch_nvidia_gpu_availability.py
+++ b/test_data/sdk_compiled_pipelines/valid/gpu/pytorch_nvidia_gpu_availability.py
@@ -1,0 +1,78 @@
+# Copyright 2025 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Vendored from red-hat-data-services/ods-ci (Apache-2.0):
+# https://github.com/red-hat-data-services/ods-ci/blob/master/ods_ci/tests/Resources/Files/pipeline-samples/v2/cache-disabled/gpu/pytorch/pytorch_nvidia_gpu_availability.py
+
+from kfp import compiler, dsl, kubernetes
+from kfp.dsl import PipelineTask
+
+# Runtime: Pytorch with CUDA and Python 3.11 (UBI 9)
+# The images for each release can be found in
+# https://github.com/red-hat-data-services/rhoai-disconnected-install-helper/blob/main/rhoai-2.21.md
+common_base_image = "quay.io/modh/odh-pipeline-runtime-pytorch-cuda-py311-ubi9@sha256:4706be608af3f33c88700ef6ef6a99e716fc95fc7d2e879502e81c0022fd840e"
+
+
+def add_gpu_toleration(task: PipelineTask, accelerator_type: str,
+                       accelerator_limit: int):
+    print(f"Adding GPU tolerations: {accelerator_type}({accelerator_limit})")
+    task.set_accelerator_type(accelerator=accelerator_type)
+    task.set_accelerator_limit(accelerator_limit)
+    kubernetes.add_toleration(task,
+                              key=accelerator_type,
+                              operator="Exists",
+                              effect="NoSchedule")
+
+
+@dsl.component(base_image=common_base_image)
+def verify_gpu_availability(gpu_toleration: bool):
+    import torch  # noqa: PLC0415
+
+    cuda_available = torch.cuda.is_available()
+    device_count = torch.cuda.device_count()
+    print("------------------------------")
+    print("GPU availability")
+    print("------------------------------")
+    print(f"cuda available: {cuda_available}")
+    print(f"device count: {device_count}")
+    if gpu_toleration:
+        assert torch.cuda.is_available()
+        assert torch.cuda.device_count() > 0
+        t = torch.tensor([5, 5, 5], dtype=torch.int64, device="cuda")
+    else:
+        assert not torch.cuda.is_available()
+        assert torch.cuda.device_count() == 0
+        t = torch.tensor([5, 5, 5], dtype=torch.int64)
+    print(f"tensor: {t}")
+    print("GPU availability test: PASS")
+
+
+@dsl.pipeline(
+    name="pytorch-nvidia-gpu-availability",
+    description="Verifies pipeline tasks run on GPU nodes only when tolerations are added",
+)
+def pytorch_nvidia_gpu_availability():
+    verify_gpu_availability(gpu_toleration=False).set_caching_options(False)
+
+    task_with_toleration = verify_gpu_availability(
+        gpu_toleration=True).set_caching_options(False)
+    add_gpu_toleration(task_with_toleration, "nvidia.com/gpu", 1)
+
+
+if __name__ == "__main__":
+    # Checked-in `.yaml` IR is copied from ods-ci `pytorch_nvidia_gpu_availability_compiled.yaml`.
+    compiler.Compiler().compile(
+        pytorch_nvidia_gpu_availability,
+        package_path=__file__.replace(".py", ".yaml"),
+    )

--- a/test_data/sdk_compiled_pipelines/valid/gpu/pytorch_nvidia_gpu_availability.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/gpu/pytorch_nvidia_gpu_availability.yaml
@@ -1,0 +1,141 @@
+# PIPELINE DEFINITION
+# Name: pytorch-nvidia-gpu-availability
+# Description: Verifies pipeline tasks run on GPU nodes only when tolerations are added
+components:
+  comp-verify-gpu-availability:
+    executorLabel: exec-verify-gpu-availability
+    inputDefinitions:
+      parameters:
+        gpu_toleration:
+          parameterType: BOOLEAN
+  comp-verify-gpu-availability-2:
+    executorLabel: exec-verify-gpu-availability-2
+    inputDefinitions:
+      parameters:
+        gpu_toleration:
+          parameterType: BOOLEAN
+deploymentSpec:
+  executors:
+    exec-verify-gpu-availability:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - verify_gpu_availability
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef verify_gpu_availability(gpu_toleration: bool):\n    import torch\
+          \  # noqa: PLC0415\n\n    cuda_available = torch.cuda.is_available()\n \
+          \   device_count = torch.cuda.device_count()\n    print(\"------------------------------\"\
+          )\n    print(\"GPU availability\")\n    print(\"------------------------------\"\
+          )\n    print(f\"cuda available: {cuda_available}\")\n    print(f\"device\
+          \ count: {device_count}\")\n    if gpu_toleration:\n        assert torch.cuda.is_available()\n\
+          \        assert torch.cuda.device_count() > 0\n        t = torch.tensor([5,\
+          \ 5, 5], dtype=torch.int64, device=\"cuda\")\n    else:\n        assert\
+          \ not torch.cuda.is_available()\n        assert torch.cuda.device_count()\
+          \ == 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64)\n    print(f\"\
+          tensor: {t}\")\n    print(\"GPU availability test: PASS\")\n\n"
+        image: quay.io/modh/odh-pipeline-runtime-pytorch-cuda-py311-ubi9@sha256:4706be608af3f33c88700ef6ef6a99e716fc95fc7d2e879502e81c0022fd840e
+    exec-verify-gpu-availability-2:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - verify_gpu_availability
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.13.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef verify_gpu_availability(gpu_toleration: bool):\n    import torch\
+          \  # noqa: PLC0415\n\n    cuda_available = torch.cuda.is_available()\n \
+          \   device_count = torch.cuda.device_count()\n    print(\"------------------------------\"\
+          )\n    print(\"GPU availability\")\n    print(\"------------------------------\"\
+          )\n    print(f\"cuda available: {cuda_available}\")\n    print(f\"device\
+          \ count: {device_count}\")\n    if gpu_toleration:\n        assert torch.cuda.is_available()\n\
+          \        assert torch.cuda.device_count() > 0\n        t = torch.tensor([5,\
+          \ 5, 5], dtype=torch.int64, device=\"cuda\")\n    else:\n        assert\
+          \ not torch.cuda.is_available()\n        assert torch.cuda.device_count()\
+          \ == 0\n        t = torch.tensor([5, 5, 5], dtype=torch.int64)\n    print(f\"\
+          tensor: {t}\")\n    print(\"GPU availability test: PASS\")\n\n"
+        image: quay.io/modh/odh-pipeline-runtime-pytorch-cuda-py311-ubi9@sha256:4706be608af3f33c88700ef6ef6a99e716fc95fc7d2e879502e81c0022fd840e
+        resources:
+          accelerator:
+            count: '1'
+            resourceCount: '1'
+            resourceType: nvidia.com/gpu
+            type: nvidia.com/gpu
+pipelineInfo:
+  description: Verifies pipeline tasks run on GPU nodes only when tolerations are
+    added
+  name: pytorch-nvidia-gpu-availability
+root:
+  dag:
+    tasks:
+      verify-gpu-availability:
+        cachingOptions: {}
+        componentRef:
+          name: comp-verify-gpu-availability
+        inputs:
+          parameters:
+            gpu_toleration:
+              runtimeValue:
+                constant: false
+        taskInfo:
+          name: verify-gpu-availability
+      verify-gpu-availability-2:
+        cachingOptions: {}
+        componentRef:
+          name: comp-verify-gpu-availability-2
+        inputs:
+          parameters:
+            gpu_toleration:
+              runtimeValue:
+                constant: true
+        taskInfo:
+          name: verify-gpu-availability-2
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.13.0
+---
+platforms:
+  kubernetes:
+    deploymentSpec:
+      executors:
+        exec-verify-gpu-availability-2:
+          tolerations:
+          - effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists


### PR DESCRIPTION
### Summary
Follow-up for layout/labels: [RHOAIENG-46526](https://redhat.atlassian.net/browse/RHOAIENG-46526). Does not fix the separate PyTorch entrypoint/image issue from that ticket.

### Changes

- Add test_data/sdk_compiled_pipelines/valid/gpu/ with ods-ci PyTorch GPU availability pipelines ([source dir](https://github.com/red-hat-data-services/ods-ci/tree/master/ods_ci/tests/Resources/Files/pipeline-samples/v2/cache-disabled/gpu/pytorch)): pytorch_nvidia_gpu_availability + pytorch_amd_gpu_availability (.py + IR .yaml).

- Add gpu-labeled E2E that uploads/runs those fixtures and checks test_data/compiled-workflows/pytorch_{nvidia,amd}_gpu_availability.yaml.

- KFP_E2E_GPU_VENDOR: nvidia (default if unset), amd, or both — which IR(s) E2E runs.

- Update AGENTS.md for the above.


Note
Running all E2E without --label-filter still pulls in gpu specs (accelerators + GPU images); on CPU-only clusters use a filter such as Smoke or --label-filter='!gpu'. See AGENTS.md (Local testing → End-to-end tests)
