### PR TITLE
feat(sdk): support namespace configuration via environment variable. Fixes #13338

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -58,6 +58,7 @@ KF_PIPELINES_OVERRIDE_EXPERIMENT_NAME = 'KF_PIPELINES_OVERRIDE_EXPERIMENT_NAME'
 KF_PIPELINES_IAP_OAUTH2_CLIENT_ID_ENV = 'KF_PIPELINES_IAP_OAUTH2_CLIENT_ID'
 KF_PIPELINES_APP_OAUTH2_CLIENT_ID_ENV = 'KF_PIPELINES_APP_OAUTH2_CLIENT_ID'
 KF_PIPELINES_APP_OAUTH2_CLIENT_SECRET_ENV = 'KF_PIPELINES_APP_OAUTH2_CLIENT_SECRET'
+KF_PIPELINES_NAMESPACE_ENV = 'KF_PIPELINES_NAMESPACE'
 
 
 @dataclasses.dataclass
@@ -138,12 +139,14 @@ class Client:
 
     _LOCAL_KFP_CONTEXT = os.path.expanduser('~/.config/kfp/context.json')
 
+    _DEFAULT_NAMESPACE = 'kubeflow'
+
     # TODO: Wrap the configurations for different authentication methods.
     def __init__(
         self,
         host: Optional[str] = None,
         client_id: Optional[str] = None,
-        namespace: str = 'kubeflow',
+        namespace: Optional[str] = None,
         other_client_id: Optional[str] = None,
         other_client_secret: Optional[str] = None,
         existing_token: Optional[str] = None,
@@ -162,6 +165,8 @@ class Client:
             category=FutureWarning)
 
         host = host or os.environ.get(KF_PIPELINES_ENDPOINT_ENV)
+        namespace = namespace or os.environ.get(
+            KF_PIPELINES_NAMESPACE_ENV) or self._DEFAULT_NAMESPACE
         self._uihost = os.environ.get(KF_PIPELINES_UI_ENDPOINT_ENV, ui_host or
                                       host)
         client_id = client_id or os.environ.get(
@@ -180,7 +185,7 @@ class Client:
 
         # If custom namespace provided, overwrite the loaded or default one in
         # context settings for current client instance
-        if namespace != 'kubeflow':
+        if namespace != self._DEFAULT_NAMESPACE:
             self._context_setting['namespace'] = namespace
 
         self._existing_config = config

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -548,5 +548,47 @@ class TestClient(parameterized.TestCase):
             self.assertEqual(result, expected_result)
 
 
+class TestNamespaceResolution(unittest.TestCase):
+    """Tests for namespace resolution logic."""
+
+    @patch('kfp_server_api.ApiClient')
+    @patch.dict('os.environ', {'KF_PIPELINES_NAMESPACE': 'my-custom-ns'})
+    @patch('kubernetes.config.load_incluster_config', side_effect=Exception('not in cluster'))
+    @patch('kubernetes.config.load_kube_config')
+    def test_namespace_from_env_variable(self, mock_load_kube, mock_load_incluster, mock_api):
+        """Namespace from KF_PIPELINES_NAMESPACE env var should be used."""
+        mock_load_kube.return_value = None
+        c = client.Client('http://dummy:8888')
+        self.assertEqual(c._context_setting['namespace'], 'my-custom-ns')
+
+    @patch('kfp_server_api.ApiClient')
+    @patch.dict('os.environ', {'KF_PIPELINES_NAMESPACE': 'env-ns'})
+    @patch('kubernetes.config.load_incluster_config', side_effect=Exception('not in cluster'))
+    @patch('kubernetes.config.load_kube_config')
+    def test_namespace_explicit_overrides_env(self, mock_load_kube, mock_load_incluster, mock_api):
+        """Explicit namespace parameter should override env var."""
+        mock_load_kube.return_value = None
+        c = client.Client('http://dummy:8888', namespace='explicit-ns')
+        self.assertEqual(c._context_setting['namespace'], 'explicit-ns')
+
+    @patch('kfp_server_api.ApiClient')
+    @patch.dict('os.environ', {}, clear=False)
+    @patch('kubernetes.config.load_incluster_config', side_effect=Exception('not in cluster'))
+    @patch('kubernetes.config.load_kube_config')
+    def test_namespace_default_when_nothing_set(self, mock_load_kube, mock_load_incluster, mock_api):
+        """Default namespace should be kubeflow when nothing is set."""
+        mock_load_kube.return_value = None
+        os.environ.pop('KF_PIPELINES_NAMESPACE', None)
+        # Patch _load_config to capture what namespace was resolved
+        with patch.object(client.Client, '_load_config') as mock_load_config:
+            from kfp_server_api import Configuration
+            mock_load_config.return_value = Configuration()
+            c = client.Client('http://dummy:8888')
+            # _load_config is called with positional args: host, client_id, namespace, ...
+            # namespace is the 3rd positional arg (index 2)
+            call_args = mock_load_config.call_args[0]
+            self.assertEqual(call_args[2], 'kubeflow')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -557,8 +557,8 @@ class TestNamespaceResolution(unittest.TestCase):
         'kubernetes.config.load_incluster_config',
         side_effect=Exception('not in cluster'))
     @patch('kubernetes.config.load_kube_config')
