### PR TITLE
test(frontend): flush PipelineDetails switch setup in act

### DIFF
--- a/frontend/src/pages/PipelineDetailsTest.test.tsx
+++ b/frontend/src/pages/PipelineDetailsTest.test.tsx
@@ -28,7 +28,11 @@ import { V2beta1Run } from 'src/apisv2beta1/run';
 import { QUERY_PARAMS, RouteParams } from 'src/components/Router';
 import * as features from 'src/features';
 import { Apis } from 'src/lib/Apis';
-import TestUtils, { flushPromisesInAct, mockResizeObserver, testBestPractices } from 'src/TestUtils';
+import TestUtils, {
+  flushPromisesInAct,
+  mockResizeObserver,
+  testBestPractices,
+} from 'src/TestUtils';
 import * as StaticGraphParser from 'src/lib/StaticGraphParser';
 import { PageProps } from './Page';
 import PipelineDetails from './PipelineDetails';

--- a/frontend/src/pages/PipelineDetailsTest.test.tsx
+++ b/frontend/src/pages/PipelineDetailsTest.test.tsx
@@ -28,7 +28,7 @@ import { V2beta1Run } from 'src/apisv2beta1/run';
 import { QUERY_PARAMS, RouteParams } from 'src/components/Router';
 import * as features from 'src/features';
 import { Apis } from 'src/lib/Apis';
-import TestUtils, { mockResizeObserver, testBestPractices } from 'src/TestUtils';
+import TestUtils, { flushPromisesInAct, mockResizeObserver, testBestPractices } from 'src/TestUtils';
 import * as StaticGraphParser from 'src/lib/StaticGraphParser';
 import { PageProps } from './Page';
 import PipelineDetails from './PipelineDetails';
@@ -227,7 +227,7 @@ spec:
     TestUtils.makeErrorResponse(createGraphSpy, 'bad graph');
 
     renderPipelineDetailsPage(<PipelineDetails {...generateProps()} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     screen.getByTestId('pipeline-detail-v1');
     expect(updateBannerSpy).toHaveBeenLastCalledWith(
@@ -328,7 +328,7 @@ spec:
     });
 
     renderPipelineDetailsPage(<PipelineDetails {...generateProps()} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     screen.getByTestId('pipeline-detail-v1');
     expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({}));
@@ -352,7 +352,7 @@ spec:
     createGraphSpy.mockImplementation(() => new graphlib.Graph());
 
     renderPipelineDetailsPage(<PipelineDetails {...generateProps()} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     screen.getByTestId('pipeline-detail-v1');
     expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({}));
@@ -370,7 +370,7 @@ spec:
     createGraphSpy.mockImplementation(() => new graphlib.Graph());
 
     renderPipelineDetailsPage(<PipelineDetails {...generateProps()} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
 
     screen.getByTestId('pipeline-detail-v2');
     expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({}));


### PR DESCRIPTION
## Summary

Wrap the async PipelineDetails v1/v2 switch setup drains with `flushPromisesInAct()`.

These tests render PipelineDetails and then flush promise-driven setup work before asserting which detail view is shown. Using the act-aware helper keeps the React state updates from that setup inside Testing Library's act boundary and removes the warning noise from this focused test file.

Part of #13349.

## Verification

- `npm run test:ui -- src/pages/PipelineDetailsTest.test.tsx` before: 6 tests passed with 408 `act(...)` warning lines
- `npm run test:ui -- src/pages/PipelineDetailsTest.test.tsx` after: 6 tests passed with zero `act(...)` warning lines
- `npm run lint:ui`
- `npm run typecheck`
- `git diff --check`
