### PR TITLE
fix(test): regenerate pipeline_with_volume goldens after CreatePVC change

### DIFF
--- a/test_data/compiled-workflows/pipeline_with_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume.yaml
@@ -7,13 +7,13 @@ spec:
     parameters:
     - name: kubernetes-comp-consumer
       value: '{"pvcMount":[{"mountPath":"/data","pvcNameParameter":{"taskOutputParameter":{"outputParameterKey":"name","producerTask":"createpvc"}},"taskOutputParameter":{"outputParameterKey":"name","producerTask":"createpvc"}}]}'
-    - name: components-d7fb91ca6b78edad062c1f44d01d414280f5740b5260436244e8b7638538eede
+    - name: components-7c670709fc771e1d79ebc2c954ea9e008eb5216e226dfa1594e8dec49167ac06
       value: '{"executorLabel":"exec-consumer","outputDefinitions":{"parameters":{"Output":{"parameterType":"STRING"}}}}'
-    - name: implementations-d7fb91ca6b78edad062c1f44d01d414280f5740b5260436244e8b7638538eede
+    - name: implementations-7c670709fc771e1d79ebc2c954ea9e008eb5216e226dfa1594e8dec49167ac06
       value: '{"args":["--executor_input","{{$}}","--function_to_execute","consumer"],"command":["sh","-c","\nif
         ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
         -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
-        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.14.3'' ''--no-deps''
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.15.2'' ''--no-deps''
         ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
         \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
         \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
@@ -24,23 +24,25 @@ spec:
     - name: components-98f254581598234b59377784d6cbf209de79e0bcda8013fe4c4397b5d3a26767
       value: '{"executorLabel":"exec-createpvc","inputDefinitions":{"parameters":{"access_modes":{"description":"AccessModes
         to request for the provisioned PVC. May\nbe one or more of ``''ReadWriteOnce''``,
-        ``''ReadOnlyMany''``, ``''ReadWriteMany''``, or\n``''ReadWriteOncePod''``.
-        Corresponds to `PersistentVolumeClaim.spec.accessModes \u003chttps://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes\u003e`_.","parameterType":"LIST"},"annotations":{"description":"Annotations
-        for the PVC''s metadata. Corresponds to `PersistentVolumeClaim.metadata.annotations
-        \u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim\u003e`_.","isOptional":true,"parameterType":"STRUCT"},"pvc_name":{"description":"Name
-        of the PVC. Corresponds to `PersistentVolumeClaim.metadata.name \u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim\u003e`_.
-        Only one of ``pvc_name`` and ``pvc_name_suffix`` can\nbe provided.","isOptional":true,"parameterType":"STRING"},"pvc_name_suffix":{"description":"Prefix
+        ``''ReadOnlyMany''``,\n``''ReadWriteMany''``, or ``''ReadWriteOncePod''``.
+        Corresponds to\n`PersistentVolumeClaim.spec.accessModes\n\u003chttps://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes\u003e`_.","parameterType":"LIST"},"annotations":{"description":"Annotations
+        for the PVC''s metadata. Corresponds to\n`PersistentVolumeClaim.metadata.annotations\n\u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim\u003e`_.","isOptional":true,"parameterType":"STRUCT"},"data_source":{"description":"Specifies
+        the data source for the PVC. This can be used to\ncreate a PVC from a VolumeSnapshot
+        or to clone an existing PVC.\nShould be a dictionary with ``''apiGroup''``,
+        ``''kind''``, and\n``''name''`` keys. For example:\n``{''apiGroup'': ''snapshot.storage.k8s.io'',
+        ''kind'': ''VolumeSnapshot'', ''name'': ''my-snapshot''}``.\nCorresponds to
+        `PersistentVolumeClaim.spec.dataSource\n\u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec\u003e`_.","isOptional":true,"parameterType":"STRUCT"},"pvc_name":{"description":"Name
+        of the PVC. Corresponds to\n`PersistentVolumeClaim.metadata.name\n\u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim\u003e`_.\nOnly
+        one of ``pvc_name`` and ``pvc_name_suffix`` can be provided.","isOptional":true,"parameterType":"STRING"},"pvc_name_suffix":{"description":"Prefix
         to use for a dynamically generated name, which\nwill take the form ``\u003cargo-workflow-name\u003e-\u003cpvc_name_suffix\u003e``.
