### PR TITLE
feat(sdk): opt-in executor deduplication in compiled IR YAML

### DIFF
--- a/sdk/python/kfp/compiler/compiler.py
+++ b/sdk/python/kfp/compiler/compiler.py
@@ -23,6 +23,7 @@ from kfp.compiler import pipeline_spec_builder as builder
 from kfp.compiler.compiler_utils import KubernetesManifestOptions
 from kfp.dsl import base_component
 from kfp.dsl.types import type_utils
+from kfp.pipeline_spec import pipeline_spec_pb2
 
 
 class Compiler:
@@ -58,6 +59,7 @@ class Compiler:
         kubernetes_manifest_options: Optional[
             'KubernetesManifestOptions'] = None,
         kubernetes_manifest_format: bool = False,
+        deduplicate_executors: bool = False,
     ) -> None:
         """Compiles the pipeline or component function into IR YAML.
 
@@ -70,6 +72,7 @@ class Compiler:
             type_check: Whether to enable type checking of component interfaces during compilation.
             kubernetes_manifest_options: KubernetesManifestOptions object for Kubernetes manifest output during pipeline compilation.
             kubernetes_manifest_format: Output the compiled pipeline as a Kubernetes manifest.
+            deduplicate_executors: When True, collapse identical entries in ``deploymentSpec.executors`` so multiple components that share the same executor body (image, command, args, env, resources) and per-executor platform configuration point to a single executor entry. Useful for pipelines that invoke the same component many times and would otherwise exceed the Kubernetes API server request-size limit. Off by default to preserve byte-identical compiler output for existing users.
         """
 
         with type_utils.TypeCheckManager(enable=type_check):
@@ -86,10 +89,21 @@ class Compiler:
                 pipeline_parameters=pipeline_parameters,
                 pipeline_display_name=pipeline_display_name)
 
