### PR TITLE
test(frontend): use act helpers in small viewer tests

### DIFF
--- a/frontend/src/components/CustomTableRow.test.tsx
+++ b/frontend/src/components/CustomTableRow.test.tsx
@@ -16,7 +16,7 @@
 
 import { render } from '@testing-library/react';
 import { Column, Row } from './CustomTable';
-import TestUtils from '../TestUtils';
+import { flushPromisesInAct } from '../TestUtils';
 import { CustomTableRow } from './CustomTableRow';
 
 describe('CustomTable', () => {
@@ -44,7 +44,7 @@ describe('CustomTable', () => {
   it('renders some rows using a custom renderer', async () => {
     columns[0].customRenderer = () => (<span>this is custom output</span>) as any;
     const { asFragment } = render(<CustomTableRow {...props} row={row} columns={columns} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(asFragment()).toMatchSnapshot();
     columns[0].customRenderer = undefined;
   });
@@ -52,7 +52,7 @@ describe('CustomTable', () => {
   it('displays warning icon with tooltip if row has error', async () => {
     row.error = 'dummy error';
     const { asFragment } = render(<CustomTableRow {...props} row={row} columns={columns} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     expect(asFragment()).toMatchSnapshot();
     row.error = undefined;
   });

--- a/frontend/src/components/viewers/HTMLViewer.test.tsx
+++ b/frontend/src/components/viewers/HTMLViewer.test.tsx
@@ -17,7 +17,7 @@
 import { render } from '@testing-library/react';
 import HTMLViewer, { HTMLViewerConfig } from './HTMLViewer';
 import { PlotType } from './Viewer';
-import TestUtils from '../../TestUtils';
+import { flushPromisesInAct } from '../../TestUtils';
 
 describe('HTMLViewer', () => {
   it('does not break on empty data', () => {
@@ -43,7 +43,7 @@ describe('HTMLViewer', () => {
 
   it('uses srcdoc to insert HTML into the iframe', async () => {
     const { container } = render(<HTMLViewer configs={[config]} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     const iframe = container.querySelector('iframe') as HTMLIFrameElement | null;
     expect(iframe).not.toBeNull();
     expect(iframe?.srcdoc).toEqual(html);
@@ -52,7 +52,7 @@ describe('HTMLViewer', () => {
 
   it('cannot be accessed from main frame of the other way around (no allow-same-origin)', async () => {
     const { container } = render(<HTMLViewer configs={[config]} />);
-    await TestUtils.flushPromises();
+    await flushPromisesInAct();
     const iframe = container.querySelector('iframe') as HTMLIFrameElement | null;
     expect(iframe).not.toBeNull();
     expect((iframe as any)?.window).toBeUndefined();

--- a/frontend/src/components/viewers/PagedTable.test.tsx
+++ b/frontend/src/components/viewers/PagedTable.test.tsx
@@ -17,7 +17,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import PagedTable from './PagedTable';
 import { PlotType } from './Viewer';
-import TestUtils from '../../TestUtils';
+import { invokeAndFlush } from '../../TestUtils';
 import { stableMuiSnapshotFragment } from 'src/testUtils/muiSnapshot';
 
 describe('PagedTable', () => {
@@ -57,8 +57,9 @@ describe('PagedTable', () => {
     const { asFragment } = render(
       <PagedTable configs={[{ data, labels, type: PlotType.TABLE }]} />,
     );
-    fireEvent.click(screen.getByText(labels[0]));
-    await TestUtils.flushPromises();
+    await invokeAndFlush(() => {
+      fireEvent.click(screen.getByText(labels[0]));
+    });
     expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   });
 
@@ -67,10 +68,13 @@ describe('PagedTable', () => {
       <PagedTable configs={[{ data, labels, type: PlotType.TABLE }]} />,
     );
     // Once for descending.
-    fireEvent.click(screen.getByText(labels[0]));
+    await invokeAndFlush(() => {
+      fireEvent.click(screen.getByText(labels[0]));
+    });
     // Once for ascending.
-    fireEvent.click(screen.getByText(labels[0]));
-    await TestUtils.flushPromises();
+    await invokeAndFlush(() => {
+      fireEvent.click(screen.getByText(labels[0]));
+    });
     expect(stableMuiSnapshotFragment(asFragment())).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## Summary
- Replace raw `TestUtils.flushPromises()` calls in small viewer/component tests with act-aware helpers.
- Use `flushPromisesInAct()` for render follow-up drains in `HTMLViewer.test.tsx` and `CustomTableRow.test.tsx`.
- Use `invokeAndFlush()` for `PagedTable.test.tsx` sort clicks so each user action and its async follow-up are flushed together.

## Why
This is helper cleanup rather than warning reduction: the focused test batch already passed with zero `act(...)` warning lines before the change. The benefit is keeping these tests on the same React 19-safe helper pattern as the rest of the cleanup work, so future async updates introduced in these tests are less likely to escape Testing Library act boundaries.

The ascending sort test intentionally keeps separate helper calls for the two clicks. Batching both clicks into one `act` changes the interaction timing because the second click can observe the pre-flush sort state, so separate action/flush boundaries preserve the original test semantics.

## Validation
- `npm run test:ui -- src/components/viewers/HTMLViewer.test.tsx src/components/viewers/PagedTable.test.tsx src/components/CustomTableRow.test.tsx`
  - Before: 16 tests passed, 0 `act(...)` warning lines.
  - After: 16 tests passed, 0 `act(...)` warning lines.
- `npm run lint:ui`
- `npm run typecheck`
- `git diff --check`