### PR TITLE
fix(backend): recursive DAG execution state propagation

### DIFF
--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -768,14 +768,31 @@ func (c *Client) PrePublishExecution(ctx context.Context, execution *Execution, 
 	return execution, nil
 }
 
-// UpdateDAGExecutionState checks all the statuses of the tasks in the given DAG, based on that it will update the DAG to the corresponding status if necessary.
+// UpdateDAGExecutionsState checks all the statuses of the tasks in the given DAG, based on that it will update the DAG to the corresponding status if necessary.
+// If the DAG reaches a terminal state, propagation continues upward to ancestor DAGs until reaching the root.
 func (c *Client) UpdateDAGExecutionsState(ctx context.Context, dag *DAG, pipeline *Pipeline) error {
+	// Prefer runtime iteration_count (set by ParallelFor) over compile-time total_dag_tasks.
+	// We must check key presence because iteration_count=0 is valid (empty loop)
+	// and distinct from the key being absent (non-iterator DAG).
+	customProperties := dag.Execution.GetExecution().GetCustomProperties()
+	iterationCountValue, hasIterationCount := customProperties[keyIterationCount]
+
+	var expectedTaskCount int64
+	if hasIterationCount {
+		expectedTaskCount = iterationCountValue.GetIntValue()
+	} else {
+		expectedTaskCount = customProperties[keyTotalDagTasks].GetIntValue()
+	}
+
+	if expectedTaskCount == 0 && !hasIterationCount {
+		glog.V(4).Infof("DAG %d has no expected task count (root DAG or unknown), skipping state update", dag.Execution.GetID())
+		return nil
+	}
+
 	tasks, err := c.GetExecutionsInDAG(ctx, dag, pipeline, true)
 	if err != nil {
 		return err
 	}
-
-	totalDagTasks := dag.Execution.Execution.CustomProperties["total_dag_tasks"].GetIntValue()
 
 	glog.V(4).Infof("tasks: %v", tasks)
 	glog.V(4).Infof("Checking Tasks' State")
@@ -798,17 +815,39 @@ func (c *Client) UpdateDAGExecutionsState(ctx context.Context, dag *DAG, pipelin
 	}
 	glog.V(4).Infof("completedTasks: %d", completedTasks)
 	glog.V(4).Infof("failedTasks: %d", failedTasks)
-	glog.V(4).Infof("totalTasks: %d", totalDagTasks)
+	glog.V(4).Infof("expectedTaskCount: %d", expectedTaskCount)
 
-	glog.Infof("Attempting to update DAG state")
-	if completedTasks == int(totalDagTasks) {
-		c.PutDAGExecutionState(ctx, dag.Execution.GetID(), pb.Execution_COMPLETE)
-	} else if failedTasks > 0 {
-		c.PutDAGExecutionState(ctx, dag.Execution.GetID(), pb.Execution_FAILED)
-	} else {
+	glog.Infof("Attempting to update DAG state for execution %d", dag.Execution.GetID())
+
+	var newState pb.Execution_State
+	switch {
+	case completedTasks == int(expectedTaskCount):
+		newState = pb.Execution_COMPLETE
+	case failedTasks > 0:
+		newState = pb.Execution_FAILED
+	default:
 		glog.V(4).Infof("DAG is still running")
+		return nil
 	}
-	return nil
+
+	if err := c.PutDAGExecutionState(ctx, dag.Execution.GetID(), newState); err != nil {
+		return err
+	}
+
+	// Propagate upward to parent DAG if this is not the root.
+	parentDagID := dag.Execution.GetExecution().GetCustomProperties()[keyParentDagID].GetIntValue()
+	if parentDagID == 0 {
+		glog.V(4).Infof("DAG %d is root or has no parent, stopping propagation", dag.Execution.GetID())
+		return nil
+	}
+
+	glog.Infof("Propagating state update to parent DAG %d", parentDagID)
+	parentDAG, err := c.GetDAG(ctx, parentDagID)
+	if err != nil {
+		return fmt.Errorf("failed to get parent DAG %d for recursive state update: %w", parentDagID, err)
+	}
+
+	return c.UpdateDAGExecutionsState(ctx, parentDAG, pipeline)
 }
 
 // PutDAGExecutionState updates the given DAG Id to the state provided.

--- a/backend/src/v2/metadata/client_update_dag_state_test.go
+++ b/backend/src/v2/metadata/client_update_dag_state_test.go
@@ -1,0 +1,546 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
+	"google.golang.org/grpc"
+)
+
+// mockMLMDClient embeds the MetadataStoreServiceClient interface and overrides
+// only the methods exercised by UpdateDAGExecutionsState's call chain.
+// Calling any non-overridden method panics (nil receiver on the embedded
+// interface), which is intentional — it surfaces unexpected calls immediately.
+type mockMLMDClient struct {
+	pb.MetadataStoreServiceClient
+
+	getExecutionsByContextFn func(ctx context.Context, req *pb.GetExecutionsByContextRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error)
+	getExecutionsByIDFn      func(ctx context.Context, req *pb.GetExecutionsByIDRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByIDResponse, error)
+	getContextsByExecutionFn func(ctx context.Context, req *pb.GetContextsByExecutionRequest, opts ...grpc.CallOption) (*pb.GetContextsByExecutionResponse, error)
+	getContextTypeFn         func(ctx context.Context, req *pb.GetContextTypeRequest, opts ...grpc.CallOption) (*pb.GetContextTypeResponse, error)
+	putExecutionFn           func(ctx context.Context, req *pb.PutExecutionRequest, opts ...grpc.CallOption) (*pb.PutExecutionResponse, error)
+}
+
+func (m *mockMLMDClient) GetExecutionsByContext(ctx context.Context, req *pb.GetExecutionsByContextRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error) {
+	return m.getExecutionsByContextFn(ctx, req, opts...)
+}
+
+func (m *mockMLMDClient) GetExecutionsByID(ctx context.Context, req *pb.GetExecutionsByIDRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByIDResponse, error) {
+	return m.getExecutionsByIDFn(ctx, req, opts...)
+}
+
+func (m *mockMLMDClient) GetContextsByExecution(ctx context.Context, req *pb.GetContextsByExecutionRequest, opts ...grpc.CallOption) (*pb.GetContextsByExecutionResponse, error) {
+	return m.getContextsByExecutionFn(ctx, req, opts...)
+}
+
+func (m *mockMLMDClient) GetContextType(ctx context.Context, req *pb.GetContextTypeRequest, opts ...grpc.CallOption) (*pb.GetContextTypeResponse, error) {
+	return m.getContextTypeFn(ctx, req, opts...)
+}
+
+func (m *mockMLMDClient) PutExecution(ctx context.Context, req *pb.PutExecutionRequest, opts ...grpc.CallOption) (*pb.PutExecutionResponse, error) {
+	return m.putExecutionFn(ctx, req, opts...)
+}
+
+// ---------- helpers ----------
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func makeExecution(id int64, state pb.Execution_State, customProperties map[string]*pb.Value) *pb.Execution {
+	return &pb.Execution{
+		Id:               int64Ptr(id),
+		LastKnownState:   state.Enum(),
+		CustomProperties: customProperties,
+	}
+}
+
+func makeDAG(execution *pb.Execution) *DAG {
+	return &DAG{Execution: &Execution{Execution: execution}}
+}
+
+// newTestClient creates a Client backed by the given mock gRPC service.
+func newTestClient(mock pb.MetadataStoreServiceClient) *Client {
+	return &Client{svc: mock}
+}
+
+// buildMock wires up a mockMLMDClient with an execution store (keyed by ID)
+// and configurable PutExecution behavior.
+func buildMock(
+	executionStore map[int64]*pb.Execution,
+	contextsByExecution map[int64][]*pb.Context,
+	executionsByContext map[int64][]*pb.Execution,
+	putExecutionFn func(ctx context.Context, req *pb.PutExecutionRequest, opts ...grpc.CallOption) (*pb.PutExecutionResponse, error),
+) *mockMLMDClient {
+	contextTypeID := int64(100)
+
+	return &mockMLMDClient{
+		getExecutionsByContextFn: func(_ context.Context, req *pb.GetExecutionsByContextRequest, _ ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error) {
+			contextID := req.GetContextId()
+			return &pb.GetExecutionsByContextResponse{
+				Executions: executionsByContext[contextID],
+			}, nil
+		},
+		getExecutionsByIDFn: func(_ context.Context, req *pb.GetExecutionsByIDRequest, _ ...grpc.CallOption) (*pb.GetExecutionsByIDResponse, error) {
+			var results []*pb.Execution
+			for _, id := range req.GetExecutionIds() {
+				if e, ok := executionStore[id]; ok {
+					results = append(results, e)
+				}
+			}
+			return &pb.GetExecutionsByIDResponse{Executions: results}, nil
+		},
+		getContextsByExecutionFn: func(_ context.Context, req *pb.GetContextsByExecutionRequest, _ ...grpc.CallOption) (*pb.GetContextsByExecutionResponse, error) {
+			executionID := req.GetExecutionId()
+			return &pb.GetContextsByExecutionResponse{
+				Contexts: contextsByExecution[executionID],
+			}, nil
+		},
+		getContextTypeFn: func(_ context.Context, _ *pb.GetContextTypeRequest, _ ...grpc.CallOption) (*pb.GetContextTypeResponse, error) {
+			return &pb.GetContextTypeResponse{
+				ContextType: &pb.ContextType{Id: &contextTypeID},
+			}, nil
+		},
+		putExecutionFn: putExecutionFn,
+	}
+}
+
+// defaultPutExecution applies the state change in-place and succeeds.
+func defaultPutExecution(store map[int64]*pb.Execution) func(context.Context, *pb.PutExecutionRequest, ...grpc.CallOption) (*pb.PutExecutionResponse, error) {
+	return func(_ context.Context, req *pb.PutExecutionRequest, _ ...grpc.CallOption) (*pb.PutExecutionResponse, error) {
+		execution := req.GetExecution()
+		if stored, ok := store[execution.GetId()]; ok {
+			stored.LastKnownState = execution.LastKnownState
+		}
+		return &pb.PutExecutionResponse{}, nil
+	}
+}
+
+// ---------- tests ----------
+
+func TestUpdateDAGExecutionsState_RootDAGSkipped(t *testing.T) {
+	// A root DAG has neither total_dag_tasks nor iteration_count set
+	// (expectedTaskCount == 0). The function should return nil without
+	// attempting any state write.
+	rootExecution := makeExecution(1, pb.Execution_RUNNING, map[string]*pb.Value{})
+	dag := makeDAG(rootExecution)
+
+	store := map[int64]*pb.Execution{1: rootExecution}
+	mock := buildMock(store, nil, map[int64][]*pb.Execution{}, nil)
+	client := newTestClient(mock)
+
+	err := client.UpdateDAGExecutionsState(context.Background(), dag, &Pipeline{})
+	if err != nil {
+		t.Fatalf("expected nil error for root DAG, got: %v", err)
+	}
+	if rootExecution.GetLastKnownState() != pb.Execution_RUNNING {
+		t.Errorf("root DAG state should remain RUNNING, got %v", rootExecution.GetLastKnownState())
+	}
+}
+
+func TestUpdateDAGExecutionsState_StateResolution(t *testing.T) {
+	tests := []struct {
+		name          string
+		taskStates    []pb.Execution_State
+		expectedTasks int64
+		expectedState pb.Execution_State
+	}{
+		{
+			name:          "all complete",
+			taskStates:    []pb.Execution_State{pb.Execution_COMPLETE, pb.Execution_COMPLETE},
+			expectedTasks: 2,
+			expectedState: pb.Execution_COMPLETE,
+		},
+		{
+			name:          "one failed",
+			taskStates:    []pb.Execution_State{pb.Execution_COMPLETE, pb.Execution_FAILED},
+			expectedTasks: 2,
+			expectedState: pb.Execution_FAILED,
+		},
+		{
+			name:          "still running",
+			taskStates:    []pb.Execution_State{pb.Execution_COMPLETE, pb.Execution_RUNNING},
+			expectedTasks: 2,
+			expectedState: pb.Execution_RUNNING,
+		},
+		{
+			name:          "cached and canceled count as complete",
+			taskStates:    []pb.Execution_State{pb.Execution_COMPLETE, pb.Execution_CACHED, pb.Execution_CANCELED},
+			expectedTasks: 3,
+			expectedState: pb.Execution_COMPLETE,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dagExecution := makeExecution(10, pb.Execution_RUNNING, map[string]*pb.Value{
+				keyTotalDagTasks: intValue(tt.expectedTasks),
+			})
+
+			var tasks []*pb.Execution
+			store := map[int64]*pb.Execution{10: dagExecution}
+			for i, state := range tt.taskStates {
+				id := int64(11 + i)
+				task := makeExecution(id, state, map[string]*pb.Value{
+					keyTaskName:    StringValue(fmt.Sprintf("task%d", i)),
+					keyParentDagID: intValue(10),
+				})
+				tasks = append(tasks, task)
+				store[id] = task
+			}
+
+			runCtxID := int64(500)
+			pipeline := &Pipeline{pipelineRunCtx: &pb.Context{Id: &runCtxID}}
+			dag := makeDAG(dagExecution)
+
+			mock := buildMock(
+				store,
+				map[int64][]*pb.Context{10: {}},
+				map[int64][]*pb.Execution{runCtxID: tasks},
+				defaultPutExecution(store),
+			)
+			client := newTestClient(mock)
+
+			err := client.UpdateDAGExecutionsState(context.Background(), dag, pipeline)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if dagExecution.GetLastKnownState() != tt.expectedState {
+				t.Errorf("expected DAG state %v, got %v", tt.expectedState, dagExecution.GetLastKnownState())
+			}
+		})
+	}
+}
+
+func TestUpdateDAGExecutionsState_ExpectedTaskCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		dagProperties map[string]*pb.Value
+		taskCount     int
+		expectedState pb.Execution_State
+	}{
+		{
+			name: "iteration_count takes priority over total_dag_tasks",
+			dagProperties: map[string]*pb.Value{
+				keyTotalDagTasks:  intValue(1),
+				keyIterationCount: intValue(3),
+			},
+			taskCount:     3,
+			expectedState: pb.Execution_COMPLETE,
+		},
+		{
+			name: "iteration_count not met remains running",
+			dagProperties: map[string]*pb.Value{
+				keyTotalDagTasks:  intValue(1),
+				keyIterationCount: intValue(3),
+			},
+			taskCount:     2,
+			expectedState: pb.Execution_RUNNING,
+		},
+		{
+			name: "iteration_count zero completes immediately",
+			dagProperties: map[string]*pb.Value{
+				keyTotalDagTasks:  intValue(0),
+				keyIterationCount: intValue(0),
+			},
+			taskCount:     0,
+			expectedState: pb.Execution_COMPLETE,
+		},
+		{
+			name: "falls back to total_dag_tasks when no iteration_count",
+			dagProperties: map[string]*pb.Value{
+				keyTotalDagTasks: intValue(1),
+			},
+			taskCount:     1,
+			expectedState: pb.Execution_COMPLETE,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dagExecution := makeExecution(10, pb.Execution_RUNNING, tt.dagProperties)
+
+			var tasks []*pb.Execution
+			store := map[int64]*pb.Execution{10: dagExecution}
+			for i := 0; i < tt.taskCount; i++ {
+				id := int64(11 + i)
+				task := makeExecution(id, pb.Execution_COMPLETE, map[string]*pb.Value{
+					keyTaskName:    StringValue(fmt.Sprintf("iter-%d", i)),
+					keyParentDagID: intValue(10),
+				})
+				tasks = append(tasks, task)
+				store[id] = task
+			}
+
+			runCtxID := int64(500)
+			pipeline := &Pipeline{pipelineRunCtx: &pb.Context{Id: &runCtxID}}
+			dag := makeDAG(dagExecution)
+
+			mock := buildMock(
+				store,
+				map[int64][]*pb.Context{10: {}},
+				map[int64][]*pb.Execution{runCtxID: tasks},
+				defaultPutExecution(store),
+			)
+			client := newTestClient(mock)
+
+			err := client.UpdateDAGExecutionsState(context.Background(), dag, pipeline)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if dagExecution.GetLastKnownState() != tt.expectedState {
+				t.Errorf("expected DAG state %v, got %v", tt.expectedState, dagExecution.GetLastKnownState())
+			}
+		})
+	}
+}
+
+func TestUpdateDAGExecutionsState_RecursivePropagation(t *testing.T) {
+	tests := []struct {
+		name          string
+		leafState     pb.Execution_State
+		expectedState pb.Execution_State
+	}{
+		{
+			name:          "complete propagates up",
+			leafState:     pb.Execution_COMPLETE,
+			expectedState: pb.Execution_COMPLETE,
+		},
+		{
+			name:          "failed propagates up",
+			leafState:     pb.Execution_FAILED,
+			expectedState: pb.Execution_FAILED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runCtxID := int64(500)
+			pipelineCtxTypeID := int64(100)
+			runCtxTypeID := int64(101)
+
+			grandparentExecution := makeExecution(1, pb.Execution_RUNNING, map[string]*pb.Value{
+				keyTotalDagTasks: intValue(1),
+			})
+			parentExecution := makeExecution(2, pb.Execution_RUNNING, map[string]*pb.Value{
+				keyTotalDagTasks: intValue(1),
+				keyParentDagID:   intValue(1),
+				keyTaskName:      StringValue("parent-task"),
+			})
+			leafExecution := makeExecution(3, tt.leafState, map[string]*pb.Value{
+				keyTaskName:    StringValue("leaf-task"),
+				keyParentDagID: intValue(2),
+			})
+
+			store := map[int64]*pb.Execution{
+				1: grandparentExecution,
+				2: parentExecution,
+				3: leafExecution,
+			}
+
+			pipelineCtx := &pb.Context{Id: int64Ptr(600), TypeId: &pipelineCtxTypeID}
+			runCtx := &pb.Context{Id: &runCtxID, TypeId: &runCtxTypeID}
+			sharedContexts := []*pb.Context{pipelineCtx, runCtx}
+
+			callCount := 0
+			mock := &mockMLMDClient{
+				getExecutionsByContextFn: func(_ context.Context, _ *pb.GetExecutionsByContextRequest, _ ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error) {
+					callCount++
+					switch callCount {
+					case 1:
+						return &pb.GetExecutionsByContextResponse{Executions: []*pb.Execution{leafExecution}}, nil
+					case 2:
+						return &pb.GetExecutionsByContextResponse{Executions: []*pb.Execution{parentExecution}}, nil
+					default:
+						return &pb.GetExecutionsByContextResponse{}, nil
+					}
+				},
+				getExecutionsByIDFn: func(_ context.Context, req *pb.GetExecutionsByIDRequest, _ ...grpc.CallOption) (*pb.GetExecutionsByIDResponse, error) {
+					var results []*pb.Execution
+					for _, id := range req.GetExecutionIds() {
+						if e, ok := store[id]; ok {
+							results = append(results, e)
+						}
+					}
+					return &pb.GetExecutionsByIDResponse{Executions: results}, nil
+				},
+				getContextsByExecutionFn: func(_ context.Context, _ *pb.GetContextsByExecutionRequest, _ ...grpc.CallOption) (*pb.GetContextsByExecutionResponse, error) {
+					return &pb.GetContextsByExecutionResponse{Contexts: sharedContexts}, nil
+				},
+				getContextTypeFn: func(_ context.Context, _ *pb.GetContextTypeRequest, _ ...grpc.CallOption) (*pb.GetContextTypeResponse, error) {
+					return &pb.GetContextTypeResponse{
+						ContextType: &pb.ContextType{Id: &pipelineCtxTypeID},
+					}, nil
+				},
+				putExecutionFn: defaultPutExecution(store),
+			}
+
+			client := newTestClient(mock)
+			parentDAG := makeDAG(parentExecution)
+			pipeline := &Pipeline{
+				pipelineCtx:    pipelineCtx,
+				pipelineRunCtx: runCtx,
+			}
+
+			err := client.UpdateDAGExecutionsState(context.Background(), parentDAG, pipeline)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if parentExecution.GetLastKnownState() != tt.expectedState {
+				t.Errorf("expected parent DAG %v, got %v", tt.expectedState, parentExecution.GetLastKnownState())
+			}
+			if grandparentExecution.GetLastKnownState() != tt.expectedState {
+				t.Errorf("expected grandparent DAG %v, got %v", tt.expectedState, grandparentExecution.GetLastKnownState())
+			}
+		})
+	}
+}
+
+func TestUpdateDAGExecutionsState_PropagationStopsAtRootDAG(t *testing.T) {
+	// parentDAG (no parent_dag_id) → task(COMPLETE)
+	// Should complete parentDAG but not attempt further propagation.
+	dagExecution := makeExecution(10, pb.Execution_RUNNING, map[string]*pb.Value{
+		keyTotalDagTasks: intValue(1),
+	})
+	task := makeExecution(11, pb.Execution_COMPLETE, map[string]*pb.Value{
+		keyTaskName:    StringValue("task1"),
+		keyParentDagID: intValue(10),
+	})
+
+	runCtxID := int64(500)
+	pipeline := &Pipeline{pipelineRunCtx: &pb.Context{Id: &runCtxID}}
+	dag := makeDAG(dagExecution)
+
+	store := map[int64]*pb.Execution{10: dagExecution, 11: task}
+
+	putCallCount := 0
+	mock := buildMock(
+		store,
+		map[int64][]*pb.Context{10: {}},
+		map[int64][]*pb.Execution{runCtxID: {task}},
+		func(_ context.Context, req *pb.PutExecutionRequest, _ ...grpc.CallOption) (*pb.PutExecutionResponse, error) {
+			putCallCount++
+			execution := req.GetExecution()
+			if stored, ok := store[execution.GetId()]; ok {
+				stored.LastKnownState = execution.LastKnownState
+			}
+			return &pb.PutExecutionResponse{}, nil
+		},
+	)
+	client := newTestClient(mock)
+
+	err := client.UpdateDAGExecutionsState(context.Background(), dag, pipeline)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if putCallCount != 1 {
+		t.Errorf("expected exactly 1 PutExecution call (no further propagation), got %d", putCallCount)
+	}
+	if dagExecution.GetLastKnownState() != pb.Execution_COMPLETE {
+		t.Errorf("expected DAG state COMPLETE, got %v", dagExecution.GetLastKnownState())
+	}
+}
+
+func TestUpdateDAGExecutionsState_ErrorPropagation(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupMock func() *mockMLMDClient
+	}{
+		{
+			name: "PutExecution error",
+			setupMock: func() *mockMLMDClient {
+				dagExecution := makeExecution(10, pb.Execution_RUNNING, map[string]*pb.Value{
+					keyTotalDagTasks: intValue(1),
+				})
+				task := makeExecution(11, pb.Execution_COMPLETE, map[string]*pb.Value{
+					keyTaskName:    StringValue("task1"),
+					keyParentDagID: intValue(10),
+				})
+				store := map[int64]*pb.Execution{10: dagExecution, 11: task}
+				runCtxID := int64(500)
+				return buildMock(
+					store,
+					map[int64][]*pb.Context{10: {}},
+					map[int64][]*pb.Execution{runCtxID: {task}},
+					func(_ context.Context, _ *pb.PutExecutionRequest, _ ...grpc.CallOption) (*pb.PutExecutionResponse, error) {
+						return nil, fmt.Errorf("simulated MLMD write failure")
+					},
+				)
+			},
+		},
+		{
+			name: "GetExecutionsByContext error",
+			setupMock: func() *mockMLMDClient {
+				return &mockMLMDClient{
+					getExecutionsByContextFn: func(_ context.Context, _ *pb.GetExecutionsByContextRequest, _ ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error) {
+						return nil, fmt.Errorf("simulated context query failure")
+					},
+				}
+			},
+		},
+		{
+			name: "parent DAG not found during recursion",
+			setupMock: func() *mockMLMDClient {
+				dagExecution := makeExecution(10, pb.Execution_RUNNING, map[string]*pb.Value{
+					keyTotalDagTasks: intValue(1),
+					keyParentDagID:   intValue(99),
+				})
+				task := makeExecution(11, pb.Execution_COMPLETE, map[string]*pb.Value{
+					keyTaskName:    StringValue("task1"),
+					keyParentDagID: intValue(10),
+				})
+				store := map[int64]*pb.Execution{10: dagExecution, 11: task}
+				runCtxID := int64(500)
+				return buildMock(
+					store,
+					map[int64][]*pb.Context{10: {}},
+					map[int64][]*pb.Execution{runCtxID: {task}},
+					defaultPutExecution(store),
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := tt.setupMock()
+			client := newTestClient(mock)
+
+			dagExecution := makeExecution(10, pb.Execution_RUNNING, map[string]*pb.Value{
+				keyTotalDagTasks: intValue(1),
+			})
+			// For the GetExecutionsByContext error case, we use the dag from here.
+			// For the other cases, the mock's internal store has the real dag.
+			// We need to use the mock's store dag if it exists.
+			if mock.getExecutionsByIDFn != nil {
+				resp, _ := mock.getExecutionsByIDFn(context.Background(), &pb.GetExecutionsByIDRequest{ExecutionIds: []int64{10}}, nil)
+				if resp != nil && len(resp.Executions) > 0 {
+					dagExecution = resp.Executions[0]
+				}
+			}
+
+			runCtxID := int64(500)
+			pipeline := &Pipeline{pipelineRunCtx: &pb.Context{Id: &runCtxID}}
+			dag := makeDAG(dagExecution)
+
+			err := client.UpdateDAGExecutionsState(context.Background(), dag, pipeline)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Fixes** #13321, #11979
- Refactors `UpdateDAGExecutionsState` in `backend/src/v2/metadata/client.go` to recursively propagate DAG execution state upward through intermediate sub-DAGs

## Problem

When a container task completes, the launcher calls `UpdateDAGExecutionsState` on its immediate parent DAG. However, for nested DAG structures (ParallelFor, If/Else/Elif, ExitHandler groups, nested pipelines), the state update stops at the first parent — intermediate sub-DAGs never propagate their COMPLETE/FAILED state upward. This causes:

- **ExitHandler groups stuck as "Running"** after all tasks finish (#13321)
- **Nested pipeline DAGs never reaching COMPLETE/FAILED** (#11979)

Additionally, ParallelFor DAGs use compile-time `total_dag_tasks` instead of runtime `iteration_count`, giving incorrect expected child counts when the actual iteration count differs.

## Changes

1. **Use runtime `iteration_count` for ParallelFor**: Prefers `iteration_count` (set at runtime by the ParallelFor driver) over `total_dag_tasks` (set at compile time). Falls back to `total_dag_tasks` when `iteration_count` is not set (non-ParallelFor DAGs).

2. **Recursive upward propagation**: After marking a DAG as COMPLETE or FAILED, reads `parent_dag_id` from the DAG's custom properties, fetches the parent DAG, and recursively calls `UpdateDAGExecutionsState`. Propagation stops at the root DAG (`parent_dag_id == 0`), whose lifecycle is managed externally by Argo/the API server.

3. **Proper error handling**: `PutDAGExecutionState` errors were previously silently ignored; they are now returned to the caller.

4. **Early return for root DAGs**: When `expectedTaskCount == 0` (root DAG or unknown), the function returns early instead of attempting state comparison.

## Edge Cases

| Scenario | Behavior |
|----------|----------|
| **ParallelFor** | Uses `iteration_count` (runtime) instead of `total_dag_tasks` (compile-time) |
| **If/Else/Elif** | Untriggered branches are CANCELED at creation → count as completed → `total_dag_tasks` works correctly |
| **Nested loops** | Each level has its own `iteration_count`/`total_dag_tasks`; recursive propagation handles naturally |
| **Failure** | `failedTasks > 0` triggers FAILED immediately, propagates up the full chain |
| **Concurrent completions** | Setting COMPLETE/FAILED twice is idempotent; pre-existing race window, not worsened |
| **Root DAG** | `parent_dag_id == 0` → propagation stops; root status managed by Argo/API server |

## Issues Remaining

The only state propagation issue I was not able to fix was the zero-iteration ParallelFor case (see test case **4: `empty-parallel-for`** below). This is because no component is ever executed that will exercise the `UpdateDAGExecutionsState` function to propagate the state upward. This is a minor edge case that I won't try to address in this PR.

## Test plan

- [x] `go build ./backend/src/v2/...` compiles cleanly
- [x] Backend unit tests: `go test -v $(go list ./backend/... | grep -v backend/test/)`
- [x] Compiler tests: `ginkgo -v ./backend/test/compiler`
- [x] Manual verification with ParallelFor + ExitHandler pipeline (issue #13321 repro)
- [x] Manual verification with nested pipeline DAGs (issue #11979 repro)
- [x] Test a large variety of different DAG structures

### issue #13321 repro

The parent DAGs show Failed as expected.

<img width="1031" height="455" alt="Screenshot 2026-04-27 at 11 01 24 PM" src="https://github.com/user-attachments/assets/b3058caa-5f93-4d1b-a360-f09362c4f539" />

<img width="1210" height="678" alt="Screenshot 2026-04-27 at 11 02 40 PM" src="https://github.com/user-attachments/assets/b8bd3897-a78b-4d93-8e18-ffba31df6e25" />

### Test Evidence for Different Pipeline DAG Structures

The following pipelines were run to validate DAG state propagation. Each pipeline targets a specific nesting/control-flow pattern. Screenshots show the pipeline run results with the fix applied.

---

#### 1. `parallel-for-exit-handler`
**What it tests:** ParallelFor inside an ExitHandler where one iteration fails (index 1), one succeeds immediately (index 0), and one is long-running (index 2). Validates that the ExitHandler resolves to FAILED instead of staying RUNNING forever, and that the exit task still executes.

**Structure:** ExitHandler → ParallelFor (3 iterations, parallelism=3) → exit_task

<!-- parallel_for_exit_handler_pipeline.png -->
<img width="1481" height="508" alt="parallel_for_exit_handler_pipeline" src="https://github.com/user-attachments/assets/79f1d93c-2e67-470a-93eb-c82683365c49" />

---

#### 2. `conditional-branches`
**What it tests:** If/Else where only the If branch triggers (value is even). Validates that the untriggered Else branch is properly marked CANCELED so the condition DAG resolves to SUCCEEDED instead of staying RUNNING.

**Structure:** conditional_task → If (even branch succeeds) / Else (odd branch, not triggered) → downstream task

<!-- conditional_branches_pipeline.png -->
<img width="1414" height="536" alt="conditional_branches_pipeline" src="https://github.com/user-attachments/assets/f9af43c7-1548-4c83-8ee9-ae7385ecb455" />

---

#### 3. `nested-loops`
**What it tests:** ParallelFor nested inside ParallelFor (2 outer × 2 inner = 4 leaf tasks, all succeed). Validates that inner loop DAG states propagate up to outer loop iteration DAGs.

**Structure:** Outer ParallelFor ["a","b"] → Inner ParallelFor [1,2] → succeed_task → downstream task

<!-- nested_loops_pipeline.png -->
<img width="1579" height="516" alt="nested_loops_pipeline" src="https://github.com/user-attachments/assets/7845a072-a792-4f86-97ff-a732f7c8c8da" />

---

#### 4. `empty-parallel-for`
**What it tests:** Zero-iteration ParallelFor (items=[] at runtime). Validates that the loop immediately resolves to SUCCEEDED instead of staying RUNNING forever due to a mismatch between compile-time total_dag_tasks=1 and 0 actual tasks.

**Structure:** ExitHandler → ParallelFor (0 items) → exit_task → downstream task

<!-- empty_parallel_for_pipeline.png -->
<img width="1480" height="507" alt="empty_parallel_for_pipeline" src="https://github.com/user-attachments/assets/37b92624-ad5c-4906-b0e6-2b3ff1377158" />

---

#### 5. `exit-handler-conditional`
**What it tests:** Three levels of nesting: ExitHandler → ParallelFor → If/Else. Item 2 (even) triggers the Else branch which fails. Validates state propagation through all three layers.

**Structure:** ExitHandler → ParallelFor [1,2,3] → conditional_task → If (odd, succeeds) / Else (even, fails) → exit_task

<!-- exit_handler_conditional_pipeline.png -->
<img width="1529" height="508" alt="exit_handler_conditional_pipeline" src="https://github.com/user-attachments/assets/a16bc5a9-c412-4031-9faa-58fd9d07dc94" />

---

#### 6. `nested-pipeline-with-loops`
**What it tests:** A sub-pipeline containing a ParallelFor (3 iterations, all succeed). Validates that ParallelFor state propagates across the sub-pipeline boundary.

**Structure:** Root → inner_loop_pipeline (sub-pipeline with ParallelFor [1,2,3]) → downstream task

<!-- nested_pipeline_with_loops_pipeline.png -->
<img width="1554" height="506" alt="nested_pipeline_with_loops_pipeline" src="https://github.com/user-attachments/assets/cceccfe1-c82c-4321-bc71-09d268fdeb06" />

---

#### 7. `deep-nesting`
**What it tests:** Maximum depth — 5 DAG levels: Root → ExitHandler → SubPipeline → ParallelFor → If/Else → leaf tasks. All branches succeed. Validates propagation through every intermediate level.

**Structure:** ExitHandler → deeply_nested_pipeline → ParallelFor [1,2,3,4] → conditional (odd/even) → succeed_task → exit_task → downstream task

<!-- deep_nesting_pipeline.png -->
<img width="1715" height="535" alt="deep_nesting_pipeline" src="https://github.com/user-attachments/assets/c4033ec6-6e19-48e1-98ec-27ae42537519" />

---

#### 8. `nested-pipeline-all-fail`
**What it tests:** A sub-pipeline where every task fails (2 parallel fail_tasks). Validates state propagation when there are zero successful tasks inside a nested pipeline.

**Structure:** ExitHandler → inner_failing_pipeline (2 parallel fail_tasks) → exit_task

<!-- nested_pipeline_all_fail_pipeline.png -->
<img width="1516" height="524" alt="nested_pipeline_all_fail_pipeline" src="https://github.com/user-attachments/assets/a8b99c5b-f4bc-4d4e-94b1-ca88d24f6cef" />

---

#### 9. `parallel-for-all-fail`
**What it tests:** ParallelFor where every iteration fails (100% failure rate, 3 iterations). Validates iteration_count logic when no iteration succeeds.

**Structure:** ExitHandler → ParallelFor [0,1,2] (all fail) → exit_task

<!-- parallel_for_all_fail_pipeline.png -->
<img width="1533" height="512" alt="parallel_for_all_fail_pipeline" src="https://github.com/user-attachments/assets/a800a278-ea39-4029-a73f-263af276d45d" />

---

#### 10. `conditional-failure-paths`
**What it tests:** If/Else where the triggered branch (odd) fails. Validates that failure propagates through conditional structures and downstream tasks are skipped.

**Structure:** conditional_task(3) → If (odd branch, fails) / Else (even branch, CANCELED) → downstream task (skipped)

<!-- conditional_failure_paths_pipeline.png -->
<img width="1419" height="527" alt="conditional_failure_paths_pipeline" src="https://github.com/user-attachments/assets/8a0a7d67-4fc7-4c56-b8a8-3ffc3cad1077" />

---

#### 11. `nested-loop-inner-failure`
**What it tests:** Failure propagation through 3 levels of loop nesting. Inner ParallelFor has a failing iteration (item=2) in each outer iteration. 6 total leaf tasks, 2 fail.

**Structure:** Outer ParallelFor ["a","b"] → Inner ParallelFor [1,2,3] (item=2 fails) → downstream task (skipped)

<!-- nested_loop_inner_failure_pipeline.png -->
<img width="1559" height="514" alt="nested_loop_inner_failure_pipeline" src="https://github.com/user-attachments/assets/daaba644-b9a9-4cf3-a62e-bd8e4f8ce408" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)