### PR TITLE
test(frontend): flush RunList setup in act

### DIFF
--- a/frontend/src/pages/RunList.test.tsx
+++ b/frontend/src/pages/RunList.test.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import * as Utils from 'src/lib/Utils';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import RunList, { RunListProps } from './RunList';
-import TestUtils from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct } from 'src/TestUtils';
 import produce from 'immer';
 import { V2beta1Filter, V2beta1PredicateOperation } from 'src/apisv2beta1/filter';
 import { V2beta1Run, V2beta1RunStorageState, V2beta1RuntimeState } from 'src/apisv2beta1/run';
@@ -75,28 +75,28 @@ describe('RunList', () => {
         <RunListTest ref={runListRef} {...(props || generateProps())} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
   }
 
   async function waitForRunListLoad(): Promise<void> {
     await waitFor(() => {
       expect(listRunsSpy).toHaveBeenCalled();
     });
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
   }
 
   async function waitForRunMaskLoadForIds(runIds: string[]): Promise<void> {
     await waitFor(() => {
       runIds.forEach((id) => expect(getRunSpy).toHaveBeenCalledWith(id));
     });
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
   }
 
   async function callLoadRuns(request: ListRequest): Promise<void> {
     await act(async () => {
       await getRunListInstance()._loadRuns(request);
     });
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
   }
 
   function mockNRuns(n: number, runTemplate: Partial<V2beta1Run>): void {


### PR DESCRIPTION
## Summary

Wrap the shared async flush helpers in `RunList.test.tsx` with `flushPromisesInAct()`.

The test file waits for promise-driven RunList state updates after rendering, list loading, run-mask loading, and direct `_loadRuns()` calls. Using the existing helper keeps those queued React updates inside Testing Library's `act()` boundary, removing React 19 warning noise without changing the assertions under test.

Part of #13349.

## Verification

- `npm run test:ui -- src/pages/RunList.test.tsx` before: 30 tests passed with 507 `act(...)` warning lines
- `npm run test:ui -- src/pages/RunList.test.tsx` after: 30 tests passed with zero `act(...)` warning lines
- `npm run lint:ui`
- `npm run typecheck`
- `git diff --check`
