### PR TITLE
feat(sdk/backed): Add retryPolicy Option to set_retry

### DIFF
--- a/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
+++ b/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
@@ -303,6 +303,64 @@ func (PipelineTaskSpec_TriggerPolicy_TriggerStrategy) EnumDescriptor() ([]byte, 
 	return file_pipeline_spec_proto_rawDescGZIP(), []int{13, 1, 0}
 }
 
+// The retry policy controls which failure types trigger a retry attempt.
+// Maps directly to Argo Workflows retryStrategy.retryPolicy.
+// Defaults to POLICY_UNSPECIFIED, which behaves like POLICY_ON_FAILURE.
+type PipelineTaskSpec_RetryPolicy_Policy int32
+
+const (
+	PipelineTaskSpec_RetryPolicy_POLICY_UNSPECIFIED        PipelineTaskSpec_RetryPolicy_Policy = 0
+	PipelineTaskSpec_RetryPolicy_POLICY_ALWAYS             PipelineTaskSpec_RetryPolicy_Policy = 1
+	PipelineTaskSpec_RetryPolicy_POLICY_ON_FAILURE         PipelineTaskSpec_RetryPolicy_Policy = 2
+	PipelineTaskSpec_RetryPolicy_POLICY_ON_ERROR           PipelineTaskSpec_RetryPolicy_Policy = 3
+	PipelineTaskSpec_RetryPolicy_POLICY_ON_TRANSIENT_ERROR PipelineTaskSpec_RetryPolicy_Policy = 4
+)
+
+// Enum value maps for PipelineTaskSpec_RetryPolicy_Policy.
+var (
+	PipelineTaskSpec_RetryPolicy_Policy_name = map[int32]string{
+		0: "POLICY_UNSPECIFIED",
+		1: "POLICY_ALWAYS",
+		2: "POLICY_ON_FAILURE",
+		3: "POLICY_ON_ERROR",
+		4: "POLICY_ON_TRANSIENT_ERROR",
+	}
+	PipelineTaskSpec_RetryPolicy_Policy_value = map[string]int32{
+		"POLICY_UNSPECIFIED":        0,
+		"POLICY_ALWAYS":             1,
+		"POLICY_ON_FAILURE":         2,
+		"POLICY_ON_ERROR":           3,
+		"POLICY_ON_TRANSIENT_ERROR": 4,
+	}
+)
+
+func (x PipelineTaskSpec_RetryPolicy_Policy) Enum() *PipelineTaskSpec_RetryPolicy_Policy {
+	p := new(PipelineTaskSpec_RetryPolicy_Policy)
+	*p = x
+	return p
+}
+
+func (x PipelineTaskSpec_RetryPolicy_Policy) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PipelineTaskSpec_RetryPolicy_Policy) Descriptor() protoreflect.EnumDescriptor {
+	return file_pipeline_spec_proto_enumTypes[4].Descriptor()
+}
+
+func (PipelineTaskSpec_RetryPolicy_Policy) Type() protoreflect.EnumType {
+	return &file_pipeline_spec_proto_enumTypes[4]
+}
+
+func (x PipelineTaskSpec_RetryPolicy_Policy) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PipelineTaskSpec_RetryPolicy_Policy.Descriptor instead.
+func (PipelineTaskSpec_RetryPolicy_Policy) EnumDescriptor() ([]byte, []int) {
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{13, 2, 0}
+}
+
 type PipelineStateEnum_PipelineTaskState int32
 
 const (
@@ -384,11 +442,11 @@ func (x PipelineStateEnum_PipelineTaskState) String() string {
 }
 
 func (PipelineStateEnum_PipelineTaskState) Descriptor() protoreflect.EnumDescriptor {
-	return file_pipeline_spec_proto_enumTypes[4].Descriptor()
+	return file_pipeline_spec_proto_enumTypes[5].Descriptor()
 }
 
 func (PipelineStateEnum_PipelineTaskState) Type() protoreflect.EnumType {
-	return &file_pipeline_spec_proto_enumTypes[4]
+	return &file_pipeline_spec_proto_enumTypes[5]
 }
 
 func (x PipelineStateEnum_PipelineTaskState) Number() protoreflect.EnumNumber {
@@ -4322,7 +4380,8 @@ type PipelineTaskSpec_RetryPolicy struct {
 	BackoffFactor float64 `protobuf:"fixed64,3,opt,name=backoff_factor,json=backoffFactor,proto3" json:"backoff_factor,omitempty"`
 	// The maximum duration during which the task will be retried according to
 	// the backoff strategy. If unspecified, will set to 1 hour.
-	BackoffMaxDuration *durationpb.Duration `protobuf:"bytes,4,opt,name=backoff_max_duration,json=backoffMaxDuration,proto3" json:"backoff_max_duration,omitempty"`
+	BackoffMaxDuration *durationpb.Duration                `protobuf:"bytes,4,opt,name=backoff_max_duration,json=backoffMaxDuration,proto3" json:"backoff_max_duration,omitempty"`
+	Policy             PipelineTaskSpec_RetryPolicy_Policy `protobuf:"varint,5,opt,name=policy,proto3,enum=ml_pipelines.PipelineTaskSpec_RetryPolicy_Policy" json:"policy,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -4383,6 +4442,13 @@ func (x *PipelineTaskSpec_RetryPolicy) GetBackoffMaxDuration() *durationpb.Durat
 		return x.BackoffMaxDuration
 	}
 	return nil
+}
+
+func (x *PipelineTaskSpec_RetryPolicy) GetPolicy() PipelineTaskSpec_RetryPolicy_Policy {
+	if x != nil {
+		return x.Policy
+	}
+	return PipelineTaskSpec_RetryPolicy_POLICY_UNSPECIFIED
 }
 
 // Iterator related settings.
@@ -5893,8 +5959,7 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\x12KUBERNETES_VOLUMES\x10\x06\"\x98\x01\n" +
 	"\x15TaskConfigPassthrough\x12[\n" +
 	"\x05field\x18\x01 \x01(\x0e2E.ml_pipelines.TaskConfigPassthroughType.TaskConfigPassthroughTypeEnumR\x05field\x12\"\n" +
-	"\rapply_to_task\x18\x02 \x01(\bR\vapplyToTask\"\xfe\n" +
-	"\n" +
+	"\rapply_to_task\x18\x02 \x01(\bR\vapplyToTask\"\xc9\f\n" +
 	"\x10PipelineTaskSpec\x12;\n" +
 	"\ttask_info\x18\x01 \x01(\v2\x1e.ml_pipelines.PipelineTaskInfoR\btaskInfo\x124\n" +
 	"\x06inputs\x18\x02 \x01(\v2\x1c.ml_pipelines.TaskInputsSpecR\x06inputs\x12'\n" +
@@ -5916,12 +5981,19 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\x0fTriggerStrategy\x12 \n" +
 	"\x1cTRIGGER_STRATEGY_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cALL_UPSTREAM_TASKS_SUCCEEDED\x10\x01\x12 \n" +
-	"\x1cALL_UPSTREAM_TASKS_COMPLETED\x10\x02\x1a\xef\x01\n" +
+	"\x1cALL_UPSTREAM_TASKS_COMPLETED\x10\x02\x1a\xba\x03\n" +
 	"\vRetryPolicy\x12&\n" +
 	"\x0fmax_retry_count\x18\x01 \x01(\x05R\rmaxRetryCount\x12D\n" +
 	"\x10backoff_duration\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0fbackoffDuration\x12%\n" +
 	"\x0ebackoff_factor\x18\x03 \x01(\x01R\rbackoffFactor\x12K\n" +
-	"\x14backoff_max_duration\x18\x04 \x01(\v2\x19.google.protobuf.DurationR\x12backoffMaxDuration\x1a=\n" +
+	"\x14backoff_max_duration\x18\x04 \x01(\v2\x19.google.protobuf.DurationR\x12backoffMaxDuration\x12I\n" +
+	"\x06policy\x18\x05 \x01(\x0e21.ml_pipelines.PipelineTaskSpec.RetryPolicy.PolicyR\x06policy\"~\n" +
+	"\x06Policy\x12\x16\n" +
+	"\x12POLICY_UNSPECIFIED\x10\x00\x12\x11\n" +
+	"\rPOLICY_ALWAYS\x10\x01\x12\x15\n" +
+	"\x11POLICY_ON_FAILURE\x10\x02\x12\x13\n" +
+	"\x0fPOLICY_ON_ERROR\x10\x03\x12\x1d\n" +
+	"\x19POLICY_ON_TRANSIENT_ERROR\x10\x04\x1a=\n" +
 	"\x0eIteratorPolicy\x12+\n" +
 	"\x11parallelism_limit\x18\x01 \x01(\x05R\x10parallelismLimitB\n" +
 	"\n" +
@@ -6178,280 +6250,282 @@ func file_pipeline_spec_proto_rawDescGZIP() []byte {
 	return file_pipeline_spec_proto_rawDescData
 }
 
-var file_pipeline_spec_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_pipeline_spec_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
 var file_pipeline_spec_proto_msgTypes = make([]protoimpl.MessageInfo, 110)
 var file_pipeline_spec_proto_goTypes = []any{
 	(PrimitiveType_PrimitiveTypeEnum)(0),                         // 0: ml_pipelines.PrimitiveType.PrimitiveTypeEnum
 	(ParameterType_ParameterTypeEnum)(0),                         // 1: ml_pipelines.ParameterType.ParameterTypeEnum
 	(TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum)(0), // 2: ml_pipelines.TaskConfigPassthroughType.TaskConfigPassthroughTypeEnum
 	(PipelineTaskSpec_TriggerPolicy_TriggerStrategy)(0),          // 3: ml_pipelines.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
-	(PipelineStateEnum_PipelineTaskState)(0),                     // 4: ml_pipelines.PipelineStateEnum.PipelineTaskState
-	(*PipelineJob)(nil),                                          // 5: ml_pipelines.PipelineJob
-	(*PipelineSpec)(nil),                                         // 6: ml_pipelines.PipelineSpec
-	(*ComponentSpec)(nil),                                        // 7: ml_pipelines.ComponentSpec
-	(*DagSpec)(nil),                                              // 8: ml_pipelines.DagSpec
-	(*DagOutputsSpec)(nil),                                       // 9: ml_pipelines.DagOutputsSpec
-	(*ComponentInputsSpec)(nil),                                  // 10: ml_pipelines.ComponentInputsSpec
-	(*ComponentOutputsSpec)(nil),                                 // 11: ml_pipelines.ComponentOutputsSpec
-	(*TaskInputsSpec)(nil),                                       // 12: ml_pipelines.TaskInputsSpec
-	(*TaskOutputsSpec)(nil),                                      // 13: ml_pipelines.TaskOutputsSpec
-	(*PrimitiveType)(nil),                                        // 14: ml_pipelines.PrimitiveType
-	(*ParameterType)(nil),                                        // 15: ml_pipelines.ParameterType
-	(*TaskConfigPassthroughType)(nil),                            // 16: ml_pipelines.TaskConfigPassthroughType
-	(*TaskConfigPassthrough)(nil),                                // 17: ml_pipelines.TaskConfigPassthrough
-	(*PipelineTaskSpec)(nil),                                     // 18: ml_pipelines.PipelineTaskSpec
-	(*ArtifactIteratorSpec)(nil),                                 // 19: ml_pipelines.ArtifactIteratorSpec
-	(*ParameterIteratorSpec)(nil),                                // 20: ml_pipelines.ParameterIteratorSpec
-	(*ComponentRef)(nil),                                         // 21: ml_pipelines.ComponentRef
-	(*PipelineInfo)(nil),                                         // 22: ml_pipelines.PipelineInfo
-	(*ArtifactTypeSchema)(nil),                                   // 23: ml_pipelines.ArtifactTypeSchema
-	(*PipelineTaskInfo)(nil),                                     // 24: ml_pipelines.PipelineTaskInfo
-	(*ValueOrRuntimeParameter)(nil),                              // 25: ml_pipelines.ValueOrRuntimeParameter
-	(*PipelineDeploymentConfig)(nil),                             // 26: ml_pipelines.PipelineDeploymentConfig
-	(*Value)(nil),                                                // 27: ml_pipelines.Value
-	(*RuntimeArtifact)(nil),                                      // 28: ml_pipelines.RuntimeArtifact
-	(*ArtifactList)(nil),                                         // 29: ml_pipelines.ArtifactList
-	(*ExecutorInput)(nil),                                        // 30: ml_pipelines.ExecutorInput
-	(*ExecutorOutput)(nil),                                       // 31: ml_pipelines.ExecutorOutput
-	(*PipelineTaskFinalStatus)(nil),                              // 32: ml_pipelines.PipelineTaskFinalStatus
-	(*PipelineStateEnum)(nil),                                    // 33: ml_pipelines.PipelineStateEnum
-	(*PlatformSpec)(nil),                                         // 34: ml_pipelines.PlatformSpec
-	(*SinglePlatformSpec)(nil),                                   // 35: ml_pipelines.SinglePlatformSpec
-	(*PlatformDeploymentConfig)(nil),                             // 36: ml_pipelines.PlatformDeploymentConfig
-	(*WorkspaceConfig)(nil),                                      // 37: ml_pipelines.WorkspaceConfig
-	(*KubernetesWorkspaceConfig)(nil),                            // 38: ml_pipelines.KubernetesWorkspaceConfig
-	(*PipelineConfig)(nil),                                       // 39: ml_pipelines.PipelineConfig
-	nil,                                                          // 40: ml_pipelines.PipelineJob.LabelsEntry
-	(*PipelineJob_RuntimeConfig)(nil),                            // 41: ml_pipelines.PipelineJob.RuntimeConfig
-	nil,                                                          // 42: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
-	nil,                                                          // 43: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
-	(*PipelineSpec_RuntimeParameter)(nil),                        // 44: ml_pipelines.PipelineSpec.RuntimeParameter
-	nil,                                                          // 45: ml_pipelines.PipelineSpec.ComponentsEntry
-	nil,                                                          // 46: ml_pipelines.DagSpec.TasksEntry
-	(*DagOutputsSpec_ArtifactSelectorSpec)(nil),                  // 47: ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
-	(*DagOutputsSpec_DagOutputArtifactSpec)(nil),                 // 48: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
-	nil, // 49: ml_pipelines.DagOutputsSpec.ArtifactsEntry
-	(*DagOutputsSpec_ParameterSelectorSpec)(nil),     // 50: ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	(*DagOutputsSpec_ParameterSelectorsSpec)(nil),    // 51: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
-	(*DagOutputsSpec_MapParameterSelectorsSpec)(nil), // 52: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec
-	(*DagOutputsSpec_DagOutputParameterSpec)(nil),    // 53: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
-	nil,                                      // 54: ml_pipelines.DagOutputsSpec.ParametersEntry
-	nil,                                      // 55: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
-	(*ComponentInputsSpec_ArtifactSpec)(nil), // 56: ml_pipelines.ComponentInputsSpec.ArtifactSpec
-	(*ComponentInputsSpec_ParameterSpec)(nil), // 57: ml_pipelines.ComponentInputsSpec.ParameterSpec
-	nil, // 58: ml_pipelines.ComponentInputsSpec.ArtifactsEntry
-	nil, // 59: ml_pipelines.ComponentInputsSpec.ParametersEntry
-	(*ComponentOutputsSpec_ArtifactSpec)(nil),  // 60: ml_pipelines.ComponentOutputsSpec.ArtifactSpec
-	(*ComponentOutputsSpec_ParameterSpec)(nil), // 61: ml_pipelines.ComponentOutputsSpec.ParameterSpec
-	nil,                                      // 62: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
-	nil,                                      // 63: ml_pipelines.ComponentOutputsSpec.ParametersEntry
-	nil,                                      // 64: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
-	nil,                                      // 65: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
-	(*TaskInputsSpec_InputArtifactSpec)(nil), // 66: ml_pipelines.TaskInputsSpec.InputArtifactSpec
-	(*TaskInputsSpec_InputParameterSpec)(nil), // 67: ml_pipelines.TaskInputsSpec.InputParameterSpec
-	nil, // 68: ml_pipelines.TaskInputsSpec.ParametersEntry
-	nil, // 69: ml_pipelines.TaskInputsSpec.ArtifactsEntry
-	(*TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec)(nil),   // 70: ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
-	(*TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec)(nil), // 71: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
-	(*TaskInputsSpec_InputParameterSpec_TaskFinalStatus)(nil),         // 72: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
-	(*TaskOutputsSpec_OutputArtifactSpec)(nil),                        // 73: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
-	(*TaskOutputsSpec_OutputParameterSpec)(nil),                       // 74: ml_pipelines.TaskOutputsSpec.OutputParameterSpec
-	nil,                                     // 75: ml_pipelines.TaskOutputsSpec.ParametersEntry
-	nil,                                     // 76: ml_pipelines.TaskOutputsSpec.ArtifactsEntry
-	nil,                                     // 77: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
-	nil,                                     // 78: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
-	(*PipelineTaskSpec_CachingOptions)(nil), // 79: ml_pipelines.PipelineTaskSpec.CachingOptions
-	(*PipelineTaskSpec_TriggerPolicy)(nil),  // 80: ml_pipelines.PipelineTaskSpec.TriggerPolicy
-	(*PipelineTaskSpec_RetryPolicy)(nil),    // 81: ml_pipelines.PipelineTaskSpec.RetryPolicy
-	(*PipelineTaskSpec_IteratorPolicy)(nil), // 82: ml_pipelines.PipelineTaskSpec.IteratorPolicy
-	(*ArtifactIteratorSpec_ItemsSpec)(nil),  // 83: ml_pipelines.ArtifactIteratorSpec.ItemsSpec
-	(*ParameterIteratorSpec_ItemsSpec)(nil), // 84: ml_pipelines.ParameterIteratorSpec.ItemsSpec
-	(*PipelineDeploymentConfig_PipelineContainerSpec)(nil),   // 85: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
-	(*PipelineDeploymentConfig_ImporterSpec)(nil),            // 86: ml_pipelines.PipelineDeploymentConfig.ImporterSpec
-	(*PipelineDeploymentConfig_ResolverSpec)(nil),            // 87: ml_pipelines.PipelineDeploymentConfig.ResolverSpec
-	(*PipelineDeploymentConfig_AIPlatformCustomJobSpec)(nil), // 88: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
-	(*PipelineDeploymentConfig_ExecutorSpec)(nil),            // 89: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
-	nil, // 90: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
-	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle)(nil),                      // 91: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
-	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec)(nil),                   // 92: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
-	(*PipelineDeploymentConfig_PipelineContainerSpec_EnvVar)(nil),                         // 93: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
-	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec)(nil),                 // 94: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
-	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig)(nil), // 95: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
-	nil, // 96: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
-	nil, // 97: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
-	(*PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec)(nil), // 98: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
-	nil,                                   // 99: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
-	nil,                                   // 100: ml_pipelines.RuntimeArtifact.PropertiesEntry
-	nil,                                   // 101: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
-	(*ExecutorInput_Inputs)(nil),          // 102: ml_pipelines.ExecutorInput.Inputs
-	(*ExecutorInput_OutputParameter)(nil), // 103: ml_pipelines.ExecutorInput.OutputParameter
-	(*ExecutorInput_Outputs)(nil),         // 104: ml_pipelines.ExecutorInput.Outputs
-	nil,                                   // 105: ml_pipelines.ExecutorInput.Inputs.ParametersEntry
-	nil,                                   // 106: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
-	nil,                                   // 107: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
-	nil,                                   // 108: ml_pipelines.ExecutorInput.Outputs.ParametersEntry
-	nil,                                   // 109: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
-	nil,                                   // 110: ml_pipelines.ExecutorOutput.ParametersEntry
-	nil,                                   // 111: ml_pipelines.ExecutorOutput.ArtifactsEntry
-	nil,                                   // 112: ml_pipelines.ExecutorOutput.ParameterValuesEntry
-	nil,                                   // 113: ml_pipelines.PlatformSpec.PlatformsEntry
-	nil,                                   // 114: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
-	(*structpb.Struct)(nil),               // 115: google.protobuf.Struct
-	(*structpb.Value)(nil),                // 116: google.protobuf.Value
-	(*status.Status)(nil),                 // 117: google.rpc.Status
-	(*durationpb.Duration)(nil),           // 118: google.protobuf.Duration
+	(PipelineTaskSpec_RetryPolicy_Policy)(0),                     // 4: ml_pipelines.PipelineTaskSpec.RetryPolicy.Policy
+	(PipelineStateEnum_PipelineTaskState)(0),                     // 5: ml_pipelines.PipelineStateEnum.PipelineTaskState
+	(*PipelineJob)(nil),                                          // 6: ml_pipelines.PipelineJob
+	(*PipelineSpec)(nil),                                         // 7: ml_pipelines.PipelineSpec
+	(*ComponentSpec)(nil),                                        // 8: ml_pipelines.ComponentSpec
+	(*DagSpec)(nil),                                              // 9: ml_pipelines.DagSpec
+	(*DagOutputsSpec)(nil),                                       // 10: ml_pipelines.DagOutputsSpec
+	(*ComponentInputsSpec)(nil),                                  // 11: ml_pipelines.ComponentInputsSpec
+	(*ComponentOutputsSpec)(nil),                                 // 12: ml_pipelines.ComponentOutputsSpec
+	(*TaskInputsSpec)(nil),                                       // 13: ml_pipelines.TaskInputsSpec
+	(*TaskOutputsSpec)(nil),                                      // 14: ml_pipelines.TaskOutputsSpec
+	(*PrimitiveType)(nil),                                        // 15: ml_pipelines.PrimitiveType
+	(*ParameterType)(nil),                                        // 16: ml_pipelines.ParameterType
+	(*TaskConfigPassthroughType)(nil),                            // 17: ml_pipelines.TaskConfigPassthroughType
+	(*TaskConfigPassthrough)(nil),                                // 18: ml_pipelines.TaskConfigPassthrough
+	(*PipelineTaskSpec)(nil),                                     // 19: ml_pipelines.PipelineTaskSpec
+	(*ArtifactIteratorSpec)(nil),                                 // 20: ml_pipelines.ArtifactIteratorSpec
+	(*ParameterIteratorSpec)(nil),                                // 21: ml_pipelines.ParameterIteratorSpec
+	(*ComponentRef)(nil),                                         // 22: ml_pipelines.ComponentRef
+	(*PipelineInfo)(nil),                                         // 23: ml_pipelines.PipelineInfo
+	(*ArtifactTypeSchema)(nil),                                   // 24: ml_pipelines.ArtifactTypeSchema
+	(*PipelineTaskInfo)(nil),                                     // 25: ml_pipelines.PipelineTaskInfo
+	(*ValueOrRuntimeParameter)(nil),                              // 26: ml_pipelines.ValueOrRuntimeParameter
+	(*PipelineDeploymentConfig)(nil),                             // 27: ml_pipelines.PipelineDeploymentConfig
+	(*Value)(nil),                                                // 28: ml_pipelines.Value
+	(*RuntimeArtifact)(nil),                                      // 29: ml_pipelines.RuntimeArtifact
+	(*ArtifactList)(nil),                                         // 30: ml_pipelines.ArtifactList
+	(*ExecutorInput)(nil),                                        // 31: ml_pipelines.ExecutorInput
+	(*ExecutorOutput)(nil),                                       // 32: ml_pipelines.ExecutorOutput
+	(*PipelineTaskFinalStatus)(nil),                              // 33: ml_pipelines.PipelineTaskFinalStatus
+	(*PipelineStateEnum)(nil),                                    // 34: ml_pipelines.PipelineStateEnum
+	(*PlatformSpec)(nil),                                         // 35: ml_pipelines.PlatformSpec
+	(*SinglePlatformSpec)(nil),                                   // 36: ml_pipelines.SinglePlatformSpec
+	(*PlatformDeploymentConfig)(nil),                             // 37: ml_pipelines.PlatformDeploymentConfig
+	(*WorkspaceConfig)(nil),                                      // 38: ml_pipelines.WorkspaceConfig
+	(*KubernetesWorkspaceConfig)(nil),                            // 39: ml_pipelines.KubernetesWorkspaceConfig
+	(*PipelineConfig)(nil),                                       // 40: ml_pipelines.PipelineConfig
+	nil,                                                          // 41: ml_pipelines.PipelineJob.LabelsEntry
+	(*PipelineJob_RuntimeConfig)(nil),                            // 42: ml_pipelines.PipelineJob.RuntimeConfig
+	nil,                                                          // 43: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
+	nil,                                                          // 44: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
+	(*PipelineSpec_RuntimeParameter)(nil),                        // 45: ml_pipelines.PipelineSpec.RuntimeParameter
+	nil,                                                          // 46: ml_pipelines.PipelineSpec.ComponentsEntry
+	nil,                                                          // 47: ml_pipelines.DagSpec.TasksEntry
+	(*DagOutputsSpec_ArtifactSelectorSpec)(nil),                  // 48: ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
+	(*DagOutputsSpec_DagOutputArtifactSpec)(nil),                 // 49: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
+	nil, // 50: ml_pipelines.DagOutputsSpec.ArtifactsEntry
+	(*DagOutputsSpec_ParameterSelectorSpec)(nil),     // 51: ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	(*DagOutputsSpec_ParameterSelectorsSpec)(nil),    // 52: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
+	(*DagOutputsSpec_MapParameterSelectorsSpec)(nil), // 53: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec
+	(*DagOutputsSpec_DagOutputParameterSpec)(nil),    // 54: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
+	nil,                                      // 55: ml_pipelines.DagOutputsSpec.ParametersEntry
+	nil,                                      // 56: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
+	(*ComponentInputsSpec_ArtifactSpec)(nil), // 57: ml_pipelines.ComponentInputsSpec.ArtifactSpec
+	(*ComponentInputsSpec_ParameterSpec)(nil), // 58: ml_pipelines.ComponentInputsSpec.ParameterSpec
+	nil, // 59: ml_pipelines.ComponentInputsSpec.ArtifactsEntry
+	nil, // 60: ml_pipelines.ComponentInputsSpec.ParametersEntry
+	(*ComponentOutputsSpec_ArtifactSpec)(nil),  // 61: ml_pipelines.ComponentOutputsSpec.ArtifactSpec
+	(*ComponentOutputsSpec_ParameterSpec)(nil), // 62: ml_pipelines.ComponentOutputsSpec.ParameterSpec
+	nil,                                      // 63: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
+	nil,                                      // 64: ml_pipelines.ComponentOutputsSpec.ParametersEntry
+	nil,                                      // 65: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
+	nil,                                      // 66: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
+	(*TaskInputsSpec_InputArtifactSpec)(nil), // 67: ml_pipelines.TaskInputsSpec.InputArtifactSpec
+	(*TaskInputsSpec_InputParameterSpec)(nil), // 68: ml_pipelines.TaskInputsSpec.InputParameterSpec
+	nil, // 69: ml_pipelines.TaskInputsSpec.ParametersEntry
+	nil, // 70: ml_pipelines.TaskInputsSpec.ArtifactsEntry
+	(*TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec)(nil),   // 71: ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
+	(*TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec)(nil), // 72: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
+	(*TaskInputsSpec_InputParameterSpec_TaskFinalStatus)(nil),         // 73: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
+	(*TaskOutputsSpec_OutputArtifactSpec)(nil),                        // 74: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
+	(*TaskOutputsSpec_OutputParameterSpec)(nil),                       // 75: ml_pipelines.TaskOutputsSpec.OutputParameterSpec
+	nil,                                     // 76: ml_pipelines.TaskOutputsSpec.ParametersEntry
+	nil,                                     // 77: ml_pipelines.TaskOutputsSpec.ArtifactsEntry
+	nil,                                     // 78: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
+	nil,                                     // 79: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
+	(*PipelineTaskSpec_CachingOptions)(nil), // 80: ml_pipelines.PipelineTaskSpec.CachingOptions
+	(*PipelineTaskSpec_TriggerPolicy)(nil),  // 81: ml_pipelines.PipelineTaskSpec.TriggerPolicy
+	(*PipelineTaskSpec_RetryPolicy)(nil),    // 82: ml_pipelines.PipelineTaskSpec.RetryPolicy
+	(*PipelineTaskSpec_IteratorPolicy)(nil), // 83: ml_pipelines.PipelineTaskSpec.IteratorPolicy
+	(*ArtifactIteratorSpec_ItemsSpec)(nil),  // 84: ml_pipelines.ArtifactIteratorSpec.ItemsSpec
+	(*ParameterIteratorSpec_ItemsSpec)(nil), // 85: ml_pipelines.ParameterIteratorSpec.ItemsSpec
+	(*PipelineDeploymentConfig_PipelineContainerSpec)(nil),   // 86: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
+	(*PipelineDeploymentConfig_ImporterSpec)(nil),            // 87: ml_pipelines.PipelineDeploymentConfig.ImporterSpec
+	(*PipelineDeploymentConfig_ResolverSpec)(nil),            // 88: ml_pipelines.PipelineDeploymentConfig.ResolverSpec
+	(*PipelineDeploymentConfig_AIPlatformCustomJobSpec)(nil), // 89: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
+	(*PipelineDeploymentConfig_ExecutorSpec)(nil),            // 90: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
+	nil, // 91: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
+	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle)(nil),                      // 92: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
+	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec)(nil),                   // 93: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
+	(*PipelineDeploymentConfig_PipelineContainerSpec_EnvVar)(nil),                         // 94: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
+	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec)(nil),                 // 95: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
+	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig)(nil), // 96: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
+	nil, // 97: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
+	nil, // 98: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
+	(*PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec)(nil), // 99: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
+	nil,                                   // 100: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
+	nil,                                   // 101: ml_pipelines.RuntimeArtifact.PropertiesEntry
+	nil,                                   // 102: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
+	(*ExecutorInput_Inputs)(nil),          // 103: ml_pipelines.ExecutorInput.Inputs
+	(*ExecutorInput_OutputParameter)(nil), // 104: ml_pipelines.ExecutorInput.OutputParameter
+	(*ExecutorInput_Outputs)(nil),         // 105: ml_pipelines.ExecutorInput.Outputs
+	nil,                                   // 106: ml_pipelines.ExecutorInput.Inputs.ParametersEntry
+	nil,                                   // 107: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
+	nil,                                   // 108: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
+	nil,                                   // 109: ml_pipelines.ExecutorInput.Outputs.ParametersEntry
+	nil,                                   // 110: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
+	nil,                                   // 111: ml_pipelines.ExecutorOutput.ParametersEntry
+	nil,                                   // 112: ml_pipelines.ExecutorOutput.ArtifactsEntry
+	nil,                                   // 113: ml_pipelines.ExecutorOutput.ParameterValuesEntry
+	nil,                                   // 114: ml_pipelines.PlatformSpec.PlatformsEntry
+	nil,                                   // 115: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
+	(*structpb.Struct)(nil),               // 116: google.protobuf.Struct
+	(*structpb.Value)(nil),                // 117: google.protobuf.Value
+	(*status.Status)(nil),                 // 118: google.rpc.Status
+	(*durationpb.Duration)(nil),           // 119: google.protobuf.Duration
 }
 var file_pipeline_spec_proto_depIdxs = []int32{
-	115, // 0: ml_pipelines.PipelineJob.pipeline_spec:type_name -> google.protobuf.Struct
-	40,  // 1: ml_pipelines.PipelineJob.labels:type_name -> ml_pipelines.PipelineJob.LabelsEntry
-	41,  // 2: ml_pipelines.PipelineJob.runtime_config:type_name -> ml_pipelines.PipelineJob.RuntimeConfig
-	22,  // 3: ml_pipelines.PipelineSpec.pipeline_info:type_name -> ml_pipelines.PipelineInfo
-	115, // 4: ml_pipelines.PipelineSpec.deployment_spec:type_name -> google.protobuf.Struct
-	45,  // 5: ml_pipelines.PipelineSpec.components:type_name -> ml_pipelines.PipelineSpec.ComponentsEntry
-	7,   // 6: ml_pipelines.PipelineSpec.root:type_name -> ml_pipelines.ComponentSpec
-	10,  // 7: ml_pipelines.ComponentSpec.input_definitions:type_name -> ml_pipelines.ComponentInputsSpec
-	11,  // 8: ml_pipelines.ComponentSpec.output_definitions:type_name -> ml_pipelines.ComponentOutputsSpec
-	8,   // 9: ml_pipelines.ComponentSpec.dag:type_name -> ml_pipelines.DagSpec
-	35,  // 10: ml_pipelines.ComponentSpec.single_platform_specs:type_name -> ml_pipelines.SinglePlatformSpec
-	17,  // 11: ml_pipelines.ComponentSpec.task_config_passthroughs:type_name -> ml_pipelines.TaskConfigPassthrough
-	46,  // 12: ml_pipelines.DagSpec.tasks:type_name -> ml_pipelines.DagSpec.TasksEntry
-	9,   // 13: ml_pipelines.DagSpec.outputs:type_name -> ml_pipelines.DagOutputsSpec
-	49,  // 14: ml_pipelines.DagOutputsSpec.artifacts:type_name -> ml_pipelines.DagOutputsSpec.ArtifactsEntry
-	54,  // 15: ml_pipelines.DagOutputsSpec.parameters:type_name -> ml_pipelines.DagOutputsSpec.ParametersEntry
-	58,  // 16: ml_pipelines.ComponentInputsSpec.artifacts:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactsEntry
-	59,  // 17: ml_pipelines.ComponentInputsSpec.parameters:type_name -> ml_pipelines.ComponentInputsSpec.ParametersEntry
-	62,  // 18: ml_pipelines.ComponentOutputsSpec.artifacts:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
-	63,  // 19: ml_pipelines.ComponentOutputsSpec.parameters:type_name -> ml_pipelines.ComponentOutputsSpec.ParametersEntry
-	68,  // 20: ml_pipelines.TaskInputsSpec.parameters:type_name -> ml_pipelines.TaskInputsSpec.ParametersEntry
-	69,  // 21: ml_pipelines.TaskInputsSpec.artifacts:type_name -> ml_pipelines.TaskInputsSpec.ArtifactsEntry
-	75,  // 22: ml_pipelines.TaskOutputsSpec.parameters:type_name -> ml_pipelines.TaskOutputsSpec.ParametersEntry
-	76,  // 23: ml_pipelines.TaskOutputsSpec.artifacts:type_name -> ml_pipelines.TaskOutputsSpec.ArtifactsEntry
+	116, // 0: ml_pipelines.PipelineJob.pipeline_spec:type_name -> google.protobuf.Struct
+	41,  // 1: ml_pipelines.PipelineJob.labels:type_name -> ml_pipelines.PipelineJob.LabelsEntry
+	42,  // 2: ml_pipelines.PipelineJob.runtime_config:type_name -> ml_pipelines.PipelineJob.RuntimeConfig
+	23,  // 3: ml_pipelines.PipelineSpec.pipeline_info:type_name -> ml_pipelines.PipelineInfo
+	116, // 4: ml_pipelines.PipelineSpec.deployment_spec:type_name -> google.protobuf.Struct
+	46,  // 5: ml_pipelines.PipelineSpec.components:type_name -> ml_pipelines.PipelineSpec.ComponentsEntry
+	8,   // 6: ml_pipelines.PipelineSpec.root:type_name -> ml_pipelines.ComponentSpec
+	11,  // 7: ml_pipelines.ComponentSpec.input_definitions:type_name -> ml_pipelines.ComponentInputsSpec
+	12,  // 8: ml_pipelines.ComponentSpec.output_definitions:type_name -> ml_pipelines.ComponentOutputsSpec
+	9,   // 9: ml_pipelines.ComponentSpec.dag:type_name -> ml_pipelines.DagSpec
+	36,  // 10: ml_pipelines.ComponentSpec.single_platform_specs:type_name -> ml_pipelines.SinglePlatformSpec
+	18,  // 11: ml_pipelines.ComponentSpec.task_config_passthroughs:type_name -> ml_pipelines.TaskConfigPassthrough
+	47,  // 12: ml_pipelines.DagSpec.tasks:type_name -> ml_pipelines.DagSpec.TasksEntry
+	10,  // 13: ml_pipelines.DagSpec.outputs:type_name -> ml_pipelines.DagOutputsSpec
+	50,  // 14: ml_pipelines.DagOutputsSpec.artifacts:type_name -> ml_pipelines.DagOutputsSpec.ArtifactsEntry
+	55,  // 15: ml_pipelines.DagOutputsSpec.parameters:type_name -> ml_pipelines.DagOutputsSpec.ParametersEntry
+	59,  // 16: ml_pipelines.ComponentInputsSpec.artifacts:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactsEntry
+	60,  // 17: ml_pipelines.ComponentInputsSpec.parameters:type_name -> ml_pipelines.ComponentInputsSpec.ParametersEntry
+	63,  // 18: ml_pipelines.ComponentOutputsSpec.artifacts:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
+	64,  // 19: ml_pipelines.ComponentOutputsSpec.parameters:type_name -> ml_pipelines.ComponentOutputsSpec.ParametersEntry
+	69,  // 20: ml_pipelines.TaskInputsSpec.parameters:type_name -> ml_pipelines.TaskInputsSpec.ParametersEntry
+	70,  // 21: ml_pipelines.TaskInputsSpec.artifacts:type_name -> ml_pipelines.TaskInputsSpec.ArtifactsEntry
+	76,  // 22: ml_pipelines.TaskOutputsSpec.parameters:type_name -> ml_pipelines.TaskOutputsSpec.ParametersEntry
+	77,  // 23: ml_pipelines.TaskOutputsSpec.artifacts:type_name -> ml_pipelines.TaskOutputsSpec.ArtifactsEntry
 	2,   // 24: ml_pipelines.TaskConfigPassthrough.field:type_name -> ml_pipelines.TaskConfigPassthroughType.TaskConfigPassthroughTypeEnum
-	24,  // 25: ml_pipelines.PipelineTaskSpec.task_info:type_name -> ml_pipelines.PipelineTaskInfo
-	12,  // 26: ml_pipelines.PipelineTaskSpec.inputs:type_name -> ml_pipelines.TaskInputsSpec
-	79,  // 27: ml_pipelines.PipelineTaskSpec.caching_options:type_name -> ml_pipelines.PipelineTaskSpec.CachingOptions
-	21,  // 28: ml_pipelines.PipelineTaskSpec.component_ref:type_name -> ml_pipelines.ComponentRef
-	80,  // 29: ml_pipelines.PipelineTaskSpec.trigger_policy:type_name -> ml_pipelines.PipelineTaskSpec.TriggerPolicy
-	19,  // 30: ml_pipelines.PipelineTaskSpec.artifact_iterator:type_name -> ml_pipelines.ArtifactIteratorSpec
-	20,  // 31: ml_pipelines.PipelineTaskSpec.parameter_iterator:type_name -> ml_pipelines.ParameterIteratorSpec
-	81,  // 32: ml_pipelines.PipelineTaskSpec.retry_policy:type_name -> ml_pipelines.PipelineTaskSpec.RetryPolicy
-	82,  // 33: ml_pipelines.PipelineTaskSpec.iterator_policy:type_name -> ml_pipelines.PipelineTaskSpec.IteratorPolicy
-	83,  // 34: ml_pipelines.ArtifactIteratorSpec.items:type_name -> ml_pipelines.ArtifactIteratorSpec.ItemsSpec
-	84,  // 35: ml_pipelines.ParameterIteratorSpec.items:type_name -> ml_pipelines.ParameterIteratorSpec.ItemsSpec
-	27,  // 36: ml_pipelines.ValueOrRuntimeParameter.constant_value:type_name -> ml_pipelines.Value
-	116, // 37: ml_pipelines.ValueOrRuntimeParameter.constant:type_name -> google.protobuf.Value
-	90,  // 38: ml_pipelines.PipelineDeploymentConfig.executors:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
-	23,  // 39: ml_pipelines.RuntimeArtifact.type:type_name -> ml_pipelines.ArtifactTypeSchema
-	100, // 40: ml_pipelines.RuntimeArtifact.properties:type_name -> ml_pipelines.RuntimeArtifact.PropertiesEntry
-	101, // 41: ml_pipelines.RuntimeArtifact.custom_properties:type_name -> ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
-	115, // 42: ml_pipelines.RuntimeArtifact.metadata:type_name -> google.protobuf.Struct
-	28,  // 43: ml_pipelines.ArtifactList.artifacts:type_name -> ml_pipelines.RuntimeArtifact
-	102, // 44: ml_pipelines.ExecutorInput.inputs:type_name -> ml_pipelines.ExecutorInput.Inputs
-	104, // 45: ml_pipelines.ExecutorInput.outputs:type_name -> ml_pipelines.ExecutorInput.Outputs
-	110, // 46: ml_pipelines.ExecutorOutput.parameters:type_name -> ml_pipelines.ExecutorOutput.ParametersEntry
-	111, // 47: ml_pipelines.ExecutorOutput.artifacts:type_name -> ml_pipelines.ExecutorOutput.ArtifactsEntry
-	112, // 48: ml_pipelines.ExecutorOutput.parameter_values:type_name -> ml_pipelines.ExecutorOutput.ParameterValuesEntry
-	117, // 49: ml_pipelines.PipelineTaskFinalStatus.error:type_name -> google.rpc.Status
-	113, // 50: ml_pipelines.PlatformSpec.platforms:type_name -> ml_pipelines.PlatformSpec.PlatformsEntry
-	36,  // 51: ml_pipelines.SinglePlatformSpec.deployment_spec:type_name -> ml_pipelines.PlatformDeploymentConfig
-	115, // 52: ml_pipelines.SinglePlatformSpec.config:type_name -> google.protobuf.Struct
-	39,  // 53: ml_pipelines.SinglePlatformSpec.pipelineConfig:type_name -> ml_pipelines.PipelineConfig
-	114, // 54: ml_pipelines.PlatformDeploymentConfig.executors:type_name -> ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
-	38,  // 55: ml_pipelines.WorkspaceConfig.kubernetes:type_name -> ml_pipelines.KubernetesWorkspaceConfig
-	115, // 56: ml_pipelines.KubernetesWorkspaceConfig.pvc_spec_patch:type_name -> google.protobuf.Struct
-	37,  // 57: ml_pipelines.PipelineConfig.workspace:type_name -> ml_pipelines.WorkspaceConfig
-	42,  // 58: ml_pipelines.PipelineJob.RuntimeConfig.parameters:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
-	43,  // 59: ml_pipelines.PipelineJob.RuntimeConfig.parameter_values:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
-	27,  // 60: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry.value:type_name -> ml_pipelines.Value
-	116, // 61: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry.value:type_name -> google.protobuf.Value
+	25,  // 25: ml_pipelines.PipelineTaskSpec.task_info:type_name -> ml_pipelines.PipelineTaskInfo
+	13,  // 26: ml_pipelines.PipelineTaskSpec.inputs:type_name -> ml_pipelines.TaskInputsSpec
+	80,  // 27: ml_pipelines.PipelineTaskSpec.caching_options:type_name -> ml_pipelines.PipelineTaskSpec.CachingOptions
+	22,  // 28: ml_pipelines.PipelineTaskSpec.component_ref:type_name -> ml_pipelines.ComponentRef
+	81,  // 29: ml_pipelines.PipelineTaskSpec.trigger_policy:type_name -> ml_pipelines.PipelineTaskSpec.TriggerPolicy
+	20,  // 30: ml_pipelines.PipelineTaskSpec.artifact_iterator:type_name -> ml_pipelines.ArtifactIteratorSpec
+	21,  // 31: ml_pipelines.PipelineTaskSpec.parameter_iterator:type_name -> ml_pipelines.ParameterIteratorSpec
+	82,  // 32: ml_pipelines.PipelineTaskSpec.retry_policy:type_name -> ml_pipelines.PipelineTaskSpec.RetryPolicy
+	83,  // 33: ml_pipelines.PipelineTaskSpec.iterator_policy:type_name -> ml_pipelines.PipelineTaskSpec.IteratorPolicy
+	84,  // 34: ml_pipelines.ArtifactIteratorSpec.items:type_name -> ml_pipelines.ArtifactIteratorSpec.ItemsSpec
+	85,  // 35: ml_pipelines.ParameterIteratorSpec.items:type_name -> ml_pipelines.ParameterIteratorSpec.ItemsSpec
+	28,  // 36: ml_pipelines.ValueOrRuntimeParameter.constant_value:type_name -> ml_pipelines.Value
+	117, // 37: ml_pipelines.ValueOrRuntimeParameter.constant:type_name -> google.protobuf.Value
+	91,  // 38: ml_pipelines.PipelineDeploymentConfig.executors:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
+	24,  // 39: ml_pipelines.RuntimeArtifact.type:type_name -> ml_pipelines.ArtifactTypeSchema
+	101, // 40: ml_pipelines.RuntimeArtifact.properties:type_name -> ml_pipelines.RuntimeArtifact.PropertiesEntry
+	102, // 41: ml_pipelines.RuntimeArtifact.custom_properties:type_name -> ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
+	116, // 42: ml_pipelines.RuntimeArtifact.metadata:type_name -> google.protobuf.Struct
+	29,  // 43: ml_pipelines.ArtifactList.artifacts:type_name -> ml_pipelines.RuntimeArtifact
+	103, // 44: ml_pipelines.ExecutorInput.inputs:type_name -> ml_pipelines.ExecutorInput.Inputs
+	105, // 45: ml_pipelines.ExecutorInput.outputs:type_name -> ml_pipelines.ExecutorInput.Outputs
+	111, // 46: ml_pipelines.ExecutorOutput.parameters:type_name -> ml_pipelines.ExecutorOutput.ParametersEntry
+	112, // 47: ml_pipelines.ExecutorOutput.artifacts:type_name -> ml_pipelines.ExecutorOutput.ArtifactsEntry
+	113, // 48: ml_pipelines.ExecutorOutput.parameter_values:type_name -> ml_pipelines.ExecutorOutput.ParameterValuesEntry
+	118, // 49: ml_pipelines.PipelineTaskFinalStatus.error:type_name -> google.rpc.Status
+	114, // 50: ml_pipelines.PlatformSpec.platforms:type_name -> ml_pipelines.PlatformSpec.PlatformsEntry
+	37,  // 51: ml_pipelines.SinglePlatformSpec.deployment_spec:type_name -> ml_pipelines.PlatformDeploymentConfig
+	116, // 52: ml_pipelines.SinglePlatformSpec.config:type_name -> google.protobuf.Struct
+	40,  // 53: ml_pipelines.SinglePlatformSpec.pipelineConfig:type_name -> ml_pipelines.PipelineConfig
+	115, // 54: ml_pipelines.PlatformDeploymentConfig.executors:type_name -> ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
+	39,  // 55: ml_pipelines.WorkspaceConfig.kubernetes:type_name -> ml_pipelines.KubernetesWorkspaceConfig
+	116, // 56: ml_pipelines.KubernetesWorkspaceConfig.pvc_spec_patch:type_name -> google.protobuf.Struct
+	38,  // 57: ml_pipelines.PipelineConfig.workspace:type_name -> ml_pipelines.WorkspaceConfig
+	43,  // 58: ml_pipelines.PipelineJob.RuntimeConfig.parameters:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
+	44,  // 59: ml_pipelines.PipelineJob.RuntimeConfig.parameter_values:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
+	28,  // 60: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry.value:type_name -> ml_pipelines.Value
+	117, // 61: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry.value:type_name -> google.protobuf.Value
 	0,   // 62: ml_pipelines.PipelineSpec.RuntimeParameter.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
-	27,  // 63: ml_pipelines.PipelineSpec.RuntimeParameter.default_value:type_name -> ml_pipelines.Value
-	7,   // 64: ml_pipelines.PipelineSpec.ComponentsEntry.value:type_name -> ml_pipelines.ComponentSpec
-	18,  // 65: ml_pipelines.DagSpec.TasksEntry.value:type_name -> ml_pipelines.PipelineTaskSpec
-	47,  // 66: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec.artifact_selectors:type_name -> ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
-	48,  // 67: ml_pipelines.DagOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
-	50,  // 68: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec.parameter_selectors:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	55,  // 69: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.mapped_parameters:type_name -> ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
-	50,  // 70: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_parameter:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	51,  // 71: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_oneof:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
-	53,  // 72: ml_pipelines.DagOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
-	50,  // 73: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	23,  // 74: ml_pipelines.ComponentInputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
+	28,  // 63: ml_pipelines.PipelineSpec.RuntimeParameter.default_value:type_name -> ml_pipelines.Value
+	8,   // 64: ml_pipelines.PipelineSpec.ComponentsEntry.value:type_name -> ml_pipelines.ComponentSpec
+	19,  // 65: ml_pipelines.DagSpec.TasksEntry.value:type_name -> ml_pipelines.PipelineTaskSpec
+	48,  // 66: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec.artifact_selectors:type_name -> ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
+	49,  // 67: ml_pipelines.DagOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
+	51,  // 68: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec.parameter_selectors:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	56,  // 69: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.mapped_parameters:type_name -> ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
+	51,  // 70: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_parameter:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	52,  // 71: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_oneof:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
+	54,  // 72: ml_pipelines.DagOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
+	51,  // 73: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	24,  // 74: ml_pipelines.ComponentInputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
 	0,   // 75: ml_pipelines.ComponentInputsSpec.ParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
 	1,   // 76: ml_pipelines.ComponentInputsSpec.ParameterSpec.parameter_type:type_name -> ml_pipelines.ParameterType.ParameterTypeEnum
-	116, // 77: ml_pipelines.ComponentInputsSpec.ParameterSpec.default_value:type_name -> google.protobuf.Value
-	116, // 78: ml_pipelines.ComponentInputsSpec.ParameterSpec.literals:type_name -> google.protobuf.Value
-	56,  // 79: ml_pipelines.ComponentInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactSpec
-	57,  // 80: ml_pipelines.ComponentInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ParameterSpec
-	23,  // 81: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
-	64,  // 82: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
-	65,  // 83: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.custom_properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
-	115, // 84: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.metadata:type_name -> google.protobuf.Struct
+	117, // 77: ml_pipelines.ComponentInputsSpec.ParameterSpec.default_value:type_name -> google.protobuf.Value
+	117, // 78: ml_pipelines.ComponentInputsSpec.ParameterSpec.literals:type_name -> google.protobuf.Value
+	57,  // 79: ml_pipelines.ComponentInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactSpec
+	58,  // 80: ml_pipelines.ComponentInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ParameterSpec
+	24,  // 81: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
+	65,  // 82: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
+	66,  // 83: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.custom_properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
+	116, // 84: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.metadata:type_name -> google.protobuf.Struct
 	0,   // 85: ml_pipelines.ComponentOutputsSpec.ParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
 	1,   // 86: ml_pipelines.ComponentOutputsSpec.ParameterSpec.parameter_type:type_name -> ml_pipelines.ParameterType.ParameterTypeEnum
-	60,  // 87: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec
-	61,  // 88: ml_pipelines.ComponentOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ParameterSpec
-	25,  // 89: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	25,  // 90: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	70,  // 91: ml_pipelines.TaskInputsSpec.InputArtifactSpec.task_output_artifact:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
-	71,  // 92: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_output_parameter:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
-	25,  // 93: ml_pipelines.TaskInputsSpec.InputParameterSpec.runtime_value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	72,  // 94: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_final_status:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
-	67,  // 95: ml_pipelines.TaskInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec
-	66,  // 96: ml_pipelines.TaskInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec
-	23,  // 97: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
-	77,  // 98: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
-	78,  // 99: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.custom_properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
+	61,  // 87: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec
+	62,  // 88: ml_pipelines.ComponentOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ParameterSpec
+	26,  // 89: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	26,  // 90: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	71,  // 91: ml_pipelines.TaskInputsSpec.InputArtifactSpec.task_output_artifact:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
+	72,  // 92: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_output_parameter:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
+	26,  // 93: ml_pipelines.TaskInputsSpec.InputParameterSpec.runtime_value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	73,  // 94: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_final_status:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
+	68,  // 95: ml_pipelines.TaskInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec
+	67,  // 96: ml_pipelines.TaskInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec
+	24,  // 97: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
+	78,  // 98: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
+	79,  // 99: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.custom_properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
 	0,   // 100: ml_pipelines.TaskOutputsSpec.OutputParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
-	74,  // 101: ml_pipelines.TaskOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputParameterSpec
-	73,  // 102: ml_pipelines.TaskOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
-	25,  // 103: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	25,  // 104: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	75,  // 101: ml_pipelines.TaskOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputParameterSpec
+	74,  // 102: ml_pipelines.TaskOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
+	26,  // 103: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	26,  // 104: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
 	3,   // 105: ml_pipelines.PipelineTaskSpec.TriggerPolicy.strategy:type_name -> ml_pipelines.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
-	118, // 106: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_duration:type_name -> google.protobuf.Duration
-	118, // 107: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_max_duration:type_name -> google.protobuf.Duration
-	91,  // 108: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.lifecycle:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
-	92,  // 109: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.resources:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
-	93,  // 110: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.env:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
-	25,  // 111: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.artifact_uri:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	23,  // 112: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.type_schema:type_name -> ml_pipelines.ArtifactTypeSchema
-	96,  // 113: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
-	97,  // 114: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.custom_properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
-	115, // 115: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.metadata:type_name -> google.protobuf.Struct
-	99,  // 116: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.output_artifact_queries:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
-	115, // 117: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec.custom_job:type_name -> google.protobuf.Struct
-	85,  // 118: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.container:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
-	86,  // 119: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.importer:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec
-	87,  // 120: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.resolver:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec
-	88,  // 121: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.custom_job:type_name -> ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
-	89,  // 122: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
-	94,  // 123: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.pre_cache_check:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
-	95,  // 124: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.accelerator:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
-	25,  // 125: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	25,  // 126: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	98,  // 127: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
-	27,  // 128: ml_pipelines.RuntimeArtifact.PropertiesEntry.value:type_name -> ml_pipelines.Value
-	27,  // 129: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry.value:type_name -> ml_pipelines.Value
-	105, // 130: ml_pipelines.ExecutorInput.Inputs.parameters:type_name -> ml_pipelines.ExecutorInput.Inputs.ParametersEntry
-	106, // 131: ml_pipelines.ExecutorInput.Inputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
-	107, // 132: ml_pipelines.ExecutorInput.Inputs.parameter_values:type_name -> ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
-	108, // 133: ml_pipelines.ExecutorInput.Outputs.parameters:type_name -> ml_pipelines.ExecutorInput.Outputs.ParametersEntry
-	109, // 134: ml_pipelines.ExecutorInput.Outputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
-	27,  // 135: ml_pipelines.ExecutorInput.Inputs.ParametersEntry.value:type_name -> ml_pipelines.Value
-	29,  // 136: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
-	116, // 137: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry.value:type_name -> google.protobuf.Value
-	103, // 138: ml_pipelines.ExecutorInput.Outputs.ParametersEntry.value:type_name -> ml_pipelines.ExecutorInput.OutputParameter
-	29,  // 139: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
-	27,  // 140: ml_pipelines.ExecutorOutput.ParametersEntry.value:type_name -> ml_pipelines.Value
-	29,  // 141: ml_pipelines.ExecutorOutput.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
-	116, // 142: ml_pipelines.ExecutorOutput.ParameterValuesEntry.value:type_name -> google.protobuf.Value
-	35,  // 143: ml_pipelines.PlatformSpec.PlatformsEntry.value:type_name -> ml_pipelines.SinglePlatformSpec
-	115, // 144: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry.value:type_name -> google.protobuf.Struct
-	145, // [145:145] is the sub-list for method output_type
-	145, // [145:145] is the sub-list for method input_type
-	145, // [145:145] is the sub-list for extension type_name
-	145, // [145:145] is the sub-list for extension extendee
-	0,   // [0:145] is the sub-list for field type_name
+	119, // 106: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_duration:type_name -> google.protobuf.Duration
+	119, // 107: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_max_duration:type_name -> google.protobuf.Duration
+	4,   // 108: ml_pipelines.PipelineTaskSpec.RetryPolicy.policy:type_name -> ml_pipelines.PipelineTaskSpec.RetryPolicy.Policy
+	92,  // 109: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.lifecycle:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
+	93,  // 110: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.resources:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
+	94,  // 111: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.env:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
+	26,  // 112: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.artifact_uri:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	24,  // 113: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.type_schema:type_name -> ml_pipelines.ArtifactTypeSchema
+	97,  // 114: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
+	98,  // 115: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.custom_properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
+	116, // 116: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.metadata:type_name -> google.protobuf.Struct
+	100, // 117: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.output_artifact_queries:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
+	116, // 118: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec.custom_job:type_name -> google.protobuf.Struct
+	86,  // 119: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.container:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
+	87,  // 120: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.importer:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec
+	88,  // 121: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.resolver:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec
+	89,  // 122: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.custom_job:type_name -> ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
+	90,  // 123: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
+	95,  // 124: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.pre_cache_check:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
+	96,  // 125: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.accelerator:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
+	26,  // 126: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	26,  // 127: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	99,  // 128: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
+	28,  // 129: ml_pipelines.RuntimeArtifact.PropertiesEntry.value:type_name -> ml_pipelines.Value
+	28,  // 130: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry.value:type_name -> ml_pipelines.Value
+	106, // 131: ml_pipelines.ExecutorInput.Inputs.parameters:type_name -> ml_pipelines.ExecutorInput.Inputs.ParametersEntry
+	107, // 132: ml_pipelines.ExecutorInput.Inputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
+	108, // 133: ml_pipelines.ExecutorInput.Inputs.parameter_values:type_name -> ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
+	109, // 134: ml_pipelines.ExecutorInput.Outputs.parameters:type_name -> ml_pipelines.ExecutorInput.Outputs.ParametersEntry
+	110, // 135: ml_pipelines.ExecutorInput.Outputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
+	28,  // 136: ml_pipelines.ExecutorInput.Inputs.ParametersEntry.value:type_name -> ml_pipelines.Value
+	30,  // 137: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
+	117, // 138: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry.value:type_name -> google.protobuf.Value
+	104, // 139: ml_pipelines.ExecutorInput.Outputs.ParametersEntry.value:type_name -> ml_pipelines.ExecutorInput.OutputParameter
+	30,  // 140: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
+	28,  // 141: ml_pipelines.ExecutorOutput.ParametersEntry.value:type_name -> ml_pipelines.Value
+	30,  // 142: ml_pipelines.ExecutorOutput.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
+	117, // 143: ml_pipelines.ExecutorOutput.ParameterValuesEntry.value:type_name -> google.protobuf.Value
+	36,  // 144: ml_pipelines.PlatformSpec.PlatformsEntry.value:type_name -> ml_pipelines.SinglePlatformSpec
+	116, // 145: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry.value:type_name -> google.protobuf.Struct
+	146, // [146:146] is the sub-list for method output_type
+	146, // [146:146] is the sub-list for method input_type
+	146, // [146:146] is the sub-list for extension type_name
+	146, // [146:146] is the sub-list for extension extendee
+	0,   // [0:146] is the sub-list for field type_name
 }
 
 func init() { file_pipeline_spec_proto_init() }
@@ -6515,7 +6589,7 @@ func file_pipeline_spec_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pipeline_spec_proto_rawDesc), len(file_pipeline_spec_proto_rawDesc)),
-			NumEnums:      5,
+			NumEnums:      6,
 			NumMessages:   110,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
+++ b/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
@@ -303,6 +303,65 @@ func (PipelineTaskSpec_TriggerPolicy_TriggerStrategy) EnumDescriptor() ([]byte, 
 	return file_pipeline_spec_proto_rawDescGZIP(), []int{13, 1, 0}
 }
 
+// The retry policy controls which failure types trigger a retry attempt.
+// Maps directly to Argo Workflows retryStrategy.retryPolicy.
+// POLICY_UNSPECIFIED omits the field, so the deployment's Argo
+// configuration decides; KFP's bundled manifests set OnError.
+type PipelineTaskSpec_RetryPolicy_Policy int32
+
+const (
+	PipelineTaskSpec_RetryPolicy_POLICY_UNSPECIFIED        PipelineTaskSpec_RetryPolicy_Policy = 0
+	PipelineTaskSpec_RetryPolicy_POLICY_ALWAYS             PipelineTaskSpec_RetryPolicy_Policy = 1
+	PipelineTaskSpec_RetryPolicy_POLICY_ON_FAILURE         PipelineTaskSpec_RetryPolicy_Policy = 2
+	PipelineTaskSpec_RetryPolicy_POLICY_ON_ERROR           PipelineTaskSpec_RetryPolicy_Policy = 3
+	PipelineTaskSpec_RetryPolicy_POLICY_ON_TRANSIENT_ERROR PipelineTaskSpec_RetryPolicy_Policy = 4
+)
+
+// Enum value maps for PipelineTaskSpec_RetryPolicy_Policy.
+var (
+	PipelineTaskSpec_RetryPolicy_Policy_name = map[int32]string{
+		0: "POLICY_UNSPECIFIED",
+		1: "POLICY_ALWAYS",
+		2: "POLICY_ON_FAILURE",
+		3: "POLICY_ON_ERROR",
+		4: "POLICY_ON_TRANSIENT_ERROR",
+	}
+	PipelineTaskSpec_RetryPolicy_Policy_value = map[string]int32{
+		"POLICY_UNSPECIFIED":        0,
+		"POLICY_ALWAYS":             1,
+		"POLICY_ON_FAILURE":         2,
+		"POLICY_ON_ERROR":           3,
+		"POLICY_ON_TRANSIENT_ERROR": 4,
+	}
+)
+
+func (x PipelineTaskSpec_RetryPolicy_Policy) Enum() *PipelineTaskSpec_RetryPolicy_Policy {
+	p := new(PipelineTaskSpec_RetryPolicy_Policy)
+	*p = x
+	return p
+}
+
+func (x PipelineTaskSpec_RetryPolicy_Policy) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PipelineTaskSpec_RetryPolicy_Policy) Descriptor() protoreflect.EnumDescriptor {
+	return file_pipeline_spec_proto_enumTypes[4].Descriptor()
+}
+
+func (PipelineTaskSpec_RetryPolicy_Policy) Type() protoreflect.EnumType {
+	return &file_pipeline_spec_proto_enumTypes[4]
+}
+
+func (x PipelineTaskSpec_RetryPolicy_Policy) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PipelineTaskSpec_RetryPolicy_Policy.Descriptor instead.
+func (PipelineTaskSpec_RetryPolicy_Policy) EnumDescriptor() ([]byte, []int) {
+	return file_pipeline_spec_proto_rawDescGZIP(), []int{13, 2, 0}
+}
+
 type PipelineStateEnum_PipelineTaskState int32
 
 const (
@@ -384,11 +443,11 @@ func (x PipelineStateEnum_PipelineTaskState) String() string {
 }
 
 func (PipelineStateEnum_PipelineTaskState) Descriptor() protoreflect.EnumDescriptor {
-	return file_pipeline_spec_proto_enumTypes[4].Descriptor()
+	return file_pipeline_spec_proto_enumTypes[5].Descriptor()
 }
 
 func (PipelineStateEnum_PipelineTaskState) Type() protoreflect.EnumType {
-	return &file_pipeline_spec_proto_enumTypes[4]
+	return &file_pipeline_spec_proto_enumTypes[5]
 }
 
 func (x PipelineStateEnum_PipelineTaskState) Number() protoreflect.EnumNumber {
@@ -4326,7 +4385,8 @@ type PipelineTaskSpec_RetryPolicy struct {
 	BackoffFactor float64 `protobuf:"fixed64,3,opt,name=backoff_factor,json=backoffFactor,proto3" json:"backoff_factor,omitempty"`
 	// The maximum duration during which the task will be retried according to
 	// the backoff strategy. If unspecified, will set to 1 hour.
-	BackoffMaxDuration *durationpb.Duration `protobuf:"bytes,4,opt,name=backoff_max_duration,json=backoffMaxDuration,proto3" json:"backoff_max_duration,omitempty"`
+	BackoffMaxDuration *durationpb.Duration                `protobuf:"bytes,4,opt,name=backoff_max_duration,json=backoffMaxDuration,proto3" json:"backoff_max_duration,omitempty"`
+	Policy             PipelineTaskSpec_RetryPolicy_Policy `protobuf:"varint,5,opt,name=policy,proto3,enum=ml_pipelines.PipelineTaskSpec_RetryPolicy_Policy" json:"policy,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -4387,6 +4447,13 @@ func (x *PipelineTaskSpec_RetryPolicy) GetBackoffMaxDuration() *durationpb.Durat
 		return x.BackoffMaxDuration
 	}
 	return nil
+}
+
+func (x *PipelineTaskSpec_RetryPolicy) GetPolicy() PipelineTaskSpec_RetryPolicy_Policy {
+	if x != nil {
+		return x.Policy
+	}
+	return PipelineTaskSpec_RetryPolicy_POLICY_UNSPECIFIED
 }
 
 // Iterator related settings.
@@ -5897,8 +5964,7 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\x12KUBERNETES_VOLUMES\x10\x06\"\x98\x01\n" +
 	"\x15TaskConfigPassthrough\x12[\n" +
 	"\x05field\x18\x01 \x01(\x0e2E.ml_pipelines.TaskConfigPassthroughType.TaskConfigPassthroughTypeEnumR\x05field\x12\"\n" +
-	"\rapply_to_task\x18\x02 \x01(\bR\vapplyToTask\"\xfe\n" +
-	"\n" +
+	"\rapply_to_task\x18\x02 \x01(\bR\vapplyToTask\"\xc9\f\n" +
 	"\x10PipelineTaskSpec\x12;\n" +
 	"\ttask_info\x18\x01 \x01(\v2\x1e.ml_pipelines.PipelineTaskInfoR\btaskInfo\x124\n" +
 	"\x06inputs\x18\x02 \x01(\v2\x1c.ml_pipelines.TaskInputsSpecR\x06inputs\x12'\n" +
@@ -5920,12 +5986,19 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\x0fTriggerStrategy\x12 \n" +
 	"\x1cTRIGGER_STRATEGY_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cALL_UPSTREAM_TASKS_SUCCEEDED\x10\x01\x12 \n" +
-	"\x1cALL_UPSTREAM_TASKS_COMPLETED\x10\x02\x1a\xef\x01\n" +
+	"\x1cALL_UPSTREAM_TASKS_COMPLETED\x10\x02\x1a\xba\x03\n" +
 	"\vRetryPolicy\x12&\n" +
 	"\x0fmax_retry_count\x18\x01 \x01(\x05R\rmaxRetryCount\x12D\n" +
 	"\x10backoff_duration\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\x0fbackoffDuration\x12%\n" +
 	"\x0ebackoff_factor\x18\x03 \x01(\x01R\rbackoffFactor\x12K\n" +
-	"\x14backoff_max_duration\x18\x04 \x01(\v2\x19.google.protobuf.DurationR\x12backoffMaxDuration\x1a=\n" +
+	"\x14backoff_max_duration\x18\x04 \x01(\v2\x19.google.protobuf.DurationR\x12backoffMaxDuration\x12I\n" +
+	"\x06policy\x18\x05 \x01(\x0e21.ml_pipelines.PipelineTaskSpec.RetryPolicy.PolicyR\x06policy\"~\n" +
+	"\x06Policy\x12\x16\n" +
+	"\x12POLICY_UNSPECIFIED\x10\x00\x12\x11\n" +
+	"\rPOLICY_ALWAYS\x10\x01\x12\x15\n" +
+	"\x11POLICY_ON_FAILURE\x10\x02\x12\x13\n" +
+	"\x0fPOLICY_ON_ERROR\x10\x03\x12\x1d\n" +
+	"\x19POLICY_ON_TRANSIENT_ERROR\x10\x04\x1a=\n" +
 	"\x0eIteratorPolicy\x12+\n" +
 	"\x11parallelism_limit\x18\x01 \x01(\x05R\x10parallelismLimitB\n" +
 	"\n" +
@@ -6182,280 +6255,282 @@ func file_pipeline_spec_proto_rawDescGZIP() []byte {
 	return file_pipeline_spec_proto_rawDescData
 }
 
-var file_pipeline_spec_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
+var file_pipeline_spec_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
 var file_pipeline_spec_proto_msgTypes = make([]protoimpl.MessageInfo, 110)
 var file_pipeline_spec_proto_goTypes = []any{
 	(PrimitiveType_PrimitiveTypeEnum)(0),                         // 0: ml_pipelines.PrimitiveType.PrimitiveTypeEnum
 	(ParameterType_ParameterTypeEnum)(0),                         // 1: ml_pipelines.ParameterType.ParameterTypeEnum
 	(TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum)(0), // 2: ml_pipelines.TaskConfigPassthroughType.TaskConfigPassthroughTypeEnum
 	(PipelineTaskSpec_TriggerPolicy_TriggerStrategy)(0),          // 3: ml_pipelines.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
-	(PipelineStateEnum_PipelineTaskState)(0),                     // 4: ml_pipelines.PipelineStateEnum.PipelineTaskState
-	(*PipelineJob)(nil),                                          // 5: ml_pipelines.PipelineJob
-	(*PipelineSpec)(nil),                                         // 6: ml_pipelines.PipelineSpec
-	(*ComponentSpec)(nil),                                        // 7: ml_pipelines.ComponentSpec
-	(*DagSpec)(nil),                                              // 8: ml_pipelines.DagSpec
-	(*DagOutputsSpec)(nil),                                       // 9: ml_pipelines.DagOutputsSpec
-	(*ComponentInputsSpec)(nil),                                  // 10: ml_pipelines.ComponentInputsSpec
-	(*ComponentOutputsSpec)(nil),                                 // 11: ml_pipelines.ComponentOutputsSpec
-	(*TaskInputsSpec)(nil),                                       // 12: ml_pipelines.TaskInputsSpec
-	(*TaskOutputsSpec)(nil),                                      // 13: ml_pipelines.TaskOutputsSpec
-	(*PrimitiveType)(nil),                                        // 14: ml_pipelines.PrimitiveType
-	(*ParameterType)(nil),                                        // 15: ml_pipelines.ParameterType
-	(*TaskConfigPassthroughType)(nil),                            // 16: ml_pipelines.TaskConfigPassthroughType
-	(*TaskConfigPassthrough)(nil),                                // 17: ml_pipelines.TaskConfigPassthrough
-	(*PipelineTaskSpec)(nil),                                     // 18: ml_pipelines.PipelineTaskSpec
-	(*ArtifactIteratorSpec)(nil),                                 // 19: ml_pipelines.ArtifactIteratorSpec
-	(*ParameterIteratorSpec)(nil),                                // 20: ml_pipelines.ParameterIteratorSpec
-	(*ComponentRef)(nil),                                         // 21: ml_pipelines.ComponentRef
-	(*PipelineInfo)(nil),                                         // 22: ml_pipelines.PipelineInfo
-	(*ArtifactTypeSchema)(nil),                                   // 23: ml_pipelines.ArtifactTypeSchema
-	(*PipelineTaskInfo)(nil),                                     // 24: ml_pipelines.PipelineTaskInfo
-	(*ValueOrRuntimeParameter)(nil),                              // 25: ml_pipelines.ValueOrRuntimeParameter
-	(*PipelineDeploymentConfig)(nil),                             // 26: ml_pipelines.PipelineDeploymentConfig
-	(*Value)(nil),                                                // 27: ml_pipelines.Value
-	(*RuntimeArtifact)(nil),                                      // 28: ml_pipelines.RuntimeArtifact
-	(*ArtifactList)(nil),                                         // 29: ml_pipelines.ArtifactList
-	(*ExecutorInput)(nil),                                        // 30: ml_pipelines.ExecutorInput
-	(*ExecutorOutput)(nil),                                       // 31: ml_pipelines.ExecutorOutput
-	(*PipelineTaskFinalStatus)(nil),                              // 32: ml_pipelines.PipelineTaskFinalStatus
-	(*PipelineStateEnum)(nil),                                    // 33: ml_pipelines.PipelineStateEnum
-	(*PlatformSpec)(nil),                                         // 34: ml_pipelines.PlatformSpec
-	(*SinglePlatformSpec)(nil),                                   // 35: ml_pipelines.SinglePlatformSpec
-	(*PlatformDeploymentConfig)(nil),                             // 36: ml_pipelines.PlatformDeploymentConfig
-	(*WorkspaceConfig)(nil),                                      // 37: ml_pipelines.WorkspaceConfig
-	(*KubernetesWorkspaceConfig)(nil),                            // 38: ml_pipelines.KubernetesWorkspaceConfig
-	(*PipelineConfig)(nil),                                       // 39: ml_pipelines.PipelineConfig
-	nil,                                                          // 40: ml_pipelines.PipelineJob.LabelsEntry
-	(*PipelineJob_RuntimeConfig)(nil),                            // 41: ml_pipelines.PipelineJob.RuntimeConfig
-	nil,                                                          // 42: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
-	nil,                                                          // 43: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
-	(*PipelineSpec_RuntimeParameter)(nil),                        // 44: ml_pipelines.PipelineSpec.RuntimeParameter
-	nil,                                                          // 45: ml_pipelines.PipelineSpec.ComponentsEntry
-	nil,                                                          // 46: ml_pipelines.DagSpec.TasksEntry
-	(*DagOutputsSpec_ArtifactSelectorSpec)(nil),                  // 47: ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
-	(*DagOutputsSpec_DagOutputArtifactSpec)(nil),                 // 48: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
-	nil, // 49: ml_pipelines.DagOutputsSpec.ArtifactsEntry
-	(*DagOutputsSpec_ParameterSelectorSpec)(nil),     // 50: ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	(*DagOutputsSpec_ParameterSelectorsSpec)(nil),    // 51: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
-	(*DagOutputsSpec_MapParameterSelectorsSpec)(nil), // 52: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec
-	(*DagOutputsSpec_DagOutputParameterSpec)(nil),    // 53: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
-	nil,                                      // 54: ml_pipelines.DagOutputsSpec.ParametersEntry
-	nil,                                      // 55: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
-	(*ComponentInputsSpec_ArtifactSpec)(nil), // 56: ml_pipelines.ComponentInputsSpec.ArtifactSpec
-	(*ComponentInputsSpec_ParameterSpec)(nil), // 57: ml_pipelines.ComponentInputsSpec.ParameterSpec
-	nil, // 58: ml_pipelines.ComponentInputsSpec.ArtifactsEntry
-	nil, // 59: ml_pipelines.ComponentInputsSpec.ParametersEntry
-	(*ComponentOutputsSpec_ArtifactSpec)(nil),  // 60: ml_pipelines.ComponentOutputsSpec.ArtifactSpec
-	(*ComponentOutputsSpec_ParameterSpec)(nil), // 61: ml_pipelines.ComponentOutputsSpec.ParameterSpec
-	nil,                                      // 62: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
-	nil,                                      // 63: ml_pipelines.ComponentOutputsSpec.ParametersEntry
-	nil,                                      // 64: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
-	nil,                                      // 65: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
-	(*TaskInputsSpec_InputArtifactSpec)(nil), // 66: ml_pipelines.TaskInputsSpec.InputArtifactSpec
-	(*TaskInputsSpec_InputParameterSpec)(nil), // 67: ml_pipelines.TaskInputsSpec.InputParameterSpec
-	nil, // 68: ml_pipelines.TaskInputsSpec.ParametersEntry
-	nil, // 69: ml_pipelines.TaskInputsSpec.ArtifactsEntry
-	(*TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec)(nil),   // 70: ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
-	(*TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec)(nil), // 71: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
-	(*TaskInputsSpec_InputParameterSpec_TaskFinalStatus)(nil),         // 72: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
-	(*TaskOutputsSpec_OutputArtifactSpec)(nil),                        // 73: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
-	(*TaskOutputsSpec_OutputParameterSpec)(nil),                       // 74: ml_pipelines.TaskOutputsSpec.OutputParameterSpec
-	nil,                                     // 75: ml_pipelines.TaskOutputsSpec.ParametersEntry
-	nil,                                     // 76: ml_pipelines.TaskOutputsSpec.ArtifactsEntry
-	nil,                                     // 77: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
-	nil,                                     // 78: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
-	(*PipelineTaskSpec_CachingOptions)(nil), // 79: ml_pipelines.PipelineTaskSpec.CachingOptions
-	(*PipelineTaskSpec_TriggerPolicy)(nil),  // 80: ml_pipelines.PipelineTaskSpec.TriggerPolicy
-	(*PipelineTaskSpec_RetryPolicy)(nil),    // 81: ml_pipelines.PipelineTaskSpec.RetryPolicy
-	(*PipelineTaskSpec_IteratorPolicy)(nil), // 82: ml_pipelines.PipelineTaskSpec.IteratorPolicy
-	(*ArtifactIteratorSpec_ItemsSpec)(nil),  // 83: ml_pipelines.ArtifactIteratorSpec.ItemsSpec
-	(*ParameterIteratorSpec_ItemsSpec)(nil), // 84: ml_pipelines.ParameterIteratorSpec.ItemsSpec
-	(*PipelineDeploymentConfig_PipelineContainerSpec)(nil),   // 85: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
-	(*PipelineDeploymentConfig_ImporterSpec)(nil),            // 86: ml_pipelines.PipelineDeploymentConfig.ImporterSpec
-	(*PipelineDeploymentConfig_ResolverSpec)(nil),            // 87: ml_pipelines.PipelineDeploymentConfig.ResolverSpec
-	(*PipelineDeploymentConfig_AIPlatformCustomJobSpec)(nil), // 88: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
-	(*PipelineDeploymentConfig_ExecutorSpec)(nil),            // 89: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
-	nil, // 90: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
-	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle)(nil),                      // 91: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
-	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec)(nil),                   // 92: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
-	(*PipelineDeploymentConfig_PipelineContainerSpec_EnvVar)(nil),                         // 93: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
-	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec)(nil),                 // 94: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
-	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig)(nil), // 95: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
-	nil, // 96: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
-	nil, // 97: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
-	(*PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec)(nil), // 98: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
-	nil,                                   // 99: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
-	nil,                                   // 100: ml_pipelines.RuntimeArtifact.PropertiesEntry
-	nil,                                   // 101: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
-	(*ExecutorInput_Inputs)(nil),          // 102: ml_pipelines.ExecutorInput.Inputs
-	(*ExecutorInput_OutputParameter)(nil), // 103: ml_pipelines.ExecutorInput.OutputParameter
-	(*ExecutorInput_Outputs)(nil),         // 104: ml_pipelines.ExecutorInput.Outputs
-	nil,                                   // 105: ml_pipelines.ExecutorInput.Inputs.ParametersEntry
-	nil,                                   // 106: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
-	nil,                                   // 107: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
-	nil,                                   // 108: ml_pipelines.ExecutorInput.Outputs.ParametersEntry
-	nil,                                   // 109: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
-	nil,                                   // 110: ml_pipelines.ExecutorOutput.ParametersEntry
-	nil,                                   // 111: ml_pipelines.ExecutorOutput.ArtifactsEntry
-	nil,                                   // 112: ml_pipelines.ExecutorOutput.ParameterValuesEntry
-	nil,                                   // 113: ml_pipelines.PlatformSpec.PlatformsEntry
-	nil,                                   // 114: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
-	(*structpb.Struct)(nil),               // 115: google.protobuf.Struct
-	(*structpb.Value)(nil),                // 116: google.protobuf.Value
-	(*status.Status)(nil),                 // 117: google.rpc.Status
-	(*durationpb.Duration)(nil),           // 118: google.protobuf.Duration
+	(PipelineTaskSpec_RetryPolicy_Policy)(0),                     // 4: ml_pipelines.PipelineTaskSpec.RetryPolicy.Policy
+	(PipelineStateEnum_PipelineTaskState)(0),                     // 5: ml_pipelines.PipelineStateEnum.PipelineTaskState
+	(*PipelineJob)(nil),                                          // 6: ml_pipelines.PipelineJob
+	(*PipelineSpec)(nil),                                         // 7: ml_pipelines.PipelineSpec
+	(*ComponentSpec)(nil),                                        // 8: ml_pipelines.ComponentSpec
+	(*DagSpec)(nil),                                              // 9: ml_pipelines.DagSpec
+	(*DagOutputsSpec)(nil),                                       // 10: ml_pipelines.DagOutputsSpec
+	(*ComponentInputsSpec)(nil),                                  // 11: ml_pipelines.ComponentInputsSpec
+	(*ComponentOutputsSpec)(nil),                                 // 12: ml_pipelines.ComponentOutputsSpec
+	(*TaskInputsSpec)(nil),                                       // 13: ml_pipelines.TaskInputsSpec
+	(*TaskOutputsSpec)(nil),                                      // 14: ml_pipelines.TaskOutputsSpec
+	(*PrimitiveType)(nil),                                        // 15: ml_pipelines.PrimitiveType
+	(*ParameterType)(nil),                                        // 16: ml_pipelines.ParameterType
+	(*TaskConfigPassthroughType)(nil),                            // 17: ml_pipelines.TaskConfigPassthroughType
+	(*TaskConfigPassthrough)(nil),                                // 18: ml_pipelines.TaskConfigPassthrough
+	(*PipelineTaskSpec)(nil),                                     // 19: ml_pipelines.PipelineTaskSpec
+	(*ArtifactIteratorSpec)(nil),                                 // 20: ml_pipelines.ArtifactIteratorSpec
+	(*ParameterIteratorSpec)(nil),                                // 21: ml_pipelines.ParameterIteratorSpec
+	(*ComponentRef)(nil),                                         // 22: ml_pipelines.ComponentRef
+	(*PipelineInfo)(nil),                                         // 23: ml_pipelines.PipelineInfo
+	(*ArtifactTypeSchema)(nil),                                   // 24: ml_pipelines.ArtifactTypeSchema
+	(*PipelineTaskInfo)(nil),                                     // 25: ml_pipelines.PipelineTaskInfo
+	(*ValueOrRuntimeParameter)(nil),                              // 26: ml_pipelines.ValueOrRuntimeParameter
+	(*PipelineDeploymentConfig)(nil),                             // 27: ml_pipelines.PipelineDeploymentConfig
+	(*Value)(nil),                                                // 28: ml_pipelines.Value
+	(*RuntimeArtifact)(nil),                                      // 29: ml_pipelines.RuntimeArtifact
+	(*ArtifactList)(nil),                                         // 30: ml_pipelines.ArtifactList
+	(*ExecutorInput)(nil),                                        // 31: ml_pipelines.ExecutorInput
+	(*ExecutorOutput)(nil),                                       // 32: ml_pipelines.ExecutorOutput
+	(*PipelineTaskFinalStatus)(nil),                              // 33: ml_pipelines.PipelineTaskFinalStatus
+	(*PipelineStateEnum)(nil),                                    // 34: ml_pipelines.PipelineStateEnum
+	(*PlatformSpec)(nil),                                         // 35: ml_pipelines.PlatformSpec
+	(*SinglePlatformSpec)(nil),                                   // 36: ml_pipelines.SinglePlatformSpec
+	(*PlatformDeploymentConfig)(nil),                             // 37: ml_pipelines.PlatformDeploymentConfig
+	(*WorkspaceConfig)(nil),                                      // 38: ml_pipelines.WorkspaceConfig
+	(*KubernetesWorkspaceConfig)(nil),                            // 39: ml_pipelines.KubernetesWorkspaceConfig
+	(*PipelineConfig)(nil),                                       // 40: ml_pipelines.PipelineConfig
+	nil,                                                          // 41: ml_pipelines.PipelineJob.LabelsEntry
+	(*PipelineJob_RuntimeConfig)(nil),                            // 42: ml_pipelines.PipelineJob.RuntimeConfig
+	nil,                                                          // 43: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
+	nil,                                                          // 44: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
+	(*PipelineSpec_RuntimeParameter)(nil),                        // 45: ml_pipelines.PipelineSpec.RuntimeParameter
+	nil,                                                          // 46: ml_pipelines.PipelineSpec.ComponentsEntry
+	nil,                                                          // 47: ml_pipelines.DagSpec.TasksEntry
+	(*DagOutputsSpec_ArtifactSelectorSpec)(nil),                  // 48: ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
+	(*DagOutputsSpec_DagOutputArtifactSpec)(nil),                 // 49: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
+	nil, // 50: ml_pipelines.DagOutputsSpec.ArtifactsEntry
+	(*DagOutputsSpec_ParameterSelectorSpec)(nil),     // 51: ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	(*DagOutputsSpec_ParameterSelectorsSpec)(nil),    // 52: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
+	(*DagOutputsSpec_MapParameterSelectorsSpec)(nil), // 53: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec
+	(*DagOutputsSpec_DagOutputParameterSpec)(nil),    // 54: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
+	nil,                                      // 55: ml_pipelines.DagOutputsSpec.ParametersEntry
+	nil,                                      // 56: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
+	(*ComponentInputsSpec_ArtifactSpec)(nil), // 57: ml_pipelines.ComponentInputsSpec.ArtifactSpec
+	(*ComponentInputsSpec_ParameterSpec)(nil), // 58: ml_pipelines.ComponentInputsSpec.ParameterSpec
+	nil, // 59: ml_pipelines.ComponentInputsSpec.ArtifactsEntry
+	nil, // 60: ml_pipelines.ComponentInputsSpec.ParametersEntry
+	(*ComponentOutputsSpec_ArtifactSpec)(nil),  // 61: ml_pipelines.ComponentOutputsSpec.ArtifactSpec
+	(*ComponentOutputsSpec_ParameterSpec)(nil), // 62: ml_pipelines.ComponentOutputsSpec.ParameterSpec
+	nil,                                      // 63: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
+	nil,                                      // 64: ml_pipelines.ComponentOutputsSpec.ParametersEntry
+	nil,                                      // 65: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
+	nil,                                      // 66: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
+	(*TaskInputsSpec_InputArtifactSpec)(nil), // 67: ml_pipelines.TaskInputsSpec.InputArtifactSpec
+	(*TaskInputsSpec_InputParameterSpec)(nil), // 68: ml_pipelines.TaskInputsSpec.InputParameterSpec
+	nil, // 69: ml_pipelines.TaskInputsSpec.ParametersEntry
+	nil, // 70: ml_pipelines.TaskInputsSpec.ArtifactsEntry
+	(*TaskInputsSpec_InputArtifactSpec_TaskOutputArtifactSpec)(nil),   // 71: ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
+	(*TaskInputsSpec_InputParameterSpec_TaskOutputParameterSpec)(nil), // 72: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
+	(*TaskInputsSpec_InputParameterSpec_TaskFinalStatus)(nil),         // 73: ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
+	(*TaskOutputsSpec_OutputArtifactSpec)(nil),                        // 74: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
+	(*TaskOutputsSpec_OutputParameterSpec)(nil),                       // 75: ml_pipelines.TaskOutputsSpec.OutputParameterSpec
+	nil,                                     // 76: ml_pipelines.TaskOutputsSpec.ParametersEntry
+	nil,                                     // 77: ml_pipelines.TaskOutputsSpec.ArtifactsEntry
+	nil,                                     // 78: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
+	nil,                                     // 79: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
+	(*PipelineTaskSpec_CachingOptions)(nil), // 80: ml_pipelines.PipelineTaskSpec.CachingOptions
+	(*PipelineTaskSpec_TriggerPolicy)(nil),  // 81: ml_pipelines.PipelineTaskSpec.TriggerPolicy
+	(*PipelineTaskSpec_RetryPolicy)(nil),    // 82: ml_pipelines.PipelineTaskSpec.RetryPolicy
+	(*PipelineTaskSpec_IteratorPolicy)(nil), // 83: ml_pipelines.PipelineTaskSpec.IteratorPolicy
+	(*ArtifactIteratorSpec_ItemsSpec)(nil),  // 84: ml_pipelines.ArtifactIteratorSpec.ItemsSpec
+	(*ParameterIteratorSpec_ItemsSpec)(nil), // 85: ml_pipelines.ParameterIteratorSpec.ItemsSpec
+	(*PipelineDeploymentConfig_PipelineContainerSpec)(nil),   // 86: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
+	(*PipelineDeploymentConfig_ImporterSpec)(nil),            // 87: ml_pipelines.PipelineDeploymentConfig.ImporterSpec
+	(*PipelineDeploymentConfig_ResolverSpec)(nil),            // 88: ml_pipelines.PipelineDeploymentConfig.ResolverSpec
+	(*PipelineDeploymentConfig_AIPlatformCustomJobSpec)(nil), // 89: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
+	(*PipelineDeploymentConfig_ExecutorSpec)(nil),            // 90: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
+	nil, // 91: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
+	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle)(nil),                      // 92: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
+	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec)(nil),                   // 93: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
+	(*PipelineDeploymentConfig_PipelineContainerSpec_EnvVar)(nil),                         // 94: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
+	(*PipelineDeploymentConfig_PipelineContainerSpec_Lifecycle_Exec)(nil),                 // 95: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
+	(*PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig)(nil), // 96: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
+	nil, // 97: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
+	nil, // 98: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
+	(*PipelineDeploymentConfig_ResolverSpec_ArtifactQuerySpec)(nil), // 99: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
+	nil,                                   // 100: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
+	nil,                                   // 101: ml_pipelines.RuntimeArtifact.PropertiesEntry
+	nil,                                   // 102: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
+	(*ExecutorInput_Inputs)(nil),          // 103: ml_pipelines.ExecutorInput.Inputs
+	(*ExecutorInput_OutputParameter)(nil), // 104: ml_pipelines.ExecutorInput.OutputParameter
+	(*ExecutorInput_Outputs)(nil),         // 105: ml_pipelines.ExecutorInput.Outputs
+	nil,                                   // 106: ml_pipelines.ExecutorInput.Inputs.ParametersEntry
+	nil,                                   // 107: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
+	nil,                                   // 108: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
+	nil,                                   // 109: ml_pipelines.ExecutorInput.Outputs.ParametersEntry
+	nil,                                   // 110: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
+	nil,                                   // 111: ml_pipelines.ExecutorOutput.ParametersEntry
+	nil,                                   // 112: ml_pipelines.ExecutorOutput.ArtifactsEntry
+	nil,                                   // 113: ml_pipelines.ExecutorOutput.ParameterValuesEntry
+	nil,                                   // 114: ml_pipelines.PlatformSpec.PlatformsEntry
+	nil,                                   // 115: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
+	(*structpb.Struct)(nil),               // 116: google.protobuf.Struct
+	(*structpb.Value)(nil),                // 117: google.protobuf.Value
+	(*status.Status)(nil),                 // 118: google.rpc.Status
+	(*durationpb.Duration)(nil),           // 119: google.protobuf.Duration
 }
 var file_pipeline_spec_proto_depIdxs = []int32{
-	115, // 0: ml_pipelines.PipelineJob.pipeline_spec:type_name -> google.protobuf.Struct
-	40,  // 1: ml_pipelines.PipelineJob.labels:type_name -> ml_pipelines.PipelineJob.LabelsEntry
-	41,  // 2: ml_pipelines.PipelineJob.runtime_config:type_name -> ml_pipelines.PipelineJob.RuntimeConfig
-	22,  // 3: ml_pipelines.PipelineSpec.pipeline_info:type_name -> ml_pipelines.PipelineInfo
-	115, // 4: ml_pipelines.PipelineSpec.deployment_spec:type_name -> google.protobuf.Struct
-	45,  // 5: ml_pipelines.PipelineSpec.components:type_name -> ml_pipelines.PipelineSpec.ComponentsEntry
-	7,   // 6: ml_pipelines.PipelineSpec.root:type_name -> ml_pipelines.ComponentSpec
-	10,  // 7: ml_pipelines.ComponentSpec.input_definitions:type_name -> ml_pipelines.ComponentInputsSpec
-	11,  // 8: ml_pipelines.ComponentSpec.output_definitions:type_name -> ml_pipelines.ComponentOutputsSpec
-	8,   // 9: ml_pipelines.ComponentSpec.dag:type_name -> ml_pipelines.DagSpec
-	35,  // 10: ml_pipelines.ComponentSpec.single_platform_specs:type_name -> ml_pipelines.SinglePlatformSpec
-	17,  // 11: ml_pipelines.ComponentSpec.task_config_passthroughs:type_name -> ml_pipelines.TaskConfigPassthrough
-	46,  // 12: ml_pipelines.DagSpec.tasks:type_name -> ml_pipelines.DagSpec.TasksEntry
-	9,   // 13: ml_pipelines.DagSpec.outputs:type_name -> ml_pipelines.DagOutputsSpec
-	49,  // 14: ml_pipelines.DagOutputsSpec.artifacts:type_name -> ml_pipelines.DagOutputsSpec.ArtifactsEntry
-	54,  // 15: ml_pipelines.DagOutputsSpec.parameters:type_name -> ml_pipelines.DagOutputsSpec.ParametersEntry
-	58,  // 16: ml_pipelines.ComponentInputsSpec.artifacts:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactsEntry
-	59,  // 17: ml_pipelines.ComponentInputsSpec.parameters:type_name -> ml_pipelines.ComponentInputsSpec.ParametersEntry
-	62,  // 18: ml_pipelines.ComponentOutputsSpec.artifacts:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
-	63,  // 19: ml_pipelines.ComponentOutputsSpec.parameters:type_name -> ml_pipelines.ComponentOutputsSpec.ParametersEntry
-	68,  // 20: ml_pipelines.TaskInputsSpec.parameters:type_name -> ml_pipelines.TaskInputsSpec.ParametersEntry
-	69,  // 21: ml_pipelines.TaskInputsSpec.artifacts:type_name -> ml_pipelines.TaskInputsSpec.ArtifactsEntry
-	75,  // 22: ml_pipelines.TaskOutputsSpec.parameters:type_name -> ml_pipelines.TaskOutputsSpec.ParametersEntry
-	76,  // 23: ml_pipelines.TaskOutputsSpec.artifacts:type_name -> ml_pipelines.TaskOutputsSpec.ArtifactsEntry
+	116, // 0: ml_pipelines.PipelineJob.pipeline_spec:type_name -> google.protobuf.Struct
+	41,  // 1: ml_pipelines.PipelineJob.labels:type_name -> ml_pipelines.PipelineJob.LabelsEntry
+	42,  // 2: ml_pipelines.PipelineJob.runtime_config:type_name -> ml_pipelines.PipelineJob.RuntimeConfig
+	23,  // 3: ml_pipelines.PipelineSpec.pipeline_info:type_name -> ml_pipelines.PipelineInfo
+	116, // 4: ml_pipelines.PipelineSpec.deployment_spec:type_name -> google.protobuf.Struct
+	46,  // 5: ml_pipelines.PipelineSpec.components:type_name -> ml_pipelines.PipelineSpec.ComponentsEntry
+	8,   // 6: ml_pipelines.PipelineSpec.root:type_name -> ml_pipelines.ComponentSpec
+	11,  // 7: ml_pipelines.ComponentSpec.input_definitions:type_name -> ml_pipelines.ComponentInputsSpec
+	12,  // 8: ml_pipelines.ComponentSpec.output_definitions:type_name -> ml_pipelines.ComponentOutputsSpec
+	9,   // 9: ml_pipelines.ComponentSpec.dag:type_name -> ml_pipelines.DagSpec
+	36,  // 10: ml_pipelines.ComponentSpec.single_platform_specs:type_name -> ml_pipelines.SinglePlatformSpec
+	18,  // 11: ml_pipelines.ComponentSpec.task_config_passthroughs:type_name -> ml_pipelines.TaskConfigPassthrough
+	47,  // 12: ml_pipelines.DagSpec.tasks:type_name -> ml_pipelines.DagSpec.TasksEntry
+	10,  // 13: ml_pipelines.DagSpec.outputs:type_name -> ml_pipelines.DagOutputsSpec
+	50,  // 14: ml_pipelines.DagOutputsSpec.artifacts:type_name -> ml_pipelines.DagOutputsSpec.ArtifactsEntry
+	55,  // 15: ml_pipelines.DagOutputsSpec.parameters:type_name -> ml_pipelines.DagOutputsSpec.ParametersEntry
+	59,  // 16: ml_pipelines.ComponentInputsSpec.artifacts:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactsEntry
+	60,  // 17: ml_pipelines.ComponentInputsSpec.parameters:type_name -> ml_pipelines.ComponentInputsSpec.ParametersEntry
+	63,  // 18: ml_pipelines.ComponentOutputsSpec.artifacts:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactsEntry
+	64,  // 19: ml_pipelines.ComponentOutputsSpec.parameters:type_name -> ml_pipelines.ComponentOutputsSpec.ParametersEntry
+	69,  // 20: ml_pipelines.TaskInputsSpec.parameters:type_name -> ml_pipelines.TaskInputsSpec.ParametersEntry
+	70,  // 21: ml_pipelines.TaskInputsSpec.artifacts:type_name -> ml_pipelines.TaskInputsSpec.ArtifactsEntry
+	76,  // 22: ml_pipelines.TaskOutputsSpec.parameters:type_name -> ml_pipelines.TaskOutputsSpec.ParametersEntry
+	77,  // 23: ml_pipelines.TaskOutputsSpec.artifacts:type_name -> ml_pipelines.TaskOutputsSpec.ArtifactsEntry
 	2,   // 24: ml_pipelines.TaskConfigPassthrough.field:type_name -> ml_pipelines.TaskConfigPassthroughType.TaskConfigPassthroughTypeEnum
-	24,  // 25: ml_pipelines.PipelineTaskSpec.task_info:type_name -> ml_pipelines.PipelineTaskInfo
-	12,  // 26: ml_pipelines.PipelineTaskSpec.inputs:type_name -> ml_pipelines.TaskInputsSpec
-	79,  // 27: ml_pipelines.PipelineTaskSpec.caching_options:type_name -> ml_pipelines.PipelineTaskSpec.CachingOptions
-	21,  // 28: ml_pipelines.PipelineTaskSpec.component_ref:type_name -> ml_pipelines.ComponentRef
-	80,  // 29: ml_pipelines.PipelineTaskSpec.trigger_policy:type_name -> ml_pipelines.PipelineTaskSpec.TriggerPolicy
-	19,  // 30: ml_pipelines.PipelineTaskSpec.artifact_iterator:type_name -> ml_pipelines.ArtifactIteratorSpec
-	20,  // 31: ml_pipelines.PipelineTaskSpec.parameter_iterator:type_name -> ml_pipelines.ParameterIteratorSpec
-	81,  // 32: ml_pipelines.PipelineTaskSpec.retry_policy:type_name -> ml_pipelines.PipelineTaskSpec.RetryPolicy
-	82,  // 33: ml_pipelines.PipelineTaskSpec.iterator_policy:type_name -> ml_pipelines.PipelineTaskSpec.IteratorPolicy
-	83,  // 34: ml_pipelines.ArtifactIteratorSpec.items:type_name -> ml_pipelines.ArtifactIteratorSpec.ItemsSpec
-	84,  // 35: ml_pipelines.ParameterIteratorSpec.items:type_name -> ml_pipelines.ParameterIteratorSpec.ItemsSpec
-	27,  // 36: ml_pipelines.ValueOrRuntimeParameter.constant_value:type_name -> ml_pipelines.Value
-	116, // 37: ml_pipelines.ValueOrRuntimeParameter.constant:type_name -> google.protobuf.Value
-	90,  // 38: ml_pipelines.PipelineDeploymentConfig.executors:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
-	23,  // 39: ml_pipelines.RuntimeArtifact.type:type_name -> ml_pipelines.ArtifactTypeSchema
-	100, // 40: ml_pipelines.RuntimeArtifact.properties:type_name -> ml_pipelines.RuntimeArtifact.PropertiesEntry
-	101, // 41: ml_pipelines.RuntimeArtifact.custom_properties:type_name -> ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
-	115, // 42: ml_pipelines.RuntimeArtifact.metadata:type_name -> google.protobuf.Struct
-	28,  // 43: ml_pipelines.ArtifactList.artifacts:type_name -> ml_pipelines.RuntimeArtifact
-	102, // 44: ml_pipelines.ExecutorInput.inputs:type_name -> ml_pipelines.ExecutorInput.Inputs
-	104, // 45: ml_pipelines.ExecutorInput.outputs:type_name -> ml_pipelines.ExecutorInput.Outputs
-	110, // 46: ml_pipelines.ExecutorOutput.parameters:type_name -> ml_pipelines.ExecutorOutput.ParametersEntry
-	111, // 47: ml_pipelines.ExecutorOutput.artifacts:type_name -> ml_pipelines.ExecutorOutput.ArtifactsEntry
-	112, // 48: ml_pipelines.ExecutorOutput.parameter_values:type_name -> ml_pipelines.ExecutorOutput.ParameterValuesEntry
-	117, // 49: ml_pipelines.PipelineTaskFinalStatus.error:type_name -> google.rpc.Status
-	113, // 50: ml_pipelines.PlatformSpec.platforms:type_name -> ml_pipelines.PlatformSpec.PlatformsEntry
-	36,  // 51: ml_pipelines.SinglePlatformSpec.deployment_spec:type_name -> ml_pipelines.PlatformDeploymentConfig
-	115, // 52: ml_pipelines.SinglePlatformSpec.config:type_name -> google.protobuf.Struct
-	39,  // 53: ml_pipelines.SinglePlatformSpec.pipelineConfig:type_name -> ml_pipelines.PipelineConfig
-	114, // 54: ml_pipelines.PlatformDeploymentConfig.executors:type_name -> ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
-	38,  // 55: ml_pipelines.WorkspaceConfig.kubernetes:type_name -> ml_pipelines.KubernetesWorkspaceConfig
-	115, // 56: ml_pipelines.KubernetesWorkspaceConfig.pvc_spec_patch:type_name -> google.protobuf.Struct
-	37,  // 57: ml_pipelines.PipelineConfig.workspace:type_name -> ml_pipelines.WorkspaceConfig
-	42,  // 58: ml_pipelines.PipelineJob.RuntimeConfig.parameters:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
-	43,  // 59: ml_pipelines.PipelineJob.RuntimeConfig.parameter_values:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
-	27,  // 60: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry.value:type_name -> ml_pipelines.Value
-	116, // 61: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry.value:type_name -> google.protobuf.Value
+	25,  // 25: ml_pipelines.PipelineTaskSpec.task_info:type_name -> ml_pipelines.PipelineTaskInfo
+	13,  // 26: ml_pipelines.PipelineTaskSpec.inputs:type_name -> ml_pipelines.TaskInputsSpec
+	80,  // 27: ml_pipelines.PipelineTaskSpec.caching_options:type_name -> ml_pipelines.PipelineTaskSpec.CachingOptions
+	22,  // 28: ml_pipelines.PipelineTaskSpec.component_ref:type_name -> ml_pipelines.ComponentRef
+	81,  // 29: ml_pipelines.PipelineTaskSpec.trigger_policy:type_name -> ml_pipelines.PipelineTaskSpec.TriggerPolicy
+	20,  // 30: ml_pipelines.PipelineTaskSpec.artifact_iterator:type_name -> ml_pipelines.ArtifactIteratorSpec
+	21,  // 31: ml_pipelines.PipelineTaskSpec.parameter_iterator:type_name -> ml_pipelines.ParameterIteratorSpec
+	82,  // 32: ml_pipelines.PipelineTaskSpec.retry_policy:type_name -> ml_pipelines.PipelineTaskSpec.RetryPolicy
+	83,  // 33: ml_pipelines.PipelineTaskSpec.iterator_policy:type_name -> ml_pipelines.PipelineTaskSpec.IteratorPolicy
+	84,  // 34: ml_pipelines.ArtifactIteratorSpec.items:type_name -> ml_pipelines.ArtifactIteratorSpec.ItemsSpec
+	85,  // 35: ml_pipelines.ParameterIteratorSpec.items:type_name -> ml_pipelines.ParameterIteratorSpec.ItemsSpec
+	28,  // 36: ml_pipelines.ValueOrRuntimeParameter.constant_value:type_name -> ml_pipelines.Value
+	117, // 37: ml_pipelines.ValueOrRuntimeParameter.constant:type_name -> google.protobuf.Value
+	91,  // 38: ml_pipelines.PipelineDeploymentConfig.executors:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry
+	24,  // 39: ml_pipelines.RuntimeArtifact.type:type_name -> ml_pipelines.ArtifactTypeSchema
+	101, // 40: ml_pipelines.RuntimeArtifact.properties:type_name -> ml_pipelines.RuntimeArtifact.PropertiesEntry
+	102, // 41: ml_pipelines.RuntimeArtifact.custom_properties:type_name -> ml_pipelines.RuntimeArtifact.CustomPropertiesEntry
+	116, // 42: ml_pipelines.RuntimeArtifact.metadata:type_name -> google.protobuf.Struct
+	29,  // 43: ml_pipelines.ArtifactList.artifacts:type_name -> ml_pipelines.RuntimeArtifact
+	103, // 44: ml_pipelines.ExecutorInput.inputs:type_name -> ml_pipelines.ExecutorInput.Inputs
+	105, // 45: ml_pipelines.ExecutorInput.outputs:type_name -> ml_pipelines.ExecutorInput.Outputs
+	111, // 46: ml_pipelines.ExecutorOutput.parameters:type_name -> ml_pipelines.ExecutorOutput.ParametersEntry
+	112, // 47: ml_pipelines.ExecutorOutput.artifacts:type_name -> ml_pipelines.ExecutorOutput.ArtifactsEntry
+	113, // 48: ml_pipelines.ExecutorOutput.parameter_values:type_name -> ml_pipelines.ExecutorOutput.ParameterValuesEntry
+	118, // 49: ml_pipelines.PipelineTaskFinalStatus.error:type_name -> google.rpc.Status
+	114, // 50: ml_pipelines.PlatformSpec.platforms:type_name -> ml_pipelines.PlatformSpec.PlatformsEntry
+	37,  // 51: ml_pipelines.SinglePlatformSpec.deployment_spec:type_name -> ml_pipelines.PlatformDeploymentConfig
+	116, // 52: ml_pipelines.SinglePlatformSpec.config:type_name -> google.protobuf.Struct
+	40,  // 53: ml_pipelines.SinglePlatformSpec.pipelineConfig:type_name -> ml_pipelines.PipelineConfig
+	115, // 54: ml_pipelines.PlatformDeploymentConfig.executors:type_name -> ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry
+	39,  // 55: ml_pipelines.WorkspaceConfig.kubernetes:type_name -> ml_pipelines.KubernetesWorkspaceConfig
+	116, // 56: ml_pipelines.KubernetesWorkspaceConfig.pvc_spec_patch:type_name -> google.protobuf.Struct
+	38,  // 57: ml_pipelines.PipelineConfig.workspace:type_name -> ml_pipelines.WorkspaceConfig
+	43,  // 58: ml_pipelines.PipelineJob.RuntimeConfig.parameters:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry
+	44,  // 59: ml_pipelines.PipelineJob.RuntimeConfig.parameter_values:type_name -> ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry
+	28,  // 60: ml_pipelines.PipelineJob.RuntimeConfig.ParametersEntry.value:type_name -> ml_pipelines.Value
+	117, // 61: ml_pipelines.PipelineJob.RuntimeConfig.ParameterValuesEntry.value:type_name -> google.protobuf.Value
 	0,   // 62: ml_pipelines.PipelineSpec.RuntimeParameter.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
-	27,  // 63: ml_pipelines.PipelineSpec.RuntimeParameter.default_value:type_name -> ml_pipelines.Value
-	7,   // 64: ml_pipelines.PipelineSpec.ComponentsEntry.value:type_name -> ml_pipelines.ComponentSpec
-	18,  // 65: ml_pipelines.DagSpec.TasksEntry.value:type_name -> ml_pipelines.PipelineTaskSpec
-	47,  // 66: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec.artifact_selectors:type_name -> ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
-	48,  // 67: ml_pipelines.DagOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
-	50,  // 68: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec.parameter_selectors:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	55,  // 69: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.mapped_parameters:type_name -> ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
-	50,  // 70: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_parameter:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	51,  // 71: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_oneof:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
-	53,  // 72: ml_pipelines.DagOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
-	50,  // 73: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
-	23,  // 74: ml_pipelines.ComponentInputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
+	28,  // 63: ml_pipelines.PipelineSpec.RuntimeParameter.default_value:type_name -> ml_pipelines.Value
+	8,   // 64: ml_pipelines.PipelineSpec.ComponentsEntry.value:type_name -> ml_pipelines.ComponentSpec
+	19,  // 65: ml_pipelines.DagSpec.TasksEntry.value:type_name -> ml_pipelines.PipelineTaskSpec
+	48,  // 66: ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec.artifact_selectors:type_name -> ml_pipelines.DagOutputsSpec.ArtifactSelectorSpec
+	49,  // 67: ml_pipelines.DagOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputArtifactSpec
+	51,  // 68: ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec.parameter_selectors:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	56,  // 69: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.mapped_parameters:type_name -> ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry
+	51,  // 70: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_parameter:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	52,  // 71: ml_pipelines.DagOutputsSpec.DagOutputParameterSpec.value_from_oneof:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorsSpec
+	54,  // 72: ml_pipelines.DagOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.DagOutputParameterSpec
+	51,  // 73: ml_pipelines.DagOutputsSpec.MapParameterSelectorsSpec.MappedParametersEntry.value:type_name -> ml_pipelines.DagOutputsSpec.ParameterSelectorSpec
+	24,  // 74: ml_pipelines.ComponentInputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
 	0,   // 75: ml_pipelines.ComponentInputsSpec.ParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
 	1,   // 76: ml_pipelines.ComponentInputsSpec.ParameterSpec.parameter_type:type_name -> ml_pipelines.ParameterType.ParameterTypeEnum
-	116, // 77: ml_pipelines.ComponentInputsSpec.ParameterSpec.default_value:type_name -> google.protobuf.Value
-	116, // 78: ml_pipelines.ComponentInputsSpec.ParameterSpec.literals:type_name -> google.protobuf.Value
-	56,  // 79: ml_pipelines.ComponentInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactSpec
-	57,  // 80: ml_pipelines.ComponentInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ParameterSpec
-	23,  // 81: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
-	64,  // 82: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
-	65,  // 83: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.custom_properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
-	115, // 84: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.metadata:type_name -> google.protobuf.Struct
+	117, // 77: ml_pipelines.ComponentInputsSpec.ParameterSpec.default_value:type_name -> google.protobuf.Value
+	117, // 78: ml_pipelines.ComponentInputsSpec.ParameterSpec.literals:type_name -> google.protobuf.Value
+	57,  // 79: ml_pipelines.ComponentInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ArtifactSpec
+	58,  // 80: ml_pipelines.ComponentInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentInputsSpec.ParameterSpec
+	24,  // 81: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
+	65,  // 82: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry
+	66,  // 83: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.custom_properties:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry
+	116, // 84: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.metadata:type_name -> google.protobuf.Struct
 	0,   // 85: ml_pipelines.ComponentOutputsSpec.ParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
 	1,   // 86: ml_pipelines.ComponentOutputsSpec.ParameterSpec.parameter_type:type_name -> ml_pipelines.ParameterType.ParameterTypeEnum
-	60,  // 87: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec
-	61,  // 88: ml_pipelines.ComponentOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ParameterSpec
-	25,  // 89: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	25,  // 90: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	70,  // 91: ml_pipelines.TaskInputsSpec.InputArtifactSpec.task_output_artifact:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
-	71,  // 92: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_output_parameter:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
-	25,  // 93: ml_pipelines.TaskInputsSpec.InputParameterSpec.runtime_value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	72,  // 94: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_final_status:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
-	67,  // 95: ml_pipelines.TaskInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec
-	66,  // 96: ml_pipelines.TaskInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec
-	23,  // 97: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
-	77,  // 98: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
-	78,  // 99: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.custom_properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
+	61,  // 87: ml_pipelines.ComponentOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ArtifactSpec
+	62,  // 88: ml_pipelines.ComponentOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.ComponentOutputsSpec.ParameterSpec
+	26,  // 89: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	26,  // 90: ml_pipelines.ComponentOutputsSpec.ArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	71,  // 91: ml_pipelines.TaskInputsSpec.InputArtifactSpec.task_output_artifact:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec.TaskOutputArtifactSpec
+	72,  // 92: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_output_parameter:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskOutputParameterSpec
+	26,  // 93: ml_pipelines.TaskInputsSpec.InputParameterSpec.runtime_value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	73,  // 94: ml_pipelines.TaskInputsSpec.InputParameterSpec.task_final_status:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec.TaskFinalStatus
+	68,  // 95: ml_pipelines.TaskInputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputParameterSpec
+	67,  // 96: ml_pipelines.TaskInputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskInputsSpec.InputArtifactSpec
+	24,  // 97: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.artifact_type:type_name -> ml_pipelines.ArtifactTypeSchema
+	78,  // 98: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry
+	79,  // 99: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.custom_properties:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry
 	0,   // 100: ml_pipelines.TaskOutputsSpec.OutputParameterSpec.type:type_name -> ml_pipelines.PrimitiveType.PrimitiveTypeEnum
-	74,  // 101: ml_pipelines.TaskOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputParameterSpec
-	73,  // 102: ml_pipelines.TaskOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
-	25,  // 103: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	25,  // 104: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	75,  // 101: ml_pipelines.TaskOutputsSpec.ParametersEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputParameterSpec
+	74,  // 102: ml_pipelines.TaskOutputsSpec.ArtifactsEntry.value:type_name -> ml_pipelines.TaskOutputsSpec.OutputArtifactSpec
+	26,  // 103: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	26,  // 104: ml_pipelines.TaskOutputsSpec.OutputArtifactSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
 	3,   // 105: ml_pipelines.PipelineTaskSpec.TriggerPolicy.strategy:type_name -> ml_pipelines.PipelineTaskSpec.TriggerPolicy.TriggerStrategy
-	118, // 106: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_duration:type_name -> google.protobuf.Duration
-	118, // 107: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_max_duration:type_name -> google.protobuf.Duration
-	91,  // 108: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.lifecycle:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
-	92,  // 109: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.resources:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
-	93,  // 110: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.env:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
-	25,  // 111: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.artifact_uri:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	23,  // 112: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.type_schema:type_name -> ml_pipelines.ArtifactTypeSchema
-	96,  // 113: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
-	97,  // 114: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.custom_properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
-	115, // 115: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.metadata:type_name -> google.protobuf.Struct
-	99,  // 116: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.output_artifact_queries:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
-	115, // 117: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec.custom_job:type_name -> google.protobuf.Struct
-	85,  // 118: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.container:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
-	86,  // 119: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.importer:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec
-	87,  // 120: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.resolver:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec
-	88,  // 121: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.custom_job:type_name -> ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
-	89,  // 122: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
-	94,  // 123: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.pre_cache_check:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
-	95,  // 124: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.accelerator:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
-	25,  // 125: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	25,  // 126: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
-	98,  // 127: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
-	27,  // 128: ml_pipelines.RuntimeArtifact.PropertiesEntry.value:type_name -> ml_pipelines.Value
-	27,  // 129: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry.value:type_name -> ml_pipelines.Value
-	105, // 130: ml_pipelines.ExecutorInput.Inputs.parameters:type_name -> ml_pipelines.ExecutorInput.Inputs.ParametersEntry
-	106, // 131: ml_pipelines.ExecutorInput.Inputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
-	107, // 132: ml_pipelines.ExecutorInput.Inputs.parameter_values:type_name -> ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
-	108, // 133: ml_pipelines.ExecutorInput.Outputs.parameters:type_name -> ml_pipelines.ExecutorInput.Outputs.ParametersEntry
-	109, // 134: ml_pipelines.ExecutorInput.Outputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
-	27,  // 135: ml_pipelines.ExecutorInput.Inputs.ParametersEntry.value:type_name -> ml_pipelines.Value
-	29,  // 136: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
-	116, // 137: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry.value:type_name -> google.protobuf.Value
-	103, // 138: ml_pipelines.ExecutorInput.Outputs.ParametersEntry.value:type_name -> ml_pipelines.ExecutorInput.OutputParameter
-	29,  // 139: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
-	27,  // 140: ml_pipelines.ExecutorOutput.ParametersEntry.value:type_name -> ml_pipelines.Value
-	29,  // 141: ml_pipelines.ExecutorOutput.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
-	116, // 142: ml_pipelines.ExecutorOutput.ParameterValuesEntry.value:type_name -> google.protobuf.Value
-	35,  // 143: ml_pipelines.PlatformSpec.PlatformsEntry.value:type_name -> ml_pipelines.SinglePlatformSpec
-	115, // 144: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry.value:type_name -> google.protobuf.Struct
-	145, // [145:145] is the sub-list for method output_type
-	145, // [145:145] is the sub-list for method input_type
-	145, // [145:145] is the sub-list for extension type_name
-	145, // [145:145] is the sub-list for extension extendee
-	0,   // [0:145] is the sub-list for field type_name
+	119, // 106: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_duration:type_name -> google.protobuf.Duration
+	119, // 107: ml_pipelines.PipelineTaskSpec.RetryPolicy.backoff_max_duration:type_name -> google.protobuf.Duration
+	4,   // 108: ml_pipelines.PipelineTaskSpec.RetryPolicy.policy:type_name -> ml_pipelines.PipelineTaskSpec.RetryPolicy.Policy
+	92,  // 109: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.lifecycle:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle
+	93,  // 110: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.resources:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec
+	94,  // 111: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.env:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.EnvVar
+	26,  // 112: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.artifact_uri:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	24,  // 113: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.type_schema:type_name -> ml_pipelines.ArtifactTypeSchema
+	97,  // 114: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry
+	98,  // 115: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.custom_properties:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry
+	116, // 116: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.metadata:type_name -> google.protobuf.Struct
+	100, // 117: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.output_artifact_queries:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry
+	116, // 118: ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec.custom_job:type_name -> google.protobuf.Struct
+	86,  // 119: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.container:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec
+	87,  // 120: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.importer:type_name -> ml_pipelines.PipelineDeploymentConfig.ImporterSpec
+	88,  // 121: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.resolver:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec
+	89,  // 122: ml_pipelines.PipelineDeploymentConfig.ExecutorSpec.custom_job:type_name -> ml_pipelines.PipelineDeploymentConfig.AIPlatformCustomJobSpec
+	90,  // 123: ml_pipelines.PipelineDeploymentConfig.ExecutorsEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ExecutorSpec
+	95,  // 124: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.pre_cache_check:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.Exec
+	96,  // 125: ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.accelerator:type_name -> ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfig
+	26,  // 126: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.PropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	26,  // 127: ml_pipelines.PipelineDeploymentConfig.ImporterSpec.CustomPropertiesEntry.value:type_name -> ml_pipelines.ValueOrRuntimeParameter
+	99,  // 128: ml_pipelines.PipelineDeploymentConfig.ResolverSpec.OutputArtifactQueriesEntry.value:type_name -> ml_pipelines.PipelineDeploymentConfig.ResolverSpec.ArtifactQuerySpec
+	28,  // 129: ml_pipelines.RuntimeArtifact.PropertiesEntry.value:type_name -> ml_pipelines.Value
+	28,  // 130: ml_pipelines.RuntimeArtifact.CustomPropertiesEntry.value:type_name -> ml_pipelines.Value
+	106, // 131: ml_pipelines.ExecutorInput.Inputs.parameters:type_name -> ml_pipelines.ExecutorInput.Inputs.ParametersEntry
+	107, // 132: ml_pipelines.ExecutorInput.Inputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry
+	108, // 133: ml_pipelines.ExecutorInput.Inputs.parameter_values:type_name -> ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry
+	109, // 134: ml_pipelines.ExecutorInput.Outputs.parameters:type_name -> ml_pipelines.ExecutorInput.Outputs.ParametersEntry
+	110, // 135: ml_pipelines.ExecutorInput.Outputs.artifacts:type_name -> ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry
+	28,  // 136: ml_pipelines.ExecutorInput.Inputs.ParametersEntry.value:type_name -> ml_pipelines.Value
+	30,  // 137: ml_pipelines.ExecutorInput.Inputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
+	117, // 138: ml_pipelines.ExecutorInput.Inputs.ParameterValuesEntry.value:type_name -> google.protobuf.Value
+	104, // 139: ml_pipelines.ExecutorInput.Outputs.ParametersEntry.value:type_name -> ml_pipelines.ExecutorInput.OutputParameter
+	30,  // 140: ml_pipelines.ExecutorInput.Outputs.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
+	28,  // 141: ml_pipelines.ExecutorOutput.ParametersEntry.value:type_name -> ml_pipelines.Value
+	30,  // 142: ml_pipelines.ExecutorOutput.ArtifactsEntry.value:type_name -> ml_pipelines.ArtifactList
+	117, // 143: ml_pipelines.ExecutorOutput.ParameterValuesEntry.value:type_name -> google.protobuf.Value
+	36,  // 144: ml_pipelines.PlatformSpec.PlatformsEntry.value:type_name -> ml_pipelines.SinglePlatformSpec
+	116, // 145: ml_pipelines.PlatformDeploymentConfig.ExecutorsEntry.value:type_name -> google.protobuf.Struct
+	146, // [146:146] is the sub-list for method output_type
+	146, // [146:146] is the sub-list for method input_type
+	146, // [146:146] is the sub-list for extension type_name
+	146, // [146:146] is the sub-list for extension extendee
+	0,   // [0:146] is the sub-list for field type_name
 }
 
 func init() { file_pipeline_spec_proto_init() }
