### PR TITLE
fix(backend): Add retry logic to launcher artifact upload if component fails

### DIFF
--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -416,15 +416,11 @@ func executeV2(
 	if err != nil {
 		glog.Errorf("Component failed to execute successfully: %v", err)
 
-		outputArtifacts, uploadErr := uploadOutputArtifacts(ctx, executorInput, executorOutput, uploadOutputArtifactsOptions{
+		outputArtifacts, _ := uploadOutputArtifactsWithRetry(ctx, executorInput, executorOutput, uploadOutputArtifactsOptions{
 			bucketConfig:   bucketConfig,
 			bucket:         bucket,
 			metadataClient: metadataClient,
-		}, false)
-
-		if uploadErr != nil {
-			glog.Errorf("Failed to upload log artifact: %v", uploadErr)
-		}
+		}, true, openBucketConfig, 2)
 
 		return executorOutput, outputArtifacts, err
 	}
@@ -436,35 +432,14 @@ func executeV2(
 		return nil, nil, err
 	}
 
-	outputArtifacts, err := uploadOutputArtifacts(ctx, executorInput, executorOutput, uploadOutputArtifactsOptions{
+	outputArtifacts, err := uploadOutputArtifactsWithRetry(ctx, executorInput, executorOutput, uploadOutputArtifactsOptions{
 		bucketConfig:   bucketConfig,
 		bucket:         bucket,
 		metadataClient: metadataClient,
-	}, true)
+	}, true, openBucketConfig, 2)
 
 	if err != nil {
-		glog.Errorf("Failed to upload output artifacts: %v", err)
-
-		glog.Info("Refreshing credentials before retrying artifacts upload.")
-		bucket, err = objectstore.OpenBucket(
-			openBucketConfig.ctx,
-			openBucketConfig.k8sClient,
-			openBucketConfig.namespace,
-			openBucketConfig.config,
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		glog.Info("Executing second uploadOutputArtifacts attempt.")
-		outputArtifacts, err = uploadOutputArtifacts(ctx, executorInput, executorOutput, uploadOutputArtifactsOptions{
-			bucketConfig:   bucketConfig,
-			bucket:         bucket,
-			metadataClient: metadataClient,
-		}, true)
-		if err != nil {
-			return nil, nil, err
-		}
+		return nil, nil, err
 	}
 
 	// TODO(Bobgy): only return executor output. Merge info in output artifacts
@@ -812,6 +787,39 @@ func uploadOutputArtifacts(
 		}
 	}
 	return outputArtifacts, nil
+}
+
+func uploadOutputArtifactsWithRetry(
+	ctx context.Context,
+	executorInput *pipelinespec.ExecutorInput,
+	executorOutput *pipelinespec.ExecutorOutput,
+	opts uploadOutputArtifactsOptions,
+	componentSucceeded bool,
+	openBucketConfig *OpenBucketConfig,
+	maxAttempts int,
+) ([]*metadata.OutputArtifact, error) {
+	var finalErr error
+	for retryCount := 0; retryCount < maxAttempts; retryCount++ {
+		glog.Infof("Executing uploadOutputArtifacts attempt: %d", retryCount+1)
+		outputArtifacts, err := uploadOutputArtifacts(ctx, executorInput, executorOutput, opts, componentSucceeded)
+
+		if err == nil {
+			return outputArtifacts, nil
+		}
+
+		glog.Warningf("Failed to upload output artifacts: %v", err)
+		finalErr = err
+
+		glog.Info("Refreshing credentials before retrying artifacts upload.")
+		opts.bucket, err = objectstore.OpenBucket(
+			openBucketConfig.ctx,
+			openBucketConfig.k8sClient,
+			openBucketConfig.namespace,
+			openBucketConfig.config,
+		)
+	}
+	glog.Errorf("All upload artifact attempts failed: %v", finalErr)
+	return nil, finalErr
 }
 
 // waitForModelcar assumes the Modelcar has already been validated by the init container on the launcher

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -420,7 +420,7 @@ func executeV2(
 			bucketConfig:   bucketConfig,
 			bucket:         bucket,
 			metadataClient: metadataClient,
-		}, true, openBucketConfig, 2)
+		}, false, openBucketConfig, 2)
 
 		return executorOutput, outputArtifacts, err
 	}
