### PR TITLE
chore(frontend): modernize querySelector to RTL patterns

### DIFF
--- a/frontend/src/components/CustomTableNameColumn.test.tsx
+++ b/frontend/src/components/CustomTableNameColumn.test.tsx
@@ -34,13 +34,13 @@ describe('NameWithTooltip', () => {
   });
 
   it('renders empty string when both display_name and name are missing', () => {
-    const { container } = render(<NameWithTooltip value={{}} id='test-id' />);
-    expect(container.querySelector('span')?.textContent).toBe('');
+    render(<NameWithTooltip value={{}} id='test-id' />);
+    expect(screen.queryByText(/\S/)).toBeNull();
   });
 
   it('renders empty string when value is undefined', () => {
-    const { container } = render(<NameWithTooltip value={undefined} id='test-id' />);
-    expect(container.querySelector('span')?.textContent).toBe('');
+    render(<NameWithTooltip value={undefined} id='test-id' />);
+    expect(screen.queryByText(/\S/)).toBeNull();
   });
 
   it('prefers display_name over name', () => {

--- a/frontend/src/components/Graph.test.tsx
+++ b/frontend/src/components/Graph.test.tsx
@@ -16,7 +16,7 @@
 
 import type * as React from 'react';
 import * as dagre from 'dagre';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 import EnhancedGraph, { Graph } from './Graph';
 import SuccessIcon from '@mui/icons-material/CheckCircle';
@@ -145,10 +145,9 @@ describe('Graph', () => {
     graph.setNode('node2', newNode('node2'));
     graph.setEdge('node2', 'node1');
     const spy = vi.fn();
-    const { container } = render(<Graph graph={graph} onClick={spy} />);
-    const node = container.querySelector('.graphNode');
-    expect(node).not.toBeNull();
-    fireEvent.click(node!);
+    render(<Graph graph={graph} onClick={spy} />);
+    const node = screen.getByTestId('graph-node-node1');
+    fireEvent.click(node);
     expect(spy).toHaveBeenCalledWith('node1');
   });
 

--- a/frontend/src/components/Graph.tsx
+++ b/frontend/src/components/Graph.tsx
@@ -272,6 +272,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
                 'graphNode',
                 node.id === this.props.selectedNodeId ? css.nodeSelected : '',
               )}
