### PR TITLE
test(frontend): flush CompareV1 setup in act

### DIFF
--- a/frontend/src/pages/CompareV1.test.tsx
+++ b/frontend/src/pages/CompareV1.test.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import EnhancedCompareV1, { TEST_ONLY, TaggedViewerConfig } from './CompareV1';
-import TestUtils from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct } from 'src/TestUtils';
 import * as Utils from 'src/lib/Utils';
 import { logger } from 'src/lib/Utils';
 import { Apis } from 'src/lib/Apis';
@@ -122,7 +122,7 @@ describe('CompareV1', () => {
         <TestCompare ref={compareRef} {...propsToUse} />
       </MemoryRouter>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     return propsToUse;
   }
 
@@ -696,7 +696,7 @@ describe('CompareV1', () => {
   });
 
   describe('EnhancedCompareV1', () => {
-    it('redirects to experiments page when namespace changes', () => {
+    it('redirects to experiments page when namespace changes', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/does-not-matter'],
       });
@@ -707,6 +707,7 @@ describe('CompareV1', () => {
           </NamespaceContext.Provider>
         </Router>,
       );
+      await flushPromisesInAct();
       expect(history.location.pathname).not.toEqual('/experiments');
       rerender(
         <Router history={history}>
@@ -715,10 +716,11 @@ describe('CompareV1', () => {
           </NamespaceContext.Provider>
         </Router>,
       );
+      await flushPromisesInAct();
       expect(history.location.pathname).toEqual('/experiments');
     });
 
-    it('does not redirect when namespace stays the same', () => {
+    it('does not redirect when namespace stays the same', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/initial-path'],
       });
@@ -729,6 +731,7 @@ describe('CompareV1', () => {
           </NamespaceContext.Provider>
         </Router>,
       );
+      await flushPromisesInAct();
       expect(history.location.pathname).toEqual('/initial-path');
       rerender(
         <Router history={history}>
@@ -737,10 +740,11 @@ describe('CompareV1', () => {
           </NamespaceContext.Provider>
         </Router>,
       );
+      await flushPromisesInAct();
       expect(history.location.pathname).toEqual('/initial-path');
     });
 
-    it('does not redirect when namespace initializes', () => {
+    it('does not redirect when namespace initializes', async () => {
       const history = createMemoryHistory({
         initialEntries: ['/initial-path'],
       });
@@ -751,6 +755,7 @@ describe('CompareV1', () => {
           </NamespaceContext.Provider>
         </Router>,
       );
+      await flushPromisesInAct();
       expect(history.location.pathname).toEqual('/initial-path');
       rerender(
         <Router history={history}>
@@ -759,6 +764,7 @@ describe('CompareV1', () => {
           </NamespaceContext.Provider>
         </Router>,
       );
+      await flushPromisesInAct();
       expect(history.location.pathname).toEqual('/initial-path');
     });
   });


### PR DESCRIPTION
## Summary

- Use the existing `flushPromisesInAct()` helper in `CompareV1.test.tsx` for the shared `renderCompare()` helper
- Flush direct `EnhancedCompareV1` wrapper renders/rerenders through the same helper
- Remove the full file's React `act(...)` warning output without changing application code or behavior assertions

## Why this helps

Most CompareV1 tests mount `CompareV1`, whose `componentDidMount()` starts async loading and then applies several state updates for runs, parameters, metrics, and viewer maps. The previous raw `TestUtils.flushPromises()` in the shared render helper let those promise-driven React updates apply outside an `act` boundary, producing heavy warning noise across the file.

`flushPromisesInAct()` already exists in `TestUtils.ts` for this pattern: it flushes queued promises inside Testing Library's `act`, so React applies the resulting state updates before the test continues. The `EnhancedCompareV1` wrapper tests bypass `renderCompare()`, so they now explicitly flush after direct render/rerender calls as well.

This is test harness synchronization only; no product behavior changes.

## Verification

- `npm run test:ui -- CompareV1.test.tsx`
  - before: passed with 1,388 `act(...)` warnings
  - after: passed with 0 `act(...)` warnings
- `npm run lint:ui`
- `npm run typecheck`
- `git diff --check`

Part of #13349.

/area frontend
/kind cleanup
