### PR TITLE
fix(backend): ensure log artifact index handling

### DIFF
--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -386,6 +386,7 @@ func executeV2(
 	customCAPath string,
 	openBucketConfig *OpenBucketConfig,
 ) (*pipelinespec.ExecutorOutput, []*metadata.OutputArtifact, error) {
+	qualifyExecutorLogsForRetry(ctx, executorInput, publishLogs, namespace, k8sClient)
 
 	// Add parameter default values to executorInput, if there is not already a user input.
 	// This process is done in the launcher because we let the component resolve default values internally.
@@ -515,7 +516,54 @@ func qualifyExecutorLogsURI(artifacts map[string]*pipelinespec.ArtifactList, ret
 	if art == nil {
 		return
 	}
-	art.Uri = art.Uri + "-" + retryIndex
+	art.Uri = appendRetryIndexSuffix(art.Uri, retryIndex)
+	if art.CustomPath != nil && *art.CustomPath != "" {
+		*art.CustomPath = appendRetryIndexSuffix(*art.CustomPath, retryIndex)
+	}
+}
+
+// appendRetryIndexSuffix appends "-<retryIndex>" to a log path or URI once,
+// preserving already-qualified values.
+func appendRetryIndexSuffix(pathOrURI, retryIndex string) string {
+	if pathOrURI == "" || retryIndex == "" {
+		return pathOrURI
+	}
+	suffix := "-" + retryIndex
+	if strings.HasSuffix(pathOrURI, suffix) {
+		return pathOrURI
+	}
+	return pathOrURI + suffix
+}
+
+// qualifyExecutorLogsForRetry resolves the current retry attempt and updates the
+// launcher-managed executor-logs artifact before placeholder compilation and
+// execution so downstream paths and serialized executor input stay aligned.
+func qualifyExecutorLogsForRetry(
+	ctx context.Context,
+	executorInput *pipelinespec.ExecutorInput,
+	publishLogs string,
+	namespace string,
+	k8sClient kubernetes.Interface,
+) {
+	if publishLogs != "true" {
+		return
+	}
+
+	retryIndex := os.Getenv(EnvRetryIndex)
+	if retryIndex == "" {
+		podName := os.Getenv(EnvPodName)
+		if podName != "" && k8sClient != nil && namespace != "" {
+			if idx, err := retryIndexFromPodAnnotation(ctx, k8sClient, namespace, podName); err == nil {
+				retryIndex = idx
+			} else {
+				glog.Warningf("Could not determine retry index from pod annotation, defaulting to 0: %v", err)
+			}
+		}
+	}
+	if retryIndex == "" {
+		retryIndex = "0"
+	}
+	qualifyExecutorLogsURI(executorInput.GetOutputs().GetArtifacts(), retryIndex)
 }
 
 // retryIndexFromPodAnnotation reads the Argo node-name annotation on the current
@@ -611,30 +659,6 @@ func execute(
 	}
 	if err := downloadArtifacts(ctx, executorInput, bucket, bucketConfig, namespace, k8sClient); err != nil {
 		return nil, err
-	}
-
-	// Qualify the executor-logs URI with the retry index before preparing output
-	// folders so the per-attempt directory is created at the correct path.
-	// Prefer KFP_RETRY_INDEX, which is injected by the Argo compiler as
-	// "{{retries}}" and resolved by Argo at pod creation time. Fall back to
-	// reading the Argo node-name pod annotation, which encodes the index as
-	// executor(N), for compatibility with older API server versions.
-	if publishLogs == "true" {
-		retryIndex := os.Getenv(EnvRetryIndex)
-		if retryIndex == "" {
-			podName := os.Getenv(EnvPodName)
-			if podName != "" && k8sClient != nil && namespace != "" {
-				if idx, err := retryIndexFromPodAnnotation(ctx, k8sClient, namespace, podName); err == nil {
-					retryIndex = idx
-				} else {
-					glog.Warningf("Could not determine retry index from pod annotation, defaulting to 0: %v", err)
-				}
-			}
-		}
-		if retryIndex == "" {
-			retryIndex = "0"
-		}
-		qualifyExecutorLogsURI(executorInput.Outputs.GetArtifacts(), retryIndex)
 	}
 
 	if err := prepareOutputFolders(executorInput); err != nil {
@@ -744,8 +768,9 @@ func uploadOutputArtifacts(
 		for _, outputArtifact := range artifactList.Artifacts {
 			glog.Infof("outputArtifact in uploadOutputArtifacts call: %s", outputArtifact.Name)
 
-			// Merge executor output artifact info with executor input
-			if executorOutput != nil {
+			// executor-logs is launcher-managed; keep its qualified location stable
+			// even if the user executor echoes an older value in ExecutorOutput.
+			if executorOutput != nil && name != "executor-logs" {
 				if list, ok := executorOutput.Artifacts[name]; ok && len(list.Artifacts) > 0 {
 					mergeRuntimeArtifacts(list.Artifacts[0], outputArtifact)
 				}
@@ -755,6 +780,11 @@ func uploadOutputArtifacts(
 			localDir, err := retrieveArtifactPath(outputArtifact)
 			if err != nil {
 				glog.Warningf("Output Artifact %q does not have a recognized storage URI %q. Skipping uploading to remote storage.", name, outputArtifact.Uri)
+				if name == "executor-logs" {
+					// Avoid registering a broken executor-logs artifact when launcher setup fails
+					// before the log file path can be initialized.
+					continue
+				}
 			} else if !strings.HasPrefix(outputArtifact.Uri, "oci://") {
 				blobKey, err := opts.bucketConfig.KeyFromURI(outputArtifact.Uri)
 				if err != nil {
@@ -764,6 +794,11 @@ func uploadOutputArtifacts(
 					//  We allow components to not produce output files
 					if errors.Is(err, os.ErrNotExist) {
 						glog.Warningf("Local filepath %q does not exist", localDir)
+						if name == "executor-logs" {
+							// If the executor never started streaming logs to disk, skip recording
+							// the log artifact instead of surfacing a dead link in the UI.
+							continue
+						}
 					} else {
 						return nil, fmt.Errorf("failed to upload output artifact %q to remote storage URI %q: %w", name, outputArtifact.Uri, err)
 					}

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -300,12 +301,145 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			logArt := test.executorInput.Outputs.Artifacts["executor-logs"].Artifacts[0]
 			assert.Contains(t, logArt.Uri, effectiveIndex,
 				"executor-logs URI should contain the retry index for attempt isolation")
+			if assert.NotNil(t, logArt.CustomPath) {
+				assert.Contains(t, *logArt.CustomPath, effectiveIndex,
+					"executor-logs CustomPath should contain the retry index for attempt isolation")
+				_, err = os.Stat(*logArt.CustomPath)
+				assert.NoError(t, err, "Expected executor-logs file to exist at the qualified custom path")
+			}
 
 			outputLog, err := bucket.ReadAll(context.TODO(), logKey)
 			assert.Nil(t, err, "Expected executor-logs to be readable at key %q", logKey)
 			assert.Equal(t, "testoutput\n", string(outputLog))
 		})
 	}
+}
+
+func Test_executeV2_publishLogs_skipsArtifactWhenSetupFailsBeforeLogsExist(t *testing.T) {
+	fakeKubernetesClientset := &fake.Clientset{}
+	fakeMetadataClient := metadata.NewFakeClient()
+	bucket, err := blob.OpenBucket(context.Background(), "mem://test-bucket")
+	assert.Nil(t, err)
+	bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket/pipeline-root/", nil)
+	assert.Nil(t, err)
+
+	tempDir := t.TempDir()
+	customPath := filepath.Join(tempDir, "executor-logs")
+	executorInput := &pipelinespec.ExecutorInput{
+		Inputs: &pipelinespec.ExecutorInput_Inputs{
+			ParameterValues: map[string]*structpb.Value{},
+		},
+		Outputs: &pipelinespec.ExecutorInput_Outputs{
+			Artifacts: map[string]*pipelinespec.ArtifactList{
+				"executor-logs": {
+					Artifacts: []*pipelinespec.RuntimeArtifact{
+						{
+							Uri:        "mem://test-bucket/pipeline-root/executor-logs",
+							Type:       &pipelinespec.ArtifactTypeSchema{Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{SchemaTitle: "system.Artifact"}},
+							CustomPath: &customPath,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, outputArtifacts, err := executeV2(
+		context.Background(),
+		executorInput,
+		addNumbersComponent,
+		"sh",
+		[]string{"-c", "echo testoutput"},
+		bucket,
+		bucketConfig,
+		fakeMetadataClient,
+		"namespace",
+		fakeKubernetesClientset,
+		"true",
+		filepath.Join(tempDir, "missing-ca.pem"),
+		&OpenBucketConfig{context.Background(), fakeKubernetesClientset, "namespace", bucketConfig},
+	)
+
+	assert.Error(t, err)
+	assert.Empty(t, outputArtifacts, "Expected no output artifacts when logs were never created")
+
+	_, err = bucket.ReadAll(context.TODO(), "executor-logs")
+	assert.Error(t, err, "Expected no executor-logs blob to be uploaded")
+}
+
+func Test_executeV2_publishLogs_qualifiesExecutorInputBeforeCommandCompilation(t *testing.T) {
+	fakeKubernetesClientset := &fake.Clientset{}
+	fakeMetadataClient := metadata.NewFakeClient()
+	bucket, err := blob.OpenBucket(context.Background(), "mem://test-bucket")
+	assert.Nil(t, err)
+	bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket/pipeline-root/", nil)
+	assert.Nil(t, err)
+
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "executor-logs")
+	outputMetadataFile := filepath.Join(tempDir, "output_metadata.json")
+	executorInput := &pipelinespec.ExecutorInput{
+		Inputs: &pipelinespec.ExecutorInput_Inputs{
+			ParameterValues: map[string]*structpb.Value{
+				"a": structpb.NewNumberValue(1),
+				"b": structpb.NewNumberValue(2),
+			},
+		},
+		Outputs: &pipelinespec.ExecutorInput_Outputs{
+			OutputFile: outputMetadataFile,
+			Artifacts: map[string]*pipelinespec.ArtifactList{
+				"executor-logs": {
+					Artifacts: []*pipelinespec.RuntimeArtifact{
+						{
+							Name:       "executor-logs",
+							Uri:        "mem://test-bucket/pipeline-root/executor-logs",
+							Type:       &pipelinespec.ArtifactTypeSchema{Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{SchemaTitle: "system.Artifact"}},
+							CustomPath: &logPath,
+						},
+					},
+				},
+			},
+		},
+	}
+	t.Setenv(EnvRetryIndex, "0")
+
+	script := fmt.Sprintf(`echo testoutput && mkdir -p %q && cat <<'EOF' > %q
+{"artifacts":{"executor-logs":{"artifacts":[{"name":"executor-logs","uri":"{{$.outputs.artifacts['executor-logs'].uri}}","customPath":"{{$.outputs.artifacts['executor-logs'].path}}","type":{"schemaTitle":"system.Artifact"}}]}}}
+EOF`, filepath.Dir(outputMetadataFile), outputMetadataFile)
+
+	_, outputArtifacts, err := executeV2(
+		context.Background(),
+		executorInput,
+		addNumbersComponent,
+		"sh",
+		[]string{"-c", script},
+		bucket,
+		bucketConfig,
+		fakeMetadataClient,
+		"namespace",
+		fakeKubernetesClientset,
+		"true",
+		"",
+		&OpenBucketConfig{context.Background(), fakeKubernetesClientset, "namespace", bucketConfig},
+	)
+
+	assert.Nil(t, err)
+	assert.Len(t, outputArtifacts, 1, "Expected executor-logs to be uploaded")
+
+	logArtifact := executorInput.Outputs.Artifacts["executor-logs"].Artifacts[0]
+	assert.Contains(t, logArtifact.Uri, "-0")
+	if assert.NotNil(t, logArtifact.CustomPath) {
+		assert.Contains(t, *logArtifact.CustomPath, "-0")
+	}
+
+	outputMetadata, err := os.ReadFile(outputMetadataFile)
+	assert.Nil(t, err)
+	assert.Contains(t, string(outputMetadata), "executor-logs-0",
+		"Expected compiled executor input placeholders to use the retry-qualified log location")
+
+	outputLog, err := bucket.ReadAll(context.TODO(), "executor-logs-0")
+	assert.Nil(t, err)
+	assert.Equal(t, "testoutput\n", string(outputLog))
 }
 
 func Test_getPlaceholders_WorkspaceArtifactPath(t *testing.T) {
@@ -473,42 +607,73 @@ func Test_get_log_Writer(t *testing.T) {
 
 func Test_qualifyExecutorLogsURI(t *testing.T) {
 	baseURI := "minio://mlpipeline/v2/artifacts/my-pipeline/run-id/always-fail/salt123/executor-logs"
+	baseCustomPath := "/minio/mlpipeline/v2/artifacts/my-pipeline/run-id/always-fail/salt123/executor-logs"
+	stringPtr := func(s string) *string { return &s }
 
 	tests := []struct {
-		name       string
-		artifacts  map[string]*pipelinespec.ArtifactList
-		retryIndex string
-		wantURI    string
+		name           string
+		artifacts      map[string]*pipelinespec.ArtifactList
+		retryIndex     string
+		wantURI        string
+		wantCustomPath *string
 	}{
 		{
 			name: "appends retry index to executor-logs URI",
 			artifacts: map[string]*pipelinespec.ArtifactList{
 				"executor-logs": {Artifacts: []*pipelinespec.RuntimeArtifact{{Uri: baseURI}}},
 			},
-			retryIndex: "2",
-			wantURI:    baseURI + "-2",
+			retryIndex:     "2",
+			wantURI:        baseURI + "-2",
+			wantCustomPath: nil,
+		},
+		{
+			name: "appends retry index to executor-logs CustomPath",
+			artifacts: map[string]*pipelinespec.ArtifactList{
+				"executor-logs": {Artifacts: []*pipelinespec.RuntimeArtifact{{
+					Uri:        baseURI,
+					CustomPath: stringPtr(baseCustomPath),
+				}}},
+			},
+			retryIndex:     "2",
+			wantURI:        baseURI + "-2",
+			wantCustomPath: stringPtr(baseCustomPath + "-2"),
+		},
+		{
+			name: "no-op when retry index already applied",
+			artifacts: map[string]*pipelinespec.ArtifactList{
+				"executor-logs": {Artifacts: []*pipelinespec.RuntimeArtifact{{
+					Uri:        baseURI + "-2",
+					CustomPath: stringPtr(baseCustomPath + "-2"),
+				}}},
+			},
+			retryIndex:     "2",
+			wantURI:        baseURI + "-2",
+			wantCustomPath: stringPtr(baseCustomPath + "-2"),
 		},
 		{
 			name: "no-op when retry index is empty",
 			artifacts: map[string]*pipelinespec.ArtifactList{
 				"executor-logs": {Artifacts: []*pipelinespec.RuntimeArtifact{{Uri: baseURI}}},
 			},
-			retryIndex: "",
-			wantURI:    baseURI,
+			retryIndex:     "",
+			wantURI:        baseURI,
+			wantCustomPath: nil,
 		},
 		{
-			name:       "no-op when executor-logs key is absent",
-			artifacts:  map[string]*pipelinespec.ArtifactList{},
-			retryIndex: "1",
-			wantURI:    "", // no artifact to check
+			name:           "no-op when executor-logs key is absent",
+			artifacts:      map[string]*pipelinespec.ArtifactList{},
+			retryIndex:     "1",
+			wantURI:        "", // no artifact to check
+			wantCustomPath: nil,
 		},
 		{
 			name: "no-op when executor-logs list is empty",
 			artifacts: map[string]*pipelinespec.ArtifactList{
 				"executor-logs": {Artifacts: []*pipelinespec.RuntimeArtifact{}},
 			},
-			retryIndex: "1",
-			wantURI:    "", // no artifact to check
+			retryIndex:     "1",
+			wantURI:        "", // no artifact to check
+			wantCustomPath: nil,
 		},
 		{
 			name: "no-op when executor-logs list has multiple artifacts",
@@ -520,21 +685,24 @@ func Test_qualifyExecutorLogsURI(t *testing.T) {
 			},
 			retryIndex: "1",
 			// list len != 1: guard should skip, original URIs unchanged
-			wantURI: baseURI,
+			wantURI:        baseURI,
+			wantCustomPath: nil,
 		},
 		{
-			name:       "no-op when ArtifactList value is nil",
-			artifacts:  map[string]*pipelinespec.ArtifactList{"executor-logs": nil},
-			retryIndex: "1",
-			wantURI:    "", // nil list: no artifact to check
+			name:           "no-op when ArtifactList value is nil",
+			artifacts:      map[string]*pipelinespec.ArtifactList{"executor-logs": nil},
+			retryIndex:     "1",
+			wantURI:        "", // nil list: no artifact to check
+			wantCustomPath: nil,
 		},
 		{
 			name: "no-op when first artifact is nil",
 			artifacts: map[string]*pipelinespec.ArtifactList{
 				"executor-logs": {Artifacts: []*pipelinespec.RuntimeArtifact{nil}},
 			},
-			retryIndex: "1",
-			wantURI:    "", // nil artifact: no URI to check
+			retryIndex:     "1",
+			wantURI:        "", // nil artifact: no URI to check
+			wantCustomPath: nil,
 		},
 	}
 
@@ -549,6 +717,11 @@ func Test_qualifyExecutorLogsURI(t *testing.T) {
 				return
 			}
 			assert.Equal(t, tc.wantURI, list.Artifacts[0].Uri)
+			if tc.wantCustomPath == nil {
+				assert.Nil(t, list.Artifacts[0].CustomPath)
+			} else if assert.NotNil(t, list.Artifacts[0].CustomPath) {
+				assert.Equal(t, *tc.wantCustomPath, *list.Artifacts[0].CustomPath)
+			}
 		})
 	}
 }

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -363,8 +363,8 @@ func Test_executeV2_publishLogs_skipsArtifactWhenSetupFailsBeforeLogsExist(t *te
 	assert.Error(t, err)
 	assert.Empty(t, outputArtifacts, "Expected no output artifacts when logs were never created")
 
-	_, err = bucket.ReadAll(context.TODO(), "executor-logs")
-	assert.Error(t, err, "Expected no executor-logs blob to be uploaded")
+	_, err = bucket.ReadAll(context.TODO(), "executor-logs-0")
+	assert.Error(t, err, "Expected no qualified executor-logs blob to be uploaded")
 }
 
 func Test_executeV2_publishLogs_qualifiesExecutorInputBeforeCommandCompilation(t *testing.T) {


### PR DESCRIPTION
## Description

This PR fixes an`executor-logs` retry-index regression introduced by https://github.com/kubeflow/pipelines/pull/13175 with the following changes:

- Qualify `executor-logs` before placeholder compilation so serialized `executor_input` and output placeholders use the retry-qualified location
- Keep the launcher-managed `executor-logs` artifact location stable during upload instead of merging a stale value echoed back in `ExecutorOutput`
- Keep `CustomPath` aligned with the retry-qualified `executor-logs` URI when it is present
- Avoid publishing a broken `executor-logs` artifact when launcher setup fails before the log file is ever created, which previously left a dead link in MLMD/UI.


It also:

- Adds doc comments for the new retry-log helper functions.
- Expand launcher unit coverage for:
  - retry-qualified `executor-logs` URI and `CustomPath`
  - early failures before logs exist
  - placeholder compilation using the retry-qualified log location

## Testing

- `go test ./backend/src/v2/component`
- Manual local Kind validation with patched `apiserver:dev` and `kfp-launcher:dev`
  - happy-path run uploaded `executor-logs-0`
  - retrying run uploaded `executor-logs-0`, `executor-logs-1`, and `executor-logs-2`
  - confirmed expected contents from workflow pod logs and object-store objects

### Screenshots

#### Happy path

<img width="1733" height="476" alt="image" src="https://github.com/user-attachments/assets/7269f11e-3dff-4656-aba4-b62410c672d7" />

#### Unhappy path (fail and retry)

<img width="1747" height="573" alt="image" src="https://github.com/user-attachments/assets/769739ed-c03c-4d84-be6b-2dda8d1eab7e" />

Huge shout out to @tarat44 for bringing this regression to my attention! 

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