-        Only one\nof ``pvc_name`` and ``pvc_name_suffix`` can be provided.","isOptional":true,"parameterType":"STRING"},"size":{"description":"The
-        size of storage requested by the PVC that will be provisioned. For example,
-        ``''5Gi''``. Corresponds to `PersistentVolumeClaim.spec.resources.requests.storage
-        \u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec\u003e`_.","parameterType":"STRING"},"storage_class_name":{"defaultValue":"","description":"Name
+        Only\none of ``pvc_name`` and ``pvc_name_suffix`` can be provided.","isOptional":true,"parameterType":"STRING"},"size":{"description":"The
+        size of storage requested by the PVC that will be\nprovisioned. For example,
+        ``''5Gi''``. Corresponds to\n`PersistentVolumeClaim.spec.resources.requests.storage\n\u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec\u003e`_.","parameterType":"STRING"},"storage_class_name":{"defaultValue":"","description":"Name
         of StorageClass from which to provision the PV\nto back the PVC. ``None``
         indicates to use the cluster''s default\nstorage_class_name. Set to ``''''``
         for a statically specified PVC.","isOptional":true,"parameterType":"STRING"},"volume_name":{"description":"Pre-existing
         PersistentVolume that should back the\nprovisioned PersistentVolumeClaim.
-        Used for statically\nspecified PV only. Corresponds to `PersistentVolumeClaim.spec.volumeName
-        \u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec\u003e`_.","isOptional":true,"parameterType":"STRING"}}},"outputDefinitions":{"parameters":{"name":{"parameterType":"STRING"}}}}'
+        Used for statically\nspecified PV only. Corresponds to\n`PersistentVolumeClaim.spec.volumeName\n\u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec\u003e`_.","isOptional":true,"parameterType":"STRING"}}},"outputDefinitions":{"parameters":{"name":{"parameterType":"STRING"}}}}'
     - name: implementations-98f254581598234b59377784d6cbf209de79e0bcda8013fe4c4397b5d3a26767
       value: '{"image":"argostub/createpvc"}'
     - name: components-ecfc655dce17b0d317707d37fc226fb7de858cc93d45916945122484a13ef725
@@ -51,13 +53,13 @@ spec:
       value: '{"image":"argostub/deletepvc"}'
     - name: kubernetes-comp-producer
       value: '{"pvcMount":[{"mountPath":"/data","pvcNameParameter":{"taskOutputParameter":{"outputParameterKey":"name","producerTask":"createpvc"}},"taskOutputParameter":{"outputParameterKey":"name","producerTask":"createpvc"}}]}'
-    - name: components-35323c00ea64cb236ca34272f55bdb938f396af10887a294134939d9819557b9
+    - name: components-7cefc145506c478b829283f76980bbba7892efa3ed3b73e4dfe0d6be991d14a8
       value: '{"executorLabel":"exec-producer","outputDefinitions":{"parameters":{"Output":{"parameterType":"STRING"}}}}'
-    - name: implementations-35323c00ea64cb236ca34272f55bdb938f396af10887a294134939d9819557b9
+    - name: implementations-7cefc145506c478b829283f76980bbba7892efa3ed3b73e4dfe0d6be991d14a8
       value: '{"args":["--executor_input","{{$}}","--function_to_execute","producer"],"command":["sh","-c","\nif
         ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
         -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
-        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.14.3'' ''--no-deps''
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.15.2'' ''--no-deps''
         ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
         \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
         \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
@@ -299,11 +301,11 @@ spec:
       - arguments:
           parameters:
           - name: component
-            value: '{{workflow.parameters.components-d7fb91ca6b78edad062c1f44d01d414280f5740b5260436244e8b7638538eede}}'
+            value: '{{workflow.parameters.components-7c670709fc771e1d79ebc2c954ea9e008eb5216e226dfa1594e8dec49167ac06}}'
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-consumer"},"dependentTasks":["createpvc","producer"],"taskInfo":{"name":"consumer"}}'
           - name: container
-            value: '{{workflow.parameters.implementations-d7fb91ca6b78edad062c1f44d01d414280f5740b5260436244e8b7638538eede}}'
+            value: '{{workflow.parameters.implementations-7c670709fc771e1d79ebc2c954ea9e008eb5216e226dfa1594e8dec49167ac06}}'
           - name: task-name
             value: consumer
           - name: parent-dag-id
@@ -355,11 +357,11 @@ spec:
       - arguments:
           parameters:
           - name: component
-            value: '{{workflow.parameters.components-35323c00ea64cb236ca34272f55bdb938f396af10887a294134939d9819557b9}}'
+            value: '{{workflow.parameters.components-7cefc145506c478b829283f76980bbba7892efa3ed3b73e4dfe0d6be991d14a8}}'
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-producer"},"dependentTasks":["createpvc"],"taskInfo":{"name":"producer"}}'
           - name: container
-            value: '{{workflow.parameters.implementations-35323c00ea64cb236ca34272f55bdb938f396af10887a294134939d9819557b9}}'
+            value: '{{workflow.parameters.implementations-7cefc145506c478b829283f76980bbba7892efa3ed3b73e4dfe0d6be991d14a8}}'
           - name: task-name
             value: producer
           - name: parent-dag-id

--- a/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
@@ -7,13 +7,13 @@ spec:
     parameters:
     - name: kubernetes-comp-consumer
       value: '{"pvcMount":[{"mountPath":"/data","pvcNameParameter":{"taskOutputParameter":{"outputParameterKey":"name","producerTask":"createpvc"}},"taskOutputParameter":{"outputParameterKey":"name","producerTask":"createpvc"}}]}'
-    - name: components-d7fb91ca6b78edad062c1f44d01d414280f5740b5260436244e8b7638538eede
+    - name: components-7c670709fc771e1d79ebc2c954ea9e008eb5216e226dfa1594e8dec49167ac06
       value: '{"executorLabel":"exec-consumer","outputDefinitions":{"parameters":{"Output":{"parameterType":"STRING"}}}}'
-    - name: implementations-d7fb91ca6b78edad062c1f44d01d414280f5740b5260436244e8b7638538eede
+    - name: implementations-7c670709fc771e1d79ebc2c954ea9e008eb5216e226dfa1594e8dec49167ac06
       value: '{"args":["--executor_input","{{$}}","--function_to_execute","consumer"],"command":["sh","-c","\nif
         ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
         -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
-        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.14.3'' ''--no-deps''
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.15.2'' ''--no-deps''
         ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
         \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
         \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
@@ -24,23 +24,25 @@ spec:
     - name: components-98f254581598234b59377784d6cbf209de79e0bcda8013fe4c4397b5d3a26767
       value: '{"executorLabel":"exec-createpvc","inputDefinitions":{"parameters":{"access_modes":{"description":"AccessModes
         to request for the provisioned PVC. May\nbe one or more of ``''ReadWriteOnce''``,
-        ``''ReadOnlyMany''``, ``''ReadWriteMany''``, or\n``''ReadWriteOncePod''``.
-        Corresponds to `PersistentVolumeClaim.spec.accessModes \u003chttps://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes\u003e`_.","parameterType":"LIST"},"annotations":{"description":"Annotations
-        for the PVC''s metadata. Corresponds to `PersistentVolumeClaim.metadata.annotations
-        \u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim\u003e`_.","isOptional":true,"parameterType":"STRUCT"},"pvc_name":{"description":"Name
-        of the PVC. Corresponds to `PersistentVolumeClaim.metadata.name \u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim\u003e`_.
-        Only one of ``pvc_name`` and ``pvc_name_suffix`` can\nbe provided.","isOptional":true,"parameterType":"STRING"},"pvc_name_suffix":{"description":"Prefix
+        ``''ReadOnlyMany''``,\n``''ReadWriteMany''``, or ``''ReadWriteOncePod''``.
+        Corresponds to\n`PersistentVolumeClaim.spec.accessModes\n\u003chttps://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes\u003e`_.","parameterType":"LIST"},"annotations":{"description":"Annotations
+        for the PVC''s metadata. Corresponds to\n`PersistentVolumeClaim.metadata.annotations\n\u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim\u003e`_.","isOptional":true,"parameterType":"STRUCT"},"data_source":{"description":"Specifies
+        the data source for the PVC. This can be used to\ncreate a PVC from a VolumeSnapshot
+        or to clone an existing PVC.\nShould be a dictionary with ``''apiGroup''``,
+        ``''kind''``, and\n``''name''`` keys. For example:\n``{''apiGroup'': ''snapshot.storage.k8s.io'',
+        ''kind'': ''VolumeSnapshot'', ''name'': ''my-snapshot''}``.\nCorresponds to
+        `PersistentVolumeClaim.spec.dataSource\n\u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec\u003e`_.","isOptional":true,"parameterType":"STRUCT"},"pvc_name":{"description":"Name
+        of the PVC. Corresponds to\n`PersistentVolumeClaim.metadata.name\n\u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim\u003e`_.\nOnly
+        one of ``pvc_name`` and ``pvc_name_suffix`` can be provided.","isOptional":true,"parameterType":"STRING"},"pvc_name_suffix":{"description":"Prefix
         to use for a dynamically generated name, which\nwill take the form ``\u003cargo-workflow-name\u003e-\u003cpvc_name_suffix\u003e``.
-        Only one\nof ``pvc_name`` and ``pvc_name_suffix`` can be provided.","isOptional":true,"parameterType":"STRING"},"size":{"description":"The
-        size of storage requested by the PVC that will be provisioned. For example,
-        ``''5Gi''``. Corresponds to `PersistentVolumeClaim.spec.resources.requests.storage
-        \u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec\u003e`_.","parameterType":"STRING"},"storage_class_name":{"defaultValue":"","description":"Name
+        Only\none of ``pvc_name`` and ``pvc_name_suffix`` can be provided.","isOptional":true,"parameterType":"STRING"},"size":{"description":"The
+        size of storage requested by the PVC that will be\nprovisioned. For example,
+        ``''5Gi''``. Corresponds to\n`PersistentVolumeClaim.spec.resources.requests.storage\n\u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec\u003e`_.","parameterType":"STRING"},"storage_class_name":{"defaultValue":"","description":"Name
         of StorageClass from which to provision the PV\nto back the PVC. ``None``
         indicates to use the cluster''s default\nstorage_class_name. Set to ``''''``
         for a statically specified PVC.","isOptional":true,"parameterType":"STRING"},"volume_name":{"description":"Pre-existing
         PersistentVolume that should back the\nprovisioned PersistentVolumeClaim.