@@ -6519,7 +6594,7 @@ func file_pipeline_spec_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pipeline_spec_proto_rawDesc), len(file_pipeline_spec_proto_rawDesc)),
-			NumEnums:      5,
+			NumEnums:      6,
 			NumMessages:   110,
 			NumExtensions: 0,
 			NumServices:   0,

--- a/api/v2alpha1/pipeline_spec.proto
+++ b/api/v2alpha1/pipeline_spec.proto
@@ -594,6 +594,18 @@ message PipelineTaskSpec {
     // The maximum duration during which the task will be retried according to
     // the backoff strategy. If unspecified, will set to 1 hour.
     google.protobuf.Duration backoff_max_duration = 4;
+
+    // The retry policy controls which failure types trigger a retry attempt.
+    // Maps directly to Argo Workflows retryStrategy.retryPolicy.
+    // Defaults to POLICY_UNSPECIFIED, which behaves like POLICY_ON_FAILURE.
+    enum Policy {
+      POLICY_UNSPECIFIED = 0;
+      POLICY_ALWAYS = 1;
+      POLICY_ON_FAILURE = 2;
+      POLICY_ON_ERROR = 3;
+      POLICY_ON_TRANSIENT_ERROR = 4;
+    }
+    Policy policy = 5;
   }
 
   // User-configured task-level retry.