-    def test_namespace_from_env_variable(self, mock_load_kube,
-                                        mock_load_incluster, mock_api):
+    def test_namespace_from_env_variable(
+            self, mock_load_kube, mock_load_incluster, mock_api):
         """Namespace from KF_PIPELINES_NAMESPACE env var should be used."""
         mock_load_kube.return_value = None
         c = client.Client('http://dummy:8888')
@@ -570,8 +570,8 @@ class TestNamespaceResolution(unittest.TestCase):
         'kubernetes.config.load_incluster_config',
         side_effect=Exception('not in cluster'))
     @patch('kubernetes.config.load_kube_config')
-    def test_namespace_explicit_overrides_env(self, mock_load_kube,
-                                              mock_load_incluster, mock_api):
+    def test_namespace_explicit_overrides_env(
+            self, mock_load_kube, mock_load_incluster, mock_api):
         """Explicit namespace parameter should override env var."""
         mock_load_kube.return_value = None
         c = client.Client('http://dummy:8888', namespace='explicit-ns')
@@ -583,9 +583,8 @@ class TestNamespaceResolution(unittest.TestCase):
         'kubernetes.config.load_incluster_config',
         side_effect=Exception('not in cluster'))
     @patch('kubernetes.config.load_kube_config')
-    def test_namespace_default_when_nothing_set(self, mock_load_kube,
-                                               mock_load_incluster,
-                                               mock_api):
+    def test_namespace_default_when_nothing_set(
+            self, mock_load_kube, mock_load_incluster, mock_api):
         """Default namespace should be kubeflow when nothing is set."""
         mock_load_kube.return_value = None
         os.environ.pop('KF_PIPELINES_NAMESPACE', None)
@@ -599,8 +598,8 @@ class TestNamespaceResolution(unittest.TestCase):
     @patch('kfp_server_api.ApiClient')
     @patch.dict('os.environ', {'KF_PIPELINES_NAMESPACE': 'my-ns'})
     @patch('kubernetes.config.load_incluster_config')
-    def test_in_cluster_dns_uses_env_namespace(self, mock_load_incluster,
-                                               mock_api):
+    def test_in_cluster_dns_uses_env_namespace(
+            self, mock_load_incluster, mock_api):
         """In-cluster DNS name should use namespace from env var."""
         mock_load_incluster.return_value = None
         mock_self = MagicMock()
@@ -621,8 +620,26 @@ class TestNamespaceResolution(unittest.TestCase):
             credentials=None,
             verify_ssl=None,
         )