-        Used for statically\nspecified PV only. Corresponds to `PersistentVolumeClaim.spec.volumeName
-        \u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec\u003e`_.","isOptional":true,"parameterType":"STRING"}}},"outputDefinitions":{"parameters":{"name":{"parameterType":"STRING"}}}}'
+        Used for statically\nspecified PV only. Corresponds to\n`PersistentVolumeClaim.spec.volumeName\n\u003chttps://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec\u003e`_.","isOptional":true,"parameterType":"STRING"}}},"outputDefinitions":{"parameters":{"name":{"parameterType":"STRING"}}}}'
     - name: implementations-98f254581598234b59377784d6cbf209de79e0bcda8013fe4c4397b5d3a26767
       value: '{"image":"argostub/createpvc"}'
     - name: components-ecfc655dce17b0d317707d37fc226fb7de858cc93d45916945122484a13ef725
@@ -51,13 +53,13 @@ spec:
       value: '{"image":"argostub/deletepvc"}'
     - name: kubernetes-comp-producer
       value: '{"pvcMount":[{"mountPath":"/data","pvcNameParameter":{"taskOutputParameter":{"outputParameterKey":"name","producerTask":"createpvc"}},"taskOutputParameter":{"outputParameterKey":"name","producerTask":"createpvc"}}]}'
