### PR TITLE
fix(backend): enforce authorization on TaskService endpoints

### DIFF
--- a/backend/src/apiserver/server/task_server.go
+++ b/backend/src/apiserver/server/task_server.go
@@ -21,13 +21,15 @@ import (
 	apiv1beta1 "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
+	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
 type TaskServer struct {
-	resourceManager *resource.ResourceManager
+	*BaseRunServer
 	apiv1beta1.UnimplementedTaskServiceServer
 }
 
@@ -37,6 +39,10 @@ func (s *TaskServer) CreateTaskV1(ctx context.Context, request *api.CreateTaskRe
 	err := s.validateCreateTaskRequest(request)
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to create a new task due to validation error")
+	}
+
+	if err := s.canAccessRun(ctx, request.GetTask().GetRunId(), &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbCreate}); err != nil {
+		return nil, util.Wrap(err, "Failed to authorize the request")
 	}
 
 	modelTask, err := toModelTask(request.GetTask())
@@ -106,6 +112,28 @@ func (s *TaskServer) ListTasksV1(ctx context.Context, request *api.ListTasksRequ
 		return nil, util.Wrap(err, "Validating filter failed")
 	}
 
+	// Resolve the namespace the caller is asking for and authorize the list
+	// against that namespace. Tasks belong to runs, so we reuse the runs
+	// RBAC verb model (the same pattern RunArtifactServer follows).
+	namespace, err := s.resolveListTasksNamespace(filterContext)
+	if err != nil {
+		return nil, util.Wrap(err, "Failed to resolve namespace for list tasks request")
+	}
+	namespace = s.resourceManager.ReplaceNamespace(namespace)
+	resourceAttributes := &authorizationv1.ResourceAttributes{
+		Namespace: namespace,
+		Verb:      common.RbacResourceVerbList,
+	}
+	if err := s.canAccessRun(ctx, "", resourceAttributes); err != nil {
+		return nil, util.Wrapf(err, "Failed to list tasks due to authorization error. Check if you have permission to access namespace %s", namespace)
+	}
+	// Ensure the storage query is scoped to the authorized namespace when no
+	// other reference key is present, so TaskStore.ListTasks applies a
+	// Namespace WHERE clause and does not leak rows across tenants.
+	if filterContext.ReferenceKey == nil && namespace != "" {
+		filterContext.ReferenceKey = &model.ReferenceKey{Type: model.NamespaceResourceType, ID: namespace}
+	}
+
 	tasks, total_size, nextPageToken, err := s.resourceManager.ListTasks(filterContext, opts)
 	if err != nil {
 		return nil, util.Wrap(err, "List tasks failed")
@@ -118,6 +146,36 @@ func (s *TaskServer) ListTasksV1(ctx context.Context, request *api.ListTasksRequ
 		nil
 }
 
+// resolveListTasksNamespace extracts the caller's intended namespace from a
+// v1beta1 ListTasksRequest filter. A NAMESPACE reference key carries the
+// namespace directly; a RUN reference key resolves it via the run's parent
+// experiment. Other reference key types (and empty) yield "" — the
+// authorization check enforces an empty-namespace ban in multi-user mode.
+func (s *TaskServer) resolveListTasksNamespace(filterContext *model.FilterContext) (string, error) {
+	if filterContext == nil || filterContext.ReferenceKey == nil {
+		return "", nil
+	}
+	switch filterContext.ReferenceKey.Type {
+	case model.NamespaceResourceType:
+		return filterContext.ReferenceKey.ID, nil
+	case model.RunResourceType:
+		run, err := s.resourceManager.GetRun(filterContext.ReferenceKey.ID)
+		if err != nil {
+			return "", util.Wrapf(err, "Failed to resolve namespace for run %s", filterContext.ReferenceKey.ID)
+		}
+		if !s.resourceManager.IsEmptyNamespace(run.Namespace) {
+			return run.Namespace, nil
+		}
+		return s.resourceManager.GetNamespaceFromExperimentId(run.ExperimentId)
+	}
+	return "", nil
+}
+
 func NewTaskServer(resourceManager *resource.ResourceManager) *TaskServer {
-	return &TaskServer{resourceManager: resourceManager}
+	return &TaskServer{
+		BaseRunServer: &BaseRunServer{
+			resourceManager: resourceManager,
+			options:         &RunServerOptions{CollectMetrics: false},
+		},
+	}
 }

--- a/backend/src/apiserver/storage/task_store.go
+++ b/backend/src/apiserver/storage/task_store.go
@@ -216,14 +216,27 @@ func (s *TaskStore) ListTasks(filterContext *model.FilterContext, opts *list.Opt
 		return nil, 0, "", util.NewInternalServerError(err, "Failed to list tasks: %v", err)
 	}
 
+	// addReferenceFilter appends the WHERE clause that scopes the query to
+	// the resource-reference key supplied by the caller. NamespaceResourceType
+	// is honored so that a caller asking for a single namespace does not
+	// receive rows from other namespaces.
+	addReferenceFilter := func(b sq.SelectBuilder) sq.SelectBuilder {
+		if filterContext.ReferenceKey == nil {
+			return b
+		}
+		switch filterContext.ReferenceKey.Type {
+		case model.PipelineResourceType:
+			return b.Where(sq.Eq{"PipelineName": filterContext.ReferenceKey.ID})
+		case model.RunResourceType:
+			return b.Where(sq.Eq{"RunUUID": filterContext.ReferenceKey.ID})
+		case model.NamespaceResourceType:
+			return b.Where(sq.Eq{"Namespace": filterContext.ReferenceKey.ID})
+		}
+		return b
+	}
+
 	// SQL for getting the filtered and paginated rows
-	sqlBuilder := sq.Select(taskColumns...).From("tasks")
-	if filterContext.ReferenceKey != nil && filterContext.ReferenceKey.Type == model.PipelineResourceType {
-		sqlBuilder = sqlBuilder.Where(sq.Eq{"PipelineName": filterContext.ReferenceKey.ID})
-	}
-	if filterContext.ReferenceKey != nil && filterContext.ReferenceKey.Type == model.RunResourceType {
-		sqlBuilder = sqlBuilder.Where(sq.Eq{"RunUUID": filterContext.ReferenceKey.ID})
-	}
+	sqlBuilder := addReferenceFilter(sq.Select(taskColumns...).From("tasks"))
 	sqlBuilder = opts.AddFilterToSelect(sqlBuilder)
 
 	rowsSql, rowsArgs, err := opts.AddPaginationToSelect(sqlBuilder).ToSql()
@@ -233,13 +246,7 @@ func (s *TaskStore) ListTasks(filterContext *model.FilterContext, opts *list.Opt
 
 	// SQL for getting total size. This matches the query to get all the rows above, in order
 	// to do the same filter, but counts instead of scanning the rows.
-	sqlBuilder = sq.Select("count(*)").From("tasks")
-	if filterContext.ReferenceKey != nil && filterContext.ReferenceKey.Type == model.PipelineResourceType {
-		sqlBuilder = sqlBuilder.Where(sq.Eq{"PipelineName": filterContext.ReferenceKey.ID})
-	}
-	if filterContext.ReferenceKey != nil && filterContext.ReferenceKey.Type == model.RunResourceType {
-		sqlBuilder = sqlBuilder.Where(sq.Eq{"RunUUID": filterContext.ReferenceKey.ID})
-	}
+	sqlBuilder = addReferenceFilter(sq.Select("count(*)").From("tasks"))
 	sizeSql, sizeArgs, err := opts.AddFilterToSelect(sqlBuilder).ToSql()
 	if err != nil {
 		return errorF(err)


### PR DESCRIPTION
## Summary

Closes missing-auth gaps on `TaskService.CreateTaskV1` and `TaskService.ListTasksV1`, and fixes the silent `NAMESPACE`-reference-key drop in `TaskStore.ListTasks`.

## Coordinated disclosure

https://huntr.com/bounties/83e8ce20-1d2f-4065-a656-1b924b6fda15

## Changes

- `CreateTaskV1` resolves the run's namespace via `getNamespaceFromExperimentId` and calls `IsAuthorized` with the resolved namespace before reaching `CreateTask`.
- `ListTasksV1` derives the caller-intended namespace from the supplied filter (NAMESPACE key directly, or RUN key → run's namespace, falling back to the experiment's namespace) and gates with `canAccessRun`. When the caller does not supply a reference key, the handler installs a `NamespaceResourceType` key so the storage layer scopes the SQL query.
- `TaskStore.ListTasks` honors `NamespaceResourceType` reference keys (a `Namespace` WHERE predicate added alongside the existing `PipelineName` / `RunUUID` predicates).

## Tests

Existing handler + storage tests pass:

```
go test ./backend/src/apiserver/server ./backend/src/apiserver/storage -count=1
```

## DCO

`Signed-off-by: ctrexs <cntrexmpls@gmail.com>` on the single commit.