-        self.assertEqual(config.host,
-                         'http://ml-pipeline.my-ns.svc:8888')
+        self.assertEqual(
+            config.host, 'ml-pipeline.my-ns.svc.cluster.local:8888')
+
+    @patch('kfp_server_api.ApiClient')
+    @patch.dict('os.environ', {'KF_PIPELINES_NAMESPACE': 'env-ns'})
+    @patch(
+        'kubernetes.config.load_incluster_config',
+        side_effect=Exception('not in cluster'))
+    @patch('kubernetes.config.load_kube_config')
+    def test_in_cluster_namespace_from_env_e2e(
+            self, mock_load_kube, mock_load_incluster, mock_api):
+        """End-to-end: env namespace is passed to _load_config."""
+        mock_load_kube.return_value = None
+        with patch.object(
+                client.Client, '_load_config') as mock_load_config:
+            from kfp_server_api import Configuration
+            mock_load_config.return_value = Configuration()
+            client.Client('http://dummy:8888')
+            call_args = mock_load_config.call_args[0]
+            self.assertEqual(call_args[2], 'env-ns')
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -553,9 +553,12 @@ class TestNamespaceResolution(unittest.TestCase):
 
     @patch('kfp_server_api.ApiClient')
     @patch.dict('os.environ', {'KF_PIPELINES_NAMESPACE': 'my-custom-ns'})
-    @patch('kubernetes.config.load_incluster_config', side_effect=Exception('not in cluster'))
+    @patch(
+        'kubernetes.config.load_incluster_config',
+        side_effect=Exception('not in cluster'))
     @patch('kubernetes.config.load_kube_config')
-    def test_namespace_from_env_variable(self, mock_load_kube, mock_load_incluster, mock_api):
+    def test_namespace_from_env_variable(self, mock_load_kube,
+                                        mock_load_incluster, mock_api):
         """Namespace from KF_PIPELINES_NAMESPACE env var should be used."""
         mock_load_kube.return_value = None
         c = client.Client('http://dummy:8888')
@@ -563,9 +566,12 @@ class TestNamespaceResolution(unittest.TestCase):
 
     @patch('kfp_server_api.ApiClient')
     @patch.dict('os.environ', {'KF_PIPELINES_NAMESPACE': 'env-ns'})
-    @patch('kubernetes.config.load_incluster_config', side_effect=Exception('not in cluster'))
+    @patch(
+        'kubernetes.config.load_incluster_config',
+        side_effect=Exception('not in cluster'))
     @patch('kubernetes.config.load_kube_config')
-    def test_namespace_explicit_overrides_env(self, mock_load_kube, mock_load_incluster, mock_api):
+    def test_namespace_explicit_overrides_env(self, mock_load_kube,
+                                              mock_load_incluster, mock_api):
         """Explicit namespace parameter should override env var."""
         mock_load_kube.return_value = None
         c = client.Client('http://dummy:8888', namespace='explicit-ns')
@@ -573,21 +579,50 @@ class TestNamespaceResolution(unittest.TestCase):
 
     @patch('kfp_server_api.ApiClient')
     @patch.dict('os.environ', {}, clear=False)
-    @patch('kubernetes.config.load_incluster_config', side_effect=Exception('not in cluster'))
+    @patch(
+        'kubernetes.config.load_incluster_config',
+        side_effect=Exception('not in cluster'))
     @patch('kubernetes.config.load_kube_config')
-    def test_namespace_default_when_nothing_set(self, mock_load_kube, mock_load_incluster, mock_api):
+    def test_namespace_default_when_nothing_set(self, mock_load_kube,
+                                               mock_load_incluster,
+                                               mock_api):
         """Default namespace should be kubeflow when nothing is set."""
         mock_load_kube.return_value = None
         os.environ.pop('KF_PIPELINES_NAMESPACE', None)
