### PR TITLE
test(frontend): wrap router navigation in act

### DIFF
--- a/frontend/src/components/Router.test.tsx
+++ b/frontend/src/components/Router.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { Router as ReactRouter } from 'react-router';
 import { MemoryRouter } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
@@ -67,7 +67,9 @@ describe('Router', () => {
       </ReactRouter>,
     );
     expect(screen.getByTestId('page-title')).toHaveTextContent('Apple');
-    history.push('/pear');
+    act(() => {
+      history.push('/pear');
+    });
     await waitFor(() => expect(screen.getByTestId('page-title')).toHaveTextContent(''));
   });
 });


### PR DESCRIPTION
## Summary

- Wrap the imperative `history.push('/pear')` in `Router.test.tsx` with Testing Library `act`
- Remove the isolated Router `act(...)` warning tracked as the first slice of #13349
- Keep the change scoped to the test harness; no production behavior changes

## Why this helps

The test manually changes routes with `history.push('/pear')`. That call updates React Router state and causes `Router` to re-render, but because the update is triggered outside Testing Library's normal render/user-event helpers, React reports:

```text
An update to Router inside a test was not wrapped in act(...)
```

Wrapping the navigation in `act` tells React that this operation is expected to cause updates and those updates should be flushed before the test continues. This makes the test harness more deterministic, removes a real synchronization warning, and reduces suite noise so future warnings are easier to spot.

This does not change application behavior. It only makes the test explicitly wait for the React update caused by manual history navigation.

## Verification

- `npm run test:ui -- Router.test.tsx`
  - before: passed with 1 `act(...)` warning
  - after: passed with 0 `act(...)` warnings
- `npm run lint:ui`
- `npm run typecheck`

Part of #13349.

/area frontend
/kind cleanup
