### PR TITLE
Fix local proxy log and artifact reads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-06-14
+- Last updated: 2026-06-17
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -663,6 +663,8 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 - `VITE_NAMESPACE=...`: Sets the target namespace for the frontend in multi-user mode
 - `LOCAL_API_SERVER=true`: Enables local API server testing mode when running integration tests on a Kind cluster
 - `TENSORBOARD_PROXY_SIGNING_SECRET=...`: Optional shared frontend-server secret for scoped TensorBoard proxy URLs; defaults to `MINIO_SECRET_KEY` when unset
+- `FRONTEND_SERVER_NAMESPACE=...`: Sets the namespace used by the local frontend Node server for Kubernetes lookups when it is not running inside a cluster pod. `npm run start:proxy-and-server` derives this from `NAMESPACE`.
+- `MINIO_ENDPOINT_REWRITE=from=to[,from=to]`: Rewrites explicit object-store endpoints for local proxy mode, for example from `seaweedfs.kubeflow:9000` to `localhost:9000`.
 
 ## Troubleshooting and pitfalls
 

--- a/frontend/scripts/start-proxy-and-server.sh
+++ b/frontend/scripts/start-proxy-and-server.sh
@@ -37,6 +37,8 @@ kubectl port-forward -n $NAMESPACE svc/ml-pipeline 3002:8888 &
 kubectl port-forward -n $NAMESPACE svc/seaweedfs 9000:9000 &
 export MINIO_HOST=localhost
 export MINIO_NAMESPACE=
+export FRONTEND_SERVER_NAMESPACE="$NAMESPACE"
+export MINIO_ENDPOINT_REWRITE="seaweedfs.${NAMESPACE}:9000=localhost:9000,seaweedfs.${NAMESPACE}:80=localhost:9000,seaweedfs.${NAMESPACE}.svc:9000=localhost:9000,seaweedfs.${NAMESPACE}.svc:80=localhost:9000,seaweedfs.${NAMESPACE}.svc.cluster.local:9000=localhost:9000,seaweedfs.${NAMESPACE}.svc.cluster.local:80=localhost:9000"
 if [ "$1" == "--inspect" ]; then
   ML_PIPELINE_SERVICE_PORT=3002 npm run mock:server:inspect 3001
 else

