### PR TITLE
 sdk: add namespace fallback to list_pipelines, list_recurring_runs,   upload_pipeline

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -1422,10 +1422,11 @@ class Client:
             pipeline_name: Name of the pipeline to be shown in the UI.
             description: Description of the pipeline to be shown in the UI.
             namespace: Optional. Kubernetes namespace where the pipeline should
-                be uploaded. Defaults to the namespace configured on the client
-                (e.g. via ``Client(namespace=...)`` or
-                ``set_user_namespace()``). For single-user deployments, leave
-                it as ``None``.
+                be uploaded. If omitted or set to ``None``, the client uses
+                its configured namespace (for example via
+                ``Client(namespace=...)`` or ``set_user_namespace()``). In
+                single-user deployments, this effectively uses the empty
+                namespace.
 
         Returns:
             ``V2beta1Pipeline`` object.

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -668,6 +668,7 @@ class Client:
         Returns:
             ``V2beta1ListPipelinesResponse`` object.
         """
+        namespace = namespace or self.get_user_namespace()
         return self._pipelines_api.pipeline_service_list_pipelines(
             namespace=namespace,
             page_token=page_token,
@@ -1302,6 +1303,7 @@ class Client:
         Returns:
             ``V2beta1ListRecurringRunsResponse`` object.
         """