@@ -798,18 +798,16 @@ func uploadOutputArtifactsWithRetry(
 	openBucketConfig *OpenBucketConfig,
 	maxAttempts int,
 ) ([]*metadata.OutputArtifact, error) {
-	var finalErr error
-	for retryCount := 0; retryCount < maxAttempts; retryCount++ {
-		glog.Infof("Executing uploadOutputArtifacts attempt: %d", retryCount+1)
-		outputArtifacts, err := uploadOutputArtifacts(ctx, executorInput, executorOutput, opts, componentSucceeded)
+	glog.Infof("Executing uploadOutputArtifacts attempt: 1")
+	outputArtifacts, err := uploadOutputArtifacts(ctx, executorInput, executorOutput, opts, componentSucceeded)
 
-		if err == nil {
-			return outputArtifacts, nil
-		}
+	if err == nil {
+		return outputArtifacts, nil
+	}
+	finalErr := err
 
+	for retryCount := 1; retryCount < maxAttempts; retryCount++ {
 		glog.Warningf("Failed to upload output artifacts: %v", err)
-		finalErr = err
-
 		glog.Info("Refreshing credentials before retrying artifacts upload.")
 		opts.bucket, err = objectstore.OpenBucket(
 			openBucketConfig.ctx,
@@ -817,6 +815,19 @@ func uploadOutputArtifactsWithRetry(
 			openBucketConfig.namespace,
 			openBucketConfig.config,
 		)
+		if err != nil {
+			glog.Infof("Failed to refresh credentials: %v", err)
+			finalErr = err
+			continue
+		}
+
+		glog.Infof("Executing uploadOutputArtifacts attempt: %d", retryCount+1)
+		outputArtifacts, err := uploadOutputArtifacts(ctx, executorInput, executorOutput, opts, componentSucceeded)
+
+		if err == nil {
+			return outputArtifacts, nil
+		}
+		finalErr = err
 	}
 	glog.Errorf("All upload artifact attempts failed: %v", finalErr)
 	return nil, finalErr

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -125,6 +125,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 		executorArgs  []string
 		retryIndex    string
 		wantErr       bool
+		uploadFailure bool
 	}{
 		{
 			"happy pass",
@@ -135,6 +136,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			},
 			[]string{"-c", "echo testoutput && test {{$.inputs.parameters['a']}} -eq 1 || exit 1\ntest {{$.inputs.parameters['b']}} -eq 2 || exit 1"},
 			"",
+			false,
 			false,
 		},
 		{
@@ -147,6 +149,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			[]string{"-c", "echo testoutput && test {{$.inputs.parameters['a']}} -eq 5 || exit 1\ntest {{$.inputs.parameters['b']}} -eq 2 || exit 1"},
 			"",
 			false,
+			false,
 		},
 		{
 			"sad fail",
@@ -157,6 +160,31 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			},
 			[]string{"-c", "echo testoutput && exit 1"},
 			"",
+			true,
+			false,
+		},
+		{
+			"retry required - component success",
+			&pipelinespec.ExecutorInput{
+				Inputs: &pipelinespec.ExecutorInput_Inputs{
+					ParameterValues: map[string]*structpb.Value{"a": structpb.NewNumberValue(1), "b": structpb.NewNumberValue(2)},
+				},
+			},
+			[]string{"-c", "echo testoutput && test {{$.inputs.parameters['a']}} -eq 1 || exit 1\ntest {{$.inputs.parameters['b']}} -eq 2 || exit 1"},
+			"",
+			false,
+			true,
+		},
+		{
+			"retry required - component failure",
+			&pipelinespec.ExecutorInput{
+				Inputs: &pipelinespec.ExecutorInput_Inputs{
+					ParameterValues: map[string]*structpb.Value{"a": structpb.NewNumberValue(1), "b": structpb.NewNumberValue(2)},
+				},
+			},
+			[]string{"-c", "echo testoutput && exit 1"},
+			"",
+			true,
 			true,
 		},
 		{
@@ -173,13 +201,23 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			[]string{"-c", "echo testoutput && test {{$.inputs.parameters['a']}} -eq 1 || exit 1"},
 			"3",
 			false,
+			false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fakeKubernetesClientset := &fake.Clientset{}
-			fakeMetadataClient := metadata.NewFakeClient()
+			var fakeMetadataClient metadata.ClientInterface
+			var countingFakeMetadataClient *metadata.RecordArtifactFailureFakeClient
+			// Use a fake client that will fail the RecordArtifact call in uploadArtifactLogs the first time,
+			// and succeed the second time, to test retry behavior
+			if test.uploadFailure {
+				countingFakeMetadataClient = metadata.NewRecordArtifactFailureFakeClient(1)
+				fakeMetadataClient = countingFakeMetadataClient
+			} else {
+				fakeMetadataClient = metadata.NewFakeClient()
+			}
 			bucket, err := blob.OpenBucket(context.Background(), "mem://test-bucket")
 			assert.Nil(t, err)
 			bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket/pipeline-root/", nil)
@@ -248,6 +286,10 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			assert.Equal(t, "testoutput\n", string(outputLog))
 
 			assert.Len(t, outputArtifacts, 1, "Expected 1 output artifact (executor-logs)")
+
+			if test.uploadFailure {
+				assert.Equal(t, 2, countingFakeMetadataClient.RecordArtifactCalls)
+			}
 		})
 	}
 }

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -222,7 +222,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			assert.Nil(t, err)
 			bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket/pipeline-root/", nil)
 			assert.Nil(t, err)
-			// Add executor-logs artifact to outputs
+			// Add executor-logs and output artifact to outputs
 			if test.executorInput.Outputs == nil {
 				test.executorInput.Outputs = &pipelinespec.ExecutorInput_Outputs{}
 			}