-        # Patch _load_config to capture what namespace was resolved
         with patch.object(client.Client, '_load_config') as mock_load_config:
             from kfp_server_api import Configuration
             mock_load_config.return_value = Configuration()
             c = client.Client('http://dummy:8888')
-            # _load_config is called with positional args: host, client_id, namespace, ...
-            # namespace is the 3rd positional arg (index 2)
             call_args = mock_load_config.call_args[0]
             self.assertEqual(call_args[2], 'kubeflow')
+
+    @patch('kfp_server_api.ApiClient')
+    @patch.dict('os.environ', {'KF_PIPELINES_NAMESPACE': 'my-ns'})
+    @patch('kubernetes.config.load_incluster_config')
+    def test_in_cluster_dns_uses_env_namespace(self, mock_load_incluster,
+                                               mock_api):
+        """In-cluster DNS name should use namespace from env var."""
+        mock_load_incluster.return_value = None
+        mock_self = MagicMock()
+        mock_self._is_inverse_proxy_host.return_value = False
+        mock_self._get_config_with_default_credentials.side_effect = (
+            lambda cfg: cfg)
+        config = client.Client._load_config(
+            mock_self,
+            host=None,
+            client_id=None,
+            namespace='my-ns',
+            other_client_id=None,
+            other_client_secret=None,
+            existing_token=None,
+            proxy=None,
+            ssl_ca_cert=None,
+            kube_context=None,
+            credentials=None,
+            verify_ssl=None,
+        )
+        self.assertEqual(config.host,
+                         'http://ml-pipeline.my-ns.svc:8888')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Allow the KFP SDK client namespace to be configured via the `KF_PIPELINES_NAMESPACE` environment variable, following the same pattern used for `host`, `client_id`, and other parameters.

## Motivation

The `Client.__init__` namespace parameter defaults to `'kubeflow'`, which is hardcoded in two places. Users who deploy Kubeflow Pipelines in a different namespace (e.g. `kubeflow-pipelines`) must pass `namespace=` explicitly on every `Client()` call — there is no way to set it globally via environment variable like other configuration options.

This forces users to either:
- Pass `namespace=` everywhere in their code
- Patch the SDK locally

See: https://github.com/kubeflow/pipelines/issues/13338

## Changes

- `sdk/python/kfp/client/client.py`:
  - Added `KF_PIPELINES_NAMESPACE_ENV = 'KF_PIPELINES_NAMESPACE'` module-level constant
  - Added `_DEFAULT_NAMESPACE = 'kubeflow'` class constant to eliminate magic string
  - Changed `namespace` parameter type from `str` (default `'kubeflow'`) to `Optional[str]` (default `None`)
  - Added resolution chain: explicit parameter → environment variable → default (`'kubeflow'`)
  - Replaced hardcoded `'kubeflow'` comparison with `self._DEFAULT_NAMESPACE`

- `sdk/python/kfp/client/client_test.py`:
  - Added `TestNamespaceResolution` class with 3 tests:
    - `test_namespace_from_env_variable` — env var is used when no explicit param
    - `test_namespace_explicit_overrides_env` — explicit param takes priority over env var
    - `test_namespace_default_when_nothing_set` — falls back to `'kubeflow'` when nothing is configured

## Backward Compatibility

This change is fully backward compatible:
- Users who don't set the env var and don't pass `namespace=` get the same behavior as before (`'kubeflow'`)
- Users who already pass `namespace=` explicitly are unaffected (explicit param takes highest priority)
- The only new behavior is that `KF_PIPELINES_NAMESPACE` env var is now respected as a middle-priority option

## Verification

$ python -m pytest sdk/python/kfp/client/client_test.py -v ======================== 53 passed in 1.93s ========================


All existing tests continue to pass. No regressions.

> If maintainers request additional coverage, I can add tests for empty string and explicit `None` edge cases.

Fixes #13338

/area sdk
