### PR TITLE
fix(frontend): download v2 directory artifacts as tar.gz. Fixes #7809

### DIFF
--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -24,6 +24,7 @@ import {
   getObjectStream,
   isNoSuchKeyError,
   listObjectsUnderPrefix,
+  summarizeDirectoryUnderPrefix,
 } from '../minio-helper.js';
 import * as tar from 'tar-stream';
 import * as zlib from 'zlib';
@@ -380,6 +381,24 @@ function getMinioArtifactHandler(
       // a .tar.gz so users can still download them. See
       // https://github.com/kubeflow/pipelines/issues/7809
       if (isNoSuchKeyError(err)) {
+        if (peek > 0) {
+          // Preview request (e.g. the run details panel calls
+          // Apis.readFile with a small peek size). We must not stream a
+          // full directory archive here — that would list every object
+          // under the prefix and gzip the whole tree just to render a few
+          // KB of inline text. Instead, answer with a small text summary
+          // backed by one capped ListObjectsV2 call: cost stays bounded
+          // (one round trip, <1KB body) and the user sees that the
+          // artifact is a directory with N files.
+          try {
+            await previewDirectorySummary(options, res);
+            return;
+          } catch (summaryErr) {
+            console.error(summaryErr);
+            res.status(500).send(`Failed to summarize directory: ${summaryErr}`);
+            return;
+          }
+        }
         try {
           await streamDirectoryAsTarGz(options, res);
           return;
@@ -397,6 +416,25 @@ function getMinioArtifactHandler(
       res.status(500).send(`Failed to get object in bucket: ${err}`);
     }
   };
+}
+
+async function previewDirectorySummary(
+  options: { bucket: string; key: string; client: MinioClient },
+  res: Response,
+) {
+  const { bucket, key, client } = options;
+  // Trailing slash so prefix "foo" doesn't also match sibling key "foobar".
+  const prefix = key.endsWith('/') ? key : `${key}/`;
+  const summary = await summarizeDirectoryUnderPrefix(client, bucket, prefix);
+  if (!summary) {
+    res.status(404).send(`No objects found at ${bucket}/${key}`);
+    return;
+  }
+  const baseName = key.replace(/\/+$/, '').split('/').pop() || 'artifact';
+  const countLabel = `${summary.count}${summary.truncated ? '+' : ''}`;
+  res
+    .type('text/plain')
+    .send(`Directory artifact "${baseName}" — ${countLabel} file(s). Download to view contents.\n`);
 }
 
 async function streamDirectoryAsTarGz(

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -19,7 +19,14 @@ import {
   parseJSONString,
   isAllowedResourceName,
 } from '../utils.js';
-import { createMinioClient, getObjectStream } from '../minio-helper.js';
+import {
+  createMinioClient,
+  getObjectStream,
+  isNoSuchKeyError,
+  listObjectsUnderPrefix,
+} from '../minio-helper.js';
+import * as tar from 'tar-stream';
+import * as zlib from 'zlib';
 import * as serverInfo from '../helpers/server-info.js';
 import { Handler, Request, Response, NextFunction } from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
@@ -368,10 +375,66 @@ function getMinioArtifactHandler(
         .pipe(new PreviewStream({ peek }))
         .pipe(res);
     } catch (err) {
+      // In KFP v2, output artifacts may be directories (prefixes) rather than
+      // single objects. Fall back to packaging the contents of the prefix as
+      // a .tar.gz so users can still download them. See
+      // https://github.com/kubeflow/pipelines/issues/7809
+      if (isNoSuchKeyError(err)) {
+        try {
+          await streamDirectoryAsTarGz(options, res);
+          return;
+        } catch (tarErr) {
+          console.error(tarErr);
+          if (!res.headersSent) {
+            res.status(500).send(`Failed to get object in bucket: ${tarErr}`);
+          } else {
+            res.end();
+          }
+          return;
+        }
+      }
       console.error(err);
       res.status(500).send(`Failed to get object in bucket: ${err}`);
     }
   };
+}
+
+async function streamDirectoryAsTarGz(
+  options: { bucket: string; key: string; client: MinioClient },
+  res: Response,
+) {
+  const { bucket, key, client } = options;
+  // Trailing slash so prefix "foo" doesn't also match sibling key "foobar".
+  const prefix = key.endsWith('/') ? key : `${key}/`;
+  const objects = await listObjectsUnderPrefix(client, bucket, prefix);
+  if (objects.length === 0) {
+    res.status(404).send(`No objects found at ${bucket}/${key}`);
+    return;
+  }
+
+  const baseName = key.replace(/\/+$/, '').split('/').pop() || 'artifact';
+  res.setHeader('Content-Type', 'application/gzip');
+  res.setHeader('Content-Disposition', `attachment; filename="${baseName}.tar.gz"`);
+
+  const pack = tar.pack();
+  const gzip = zlib.createGzip();
+  pack.pipe(gzip).pipe(res);
+
+  try {
+    for (const { name, size } of objects) {
+      const objStream = await client.getObject(bucket, name);
+      const entryName = name.startsWith(prefix) ? name.slice(prefix.length) : name;
+      await new Promise<void>((resolve, reject) => {
+        const entry = pack.entry({ name: entryName, size }, (err) =>
+          err ? reject(err) : resolve(),
+        );
+        objStream.on('error', reject);
+        objStream.pipe(entry);
+      });
+    }
+  } finally {
+    pack.finalize();
+  }
 }
 
 /**

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -406,35 +406,82 @@ async function streamDirectoryAsTarGz(
   const { bucket, key, client } = options;
   // Trailing slash so prefix "foo" doesn't also match sibling key "foobar".
   const prefix = key.endsWith('/') ? key : `${key}/`;
-  const objects = await listObjectsUnderPrefix(client, bucket, prefix);
-  if (objects.length === 0) {
+
+  // Peek the first object before sending headers so an empty prefix can still
+  // produce a 404 instead of an empty 200 tarball.
+  const iterator = listObjectsUnderPrefix(client, bucket, prefix);
+  const first = await iterator.next();
+  if (first.done) {
     res.status(404).send(`No objects found at ${bucket}/${key}`);
     return;
   }
 
   const baseName = key.replace(/\/+$/, '').split('/').pop() || 'artifact';
   res.setHeader('Content-Type', 'application/gzip');
-  res.setHeader('Content-Disposition', `attachment; filename="${baseName}.tar.gz"`);
+  res.setHeader('Content-Disposition', buildAttachmentDisposition(`${baseName}.tar.gz`));
 
   const pack = tar.pack();
   const gzip = zlib.createGzip();
   pack.pipe(gzip).pipe(res);
 
+  const writeEntry = async ({ name, size }: { name: string; size: number }) => {
+    const relativeName = name.startsWith(prefix) ? name.slice(prefix.length) : name;
+    const safeName = sanitizeTarEntryName(relativeName);
+    if (!safeName) {
+      // Skip directory-marker objects (key === prefix) and any keys that
+      // sanitize to an empty path.
+      return;
+    }
+    const objStream = await client.getObject(bucket, name);
+    await new Promise<void>((resolve, reject) => {
+      const entry = pack.entry({ name: safeName, size }, (err) => (err ? reject(err) : resolve()));
+      objStream.on('error', reject);
+      objStream.pipe(entry);
+    });
+  };
+
   try {
-    for (const { name, size } of objects) {
-      const objStream = await client.getObject(bucket, name);
-      const entryName = name.startsWith(prefix) ? name.slice(prefix.length) : name;
-      await new Promise<void>((resolve, reject) => {
-        const entry = pack.entry({ name: entryName, size }, (err) =>
-          err ? reject(err) : resolve(),
-        );
-        objStream.on('error', reject);
-        objStream.pipe(entry);
-      });
+    await writeEntry(first.value);
+    for await (const item of iterator) {
+      await writeEntry(item);
     }
   } finally {
     pack.finalize();
   }
+}
+
+// Builds a `Content-Disposition: attachment` header that is safe to pass to
+// `res.setHeader` regardless of the user-controlled filename. The legacy
+// `filename=` parameter is reduced to an ASCII-only form so older clients
+// don't see broken quoting; the modern `filename*` parameter carries the
+// real name via RFC 5987 percent-encoding (UTF-8). Without this, a key
+// containing quotes, control characters, or anything outside latin-1 could
+// cause `setHeader` to throw or produce a malformed download name.
+function buildAttachmentDisposition(filename: string): string {
+  // Path separators have no place in a filename and are not valid in either
+  // disposition parameter.
+  const stripped = filename.replace(/[/\\]+/g, '_');
+  const asciiFallback = stripped.replace(/[^A-Za-z0-9._-]/g, '_') || 'artifact';
+  // encodeURIComponent leaves a few characters (', (, ), *) unencoded that
+  // RFC 5987's `attr-char` set excludes; encode them explicitly so the
+  // result conforms to `ext-value` from RFC 5987.
+  const rfc5987Encoded = encodeURIComponent(stripped).replace(
+    /['()*]/g,
+    (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase(),
+  );
+  return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${rfc5987Encoded}`;
+}
+
+// Sanitizes an object key into a safe relative POSIX path for inclusion in a
+// tarball. Strips leading slashes and removes "." and ".." segments to
+// prevent tar-slip path traversal during extraction. Returns null when the
+// result is empty (e.g. for directory-marker objects whose key equals the
+// prefix, or paths consisting entirely of unsafe segments).
+function sanitizeTarEntryName(name: string): string | null {
+  const segments = name
+    .split('/')
+    .filter((segment) => segment !== '' && segment !== '.' && segment !== '..');
+  return segments.length > 0 ? segments.join('/') : null;
 }
 
 /**

--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -18,7 +18,6 @@ import * as minio from 'minio';
 import * as path from 'path';
 import * as tar from 'tar-stream';
 import * as zlib from 'zlib';
-import { EventEmitter } from 'events';
 import { PassThrough, Readable } from 'stream';
 import requests from 'supertest';
 import { UIServer } from '../app.js';
@@ -962,21 +961,16 @@ describe('/artifacts', () => {
               }
               throw makeNoSuchKeyError();
             },
-            listObjectsV2Query: (_bucket: string, prefix: string) => {
-              const emitter = new EventEmitter();
-              // Emit asynchronously so the handler's `.on('data', ...)` is
-              // attached before the event fires.
-              setImmediate(() => {
-                emitter.emit('data', {
-                  objects: Object.entries(fileContents)
-                    .filter(([key]) => key.startsWith(prefix))
-                    .map(([name, content]) => ({ name, size: content.length })),
-                  isTruncated: false,
-                  nextContinuationToken: '',
-                });
-              });
-              return emitter;
-            },
+            // minio@8.x exposes listObjectsV2Query as an async method that
+            // resolves to the parsed page; mirror that here so the mock
+            // matches the real client's runtime shape.
+            listObjectsV2Query: async (_bucket: string, prefix: string) => ({
+              objects: Object.entries(fileContents)
+                .filter(([key]) => key.startsWith(prefix))
+                .map(([name, content]) => ({ name, size: content.length })),
+              isTruncated: false,
+              nextContinuationToken: '',
+            }),
           };
         });
       }

--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -1031,6 +1031,120 @@ describe('/artifacts', () => {
         expect(entries.get('sub/file2.txt')!.toString()).toBe('second file contents');
       });
 
+      it('returns a small text summary for preview requests instead of streaming the archive', async () => {
+        // The run details panel calls Apis.readFile with peek=N to render a
+        // small inline preview. Falling through to the tar fallback would
+        // list every object under the prefix and stream the whole gzip just
+        // to render a few KB. The preview path must instead answer with a
+        // bounded summary: exactly one capped listObjectsV2Query call (no
+        // pagination), no per-child getObject fetches, small text body.
+        const listObjectsV2Query = vi.fn(
+          async (
+            _bucket: string,
+            _prefix: string,
+            _continuationToken: string,
+            _delimiter: string,
+            _maxKeys: number,
+          ) => ({
+            objects: Array.from({ length: 5 }, (_, i) => ({
+              name: `some-directory/file-${i}.txt`,
+              size: 10,
+            })),
+            isTruncated: false,
+            nextContinuationToken: '',
+          }),
+        );
+        const getObject = vi.fn(async (bucket: string, key: string) => {
+          if (bucket === 'ml-pipeline' && key === 'some-directory') {
+            throw makeNoSuchKeyError();
+          }
+          throw new Error(`unexpected getObject(${bucket}, ${key})`);
+        });
+        const mockedMinioClient = minio.Client as any;
+        mockedMinioClient.mockImplementation(function () {
+          return { getObject, listObjectsV2Query };
+        });
+
+        const configs = loadConfigs(argv, minioConfigEnv);
+        app = new UIServer(configs);
+
+        const request = requests(app.app);
+        const res = await request
+          .get('/artifacts/get?source=minio&bucket=ml-pipeline&key=some-directory&peek=256')
+          .expect(200);
+
+        // Response is small text, not a gzip archive.
+        expect(res.headers['content-type']).toMatch(/^text\/plain/);
+        expect(res.headers['content-type']).not.toMatch(/gzip/);
+        expect(res.text.length).toBeLessThan(512);
+        expect(res.text).toContain('Directory artifact');
+        expect(res.text).toContain('some-directory');
+        expect(res.text).toContain('5');
+
+        // Exactly one listing call; no pagination loop.
+        expect(listObjectsV2Query).toHaveBeenCalledTimes(1);
+        // Only the original single-object lookup was attempted; no per-file
+        // fetches under the prefix.
+        expect(getObject).toHaveBeenCalledTimes(1);
+        expect(getObject).toHaveBeenCalledWith('ml-pipeline', 'some-directory');
+      });
+
+      it('marks the file count as truncated when minio reports more pages exist', async () => {
+        // For very large directories the single capped list call only sees
+        // the first page; surface that to the user as "N+" rather than a
+        // misleading exact count.
+        const listObjectsV2Query = vi.fn(async () => ({
+          objects: Array.from({ length: 50 }, (_, i) => ({
+            name: `huge-dir/file-${i}.txt`,
+            size: 1,
+          })),
+          isTruncated: true,
+          nextContinuationToken: 'next-page-token',
+        }));
+        const getObject = vi.fn(async () => {
+          throw makeNoSuchKeyError();
+        });
+        const mockedMinioClient = minio.Client as any;
+        mockedMinioClient.mockImplementation(function () {
+          return { getObject, listObjectsV2Query };
+        });
+
+        const configs = loadConfigs(argv, minioConfigEnv);
+        app = new UIServer(configs);
+
+        const request = requests(app.app);
+        const res = await request
+          .get('/artifacts/get?source=minio&bucket=ml-pipeline&key=huge-dir&peek=256')
+          .expect(200);
+
+        expect(res.text).toContain('50+');
+        // Did not paginate even though more pages exist.
+        expect(listObjectsV2Query).toHaveBeenCalledTimes(1);
+      });
+
+      it('returns 404 for preview requests on an empty prefix', async () => {
+        const listObjectsV2Query = vi.fn(async () => ({
+          objects: [],
+          isTruncated: false,
+          nextContinuationToken: '',
+        }));
+        const getObject = vi.fn(async () => {
+          throw makeNoSuchKeyError();
+        });
+        const mockedMinioClient = minio.Client as any;
+        mockedMinioClient.mockImplementation(function () {
+          return { getObject, listObjectsV2Query };
+        });
+
+        const configs = loadConfigs(argv, minioConfigEnv);
+        app = new UIServer(configs);
+
+        const request = requests(app.app);
+        await request
+          .get('/artifacts/get?source=minio&bucket=ml-pipeline&key=missing-dir&peek=256')
+          .expect(404);
+      });
+
       it('returns 404 when the prefix has no objects', async () => {
         mockMinioForDirectory({});
 

--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -16,6 +16,9 @@ import { vi, describe, it, expect, afterAll, afterEach, beforeEach, Mock } from 
 import * as fs from 'fs';
 import * as minio from 'minio';
 import * as path from 'path';
+import * as tar from 'tar-stream';
+import * as zlib from 'zlib';
+import { EventEmitter } from 'events';
 import { PassThrough, Readable } from 'stream';
 import requests from 'supertest';
 import { UIServer } from '../app.js';
@@ -917,6 +920,191 @@ describe('/artifacts', () => {
             'a'.repeat(1025),
         )
         .expect(500, 'Object key too long');
+    });
+
+    // KFP v2 stores some output artifacts as object-store directories
+    // (prefixes) instead of single objects. When the user clicks download on
+    // one, getObject fails with NoSuchKey and the handler falls back to
+    // packaging the contents of the prefix as a .tar.gz. See
+    // https://github.com/kubeflow/pipelines/issues/7809.
+    describe('directory artifact fallback', () => {
+      const minioConfigEnv = {
+        MINIO_ACCESS_KEY: 'minio',
+        MINIO_HOST: 'seaweedfs',
+        MINIO_NAMESPACE: 'kubeflow',
+        MINIO_PORT: '9000',
+        MINIO_SECRET_KEY: 'minio123',
+        MINIO_SSL: 'false',
+      };
+
+      function makeNoSuchKeyError(): Error {
+        return Object.assign(new Error('The specified key does not exist.'), {
+          code: 'NoSuchKey',
+        });
+      }
+
+      function mockMinioForDirectory(fileContents: Record<string, string>) {
+        const mockedMinioClient = minio.Client as any;
+        // The production code uses `new MinioClient(...)`, so the mock must
+        // be constructable. Use a `function` expression rather than an arrow
+        // — vitest warns otherwise and the constructed instance ends up
+        // missing the methods we attach below.
+        mockedMinioClient.mockImplementation(function () {
+          return {
+            getObject: async (bucket: string, key: string) => {
+              if (bucket !== 'ml-pipeline') {
+                throw new Error(`unexpected bucket ${bucket}`);
+              }
+              if (key in fileContents) {
+                const objStream = new PassThrough();
+                objStream.end(fileContents[key]);
+                return objStream;
+              }
+              throw makeNoSuchKeyError();
+            },
+            listObjectsV2Query: (_bucket: string, prefix: string) => {
+              const emitter = new EventEmitter();
+              // Emit asynchronously so the handler's `.on('data', ...)` is
+              // attached before the event fires.
+              setImmediate(() => {
+                emitter.emit('data', {
+                  objects: Object.entries(fileContents)
+                    .filter(([key]) => key.startsWith(prefix))
+                    .map(([name, content]) => ({ name, size: content.length })),
+                  isTruncated: false,
+                  nextContinuationToken: '',
+                });
+              });
+              return emitter;
+            },
+          };
+        });
+      }
+
+      async function readTarGzEntries(buffer: Buffer): Promise<Map<string, Buffer>> {
+        const extract = tar.extract();
+        const entries = new Map<string, Buffer>();
+        return new Promise((resolve, reject) => {
+          extract.on('entry', (header, stream, next) => {
+            const chunks: Uint8Array[] = [];
+            stream.on('data', (chunk: Uint8Array) => chunks.push(chunk));
+            stream.on('end', () => {
+              entries.set(header.name, Buffer.concat(chunks));
+              next();
+            });
+            stream.on('error', reject);
+            stream.resume();
+          });
+          extract.on('finish', () => resolve(entries));
+          extract.on('error', reject);
+          // Write the gunzipped tar bytes directly into the extract stream
+          // rather than piping through a PassThrough — newer @types/node and
+          // older @types/tar-stream disagree on the WritableStream shape, and
+          // pipe() trips that mismatch.
+          extract.end(zlib.gunzipSync(buffer));
+        });
+      }
+
+      function captureBinaryResponse(req: requests.Test): requests.Test {
+        return req.buffer(true).parse((response: any, callback: any) => {
+          const chunks: Uint8Array[] = [];
+          response.on('data', (chunk: Uint8Array) => chunks.push(chunk));
+          response.on('end', () => callback(null, Buffer.concat(chunks)));
+          response.on('error', callback);
+        });
+      }
+
+      it('packages the prefix as a tar.gz when getObject returns NoSuchKey', async () => {
+        mockMinioForDirectory({
+          'directory/file1.txt': 'first file contents',
+          'directory/sub/file2.txt': 'second file contents',
+        });
+
+        const configs = loadConfigs(argv, minioConfigEnv);
+        app = new UIServer(configs);
+
+        const request = requests(app.app);
+        const res = await captureBinaryResponse(
+          request.get('/artifacts/get?source=minio&bucket=ml-pipeline&key=directory'),
+        ).expect(200);
+
+        expect(res.headers['content-type']).toBe('application/gzip');
+        expect(res.headers['content-disposition']).toContain('filename="directory.tar.gz"');
+
+        const entries = await readTarGzEntries(res.body as Buffer);
+        expect(Array.from(entries.keys()).sort()).toEqual(['file1.txt', 'sub/file2.txt']);
+        expect(entries.get('file1.txt')!.toString()).toBe('first file contents');
+        expect(entries.get('sub/file2.txt')!.toString()).toBe('second file contents');
+      });
+
+      it('returns 404 when the prefix has no objects', async () => {
+        mockMinioForDirectory({});
+
+        const configs = loadConfigs(argv, minioConfigEnv);
+        app = new UIServer(configs);
+
+        const request = requests(app.app);
+        await request
+          .get('/artifacts/get?source=minio&bucket=ml-pipeline&key=missing-directory')
+          .expect(404);
+      });
+
+      it('produces a safe Content-Disposition for keys with non-ASCII or quoting characters', async () => {
+        const trickyKey = 'weird name "with quotes" 中文';
+        mockMinioForDirectory({
+          [`${trickyKey}/file.txt`]: 'payload',
+        });
+
+        const configs = loadConfigs(argv, minioConfigEnv);
+        app = new UIServer(configs);
+
+        const request = requests(app.app);
+        const res = await captureBinaryResponse(
+          request.get(
+            `/artifacts/get?source=minio&bucket=ml-pipeline&key=${encodeURIComponent(trickyKey)}`,
+          ),
+        ).expect(200);
+
+        const disposition = res.headers['content-disposition'] as string;
+        expect(disposition).toMatch(/^attachment;/);
+
+        // The legacy `filename=` parameter must be ASCII-only and quote-safe.
+        const fallback = disposition.match(/filename="([^"]+)"/);
+        expect(fallback).not.toBeNull();
+        expect(fallback![1]).toMatch(/^[A-Za-z0-9._-]+$/);
+
+        // The `filename*` parameter carries the real name via RFC 5987.
+        expect(disposition).toContain("filename*=UTF-8''");
+        // Spaces, quotes, and the Chinese characters must all be percent-encoded.
+        expect(disposition).toContain(encodeURIComponent(`${trickyKey}.tar.gz`));
+      });
+
+      it('strips path-traversal segments from tar entry names (tar-slip protection)', async () => {
+        // listObjectsV2Query under prefix "directory/" returning a key whose
+        // relative path begins with ".." would, without sanitization, write
+        // outside the user's extraction target.
+        mockMinioForDirectory({
+          'directory/../etc/passwd': 'malicious payload',
+          'directory/legit.txt': 'real payload',
+        });
+
+        const configs = loadConfigs(argv, minioConfigEnv);
+        app = new UIServer(configs);
+
+        const request = requests(app.app);
+        const res = await captureBinaryResponse(
+          request.get('/artifacts/get?source=minio&bucket=ml-pipeline&key=directory'),
+        ).expect(200);
+
+        const entries = await readTarGzEntries(res.body as Buffer);
+        const names = Array.from(entries.keys());
+        expect(names).toContain('legit.txt');
+        // No entry whose path traverses out of the extraction root.
+        for (const name of names) {
+          expect(name.startsWith('/')).toBe(false);
+          expect(name.split('/')).not.toContain('..');
+        }
+      });
     });
   });
 

--- a/frontend/server/minio-helper.test.ts
+++ b/frontend/server/minio-helper.test.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 import { vi, describe, it, expect, beforeEach, Mock } from 'vitest';
 import * as zlib from 'zlib';
-import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
 import { Client as MinioClient } from 'minio';
 import {
@@ -271,21 +270,15 @@ describe('minio-helper', () => {
 
   // listObjectsUnderPrefix drives the directory-artifact download path. Its
   // pagination logic (continuation tokens) and result normalization (default
-  // size, missing-name skip) are easy to break without coverage.
+  // size, missing-name skip) are easy to break without coverage. Mocks
+  // mirror the real minio@8.x shape — `listObjectsV2Query` is async and
+  // resolves to a {objects, isTruncated, nextContinuationToken} record.
   describe('listObjectsUnderPrefix', () => {
     type Page = {
       objects: Array<{ name?: string; size?: number }>;
       isTruncated: boolean;
       nextContinuationToken: string;
     };
-
-    function emitPage(page: Page): EventEmitter {
-      const emitter = new EventEmitter();
-      // Emit asynchronously so the consumer's `.on('data', ...)` is attached
-      // before the event fires.
-      setImmediate(() => emitter.emit('data', page));
-      return emitter;
-    }
 
     async function collect<T>(iter: AsyncGenerator<T>): Promise<T[]> {
       const items: T[] = [];
@@ -297,8 +290,8 @@ describe('minio-helper', () => {
 
     it('yields a single page of objects with name and size', async () => {
       const client = {
-        listObjectsV2Query: vi.fn(() =>
-          emitPage({
+        listObjectsV2Query: vi.fn(
+          async (): Promise<Page> => ({
             objects: [
               { name: 'a.txt', size: 10 },
               { name: 'b.txt', size: 20 },
@@ -340,10 +333,12 @@ describe('minio-helper', () => {
         },
       };
       const client = {
-        listObjectsV2Query: vi.fn((_bucket: string, _prefix: string, continuationToken: string) => {
-          seenTokens.push(continuationToken);
-          return emitPage(pagesByToken[continuationToken]);
-        }),
+        listObjectsV2Query: vi.fn(
+          async (_bucket: string, _prefix: string, continuationToken: string): Promise<Page> => {
+            seenTokens.push(continuationToken);
+            return pagesByToken[continuationToken];
+          },
+        ),
       } as unknown as MinioClient;
 
       const results = await collect(listObjectsUnderPrefix(client, 'bucket', 'p/'));
@@ -355,8 +350,8 @@ describe('minio-helper', () => {
 
     it('defaults missing size to 0 and skips entries without a name', async () => {
       const client = {
-        listObjectsV2Query: vi.fn(() =>
-          emitPage({
+        listObjectsV2Query: vi.fn(
+          async (): Promise<Page> => ({
             objects: [{ name: 'has-size', size: 42 }, { name: 'no-size' }, { size: 99 }],
             isTruncated: false,
             nextContinuationToken: '',

--- a/frontend/server/minio-helper.test.ts
+++ b/frontend/server/minio-helper.test.ts
@@ -22,6 +22,7 @@ import {
   getObjectStream,
   isNoSuchKeyError,
   listObjectsUnderPrefix,
+  summarizeDirectoryUnderPrefix,
   MinioClientOptionsWithOptionalSecrets,
   Credentials,
 } from './minio-helper.js';
@@ -370,6 +371,66 @@ describe('minio-helper', () => {
       const client = {} as unknown as MinioClient;
       const iter = listObjectsUnderPrefix(client, 'bucket', 'p/');
       await expect(iter.next()).rejects.toThrow(/listObjectsV2Query/);
+    });
+  });
+
+  // summarizeDirectoryUnderPrefix backs the bounded directory preview path.
+  // It must not paginate — large directories should still cost one round
+  // trip, with `truncated: true` signalling there's more.
+  describe('summarizeDirectoryUnderPrefix', () => {
+    it('returns count and truncated=false for a small, complete listing', async () => {
+      const listObjectsV2Query = vi.fn(async () => ({
+        objects: [
+          { name: 'a', size: 1 },
+          { name: 'b', size: 2 },
+          { name: 'c', size: 3 },
+        ],
+        isTruncated: false,
+        nextContinuationToken: '',
+      }));
+      const client = { listObjectsV2Query } as unknown as MinioClient;
+
+      const summary = await summarizeDirectoryUnderPrefix(client, 'bucket', 'p/');
+      expect(summary).toEqual({ count: 3, truncated: false });
+      expect(listObjectsV2Query).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns truncated=true when minio reports more pages exist', async () => {
+      const listObjectsV2Query = vi.fn(async () => ({
+        objects: Array.from({ length: 50 }, (_, i) => ({ name: `f-${i}`, size: 1 })),
+        isTruncated: true,
+        nextContinuationToken: 'next',
+      }));
+      const client = { listObjectsV2Query } as unknown as MinioClient;
+
+      const summary = await summarizeDirectoryUnderPrefix(client, 'bucket', 'p/');
+      expect(summary).toEqual({ count: 50, truncated: true });
+      // Bounded — does not loop on the continuation token.
+      expect(listObjectsV2Query).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null for an empty prefix so callers can answer 404', async () => {
+      const listObjectsV2Query = vi.fn(async () => ({
+        objects: [],
+        isTruncated: false,
+        nextContinuationToken: '',
+      }));
+      const client = { listObjectsV2Query } as unknown as MinioClient;
+
+      const summary = await summarizeDirectoryUnderPrefix(client, 'bucket', 'p/');
+      expect(summary).toBeNull();
+    });
+
+    it('passes the configured maxKeys cap to listObjectsV2Query', async () => {
+      const listObjectsV2Query = vi.fn(async () => ({
+        objects: [{ name: 'a', size: 1 }],
+        isTruncated: false,
+        nextContinuationToken: '',
+      }));
+      const client = { listObjectsV2Query } as unknown as MinioClient;
+
+      await summarizeDirectoryUnderPrefix(client, 'bucket', 'p/', 25);
+      expect(listObjectsV2Query).toHaveBeenCalledWith('bucket', 'p/', '', '', 25, '');
     });
   });
 });

--- a/frontend/server/minio-helper.test.ts
+++ b/frontend/server/minio-helper.test.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 import { vi, describe, it, expect, beforeEach, Mock } from 'vitest';
 import * as zlib from 'zlib';
+import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
 import { Client as MinioClient } from 'minio';
 import {
@@ -20,6 +21,8 @@ import {
   isTarball,
   maybeTarball,
   getObjectStream,
+  isNoSuchKeyError,
+  listObjectsUnderPrefix,
   MinioClientOptionsWithOptionalSecrets,
   Credentials,
 } from './minio-helper.js';
@@ -224,6 +227,154 @@ describe('minio-helper', () => {
       stream.on('finish', () => {
         expect(stream.read().toString().trim()).toBe('hello world');
       });
+    });
+  });
+
+  // Different s3-compatible providers surface "object not found" through
+  // different fields. minio uses lowercase `code`, the AWS SDK and some
+  // proxies use uppercase `Code`, and a few wrap the SDK error in a generic
+  // Error whose only signal is the message text. The helper has to recognize
+  // all three so the directory-fallback download path can trigger
+  // consistently.
+  describe('isNoSuchKeyError', () => {
+    it('matches lowercase "code: NoSuchKey" (minio convention)', () => {
+      expect(isNoSuchKeyError({ code: 'NoSuchKey' })).toBe(true);
+    });
+
+    it('matches lowercase "code: NotFound"', () => {
+      expect(isNoSuchKeyError({ code: 'NotFound' })).toBe(true);
+    });
+
+    it('matches uppercase "Code" (AWS SDK convention)', () => {
+      expect(isNoSuchKeyError({ Code: 'NoSuchKey' })).toBe(true);
+      expect(isNoSuchKeyError({ Code: 'NotFound' })).toBe(true);
+    });
+
+    it('falls back to message substring when no code field is present', () => {
+      expect(isNoSuchKeyError(new Error('NoSuchKey: object does not exist'))).toBe(true);
+    });
+
+    it('does not match unrelated errors', () => {
+      expect(isNoSuchKeyError({ code: 'AccessDenied' })).toBe(false);
+      expect(isNoSuchKeyError({ Code: 'InternalError' })).toBe(false);
+      expect(isNoSuchKeyError(new Error('something else went wrong'))).toBe(false);
+    });
+
+    it('handles non-object inputs safely', () => {
+      expect(isNoSuchKeyError(null)).toBe(false);
+      expect(isNoSuchKeyError(undefined)).toBe(false);
+      expect(isNoSuchKeyError('NoSuchKey')).toBe(false);
+      expect(isNoSuchKeyError(42)).toBe(false);
+      expect(isNoSuchKeyError({})).toBe(false);
+    });
+  });
+
+  // listObjectsUnderPrefix drives the directory-artifact download path. Its
+  // pagination logic (continuation tokens) and result normalization (default
+  // size, missing-name skip) are easy to break without coverage.
+  describe('listObjectsUnderPrefix', () => {
+    type Page = {
+      objects: Array<{ name?: string; size?: number }>;
+      isTruncated: boolean;
+      nextContinuationToken: string;
+    };
+
+    function emitPage(page: Page): EventEmitter {
+      const emitter = new EventEmitter();
+      // Emit asynchronously so the consumer's `.on('data', ...)` is attached
+      // before the event fires.
+      setImmediate(() => emitter.emit('data', page));
+      return emitter;
+    }
+
+    async function collect<T>(iter: AsyncGenerator<T>): Promise<T[]> {
+      const items: T[] = [];
+      for await (const item of iter) {
+        items.push(item);
+      }
+      return items;
+    }
+
+    it('yields a single page of objects with name and size', async () => {
+      const client = {
+        listObjectsV2Query: vi.fn(() =>
+          emitPage({
+            objects: [
+              { name: 'a.txt', size: 10 },
+              { name: 'b.txt', size: 20 },
+            ],
+            isTruncated: false,
+            nextContinuationToken: '',
+          }),
+        ),
+      } as unknown as MinioClient;
+
+      const results = await collect(listObjectsUnderPrefix(client, 'bucket', 'p/'));
+      expect(results).toEqual([
+        { name: 'a.txt', size: 10 },
+        { name: 'b.txt', size: 20 },
+      ]);
+      expect((client as any).listObjectsV2Query).toHaveBeenCalledTimes(1);
+    });
+
+    it('paginates across multiple pages, threading continuation tokens', async () => {
+      const seenTokens: string[] = [];
+      const pagesByToken: Record<string, Page> = {
+        '': {
+          objects: [
+            { name: 'page1-a', size: 1 },
+            { name: 'page1-b', size: 2 },
+          ],
+          isTruncated: true,
+          nextContinuationToken: 'tok-1',
+        },
+        'tok-1': {
+          objects: [{ name: 'page2-a', size: 3 }],
+          isTruncated: true,
+          nextContinuationToken: 'tok-2',
+        },
+        'tok-2': {
+          objects: [{ name: 'page3-a', size: 4 }],
+          isTruncated: false,
+          nextContinuationToken: '',
+        },
+      };
+      const client = {
+        listObjectsV2Query: vi.fn((_bucket: string, _prefix: string, continuationToken: string) => {
+          seenTokens.push(continuationToken);
+          return emitPage(pagesByToken[continuationToken]);
+        }),
+      } as unknown as MinioClient;
+
+      const results = await collect(listObjectsUnderPrefix(client, 'bucket', 'p/'));
+      expect(results.map((r) => r.name)).toEqual(['page1-a', 'page1-b', 'page2-a', 'page3-a']);
+      // Pages are visited in order, with each call's token coming from the
+      // previous response.
+      expect(seenTokens).toEqual(['', 'tok-1', 'tok-2']);
+    });
+
+    it('defaults missing size to 0 and skips entries without a name', async () => {
+      const client = {
+        listObjectsV2Query: vi.fn(() =>
+          emitPage({
+            objects: [{ name: 'has-size', size: 42 }, { name: 'no-size' }, { size: 99 }],
+            isTruncated: false,
+            nextContinuationToken: '',
+          }),
+        ),
+      } as unknown as MinioClient;
+
+      const results = await collect(listObjectsUnderPrefix(client, 'bucket', 'p/'));
+      expect(results).toEqual([
+        { name: 'has-size', size: 42 },
+        { name: 'no-size', size: 0 },
+      ]);
+    });
+
+    it('throws a clear error if the client does not expose listObjectsV2Query', async () => {
+      const client = {} as unknown as MinioClient;
+      const iter = listObjectsUnderPrefix(client, 'bucket', 'p/');
+      await expect(iter.next()).rejects.toThrow(/listObjectsV2Query/);
     });
   });
 });

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -315,3 +315,76 @@ export async function getObjectStream({
   const stream = await client.getObject(bucket, key);
   return tryExtract ? stream.pipe(gunzip()).pipe(maybeTarball()) : stream.pipe(new PassThrough());
 }
+
+/**
+ * Returns a minio/s3 error as a NoSuchKey error if applicable. Different
+ * providers surface the "object not found" condition slightly differently
+ * (code, Code, or message). This normalizes the check.
+ */
+export function isNoSuchKeyError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+  const e = err as { code?: string; Code?: string; message?: string };
+  const code = e.code || e.Code;
+  if (code === 'NoSuchKey' || code === 'NotFound') {
+    return true;
+  }
+  return typeof e.message === 'string' && e.message.includes('NoSuchKey');
+}
+
+/**
+ * Lists all objects under a given prefix in an s3-compatible bucket,
+ * recursively, along with their sizes.
+ *
+ * Pages via the lower-level `listObjectsV2Query` instead of the public
+ * `listObjectsV2` streaming API. The public API hard-codes maxKeys=1000 per
+ * page, and minio's bundled fast-xml-parser caps entity expansions at 1000;
+ * each Contents entry has ~2 `&quot;` entities in its ETag, so a full page
+ * trips "Entity expansion limit exceeded" once a directory holds more than
+ * ~500 objects. A smaller page size keeps each XML parse under the cap.
+ */
+export async function listObjectsUnderPrefix(
+  client: MinioClient,
+  bucket: string,
+  prefix: string,
+): Promise<Array<{ name: string; size: number }>> {
+  const PAGE_SIZE = 300;
+  const items: Array<{ name: string; size: number }> = [];
+  let continuationToken = '';
+  let isTruncated = true;
+
+  while (isTruncated) {
+    const page = await new Promise<{
+      objects: Array<{ name?: string; size?: number }>;
+      isTruncated: boolean;
+      nextContinuationToken: string;
+    }>((resolve, reject) => {
+      const stream = (
+        client as unknown as {
+          listObjectsV2Query: (
+            bucket: string,
+            prefix: string,
+            continuationToken: string,
+            delimiter: string,
+            maxKeys: number,
+            startAfter: string,
+          ) => NodeJS.EventEmitter;
+        }
+      ).listObjectsV2Query(bucket, prefix, continuationToken, '', PAGE_SIZE, '');
+      stream.on('error', reject);
+      stream.on('data', resolve);
+    });
+
+    for (const item of page.objects) {
+      if (item.name) {
+        items.push({ name: item.name, size: item.size ?? 0 });
+      }
+    }
+
+    isTruncated = page.isTruncated;
+    continuationToken = page.nextContinuationToken;
+  }
+
+  return items;
+}

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -400,3 +400,28 @@ export async function* listObjectsUnderPrefix(
     continuationToken = page.nextContinuationToken;
   }
 }