+        namespace = namespace or self.get_user_namespace()
         if experiment_id is not None:
             return self._recurring_run_api.recurring_run_service_list_recurring_runs(
                 page_token=page_token,
@@ -1420,12 +1422,15 @@ class Client:
             pipeline_name: Name of the pipeline to be shown in the UI.
             description: Description of the pipeline to be shown in the UI.
             namespace: Optional. Kubernetes namespace where the pipeline should
-                be uploaded. For single user deployment, leave it as None; For
-                multi user, input a namespace where the user is authorized.
+                be uploaded. Defaults to the namespace configured on the client
+                (e.g. via ``Client(namespace=...)`` or
+                ``set_user_namespace()``). For single-user deployments, leave
+                it as ``None``.
 
         Returns:
             ``V2beta1Pipeline`` object.
         """
+        namespace = namespace or self.get_user_namespace()
         if pipeline_name is None:
             pipeline_doc = _extract_pipeline_yaml(pipeline_package_path)
             pipeline_name = pipeline_doc.pipeline_spec.pipeline_info.name

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -547,6 +547,141 @@ class TestClient(parameterized.TestCase):
 
             self.assertEqual(result, expected_result)
 
+    def test_list_pipelines_falls_back_to_user_namespace_when_omitted(self):
+        """Omitting namespace resolves to the namespace from get_user_namespace()."""
+        with patch.object(
+                self.client._pipelines_api,
+                'pipeline_service_list_pipelines',
+                return_value=Mock()) as mock_list:
+            with patch.object(
+                    self.client,
+                    'get_user_namespace',
+                    return_value='ctx-ns') as mock_get_ns:
+                self.client.list_pipelines()
+                mock_get_ns.assert_called_once()
+                mock_list.assert_called_once_with(
+                    namespace='ctx-ns',
+                    page_token='',
+                    page_size=10,
+                    sort_by='',
+                    filter=None)
+
+    def test_list_pipelines_explicit_namespace_is_not_overridden(self):
+        """An explicit namespace argument is used as-is; get_user_namespace is not called."""
+        with patch.object(
+                self.client._pipelines_api,
+                'pipeline_service_list_pipelines',
+                return_value=Mock()) as mock_list:
+            with patch.object(
+                    self.client,
+                    'get_user_namespace',
+                    return_value='ctx-ns') as mock_get_ns:
+                self.client.list_pipelines(namespace='explicit-ns')
+                mock_get_ns.assert_not_called()
+                mock_list.assert_called_once_with(
+                    namespace='explicit-ns',
+                    page_token='',
+                    page_size=10,
+                    sort_by='',
+                    filter=None)
+
+    def test_list_recurring_runs_falls_back_to_user_namespace_when_omitted(
+            self):
+        """Omitting namespace resolves to the namespace from get_user_namespace()."""
+        with patch.object(
+                self.client._recurring_run_api,
+                'recurring_run_service_list_recurring_runs',
+                return_value=Mock()) as mock_list:
+            with patch.object(
+                    self.client,
+                    'get_user_namespace',
+                    return_value='ctx-ns') as mock_get_ns:
+                self.client.list_recurring_runs()
+                mock_get_ns.assert_called_once()
+                mock_list.assert_called_once_with(
+                    page_token='',
+                    page_size=10,
+                    sort_by='',
+                    namespace='ctx-ns',
+                    filter=None)
+
+    def test_list_recurring_runs_explicit_namespace_is_not_overridden(self):
+        """An explicit namespace argument is used as-is; get_user_namespace is not called."""
+        with patch.object(
+                self.client._recurring_run_api,
+                'recurring_run_service_list_recurring_runs',
+                return_value=Mock()) as mock_list:
+            with patch.object(
+                    self.client,
+                    'get_user_namespace',
+                    return_value='ctx-ns') as mock_get_ns:
+                self.client.list_recurring_runs(namespace='explicit-ns')
+                mock_get_ns.assert_not_called()
+                mock_list.assert_called_once_with(
+                    page_token='',
+                    page_size=10,
+                    sort_by='',
+                    namespace='explicit-ns',
+                    filter=None)
+
+    def test_list_recurring_runs_with_experiment_id_does_not_forward_namespace(
+            self):
+        """When experiment_id is given, namespace must not be forwarded to the API call."""
+        with patch.object(
+                self.client._recurring_run_api,
+                'recurring_run_service_list_recurring_runs',
+                return_value=Mock()) as mock_list:
+            self.client.list_recurring_runs(experiment_id='exp-123')
+            mock_list.assert_called_once_with(
+                page_token='',
+                page_size=10,
+                sort_by='',
+                experiment_id='exp-123',
+                filter=None)
+
+    def test_upload_pipeline_falls_back_to_user_namespace_when_omitted(self):
+        """Omitting namespace resolves to the namespace from get_user_namespace()."""
+        with patch.object(
+                self.client._upload_api,
+                'upload_pipeline',
+                return_value=Mock(pipeline_id='pipe-1')) as mock_upload:
+            with patch.object(
+                    self.client,
+                    'get_user_namespace',
+                    return_value='ctx-ns') as mock_get_ns:
+                with patch.object(auth, 'is_ipython', return_value=False):
+                    self.client.upload_pipeline(
+                        pipeline_package_path='fake.yaml',
+                        pipeline_name='my-pipeline')
+                    mock_get_ns.assert_called_once()
+                    mock_upload.assert_called_once_with(
+                        'fake.yaml',
+                        name='my-pipeline',
+                        description=None,
+                        namespace='ctx-ns')
+
+    def test_upload_pipeline_explicit_namespace_is_not_overridden(self):
+        """An explicit namespace argument is used as-is; get_user_namespace is not called."""
+        with patch.object(
+                self.client._upload_api,
+                'upload_pipeline',
+                return_value=Mock(pipeline_id='pipe-1')) as mock_upload:
+            with patch.object(
+                    self.client,
+                    'get_user_namespace',
+                    return_value='ctx-ns') as mock_get_ns:
+                with patch.object(auth, 'is_ipython', return_value=False):
+                    self.client.upload_pipeline(
+                        pipeline_package_path='fake.yaml',
+                        pipeline_name='my-pipeline',
+                        namespace='explicit-ns')
+                    mock_get_ns.assert_not_called()
+                    mock_upload.assert_called_once_with(
+                        'fake.yaml',
+                        name='my-pipeline',
+                        description=None,
+                        namespace='explicit-ns')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #13397
  
  ### What
  
  Three client methods accepted `namespace` but didn't fall back to the
  client-configured namespace when it was omitted. In multi-user mode
  this
  caused `upload_pipeline` to fail with HTTP 400 and `list_*` methods
  to
  query across all namespaces instead of the configured one.
  
  ### Change
  
  Applied `namespace = namespace or self.get_user_namespace()` to:
  - `list_pipelines`
  - `list_recurring_runs`
  - `upload_pipeline`
  
  This is the same pattern already used by `create_experiment`,
  `list_experiments`, `get_experiment`, and `list_runs`.
  
  Also updated the `upload_pipeline` docstring to reflect the new
  default
  behaviour.
  
  ### Tests
  
  7 new unit tests in `client_test.py`:
  - fallback fires when namespace is omitted
  - explicit namespace is not overridden
  - `list_recurring_runs` with `experiment_id` does not forward
  namespace
  
  ### Notes
  
  - No behaviour change for single-user deployments
  (`get_user_namespace()`
    returns `''`, backend blanks it via `ReplaceNamespace` anyway).