### PR TITLE
fix(frontend): stop persistent spinner on MLMD detail page errors

### DIFF
--- a/frontend/src/pages/ArtifactDetails.test.tsx
+++ b/frontend/src/pages/ArtifactDetails.test.tsx
@@ -181,6 +181,7 @@ describe('ArtifactDetails', () => {
         }),
       );
     });
+    expect(screen.queryByRole('progressbar')).toBeNull();
   });
 
   it('shows page error banner when multiple artifacts found for the given ID', async () => {
@@ -213,6 +214,7 @@ describe('ArtifactDetails', () => {
         }),
       );
     });
+    expect(screen.queryByRole('progressbar')).toBeNull();
   });
 
   it('shows fallback error message when a non-service error with no message is thrown', async () => {
@@ -228,6 +230,7 @@ describe('ArtifactDetails', () => {
         }),
       );
     });
+    expect(screen.queryByRole('progressbar')).toBeNull();
   });
 
   it('shows extracted error message when a non-service error with text() is thrown', async () => {

--- a/frontend/src/pages/ArtifactDetails.test.tsx
+++ b/frontend/src/pages/ArtifactDetails.test.tsx
@@ -248,6 +248,33 @@ describe('ArtifactDetails', () => {
     });
   });
 
+  it('shows spinner again when retrying after a failure', async () => {
+    getArtifactsByIDSpy.mockRejectedValueOnce(new Error('transient'));
+
+    renderWithRouter(generateProps());
+
+    let refreshFn: (() => Promise<void>) | undefined;
+    await waitFor(() => {
+      expect(updateBannerSpy).toHaveBeenCalledWith(expect.objectContaining({ mode: 'error' }));
+      const bannerCall = updateBannerSpy.mock.calls.find(
+        (call) => call[0]?.mode === 'error' && typeof call[0]?.refresh === 'function',
+      );
+      expect(bannerCall).toBeDefined();
+      refreshFn = bannerCall![0].refresh;
+    });
+    expect(screen.queryByRole('progressbar')).toBeNull();
+
+    mockSuccessfulLoad();
+    updateBannerSpy.mockClear();
+
+    await refreshFn!();
+
+    await waitFor(() => {
+      expect(screen.getByText('Overview')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+
   it('renders a new ArtifactDetails instance when artifact ID in URL changes', async () => {
     getArtifactsByIDSpy.mockImplementation((req) => {
       const id = req.getArtifactIdsList()[0];

--- a/frontend/src/pages/ArtifactDetails.tsx
+++ b/frontend/src/pages/ArtifactDetails.tsx
@@ -65,6 +65,7 @@ const TAB_NAMES = [ArtifactDetailsTab.OVERVIEW, ArtifactDetailsTab.LINEAGE_EXPLO
 interface ArtifactDetailsState {
   artifact?: Artifact;
   artifactType?: ArtifactType;
+  hasError?: boolean;
 }
 
 class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
@@ -108,12 +109,15 @@ class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
   }
 
   public render(): React.JSX.Element {
-    if (!this.state.artifact) {
+    if (!this.state.artifact && !this.state.hasError) {
       return (
         <div className={commonCss.page}>
           <CircularProgress className={commonCss.absoluteCenter} />
         </div>
       );
+    }
+    if (!this.state.artifact) {
+      return <div className={commonCss.page} />;
     }
     return (
       <div className={classes(commonCss.page)}>
@@ -179,10 +183,12 @@ class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
     try {
       const response = await this.api.metadataStoreService.getArtifactsByID(request);
       if (response.getArtifactsList().length === 0) {
+        this.setStateSafe({ hasError: true });
         this.showPageError(`No artifact identified by id: ${this.id}`);
         return;
       }
       if (response.getArtifactsList().length > 1) {
+        this.setStateSafe({ hasError: true });
         this.showPageError(`Found multiple artifacts with ID: ${this.id}`);
         return;
       }
@@ -206,6 +212,7 @@ class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
       });
       this.setStateSafe({ artifact, artifactType });
     } catch (err) {
+      this.setStateSafe({ hasError: true });
       if (isServiceError(err)) {
         this.showPageError(serviceErrorToString(err));
       } else {

--- a/frontend/src/pages/ArtifactDetails.tsx
+++ b/frontend/src/pages/ArtifactDetails.tsx
@@ -177,6 +177,7 @@ class ArtifactDetails extends Page<{}, ArtifactDetailsState> {
   }
 
   private load = async (): Promise<void> => {
+    this.setStateSafe({ hasError: false });
     const request = new GetArtifactsByIDRequest();
     request.setArtifactIdsList([Number(this.id)]);
 

--- a/frontend/src/pages/ExecutionDetails.test.tsx
+++ b/frontend/src/pages/ExecutionDetails.test.tsx
@@ -139,6 +139,7 @@ describe('ExecutionDetailsContent', () => {
   let getExecutionTypesByIDSpy: Mock;
   let getArtifactTypesSpy: Mock;
   let getArtifactsByIDSpy: Mock;
+  let getLinkedArtifactsByEventsSpy: ReturnType<typeof vi.spyOn>;
   let getContextByExecutionSpy: ReturnType<typeof vi.spyOn>;
   let onErrorSpy: Mock;
   let onTitleUpdateSpy: Mock;
@@ -157,6 +158,7 @@ describe('ExecutionDetailsContent', () => {
     );
     getArtifactTypesSpy = vi.spyOn(Api.getInstance().metadataStoreService, 'getArtifactTypes');
     getArtifactsByIDSpy = vi.spyOn(Api.getInstance().metadataStoreService, 'getArtifactsByID');
+    getLinkedArtifactsByEventsSpy = vi.spyOn(MlmdUtils, 'getLinkedArtifactsByEvents');
     getContextByExecutionSpy = vi.spyOn(MlmdUtils, 'getContextByExecution');
 
     getArtifactTypesSpy.mockResolvedValue(new GetArtifactTypesResponse());
@@ -229,6 +231,7 @@ describe('ExecutionDetailsContent', () => {
         expect.any(Function),
       );
     });
+    expect(screen.queryByRole('progressbar')).toBeNull();
   });
 
   it('shows page error when multiple executions found', async () => {
@@ -301,6 +304,18 @@ describe('ExecutionDetailsContent', () => {
     });
   });
 
+  it('removes spinner after load fails with a ServiceError', async () => {
+    getExecutionsByIDSpy.mockRejectedValue({ message: 'GRPC unavailable', code: 14 });
+    getEventsByExecutionIDsSpy.mockRejectedValue({ message: 'GRPC unavailable', code: 14 });
+
+    renderContent();
+
+    await waitFor(() => {
+      expect(onErrorSpy).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole('progressbar')).toBeNull();
+  });
+
   it('shows fallback error when load fails with a non-service error', async () => {
     getExecutionsByIDSpy.mockRejectedValue(undefined);
     getEventsByExecutionIDsSpy.mockRejectedValue(undefined);
@@ -315,6 +330,18 @@ describe('ExecutionDetailsContent', () => {
         expect.any(Function),
       );
     });
+  });
+
+  it('removes spinner after load fails with a non-service error', async () => {
+    getExecutionsByIDSpy.mockRejectedValue(undefined);
+    getEventsByExecutionIDsSpy.mockRejectedValue(undefined);
+
+    renderContent();
+
+    await waitFor(() => {
+      expect(onErrorSpy).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole('progressbar')).toBeNull();
   });
 
   it('shows warning when artifact types fetch fails', async () => {
@@ -390,6 +417,19 @@ describe('ExecutionDetailsContent', () => {
       const outputsSection = screen.getByText('Outputs').closest('section')!;
       const outputRows = within(outputsSection as HTMLElement).getAllByRole('row');
       expect(outputRows).toHaveLength(2); // 1 header + 1 data row
+    });
+  });
+
+  it('shows error message in IO section when linked artifacts fetch fails', async () => {
+    getLinkedArtifactsByEventsSpy.mockRejectedValue(new Error('MLMD unavailable'));
+    mockLoadWithEvents([buildEvent(Event.Type.INPUT, 10)]);
+
+    renderContent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Failed to load artifact details for this section.'),
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/ExecutionDetails.test.tsx
+++ b/frontend/src/pages/ExecutionDetails.test.tsx
@@ -344,6 +344,28 @@ describe('ExecutionDetailsContent', () => {
     expect(screen.queryByRole('progressbar')).toBeNull();
   });
 
+  it('shows spinner again when retrying after a failure', async () => {
+    getExecutionsByIDSpy.mockRejectedValueOnce(new Error('transient'));
+    getEventsByExecutionIDsSpy.mockRejectedValueOnce(new Error('transient'));
+
+    renderContent();
+
+    await waitFor(() => {
+      expect(onErrorSpy).toHaveBeenCalled();
+    });
+    expect(screen.queryByRole('progressbar')).toBeNull();
+
+    const refreshFn = onErrorSpy.mock.calls[0][3] as () => Promise<void>;
+    mockSuccessfulLoad();
+    onErrorSpy.mockClear();
+
+    await refreshFn();
+
+    await waitFor(() => {
+      expect(screen.getByText('Reference')).toBeInTheDocument();
+    });
+  });
+
   it('shows warning when artifact types fetch fails', async () => {
     mockSuccessfulLoad();
     getArtifactTypesSpy.mockRejectedValue(new Error('artifact types unavailable'));

--- a/frontend/src/pages/ExecutionDetails.tsx
+++ b/frontend/src/pages/ExecutionDetails.tsx
@@ -52,6 +52,7 @@ interface ExecutionDetailsState {
   executionType?: ExecutionType;
   events?: Record<Event.Type, Event[]>;
   artifactTypeMap?: Map<number, ArtifactType>;
+  hasError?: boolean;
 }
 
 export default class ExecutionDetails extends Page<{}, ExecutionDetailsState> {
@@ -111,8 +112,11 @@ export class ExecutionDetailsContent extends Component<
   }
 
   public render(): React.JSX.Element {
-    if (!this.state.execution || !this.state.events) {
+    if ((!this.state.execution || !this.state.events) && !this.state.hasError) {
       return <CircularProgress />;
+    }
+    if (!this.state.execution || !this.state.events) {
+      return <div />;
     }
 
     return (
@@ -176,6 +180,7 @@ export class ExecutionDetailsContent extends Component<
     const numberId = this.props.id;
     if (isNaN(numberId) || numberId < 0) {
       const error = new Error(`Invalid execution id: ${this.props.id}`);
+      this.setState({ hasError: true });
       this.props.onError(error.message, error, 'error', this.refresh);
       return;
     }
@@ -192,6 +197,7 @@ export class ExecutionDetailsContent extends Component<
       ]);
 
       if (!executionResponse.getExecutionsList().length) {
+        this.setState({ hasError: true });
         this.props.onError(
           `No execution identified by id: ${this.props.id}`,
           undefined,
@@ -202,6 +208,7 @@ export class ExecutionDetailsContent extends Component<
       }
 
       if (executionResponse.getExecutionsList().length > 1) {
+        this.setState({ hasError: true });
         this.props.onError(
           `Found multiple executions with ID: ${this.props.id}`,
           undefined,
@@ -220,6 +227,7 @@ export class ExecutionDetailsContent extends Component<
       const types = typeResponse.getExecutionTypesList();
       let executionType: ExecutionType | undefined;
       if (!types || types.length === 0) {
+        this.setState({ hasError: true });
         this.props.onError(
           `Cannot find execution type with id: ${execution.getTypeId()}`,
           undefined,
@@ -228,6 +236,7 @@ export class ExecutionDetailsContent extends Component<
         );
         return;
       } else if (types.length > 1) {
+        this.setState({ hasError: true });
         this.props.onError(
           `More than one execution type found with id: ${execution.getTypeId()}`,
           undefined,
@@ -247,6 +256,7 @@ export class ExecutionDetailsContent extends Component<
         executionType,
       });
     } catch (err) {
+      this.setState({ hasError: true });
       if (isServiceError(err)) {
         this.props.onError(
           serviceErrorToString(err),
@@ -312,7 +322,7 @@ interface SectionIOProps {
 }
 class SectionIO extends Component<
   SectionIOProps,
-  { artifactDataMap: { [id: number]: ArtifactInfo } }
+  { artifactDataMap: { [id: number]: ArtifactInfo }; loadError?: boolean }
 > {
   constructor(props: any) {
     super(props);
@@ -344,7 +354,8 @@ class SectionIO extends Component<
         artifactDataMap,
       });
     } catch (err) {
-      return;
+      logger.error(`Failed to load linked artifacts for "${this.props.title}":`, err);
+      this.setState({ loadError: true });
     }
   }
 
@@ -357,6 +368,11 @@ class SectionIO extends Component<
     return (
       <section>
         <h2 className={commonCss.header2}>{title}</h2>
+        {this.state.loadError && (
+          <p style={{ color: color.warningText }}>
+            Failed to load artifact details for this section.
+          </p>
+        )}
         <table>
           <thead>
             <tr>

--- a/frontend/src/pages/ExecutionDetails.tsx
+++ b/frontend/src/pages/ExecutionDetails.tsx
@@ -164,6 +164,7 @@ export class ExecutionDetailsContent extends Component<
   };
 
   private load = async (): Promise<void> => {
+    this.setState({ hasError: false });
     const metadataStoreServiceClient = Api.getInstance().metadataStoreService;
 
     // this runs parallelly because it's not a critical resource


### PR DESCRIPTION
**Description of your changes:**

`ArtifactDetails` and `ExecutionDetailsContent` show a `CircularProgress` spinner while loading MLMD data, but never clear it when loading fails. The error banner appears via `showPageError` / `onError`, but the spinner condition (`!this.state.artifact` / `!this.state.execution || !this.state.events`) remains true because state is only set on success. The result is a spinner that keeps spinning forever alongside the error banner.

Additionally, `SectionIO` in `ExecutionDetails.tsx` has an empty `catch` block (`catch (err) { return; }`) that silently swallows errors from `getLinkedArtifactsByEvents`, giving the user no feedback when I/O artifact details fail to load.

### Changes

- **`ArtifactDetails.tsx`**: Add `hasError` flag to state. Set it in all error paths (`showPageError` calls and `catch` block). Update `render()` to stop showing the spinner when `hasError` is true.
- **`ExecutionDetails.tsx` (`ExecutionDetailsContent`)**: Same `hasError` pattern — set the flag in all `onError` calls and the `catch` block, stop spinner when error is set.
- **`ExecutionDetails.tsx` (`SectionIO`)**: Replace the empty `catch` with `logger.error()` and a `loadError` state flag that renders an inline warning message in the section.
- **Tests**: Add assertions that the spinner is removed after error in both `ArtifactDetails.test.tsx` and `ExecutionDetails.test.tsx`. Add a new test for the `SectionIO` error message.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

Made with [Cursor](https://cursor.com)