### PR TITLE
test(frontend): flush CompareV2 setup in act

### DIFF
--- a/frontend/src/pages/CompareV2.test.tsx
+++ b/frontend/src/pages/CompareV2.test.tsx
@@ -17,7 +17,7 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { useEffect, useState } from 'react';
 import { CommonTestWrapper } from 'src/TestWrapper';
-import TestUtils, { expectErrors, testBestPractices } from 'src/TestUtils';
+import TestUtils, { expectErrors, flushPromisesInAct, testBestPractices } from 'src/TestUtils';
 import { Artifact, Context, Event, Execution } from 'src/third_party/mlmd';
 import { Apis } from 'src/lib/Apis';
 import { ButtonKeys } from 'src/lib/Buttons';
@@ -505,7 +505,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     // Wait for runs to render (indicates all queries resolved) before banner clears
     await waitForRunCheckboxes(3);
@@ -558,7 +558,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitForRunCheckboxes(3);
 
     await waitFor(
@@ -671,7 +671,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     screen.getByLabelText('Filter runs');
     screen.getByText('There are no Parameters available on the selected runs.');
@@ -711,7 +711,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(3);
     const headerCheckbox = getHeaderCheckbox();
@@ -732,11 +732,11 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(3);
     fireEvent.click(getRunRow(MOCK_RUN_2_ID));
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(2);
     expect(getHeaderCheckbox()).not.toBeChecked();
@@ -752,7 +752,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitFor(() => {
       expect(updateToolbarSpy).toHaveBeenCalled();
@@ -760,7 +760,7 @@ describe('CompareV2', () => {
     await waitForRunCheckboxes(3);
 
     fireEvent.click(getRunRow(MOCK_RUN_2_ID));
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitForRunCheckboxes(2);
     expect(getRunRow(MOCK_RUN_2_ID)).toHaveAttribute('aria-checked', 'false');
 
@@ -769,7 +769,7 @@ describe('CompareV2', () => {
     await act(async () => {
       await refreshAction();
     });
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(2);
     expect(getRunRow(MOCK_RUN_1_ID)).toHaveAttribute('aria-checked', 'true');
@@ -797,7 +797,7 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitFor(() => {
       expect(updateToolbarSpy).toHaveBeenCalled();
@@ -805,7 +805,7 @@ describe('CompareV2', () => {
     await waitForRunCheckboxes(3);
 
     fireEvent.click(getRunRow(MOCK_RUN_2_ID));
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitForRunCheckboxes(2);
 
     refreshedRunIds.add(MOCK_RUN_3_ID);
@@ -814,7 +814,7 @@ describe('CompareV2', () => {
     await act(async () => {
       await refreshAction();
     });
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(1);
     expect(getRunRow(MOCK_RUN_1_ID)).toHaveAttribute('aria-checked', 'true');
@@ -833,11 +833,11 @@ describe('CompareV2', () => {
         <CompareV2 {...generateProps()} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(3);
     fireEvent.click(getRunRow(MOCK_RUN_2_ID));
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitForRunCheckboxes(2);
 
     const nextProps = generateProps();
@@ -847,7 +847,7 @@ describe('CompareV2', () => {
         <CompareV2 {...nextProps} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitForRunCheckboxes(2);
     expect(getRunRow(MOCK_RUN_2_ID)).toHaveAttribute('aria-checked', 'true');
@@ -942,7 +942,7 @@ describe('CompareV2', () => {
       </CommonTestWrapper>,
     );
 
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitFor(() => {
       const lastCall = getHtmlViewerConfigSpy.mock.lastCall;
       expect(lastCall?.[0]?.[0]?.artifact.getId()).toBe(updatedArtifact.getId());


### PR DESCRIPTION
## Summary

- Use the existing `flushPromisesInAct()` helper for non-error-path promise flushing in `CompareV2.test.tsx`
- Remove the full file's React `act(...)` warning output while keeping behavior assertions unchanged
- Keep `expectErrors()` cases on raw `TestUtils.flushPromises()` because wrapping those changed the console-error assertion behavior those tests intentionally verify

## Why this helps

Several CompareV2 tests render the page or trigger a route/selection refresh, then flush queued promises before asserting the resulting UI state. Raw `TestUtils.flushPromises()` lets promise-driven React updates apply outside an `act` boundary, which produced `act(...)` warnings from `CompareV2`, `RunList`, `CustomTable`, and MUI internals.

`flushPromisesInAct()` already exists in `TestUtils.ts` for this exact pattern: it flushes queued promises inside Testing Library's `act`, so React applies the resulting state updates before the test continues. This makes the test harness more deterministic and removes warning noise without changing application behavior.

This PR converts all safe `CompareV2.test.tsx` queued-promise flushes to the act-aware helper. The error-path tests that call `expectErrors()` intentionally observe React's console error behavior, so those remain on the raw flush to preserve the assertions being tested.

## Verification

- `npm run test:ui -- CompareV2.test.tsx -t "All runs are initially selected"`
  - before: passed with 4 `act(...)` warnings
  - after: passed with 0 `act(...)` warnings
- `npm run test:ui -- CompareV2.test.tsx`
  - passed with 0 `act(...)` warnings
- `npm run lint:ui`
- `npm run typecheck`
- `git diff --check`

Part of #13349.

/area frontend
/kind cleanup