+
+/**
+ * Returns a bounded summary of a prefix using a single capped
+ * `listObjectsV2Query` call — does not paginate. Designed for preview-style
+ * requests where the caller just needs to know "is there anything here, and
+ * roughly how many files?" without paying for a full listing of a
+ * potentially huge directory.
+ *
+ * Resolves to `null` for an empty prefix so callers can answer with a 404.
+ * `truncated: true` means the directory has more than `maxKeys` files; the
+ * caller should treat `count` as a lower bound.
+ */
+export async function summarizeDirectoryUnderPrefix(
+  client: MinioClient,
+  bucket: string,
+  prefix: string,
+  maxKeys: number = 50,
+): Promise<{ count: number; truncated: boolean } | null> {
+  const listObjectsV2Query = getListObjectsV2Query(client);
+  const page = await listObjectsV2Query(bucket, prefix, '', '', maxKeys, '');
+  if (page.objects.length === 0) {
+    return null;
+  }
+  return { count: page.objects.length, truncated: page.isTruncated };
+}

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -333,9 +333,36 @@ export function isNoSuchKeyError(err: unknown): boolean {
   return typeof e.message === 'string' && e.message.includes('NoSuchKey');
 }
 
+type ListObjectsV2Query = (
+  bucket: string,
+  prefix: string,
+  continuationToken: string,
+  delimiter: string,
+  maxKeys: number,
+  startAfter: string,
+) => NodeJS.EventEmitter;
+
+// `listObjectsV2Query` is an internal helper on the minio client and is not
+// declared in its public type definitions. We narrow to it via a runtime
+// check so a future minio upgrade that removes the method fails fast with a
+// clear message instead of throwing `undefined is not a function` deep inside
+// a stream pipeline.
+function getListObjectsV2Query(client: MinioClient): ListObjectsV2Query {
+  const candidate = (client as unknown as { listObjectsV2Query?: unknown }).listObjectsV2Query;
+  if (typeof candidate !== 'function') {
+    throw new Error(
+      'Minio client does not expose listObjectsV2Query; the bundled minio version may be incompatible with listObjectsUnderPrefix',
+    );
+  }
+  return (candidate as ListObjectsV2Query).bind(client);
+}
+
 /**
- * Lists all objects under a given prefix in an s3-compatible bucket,
- * recursively, along with their sizes.
+ * Yields all objects under a given prefix in an s3-compatible bucket,
+ * recursively, along with their sizes. Implemented as an async generator so
+ * callers can begin streaming the first object before the full listing
+ * completes — important for large directory artifacts where buffering all
+ * keys would delay the first byte and inflate memory use.
  *
  * Pages via the lower-level `listObjectsV2Query` instead of the public
  * `listObjectsV2` streaming API. The public API hard-codes maxKeys=1000 per
@@ -344,13 +371,13 @@ export function isNoSuchKeyError(err: unknown): boolean {
  * trips "Entity expansion limit exceeded" once a directory holds more than
  * ~500 objects. A smaller page size keeps each XML parse under the cap.
  */