--- a/api/v2alpha1/pipeline_spec.proto
+++ b/api/v2alpha1/pipeline_spec.proto
@@ -598,6 +598,19 @@ message PipelineTaskSpec {
     // The maximum duration during which the task will be retried according to
     // the backoff strategy. If unspecified, will set to 1 hour.
     google.protobuf.Duration backoff_max_duration = 4;
+
+    // The retry policy controls which failure types trigger a retry attempt.
+    // Maps directly to Argo Workflows retryStrategy.retryPolicy.
+    // POLICY_UNSPECIFIED omits the field, so the deployment's Argo
+    // configuration decides; KFP's bundled manifests set OnError.
+    enum Policy {
+      POLICY_UNSPECIFIED = 0;
+      POLICY_ALWAYS = 1;
+      POLICY_ON_FAILURE = 2;
+      POLICY_ON_ERROR = 3;
+      POLICY_ON_TRANSIENT_ERROR = 4;
+    }
+    Policy policy = 5;
   }
 
   // User-configured task-level retry.

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -370,6 +370,13 @@ func (c *workflowCompiler) addContainerExecutorTemplate(task *pipelinespec.Pipel
 		if task != nil && task.GetDag() == nil {
 			nameContainerExecutor = "retry-" + nameContainerExecutor
 			nameContainerImpl = "retry-" + nameContainerImpl
+			// retryPolicy can't be parameterized (Argo validates it as a strict enum at submission),
+			// so bake it into the template name.
+			if policy := protoRetryPolicyToArgo(taskRetrySpec.GetPolicy()); policy != "" {
+				suffix := "-" + strings.ToLower(policy)
+				nameContainerExecutor += suffix
+				nameContainerImpl += suffix
+			}
 		}
 	}
 	podMetadata := k8sExecCfg.GetPodMetadata()
