### PR TITLE
fix(frontend): block proxy middleware SSRF to internal/private targets

### DIFF
--- a/frontend/server/proxy-middleware.test.ts
+++ b/frontend/server/proxy-middleware.test.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { describe, it, expect } from 'vitest';
+import express from 'express';
+import requests from 'supertest';
 import {
   _isBlockedTarget,
   _extractUrlFromReferer,
@@ -19,6 +21,7 @@ import {
   _routePathWithReferer,
   _rewritePath,
 } from './proxy-middleware.js';
+import proxyMiddleware from './proxy-middleware.js';
 
 describe('_isBlockedTarget', () => {
   describe('cloud metadata endpoints', () => {
@@ -58,6 +61,11 @@ describe('_isBlockedTarget', () => {
 
     it('blocks LOCALHOST (case-insensitive)', () => {
       expect(_isBlockedTarget('LOCALHOST')).toBe(true);
+    });
+
+    it('blocks *.localhost subdomains (RFC 6761)', () => {
+      expect(_isBlockedTarget('anything.localhost')).toBe(true);
+      expect(_isBlockedTarget('foo.bar.localhost')).toBe(true);
     });
 
     it('blocks IPv6 loopback ::1', () => {
@@ -105,7 +113,7 @@ describe('_isBlockedTarget', () => {
     });
   });
 
-  describe('IPv4-mapped IPv6', () => {
+  describe('IPv4-mapped IPv6 (dotted-decimal form)', () => {
     it('blocks ::ffff:127.0.0.1', () => {
       expect(_isBlockedTarget('::ffff:127.0.0.1')).toBe(true);
     });
@@ -116,6 +124,52 @@ describe('_isBlockedTarget', () => {
 
     it('blocks ::ffff:192.168.1.1', () => {
       expect(_isBlockedTarget('::ffff:192.168.1.1')).toBe(true);
+    });
+
+    it('blocks ::ffff:169.254.169.254 (cloud metadata)', () => {
+      expect(_isBlockedTarget('::ffff:169.254.169.254')).toBe(true);
+    });
+
+    it('blocks ::ffff:0.0.0.1', () => {
+      expect(_isBlockedTarget('::ffff:0.0.0.1')).toBe(true);
+    });
+  });
+
+  describe('IPv4-mapped IPv6 (hex form, as normalised by Node.js URL parser)', () => {
+    it('blocks ::ffff:7f00:1 (127.0.0.1 in hex)', () => {
+      expect(_isBlockedTarget('::ffff:7f00:1')).toBe(true);
+    });
+
+    it('blocks the hostname from new URL("http://[::ffff:127.0.0.1]")', () => {
+      const hostname = new URL('http://[::ffff:127.0.0.1]').hostname;
+      expect(_isBlockedTarget(hostname)).toBe(true);
+    });
+
+    it('blocks the hostname from new URL("http://[::ffff:10.0.0.1]")', () => {
+      const hostname = new URL('http://[::ffff:10.0.0.1]').hostname;
+      expect(_isBlockedTarget(hostname)).toBe(true);
+    });
+
+    it('blocks the hostname from new URL("http://[::ffff:192.168.1.1]")', () => {
+      const hostname = new URL('http://[::ffff:192.168.1.1]').hostname;
+      expect(_isBlockedTarget(hostname)).toBe(true);
+    });
+
+    it('blocks the hostname from new URL("http://[::ffff:169.254.169.254]")', () => {
+      const hostname = new URL('http://[::ffff:169.254.169.254]').hostname;
+      expect(_isBlockedTarget(hostname)).toBe(true);
+    });
+
+    it('blocks ::ffff:a00:1 (10.0.0.1 in hex)', () => {
+      expect(_isBlockedTarget('::ffff:a00:1')).toBe(true);
+    });
+
+    it('blocks ::ffff:c0a8:101 (192.168.1.1 in hex)', () => {
+      expect(_isBlockedTarget('::ffff:c0a8:101')).toBe(true);
+    });
+
+    it('does not block ::ffff: with public IP in hex (8.8.8.8 = 808:808)', () => {
+      expect(_isBlockedTarget('::ffff:808:808')).toBe(false);
     });
   });
 
@@ -182,6 +236,52 @@ describe('_routePathWithReferer', () => {
 
   it('prepends http:// when scheme is missing', () => {
     expect(_routePathWithReferer(prefix, prefix + 'example.com%2Fpath')).toBe('http://example.com');
+  });
+});
+
+describe('proxy middleware integration', () => {
+  const apisPrefix = '/apis/v1beta1';
+  const proxyPrefix = apisPrefix + '/_proxy/';
+
+  function createApp(): express.Application {
+    const app = express();
+    proxyMiddleware(app, apisPrefix);
+    return app;
+  }
+
+  it('returns 403 for requests targeting cloud metadata IP', async () => {
+    const app = createApp();
+    await requests(app)
+      .get(proxyPrefix + encodeURIComponent('http://169.254.169.254/latest/meta-data/'))
+      .expect(403, 'Proxy target is not allowed.');
+  });
+
+  it('returns 403 for requests targeting localhost', async () => {
+    const app = createApp();
+    await requests(app)
+      .get(proxyPrefix + encodeURIComponent('http://localhost:8080/secret'))
+      .expect(403, 'Proxy target is not allowed.');
+  });
+
+  it('returns 403 for requests targeting private IP 10.0.0.1', async () => {
+    const app = createApp();
+    await requests(app)
+      .get(proxyPrefix + encodeURIComponent('http://10.0.0.1:8080/'))
+      .expect(403, 'Proxy target is not allowed.');
+  });
+
+  it('returns 403 for IPv4-mapped IPv6 targeting loopback', async () => {
+    const app = createApp();
+    await requests(app)
+      .get(proxyPrefix + encodeURIComponent('http://[::ffff:127.0.0.1]:8080/'))
+      .expect(403, 'Proxy target is not allowed.');
+  });
+
+  it('returns 400 for unparseable proxy target URL', async () => {
+    const app = createApp();
+    await requests(app)
+      .get(proxyPrefix + '://:::invalid')
+      .expect(400, 'Invalid proxy target URL.');
   });
 });
 

--- a/frontend/server/proxy-middleware.test.ts
+++ b/frontend/server/proxy-middleware.test.ts
@@ -1,0 +1,204 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { describe, it, expect } from 'vitest';
+import {
+  _isBlockedTarget,
+  _extractUrlFromReferer,
+  _trimProxyPrefix,
+  _routePathWithReferer,
+  _rewritePath,
+} from './proxy-middleware.js';
+
+describe('_isBlockedTarget', () => {
+  describe('cloud metadata endpoints', () => {
+    it('blocks AWS/GCP/Azure metadata IP', () => {
+      expect(_isBlockedTarget('169.254.169.254')).toBe(true);
+    });
+
+    it('blocks GCP metadata hostname', () => {
+      expect(_isBlockedTarget('metadata.google.internal')).toBe(true);
+    });
+
+    it('blocks GCP metadata.goog hostname', () => {
+      expect(_isBlockedTarget('metadata.goog')).toBe(true);
+    });
+
+    it('blocks Alibaba Cloud metadata IP', () => {
+      expect(_isBlockedTarget('100.100.100.200')).toBe(true);
+    });
+
+    it('is case-insensitive for metadata hostnames', () => {
+      expect(_isBlockedTarget('Metadata.Google.Internal')).toBe(true);
+    });
+  });
+
+  describe('loopback addresses', () => {
+    it('blocks 127.0.0.1', () => {
+      expect(_isBlockedTarget('127.0.0.1')).toBe(true);
+    });
+
+    it('blocks any 127.x.x.x address', () => {
+      expect(_isBlockedTarget('127.255.0.1')).toBe(true);
+    });
+
+    it('blocks localhost', () => {
+      expect(_isBlockedTarget('localhost')).toBe(true);
+    });
+
+    it('blocks LOCALHOST (case-insensitive)', () => {
+      expect(_isBlockedTarget('LOCALHOST')).toBe(true);
+    });
+
+    it('blocks IPv6 loopback ::1', () => {
+      expect(_isBlockedTarget('::1')).toBe(true);
+    });
+
+    it('blocks bracketed IPv6 loopback [::1]', () => {
+      expect(_isBlockedTarget('[::1]')).toBe(true);
+    });
+  });
+
+  describe('private network ranges', () => {
+    it('blocks 10.0.0.0/8', () => {
+      expect(_isBlockedTarget('10.0.0.1')).toBe(true);
+      expect(_isBlockedTarget('10.255.255.255')).toBe(true);
+    });
+
+    it('blocks 172.16.0.0/12', () => {
+      expect(_isBlockedTarget('172.16.0.1')).toBe(true);
+      expect(_isBlockedTarget('172.31.255.255')).toBe(true);
+    });
+
+    it('does not block 172.15.x.x or 172.32.x.x', () => {
+      expect(_isBlockedTarget('172.15.0.1')).toBe(false);
+      expect(_isBlockedTarget('172.32.0.1')).toBe(false);
+    });
+
+    it('blocks 192.168.0.0/16', () => {
+      expect(_isBlockedTarget('192.168.0.1')).toBe(true);
+      expect(_isBlockedTarget('192.168.255.255')).toBe(true);
+    });
+
+    it('blocks 0.0.0.0/8', () => {
+      expect(_isBlockedTarget('0.0.0.0')).toBe(true);
+    });
+  });
+
+  describe('link-local addresses', () => {
+    it('blocks 169.254.x.x', () => {
+      expect(_isBlockedTarget('169.254.0.1')).toBe(true);
+    });
+
+    it('blocks IPv6 link-local fe80::', () => {
+      expect(_isBlockedTarget('fe80::1')).toBe(true);
+    });
+  });
+
+  describe('IPv4-mapped IPv6', () => {
+    it('blocks ::ffff:127.0.0.1', () => {
+      expect(_isBlockedTarget('::ffff:127.0.0.1')).toBe(true);
+    });
+
+    it('blocks ::ffff:10.0.0.1', () => {
+      expect(_isBlockedTarget('::ffff:10.0.0.1')).toBe(true);
+    });
+
+    it('blocks ::ffff:192.168.1.1', () => {
+      expect(_isBlockedTarget('::ffff:192.168.1.1')).toBe(true);
+    });
+  });
+
+  describe('allowed targets', () => {
+    it('allows public IPs', () => {
+      expect(_isBlockedTarget('8.8.8.8')).toBe(false);
+      expect(_isBlockedTarget('203.0.113.1')).toBe(false);
+    });
+
+    it('allows public hostnames', () => {
+      expect(_isBlockedTarget('example.com')).toBe(false);
+      expect(_isBlockedTarget('tensorboard.my-org.com')).toBe(false);
+    });
+
+    it('allows Kubernetes service hostnames', () => {
+      expect(_isBlockedTarget('my-service.my-namespace.svc.cluster.local')).toBe(false);
+    });
+  });
+});
+
+describe('_extractUrlFromReferer', () => {
+  const prefix = '/apis/v1beta1/_proxy/';
+
+  it('extracts URL from referer containing proxy prefix', () => {
+    expect(
+      _extractUrlFromReferer(
+        prefix,
+        'http://localhost:3000/apis/v1beta1/_proxy/http%3A%2F%2Fexample.com',
+      ),
+    ).toBe('http%3A%2F%2Fexample.com');
+  });
+
+  it('returns empty string when referer does not contain prefix', () => {
+    expect(_extractUrlFromReferer(prefix, 'http://localhost:3000/other')).toBe('');
+  });
+
+  it('returns empty string for undefined referer', () => {
+    expect(_extractUrlFromReferer(prefix)).toBe('');
+  });
+});
+
+describe('_trimProxyPrefix', () => {
+  const prefix = '/apis/v1beta1/_proxy/';
+
+  it('trims prefix when path starts with it', () => {
+    expect(_trimProxyPrefix(prefix, '/apis/v1beta1/_proxy/http://example.com')).toBe(
+      'http://example.com',
+    );
+  });
+
+  it('returns path unchanged when prefix is absent', () => {
+    expect(_trimProxyPrefix(prefix, '/other/path')).toBe('/other/path');
+  });
+});
+
+describe('_routePathWithReferer', () => {
+  const prefix = '/apis/v1beta1/_proxy/';
+
+  it('extracts origin from path', () => {
+    expect(_routePathWithReferer(prefix, prefix + 'http%3A%2F%2Fexample.com%2Fpath')).toBe(
+      'http://example.com',
+    );
+  });
+
+  it('prepends http:// when scheme is missing', () => {
+    expect(_routePathWithReferer(prefix, prefix + 'example.com%2Fpath')).toBe('http://example.com');
+  });
+});
+
+describe('_rewritePath', () => {
+  const prefix = '/apis/v1beta1/_proxy/';
+
+  it('trims proxy prefix from path', () => {
+    expect(_rewritePath(prefix, prefix + 'http%3A%2F%2Fexample.com/path', '')).toBe(
+      'http://example.com/path',
+    );
+  });
+
+  it('appends query string when present', () => {
+    expect(_rewritePath(prefix, '/some/path', 'key=value')).toBe('/some/path?key=value');
+  });
+
+  it('returns path without query string when query is empty', () => {
+    expect(_rewritePath(prefix, '/some/path', '')).toBe('/some/path');
+  });
+});

--- a/frontend/server/proxy-middleware.test.ts
+++ b/frontend/server/proxy-middleware.test.ts
@@ -44,6 +44,11 @@ describe('_isBlockedTarget', () => {
     it('is case-insensitive for metadata hostnames', () => {
       expect(_isBlockedTarget('Metadata.Google.Internal')).toBe(true);
     });
+
+    it('blocks trailing-dot FQDN forms of metadata hostnames', () => {
+      expect(_isBlockedTarget('metadata.google.internal.')).toBe(true);
+      expect(_isBlockedTarget('metadata.goog.')).toBe(true);
+    });
   });
 
   describe('loopback addresses', () => {
@@ -66,6 +71,11 @@ describe('_isBlockedTarget', () => {
     it('blocks *.localhost subdomains (RFC 6761)', () => {
       expect(_isBlockedTarget('anything.localhost')).toBe(true);
       expect(_isBlockedTarget('foo.bar.localhost')).toBe(true);
+    });
+
+    it('blocks trailing-dot FQDN forms of localhost', () => {
+      expect(_isBlockedTarget('localhost.')).toBe(true);
+      expect(_isBlockedTarget('foo.localhost.')).toBe(true);
     });
 
     it('blocks IPv6 loopback ::1', () => {
@@ -110,6 +120,15 @@ describe('_isBlockedTarget', () => {
 
     it('blocks IPv6 link-local fe80::', () => {
       expect(_isBlockedTarget('fe80::1')).toBe(true);
+    });
+
+    it('blocks IPv6 Unique Local Addresses (fc00::/7)', () => {
+      expect(_isBlockedTarget('fc00::1')).toBe(true);
+      expect(_isBlockedTarget('fd12:3456:789a::1')).toBe(true);
+    });
+
+    it('blocks IPv6 unspecified address ::', () => {
+      expect(_isBlockedTarget('::')).toBe(true);
     });
   });
 

--- a/frontend/server/proxy-middleware.ts
+++ b/frontend/server/proxy-middleware.ts
@@ -17,6 +17,60 @@ import { createProxyMiddleware } from 'http-proxy-middleware';
 import { URL, URLSearchParams } from 'url';
 import { HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS } from './consts.js';
 
+/**
+ * Returns true when the hostname resolves to a private, loopback, or
+ * link-local IP address, or when the hostname matches a known cloud
+ * metadata endpoint. These destinations must never be reachable through
+ * the proxy.
+ */
+export function _isBlockedTarget(hostname: string): boolean {
+  // Cloud metadata endpoints (AWS, GCP, Azure, DigitalOcean, Oracle, Alibaba)
+  const blockedHosts = [
+    '169.254.169.254',
+    'metadata.google.internal',
+    'metadata.goog',
+    '100.100.100.200',
+  ];
+  if (blockedHosts.includes(hostname.toLowerCase())) {
+    return true;
+  }
+
+  // Block raw IPv4 loopback and private ranges
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
+    const parts = hostname.split('.').map(Number);
+    const [a, b] = parts;
+    if (
+      a === 127 || // 127.0.0.0/8 loopback
+      a === 10 || // 10.0.0.0/8
+      (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
+      (a === 192 && b === 168) || // 192.168.0.0/16
+      (a === 169 && b === 254) || // 169.254.0.0/16 link-local
+      a === 0 // 0.0.0.0/8
+    ) {
+      return true;
+    }
+  }
+
+  // Block IPv6 loopback and link-local (covers [::1], [fe80::...], etc.)
+  if (hostname === '::1' || hostname === '[::1]') {
+    return true;
+  }
+  const bare = hostname.replace(/^\[|\]$/g, '');
+  if (
+    /^fe80:/i.test(bare) ||
+    /^::ffff:(127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/i.test(bare)
+  ) {
+    return true;
+  }
+
+  // Block localhost variants
+  if (/^localhost$/i.test(hostname)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function _extractUrlFromReferer(proxyPrefix: string, referer = ''): string {
   const index = referer.indexOf(proxyPrefix);
   return index > -1 ? referer.substr(index + proxyPrefix.length) : '';
@@ -63,6 +117,24 @@ export default (app: express.Application, apisPrefix: string) => {
         const proxiedOrigin = new URL(proxiedUrl).origin;
         req.url = proxyPrefix + encodeURIComponent(proxiedOrigin + req.url);
       }
+    }
+    next();
+  });
+
+  // Validate the proxy target before forwarding. Reject requests aimed at
+  // private networks, loopback addresses, or cloud metadata endpoints.
+  app.all(proxyPrefix + '*', (req, res, next) => {
+    try {
+      const target = _routePathWithReferer(proxyPrefix, req.path, req.headers.referer as string);
+      const targetUrl = new URL(target);
+      if (_isBlockedTarget(targetUrl.hostname)) {
+        console.warn(`Blocked proxy request to private/internal target: ${targetUrl.hostname}`);
+        res.status(403).send('Proxy target is not allowed.');
+        return;
+      }
+    } catch {
+      res.status(400).send('Invalid proxy target URL.');
+      return;
     }
     next();
   });

--- a/frontend/server/proxy-middleware.ts
+++ b/frontend/server/proxy-middleware.ts
@@ -17,36 +17,49 @@ import { createProxyMiddleware } from 'http-proxy-middleware';
 import { URL, URLSearchParams } from 'url';
 import { HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS } from './consts.js';
 
+// Cloud metadata endpoints (AWS, GCP, Azure, DigitalOcean, Oracle, Alibaba).
+const BLOCKED_HOSTS = new Set([
+  '169.254.169.254',
+  'metadata.google.internal',
+  'metadata.goog',
+  '100.100.100.200',
+]);
+
+/**
+ * Returns true when the IPv4 address (as four numeric octets) falls in a
+ * private, loopback, or link-local range.
+ */
+function _isPrivateIPv4(a: number, b: number): boolean {
+  return (
+    a === 127 || // 127.0.0.0/8  loopback
+    a === 10 || // 10.0.0.0/8   private
+    (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12 private
+    (a === 192 && b === 168) || // 192.168.0.0/16 private
+    (a === 169 && b === 254) || // 169.254.0.0/16 link-local
+    a === 0 // 0.0.0.0/8
+  );
+}
+
 /**
  * Returns true when the hostname resolves to a private, loopback, or
  * link-local IP address, or when the hostname matches a known cloud
  * metadata endpoint. These destinations must never be reachable through
  * the proxy.
+ *
+ * NOTE: This check is hostname-based and does not perform DNS resolution.
+ * Wildcard DNS services (e.g., 169.254.169.254.nip.io) or DNS rebinding
+ * attacks can bypass it. Defence in depth (network policies, egress
+ * firewalls) is recommended in addition to this check.
  */
 export function _isBlockedTarget(hostname: string): boolean {
-  // Cloud metadata endpoints (AWS, GCP, Azure, DigitalOcean, Oracle, Alibaba)
-  const blockedHosts = [
-    '169.254.169.254',
-    'metadata.google.internal',
-    'metadata.goog',
-    '100.100.100.200',
-  ];
-  if (blockedHosts.includes(hostname.toLowerCase())) {
+  if (BLOCKED_HOSTS.has(hostname.toLowerCase())) {
     return true;
   }
 
   // Block raw IPv4 loopback and private ranges
   if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
     const parts = hostname.split('.').map(Number);
-    const [a, b] = parts;
-    if (
-      a === 127 || // 127.0.0.0/8 loopback
-      a === 10 || // 10.0.0.0/8
-      (a === 172 && b >= 16 && b <= 31) || // 172.16.0.0/12
-      (a === 192 && b === 168) || // 192.168.0.0/16
-      (a === 169 && b === 254) || // 169.254.0.0/16 link-local
-      a === 0 // 0.0.0.0/8
-    ) {
+    if (_isPrivateIPv4(parts[0], parts[1])) {
       return true;
     }
   }
@@ -56,15 +69,28 @@ export function _isBlockedTarget(hostname: string): boolean {
     return true;
   }
   const bare = hostname.replace(/^\[|\]$/g, '');
-  if (
-    /^fe80:/i.test(bare) ||
-    /^::ffff:(127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.)/i.test(bare)
-  ) {
+  if (/^fe80:/i.test(bare)) {
     return true;
   }
 
-  // Block localhost variants
-  if (/^localhost$/i.test(hostname)) {
+  // IPv4-mapped IPv6 addresses: Node.js normalises ::ffff:127.0.0.1 to the
+  // hex form ::ffff:7f00:1, so we must handle both dotted-decimal and hex.
+  const mappedDotted = bare.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  if (mappedDotted) {
+    const parts = mappedDotted[1].split('.').map(Number);
+    return _isPrivateIPv4(parts[0], parts[1]);
+  }
+  const mappedHex = bare.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (mappedHex) {
+    const hi = parseInt(mappedHex[1], 16);
+    const lo = parseInt(mappedHex[2], 16);
+    const a = (hi >> 8) & 0xff;
+    const b = hi & 0xff;
+    return _isPrivateIPv4(a, b);
+  }
+
+  // Block localhost and *.localhost (RFC 6761)
+  if (/^localhost$/i.test(hostname) || /\.localhost$/i.test(hostname)) {
     return true;
   }
 

--- a/frontend/server/proxy-middleware.ts
+++ b/frontend/server/proxy-middleware.ts
@@ -90,7 +90,6 @@ export function _isBlockedTarget(hostname: string): boolean {
   const mappedHex = h.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
   if (mappedHex) {
     const hi = parseInt(mappedHex[1], 16);
-    const lo = parseInt(mappedHex[2], 16);
     const a = (hi >> 8) & 0xff;
     const b = hi & 0xff;
     return _isPrivateIPv4(a, b);

--- a/frontend/server/proxy-middleware.ts
+++ b/frontend/server/proxy-middleware.ts
@@ -52,35 +52,42 @@ function _isPrivateIPv4(a: number, b: number): boolean {
  * firewalls) is recommended in addition to this check.
  */
 export function _isBlockedTarget(hostname: string): boolean {
-  if (BLOCKED_HOSTS.has(hostname.toLowerCase())) {
+  // Normalise: strip brackets, lowercase, and remove a single trailing dot
+  // (FQDN form). Resolvers treat "localhost." the same as "localhost", so
+  // without this step an attacker can bypass every string check below.
+  let h = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  if (h.endsWith('.')) {
+    h = h.slice(0, -1);
+  }
+
+  if (BLOCKED_HOSTS.has(h)) {
     return true;
   }
 
   // Block raw IPv4 loopback and private ranges
-  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) {
-    const parts = hostname.split('.').map(Number);
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(h)) {
+    const parts = h.split('.').map(Number);
     if (_isPrivateIPv4(parts[0], parts[1])) {
       return true;
     }
   }
 
-  // Block IPv6 loopback and link-local (covers [::1], [fe80::...], etc.)
-  if (hostname === '::1' || hostname === '[::1]') {
+  // Block IPv6 loopback, link-local, and Unique Local Addresses (ULA)
+  if (h === '::1' || h === '' || h === '::') {
     return true;
   }
-  const bare = hostname.replace(/^\[|\]$/g, '');
-  if (/^fe80:/i.test(bare)) {
+  if (/^fe80:/i.test(h) || /^fc00:/i.test(h) || /^fd[0-9a-f]{2}:/i.test(h)) {
     return true;
   }
 
   // IPv4-mapped IPv6 addresses: Node.js normalises ::ffff:127.0.0.1 to the
   // hex form ::ffff:7f00:1, so we must handle both dotted-decimal and hex.
-  const mappedDotted = bare.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i);
+  const mappedDotted = h.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
   if (mappedDotted) {
     const parts = mappedDotted[1].split('.').map(Number);
     return _isPrivateIPv4(parts[0], parts[1]);
   }
-  const mappedHex = bare.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  const mappedHex = h.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
   if (mappedHex) {
     const hi = parseInt(mappedHex[1], 16);
     const lo = parseInt(mappedHex[2], 16);
@@ -90,7 +97,7 @@ export function _isBlockedTarget(hostname: string): boolean {
   }
 
   // Block localhost and *.localhost (RFC 6761)
-  if (/^localhost$/i.test(hostname) || /\.localhost$/i.test(hostname)) {
+  if (h === 'localhost' || h.endsWith('.localhost')) {
     return true;
   }
 


### PR DESCRIPTION
**Description of your changes:**

The `/_proxy/` endpoint in the frontend server forwards HTTP requests to arbitrary hosts derived from the URL path. There is no validation of the target URL, allowing any user who can reach the frontend to proxy requests to internal services, cloud metadata endpoints, or other pods in the cluster (Server-Side Request Forgery).

This PR adds a validation middleware that checks the resolved target hostname before forwarding. Requests aimed at private RFC1918 ranges, loopback addresses, link-local IPs, IPv4-mapped IPv6 variants, `*.localhost` subdomains, and cloud metadata endpoints are rejected with HTTP 403.

## Problem

A request to `/_proxy/http%3A%2F%2F169.254.169.254%2Flatest%2Fmeta-data%2F` causes the frontend server to issue a request to the AWS/GCP metadata service on behalf of the caller. Similarly, `/_proxy/http%3A%2F%2F10.0.0.1%3A3306%2F` can reach internal databases. IPv4-mapped IPv6 forms like `http://[::ffff:127.0.0.1]` bypass naive hostname checks because Node.js normalizes them to hex form (`::ffff:7f00:1`).

## Changes

| File | Change |
|------|--------|
| `frontend/server/proxy-middleware.ts` | Add `_isBlockedTarget()` with private IP, loopback, link-local, cloud metadata, and IPv4-mapped IPv6 (both dotted-decimal and hex) detection. Register Express middleware before `createProxyMiddleware` to validate targets. |
| `frontend/server/proxy-middleware.test.ts` | 50 tests covering unit tests for all blocked/allowed cases, URL-parsed hostname tests (verifying Node.js hex normalization is handled), and integration tests using `supertest`. |

## Related issues and PRs

**This project:**
- https://github.com/kubeflow/pipelines/issues/9889 - Security exploit in mlpipeline-UI (unauthorized cross-namespace artifact access via proxy)
- https://github.com/kubeflow/pipelines/pull/12860 - fix(frontend): Prevent Unauthorized Cross-Namespace Artifact Access
- https://github.com/kubeflow/pipelines/pull/13126 - fix(security): validate namespace in getArtifactServiceGetter to prevent SSRF (CVE-2023-6570)

**Similar SSRF vulnerabilities in other AI/ML projects:**
- [MLflow CVE-2025-52967 (GHSA-wxj7-3fx5-pp9m)](https://github.com/advisories/GHSA-wxj7-3fx5-pp9m) - SSRF in MLflow gateway_proxy_handler allowed proxying to arbitrary internal endpoints. Fixed by strict path allowlisting ([mlflow/mlflow#15970](https://github.com/mlflow/mlflow/pull/15970)).
- [OpenClaw GHSA-56f2-hvwg-5743](https://github.com/openclaw/openclaw/security/advisories/GHSA-56f2-hvwg-5743) - SSRF via image tool remote fetch, allowing requests to private IPs and cloud metadata. Fixed with centralized SSRF guard with private IP blocking and DNS pinning.

**Kubernetes ecosystem:**
- [CVE-2020-8555](https://github.com/advisories/GHSA-x6mj-w4jf-jmgw) - Half-blind SSRF in kube-controller-manager.

## Limitations

This check is hostname-based and does not perform DNS resolution. Wildcard DNS services (e.g., `169.254.169.254.nip.io`) or DNS rebinding attacks can bypass it. Defence in depth via network policies is recommended. This limitation is documented in a code comment.

## Testing

- 50 tests passing (unit + URL-parsed hostname + integration via supertest)
- Verified IPv4-mapped IPv6 hex normalization bypass is blocked
- Existing server tests unaffected

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).