### PR TITLE
fix(backend): apply recurring run service account unconditionally

### DIFF
--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -31,6 +31,7 @@ import (
 	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"
 	scheduledworkflow "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	structpb "google.golang.org/protobuf/types/known/structpb"
@@ -245,6 +246,40 @@ func TestScheduledWorkflow(t *testing.T) {
 	// It is also tested in compiler.
 	actualScheduledWorkflow.Spec.Workflow.Spec = ""
 	assert.Equal(t, &expectedScheduledWorkflow, actualScheduledWorkflow)
+}
+
+func TestScheduledWorkflow_CustomServiceAccount(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+
+	v2SpecHelloWorldYAML := loadYaml(t, "testdata/hello_world.yaml")
+	v2Template, _ := New([]byte(v2SpecHelloWorldYAML), TemplateOptions{CacheDisabled: true, DefaultWorkspace: defaultPVC})
+
+	modelJob := &model.Job{
+		K8SName:        "name1",
+		Enabled:        true,
+		MaxConcurrency: 1,
+		NoCatchup:      true,
+		ServiceAccount: "custom-sa",
+		Trigger: model.Trigger{
+			CronSchedule: model.CronSchedule{
+				CronScheduleStartTimeInSec: util.Int64Pointer(1),
+				CronScheduleEndTimeInSec:   util.Int64Pointer(10),
+				Cron:                       util.StringPointer("1 * * * *"),
+			},
+		},
+		PipelineSpec: model.PipelineSpec{
+			PipelineId:           "1",
+			PipelineName:         "pipeline name",
+			PipelineSpecManifest: model.LargeText(v2SpecHelloWorldYAML),
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters: "{\"y\":\"world\"}",
+			},
+		},
+	}
+
+	actualScheduledWorkflow, err := v2Template.ScheduledWorkflow(modelJob)
+	require.Nil(t, err)
+	assert.Equal(t, "custom-sa", actualScheduledWorkflow.Spec.ServiceAccount)
 }
 
 func TestModelToCRDTrigger_Cron(t *testing.T) {

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -146,9 +146,7 @@ func (t *V2Spec) ScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.Sche
 	if modelJob.Namespace != "" {
 		executionSpec.SetExecutionNamespace(modelJob.Namespace)
 	}
-	if executionSpec.ServiceAccount() == "" {
-		setDefaultServiceAccount(executionSpec, modelJob.ServiceAccount)
-	}
+	setDefaultServiceAccount(executionSpec, modelJob.ServiceAccount)
 	// Disable istio sidecar injection if not specified
 	executionSpec.SetAnnotationsToAllTemplatesIfKeyNotExist(util.AnnotationKeyIstioSidecarInject, util.AnnotationValueIstioSidecarInjectDisabled)
 	parameters, err := StringMapToCRDParameters(string(modelJob.RuntimeConfig.Parameters))


### PR DESCRIPTION
## Summary

When creating a recurring run with a user-specified service account, the service account is silently dropped and the workflow always runs with the compiler default instead.

**Root cause:** In `ScheduledWorkflow()`, `setDefaultServiceAccount` was guarded by `if executionSpec.ServiceAccount() == ""`. Since the Argo compiler (via `argocompiler.Compile`) always sets a `ServiceAccountName` on the workflow spec (changed from hardcoded `"pipeline-runner"` to a configurable default in #11578), this condition is never true for V2 pipelines. As a result, `modelJob.ServiceAccount` is never applied.

**Fix:** Remove the guard and call `setDefaultServiceAccount` unconditionally. This matches what `RunWorkflow()` already does (line 388 in the same file), and `setDefaultServiceAccount` already handles both cases internally: it applies the user-specified SA when non-empty, and falls back to the configured default otherwise.

## Related issues

- Fixes #13311 — scheduled workflow service account ignored
- Regressed in #11481 — added the `if executionSpec.ServiceAccount() == ""` guard that is always false because the Argo compiler populates the field
- Related to #11597 — recurring runs failing because the compiler-injected default SA (`pipeline-runner`) didn't exist in the target namespace, while the user-configured SA was silently dropped
- Related to #11578 — replaced the hardcoded `pipeline-runner` with a configurable default in the Argo compiler, which made the guard condition in `ScheduledWorkflow` permanently false for any non-default configuration

## Test plan

- [ ] Existing unit tests pass (`go test ./backend/src/apiserver/template/...`)
- [ ] Create a recurring run with a custom service account; verify the resulting ScheduledWorkflow uses it
- [ ] Create a recurring run without specifying a service account; verify it falls back to the configured default
- [ ] Verify one-off runs are unaffected (the `RunWorkflow` path was already unconditional)