-    - name: components-35323c00ea64cb236ca34272f55bdb938f396af10887a294134939d9819557b9
+    - name: components-7cefc145506c478b829283f76980bbba7892efa3ed3b73e4dfe0d6be991d14a8
       value: '{"executorLabel":"exec-producer","outputDefinitions":{"parameters":{"Output":{"parameterType":"STRING"}}}}'
-    - name: implementations-35323c00ea64cb236ca34272f55bdb938f396af10887a294134939d9819557b9
+    - name: implementations-7cefc145506c478b829283f76980bbba7892efa3ed3b73e4dfe0d6be991d14a8
       value: '{"args":["--executor_input","{{$}}","--function_to_execute","producer"],"command":["sh","-c","\nif
         ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
         -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
-        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.14.3'' ''--no-deps''
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.15.2'' ''--no-deps''
         ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
         \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
         \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
@@ -299,11 +301,11 @@ spec:
       - arguments:
           parameters:
           - name: component
-            value: '{{workflow.parameters.components-d7fb91ca6b78edad062c1f44d01d414280f5740b5260436244e8b7638538eede}}'
+            value: '{{workflow.parameters.components-7c670709fc771e1d79ebc2c954ea9e008eb5216e226dfa1594e8dec49167ac06}}'
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-consumer"},"dependentTasks":["createpvc","producer"],"taskInfo":{"name":"consumer"}}'
           - name: container