@@ -582,7 +589,8 @@ func (c *workflowCompiler) addContainerExecutorTemplate(task *pipelinespec.Pipel
 		executor.RetryStrategy = c.getTaskRetryStrategyFromInput(inputParameter(paramRetryMaxCount),
 			inputParameter(paramRetryBackOffDuration),
 			inputParameter(paramRetryBackOffFactor),
-			inputParameter(paramRetryBackOffMaxDuration))
+			inputParameter(paramRetryBackOffMaxDuration),
+			protoRetryPolicyToArgo(taskRetrySpec.GetPolicy()))
 		executor.Container.Env = append(executor.Container.Env, retryIndexEnv)
 	}
 	// Update pod metadata if it defined in the Kubernetes Spec
@@ -648,9 +656,12 @@ func (c *workflowCompiler) getTaskRetryParametersWithValues(task *pipelinespec.P
 }
 
 func (c *workflowCompiler) addParameterDefault(parameters []wfapi.Parameter, defaultValue string) []wfapi.Parameter {
-	// Set the "Default" field of each parameter in input slice with input defaultValue.
+	// Set the "Default" field of each parameter in input slice with defaultValue,
+	// unless the parameter already has an explicit default set.
 	for i := range parameters {
-		parameters[i].Default = wfapi.AnyStringPtr(defaultValue)
+		if parameters[i].Default == nil {
+			parameters[i].Default = wfapi.AnyStringPtr(defaultValue)
+		}
 	}
 	return parameters
 }