-export async function listObjectsUnderPrefix(
+export async function* listObjectsUnderPrefix(
   client: MinioClient,
   bucket: string,
   prefix: string,
-): Promise<Array<{ name: string; size: number }>> {
+): AsyncGenerator<{ name: string; size: number }> {
   const PAGE_SIZE = 300;
-  const items: Array<{ name: string; size: number }> = [];
+  const listObjectsV2Query = getListObjectsV2Query(client);
   let continuationToken = '';
   let isTruncated = true;
 
@@ -360,31 +387,18 @@ export async function listObjectsUnderPrefix(
       isTruncated: boolean;
       nextContinuationToken: string;
     }>((resolve, reject) => {
-      const stream = (
-        client as unknown as {
-          listObjectsV2Query: (
-            bucket: string,
-            prefix: string,
-            continuationToken: string,
-            delimiter: string,
-            maxKeys: number,
-            startAfter: string,
-          ) => NodeJS.EventEmitter;
-        }
-      ).listObjectsV2Query(bucket, prefix, continuationToken, '', PAGE_SIZE, '');
+      const stream = listObjectsV2Query(bucket, prefix, continuationToken, '', PAGE_SIZE, '');
       stream.on('error', reject);
       stream.on('data', resolve);
     });
 
     for (const item of page.objects) {
       if (item.name) {
-        items.push({ name: item.name, size: item.size ?? 0 });
+        yield { name: item.name, size: item.size ?? 0 };
       }
     }
 
     isTruncated = page.isTruncated;
     continuationToken = page.nextContinuationToken;
   }
-
-  return items;
 }

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -333,6 +333,12 @@ export function isNoSuchKeyError(err: unknown): boolean {
   return typeof e.message === 'string' && e.message.includes('NoSuchKey');
 }
 
