### PR TITLE
fix(frontend): show loading spinner on Compare page instead of blank content

### DIFF
--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -108,9 +108,7 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     );
 
     await waitFor(() => {
-      expect(updateBannerSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ mode: 'error' }),
-      );
+      expect(updateBannerSpy).toHaveBeenCalledWith(expect.objectContaining({ mode: 'error' }));
     });
 
     expect(screen.queryByRole('progressbar')).toBeNull();

--- a/frontend/src/pages/Compare.test.tsx
+++ b/frontend/src/pages/Compare.test.tsx
@@ -82,6 +82,40 @@ describe('Switch between v1 and v2 Run Comparison pages', () => {
     vi.spyOn(Apis.runServiceApiV2, 'getRun').mockImplementation((id: string) => newMockV2Run(id));
   });
 
+  it('shows a loading spinner while runs are being fetched', () => {
+    vi.spyOn(Apis.runServiceApi, 'getRun').mockReturnValue(new Promise(() => {}));
+
+    render(
+      <CommonTestWrapper>
+        <Compare {...generateProps()} />
+      </CommonTestWrapper>,
+    );
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('does not show a loading spinner after runs fail to load', async () => {
+    vi.spyOn(Apis.runServiceApi, 'getRun').mockRejectedValue(new Error('fail'));
+
+    vi.spyOn(features, 'isFeatureEnabled').mockImplementation(
+      (featureKey) => featureKey === features.FeatureKey.V2_ALPHA,
+    );
+
+    render(
+      <CommonTestWrapper>
+        <Compare {...generateProps()} />
+      </CommonTestWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(updateBannerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'error' }),
+      );
+    });
+
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+
   it('getRun is called with query param IDs', async () => {
     const getRunSpy = vi.spyOn(Apis.runServiceApi, 'getRun');
     runs = [

--- a/frontend/src/pages/Compare.tsx
+++ b/frontend/src/pages/Compare.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { CircularProgress } from '@mui/material';
 import { ApiRunDetail } from 'src/apis/run';
 import { QUERY_PARAMS } from 'src/components/Router';
 import { queryKeys } from 'src/hooks/queryKeys';
@@ -110,7 +111,15 @@ export default function Compare(props: PageProps) {
     }
   }, [compareVersion, isError, error, isLoading, updateBanner, runIds.length]);
 
-  if (isError || isLoading) {
+  if (isLoading) {
+    return (
+      <div style={{ textAlign: 'center', paddingTop: 40 }}>
+        <CircularProgress />
+      </div>
+    );
+  }
+
+  if (isError) {
     return <></>;
   }
 


### PR DESCRIPTION
**Description of your changes:**

The `Compare` page router renders `<></>` (empty fragment) while run details are being fetched, leaving the user with a completely blank page body and no loading feedback. The same blank render also occurs on error, though the banner effect already surfaces the error message in the page header.

### Changes

**`Compare.tsx`**
- Split the combined `if (isError || isLoading) { return <></>; }` guard into two separate branches.
- **Loading**: render a centered `CircularProgress` spinner, consistent with other routers (`NewRunSwitcher`, `RecurringRunDetailsRouter`).
- **Error**: keep the empty body (the `useEffect` banner already provides the error feedback in the page header).

### Tests added

- **`Compare.test.tsx`**: verifies the loading spinner appears while run details are being fetched.
- **`Compare.test.tsx`**: verifies the spinner is not shown after an error, and the error banner fires.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

Made with [Cursor](https://cursor.com)