@@ -664,7 +675,7 @@ func (c *workflowCompiler) addParameterInputPath(parameters []wfapi.Parameter) [
 }
 
 func (c *workflowCompiler) getTaskRetryStrategyFromInput(maxCount string, backOffDuration string, backOffFactor string,
-	backOffMaxDuration string) *wfapi.RetryStrategy {
+	backOffMaxDuration string, retryPolicy string) *wfapi.RetryStrategy {
 	backoff := &wfapi.Backoff{
 		Factor: &intstr.IntOrString{
 			Type:   intstr.String,
@@ -679,7 +690,26 @@ func (c *workflowCompiler) getTaskRetryStrategyFromInput(maxCount string, backOf
 			Type:   intstr.String,
 			StrVal: maxCount,
 		},
-		Backoff: backoff,
+		Backoff:     backoff,
+		RetryPolicy: wfapi.RetryPolicy(retryPolicy),
+	}
+}
+
+// protoRetryPolicyToArgo maps a KFP proto RetryPolicy_Policy enum value to the
+// corresponding Argo Workflows RetryPolicy string. An empty string is returned
+// for POLICY_UNSPECIFIED, which causes Argo to use its default (OnFailure).
+func protoRetryPolicyToArgo(policy pipelinespec.PipelineTaskSpec_RetryPolicy_Policy) string {
+	switch policy {
+	case pipelinespec.PipelineTaskSpec_RetryPolicy_POLICY_ALWAYS:
+		return string(wfapi.RetryPolicyAlways)
+	case pipelinespec.PipelineTaskSpec_RetryPolicy_POLICY_ON_FAILURE:
+		return string(wfapi.RetryPolicyOnFailure)
+	case pipelinespec.PipelineTaskSpec_RetryPolicy_POLICY_ON_ERROR:
+		return string(wfapi.RetryPolicyOnError)
+	case pipelinespec.PipelineTaskSpec_RetryPolicy_POLICY_ON_TRANSIENT_ERROR:
+		return string(wfapi.RetryPolicyOnTransientError)
+	default:
+		return "" // POLICY_UNSPECIFIED → Argo uses OnFailure by default
 	}
 }
 

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -384,6 +384,13 @@ func (c *workflowCompiler) addContainerExecutorTemplate(task *pipelinespec.Pipel
 		if task != nil && task.GetDag() == nil {
 			nameContainerExecutor = "retry-" + nameContainerExecutor
 			nameContainerImpl = "retry-" + nameContainerImpl
+			// retryPolicy can't be parameterized (Argo validates it as a strict enum at submission),
+			// so bake it into the template name.
+			if policy := protoRetryPolicyToArgo(taskRetrySpec.GetPolicy()); policy != "" {
+				suffix := "-" + strings.ToLower(policy)
+				nameContainerExecutor += suffix
+				nameContainerImpl += suffix
+			}
 		}
 	}
 	podMetadata := k8sExecCfg.GetPodMetadata()
@@ -446,6 +453,14 @@ func (c *workflowCompiler) addContainerExecutorTemplate(task *pipelinespec.Pipel
 				When: inputParameter(paramCachedDecision) + " != true",
 			}},
 		},