--- a/frontend/server/k8s-helper.test.ts
+++ b/frontend/server/k8s-helper.test.ts
@@ -454,14 +454,78 @@ describe('k8s-helper', () => {
   describe('getArgoWorkflow', () => {
     // Note: getArgoWorkflow requires serverNamespace which is read from
     // /var/run/secrets/kubernetes.io/serviceaccount/namespace at module load time.
-    // In a non-cluster environment, this file doesn't exist so serverNamespace is undefined.
-    // These tests verify the namespace validation behavior and error handling.
+    // In local development, FRONTEND_SERVER_NAMESPACE can provide the same value.
+    // These tests verify the namespace validation and fallback behavior.
 
     it('throws error when serverNamespace is not available', async () => {
-      // This test verifies behavior when running outside a kubernetes cluster
-      await expect(getArgoWorkflow('test-workflow')).rejects.toThrow(
-        'Cannot get namespace from /var/run/secrets/kubernetes.io/serviceaccount/namespace',
-      );
+      const originalNamespace = process.env.FRONTEND_SERVER_NAMESPACE;
+      delete process.env.FRONTEND_SERVER_NAMESPACE;
+      try {
+        // This test verifies behavior when running outside a kubernetes cluster
+        await expect(getArgoWorkflow('test-workflow')).rejects.toThrow(
+          'Cannot get namespace from /var/run/secrets/kubernetes.io/serviceaccount/namespace',
+        );
+      } finally {
+        if (originalNamespace === undefined) {
+          delete process.env.FRONTEND_SERVER_NAMESPACE;
+        } else {
+          process.env.FRONTEND_SERVER_NAMESPACE = originalNamespace;
+        }
+      }
+    });
+
+    it('uses FRONTEND_SERVER_NAMESPACE when no namespace is provided', async () => {
+      const originalNamespace = process.env.FRONTEND_SERVER_NAMESPACE;
+      process.env.FRONTEND_SERVER_NAMESPACE = 'local-dev-namespace';
+      const getNamespacedCustomObjectSpy = vi
+        .spyOn(K8S_TEST_EXPORT.k8sV1CustomObjectClient, 'getNamespacedCustomObject')
+        .mockResolvedValue({ body: { metadata: { name: 'test-workflow' } } });
+
+      try {
+        await getArgoWorkflow('test-workflow');
+
+        expect(getNamespacedCustomObjectSpy).toHaveBeenCalledWith({
+          group: 'argoproj.io',
+          version: 'v1alpha1',
+          namespace: 'local-dev-namespace',
+          plural: 'workflows',
+          name: 'test-workflow',
+        });
+      } finally {
+        getNamespacedCustomObjectSpy.mockRestore();
+        if (originalNamespace === undefined) {
+          delete process.env.FRONTEND_SERVER_NAMESPACE;
+        } else {
+          process.env.FRONTEND_SERVER_NAMESPACE = originalNamespace;
+        }
+      }
+    });
+
+    it('uses the provided namespace before FRONTEND_SERVER_NAMESPACE', async () => {
+      const originalNamespace = process.env.FRONTEND_SERVER_NAMESPACE;
+      process.env.FRONTEND_SERVER_NAMESPACE = 'local-dev-namespace';
+      const getNamespacedCustomObjectSpy = vi
+        .spyOn(K8S_TEST_EXPORT.k8sV1CustomObjectClient, 'getNamespacedCustomObject')
+        .mockResolvedValue({ body: { metadata: { name: 'test-workflow' } } });
+
+      try {
+        await getArgoWorkflow('test-workflow', 'provided-namespace');
+
+        expect(getNamespacedCustomObjectSpy).toHaveBeenCalledWith({
+          group: 'argoproj.io',
+          version: 'v1alpha1',
+          namespace: 'provided-namespace',
+          plural: 'workflows',
+          name: 'test-workflow',
+        });
+      } finally {
+        getNamespacedCustomObjectSpy.mockRestore();
+        if (originalNamespace === undefined) {
+          delete process.env.FRONTEND_SERVER_NAMESPACE;
+        } else {
+          process.env.FRONTEND_SERVER_NAMESPACE = originalNamespace;
+        }
+      }
     });
   });
 

--- a/frontend/server/k8s-helper.ts
+++ b/frontend/server/k8s-helper.ts
@@ -48,13 +48,21 @@ export const defaultPodTemplateSpec = {
 
 // The file path contains pod namespace when in Kubernetes cluster.
 if (fs.existsSync(namespaceFilePath)) {
-  serverNamespace = fs.readFileSync(namespaceFilePath, 'utf-8');
+  serverNamespace = fs.readFileSync(namespaceFilePath, 'utf-8').trim();
 }
 const kc = new KubeConfig();
 // This loads kubectl config when not in cluster.
 kc.loadFromDefault();
 const k8sV1Client = kc.makeApiClient(CoreV1Api);
 const k8sV1CustomObjectClient = kc.makeApiClient(CustomObjectsApi);
+
+function getConfiguredServerNamespace(): string | undefined {
+  return serverNamespace || process.env.FRONTEND_SERVER_NAMESPACE?.trim() || undefined;
+}
+
+function resolveNamespace(providedNamespace?: string): string | undefined {
+  return providedNamespace || getConfiguredServerNamespace();
+}
 
 function getNameOfViewerResource(logdir: string): string {
   // TODO: find some hash function with shorter resulting message.
@@ -259,7 +267,7 @@ export function getPodLogs(
   podNamespace?: string,
   containerName: string = 'main',
 ): Promise<string> {
-  podNamespace = podNamespace || serverNamespace;
+  podNamespace = resolveNamespace(podNamespace);
   if (!podNamespace) {
     throw new Error(
       `podNamespace is not specified and cannot get namespace from ${namespaceFilePath}.`,
@@ -340,16 +348,21 @@ export async function listPodEvents(podName: string, podNamespace: string): Prom
 /**
  * Retrieves the argo workflow CRD.
  * @param workflowName name of the argo workflow
+ * @param providedNamespace use this namespace when provided, otherwise default to server's namespace
  */
-export async function getArgoWorkflow(workflowName: string): Promise<PartialArgoWorkflow> {
-  if (!serverNamespace) {
+export async function getArgoWorkflow(
+  workflowName: string,
+  providedNamespace?: string,
+): Promise<PartialArgoWorkflow> {
+  const namespace = resolveNamespace(providedNamespace);
+  if (!namespace) {
     throw new Error(`Cannot get namespace from ${namespaceFilePath}`);
   }
 
   const res = await k8sV1CustomObjectClient.getNamespacedCustomObject({
     group: workflowGroup,
     version: workflowVersion,
-    namespace: serverNamespace,
+    namespace,
     plural: workflowPlural,
     name: workflowName,
   });
@@ -364,11 +377,7 @@ export async function getArgoWorkflow(workflowName: string): Promise<PartialArgo
  * @param providedNamespace use this namespace when provided, otherwise default to server's namespace
  */
 export async function getK8sSecret(name: string, key: string, providedNamespace?: string) {
-  let namespace = serverNamespace;
-
-  if (providedNamespace) {
-    namespace = providedNamespace;
-  }
+  const namespace = resolveNamespace(providedNamespace);
 
   if (!namespace) {
     throw new Error(`Cannot get namespace from ${namespaceFilePath}`);
@@ -384,4 +393,5 @@ export const TEST_ONLY = {
   k8sV1Client,
   k8sV1CustomObjectClient,
   parseTensorboardLogDir,
+  resolveNamespace,
 };

--- a/frontend/server/minio-helper.test.ts
+++ b/frontend/server/minio-helper.test.ts
@@ -143,6 +143,35 @@ describe('minio-helper', () => {
         useSSL: false,
       });
     });
+
+    it('skips invalid endpoint rewrite rules.', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      const client = await createMinioClient(
+        {
+          accessKey: 'accesskey',
+          endPoint: 'seaweedfs.kubeflow.svc',
+          endpointRewrite:
+            'seaweedfs.kubeflow.svc:9000=::::,seaweedfs.kubeflow.svc:9000=localhost:9000',
+          port: 9000,
+          secretKey: 'secretkey',
+          useSSL: false,
+        },
+        's3',
+      );
+
+      expect(client).toBeInstanceOf(MinioClient);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Ignoring invalid MinIO endpoint rewrite endpoint "::::"'),
+      );
+      expect(MockedMinioClient).toHaveBeenCalledWith({
+        accessKey: 'accesskey',
+        endPoint: 'localhost',
+        port: 9000,
+        secretKey: 'secretkey',
+        useSSL: false,
+      });
+    });
   });
 
   describe('isTarball', () => {

--- a/frontend/server/minio-helper.test.ts
+++ b/frontend/server/minio-helper.test.ts
@@ -119,6 +119,30 @@ describe('minio-helper', () => {
       });
       expect(MockedMinioClient).toBeCalledTimes(1);
     });
+
+    it('rewrites configured in-cluster endpoints to local proxy endpoints.', async () => {
+      const client = await createMinioClient(
+        {
+          accessKey: 'accesskey',
+          endPoint: 'seaweedfs.kubeflow.svc',
+          endpointRewrite:
+            'seaweedfs.kubeflow:9000=localhost:9000,seaweedfs.kubeflow.svc:9000=localhost:9000',
+          port: 9000,
+          secretKey: 'secretkey',
+          useSSL: false,
+        },
+        's3',
+      );
+
+      expect(client).toBeInstanceOf(MinioClient);
+      expect(MockedMinioClient).toHaveBeenCalledWith({
+        accessKey: 'accesskey',
+        endPoint: 'localhost',
+        port: 9000,
+        secretKey: 'secretkey',
+        useSSL: false,
+      });
+    });
   });
 
   describe('isTarball', () => {

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -172,6 +172,9 @@ function applyEndpointRewrite(
     }
 
     const from = parseEndpoint(rawFrom);
+    if (!from) {
+      continue;
+    }
     if (
       from.host !== clientConfig.endPoint ||
       (from.port !== undefined && from.port !== clientConfig.port)
@@ -180,6 +183,9 @@ function applyEndpointRewrite(
     }
 
     const to = parseEndpoint(rawTo);
+    if (!to) {
+      continue;
+    }
     clientConfig.endPoint = to.host;
     if (to.port !== undefined) {
       clientConfig.port = to.port;
@@ -193,17 +199,25 @@ function applyEndpointRewrite(
   return clientConfig;
 }
 
-function parseEndpoint(endpoint: string): { host: string; port?: number; useSSL?: boolean } {
-  const url = new URL(endpoint.match(/^https?:\/\//) ? endpoint : `http://${endpoint}`);
-  return {
-    host: url.hostname,
-    port: url.port ? Number(url.port) : undefined,
-    useSSL: endpoint.startsWith('https://')
-      ? true
-      : endpoint.startsWith('http://')
-        ? false
-        : undefined,
-  };
+function parseEndpoint(
+  endpoint: string,
+): { host: string; port?: number; useSSL?: boolean } | undefined {
+  try {
+    const url = new URL(endpoint.match(/^https?:\/\//) ? endpoint : `http://${endpoint}`);
+    return {
+      host: url.hostname,
+      port: url.port ? Number(url.port) : undefined,
+      useSSL: endpoint.startsWith('https://')
+        ? true
+        : endpoint.startsWith('http://')
+          ? false
+          : undefined,
+    };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    console.warn(`Ignoring invalid MinIO endpoint rewrite endpoint "${endpoint}": ${reason}`);
+    return undefined;
+  }
 }
 
 /**

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -33,6 +33,7 @@ export interface MinioRequestConfig {
 /** MinioClientOptionsWithOptionalSecrets wraps around MinioClientOptions where only endPoint is required (accesskey and secretkey are optional). */
 export interface MinioClientOptionsWithOptionalSecrets extends Partial<MinioClientOptions> {
   endPoint: string;
+  endpointRewrite?: string;
 }
 
 export interface Credentials {
@@ -79,12 +80,14 @@ export async function createMinioClient(
       const creds = await customCredentialProvider();
 
       if (creds && creds.accessKeyId && creds.secretAccessKey) {
-        return new MinioClient({
-          ...config,
-          accessKey: creds.accessKeyId,
-          secretKey: creds.secretAccessKey,
-          sessionToken: creds.sessionToken,
-        });
+        return new MinioClient(
+          applyEndpointRewrite({
+            ...config,
+            accessKey: creds.accessKeyId,
+            secretKey: creds.secretAccessKey,
+            sessionToken: creds.sessionToken,
+          }) as MinioClientOptions,
+        );
       } else {
         console.warn(
           'Custom credential resolver returned incomplete credentials, falling back to default chain',
@@ -124,7 +127,14 @@ export async function createMinioClient(
             secretAccessKey: secretKey,
             sessionToken,
           } = awsCredentials;
-          return new MinioClient({ ...config, accessKey, secretKey, sessionToken });
+          return new MinioClient(
+            applyEndpointRewrite({
+              ...config,
+              accessKey,
+              secretKey,
+              sessionToken,
+            }) as MinioClientOptions,
+          );
         }
       } catch (e) {
         console.error('Unable to get aws instance profile credentials: ', e);
@@ -139,11 +149,61 @@ export async function createMinioClient(
   // If using any AWS or S3 compatible store (e.g. minio, aws s3 when using manual creds, ceph, etc.)
   let mc: MinioClient;
   try {
-    mc = await new MinioClient(config as MinioClientOptions);
+    mc = await new MinioClient(applyEndpointRewrite(config) as MinioClientOptions);
   } catch (err) {
     throw new Error(`Failed to create MinioClient: ${err}`);
   }
   return mc;
+}
+
+function applyEndpointRewrite(
+  config: MinioClientOptionsWithOptionalSecrets,
+): MinioClientOptionsWithOptionalSecrets {
+  const { endpointRewrite, ...clientConfig } = config;
+  const rewriteConfig = endpointRewrite || process.env.MINIO_ENDPOINT_REWRITE || '';
+  if (!rewriteConfig) {
+    return clientConfig;
+  }
+
+  for (const rule of rewriteConfig.split(',')) {
+    const [rawFrom, rawTo] = rule.split('=').map((part) => part.trim());
+    if (!rawFrom || !rawTo) {
+      continue;
+    }
+
+    const from = parseEndpoint(rawFrom);
+    if (
+      from.host !== clientConfig.endPoint ||
+      (from.port !== undefined && from.port !== clientConfig.port)
+    ) {
+      continue;
+    }
+
+    const to = parseEndpoint(rawTo);
+    clientConfig.endPoint = to.host;
+    if (to.port !== undefined) {
+      clientConfig.port = to.port;
+    }
+    if (to.useSSL !== undefined) {
+      clientConfig.useSSL = to.useSSL;
+    }
+    break;
+  }
+
+  return clientConfig;
+}
+
+function parseEndpoint(endpoint: string): { host: string; port?: number; useSSL?: boolean } {
+  const url = new URL(endpoint.match(/^https?:\/\//) ? endpoint : `http://${endpoint}`);
+  return {
+    host: url.hostname,
+    port: url.port ? Number(url.port) : undefined,
+    useSSL: endpoint.startsWith('https://')
+      ? true
+      : endpoint.startsWith('http://')
+        ? false
+        : undefined,
+  };
 }
 
 /**

--- a/frontend/server/workflow-helper.test.ts
+++ b/frontend/server/workflow-helper.test.ts
@@ -231,13 +231,14 @@ describe('workflow-helper', () => {
       const stream = await getPodLogsStreamFromWorkflow(
         'workflow-name-system-container-impl-abc',
         '2024-07-09',
+        'kubeflow',
       );
 
-      expect(mockedGetArgoWorkflow).toBeCalledWith('workflow-name');
+      expect(mockedGetArgoWorkflow).toBeCalledWith('workflow-name', 'kubeflow');
 
       expect(mockedGetK8sSecret).toBeCalledTimes(2);
-      expect(mockedGetK8sSecret).toBeCalledWith('accessKeyName', 'accessKey');
-      expect(mockedGetK8sSecret).toBeCalledWith('secretKeyName', 'secretKey');
+      expect(mockedGetK8sSecret).toBeCalledWith('accessKeyName', 'accessKey', 'kubeflow');
+      expect(mockedGetK8sSecret).toBeCalledWith('secretKeyName', 'secretKey', 'kubeflow');
 
       expect(mockedClient).toBeCalledTimes(1);
       expect(mockedClient).toBeCalledWith({

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -285,13 +285,15 @@ export function createPodLogsMinioRequestConfig(
  */
 export async function getPodLogsMinioRequestConfigfromWorkflow(
   podName: string,
+  _createdAt?: string,
+  namespace?: string,
 ): Promise<MinioRequestConfig> {
   let workflow: PartialArgoWorkflow;
   // We should probably parameterize this replace statement. It's brittle to
   // changes in implementation. But brittle is better than completely broken.
   let workflowName = podName.replace(/-system-container-impl-.*/, '');
   try {
-    workflow = await getArgoWorkflow(workflowName);
+    workflow = await getArgoWorkflow(workflowName, namespace);
   } catch (err) {
     throw new Error(`Unable to retrieve workflow status: ${err}.`);
   }
@@ -326,7 +328,7 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
   }
 
   const { host, port } = urlSplit(s3Artifact.endpoint, s3Artifact.insecure);
-  const { accessKey, secretKey } = await getMinioClientSecrets(s3Artifact);
+  const { accessKey, secretKey } = await getMinioClientSecrets(s3Artifact, namespace);
 
   const client = await createMinioClient(
     {
@@ -353,12 +355,15 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
  * Returns the k8s access key and secret used to connect to the s3 artifactory.
  * @param s3artifact s3artifact object describing the s3 artifactory config for argo workflow.
  */
-async function getMinioClientSecrets({ accessKeySecret, secretKeySecret }: S3Artifact) {
+async function getMinioClientSecrets(
+  { accessKeySecret, secretKeySecret }: S3Artifact,
+  namespace?: string,
+) {
   if (!accessKeySecret || !secretKeySecret) {
     return {};
   }
-  const accessKey = await getK8sSecret(accessKeySecret.name, accessKeySecret.key);
-  const secretKey = await getK8sSecret(secretKeySecret.name, secretKeySecret.key);
+  const accessKey = await getK8sSecret(accessKeySecret.name, accessKeySecret.key, namespace);
+  const secretKey = await getK8sSecret(secretKeySecret.name, secretKeySecret.key, namespace);
   return { accessKey, secretKey };
 }
 


### PR DESCRIPTION
## Summary

- Pass the selected local development namespace into the frontend Node server when using `start:proxy-and-server`.
- Thread that namespace through Kubernetes workflow and secret lookups used by pod-log fallback paths.
- Add explicit MinIO endpoint rewriting so in-cluster SeaweedFS endpoints resolve through the local port-forward during local proxy development.
- Document the new local proxy environment variables and cover the behavior with focused server tests.

## Root Cause

The local proxy path was running the frontend server outside the cluster, but log and artifact helpers still assumed in-cluster runtime details. Pod log fallback tried to read the serviceaccount namespace file, and artifact reads used providerInfo endpoints such as `seaweedfs.kubeflow:9000` / `seaweedfs.kubeflow.svc:9000`, which local Node cannot resolve even though the script already forwards SeaweedFS to `localhost:9000`.

## Validation

- `npm --prefix frontend/server test -- k8s-helper.test.ts workflow-helper.test.ts minio-helper.test.ts`
- `npm --prefix frontend/server run build`
- `npm --prefix frontend run lint:server`
- `git diff --check`
- Fresh Kind-backed run validation:
  - Created run `b5c7eee2-aa40-41cd-b568-e746d2eb95cf` (`Codex proxy validation 20260510T054841Z`).
  - Run reached `SUCCEEDED` at `2026-05-10T05:49:54Z`.
  - `GET /k8s/pod/logs?podname=tutorial-data-passing-lmzx5-system-container-impl-3514225018&runid=b5c7eee2-aa40-41cd-b568-e746d2eb95cf&podnamespace=kubeflow&createdat=2026-05-10` returned HTTP 200 with fresh KFP executor logs.
  - `GET /artifacts/get` returned the fresh output artifact content through both the default local MinIO path and explicit providerInfo carrying in-cluster SeaweedFS DNS.
  - Browser validation on `#/runs/details/b5c7eee2-aa40-41cd-b568-e746d2eb95cf` rendered task artifacts and the Logs tab without the previous failure banner.
