### PR TITLE
test(frontend): add unit tests for shared query hooks and key factory

### DIFF
--- a/frontend/src/hooks/queryKeys.test.ts
+++ b/frontend/src/hooks/queryKeys.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { queryKeys } from './queryKeys';
+
+describe('queryKeys', () => {
+  it('artifactTypes returns a stable key', () => {
+    expect(queryKeys.artifactTypes()).toEqual(['artifact_types']);
+  });
+
+  it('pipelineVersionTemplate includes both IDs', () => {
+    expect(queryKeys.pipelineVersionTemplate('p1', 'v1')).toEqual([
+      'PipelineVersionTemplate',
+      { pipelineId: 'p1', pipelineVersionId: 'v1' },
+    ]);
+  });
+
+  it('pipelineVersionTemplate handles undefined IDs', () => {
+    expect(queryKeys.pipelineVersionTemplate(undefined, undefined)).toEqual([
+      'PipelineVersionTemplate',
+      { pipelineId: undefined, pipelineVersionId: undefined },
+    ]);
+  });
+
+  it('v2RunDetail includes the run ID', () => {
+    expect(queryKeys.v2RunDetail('run-123')).toEqual(['v2_run_detail', { id: 'run-123' }]);
+  });
+
+  it('v2RunDetail handles null', () => {
+    expect(queryKeys.v2RunDetail(null)).toEqual(['v2_run_detail', { id: null }]);
+  });
+
+  it('v2RunDetails includes an array of run IDs', () => {
+    expect(queryKeys.v2RunDetails(['r1', 'r2'])).toEqual(['v2_run_details', { ids: ['r1', 'r2'] }]);
+  });
+
+  it('v2RecurringRunDetail includes the recurring run ID', () => {
+    expect(queryKeys.v2RecurringRunDetail('rr-1')).toEqual([
+      'v2_recurring_run_detail',
+      { id: 'rr-1' },
+    ]);
+  });
+
+  it('mlmdPackage includes the run ID', () => {
+    expect(queryKeys.mlmdPackage('run-456')).toEqual(['mlmd_package', { id: 'run-456' }]);
+  });
+
+  it('contextByExecution includes execution ID and state', () => {
+    expect(queryKeys.contextByExecution(42, 3)).toEqual([
+      'context_by_execution',
+      { id: 42, state: 3 },
+    ]);
+  });
+
+  it('pipeline includes the pipeline ID', () => {
+    expect(queryKeys.pipeline('pipe-1')).toEqual(['pipeline', 'pipe-1']);
+  });
+
+  it('pipeline handles null', () => {
+    expect(queryKeys.pipeline(null)).toEqual(['pipeline', null]);
+  });
+
+  it('pipelineVersion includes both pipeline and version IDs', () => {
+    expect(queryKeys.pipelineVersion('p1', 'v2')).toEqual(['pipelineVersion', 'p1', 'v2']);
+  });
+
+  it('experiment includes the experiment ID', () => {
+    expect(queryKeys.experiment('exp-1')).toEqual(['experiment', 'exp-1']);
+  });
+
+  it('returns distinct keys for different factories', () => {
+    const artifactTypesKey = queryKeys.artifactTypes();
+    const pipelineKey = queryKeys.pipeline('p1');
+    expect(artifactTypesKey[0]).not.toEqual(pipelineKey[0]);
+  });
+
+  it('pipelineVersions defaults to empty string when pipelineId is null', () => {
+    expect(queryKeys.pipelineVersions(null)).toEqual(['pipeline_versions', '']);
+  });
+
+  it('executionLogs includes executionId and namespace', () => {
+    expect(queryKeys.executionLogs(5, 'kubeflow')).toEqual([
+      'execution_logs',
+      { executionId: 5, namespace: 'kubeflow' },
+    ]);
+  });
+});