+	}
+	// templateDefaults would give this wrapper the deployment's retryStrategy,
+	// retrying on top of the impl template's. A zero limit keeps retry on the
+	// impl alone, so num_retries and the policy mean what they say.
+	if taskRetrySpec != nil {
+		container.RetryStrategy = &wfapi.RetryStrategy{
+			Limit: &intstr.IntOrString{Type: intstr.Int, IntVal: 0},
+		}
 	}
 	c.templates[nameContainerExecutor] = container
 
@@ -587,7 +602,8 @@ func (c *workflowCompiler) addContainerExecutorTemplate(task *pipelinespec.Pipel
 		executor.RetryStrategy = c.getTaskRetryStrategyFromInput(inputParameter(paramRetryMaxCount),
 			inputParameter(paramRetryBackOffDuration),
 			inputParameter(paramRetryBackOffFactor),
-			inputParameter(paramRetryBackOffMaxDuration))
+			inputParameter(paramRetryBackOffMaxDuration),
+			protoRetryPolicyToArgo(taskRetrySpec.GetPolicy()))
 		executor.Container.Env = append(executor.Container.Env, retryIndexEnv)
 	}
 	// Update pod metadata if it defined in the Kubernetes Spec
@@ -653,9 +669,12 @@ func (c *workflowCompiler) getTaskRetryParametersWithValues(task *pipelinespec.P
 }
 
 func (c *workflowCompiler) addParameterDefault(parameters []wfapi.Parameter, defaultValue string) []wfapi.Parameter {
-	// Set the "Default" field of each parameter in input slice with input defaultValue.
+	// Set the "Default" field of each parameter in input slice with defaultValue,
+	// unless the parameter already has an explicit default set.
 	for i := range parameters {
-		parameters[i].Default = wfapi.AnyStringPtr(defaultValue)
+		if parameters[i].Default == nil {
+			parameters[i].Default = wfapi.AnyStringPtr(defaultValue)
+		}
 	}
 	return parameters
 }