+              data-testid={`graph-node-${node.id}`}
               key={i}
               onMouseEnter={() => {
                 if (!this.props.selectedNodeId) {

--- a/frontend/src/components/PlotCard.test.tsx
+++ b/frontend/src/components/PlotCard.test.tsx
@@ -39,38 +39,23 @@ describe('PlotCard', () => {
   });
 
   it('opens the fullscreen dialog', () => {
-    const { container } = render(<PlotCard title='' configs={[config]} maxDimension={100} />);
-    const popOutButton = container.querySelector('.popOutButton');
-    if (!popOutButton) {
-      throw new Error('Pop out button not found');
-    }
-    fireEvent.click(popOutButton);
+    render(<PlotCard title='' configs={[config]} maxDimension={100} />);
+    fireEvent.click(screen.getByTestId('pop-out-button'));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Confusion matrix')).toBeInTheDocument();
   });
 
   it('closes the fullscreen dialog with the close button', async () => {
-    const { container } = render(<PlotCard title='' configs={[config]} maxDimension={100} />);
-    const popOutButton = container.querySelector('.popOutButton');
-    if (!popOutButton) {
-      throw new Error('Pop out button not found');
-    }
-    fireEvent.click(popOutButton);
-    const closeButton = document.querySelector('.fullscreenCloseButton');
-    if (!closeButton) {
-      throw new Error('Close button not found');
-    }
-    fireEvent.click(closeButton);
+    render(<PlotCard title='' configs={[config]} maxDimension={100} />);
+    fireEvent.click(screen.getByTestId('pop-out-button'));
+    fireEvent.click(screen.getByTestId('fullscreen-close-button'));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 
   it('closes the fullscreen dialog when the backdrop is clicked', async () => {
-    const { container } = render(<PlotCard title='' configs={[config]} maxDimension={100} />);
-    const popOutButton = container.querySelector('.popOutButton');
-    if (!popOutButton) {
-      throw new Error('Pop out button not found');
-    }
-    fireEvent.click(popOutButton);
+    render(<PlotCard title='' configs={[config]} maxDimension={100} />);
+    fireEvent.click(screen.getByTestId('pop-out-button'));
+    // MUI backdrop is third-party internal DOM — querySelector retained
     const backdrop = document.querySelector('[class*="MuiBackdrop-root"]');
     if (!backdrop) {
       throw new Error('Backdrop not found');

--- a/frontend/src/components/PlotCard.tsx
+++ b/frontend/src/components/PlotCard.tsx
@@ -123,6 +123,7 @@ class PlotCard extends React.Component<PlotCardProps, PlotCardState> {
                 onClick={() => this.setState({ fullscreenDialogOpen: true })}
                 style={{ padding: 4, minHeight: 0, minWidth: 0 }}
                 className='popOutButton'
+                data-testid='pop-out-button'
               >
                 <Tooltip title='Pop out'>
                   <PopOutIcon classes={{ root: css.popoutIcon }} />
@@ -142,6 +143,7 @@ class PlotCard extends React.Component<PlotCardProps, PlotCardState> {
             <Button
               onClick={() => this.setState({ fullscreenDialogOpen: false })}
               className={classes(css.fullscreenCloseBtn, 'fullscreenCloseButton')}
+              data-testid='fullscreen-close-button'
             >
               <CloseIcon />
             </Button>

--- a/frontend/src/components/SideNav.test.tsx
+++ b/frontend/src/components/SideNav.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react';
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { vi } from 'vitest';
@@ -39,9 +39,9 @@ const defaultProps = {
   },
 };
 
-function isCollapsed(container: HTMLElement): boolean {
-  const root = container.querySelector('#sideNav');
-  return !!root && root.classList.contains(css.collapsedRoot);
+function isCollapsed(): boolean {
+  const root = screen.getByTestId('sideNav');
+  return root.classList.contains(css.collapsedRoot);
 }
 
 function renderSideNav(
@@ -91,13 +91,13 @@ describe('SideNav', () => {
     localStorageHasKeySpy.mockImplementationOnce(() => false);
     (window as any).innerWidth = wideWidth;
     const { renderResult } = renderSideNav(RoutePage.PIPELINES);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders sidebar nav buttons without primary button styling', async () => {
     const { renderResult } = renderSideNav(RoutePage.PIPELINES);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
 
     const pipelinesButton = renderResult.getByRole('button', { name: 'Pipelines' });
     const docsButton = renderResult.getByRole('button', { name: 'Documentation' });
@@ -116,79 +116,79 @@ describe('SideNav', () => {
     localStorageHasKeySpy.mockImplementationOnce(() => false);
     (window as any).innerWidth = narrowWidth;
     const { renderResult } = renderSideNav(RoutePage.PIPELINES);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(true));
+    await waitFor(() => expect(isCollapsed()).toBe(true));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders Pipelines as active page', async () => {
     const { renderResult } = renderSideNav(RoutePage.PIPELINES);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders Pipelines as active when on PipelineDetails page', async () => {
     const { renderResult } = renderSideNav(RoutePage.PIPELINE_DETAILS);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders experiments as active page', async () => {
     const { renderResult } = renderSideNav(RoutePage.EXPERIMENTS);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders experiments as active when on ExperimentDetails page', async () => {
     const { renderResult } = renderSideNav(RoutePage.EXPERIMENT_DETAILS);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders experiments as active page when on NewExperiment page', async () => {
     const { renderResult } = renderSideNav(RoutePage.NEW_EXPERIMENT);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders experiments as active page when on Compare page', async () => {
     const { renderResult } = renderSideNav(RoutePage.COMPARE);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders experiments as active page when on AllRuns page', async () => {
     const { renderResult } = renderSideNav(RoutePage.RUNS);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders experiments as active page when on RunDetails page', async () => {
     const { renderResult } = renderSideNav(RoutePage.RUN_DETAILS);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders experiments as active page when on RecurringRunDetails page', async () => {
     const { renderResult } = renderSideNav(RoutePage.RECURRING_RUN_DETAILS);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders experiments as active page when on NewRun page', async () => {
     const { renderResult } = renderSideNav(RoutePage.NEW_RUN);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders recurring runs as active page', async () => {
     const { renderResult } = renderSideNav(RoutePage.RECURRING_RUNS);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
   it('renders jobs as active page when on JobDetails page', async () => {
     const { renderResult } = renderSideNav(RoutePage.RECURRING_RUN_DETAILS);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
     expect(renderResult.asFragment()).toMatchSnapshot();
   });
 
@@ -205,14 +205,14 @@ describe('SideNav', () => {
     localStorageHasKeySpy.mockImplementation(() => true);
     (window as any).innerWidth = wideWidth;
     const { renderResult } = renderSideNav(RoutePage.COMPARE);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(true));
+    await waitFor(() => expect(isCollapsed()).toBe(true));
   });
 
   it('expands if collapse state is false in localStorage', async () => {
     localStorageIsCollapsedSpy.mockImplementationOnce(() => false);
     localStorageHasKeySpy.mockImplementationOnce(() => true);
     const { renderResult } = renderSideNav(RoutePage.COMPARE);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
   });
 
   it('collapses if no collapse state in localStorage, and window is too narrow', async () => {
@@ -220,7 +220,7 @@ describe('SideNav', () => {
     localStorageHasKeySpy.mockImplementationOnce(() => false);
     (window as any).innerWidth = narrowWidth;
     const { renderResult } = renderSideNav(RoutePage.COMPARE);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(true));
+    await waitFor(() => expect(isCollapsed()).toBe(true));
   });
 
   it('expands if no collapse state in localStorage, and window is wide', async () => {
@@ -228,7 +228,7 @@ describe('SideNav', () => {
     localStorageHasKeySpy.mockImplementationOnce(() => false);
     (window as any).innerWidth = wideWidth;
     const { renderResult } = renderSideNav(RoutePage.COMPARE);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
   });
 
   it('collapses if no collapse state in localStorage, and window goes from wide to narrow', async () => {
@@ -236,13 +236,13 @@ describe('SideNav', () => {
     localStorageHasKeySpy.mockImplementationOnce(() => false);
     (window as any).innerWidth = wideWidth;
     const { renderResult } = renderSideNav(RoutePage.COMPARE);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
 
     act(() => {
       (window as any).innerWidth = narrowWidth;
       window.dispatchEvent(new Event('resize'));
     });
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(true));
+    await waitFor(() => expect(isCollapsed()).toBe(true));
   });
 
   it('expands if no collapse state in localStorage, and window goes from narrow to wide', async () => {
@@ -250,13 +250,13 @@ describe('SideNav', () => {
     localStorageHasKeySpy.mockImplementationOnce(() => false);
     (window as any).innerWidth = narrowWidth;
     const { renderResult } = renderSideNav(RoutePage.COMPARE);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(true));
+    await waitFor(() => expect(isCollapsed()).toBe(true));
 
     act(() => {
       (window as any).innerWidth = wideWidth;
       window.dispatchEvent(new Event('resize'));
     });
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
   });
 
   it('saves state in localStorage if chevron is clicked', async () => {
@@ -266,13 +266,9 @@ describe('SideNav', () => {
 
     (window as any).innerWidth = narrowWidth;
     const { renderResult } = renderSideNav(RoutePage.COMPARE);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(true));
+    await waitFor(() => expect(isCollapsed()).toBe(true));
 
-    const chevron = renderResult.container.querySelector(`.${css.chevron}`);
-    if (!chevron) {
-      throw new Error('Chevron button not found');
-    }
-    fireEvent.click(chevron);
+    fireEvent.click(screen.getByTestId('chevron-toggle'));
     expect(spy).toHaveBeenCalledWith(false);
   });
 
@@ -282,13 +278,13 @@ describe('SideNav', () => {
 
     (window as any).innerWidth = wideWidth;
     const { renderResult } = renderSideNav(RoutePage.COMPARE);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
 
     act(() => {
       (window as any).innerWidth = narrowWidth;
       window.dispatchEvent(new Event('resize'));
     });
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(false));
+    await waitFor(() => expect(isCollapsed()).toBe(false));
   });
 
   it('populates the display build information using the default props', () => {
@@ -420,6 +416,6 @@ describe('SideNav', () => {
     (window as any).innerWidth = narrowWidth;
 
     const { renderResult } = renderSideNav(RoutePage.COMPARE);
-    await waitFor(() => expect(isCollapsed(renderResult.container)).toBe(true));
+    await waitFor(() => expect(isCollapsed()).toBe(true));
   });
 });

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -272,6 +272,7 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
     return (
       <div
         id='sideNav'
+        data-testid='sideNav'
         className={classes(
           css.root,
           commonCss.flexColumn,
@@ -543,6 +544,7 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
           <IconButton
             className={classes(css.chevron, collapsed && css.collapsedChevron)}
             onClick={this._toggleNavClicked.bind(this)}
+            data-testid='chevron-toggle'
             size='large'
           >
             <ChevronLeftIcon />

--- a/frontend/src/components/__snapshots__/Graph.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Graph.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Graph > gracefully renders a graph with a selected node id that does no
   >
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node1"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -36,6 +37,7 @@ exports[`Graph > gracefully renders a graph with a selected node id that does no
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node2"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 65px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -92,6 +94,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
   >
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-flipcoin1"
       style="left: 75px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -121,6 +124,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-tails1"
       style="left: 45px; max-height: 10px; min-height: 10px; top: 65px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -150,6 +154,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-heads1"
       style="left: 105px; max-height: 10px; min-height: 10px; top: 65px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -179,6 +184,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-flipcoin2"
       style="left: 45px; max-height: 10px; min-height: 10px; top: 125px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -208,6 +214,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-heads2"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 185px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -237,6 +244,7 @@ exports[`Graph > renders a complex graph with six nodes and seven edges 1`] = `
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-tails2"
       style="left: 85px; max-height: 10px; min-height: 10px; top: 185px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -417,6 +425,7 @@ exports[`Graph > renders a graph with a placeholder node and edge 1`] = `
   >
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node1"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -446,6 +455,7 @@ exports[`Graph > renders a graph with a placeholder node and edge 1`] = `
     </div>
     <div
       class="placeholderNode_f1hx9p42 graphNode"
+      data-testid="graph-node-node2"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 65px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -487,6 +497,7 @@ exports[`Graph > renders a graph with a selected node 1`] = `
   >
     <div
       class="node_flbuigk graphNode nodeSelected_f1a563lq"
+      data-testid="graph-node-node1"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -516,6 +527,7 @@ exports[`Graph > renders a graph with a selected node 1`] = `
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node2"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 65px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -572,6 +584,7 @@ exports[`Graph > renders a graph with colored edges 1`] = `
   >
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node1"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -601,6 +614,7 @@ exports[`Graph > renders a graph with colored edges 1`] = `
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node2"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 65px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -657,6 +671,7 @@ exports[`Graph > renders a graph with colored nodes 1`] = `
   >
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node1"
       style="background-color: red; left: 5px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -686,6 +701,7 @@ exports[`Graph > renders a graph with colored nodes 1`] = `
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node2"
       style="background-color: green; left: 65px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -724,6 +740,7 @@ exports[`Graph > renders a graph with one node 1`] = `
   >
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node1"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -762,6 +779,7 @@ exports[`Graph > renders a graph with two connectd nodes 1`] = `
   >
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node1"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -791,6 +809,7 @@ exports[`Graph > renders a graph with two connectd nodes 1`] = `
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node2"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 65px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -847,6 +866,7 @@ exports[`Graph > renders a graph with two connectd nodes in reverse order 1`] = 
   >
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node1"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 65px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -876,6 +896,7 @@ exports[`Graph > renders a graph with two connectd nodes in reverse order 1`] = 
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node2"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -932,6 +953,7 @@ exports[`Graph > renders a graph with two disparate nodes 1`] = `
   >
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node1"
       style="left: 5px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div
@@ -961,6 +983,7 @@ exports[`Graph > renders a graph with two disparate nodes 1`] = `
     </div>
     <div
       class="node_flbuigk graphNode"
+      data-testid="graph-node-node2"
       style="left: 65px; max-height: 10px; min-height: 10px; top: 5px; transition: left 0.5s, top 0.5s; width: 10px;"
     >
       <div

--- a/frontend/src/components/__snapshots__/PlotCard.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/PlotCard.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`PlotCard > renders a confusion matrix plot card 1`] = `
         <div>
           <button
             class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+            data-testid="pop-out-button"
             style="padding: 4px; min-height: 0; min-width: 0;"
             tabindex="0"
             type="button"

--- a/frontend/src/components/__snapshots__/Router.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/Router.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`Router > initial render 1`] = `
     >
       <div
         class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+        data-testid="sideNav"
         id="sideNav"
       >
         <div
@@ -446,6 +447,7 @@ exports[`Router > initial render 1`] = `
           />
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+            data-testid="chevron-toggle"
             tabindex="0"
             type="button"
           >

--- a/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -440,6 +441,7 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -519,6 +521,7 @@ exports[`SideNav > populates the display build information using the default pro
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -955,6 +958,7 @@ exports[`SideNav > populates the display build information using the default pro
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -1017,6 +1021,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -1453,6 +1458,7 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -1515,6 +1521,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -1951,6 +1958,7 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -2013,6 +2021,7 @@ exports[`SideNav > renders collapsed state 1`] = `
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c collapsedRoot_fq9pe1f"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -2449,6 +2458,7 @@ exports[`SideNav > renders collapsed state 1`] = `
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj collapsedChevron_f18a0vkk css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -2511,6 +2521,7 @@ exports[`SideNav > renders expanded state 1`] = `
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -2947,6 +2958,7 @@ exports[`SideNav > renders expanded state 1`] = `
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -3009,6 +3021,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -3445,6 +3458,7 @@ exports[`SideNav > renders experiments as active page 1`] = `
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -3507,6 +3521,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -3943,6 +3958,7 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -4005,6 +4021,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -4441,6 +4458,7 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -4503,6 +4521,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -4939,6 +4958,7 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -5001,6 +5021,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -5437,6 +5458,7 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -5499,6 +5521,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -5935,6 +5958,7 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -5997,6 +6021,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -6433,6 +6458,7 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -6495,6 +6521,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -6931,6 +6958,7 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -6993,6 +7021,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -7429,6 +7458,7 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -7491,6 +7521,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -7927,6 +7958,7 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >
@@ -7989,6 +8021,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
 <DocumentFragment>
   <div
     class="root_f1a1w2f7 flexColumn_fr3ikkd noShrink_f16j9z5c"
+    data-testid="sideNav"
     id="sideNav"
   >
     <div
@@ -8476,6 +8509,7 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
       />
       <button
         class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeLarge chevron_f1eaw8uj css-mf1cb5-MuiButtonBase-root-MuiIconButton-root"
+        data-testid="chevron-toggle"
         tabindex="0"
         type="button"
       >

--- a/frontend/src/mlmd/LineageCard.test.tsx
+++ b/frontend/src/mlmd/LineageCard.test.tsx
@@ -124,23 +124,21 @@ describe('LineageCard', () => {
   it('renders one LineageCardRow per element in rows', () => {
     const rows = [buildArtifactRow('row-1'), buildArtifactRow('row-2'), buildArtifactRow('row-3')];
 
-    const { container } = renderLineageCard({
+    renderLineageCard({
       title: 'Multi Row',
       type: 'artifact',
       rows,
       addSpacer: false,
     });
 
-    const cardBody = container.querySelector('.cardBody');
-    expect(cardBody).not.toBeNull();
-    expect(cardBody?.children.length).toBe(3);
+    expect(screen.getAllByTestId('card-row')).toHaveLength(3);
   });
 
   it('passes setLineageViewTarget down to each row', () => {
     const setLineageViewTarget = vi.fn();
     const rows = [buildArtifactRow('clickable-row')];
 
-    const { container } = renderLineageCard({
+    renderLineageCard({
       title: 'Clickable Card',
       type: 'artifact',
       rows,
@@ -148,9 +146,7 @@ describe('LineageCard', () => {
       setLineageViewTarget,
     });
 
-    const cardRow = container.querySelector('.cardRow');
-    expect(cardRow).not.toBeNull();
-    fireEvent.click(cardRow!);
+    fireEvent.click(screen.getByTestId('card-row'));
     expect(setLineageViewTarget).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/mlmd/LineageCardRow.test.tsx
+++ b/frontend/src/mlmd/LineageCardRow.test.tsx
@@ -88,21 +88,19 @@ describe('LineageCardRow', () => {
   });
 
   it('hides radio button when hideRadio is true', () => {
-    const { container } = renderCardRow({ hideRadio: true });
+    renderCardRow({ hideRadio: true });
 
-    expect(container.querySelector('.noRadio')).not.toBeNull();
-    expect(container.querySelector('.form-radio')).toBeNull();
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
   });
 
   it('calls setLineageViewTarget once when an artifact radio is clicked', () => {
     const setLineageViewTarget = vi.fn();
     const typedResource = buildArtifactResource('clickable');
 
-    const { container } = renderCardRow({ typedResource, setLineageViewTarget });
+    renderCardRow({ typedResource, setLineageViewTarget });
 
-    const radio = container.querySelector('.form-radio');
-    expect(radio).not.toBeNull();
-    fireEvent.click(radio!);
+    const radio = screen.getAllByRole('radio')[0];
+    fireEvent.click(radio);
     expect(setLineageViewTarget).toHaveBeenCalledTimes(1);
     expect(setLineageViewTarget).toHaveBeenCalledWith(typedResource.resource);
   });
@@ -110,40 +108,37 @@ describe('LineageCardRow', () => {
   it('does NOT call setLineageViewTarget when row is an execution type', () => {
     const setLineageViewTarget = vi.fn();
 
-    const { container } = renderCardRow({
+    renderCardRow({
       typedResource: buildExecutionResource(),
       resourceDetailsRoute: '/executions/1',
       hideRadio: true,
       setLineageViewTarget,
     });
 
-    const row = container.querySelector('.cardRow');
-    expect(row).not.toBeNull();
-    fireEvent.click(row!);
+    const row = screen.getByTestId('card-row');
+    fireEvent.click(row);
     expect(setLineageViewTarget).not.toHaveBeenCalled();
   });
 
   it('does not throw when clicked without setLineageViewTarget provided', () => {
-    const { container } = renderCardRow({
+    renderCardRow({
       typedResource: buildArtifactResource('no-handler'),
       setLineageViewTarget: undefined,
     });
 
-    const row = container.querySelector('.cardRow');
-    expect(row).not.toBeNull();
+    const row = screen.getByTestId('card-row');
     expect(() => {
-      fireEvent.click(row!);
+      fireEvent.click(row);
     }).not.toThrow();
   });
 
   it('toggles the hover hint class when hovering the resource link', () => {
-    const { container } = renderCardRow({
+    renderCardRow({
       typedResource: buildArtifactResource('hoverable'),
     });
 
-    const row = container.querySelector('.cardRow');
+    const row = screen.getByTestId('card-row');
     const link = screen.getByRole('link', { name: 'hoverable' });
-    expect(row).not.toBeNull();
 
     expect(row).toHaveClass('clickTarget');
     fireEvent.mouseEnter(link);

--- a/frontend/src/mlmd/LineageCardRow.tsx
+++ b/frontend/src/mlmd/LineageCardRow.tsx
@@ -202,7 +202,12 @@ export class LineageCardRow extends React.Component<LineageCardRowProps> {
     );
 
     return (
-      <div className={cardRowClasses} ref={this.rowContainerRef} onClick={this.handleClick}>
+      <div
+        className={cardRowClasses}
+        ref={this.rowContainerRef}
+        onClick={this.handleClick}
+        data-testid='card-row'
+      >
         {this.checkRadio()}
         <footer>
           <Link

--- a/frontend/src/pages/CompareV2.test.tsx
+++ b/frontend/src/pages/CompareV2.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { useEffect, useState } from 'react';
 import { CommonTestWrapper } from 'src/TestWrapper';
 import TestUtils, { expectErrors, testBestPractices } from 'src/TestUtils';
@@ -198,10 +198,7 @@ describe('CompareV2', () => {
   }
 
   function getRunRow(id: string): HTMLElement {
-    const runListContainer = getRunListContainer();
-    const runRows = Array.from(
-      runListContainer.querySelectorAll('[data-testid="table-row"]'),
-    ) as HTMLElement[];
+    const runRows = within(getRunListContainer()).getAllByTestId('table-row');
     const runRow = runRows.find((row) => row.textContent?.includes(`test run ${id}`));
     if (!runRow) {
       throw new Error(`Run row not found for ${id}`);
@@ -212,10 +209,8 @@ describe('CompareV2', () => {
   async function waitForRunCheckboxes(expectedCount: number): Promise<HTMLElement[]> {
     let runCheckboxes: HTMLElement[] = [];
     await waitFor(() => {
-      const runListContainer = getRunListContainer();
-      runCheckboxes = Array.from(
-        runListContainer.querySelectorAll('[data-testid="table-row"][aria-checked="true"]'),
-      );
+      const allRows = within(getRunListContainer()).getAllByTestId('table-row');
+      runCheckboxes = allRows.filter((row) => row.getAttribute('aria-checked') === 'true');
       expect(runCheckboxes).toHaveLength(expectedCount);
     });
     return runCheckboxes;

--- a/frontend/src/pages/__snapshots__/CompareV1.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/CompareV1.test.tsx.snap
@@ -638,6 +638,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -789,6 +790,7 @@ exports[`CompareV1 > creates a map of viewers 1`] = `
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -1607,6 +1609,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -1719,6 +1722,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -1831,6 +1835,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -1982,6 +1987,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -2268,6 +2274,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -2523,6 +2530,7 @@ exports[`CompareV1 > creates an extra aggregation plot for compatible viewers 1`
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -6263,6 +6271,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -6375,6 +6384,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -6487,6 +6497,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -6638,6 +6649,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"
@@ -6840,6 +6852,7 @@ exports[`CompareV1 > expands all sections if they were collapsed 1`] = `
               <div>
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary popOutButton css-1e6y48t-MuiButtonBase-root-MuiButton-root"
+                  data-testid="pop-out-button"
                   style="padding: 4px; min-height: 0; min-width: 0;"
                   tabindex="0"
                   type="button"


### PR DESCRIPTION
**Description of your changes:**
Replace `querySelector` based test selectors with React Testing Library queries across 7 test files.
Add `data-testid` to 4 production components (`Graph`, `SideNav`, `LineageCardRow`, `PlotCard`). No logic changes.

**Test files modernized (7):**
- CustomTableNameColumn, Graph, SideNav, LineageCard, LineageCardRow, PlotCard, CompareV2
- Replaced `querySelector` with `getByTestId`, `getByRole`, `queryByText`, `within().getAllByTestId`

**querySelector kept for:**

- Edge dots (visual decoration), MUI backdrop (third-party DOM), CustomTable header checkbox (shared component).

Part of #13228 