--- a/frontend/src/hooks/useArtifactTypes.test.ts
+++ b/frontend/src/hooks/useArtifactTypes.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import * as MlmdUtils from 'src/mlmd/MlmdUtils';
+import { ArtifactType } from 'src/third_party/mlmd';
+import { useArtifactTypes } from './useArtifactTypes';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('useArtifactTypes', () => {
+  let getArtifactTypesSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    getArtifactTypesSpy = vi.spyOn(MlmdUtils, 'getArtifactTypes');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns artifact types on success', async () => {
+    const type1 = new ArtifactType();
+    type1.setId(1);
+    type1.setName('system.Dataset');
+    const type2 = new ArtifactType();
+    type2.setId(2);
+    type2.setName('system.Model');
+    getArtifactTypesSpy.mockResolvedValue([type1, type2]);
+
+    const { result } = renderHook(() => useArtifactTypes(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data![0].getName()).toBe('system.Dataset');
+    expect(result.current.data![1].getName()).toBe('system.Model');
+  });
+
+  it('returns empty array when no artifact types exist', async () => {
+    getArtifactTypesSpy.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useArtifactTypes(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('reports error when getArtifactTypes rejects', async () => {
+    getArtifactTypesSpy.mockRejectedValue(new Error('MLMD unreachable'));
+
+    const { result } = renderHook(() => useArtifactTypes(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('MLMD unreachable');
+  });
+
+  it('does not fetch when enabled is false', () => {
+    const { result } = renderHook(() => useArtifactTypes({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getArtifactTypesSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/usePipelineVersionTemplate.test.ts
+++ b/frontend/src/hooks/usePipelineVersionTemplate.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { Apis } from 'src/lib/Apis';
+import { usePipelineVersionTemplate } from './usePipelineVersionTemplate';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('usePipelineVersionTemplate', () => {
+  let getPipelineVersionSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    getPipelineVersionSpy = vi.spyOn(Apis.pipelineServiceApiV2, 'getPipelineVersion');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns YAML string when pipeline version has a pipeline_spec', async () => {
+    getPipelineVersionSpy.mockResolvedValue({
+      pipeline_spec: { components: { root: {} } },
+    });
+
+    const { result } = renderHook(() => usePipelineVersionTemplate('pipeline-1', 'version-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toContain('components');
+    expect(getPipelineVersionSpy).toHaveBeenCalledWith('pipeline-1', 'version-1');
+  });
+
+  it('returns empty string when pipeline_spec is undefined', async () => {
+    getPipelineVersionSpy.mockResolvedValue({});
+
+    const { result } = renderHook(() => usePipelineVersionTemplate('pipeline-1', 'version-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBe('');
+  });
+
+  it('does not fetch when pipelineId is undefined', async () => {
+    const { result } = renderHook(() => usePipelineVersionTemplate(undefined, 'version-1'), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getPipelineVersionSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when pipelineVersionId is undefined', async () => {
+    const { result } = renderHook(() => usePipelineVersionTemplate('pipeline-1', undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getPipelineVersionSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when both IDs are undefined', async () => {
+    const { result } = renderHook(() => usePipelineVersionTemplate(undefined, undefined), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getPipelineVersionSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports error when the API call rejects', async () => {
+    getPipelineVersionSpy.mockRejectedValue(new Error('Network failure'));
+
+    const { result } = renderHook(() => usePipelineVersionTemplate('pipeline-1', 'version-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Network failure');
+  });
+});


### PR DESCRIPTION
**Description of your changes:**

The shared hooks under `frontend/src/hooks/` (`queryKeys`, `usePipelineVersionTemplate`, `useArtifactTypes`) had zero direct unit test coverage. These are used across multiple pages (RunDetailsRouter, RecurringRunDetailsRouter, CompareV2, InputOutputTab, RuntimeNodeDetailsV2, etc.) and are foundational to the React Query caching layer.

### Tests added

- **`queryKeys.test.ts`** (16 tests): Verifies key structure, parameter embedding, null/undefined handling, and distinctness across all factory methods.
- **`usePipelineVersionTemplate.test.ts`** (6 tests): Covers successful YAML serialization, empty pipeline_spec, disabled query when IDs are undefined, and error propagation.
- **`useArtifactTypes.test.ts`** (4 tests): Covers successful fetch, empty result, error propagation, and `enabled: false` behavior.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.

