### PR TITLE
test(frontend): use act helpers in NewPipelineVersion

### DIFF
--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -19,7 +19,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { NewPipelineVersion } from './NewPipelineVersion';
-import TestUtils from 'src/TestUtils';
+import { flushPromisesInAct, invokeAndFlush } from 'src/TestUtils';
 import { PageProps } from './Page';
 import { Apis } from 'src/lib/Apis';
 import { RoutePage, QUERY_PARAMS } from 'src/components/Router';
@@ -94,9 +94,7 @@ describe('NewPipelineVersion', () => {
     } else {
       renderResult = render(<NewPipelineVersion {...props} />);
     }
-    await act(async () => {
-      await TestUtils.flushPromises();
-    });
+    await flushPromisesInAct();
   }
 
   /**
@@ -108,9 +106,8 @@ describe('NewPipelineVersion', () => {
     if (!componentRef?.current) {
       throw new Error('componentRef not available — did you forget { withRef: true }?');
     }
-    await act(async () => {
+    await invokeAndFlush(() => {
       componentRef!.current!.simulateDrop(files);
-      await TestUtils.flushPromises();
     });
   }
 
@@ -257,9 +254,8 @@ describe('NewPipelineVersion', () => {
       await waitFor(() => expect(versionNameInput).toHaveValue('my-custom-version-name'));
 
       // Simulate a rejected drop (JSDOM workaround — same as file drop tests)
-      await act(async () => {
+      await invokeAndFlush(() => {
         componentRef!.current!.simulateDropRejected();
-        await TestUtils.flushPromises();
       });
 
       // Version name must NOT be cleared

--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import * as React from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { NewPipelineVersion } from './NewPipelineVersion';


### PR DESCRIPTION
## Summary

Replace the manual `act(async () => TestUtils.flushPromises())` patterns in `NewPipelineVersion.test.tsx` with the existing act-aware helpers.

This is helper cleanup rather than warning reduction: the focused test already passed with zero `act(...)` warning lines before the change because the raw flushes were manually wrapped in `act`. The new form keeps the same semantics while matching the shared `flushPromisesInAct()` / `invokeAndFlush()` patterns used by the surrounding cleanup work.

Part of #13349.

## Verification

- `npm run test:ui -- src/pages/NewPipelineVersion.test.tsx` before: 23 tests passed with zero `act(...)` warning lines
- `npm run test:ui -- src/pages/NewPipelineVersion.test.tsx` after: 23 tests passed with zero `act(...)` warning lines
- `npm run lint:ui`
- `npm run typecheck`
- `git diff --check`
