### PR TITLE
Return to recurring runs after canceling creation

### DIFF
--- a/frontend/src/components/Router.test.tsx
+++ b/frontend/src/components/Router.test.tsx
@@ -18,7 +18,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import { Router as ReactRouter } from 'react-router';
 import { MemoryRouter } from 'react-router-dom';
 import { createMemoryHistory } from 'history';
-import Router, { RouteConfig } from './Router';
+import Router, { getSafeReturnPath, RouteConfig, RoutePage } from './Router';
 import { Page } from '../pages/Page';
 import { ToolbarProps } from './Toolbar';
 
@@ -71,5 +71,12 @@ describe('Router', () => {
       history.push('/pear');
     });
     await waitFor(() => expect(screen.getByTestId('page-title')).toHaveTextContent(''));
+  });
+
+  it('only accepts same-app return paths', () => {
+    expect(getSafeReturnPath(RoutePage.RECURRING_RUNS)).toBe(RoutePage.RECURRING_RUNS);
+    expect(getSafeReturnPath('https://example.com')).toBeUndefined();
+    expect(getSafeReturnPath('//example.com')).toBeUndefined();
+    expect(getSafeReturnPath(null)).toBeUndefined();
   });
 });

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -71,6 +71,7 @@ export enum QUERY_PARAMS {
   firstRunInExperiment = 'firstRunInExperiment',
   pipelineId = 'pipelineId',
   pipelineVersionId = 'pipelineVersionId',
+  returnTo = 'returnTo',
   fromRunId = 'fromRun',
   fromRecurringRunId = 'fromRecurringRun',
   runlist = 'runlist',
@@ -133,6 +134,13 @@ export const RoutePageFactory = {
     return RoutePage.PIPELINE_DETAILS_NO_VERSION.replace(`:${RouteParams.pipelineId}`, id);
   },
 };
+
+export function getSafeReturnPath(path: string | null): string | undefined {
+  if (!path || !path.startsWith('/') || path.startsWith('//') || path.includes('://')) {
+    return undefined;
+  }
+  return path;
+}
 
 export const ExternalLinks = {
   DOCUMENTATION: 'https://www.kubeflow.org/docs/pipelines/',

--- a/frontend/src/lib/Buttons.ts
+++ b/frontend/src/lib/Buttons.ts
@@ -705,6 +705,9 @@ export default class Buttons {
     const searchString = this._urlParser.build({
       [QUERY_PARAMS.experimentId]: experimentId || '',
       ...(isRecurring ? { [QUERY_PARAMS.isRecurring]: '1' } : {}),
+      ...(isRecurring && this._props.location.pathname === RoutePage.RECURRING_RUNS
+        ? { [QUERY_PARAMS.returnTo]: RoutePage.RECURRING_RUNS }
+        : {}),
     });
     this._props.history.push(RoutePage.NEW_RUN + searchString);
   }

--- a/frontend/src/pages/AllRecurringRunsList.test.tsx
+++ b/frontend/src/pages/AllRecurringRunsList.test.tsx
@@ -17,7 +17,7 @@
 import * as React from 'react';
 import { render } from '@testing-library/react';
 import { vi } from 'vitest';
-import { RoutePage } from 'src/components/Router';
+import { QUERY_PARAMS, RoutePage } from 'src/components/Router';
 import { ButtonKeys } from 'src/lib/Buttons';
 import { AllRecurringRunsList } from './AllRecurringRunsList';
 import { PageProps } from './Page';
@@ -45,7 +45,7 @@ describe('AllRecurringRunsList', () => {
   function baseProps(): PageProps {
     return {
       history: { push: historyPushSpy } as any,
-      location: '' as any,
+      location: { pathname: RoutePage.RECURRING_RUNS, search: '' } as any,
       match: '' as any,
       toolbarProps: { actions: {}, breadcrumbs: [], pageTitle: '' },
       updateBanner: updateBannerSpy,
@@ -107,7 +107,7 @@ describe('AllRecurringRunsList', () => {
     renderAllRecurringRunsList();
     toolbarProps!.actions[ButtonKeys.NEW_RECURRING_RUN].action();
     expect(historyPushSpy).toHaveBeenLastCalledWith(
-      RoutePage.NEW_RUN + '?experimentId=&recurring=1',
+      `${RoutePage.NEW_RUN}?${QUERY_PARAMS.experimentId}=&${QUERY_PARAMS.isRecurring}=1&${QUERY_PARAMS.returnTo}=${RoutePage.RECURRING_RUNS}`,
     );
   });
 });

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -2295,4 +2295,15 @@ describe('NewRun', () => {
       );
     });
   });
+
+  it('exits to a safe return path when one is present in the query params', async () => {
+    const props = generateProps();
+    props.location.search = `?${QUERY_PARAMS.returnTo}=${RoutePage.RECURRING_RUNS}`;
+
+    tree = await renderNewRunElement(<TestNewRun {...props} />);
+    await flushPromisesInAct();
+    tree.find('#exitNewRunPageBtn').simulate('click');
+
+    expect(historyPushSpy).toHaveBeenCalledWith(RoutePage.RECURRING_RUNS);
+  });
 });

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -38,7 +38,7 @@ import { CustomRendererProps } from '../components/CustomTable';
 import { NameWithTooltip } from '../components/CustomTableNameColumn';
 import { Description } from '../components/Description';
 import NewRunParameters from '../components/NewRunParameters';
