### PR TITLE
test(frontend): flush small pipeline tests in act

### DIFF
--- a/frontend/src/components/PipelinesDialog.test.tsx
+++ b/frontend/src/components/PipelinesDialog.test.tsx
@@ -20,7 +20,7 @@ import PipelinesDialog, { PipelinesDialogProps } from './PipelinesDialog';
 import { PageProps } from '../pages/Page';
 import { Apis, PipelineSortKeys } from '../lib/Apis';
 import { ApiListPipelinesResponse, ApiPipeline } from '../apis/pipeline';
-import TestUtils from '../TestUtils';
+import { flushPromisesInAct } from '../TestUtils';
 import { BuildInfoContext } from '../lib/BuildInfo';
 import { NameWithTooltip } from './CustomTableNameColumn';
 
@@ -98,7 +98,7 @@ describe('PipelinesDialog', () => {
         <PipelinesDialog {...generateProps()} />
       </BuildInfoContext.Provider>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(tree).toMatchSnapshot();
   });
 
@@ -108,7 +108,7 @@ describe('PipelinesDialog', () => {
         <PipelinesDialog {...generateProps()} />
       </BuildInfoContext.Provider>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(tree).toMatchSnapshot();
   });
 });

--- a/frontend/src/components/PipelinesDialogV2.test.tsx
+++ b/frontend/src/components/PipelinesDialogV2.test.tsx
@@ -20,7 +20,7 @@ import PipelinesDialogV2, { PipelinesDialogV2Props } from './PipelinesDialogV2';
 import { PageProps } from 'src/pages/Page';
 import { Apis, PipelineSortKeys } from 'src/lib/Apis';
 import { V2beta1Pipeline, V2beta1ListPipelinesResponse } from 'src/apisv2beta1/pipeline';
-import TestUtils from 'src/TestUtils';
+import { flushPromisesInAct } from 'src/TestUtils';
 import { BuildInfoContext } from 'src/lib/BuildInfo';
 import { NameWithTooltip } from 'src/components/CustomTableNameColumn';
 
@@ -95,7 +95,7 @@ describe('PipelinesDialog', () => {
         <PipelinesDialogV2 {...generateProps()} />
       </BuildInfoContext.Provider>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     expect(listPipelineSpy).toHaveBeenCalledWith('ns', '', 10, 'created_at desc', '');
     // Verify the display names are shown instead of the names
@@ -109,7 +109,7 @@ describe('PipelinesDialog', () => {
         <PipelinesDialogV2 {...generateProps()} />
       </BuildInfoContext.Provider>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     expect(listPipelineSpy).toHaveBeenCalledWith(undefined, '', 10, 'created_at desc', '');
     // Verify the display names are shown instead of the names

--- a/frontend/src/pages/GettingStarted.test.tsx
+++ b/frontend/src/pages/GettingStarted.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import TestUtils from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct } from 'src/TestUtils';
 import { Apis } from 'src/lib/Apis';
 import { V2beta1ListPipelinesResponse } from 'src/apisv2beta1/pipeline';
 import { GettingStarted } from './GettingStarted';
@@ -63,9 +63,10 @@ describe('GettingStarted page', () => {
     pipelineListSpy.mockImplementation(() => Promise.resolve(empty));
   });
 
-  it('initially renders documentation', () => {
+  it('initially renders documentation', async () => {
     const { container } = render(<GettingStarted {...generateProps()} />);
     expect(container).toMatchSnapshot();
+    await flushPromisesInAct();
   });
 
   it('renders documentation with pipeline deep link after querying demo pipelines', async () => {
@@ -86,7 +87,7 @@ describe('GettingStarted page', () => {
       return Promise.resolve({ pipelines: [], total_size: 0 });
     });
     render(<GettingStarted {...generateProps()} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(pipelineListSpy.mock.calls).toMatchSnapshot();
     expect(screen.getByRole('link', { name: 'Data passing in Python components' })).toHaveAttribute(
       'href',
@@ -113,7 +114,7 @@ describe('GettingStarted page', () => {
       return Promise.resolve({ pipelines: [], total_size: 0 });
     });
     render(<GettingStarted {...generateProps()} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(screen.getByRole('link', { name: 'Data passing in Python components' })).toHaveAttribute(
       'href',
       '#/pipelines',

--- a/frontend/src/pages/PrivateAndSharedPipelines.test.tsx
+++ b/frontend/src/pages/PrivateAndSharedPipelines.test.tsx
@@ -19,7 +19,7 @@ import { createMemoryHistory } from 'history';
 import { PageProps } from './Page';
 import { Apis } from 'src/lib/Apis';
 import { V2beta1Pipeline, V2beta1ListPipelinesResponse } from 'src/apisv2beta1/pipeline';
-import TestUtils from 'src/TestUtils';
+import { flushPromisesInAct } from 'src/TestUtils';
 import { BuildInfoContext } from 'src/lib/BuildInfo';
 import PrivateAndSharedPipelines, {
   PrivateAndSharedProps,
@@ -93,7 +93,7 @@ describe('PrivateAndSharedPipelines', () => {
         </BuildInfoContext.Provider>
       </Router>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(tree).toMatchSnapshot();
   });
 
@@ -107,7 +107,7 @@ describe('PrivateAndSharedPipelines', () => {
         </BuildInfoContext.Provider>
       </Router>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(tree).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

Wrap render follow-up promise drains in a small group of pipeline-focused tests with `flushPromisesInAct()`.

This covers:

- `PrivateAndSharedPipelines.test.tsx`
- `GettingStarted.test.tsx`
- `PipelinesDialog.test.tsx`
- `PipelinesDialogV2.test.tsx`

Most changes are direct replacements of raw `TestUtils.flushPromises()` calls after render. `GettingStarted` also drains queued async work after its initial snapshot assertion so the snapshot still captures the initial documentation render while the test no longer leaves pending React updates behind.

Part of #13349.

## Verification

- `npm run test:ui -- src/pages/PrivateAndSharedPipelines.test.tsx src/pages/GettingStarted.test.tsx src/components/PipelinesDialog.test.tsx src/components/PipelinesDialogV2.test.tsx` before: 9 tests passed with 160 `act(...)` warning lines
- `npm run test:ui -- src/pages/PrivateAndSharedPipelines.test.tsx src/pages/GettingStarted.test.tsx src/components/PipelinesDialog.test.tsx src/components/PipelinesDialogV2.test.tsx` after: 9 tests passed with zero `act(...)` warning lines
- `npm run lint:ui`
- `npm run typecheck`
- `git diff --check`