@@ -669,7 +688,7 @@ func (c *workflowCompiler) addParameterInputPath(parameters []wfapi.Parameter) [
 }
 
 func (c *workflowCompiler) getTaskRetryStrategyFromInput(maxCount string, backOffDuration string, backOffFactor string,
-	backOffMaxDuration string) *wfapi.RetryStrategy {
+	backOffMaxDuration string, retryPolicy string) *wfapi.RetryStrategy {
 	backoff := &wfapi.Backoff{
 		Factor: &intstr.IntOrString{
 			Type:   intstr.String,
@@ -684,7 +703,26 @@ func (c *workflowCompiler) getTaskRetryStrategyFromInput(maxCount string, backOf
 			Type:   intstr.String,
 			StrVal: maxCount,
 		},
-		Backoff: backoff,
+		Backoff:     backoff,
+		RetryPolicy: wfapi.RetryPolicy(retryPolicy),
+	}
+}
+
+// protoRetryPolicyToArgo maps a KFP proto RetryPolicy_Policy enum value to the
+// corresponding Argo Workflows RetryPolicy string. An empty string is returned
+// for POLICY_UNSPECIFIED, which causes Argo to use its default (OnFailure).
+func protoRetryPolicyToArgo(policy pipelinespec.PipelineTaskSpec_RetryPolicy_Policy) string {
+	switch policy {
+	case pipelinespec.PipelineTaskSpec_RetryPolicy_POLICY_ALWAYS:
+		return string(wfapi.RetryPolicyAlways)
+	case pipelinespec.PipelineTaskSpec_RetryPolicy_POLICY_ON_FAILURE:
+		return string(wfapi.RetryPolicyOnFailure)
+	case pipelinespec.PipelineTaskSpec_RetryPolicy_POLICY_ON_ERROR:
+		return string(wfapi.RetryPolicyOnError)
+	case pipelinespec.PipelineTaskSpec_RetryPolicy_POLICY_ON_TRANSIENT_ERROR:
+		return string(wfapi.RetryPolicyOnTransientError)
+	default:
+		return "" // POLICY_UNSPECIFIED → Argo uses OnFailure by default
 	}
 }
 

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -1818,6 +1818,28 @@ class TestSetRetryCompilation(unittest.TestCase):
         self.assertEqual(retry_policy.backoff_factor, 1.0)
         self.assertEqual(retry_policy.backoff_max_duration.seconds, 10800)
 
+    def test_set_retry_with_policy(self):
+
+        @dsl.pipeline(name='hello-world', description='A simple intro pipeline')
+        def pipeline_hello_world(text: str = 'hi there'):
+            """Hello world pipeline."""
+
+            hello_world(text=text).set_retry(
+                num_retries=3,
+                policy='OnError',
+            )
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            package_path = os.path.join(tempdir, 'pipeline.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=pipeline_hello_world, package_path=package_path)
+            pipeline_spec = pipeline_spec_from_file(package_path)
+
+        _Policy = pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy.Policy
+        retry_policy = pipeline_spec.root.dag.tasks['hello-world'].retry_policy
+        self.assertEqual(retry_policy.max_retry_count, 3)
+        self.assertEqual(retry_policy.policy, _Policy.POLICY_ON_ERROR)
+
 
 from google.protobuf import json_format
 

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -605,12 +605,15 @@ class PipelineTask:
 
         return self
 
+    _VALID_RETRY_POLICIES = frozenset(structures._RETRY_POLICY_MAP)
+
     @block_if_final()
     def set_retry(self,
                   num_retries: int,
                   backoff_duration: Optional[str] = None,
                   backoff_factor: Optional[float] = None,
-                  backoff_max_duration: Optional[str] = None) -> 'PipelineTask':
+                  backoff_max_duration: Optional[str] = None,
+                  policy: Optional[str] = None) -> 'PipelineTask':
         """Sets task retry parameters.
 
         Args:
@@ -618,15 +621,26 @@ class PipelineTask:
             backoff_duration: Number of seconds to wait before triggering a retry. Defaults to ``'0s'`` (immediate retry).
             backoff_factor: Exponential backoff factor applied to ``backoff_duration``. For example, if ``backoff_duration="60"`` (60 seconds) and ``backoff_factor=2``, the first retry will happen after 60 seconds, then again after 120, 240, and so on. Defaults to ``2.0``.
             backoff_max_duration: Maximum duration during which the task will be retried. Defaults to ``'3600s'``.
+            policy: Controls which failure types trigger a retry. Only supported
+                when using Argo Workflows as the pipeline execution engine. One of
+                ``'Always'``, ``'OnFailure'`` (default), ``'OnError'``, or
+                ``'OnTransientError'``. Use ``'OnError'`` or ``'Always'`` to retry on
+                node-level failures such as eviction or SIGTERM (exit code 143).
+                Defaults to ``None`` (equivalent to ``'OnFailure'``).
 
         Returns:
             Self return to allow chained setting calls.
         """
+        if policy is not None and policy not in self._VALID_RETRY_POLICIES:
+            raise ValueError(
+                f'Invalid retry policy {policy!r}. '
+                f'Must be one of: {sorted(self._VALID_RETRY_POLICIES)}')
         self._task_spec.retry_policy = structures.RetryPolicy(
             max_retry_count=num_retries,
             backoff_duration=backoff_duration,
             backoff_factor=backoff_factor,
             backoff_max_duration=backoff_max_duration,
+            policy=policy,
         )
         return self
 

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -610,12 +610,15 @@ class PipelineTask:
 
         return self
 
+    _VALID_RETRY_POLICIES = frozenset(structures._RETRY_POLICY_MAP)
+
     @block_if_final()
     def set_retry(self,
                   num_retries: int,
                   backoff_duration: Optional[str] = None,
                   backoff_factor: Optional[float] = None,
-                  backoff_max_duration: Optional[str] = None) -> 'PipelineTask':
+                  backoff_max_duration: Optional[str] = None,
+                  policy: Optional[str] = None) -> 'PipelineTask':
         """Sets task retry parameters.
 
         Args:
@@ -623,15 +626,32 @@ class PipelineTask:
             backoff_duration: Number of seconds to wait before triggering a retry. Defaults to ``'0s'`` (immediate retry).
             backoff_factor: Exponential backoff factor applied to ``backoff_duration``. For example, if ``backoff_duration="60"`` (60 seconds) and ``backoff_factor=2``, the first retry will happen after 60 seconds, then again after 120, 240, and so on. Defaults to ``2.0``.
             backoff_max_duration: Maximum duration during which the task will be retried. Defaults to ``'3600s'``.
+            policy: Controls which failure types trigger a retry. Only supported
+                when using Argo Workflows as the pipeline execution engine. One of
+                ``'Always'``, ``'OnFailure'``, ``'OnError'``, or
+                ``'OnTransientError'``. ``'OnFailure'`` retries container exits,
+                including SIGTERM (exit code 143); ``'OnError'`` retries pods that
+                report no exit code, such as deletion or node loss;
+                ``'OnTransientError'`` retries either when the failure message
+                matches the controller's transient-error pattern; ``'Always'``
+                retries both.
+                Defaults to ``None``, which omits the policy so the
+                deployment's Argo configuration applies; KFP's bundled
+                manifests set ``'OnError'``.
 
         Returns:
             Self return to allow chained setting calls.
         """
+        if policy is not None and policy not in self._VALID_RETRY_POLICIES:
+            raise ValueError(
+                f'Invalid retry policy {policy!r}. '
+                f'Must be one of: {sorted(self._VALID_RETRY_POLICIES)}')
         self._task_spec.retry_policy = structures.RetryPolicy(
             max_retry_count=num_retries,
             backoff_duration=backoff_duration,
             backoff_factor=backoff_factor,
             backoff_max_duration=backoff_max_duration,
+            policy=policy,
         )
         return self
 

--- a/sdk/python/kfp/dsl/pipeline_task_test.py
+++ b/sdk/python/kfp/dsl/pipeline_task_test.py
@@ -447,6 +447,25 @@ class PipelineTaskTest(parameterized.TestCase):
                 r"At least one of 'before' or 'after' must be True"):
             task.set_debug_pause(before=False, after=False)
 