-import { QUERY_PARAMS, RoutePage, RouteParams } from '../components/Router';
+import { getSafeReturnPath, QUERY_PARAMS, RoutePage, RouteParams } from '../components/Router';
 import { ToolbarProps } from '../components/Toolbar';
 import Trigger from '../components/Trigger';
 import UploadPipelineDialog, { ImportMethod } from '../components/UploadPipelineDialog';
@@ -603,14 +603,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
             <Button
               id='exitNewRunPageBtn'
               onClick={() => {
-                this.props.history.push(
-                  this.state.experiment
-                    ? RoutePage.EXPERIMENT_DETAILS.replace(
-                        ':' + RouteParams.experimentId,
-                        this.state.experiment.id!,
-                      )
-                    : RoutePage.RUNS,
-                );
+                this.props.history.push(this._getCancelRoute());
               }}
             >
               {isFirstRunInExperiment ? 'Skip this step' : 'Cancel'}
@@ -1157,6 +1150,20 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
       }
     }
     return 'Parameters will appear after you select a pipeline';
+  }
+
+  private _getCancelRoute(): string {
+    const returnPath = getSafeReturnPath(new URLParser(this.props).get(QUERY_PARAMS.returnTo));
+    if (returnPath) {
+      return returnPath;
+    }
+
+    return this.state.experiment
+      ? RoutePage.EXPERIMENT_DETAILS.replace(
+          ':' + RouteParams.experimentId,
+          this.state.experiment.id!,
+        )
+      : RoutePage.RUNS;
   }
 
   private _start(): void {

--- a/frontend/src/pages/NewRunV2.test.tsx
+++ b/frontend/src/pages/NewRunV2.test.tsx
@@ -359,6 +359,22 @@ describe('NewRunV2', () => {
     );
   });
 
+  it('exits to a safe return path when one is present in the query params', async () => {
+    renderNewRunV2({
+      location: {
+        pathname: RoutePage.NEW_RUN,
+        search:
+          `?${QUERY_PARAMS.pipelineId}=${ORIGINAL_TEST_PIPELINE_ID}` +
+          `&${QUERY_PARAMS.pipelineVersionId}=${ORIGINAL_TEST_PIPELINE_VERSION_ID}` +
+          `&${QUERY_PARAMS.returnTo}=${RoutePage.RECURRING_RUNS}`,
+      } as any,
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    expect(historyPushSpy).toHaveBeenCalledWith(RoutePage.RECURRING_RUNS);
+  });
+
   it('Submit run ', async () => {
     const getPipelineSpy = vi.spyOn(Apis.pipelineServiceApiV2, 'getPipeline');
     getPipelineSpy.mockResolvedValue(ORIGINAL_TEST_PIPELINE);

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -40,7 +40,7 @@ import { CustomRendererProps } from 'src/components/CustomTable';
 import { NameWithTooltip } from 'src/components/CustomTableNameColumn';
 import { Description } from 'src/components/Description';
 import NewRunParametersV2 from 'src/components/NewRunParametersV2';
-import { QUERY_PARAMS, RoutePage, RouteParams } from 'src/components/Router';
+import { getSafeReturnPath, QUERY_PARAMS, RoutePage, RouteParams } from 'src/components/Router';
 import Trigger from 'src/components/Trigger';
 import { color, commonCss, padding } from 'src/Css';
 import { Apis, ExperimentSortKeys, PipelineSortKeys, PipelineVersionSortKeys } from 'src/lib/Apis';
@@ -252,6 +252,7 @@ function NewRunV2(props: NewRunV2Props) {
   } = props;
   const cloneOrigin = getCloneOrigin(existingRun, existingRecurringRun);
   const urlParser = new URLParser(props);
+  const returnPath = getSafeReturnPath(urlParser.get(QUERY_PARAMS.returnTo));
   const [customRunName, setCustomRunName] = useState<string | null>(null);
   const [runDescription, setRunDescription] = useState('');
   const [serviceAccount, setServiceAccount] = useState('');
@@ -749,8 +750,7 @@ function NewRunV2(props: NewRunV2Props) {
           <Button
             id='exitNewRunPageBtn'
             onClick={() => {
-              // TODO(zijianjoy): Return to previous page instead of defaulting to RUNS page.
-              props.history.push(RoutePage.RUNS);
+              props.history.push(returnPath || RoutePage.RUNS);
             }}
           >
             {'Cancel'}


### PR DESCRIPTION
## Summary

- Return users to `#/recurringruns` when canceling recurring-run creation launched from the all recurring-runs page.
- Add a `returnTo` query parameter for the recurring-runs entrypoint and validate it as a same-app path before using it.
- Keep the existing `/runs` fallback for new-run pages without a safe return target.

## Validation

- `npm --prefix frontend run test:ui -- AllRecurringRunsList.test.tsx NewRunV2.test.tsx Router.test.tsx`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run typecheck`
- `npx --prefix frontend prettier --check frontend/src/components/Router.tsx frontend/src/components/Router.test.tsx frontend/src/lib/Buttons.ts frontend/src/pages/AllRecurringRunsList.test.tsx frontend/src/pages/NewRunV2.tsx frontend/src/pages/NewRunV2.test.tsx`
- `git diff --check`
