### PR TITLE
test(frontend): flush PipelineList updates in act

### DIFF
--- a/frontend/src/pages/PipelineList.test.tsx
+++ b/frontend/src/pages/PipelineList.test.tsx
@@ -21,7 +21,7 @@ import { range } from 'lodash';
 import { RoutePage, RouteParams } from 'src/components/Router';
 import { Apis } from 'src/lib/Apis';
 import { ButtonKeys } from 'src/lib/Buttons';
-import TestUtils from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct } from 'src/TestUtils';
 import { PageProps } from './Page';
 import PipelineList from './PipelineList';
 import { CommonTestWrapper } from 'src/TestWrapper';
@@ -180,7 +180,7 @@ describe('PipelineList', () => {
         <PipelineList ref={pipelineListRef} {...props} namespace={options?.namespace} />
       </CommonTestWrapper>,
     );
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     await waitForPipelinesLoad();
   }
 
@@ -188,7 +188,7 @@ describe('PipelineList', () => {
     await waitFor(() => {
       expect(listPipelinesSpy).toHaveBeenCalled();
     });
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
   }
 
   async function mountWithNPipelines(n: number, options?: { namespace?: string }) {
@@ -706,7 +706,7 @@ describe('PipelineList', () => {
     await waitFor(() => {
       expect(deletePipelineVersionSpy).toHaveBeenCalledTimes(2);
     });
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     expect(updateSnackbarSpy).not.toHaveBeenCalled();
     expect(updateDialogSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

Wrap the remaining promise drains in `PipelineList.test.tsx` with `flushPromisesInAct()`.

The shared render/load helpers wait for promise-driven React updates after PipelineList fetches data and updates its table state. The pending-delete test also uses a flush to observe intermediate state while one deletion promise is unresolved; using the act-aware helper keeps any queued React work inside the test boundary without changing the assertions.

Part of #13349.

## Verification

- `npm run test:ui -- src/pages/PipelineList.test.tsx` before: 30 tests passed with 820 `act(...)` warning lines
- `npm run test:ui -- src/pages/PipelineList.test.tsx` after: 30 tests passed with zero `act(...)` warning lines
- `npm run lint:ui`
- `npm run typecheck`
- `git diff --check`