+    def test_set_retry_invalid_policy_raises(self):
+        task = pipeline_task.PipelineTask(
+            component_spec=structures.ComponentSpec.from_yaml_documents(
+                V2_YAML),
+            args={'input1': 'value'},
+        )
+        with self.assertRaisesRegex(ValueError, 'Invalid retry policy'):
+            task.set_retry(num_retries=1, policy='BadValue')
+
+    def test_set_retry_valid_policies(self):
+        for policy in ('Always', 'OnFailure', 'OnError', 'OnTransientError'):
+            task = pipeline_task.PipelineTask(
+                component_spec=structures.ComponentSpec.from_yaml_documents(
+                    V2_YAML),
+                args={'input1': 'value'},
+            )
+            task.set_retry(num_retries=2, policy=policy)
+            self.assertEqual(task._task_spec.retry_policy.policy, policy)
+
     def test_set_display_name(self):
         task = pipeline_task.PipelineTask(
             component_spec=structures.ComponentSpec.from_yaml_documents(

--- a/sdk/python/kfp/dsl/pipeline_task_test.py
+++ b/sdk/python/kfp/dsl/pipeline_task_test.py
@@ -447,6 +447,25 @@ class PipelineTaskTest(parameterized.TestCase):
                 r"At least one of 'before' or 'after' must be True"):
             task.set_debug_pause(before=False, after=False)
 
+    def test_set_retry_invalid_policy_raises(self):
+        task = pipeline_task.PipelineTask(
+            component_spec=structures.ComponentSpec.from_yaml_documents(
+                V2_YAML),
+            args={'input1': 'value'},
+        )
+        with self.assertRaisesRegex(ValueError, 'Invalid retry policy'):
+            task.set_retry(num_retries=1, policy='BadValue')
+
+    def test_set_retry_valid_policies(self):
+        for policy in ('Always', 'OnFailure', 'OnError', 'OnTransientError'):
+            task = pipeline_task.PipelineTask(
+                component_spec=structures.ComponentSpec.from_yaml_documents(
+                    V2_YAML),
+                args={'input1': 'value'},
+            )
+            task.set_retry(num_retries=2, policy=policy)
+            self.assertEqual(task._task_spec.retry_policy.policy, policy)
+
     def test_set_display_name(self):
         task = pipeline_task.PipelineTask(
             component_spec=structures.ComponentSpec.from_yaml_documents(
@@ -500,7 +519,9 @@ class TestTaskInFinalState(unittest.TestCase):
 
     Many properties and methods will be blocked.
 
-    Also tests that the .output and .outputs behavior behaves as expected when the outputs are values, not placeholders, as will be the case when PipelineTask is in the state FINAL.
+    Also tests that the .output and .outputs behavior behaves as
+    expected when the outputs are values, not placeholders, as will be
+    the case when PipelineTask is in the state FINAL.
     """
 
     def test_output_property(self):

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -358,6 +358,14 @@ class ContainerSpecImplementation:
             resources=None)  # can only be set on tasks
 
 
+_RETRY_POLICY_MAP = {
+    'Always': 'POLICY_ALWAYS',
+    'OnFailure': 'POLICY_ON_FAILURE',
+    'OnError': 'POLICY_ON_ERROR',
+    'OnTransientError': 'POLICY_ON_TRANSIENT_ERROR',
+}
+
+
 @dataclasses.dataclass
 class RetryPolicy:
     """The retry policy of a container execution.
@@ -367,11 +375,18 @@ class RetryPolicy:
         backoff_duration (int): The the number of seconds to wait before triggering a retry.
         backoff_factor (float): The exponential backoff factor applied to backoff_duration. For example, if backoff_duration="60" (60 seconds) and backoff_factor=2, the first retry will happen after 60 seconds, then after 120, 240, and so on.
         backoff_max_duration (int): The maximum duration during which the task will be retried.
+        policy (str): Controls which failure types trigger a retry. Only
+            supported when using Argo Workflows as the pipeline execution
+            engine. One of ``'Always'``, ``'OnFailure'`` (default),
+            ``'OnError'``, or ``'OnTransientError'``. Use ``'OnError'`` or
+            ``'Always'`` to retry on node-level failures such as eviction or
+            SIGTERM (exit code 143).
     """
     max_retry_count: Optional[int] = None
     backoff_duration: Optional[str] = None
     backoff_factor: Optional[float] = None
     backoff_max_duration: Optional[str] = None
+    policy: Optional[str] = None
 
     def to_proto(self) -> pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy:
         # include defaults so that IR is more reflective of runtime behavior
@@ -383,13 +398,19 @@ class RetryPolicy:
         backoff_duration_seconds = f'{convert_duration_to_seconds(backoff_duration)}s'
         backoff_max_duration_seconds = f'{convert_duration_to_seconds(backoff_max_duration)}s'
 
+        d = {
+            'max_retry_count': max_retry_count,
+            'backoff_duration': backoff_duration_seconds,
+            'backoff_factor': backoff_factor,
+            'backoff_max_duration': backoff_max_duration_seconds,
+        }
+        if self.policy:
+            if self.policy not in _RETRY_POLICY_MAP:
+                raise ValueError(f'Invalid retry policy {self.policy!r}. '
+                                 f'Must be one of: {sorted(_RETRY_POLICY_MAP)}')
+            d['policy'] = _RETRY_POLICY_MAP[self.policy]
         return json_format.ParseDict(
-            {
-                'max_retry_count': max_retry_count,
-                'backoff_duration': backoff_duration_seconds,
-                'backoff_factor': backoff_factor,
-                'backoff_max_duration': backoff_max_duration_seconds,
-            }, pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy())
+            d, pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy())
 
 
 @dataclasses.dataclass

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -356,6 +356,14 @@ class ContainerSpecImplementation:
             resources=None)  # can only be set on tasks
 
 
+_RETRY_POLICY_MAP = {
+    'Always': 'POLICY_ALWAYS',
+    'OnFailure': 'POLICY_ON_FAILURE',
+    'OnError': 'POLICY_ON_ERROR',
+    'OnTransientError': 'POLICY_ON_TRANSIENT_ERROR',
+}
+
+
 @dataclasses.dataclass
 class RetryPolicy:
     """The retry policy of a container execution.
@@ -365,11 +373,23 @@ class RetryPolicy:
         backoff_duration (int): The the number of seconds to wait before triggering a retry.
         backoff_factor (float): The exponential backoff factor applied to backoff_duration. For example, if backoff_duration="60" (60 seconds) and backoff_factor=2, the first retry will happen after 60 seconds, then after 120, 240, and so on.
         backoff_max_duration (int): The maximum duration during which the task will be retried.
+        policy (str): Controls which failure types trigger a retry. Only
+            supported when using Argo Workflows as the pipeline execution
+            engine. One of ``'Always'``, ``'OnFailure'``, ``'OnError'``, or
+            ``'OnTransientError'``. ``'OnFailure'`` retries container exits,
+            including SIGTERM (exit code 143); ``'OnError'`` retries pods that
+            report no exit code, such as deletion or node loss;
+            ``'OnTransientError'`` retries either when the failure message
+            matches the controller's transient-error pattern; ``'Always'``
+            retries both. Defaults to ``None``, which omits the policy so the
+            deployment's Argo configuration applies; KFP's bundled manifests
+            set ``'OnError'``.
     """
     max_retry_count: Optional[int] = None
     backoff_duration: Optional[str] = None
     backoff_factor: Optional[float] = None
     backoff_max_duration: Optional[str] = None
+    policy: Optional[str] = None
 
     def to_proto(self) -> pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy:
         # include defaults so that IR is more reflective of runtime behavior
@@ -381,13 +401,19 @@ class RetryPolicy:
         backoff_duration_seconds = f'{convert_duration_to_seconds(backoff_duration)}s'
         backoff_max_duration_seconds = f'{convert_duration_to_seconds(backoff_max_duration)}s'
 
+        retry_policy_dict = {
+            'max_retry_count': max_retry_count,
+            'backoff_duration': backoff_duration_seconds,
+            'backoff_factor': backoff_factor,
+            'backoff_max_duration': backoff_max_duration_seconds,
+        }
+        if self.policy:
+            if self.policy not in _RETRY_POLICY_MAP:
+                raise ValueError(f'Invalid retry policy {self.policy!r}. '
+                                 f'Must be one of: {sorted(_RETRY_POLICY_MAP)}')
+            retry_policy_dict['policy'] = _RETRY_POLICY_MAP[self.policy]
         return json_format.ParseDict(
-            {
-                'max_retry_count': max_retry_count,
-                'backoff_duration': backoff_duration_seconds,
-                'backoff_factor': backoff_factor,
-                'backoff_max_duration': backoff_max_duration_seconds,
-            }, pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy())
+            retry_policy_dict, pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy())
 
 
 @dataclasses.dataclass

--- a/sdk/python/kfp/dsl/structures_test.py
+++ b/sdk/python/kfp/dsl/structures_test.py
@@ -25,6 +25,7 @@ from kfp import dsl
 from kfp.dsl import component_factory
 from kfp.dsl import placeholders
 from kfp.dsl import structures
+from kfp.pipeline_spec import pipeline_spec_pb2
 
 V1_YAML_IF_PLACEHOLDER = textwrap.dedent("""\
     implementation:
@@ -914,6 +915,34 @@ class TestRetryPolicy(unittest.TestCase):
         self.assertEqual(retry_policy_proto.backoff_factor, 1.5)
         self.assertEqual(retry_policy_proto.backoff_max_duration.seconds,
                          1209600)
+
+    def test_to_proto_with_policy(self):
+        _Policy = pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy.Policy
+        retry_policy_struct = structures.RetryPolicy(
+            max_retry_count=2, policy='OnError')
+        retry_policy_proto = retry_policy_struct.to_proto()
+        self.assertEqual(retry_policy_proto.max_retry_count, 2)
+        self.assertEqual(retry_policy_proto.policy, _Policy.POLICY_ON_ERROR)
+
+    def test_to_proto_policy_unspecified_by_default(self):
+        _Policy = pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy.Policy
+        retry_policy_struct = structures.RetryPolicy(max_retry_count=1)
+        retry_policy_proto = retry_policy_struct.to_proto()
+        self.assertEqual(retry_policy_proto.policy, _Policy.POLICY_UNSPECIFIED)
+
+    def test_to_proto_all_policy_values(self):
+        _Policy = pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy.Policy
+        expected = {
+            'Always': _Policy.POLICY_ALWAYS,
+            'OnFailure': _Policy.POLICY_ON_FAILURE,
+            'OnError': _Policy.POLICY_ON_ERROR,
+            'OnTransientError': _Policy.POLICY_ON_TRANSIENT_ERROR,
+        }
+        for policy_str, proto_val in expected.items():
+            with self.subTest(policy=policy_str):
+                proto = structures.RetryPolicy(
+                    max_retry_count=1, policy=policy_str).to_proto()
+                self.assertEqual(proto.policy, proto_val)
 
 
 class TestDeserializeV1ComponentYamlDefaults(unittest.TestCase):

--- a/sdk/python/kfp/dsl/structures_test.py
+++ b/sdk/python/kfp/dsl/structures_test.py
@@ -25,6 +25,7 @@ from kfp import dsl
 from kfp.dsl import component_factory
 from kfp.dsl import placeholders
 from kfp.dsl import structures
+from kfp.pipeline_spec import pipeline_spec_pb2
 
 V1_YAML_IF_PLACEHOLDER = textwrap.dedent("""\
     implementation:
@@ -925,6 +926,34 @@ class TestRetryPolicy(unittest.TestCase):
         self.assertEqual(retry_policy_proto.backoff_factor, 1.5)
         self.assertEqual(retry_policy_proto.backoff_max_duration.seconds,
                          1209600)
+
+    def test_to_proto_with_policy(self):
+        _Policy = pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy.Policy
+        retry_policy_struct = structures.RetryPolicy(
+            max_retry_count=2, policy='OnError')
+        retry_policy_proto = retry_policy_struct.to_proto()
+        self.assertEqual(retry_policy_proto.max_retry_count, 2)
+        self.assertEqual(retry_policy_proto.policy, _Policy.POLICY_ON_ERROR)
+
+    def test_to_proto_policy_unspecified_by_default(self):
+        _Policy = pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy.Policy
+        retry_policy_struct = structures.RetryPolicy(max_retry_count=1)
+        retry_policy_proto = retry_policy_struct.to_proto()
+        self.assertEqual(retry_policy_proto.policy, _Policy.POLICY_UNSPECIFIED)
+
+    def test_to_proto_all_policy_values(self):
+        _Policy = pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy.Policy
+        expected = {
+            'Always': _Policy.POLICY_ALWAYS,
+            'OnFailure': _Policy.POLICY_ON_FAILURE,
+            'OnError': _Policy.POLICY_ON_ERROR,
+            'OnTransientError': _Policy.POLICY_ON_TRANSIENT_ERROR,
+        }
+        for policy_str, proto_val in expected.items():
+            with self.subTest(policy=policy_str):
+                proto = structures.RetryPolicy(
+                    max_retry_count=1, policy=policy_str).to_proto()
+                self.assertEqual(proto.policy, proto_val)
 
 
 class TestDeserializeV1ComponentYamlDefaults(unittest.TestCase):

--- a/test_data/compiled-workflows/pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry.yaml
@@ -184,6 +184,8 @@ spec:
     metadata: {}
     name: retry-system-container-executor
     outputs: {}
+    retryStrategy:
+      limit: 0
   - container:
       command:
       - should-be-overridden-during-runtime

--- a/test_data/compiled-workflows/pipeline_with_retry_policy.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry_policy.yaml
@@ -1,0 +1,448 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: test-pipeline-
+spec:
+  arguments:
+    parameters:
+    - name: components-df9adcbe603768f30acc82bf916febdb4b094013d76f7f79be0fa9ab14c8fcf3
+      value: '{"executorLabel":"exec-add","inputDefinitions":{"parameters":{"a":{"parameterType":"NUMBER_DOUBLE"},"b":{"parameterType":"NUMBER_DOUBLE"}}},"outputDefinitions":{"parameters":{"Output":{"parameterType":"NUMBER_DOUBLE"}}}}'
+    - name: implementations-df9adcbe603768f30acc82bf916febdb4b094013d76f7f79be0fa9ab14c8fcf3
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","add"],"command":["sh","-c","\nif
+        ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
+        -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
+        python3 -m pip install --quiet --no-warn-script-location ''kfp==2.15.2'' ''--no-deps''
+        ''typing-extensions\u003e=3.7.4,\u003c5; python_version\u003c\"3.9\"'' \u0026\u0026
+        \"$0\" \"$@\"\n","sh","-ec","program_path=$(mktemp -d)\n\nprintf \"%s\" \"$0\"
+        \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
+        -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
+        kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
+        add(a: float, b: float) -\u003e float:\n    return a + b\n\n"],"image":"python:3.11"}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"add":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-add"},"inputs":{"parameters":{"a":{"componentInputParameter":"a"},"b":{"componentInputParameter":"b"}}},"retryPolicy":{"backoffDuration":"0s","backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":3,"policy":"POLICY_ON_ERROR"},"taskInfo":{"name":"add"}}}},"inputDefinitions":{"parameters":{"a":{"defaultValue":1,"isOptional":true,"parameterType":"NUMBER_DOUBLE"},"b":{"defaultValue":7,"isOptional":true,"parameterType":"NUMBER_DOUBLE"}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - test-pipeline
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      command:
+      - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: task-name
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: driver
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+          - name: retry-max-count
+            value: '{{inputs.parameters.retry-max-count}}'
+          - name: retry-backoff-duration
+            value: '{{inputs.parameters.retry-backoff-duration}}'
+          - name: retry-backoff-factor
+            value: '{{inputs.parameters.retry-backoff-factor}}'
+          - name: retry-backoff-max-duration
+            value: '{{inputs.parameters.retry-backoff-max-duration}}'
+        name: executor
+        template: retry-system-container-impl-onerror
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+      - default: "0"
+        name: retry-max-count
+      - default: "0"
+        name: retry-backoff-duration
+      - default: "0"
+        name: retry-backoff-factor
+      - default: "0"
+        name: retry-backoff-max-duration
+    metadata: {}
+    name: retry-system-container-executor-onerror
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      - name: KFP_RETRY_INDEX
+        value: '{{retries}}'
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher:latest
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - name: retry-max-count
+      - name: retry-backoff-duration
+      - name: retry-backoff-factor
+      - name: retry-backoff-max-duration
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: launcher
+    name: retry-system-container-impl-onerror
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    retryStrategy:
+      backoff:
+        duration: '{{inputs.parameters.retry-backoff-duration}}'
+        factor: '{{inputs.parameters.retry-backoff-factor}}'
+        maxDuration: '{{inputs.parameters.retry-backoff-max-duration}}'
+      limit: '{{inputs.parameters.retry-max-count}}'
+      retryPolicy: OnError
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-df9adcbe603768f30acc82bf916febdb4b094013d76f7f79be0fa9ab14c8fcf3}}'
+          - name: task
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-add"},"inputs":{"parameters":{"a":{"componentInputParameter":"a"},"b":{"componentInputParameter":"b"}}},"retryPolicy":{"backoffDuration":"0s","backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":3,"policy":"POLICY_ON_ERROR"},"taskInfo":{"name":"add"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-df9adcbe603768f30acc82bf916febdb4b094013d76f7f79be0fa9ab14c8fcf3}}'
+          - name: task-name
+            value: add
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: add-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.add-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.add-driver.outputs.parameters.cached-decision}}'
+          - name: retry-max-count
+            value: "3"
+          - name: retry-backoff-duration
+            value: "0"
+          - name: retry-backoff-factor
+            value: "2"
+          - name: retry-backoff-max-duration
+            value: "3600"
+        depends: add-driver.Succeeded
+        name: add
+        template: retry-system-container-executor-onerror
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - test-pipeline
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: ""
+        name: task-name
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: driver
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{"parameterValues":{"a":1,"b":7}}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/test_data/compiled-workflows/pipeline_with_retry_policy.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry_policy.yaml
@@ -1,14 +1,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
-  generateName: pipeline-with-retry-
+  generateName: test-pipeline-
 spec:
   arguments:
     parameters:
-    - name: components-b52de15852f3d1e1fc69f3596142f156a05ecf4305fbe662ae3d89f8b71f5ab3
-      value: '{"executorLabel":"exec-flaky","inputDefinitions":{"parameters":{"counter_path":{"parameterType":"STRING"}}},"outputDefinitions":{"parameters":{"Output":{"parameterType":"STRING"}}}}'
-    - name: implementations-b52de15852f3d1e1fc69f3596142f156a05ecf4305fbe662ae3d89f8b71f5ab3
-      value: '{"args":["--executor_input","{{$}}","--function_to_execute","flaky"],"command":["sh","-c","\nif
+    - name: components-df9adcbe603768f30acc82bf916febdb4b094013d76f7f79be0fa9ab14c8fcf3
+      value: '{"executorLabel":"exec-add","inputDefinitions":{"parameters":{"a":{"parameterType":"NUMBER_DOUBLE"},"b":{"parameterType":"NUMBER_DOUBLE"}}},"outputDefinitions":{"parameters":{"Output":{"parameterType":"NUMBER_DOUBLE"}}}}'
+    - name: implementations-df9adcbe603768f30acc82bf916febdb4b094013d76f7f79be0fa9ab14c8fcf3
+      value: '{"args":["--executor_input","{{$}}","--function_to_execute","add"],"command":["sh","-c","\nif
         ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip || python3
         -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1
         python3 -m pip install --quiet --no-warn-script-location ''kfp==2.15.2'' ''--no-deps''
@@ -17,13 +17,9 @@ spec:
         \u003e \"$program_path/ephemeral_component.py\"\n_KFP_RUNTIME=true python3
         -m kfp.dsl.executor_main                         --component_module_path                         \"$program_path/ephemeral_component.py\"                         \"$@\"\n","\nimport
         kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
-        flaky(counter_path: str) -\u003e str:\n    import os\n    count = 0\n    if
-        os.path.exists(counter_path):\n        with open(counter_path) as f:\n            count
-        = int(f.read().strip() or ''0'')\n    count += 1\n    with open(counter_path,
-        ''w'') as f:\n        f.write(str(count))\n    if count \u003c= 1:\n        raise
-        RuntimeError(f''flaky attempt {count}'')\n    return f''attempt={count}''\n\n"],"image":"python:3.11"}'
+        add(a: float, b: float) -\u003e float:\n    return a + b\n\n"],"image":"python:3.11"}'
     - name: components-root
-      value: '{"dag":{"outputs":{"parameters":{"Output":{"valueFromParameter":{"outputParameterKey":"Output","producerSubtask":"flaky"}}}},"tasks":{"flaky":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-flaky"},"inputs":{"parameters":{"counter_path":{"componentInputParameter":"counter_path"}}},"retryPolicy":{"backoffDuration":"0s","backoffFactor":1,"backoffMaxDuration":"3600s","maxRetryCount":3},"taskInfo":{"name":"flaky"}}}},"inputDefinitions":{"parameters":{"counter_path":{"parameterType":"STRING"}}},"outputDefinitions":{"parameters":{"Output":{"parameterType":"STRING"}}}}'
+      value: '{"dag":{"tasks":{"add":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-add"},"inputs":{"parameters":{"a":{"componentInputParameter":"a"},"b":{"componentInputParameter":"b"}}},"retryPolicy":{"backoffDuration":"0s","backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":3,"policy":"POLICY_ON_ERROR"},"taskInfo":{"name":"add"}}}},"inputDefinitions":{"parameters":{"a":{"defaultValue":1,"isOptional":true,"parameterType":"NUMBER_DOUBLE"},"b":{"defaultValue":7,"isOptional":true,"parameterType":"NUMBER_DOUBLE"}}}}'
   entrypoint: entrypoint
   podMetadata:
     annotations:
@@ -41,7 +37,7 @@ spec:
       - --type
       - CONTAINER
       - --pipeline_name
-      - pipeline-with-retry
+      - test-pipeline
       - --run_id
       - '{{workflow.uid}}'
       - --run_name
@@ -170,7 +166,7 @@ spec:
           - name: retry-backoff-max-duration
             value: '{{inputs.parameters.retry-backoff-max-duration}}'
         name: executor
-        template: retry-system-container-impl
+        template: retry-system-container-impl-onerror
         when: '{{inputs.parameters.cached-decision}} != true'
     inputs:
       parameters:
@@ -186,7 +182,7 @@ spec:
       - default: "0"
         name: retry-backoff-max-duration
     metadata: {}
-    name: retry-system-container-executor
+    name: retry-system-container-executor-onerror
     outputs: {}
     retryStrategy:
       limit: 0
@@ -268,7 +264,7 @@ spec:
     metadata:
       annotations:
         pipelines.kubeflow.org/runtime-role: launcher
-    name: retry-system-container-impl
+    name: retry-system-container-impl-onerror
     outputs: {}
     podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
     retryStrategy:
@@ -277,6 +273,7 @@ spec:
         factor: '{{inputs.parameters.retry-backoff-factor}}'
         maxDuration: '{{inputs.parameters.retry-backoff-max-duration}}'
       limit: '{{inputs.parameters.retry-max-count}}'
+      retryPolicy: OnError
     securityContext:
       seccompProfile:
         type: RuntimeDefault
@@ -300,35 +297,35 @@ spec:
       - arguments:
           parameters:
           - name: component
-            value: '{{workflow.parameters.components-b52de15852f3d1e1fc69f3596142f156a05ecf4305fbe662ae3d89f8b71f5ab3}}'
+            value: '{{workflow.parameters.components-df9adcbe603768f30acc82bf916febdb4b094013d76f7f79be0fa9ab14c8fcf3}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-flaky"},"inputs":{"parameters":{"counter_path":{"componentInputParameter":"counter_path"}}},"retryPolicy":{"backoffDuration":"0s","backoffFactor":1,"backoffMaxDuration":"3600s","maxRetryCount":3},"taskInfo":{"name":"flaky"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-add"},"inputs":{"parameters":{"a":{"componentInputParameter":"a"},"b":{"componentInputParameter":"b"}}},"retryPolicy":{"backoffDuration":"0s","backoffFactor":2,"backoffMaxDuration":"3600s","maxRetryCount":3,"policy":"POLICY_ON_ERROR"},"taskInfo":{"name":"add"}}'
           - name: container
-            value: '{{workflow.parameters.implementations-b52de15852f3d1e1fc69f3596142f156a05ecf4305fbe662ae3d89f8b71f5ab3}}'
+            value: '{{workflow.parameters.implementations-df9adcbe603768f30acc82bf916febdb4b094013d76f7f79be0fa9ab14c8fcf3}}'
           - name: task-name
-            value: flaky
+            value: add
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
-        name: flaky-driver
+        name: add-driver
         template: system-container-driver
       - arguments:
           parameters:
           - name: pod-spec-patch
-            value: '{{tasks.flaky-driver.outputs.parameters.pod-spec-patch}}'
+            value: '{{tasks.add-driver.outputs.parameters.pod-spec-patch}}'
           - default: "false"
             name: cached-decision
-            value: '{{tasks.flaky-driver.outputs.parameters.cached-decision}}'
+            value: '{{tasks.add-driver.outputs.parameters.cached-decision}}'
           - name: retry-max-count
             value: "3"
           - name: retry-backoff-duration
             value: "0"
           - name: retry-backoff-factor
-            value: "1"
+            value: "2"
           - name: retry-backoff-max-duration
             value: "3600"
-        depends: flaky-driver.Succeeded
-        name: flaky
-        template: retry-system-container-executor
+        depends: add-driver.Succeeded
+        name: add
+        template: retry-system-container-executor-onerror
     inputs:
       parameters:
       - name: parent-dag-id
@@ -340,7 +337,7 @@ spec:
       - --type
       - '{{inputs.parameters.driver-type}}'
       - --pipeline_name
-      - pipeline-with-retry
+      - test-pipeline
       - --run_id
       - '{{workflow.uid}}'
       - --run_name
@@ -452,7 +449,7 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-root}}'
           - name: runtime-config
-            value: '{}'
+            value: '{"parameterValues":{"a":1,"b":7}}'
           - name: driver-type
             value: ROOT_DAG
         name: root-driver

--- a/test_data/sdk_compiled_pipelines/valid/pipeline_with_retry_policy.py
+++ b/test_data/sdk_compiled_pipelines/valid/pipeline_with_retry_policy.py
@@ -1,0 +1,33 @@
+# Copyright 2025 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import compiler
+from kfp import dsl
+
+
+@dsl.component
+def add(a: float, b: float) -> float:
+    return a + b
+
+
+@dsl.pipeline(name='test-pipeline')
+def my_pipeline(a: float = 1, b: float = 7):
+    add_task = add(a=a, b=b)
+    add_task.set_retry(num_retries=3, policy='OnError')
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=my_pipeline,
+        package_path=__file__.replace('.py', '.yaml'))

--- a/test_data/sdk_compiled_pipelines/valid/pipeline_with_retry_policy.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/pipeline_with_retry_policy.yaml
@@ -1,0 +1,84 @@
+# PIPELINE DEFINITION
+# Name: test-pipeline
+# Inputs:
+#    a: float [Default: 1.0]
+#    b: float [Default: 7.0]
+components:
+  comp-add:
+    executorLabel: exec-add
+    inputDefinitions:
+      parameters:
+        a:
+          parameterType: NUMBER_DOUBLE
+        b:
+          parameterType: NUMBER_DOUBLE
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: NUMBER_DOUBLE
+deploymentSpec:
+  executors:
+    exec-add:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - add
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef add(a: float, b: float) -> float:\n    return a + b\n\n"
+        image: python:3.11
+pipelineInfo:
+  name: test-pipeline
+root:
+  dag:
+    tasks:
+      add:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-add
+        inputs:
+          parameters:
+            a:
+              componentInputParameter: a
+            b:
+              componentInputParameter: b
+        retryPolicy:
+          backoffDuration: 0s
+          backoffFactor: 2.0
+          backoffMaxDuration: 3600s
+          maxRetryCount: 3
+          policy: POLICY_ON_ERROR
+        taskInfo:
+          name: add
+  inputDefinitions:
+    parameters:
+      a:
+        defaultValue: 1.0
+        isOptional: true
+        parameterType: NUMBER_DOUBLE
+      b:
+        defaultValue: 7.0
+        isOptional: true
+        parameterType: NUMBER_DOUBLE
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.15.2


### PR DESCRIPTION
## Description of your changes

Currently `set_retry` only retries when the container exits non-zero (Argo's default `OnFailure`). Pods that disappear due to eviction, node loss, etc end up in Argo's error phase and are never retried. The only existing workaround is a cluster-wide `retryStrategy` default in the Argo workflow controller cm

This PR adds an optional `policy` parameter to `set_retry()` that maps to Argo Workflow `retryStrategy.retryPolicy`. Individual components can now opt into retry on infra level failures without any cluster level config

```python
hello_world().set_retry(num_retries=3, policy='OnError')
```

Valid values: `'Always'`, `'OnFailure'`, `'OnError'`, `'OnTransientError'`. Defaults to `None`, which compiles to Argo's default `OnFailure`  (existing pipelines are unchanged)

Implementation notes:

- Proto: new `PipelineTaskSpec.RetryPolicy.Policy` enum (`POLICY_UNSPECIFIED`, `POLICY_ALWAYS`, `POLICY_ON_FAILURE`, `POLICY_ON_ERROR`, `POLICY_ON_TRANSIENT_ERROR`).
- SDK: validates the string value at `set_retry()` call time and again at proto serialization.
- Backend: the policy can't be parameterized — Argo strict-validates `retryStrategy.retryPolicy` against the enum at workflow submission, so any placeholder string fails. Instead, the policy is baked into the impl template name (`retry-system-container-impl-onerror` etc.) and the literal policy value is emitted into the `retryStrategy`. Tasks with the same policy still share a template.

## Live Cluster Testing

**Before** (no `policy`):

```python
@dsl.pipeline(name='retry-policy-on-error-demo')
def retry_policy_demo():
    hello_world().set_retry(num_retries=3)
```

Delete the running pod → Argo marks the node Error → no retry → workflow fails.

<img width="1462" height="403" alt="Screenshot 2026-05-31 at 2 15 30 PM" src="https://github.com/user-attachments/assets/757f3a0a-e26a-4488-bcf7-40ddac5b607b" />
<img width="1460" height="511" alt="Screenshot 2026-05-31 at 2 16 05 PM" src="https://github.com/user-attachments/assets/c56f0e3a-2a72-4832-94a8-e73d5c25b97c" />
<img width="1470" height="483" alt="Screenshot 2026-05-31 at 2 16 14 PM" src="https://github.com/user-attachments/assets/0d0784dc-3d97-4544-8d2b-2b5c53682f92" />



**After** (`policy='OnError'`):

```python
@dsl.pipeline(name='retry-policy-on-error-demo')
def retry_policy_demo():
    hello_world().set_retry(num_retries=3, policy='OnError')
```

Delete the running pod → Argo marks the node Error → retry scheduled → workflow succeeds on attempt 2.

<img width="1469" height="679" alt="Screenshot 2026-05-31 at 2 43 08 PM" src="https://github.com/user-attachments/assets/8cba4c75-5d6d-4b1e-b952-ae8839392e1c" />
<img width="1461" height="735" alt="Screenshot 2026-05-31 at 2 43 25 PM" src="https://github.com/user-attachments/assets/10d2110e-3e34-4a9a-90e5-f95bb7751e9b" />
<img width="1459" height="730" alt="Screenshot 2026-05-31 at 2 44 03 PM" src="https://github.com/user-attachments/assets/99c5a7dd-e339-4561-a815-3c4a79182b18" />


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
