### PR TITLE
fix: preserve Docker runner exit status

### DIFF
--- a/sdk/python/kfp/local/docker_task_handler.py
+++ b/sdk/python/kfp/local/docker_task_handler.py
@@ -140,21 +140,16 @@ def run_docker_container(client: 'docker.DockerClient', image: str,
         stdout=True,
         stderr=True,
         volumes=volumes,
-        auto_remove=True,
+        auto_remove=False,
         **container_run_args)
     try:
         for line in container.logs(stream=True):
             # the inner logs should already have trailing \n
             # we do not need to add another
             print(line.decode(), end='')
-    except docker.errors.NotFound:
-        # Container was auto-removed before we could stream logs
-        # This can happen if the container exits very quickly
-        pass
-    try:
         return container.wait()['StatusCode']
-    except docker.errors.NotFound:
-        # Container was auto-removed after logs completed
-        # This means the container exited successfully (logs streaming completed)
-        # We assume success since we couldn't get the actual status code
-        return 0
+    finally:
+        try:
+            container.remove(force=True)
+        except docker.errors.NotFound:
+            pass

--- a/sdk/python/kfp/local/docker_task_handler_test.py
+++ b/sdk/python/kfp/local/docker_task_handler_test.py
@@ -66,7 +66,7 @@ class TestRunDockerContainer(DockerMockTestCase):
             stdout=True,
             stderr=True,
             volumes={},
-            auto_remove=True,
+            auto_remove=False,
         )
 
     def test_cwd_volume(self):
@@ -90,8 +90,25 @@ class TestRunDockerContainer(DockerMockTestCase):
                 'bind': '/localdir',
                 'mode': 'ro'
             }},
-            auto_remove=True,
+            auto_remove=False,
         )
+        self.mocked_docker_client.containers.run.return_value.remove.assert_called_once_with(
+            force=True)
+
+    def test_returns_container_exit_status_before_removing_container(self):
+        mock_container = self.mocked_docker_client.containers.run.return_value
+        mock_container.wait.return_value = {'StatusCode': 1}
+
+        return_code = docker_task_handler.run_docker_container(
+            docker.from_env(),
+            image='alpine',
+            command=['false'],
+            volumes={},
+        )
+
+        self.assertEqual(return_code, 1)
+        mock_container.wait.assert_called_once()
+        mock_container.remove.assert_called_once_with(force=True)
 
 
 class TestDockerTaskHandler(DockerMockTestCase):
@@ -239,7 +256,7 @@ class TestDockerTaskHandler(DockerMockTestCase):
                         'mode': 'rw'
                     }
                 },
-                auto_remove=True,
+                auto_remove=False,
             )
 
     def test_run_passes_env_vars(self):


### PR DESCRIPTION
### Description of your changes

Fixes the local Docker runner path so container failures are propagated back to callers.

The previous implementation used `auto_remove=True` and then inspected the container after `run()`. When Docker removed the container before inspection, `docker.errors.NotFound` was treated as success and the local task returned `0`, even if the container process failed.

This change keeps the container available until its status is read, returns the Docker `StatusCode`, and removes the container in a cleanup block. The tests cover the regression and the cleanup behavior.

Fixes #13332

### How has this code been tested?

- `python3 -m py_compile sdk/python/kfp/local/docker_task_handler.py sdk/python/kfp/local/docker_task_handler_test.py`

I could not run the unit test module locally because this environment is missing test/runtime dependencies:

- `python3 -m pytest ...` failed because `pytest` is not installed
- `PYTHONPATH=sdk/python python3 -m unittest ...` failed because `docstring_parser` is not installed

### Checklist

- [x] The title for your pull request (PR) should follow our title requirements. If the PR fully addresses an existing Github issue, please include "Fixes #1234" in the PR body to automatically close the issue when the PR is merged.
- [x] Tests have been added / updated.
- [x] Code compiles locally.
