### PR TITLE
test(frontend): flush MetricsDropdown setup in act

### DIFF
--- a/frontend/src/components/viewers/MetricsDropdown.test.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.test.tsx
@@ -16,7 +16,7 @@
 
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { CommonTestWrapper } from 'src/TestWrapper';
-import TestUtils, { testBestPractices } from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct, testBestPractices } from 'src/TestUtils';
 import { Artifact, Event, Execution, Value } from 'src/third_party/mlmd';
 import * as metricsVisualizations from 'src/components/viewers/MetricsVisualizations';
 import * as Utils from 'src/lib/Utils';
@@ -156,7 +156,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('There are no Confusion Matrix artifacts available on the selected runs.');
   });
 
@@ -169,7 +169,7 @@ describe('MetricsDropdown', () => {
         updateSelectedArtifacts={updateSelectedArtifactsSpy}
       />,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('There are no HTML artifacts available on the selected runs.');
   });
 
@@ -184,7 +184,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('There are no Markdown artifacts available on the selected runs.');
   });
 
@@ -199,7 +199,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     screen.getByText('Choose a first Confusion Matrix artifact');
   });
 
@@ -230,7 +230,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     await waitFor(() => {
       expect(warnSpy).toHaveBeenLastCalledWith(
@@ -254,7 +254,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     fireEvent.click(screen.getByText('Choose a first Confusion Matrix artifact'));
     fireEvent.mouseEnter(screen.getByText('run1'));
@@ -293,7 +293,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     // Choose the first HTML element.
     fireEvent.click(screen.getByText('Choose a first HTML artifact'));
@@ -338,7 +338,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     // Choose the first Markdown element.
     fireEvent.click(screen.getByText('Choose a first Markdown artifact'));
@@ -387,7 +387,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     fireEvent.click(screen.getByText('Choose a first HTML artifact'));
     fireEvent.mouseEnter(screen.getByText('run1'));
@@ -431,7 +431,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     screen.getByText('Choose a first Confusion Matrix artifact');
     screen.getByLabelText('run1 > execution1 > artifact1');
@@ -448,7 +448,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     const nextSelectedArtifacts: SelectedArtifact[] = [
       {
@@ -517,7 +517,7 @@ describe('MetricsDropdown', () => {
         />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitFor(() => {
       expect(getHtmlViewerConfigSpy).toHaveBeenLastCalledWith([staleLinkedArtifact], undefined);
     });


### PR DESCRIPTION
## Summary

Replace the raw setup promise flushes in `MetricsDropdown.test.tsx` with `flushPromisesInAct()`.

The file uses promise drains after rendering MetricsDropdown test fixtures before asserting on dropdown content or driving selections. Using the existing act-aware helper keeps those React updates inside the test boundary and removes the remaining focused warning.

Part of #13349.

## Verification

- `npm run test:ui -- src/components/viewers/MetricsDropdown.test.tsx` before: 12 tests passed with 1 `act(...)` warning line
- `npm run test:ui -- src/components/viewers/MetricsDropdown.test.tsx` after: 12 tests passed with zero `act(...)` warning lines
- `npm run lint:ui`
- `npm run typecheck`
- `git diff --check`