@@ -238,6 +238,16 @@ func Test_executeV2_publishLogs(t *testing.T) {
 						Uri:        "mem://test-bucket/pipeline-root/executor-logs",
 						Type:       &pipelinespec.ArtifactTypeSchema{Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{SchemaTitle: "system.Artifact"}},
 						CustomPath: &customPath,
+					},
+				},
+			}
+			outputDataPath := filepath.Join(tempDir, "output-data")
+			test.executorInput.Outputs.Artifacts["output-data"] = &pipelinespec.ArtifactList{
+				Artifacts: []*pipelinespec.RuntimeArtifact{
+					{
+						Uri:        "mem://test-bucket/pipeline-root/output-data",
+						Type:       &pipelinespec.ArtifactTypeSchema{Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{SchemaTitle: "system.Dataset"}},
+						CustomPath: &outputDataPath,
 					},
 				},
 			}
@@ -265,8 +275,18 @@ func Test_executeV2_publishLogs(t *testing.T) {
 
 			if test.wantErr {
 				assert.NotNil(t, err)
+				assert.Len(t, outputArtifacts, 1, "Expected 1 output artifact (executor-logs)")
+				if test.uploadFailure {
+					// Only logs uploaded - first call fails, second call succeeds
+					assert.Equal(t, 2, countingFakeMetadataClient.RecordArtifactCalls)
+				}
 			} else {
 				assert.Nil(t, err)
+				assert.Len(t, outputArtifacts, 2, "Expected 2 output artifacts (executor-logs and output-data)")
+				if test.uploadFailure {
+					// First call fails and returns early, then both artifacts succeed on retry
+					assert.Equal(t, 3, countingFakeMetadataClient.RecordArtifactCalls)
+				}
 			}
 
 			// When a retry index is set, the executor-logs URI (and therefore the
@@ -284,12 +304,6 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			outputLog, err := bucket.ReadAll(context.TODO(), logKey)
 			assert.Nil(t, err, "Expected executor-logs to be readable at key %q", logKey)
 			assert.Equal(t, "testoutput\n", string(outputLog))
-
-			assert.Len(t, outputArtifacts, 1, "Expected 1 output artifact (executor-logs)")
-
-			if test.uploadFailure {
-				assert.Equal(t, 2, countingFakeMetadataClient.RecordArtifactCalls)
-			}
 		})
 	}
 }

--- a/backend/src/v2/metadata/client_fake.go
+++ b/backend/src/v2/metadata/client_fake.go
@@ -19,6 +19,7 @@ package metadata
 
 import (
 	"context"
+	"errors"
 
 	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 
@@ -109,5 +110,27 @@ func (c *FakeClient) GetOrInsertArtifactType(ctx context.Context, schema string)
 }
 
 func (c *FakeClient) FindMatchedArtifact(ctx context.Context, artifactToMatch *pb.Artifact, pipelineContextId int64) (matchedArtifact *pb.Artifact, err error) {
+	return nil, nil
+}
+
+// Fake client used for testing launcher publish failure handling
+type RecordArtifactFailureFakeClient struct {
+	*FakeClient
+	RecordArtifactCalls int
+	FailUntilCall       int
+}
+
+func NewRecordArtifactFailureFakeClient(failUntilCall int) *RecordArtifactFailureFakeClient {
+	return &RecordArtifactFailureFakeClient{
+		FakeClient:    NewFakeClient(),
+		FailUntilCall: failUntilCall,
+	}
+}
+
+func (c *RecordArtifactFailureFakeClient) RecordArtifact(ctx context.Context, outputName, schema string, runtimeArtifact *pipelinespec.RuntimeArtifact, state pb.Artifact_State, bucketConfig *objectstore.Config) (*OutputArtifact, error) {
+	c.RecordArtifactCalls++
+	if c.RecordArtifactCalls <= c.FailUntilCall {
+		return nil, errors.New("simulated error")
+	}
 	return nil, nil
 }

--- a/backend/src/v2/metadata/client_fake.go
+++ b/backend/src/v2/metadata/client_fake.go
@@ -113,7 +113,7 @@ func (c *FakeClient) FindMatchedArtifact(ctx context.Context, artifactToMatch *p
 	return nil, nil
 }
 
-// Fake client used for testing launcher publish failure handling
+// RecordArtifactFailureFakeClient is used for testing launcher publish failure handling
 type RecordArtifactFailureFakeClient struct {
 	*FakeClient
 	RecordArtifactCalls int


### PR DESCRIPTION
Co-authored-by: tarat44 <32471142+tarat44@users.noreply.github.com>

**Description of your changes:**
Currently in kfpv2, the launcher will retry uploading output artifacts if the first attempt fails when the main component logic has succeeded, but does not retry if the component failed. This PR adds an `uploadOutputArtifactsWithRetry` function with a configurable retry count and updates both upload calls (on component success and failure) to attempt to upload twice.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