+type ListObjectsV2QueryResult = {
+  objects: Array<{ name?: string; size?: number }>;
+  isTruncated: boolean;
+  nextContinuationToken: string;
+};
+
 type ListObjectsV2Query = (
   bucket: string,
   prefix: string,
@@ -340,13 +346,13 @@ type ListObjectsV2Query = (
   delimiter: string,
   maxKeys: number,
   startAfter: string,
-) => NodeJS.EventEmitter;
+) => Promise<ListObjectsV2QueryResult>;
 
 // `listObjectsV2Query` is an internal helper on the minio client and is not
 // declared in its public type definitions. We narrow to it via a runtime
 // check so a future minio upgrade that removes the method fails fast with a
 // clear message instead of throwing `undefined is not a function` deep inside
-// a stream pipeline.
+// the listing loop.
 function getListObjectsV2Query(client: MinioClient): ListObjectsV2Query {
   const candidate = (client as unknown as { listObjectsV2Query?: unknown }).listObjectsV2Query;
   if (typeof candidate !== 'function') {
@@ -382,15 +388,7 @@ export async function* listObjectsUnderPrefix(
   let isTruncated = true;
 
   while (isTruncated) {
-    const page = await new Promise<{
-      objects: Array<{ name?: string; size?: number }>;
-      isTruncated: boolean;
-      nextContinuationToken: string;
-    }>((resolve, reject) => {
-      const stream = listObjectsV2Query(bucket, prefix, continuationToken, '', PAGE_SIZE, '');
-      stream.on('error', reject);
-      stream.on('data', resolve);
-    });
+    const page = await listObjectsV2Query(bucket, prefix, continuationToken, '', PAGE_SIZE, '');
 
     for (const item of page.objects) {
       if (item.name) {


### PR DESCRIPTION
**Description of your changes:**

KFP v2 output artifacts can be directories (S3 prefixes) rather than single
objects. The artifact download handler currently fails with `500 NoSuchKey`
when a user clicks download on a directory artifact.

This adds a fallback: when `getObject` returns NoSuchKey, the handler lists
the prefix and streams the contents back as `<artifact>.tar.gz`.

Implementation notes:

- New `isNoSuchKeyError` helper normalizes the error code across providers
  (`NoSuchKey` / `NotFound` / message-based).
- New `listObjectsUnderPrefix` helper pages via the lower-level
  `listObjectsV2Query` at 300 keys/page. The public `listObjectsV2` API
  hard-codes `maxKeys=1000`, but minio's bundled fast-xml-parser caps
  entity expansions at 1000 — each Contents entry has ~2 `&quot;` entities
  in its ETag, so 1000-key pages fail with "Entity expansion limit
  exceeded" once a directory holds more than ~500 objects.
- `tar-stream` is already a dependency; `zlib` is a Node built-in. No new
  deps.

Fixes #7809

**Checklist:**
- [x] You have signed off your commits
- [x] The title for your pull request (PR) follows our title convention