-            value: '{{workflow.parameters.implementations-d7fb91ca6b78edad062c1f44d01d414280f5740b5260436244e8b7638538eede}}'
+            value: '{{workflow.parameters.implementations-7c670709fc771e1d79ebc2c954ea9e008eb5216e226dfa1594e8dec49167ac06}}'
           - name: task-name
             value: consumer
           - name: parent-dag-id
@@ -355,11 +357,11 @@ spec:
       - arguments:
           parameters:
           - name: component
-            value: '{{workflow.parameters.components-35323c00ea64cb236ca34272f55bdb938f396af10887a294134939d9819557b9}}'
+            value: '{{workflow.parameters.components-7cefc145506c478b829283f76980bbba7892efa3ed3b73e4dfe0d6be991d14a8}}'
           - name: task
             value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-producer"},"dependentTasks":["createpvc"],"taskInfo":{"name":"producer"}}'
           - name: container
-            value: '{{workflow.parameters.implementations-35323c00ea64cb236ca34272f55bdb938f396af10887a294134939d9819557b9}}'
+            value: '{{workflow.parameters.implementations-7cefc145506c478b829283f76980bbba7892efa3ed3b73e4dfe0d6be991d14a8}}'
           - name: task-name
             value: producer
           - name: parent-dag-id

--- a/test_data/sdk_compiled_pipelines/valid/pipeline_with_volume.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/pipeline_with_volume.yaml
@@ -14,37 +14,65 @@ components:
         access_modes:
           description: 'AccessModes to request for the provisioned PVC. May
 
-            be one or more of ``''ReadWriteOnce''``, ``''ReadOnlyMany''``, ``''ReadWriteMany''``,
-            or
+            be one or more of ``''ReadWriteOnce''``, ``''ReadOnlyMany''``,
 
-            ``''ReadWriteOncePod''``. Corresponds to `PersistentVolumeClaim.spec.accessModes
+            ``''ReadWriteMany''``, or ``''ReadWriteOncePod''``. Corresponds to
+
+            `PersistentVolumeClaim.spec.accessModes
+
             <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes>`_.'
           parameterType: LIST
         annotations:
-          description: Annotations for the PVC's metadata. Corresponds to `PersistentVolumeClaim.metadata.annotations
-            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
+          description: 'Annotations for the PVC''s metadata. Corresponds to
+
+            `PersistentVolumeClaim.metadata.annotations
+
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.'
+          isOptional: true
+          parameterType: STRUCT
+        data_source:
+          description: 'Specifies the data source for the PVC. This can be used to
+
+            create a PVC from a VolumeSnapshot or to clone an existing PVC.
+
+            Should be a dictionary with ``''apiGroup''``, ``''kind''``, and
+
+            ``''name''`` keys. For example:
+
+            ``{''apiGroup'': ''snapshot.storage.k8s.io'', ''kind'': ''VolumeSnapshot'',
+            ''name'': ''my-snapshot''}``.
+
+            Corresponds to `PersistentVolumeClaim.spec.dataSource
+
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.'
           isOptional: true
           parameterType: STRUCT
         pvc_name:
-          description: 'Name of the PVC. Corresponds to `PersistentVolumeClaim.metadata.name
-            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
-            Only one of ``pvc_name`` and ``pvc_name_suffix`` can
+          description: 'Name of the PVC. Corresponds to
 
-            be provided.'
+            `PersistentVolumeClaim.metadata.name
+
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
+
+            Only one of ``pvc_name`` and ``pvc_name_suffix`` can be provided.'
           isOptional: true
           parameterType: STRING
         pvc_name_suffix:
           description: 'Prefix to use for a dynamically generated name, which
 
-            will take the form ``<argo-workflow-name>-<pvc_name_suffix>``. Only one
+            will take the form ``<argo-workflow-name>-<pvc_name_suffix>``. Only
 
-            of ``pvc_name`` and ``pvc_name_suffix`` can be provided.'
+            one of ``pvc_name`` and ``pvc_name_suffix`` can be provided.'
           isOptional: true
           parameterType: STRING
         size:
-          description: The size of storage requested by the PVC that will be provisioned.
-            For example, ``'5Gi'``. Corresponds to `PersistentVolumeClaim.spec.resources.requests.storage
-            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.
+          description: 'The size of storage requested by the PVC that will be
+
+            provisioned. For example, ``''5Gi''``. Corresponds to
+
+            `PersistentVolumeClaim.spec.resources.requests.storage
+
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.'
           parameterType: STRING
         storage_class_name:
           defaultValue: ''
@@ -60,7 +88,10 @@ components:
 
             provisioned PersistentVolumeClaim. Used for statically
 
-            specified PV only. Corresponds to `PersistentVolumeClaim.spec.volumeName
+            specified PV only. Corresponds to
+
+            `PersistentVolumeClaim.spec.volumeName
+
             <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.'
           isOptional: true
           parameterType: STRING
@@ -96,7 +127,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.14.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -132,7 +163,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.14.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -214,7 +245,7 @@ root:
         taskInfo:
           name: producer
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.13.0
+sdkVersion: kfp-2.15.2
 ---
 platforms:
   kubernetes:

--- a/test_data/sdk_compiled_pipelines/valid/pipeline_with_volume_no_cache.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/pipeline_with_volume_no_cache.yaml
@@ -14,37 +14,65 @@ components:
         access_modes:
           description: 'AccessModes to request for the provisioned PVC. May
 
-            be one or more of ``''ReadWriteOnce''``, ``''ReadOnlyMany''``, ``''ReadWriteMany''``,
-            or
+            be one or more of ``''ReadWriteOnce''``, ``''ReadOnlyMany''``,
 
-            ``''ReadWriteOncePod''``. Corresponds to `PersistentVolumeClaim.spec.accessModes
+            ``''ReadWriteMany''``, or ``''ReadWriteOncePod''``. Corresponds to
+
+            `PersistentVolumeClaim.spec.accessModes
+
             <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes>`_.'
           parameterType: LIST
         annotations:
-          description: Annotations for the PVC's metadata. Corresponds to `PersistentVolumeClaim.metadata.annotations
-            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
+          description: 'Annotations for the PVC''s metadata. Corresponds to
+
+            `PersistentVolumeClaim.metadata.annotations
+
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.'
+          isOptional: true
+          parameterType: STRUCT
+        data_source:
+          description: 'Specifies the data source for the PVC. This can be used to
+
+            create a PVC from a VolumeSnapshot or to clone an existing PVC.
+
+            Should be a dictionary with ``''apiGroup''``, ``''kind''``, and
+
+            ``''name''`` keys. For example:
+
+            ``{''apiGroup'': ''snapshot.storage.k8s.io'', ''kind'': ''VolumeSnapshot'',
+            ''name'': ''my-snapshot''}``.
+
+            Corresponds to `PersistentVolumeClaim.spec.dataSource
+
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.'
           isOptional: true
           parameterType: STRUCT
         pvc_name:
-          description: 'Name of the PVC. Corresponds to `PersistentVolumeClaim.metadata.name
-            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
-            Only one of ``pvc_name`` and ``pvc_name_suffix`` can
+          description: 'Name of the PVC. Corresponds to
 
-            be provided.'
+            `PersistentVolumeClaim.metadata.name
+
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
+
+            Only one of ``pvc_name`` and ``pvc_name_suffix`` can be provided.'
           isOptional: true
           parameterType: STRING
         pvc_name_suffix:
           description: 'Prefix to use for a dynamically generated name, which
 
-            will take the form ``<argo-workflow-name>-<pvc_name_suffix>``. Only one
+            will take the form ``<argo-workflow-name>-<pvc_name_suffix>``. Only
 
-            of ``pvc_name`` and ``pvc_name_suffix`` can be provided.'
+            one of ``pvc_name`` and ``pvc_name_suffix`` can be provided.'
           isOptional: true
           parameterType: STRING
         size:
-          description: The size of storage requested by the PVC that will be provisioned.
-            For example, ``'5Gi'``. Corresponds to `PersistentVolumeClaim.spec.resources.requests.storage
-            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.
+          description: 'The size of storage requested by the PVC that will be
+
+            provisioned. For example, ``''5Gi''``. Corresponds to
+
+            `PersistentVolumeClaim.spec.resources.requests.storage
+
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.'
           parameterType: STRING
         storage_class_name:
           defaultValue: ''
@@ -60,7 +88,10 @@ components:
 
             provisioned PersistentVolumeClaim. Used for statically
 
-            specified PV only. Corresponds to `PersistentVolumeClaim.spec.volumeName
+            specified PV only. Corresponds to
+
+            `PersistentVolumeClaim.spec.volumeName
+
             <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.'
           isOptional: true
           parameterType: STRING
@@ -96,7 +127,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.14.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -132,7 +163,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.14.3'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -212,7 +243,7 @@ root:
         taskInfo:
           name: producer
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.13.0
+sdkVersion: kfp-2.15.2
 ---
 platforms:
   kubernetes:


### PR DESCRIPTION
## Summary
Regenerate the SDK compilation goldens for `pipeline_with_volume` and `pipeline_with_volume_no_cache` after #12696 added a `data_source` parameter to `kfp.kubernetes.CreatePVC` and reformatted the parameter docstrings.

## Why
`KFP SDK Tests` has been **failing on every master run since 2026-04-26 (10/10)** with:

```
AssertionError: Value for "description" is not the same
FAILED sdk/python/test/compilation/pipeline_compilation_test.py::TestPipelineCompilation::test_compilation[Compilation Data: name=pipeline-with-volume ...]
FAILED sdk/python/test/compilation/pipeline_compilation_test.py::TestPipelineCompilation::test_compilation[Compilation Data: name=pipeline-with-volume-no-cache ...]
```

#12696 (commit `ab1231a5c`, *"feat(kubernetes_platform): add data_source parameter to CreatePVC"*) regenerated the kfp-kubernetes snapshot goldens under `kubernetes_platform/python/test/snapshot/data/`, but missed these two SDK-compilation goldens. Both pipelines call `kubernetes.CreatePVC`, so their compiled output diverges from the goldens on:

- the new `data_source` input parameter
- description line-wrapping changes from #12696's reformatting pass

## What's in the diff
Only the two golden YAMLs:

- `test_data/sdk_compiled_pipelines/valid/pipeline_with_volume.yaml`
- `test_data/sdk_compiled_pipelines/valid/pipeline_with_volume_no_cache.yaml`

The change is mechanical — recompiled with the current `kfp` + `kfp-kubernetes` sources. No test-only `base_image` override applied, so the goldens keep the pipeline-source default `python:3.11` image (`image` is ignored by `ComparisonUtils` anyway). The `kfp==2.15.2` in the pip-install command line tracks the current SDK version (the `command` field is also skipped by `ComparisonUtils`).

## Verification
```
$ pytest sdk/python/test/compilation/pipeline_compilation_test.py -k "pipeline-with-volume" -v
================ 2 passed, 113 deselected ================
```