+            platform_spec = pipeline_func.platform_spec
+            if deduplicate_executors:
+                # Copy so the in-place dedup pass doesn't mutate the
+                # GraphComponent's cached platform_spec across compile calls.
+                platform_spec = pipeline_spec_pb2.PlatformSpec()
+                platform_spec.CopyFrom(pipeline_func.platform_spec)
+                builder.deduplicate_executors_in_place(
+                    pipeline_spec=pipeline_spec,
+                    platform_spec=platform_spec,
+                )
+
             builder.write_pipeline_spec_to_file(
                 pipeline_spec=pipeline_spec,
                 pipeline_description=pipeline_func.description,
-                platform_spec=pipeline_func.platform_spec,
+                platform_spec=platform_spec,
                 package_path=package_path,
                 kubernetes_manifest_options=kubernetes_manifest_options,
                 kubernetes_manifest_format=kubernetes_manifest_format,

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -6681,8 +6681,7 @@ def _compile_and_load(
 
 
 def _executors_dict(
-    pipeline_spec: pipeline_spec_pb2.PipelineSpec
-) -> Dict[str, Any]:
+        pipeline_spec: pipeline_spec_pb2.PipelineSpec) -> Dict[str, Any]:
     deployment_config = pipeline_spec_pb2.PipelineDeploymentConfig()
     json_format.ParseDict(
         json_format.MessageToDict(pipeline_spec.deployment_spec),
@@ -6698,7 +6697,8 @@ def _assert_refs_valid(test_case: unittest.TestCase,
     executors = _executors_dict(pipeline_spec)
     components = pipeline_spec.components
 
-    def check_component(component_spec: pipeline_spec_pb2.ComponentSpec) -> None:
+    def check_component(
+            component_spec: pipeline_spec_pb2.ComponentSpec) -> None:
         if component_spec.executor_label:
             test_case.assertIn(component_spec.executor_label, executors)
         if component_spec.HasField('dag'):
@@ -6800,11 +6800,9 @@ class TestExecutorDeduplication(unittest.TestCase):
         @dsl.pipeline
         def my_pipeline():
             dsl.importer(
-                artifact_uri='gs://bucket/file.txt',
-                artifact_class=dsl.Dataset)
+                artifact_uri='gs://bucket/file.txt', artifact_class=dsl.Dataset)
             dsl.importer(
-                artifact_uri='gs://bucket/file.txt',
-                artifact_class=dsl.Dataset)
+                artifact_uri='gs://bucket/file.txt', artifact_class=dsl.Dataset)
 
         on_spec, _ = _compile_and_load(my_pipeline, deduplicate_executors=True)
         self.assertEqual(len(_executors_dict(on_spec)), 1)

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -6658,5 +6658,266 @@ class TestPipelineSpecAttributeUniqueError(unittest.TestCase):
         self.assertTrue(my_pipeline.pipeline_spec)
 
 
+def _compile_and_load(
+    pipeline: graph_component.GraphComponent,
+    *,
+    deduplicate_executors: bool = False,
+) -> 'tuple[pipeline_spec_pb2.PipelineSpec, pipeline_spec_pb2.PlatformSpec]':
+    with tempfile.TemporaryDirectory() as tempdir:
+        output_yaml = os.path.join(tempdir, 'pipeline.yaml')
+        compiler.Compiler().compile(
+            pipeline_func=pipeline,
+            package_path=output_yaml,
+            deduplicate_executors=deduplicate_executors,
+        )
+        with open(output_yaml) as f:
+            docs = list(yaml.safe_load_all(f))
+    pipeline_spec = json_format.ParseDict(docs[0],
+                                          pipeline_spec_pb2.PipelineSpec())
+    platform_spec = pipeline_spec_pb2.PlatformSpec()
+    if len(docs) >= 2 and docs[1] is not None:
+        json_format.ParseDict(docs[1], platform_spec)
+    return pipeline_spec, platform_spec
+
+
+def _executors_dict(
+    pipeline_spec: pipeline_spec_pb2.PipelineSpec
+) -> Dict[str, Any]:
+    deployment_config = pipeline_spec_pb2.PipelineDeploymentConfig()
+    json_format.ParseDict(
+        json_format.MessageToDict(pipeline_spec.deployment_spec),
+        deployment_config)
+    return dict(deployment_config.executors)
+
+
+def _assert_refs_valid(test_case: unittest.TestCase,
+                       pipeline_spec: pipeline_spec_pb2.PipelineSpec) -> None:
+    """Every component_ref.name resolves to a components entry, and every
+    executor_label on a ComponentSpec resolves to a deployment_config
+    executor entry."""
+    executors = _executors_dict(pipeline_spec)
+    components = pipeline_spec.components
+
+    def check_component(component_spec: pipeline_spec_pb2.ComponentSpec) -> None:
+        if component_spec.executor_label:
+            test_case.assertIn(component_spec.executor_label, executors)
+        if component_spec.HasField('dag'):
+            for task_spec in component_spec.dag.tasks.values():
+                ref = task_spec.component_ref.name
+                test_case.assertIn(ref, components)
+                check_component(components[ref])
+
+    check_component(pipeline_spec.root)
+
+
+class TestExecutorDeduplication(unittest.TestCase):
+
+    def test_dedup_collapses_identical_invocations(self):
+
+        @dsl.pipeline
+        def my_pipeline():
+            for _ in range(10):
+                return_1()
+
+        off_spec, _ = _compile_and_load(my_pipeline)
+        on_spec, _ = _compile_and_load(my_pipeline, deduplicate_executors=True)
+
+        self.assertEqual(len(_executors_dict(off_spec)), 10)
+        off_labels = {
+            comp.executor_label for comp in off_spec.components.values()
+        }
+        self.assertEqual(len(off_labels), 10)
+
+        on_executors = _executors_dict(on_spec)
+        self.assertEqual(len(on_executors), 1)
+        on_labels = {
+            comp.executor_label for comp in on_spec.components.values()
+        }
+        self.assertEqual(len(on_labels), 1)
+        self.assertEqual(next(iter(on_labels)), next(iter(on_executors)))
+        _assert_refs_valid(self, on_spec)
+
+    def test_dedup_distinct_components_unchanged(self):
+
+        @dsl.pipeline
+        def my_pipeline():
+            return_1()
+            print_hello()
+            cleanup()
+
+        on_spec, _ = _compile_and_load(my_pipeline, deduplicate_executors=True)
+        self.assertEqual(len(_executors_dict(on_spec)), 3)
+        _assert_refs_valid(self, on_spec)
+
+    def test_dedup_respects_resource_overrides(self):
+
+        @dsl.pipeline
+        def my_pipeline():
+            return_1().set_cpu_limit('2')
+            return_1().set_cpu_limit('4')
+
+        on_spec, _ = _compile_and_load(my_pipeline, deduplicate_executors=True)
+        # Different resources -> different container specs -> 2 distinct executors.
+        self.assertEqual(len(_executors_dict(on_spec)), 2)
+        _assert_refs_valid(self, on_spec)
+
+    def test_dedup_respects_platform_config(self):
+
+        @dsl.pipeline
+        def my_pipeline():
+            task1 = return_1()
+            task1.platform_config['platform_foo'] = {'bar': 'one'}
+            task2 = return_1()
+            task2.platform_config['platform_foo'] = {'bar': 'two'}
+
+        on_spec, on_platform = _compile_and_load(
+            my_pipeline, deduplicate_executors=True)
+        # Different per-executor platform entries -> 2 distinct executors.
+        self.assertEqual(len(_executors_dict(on_spec)), 2)
+        # Both platform entries are retained.
+        platform_executors = on_platform.platforms[
+            'platform_foo'].deployment_spec.executors
+        self.assertEqual(len(platform_executors), 2)
+        _assert_refs_valid(self, on_spec)
+
+    def test_dedup_default_off(self):
+        # Default behavior must be byte-identical to today: a component used
+        # twice produces two executor entries.
+
+        @dsl.pipeline
+        def my_pipeline():
+            hello_world(text='hi')
+            hello_world(text='hi again')
+
+        off_spec, _ = _compile_and_load(my_pipeline)
+        executors = _executors_dict(off_spec)
+        self.assertEqual(len(executors), 2)
+        self.assertIn('exec-hello-world', executors)
+        self.assertIn('exec-hello-world-2', executors)
+
+    def test_dedup_importer_specs(self):
+
+        @dsl.pipeline
+        def my_pipeline():
+            dsl.importer(
+                artifact_uri='gs://bucket/file.txt',
+                artifact_class=dsl.Dataset)
+            dsl.importer(
+                artifact_uri='gs://bucket/file.txt',
+                artifact_class=dsl.Dataset)
+
+        on_spec, _ = _compile_and_load(my_pipeline, deduplicate_executors=True)
+        self.assertEqual(len(_executors_dict(on_spec)), 1)
+        _assert_refs_valid(self, on_spec)
+
+    def test_dedup_inside_parallelfor_and_outside(self):
+        # The interesting assertion: the in-loop executor and the outside-loop
+        # executor collapse into a single entry (not the trivial fact that
+        # ParallelFor's body emits one executor on its own).
+
+        @dsl.pipeline
+        def my_pipeline():
+            return_1()  # outside loop
+            with dsl.ParallelFor([1, 2, 3]):
+                return_1()  # inside loop, same component
+
+        off_spec, _ = _compile_and_load(my_pipeline)
+        on_spec, _ = _compile_and_load(my_pipeline, deduplicate_executors=True)
+
+        self.assertEqual(len(_executors_dict(off_spec)), 2)
+        on_executors = _executors_dict(on_spec)
+        self.assertEqual(len(on_executors), 1)
+        canonical = next(iter(on_executors))
+        labels_in_components = {
+            comp.executor_label
+            for comp in on_spec.components.values()
+            if comp.executor_label
+        }
+        self.assertEqual(labels_in_components, {canonical})
+        _assert_refs_valid(self, on_spec)
+
+    def test_dedup_dag_task_and_exit_task_share(self):
+
+        @dsl.pipeline
+        def my_pipeline():
+            print_hello()  # regular DAG task
+            exit_task = print_hello()  # same component, used as exit task
+            with dsl.ExitHandler(exit_task):
+                cleanup()
+
+        off_spec, _ = _compile_and_load(my_pipeline)
+        on_spec, _ = _compile_and_load(my_pipeline, deduplicate_executors=True)
+
+        self.assertEqual(len(_executors_dict(off_spec)), 3)
+        on_executors = _executors_dict(on_spec)
+        # Two distinct components: print_hello (shared) + cleanup.
+        self.assertEqual(len(on_executors), 2)
+        # Confirm both print_hello components point to the same executor_label.
+        print_hello_labels = {
+            comp.executor_label
+            for name, comp in on_spec.components.items()
+            if 'print-hello' in name
+        }
+        self.assertEqual(len(print_hello_labels), 1)
+        _assert_refs_valid(self, on_spec)
+
+    def test_dedup_two_exit_handlers_same_component(self):
+
+        @dsl.pipeline
+        def my_pipeline():
+            exit_one = cleanup()
+            with dsl.ExitHandler(exit_one):
+                print_hello()
+
+            exit_two = cleanup()
+            with dsl.ExitHandler(exit_two):
+                print_hello()
+
+        on_spec, _ = _compile_and_load(my_pipeline, deduplicate_executors=True)
+        on_executors = _executors_dict(on_spec)
+        # cleanup (shared across both exit tasks) + print_hello (shared across
+        # both handler bodies) = 2.
+        self.assertEqual(len(on_executors), 2)
+        _assert_refs_valid(self, on_spec)
+
+    def test_dedup_across_sub_pipeline_and_parent(self):
+
+        @dsl.pipeline
+        def inner_pipeline():
+            print_hello()
+
+        @dsl.pipeline
+        def outer_pipeline():
+            print_hello()
+            inner_pipeline()
+
+        off_spec, _ = _compile_and_load(outer_pipeline)
+        on_spec, _ = _compile_and_load(
+            outer_pipeline, deduplicate_executors=True)
+
+        self.assertEqual(len(_executors_dict(off_spec)), 2)
+        self.assertEqual(len(_executors_dict(on_spec)), 1)
+        _assert_refs_valid(self, on_spec)
+
+    def test_dedup_nested_pipeline_distinct_platform(self):
+
+        @dsl.pipeline
+        def inner_pipeline():
+            task = print_hello()
+            task.platform_config['platform_foo'] = {'bar': 'inner'}
+
+        @dsl.pipeline
+        def outer_pipeline():
+            print_hello()  # no platform config
+            inner_pipeline()
+
+        on_spec, _ = _compile_and_load(
+            outer_pipeline, deduplicate_executors=True)
+        # One executor has a platform_foo entry, the other doesn't -> they
+        # cannot share a label.
+        self.assertEqual(len(_executors_dict(on_spec)), 2)
+        _assert_refs_valid(self, on_spec)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -70,7 +70,7 @@ def _compute_executor_dedup_key(
     h.update(
         json.dumps(per_executor_platform_entries,
                    sort_keys=True).encode('utf-8'))
-    return h.hexdigest()[:16]
+    return h.hexdigest()
 
 
 def deduplicate_executors_in_place(

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -57,12 +57,10 @@ def _compute_executor_dedup_key(
 ) -> str:
     """Stable hash of an executor body plus its per-executor platform entries.
 
-    Two executors collapse only if their ExecutorSpec protos are byte-equal
-    AND their per-executor platform-spec entries match. The platform entries
-    must be in the key because PlatformSpec.platforms[*].deployment_spec.
-    executors is keyed by executor_label, so two tasks with identical
-    executor bodies but different node selectors or pod metadata cannot
-    share a label.
+    Two executors collapse only when their ExecutorSpec protos are
+    bytewise identical AND their platform entries match. Identical
+    bodies with different node selectors or pod metadata must not share
+    a label, since platform entries are keyed by executor_label.
     """
     h = hashlib.sha256()
     h.update(executor_spec.SerializeToString(deterministic=True))
@@ -106,8 +104,8 @@ def deduplicate_executors_in_place(
     rename_map: Dict[str, str] = {}
     for label in sorted(deployment_config.executors.keys()):
         executor_spec = deployment_config.executors[label]
-        key = _compute_executor_dedup_key(
-            executor_spec, per_executor_platform_for(label))
+        key = _compute_executor_dedup_key(executor_spec,
+                                          per_executor_platform_for(label))
         canonical = hash_to_canonical.get(key)
         if canonical is None:
             hash_to_canonical[key] = label

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -14,6 +14,7 @@
 """Functions for creating PipelineSpec proto objects."""
 
 import copy
+import hashlib
 import json
 import typing
 from typing import (Any, DefaultDict, Dict, List, Mapping, Optional, Tuple,
@@ -48,6 +49,95 @@ group_type_to_dsl_class = {
     tasks_group.TasksGroupType.FOR_LOOP: tasks_group.ParallelFor,
     tasks_group.TasksGroupType.EXIT_HANDLER: tasks_group.ExitHandler,
 }
+
+
+def _compute_executor_dedup_key(
+    executor_spec: pipeline_spec_pb2.PipelineDeploymentConfig.ExecutorSpec,
+    per_executor_platform_entries: dict,
+) -> str:
+    """Stable hash of an executor body plus its per-executor platform entries.
+
+    Two executors collapse only if their ExecutorSpec protos are byte-equal
+    AND their per-executor platform-spec entries match. The platform entries
+    must be in the key because PlatformSpec.platforms[*].deployment_spec.
+    executors is keyed by executor_label, so two tasks with identical
+    executor bodies but different node selectors or pod metadata cannot
+    share a label.
+    """
+    h = hashlib.sha256()
+    h.update(executor_spec.SerializeToString(deterministic=True))
+    h.update(b'|')
+    h.update(
+        json.dumps(per_executor_platform_entries,
+                   sort_keys=True).encode('utf-8'))
+    return h.hexdigest()[:16]
+
+
+def deduplicate_executors_in_place(
+    pipeline_spec: pipeline_spec_pb2.PipelineSpec,
+    platform_spec: pipeline_spec_pb2.PlatformSpec,
+) -> None:
+    """Collapses identical entries in pipeline_spec.deployment_spec.executors.
+
+    Two executor entries are considered identical when their ExecutorSpec
+    protos and their per-executor platform-spec entries are byte-equal.
+    For each equivalence class, the lexicographically smallest label is
+    kept; all other labels are removed and every reference to them is
+    rewritten to the canonical label.
+
+    Mutates pipeline_spec.deployment_spec and platform_spec in place.
+    """
+    deployment_config = pipeline_spec_pb2.PipelineDeploymentConfig()
+    json_format.ParseDict(
+        json_format.MessageToDict(pipeline_spec.deployment_spec),
+        deployment_config)
+
+    def per_executor_platform_for(label: str) -> dict:
+        out = {}
+        for platform_key, platform_config in platform_spec.platforms.items():
+            executors = platform_config.deployment_spec.executors
+            if label in executors:
+                out[platform_key] = json_format.MessageToDict(executors[label])
+        return out
+
+    # Iterate in sorted order so canonical-label choice is deterministic
+    # regardless of protobuf map iteration order.
+    hash_to_canonical: Dict[str, str] = {}
+    rename_map: Dict[str, str] = {}
+    for label in sorted(deployment_config.executors.keys()):
+        executor_spec = deployment_config.executors[label]
+        key = _compute_executor_dedup_key(
+            executor_spec, per_executor_platform_for(label))
+        canonical = hash_to_canonical.get(key)
+        if canonical is None:
+            hash_to_canonical[key] = label
+        elif canonical != label:
+            rename_map[label] = canonical
+
+    if not rename_map:
+        return
+
+    for old_label in rename_map:
+        del deployment_config.executors[old_label]
+    for platform_key in list(platform_spec.platforms.keys()):
+        executors_map = platform_spec.platforms[
+            platform_key].deployment_spec.executors
+        for old_label in rename_map:
+            if old_label in executors_map:
+                del executors_map[old_label]
+
+    def _rewrite(component_spec: pipeline_spec_pb2.ComponentSpec) -> None:
+        if component_spec.executor_label in rename_map:
+            component_spec.executor_label = rename_map[
+                component_spec.executor_label]
+
+    _rewrite(pipeline_spec.root)
+    for component_spec in pipeline_spec.components.values():
+        _rewrite(component_spec)
+
+    pipeline_spec.deployment_spec.Clear()
+    pipeline_spec.deployment_spec.update(
+        json_format.MessageToDict(deployment_config))
 
 
 def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:


### PR DESCRIPTION
**Description of your changes:**

## Summary

Adds an opt-in `deduplicate_executors` flag to `Compiler.compile()` that collapses identical entries in `deploymentSpec.executors` after compilation. Default behavior is byte-identical to today; users hitting the 3 MB Kubernetes request-size limit set the flag to drop the duplicated executor bodies.

## Motivation

Pipelines that invoke the same `@dsl.component` many times duplicate the executor body (image, command, args, env, resources, and the bundled Python wrapper script) for every invocation. Once the IR YAML grows past 3 MB the Kubernetes API server rejects it with:

```
Request entity too large: limit is 3145728
```

Long-standing related issues: #4170, #7242, #10529, #8374. #10979 fixed a related size symptom in the Argo backend compiler by hashing container specs into workflow parameters, but the SDK-side IR upload still hits the limit because the duplication happens earlier in the chain — before the backend ever sees it.

The IR proto already supports many components sharing one executor: `ComponentSpec.executor_label` is a plain string keying into `PipelineDeploymentConfig.executors` (`api/v2alpha1/pipeline_spec.proto:94, 942`). What was missing was a compiler pass that takes advantage of that. This PR adds it.

## How it works

A post-compile pass on the proto (chosen over compile-time threading because `create_pipeline_spec` runs at `@dsl.pipeline` decoration time, before `Compiler.compile` has the chance to influence it):

1. `_compute_executor_dedup_key` hashes `(executor_spec.SerializeToString(deterministic=True), per-executor PlatformSpec entries)` with SHA256. Platform entries are in the key because `PlatformSpec.platforms[*].deployment_spec.executors` is keyed by `executor_label`, and sharing a label across tasks with different node selectors / pod metadata would silently merge their configs.
2. `deduplicate_executors_in_place` iterates executor labels in sorted order so canonical-label selection is deterministic (protobuf map iteration order is not contractual). The lexicographically smallest label in each equivalence class becomes canonical.
3. Non-canonical entries are removed from `deployment_spec.executors` and from every `platform_spec.platforms[*].deployment_spec.executors`.
4. `executor_label` references are rewritten on `pipeline_spec.root` and every `pipeline_spec.components[*]`. (Tasks reference components via `component_ref.name`, not by executor label, so nothing under `dag.tasks[*]` needs to change.)

The pass runs between `modify_pipeline_spec_with_override` and `write_pipeline_spec_to_file`, on a defensive copy of `pipeline_func.platform_spec` so repeated `.compile()` calls don't accumulate state on the `GraphComponent`.

## What is NOT deduplicated

- `ComponentSpec` entries in `pipeline_spec.components` stay distinct even when their input/output definitions match. The marginal win is small and the blast radius is larger (would need to compare `single_platform_specs`, `task_config_passthroughs`, full sub-DAG contents, and remap every `PipelineTaskSpec.component_ref.name`). Easy follow-up if there's demand.
- Tasks with **different** resource limits, env vars, or platform configs — their executor bodies hash differently and stay separate, as they should.

## Files changed

- `sdk/python/kfp/compiler/pipeline_spec_builder.py` — two new module-level functions: `_compute_executor_dedup_key` and `deduplicate_executors_in_place`.
- `sdk/python/kfp/compiler/compiler.py` — new `deduplicate_executors` kwarg on `Compiler.compile()`.
- `sdk/python/kfp/compiler/compiler_test.py` — new `TestExecutorDeduplication` (11 cases).

No proto changes, no backend changes, no changes to existing build functions, no changes to golden IR files.

## Usage

```python
from kfp import compiler
compiler.Compiler().compile(
    pipeline_func=my_pipeline,
    package_path='pipeline.yaml',
    deduplicate_executors=True,
)
```

## Size impact (smoke check)

A trivial pipeline calling one `@dsl.component` 10 times in a row:

| flag | bytes  |
|------|-------:|
| off  | 17,401 |
| on   |  6,914 |

60% reduction on a trivial component. Production pipelines with source-code-heavy components typically see far more, since the duplicated portion is essentially all of `deploymentSpec.executors`.

## Test plan

New `TestExecutorDeduplication` in `sdk/python/kfp/compiler/compiler_test.py` covers:

- `test_dedup_collapses_identical_invocations` — 10x same component collapses to 1 executor.
- `test_dedup_distinct_components_unchanged` — 3 different components stay as 3 executors.
- `test_dedup_respects_resource_overrides` — same component with different `set_cpu_limit` stays as 2 executors.
- `test_dedup_respects_platform_config` — different platform configs produce 2 executors; both platform entries retained.
- `test_dedup_default_off` — flag off produces today's byte-identical output (`exec-hello-world` and `exec-hello-world-2` both present).
- `test_dedup_importer_specs` — duplicate `dsl.importer` calls collapse.
- `test_dedup_inside_parallelfor_and_outside` — in-loop and outside-loop executors of the same component collapse to **one** entry (not the trivial "ParallelFor emits one for its body" assertion).
- `test_dedup_dag_task_and_exit_task_share` — DAG task and exit task share an executor.
- `test_dedup_two_exit_handlers_same_component` — two exit handlers using the same component share an executor.
- `test_dedup_across_sub_pipeline_and_parent` — sub-pipeline and parent dedup across the `_merge_deployment_spec` boundary.
- `test_dedup_nested_pipeline_distinct_platform` — sub-pipeline with platform config stays separate from a parent invocation without one.

Each on-flag test runs an `_assert_refs_valid` helper that verifies every `component_ref.name` resolves and every `executor_label` resolves to an entry in `deployment_config.executors`.

Regression check: the rest of `compiler_test.py` passes on this branch.

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
