### PR TITLE
fix(local): resolve PIPELINE_JOB_RESOURCE_NAME, CREATE_TIME, and SCHEDULE_TIME   placeholders

### DIFF
--- a/sdk/python/kfp/local/placeholder_utils.py
+++ b/sdk/python/kfp/local/placeholder_utils.py
@@ -39,10 +39,23 @@ def replace_placeholders(
 ) -> List[str]:
     """Iterates over each element in the command and replaces placeholders.
 
-    This should only be called once per each task, since the task's
-    random ID is created within the scope of the function. Multiple
-    calls on the same task will result in multiple random IDs per single
-    task.
+    Args:
+        full_command: List of command elements to process.
+        executor_input_dict: The executor input dictionary.
+        pipeline_resource_name: Pipeline display name or resource identifier.
+            Used for both {{$.pipeline_job_name}} and
+            {{$.pipeline_job_resource_name}} in local execution.
+        task_resource_name: Task display name.
+        pipeline_root: Root directory for pipeline artifacts.
+        unique_pipeline_id: Unique identifier for the pipeline run.
+
+    Returns:
+        List of command elements with all placeholders resolved.
+
+    Note:
+        This function should only be called once per task, as it generates
+        a unique task ID and UTC timestamp internally. Multiple calls on
+        the same task will result in different random IDs and timestamps.
     """
     unique_task_id = make_random_id()
     utc_timestamp = datetime.datetime.now(
@@ -349,7 +362,27 @@ def resolve_individual_placeholder(
     pipeline_task_id: str,
     utc_timestamp: str = '',
 ) -> str:
-    """Replaces placeholders for a single element."""
+    """Replaces placeholders for a single element.
+
+    Args:
+        element: The command element containing placeholders to resolve.
+        executor_input_dict: The executor input dictionary.
+        pipeline_resource_name: Pipeline display name or resource identifier.
+        task_resource_name: Task display name.
+        pipeline_root: Root directory for pipeline artifacts.
+        pipeline_job_id: Unique identifier for the pipeline run.
+        pipeline_task_id: Unique identifier for the task.
+        utc_timestamp: ISO8601-formatted UTC timestamp string. If not provided
+            (defaults to empty string), timestamp placeholders
+            ({{$.pipeline_job_create_time_utc}} and
+            {{$.pipeline_job_schedule_time_utc}}) will be replaced with
+            an empty string. This parameter should be provided by
+            replace_placeholders(), which generates a timestamp for all
+            placeholders in a command.
+
+    Returns:
+        The element with all placeholders resolved.
+    """
 
     if dsl.WORKSPACE_PATH_PLACEHOLDER in element or dsl_constants.WORKSPACE_MOUNT_PATH in element:
         # Ensure local config and workspace are available
@@ -371,6 +404,12 @@ def resolve_individual_placeholder(
                                   workspace_value)
 
     # match on literal for constant placeholders
+    # Note: In local execution, PIPELINE_JOB_NAME_PLACEHOLDER and
+    # PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER both resolve to
+    # pipeline_resource_name, which serves as both the job display name
+    # and resource identifier. This differs from remote execution where
+    # these may have different values, but local execution uses them
+    # interchangeably.
     PLACEHOLDERS = {
         r'{{$.outputs.output_file}}':
             executor_input_dict['outputs']['outputFile'],

--- a/sdk/python/kfp/local/placeholder_utils.py
+++ b/sdk/python/kfp/local/placeholder_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Utilities for working with placeholders."""
+import datetime
 import functools
 import json
 import random
@@ -360,6 +361,10 @@ def resolve_individual_placeholder(
                                   workspace_value)
 
     # match on literal for constant placeholders
+    # Generate UTC timestamp in ISO 8601 format for create and schedule times.
+    utc_timestamp = datetime.datetime.now(
+        datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+
     PLACEHOLDERS = {
         r'{{$.outputs.output_file}}':
             executor_input_dict['outputs']['outputFile'],
@@ -369,8 +374,14 @@ def resolve_individual_placeholder(
             json.dumps(executor_input_dict),
         dsl.PIPELINE_JOB_NAME_PLACEHOLDER:
             pipeline_resource_name,
+        dsl.PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER:
+            pipeline_resource_name,
         dsl.PIPELINE_JOB_ID_PLACEHOLDER:
             pipeline_job_id,
+        dsl.PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER:
+            utc_timestamp,
+        dsl.PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER:
+            utc_timestamp,
         dsl.PIPELINE_TASK_NAME_PLACEHOLDER:
             task_resource_name,
         dsl.PIPELINE_TASK_ID_PLACEHOLDER:

--- a/sdk/python/kfp/local/placeholder_utils.py
+++ b/sdk/python/kfp/local/placeholder_utils.py
@@ -45,6 +45,8 @@ def replace_placeholders(
     task.
     """
     unique_task_id = make_random_id()
+    utc_timestamp = datetime.datetime.now(
+        datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
     executor_input_dict = resolve_self_references_in_executor_input(
         executor_input_dict=executor_input_dict,
         pipeline_resource_name=pipeline_resource_name,
@@ -52,6 +54,7 @@ def replace_placeholders(
         pipeline_root=pipeline_root,
         pipeline_job_id=unique_pipeline_id,
         pipeline_task_id=unique_task_id,
+        utc_timestamp=utc_timestamp,
     )
     provided_inputs = get_provided_inputs(executor_input_dict)
     full_command = [
@@ -71,6 +74,7 @@ def replace_placeholders(
             pipeline_root=pipeline_root,
             pipeline_job_id=unique_pipeline_id,
             pipeline_task_id=unique_task_id,
+            utc_timestamp=utc_timestamp,
         )
         if resolved_el is None:
             continue
@@ -92,6 +96,7 @@ def resolve_self_references_in_executor_input(
     pipeline_root: str,
     pipeline_job_id: str,
     pipeline_task_id: str,
+    utc_timestamp: str = '',
 ) -> Dict[str, Any]:
     """Resolve parameter placeholders that point to other parameter
     placeholders in the same ExecutorInput message.
@@ -120,6 +125,7 @@ def resolve_self_references_in_executor_input(
                     pipeline_root=pipeline_root,
                     pipeline_job_id=pipeline_job_id,
                     pipeline_task_id=pipeline_task_id,
+                    utc_timestamp=utc_timestamp,
                 )
     return executor_input_dict
 
@@ -132,6 +138,7 @@ def recursively_resolve_json_dict_placeholders(
     pipeline_root: str,
     pipeline_job_id: str,
     pipeline_task_id: str,
+    utc_timestamp: str = '',
 ) -> Any:
     """Recursively resolves any placeholders in a dictionary representation of
     a JSON object.
@@ -148,6 +155,7 @@ def recursively_resolve_json_dict_placeholders(
         pipeline_root=pipeline_root,
         pipeline_job_id=pipeline_job_id,
         pipeline_task_id=pipeline_task_id,
+        utc_timestamp=utc_timestamp,
     )
     if isinstance(obj, list):
         return [inner_fn(item) for item in obj]
@@ -162,6 +170,7 @@ def recursively_resolve_json_dict_placeholders(
             pipeline_root=pipeline_root,
             pipeline_job_id=pipeline_job_id,
             pipeline_task_id=pipeline_task_id,
+            utc_timestamp=utc_timestamp,
         )
     else:
         return obj
@@ -338,6 +347,7 @@ def resolve_individual_placeholder(
     pipeline_root: str,
     pipeline_job_id: str,
     pipeline_task_id: str,
+    utc_timestamp: str = '',
 ) -> str:
     """Replaces placeholders for a single element."""
 
@@ -361,10 +371,6 @@ def resolve_individual_placeholder(
                                   workspace_value)
 
     # match on literal for constant placeholders
-    # Generate UTC timestamp in ISO 8601 format for create and schedule times.
-    utc_timestamp = datetime.datetime.now(
-        datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-
     PLACEHOLDERS = {
         r'{{$.outputs.output_file}}':
             executor_input_dict['outputs']['outputFile'],

--- a/sdk/python/kfp/local/placeholder_utils_test.py
+++ b/sdk/python/kfp/local/placeholder_utils_test.py
@@ -163,10 +163,10 @@ class TestReplacePlaceholders(unittest.TestCase):
 
         self.assertIsNotNone(
             create_time_match,
-            f"Could not extract create-time from {actual[1]!r}")
+            f'Could not extract create-time from {actual[1]!r}')
         self.assertIsNotNone(
             schedule_time_match,
-            f"Could not extract schedule-time from {actual[2]!r}")
+            f'Could not extract schedule-time from {actual[2]!r}')
 
         create_timestamp = create_time_match.group(1)
         schedule_timestamp = schedule_time_match.group(1)
@@ -174,10 +174,10 @@ class TestReplacePlaceholders(unittest.TestCase):
         # Verify both timestamps are valid ISO8601 format
         self.assertRegex(
             create_timestamp, iso8601_pattern,
-            f"Create timestamp {create_timestamp!r} is not valid ISO8601")
+            f'Create timestamp {create_timestamp!r} is not valid ISO8601')
         self.assertRegex(
             schedule_timestamp, iso8601_pattern,
-            f"Schedule timestamp {schedule_timestamp!r} is not valid ISO8601")
+            f'Schedule timestamp {schedule_timestamp!r} is not valid ISO8601')
 
         # Verify both timestamps are identical (stability within replace_placeholders call)
         self.assertEqual(

--- a/sdk/python/kfp/local/placeholder_utils_test.py
+++ b/sdk/python/kfp/local/placeholder_utils_test.py
@@ -145,6 +145,10 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
             'my-pipeline-2023-10-10-13-32-59-420710',
         ),
         (
+            '{{$.pipeline_job_resource_name}}',
+            'my-pipeline-2023-10-10-13-32-59-420710',
+        ),
+        (
             '{{$.pipeline_job_uuid}}',
             '123456789',
         ),
@@ -292,6 +296,38 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
             pipeline_task_id='987654321',
         )
         self.assertEqual(actual, expected)
+
+    def test_pipeline_job_create_time_utc_placeholder(self):
+        """Test that PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER is replaced with a valid UTC timestamp."""
+        actual = placeholder_utils.resolve_individual_placeholder(
+            element='{{$.pipeline_job_create_time_utc}}',
+            executor_input_dict=EXECUTOR_INPUT_DICT,
+            pipeline_resource_name='my-pipeline-2023-10-10-13-32-59-420710',
+            task_resource_name='comp',
+            pipeline_root='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
+            pipeline_job_id='123456789',
+            pipeline_task_id='987654321',
+        )
+        # Verify that the result is a non-empty string in ISO 8601 format (YYYY-MM-DDTHH:MM:SS.sssZ)
+        import re
+        iso8601_pattern = r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z'
+        self.assertRegex(actual, iso8601_pattern)
+
+    def test_pipeline_job_schedule_time_utc_placeholder(self):
+        """Test that PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER is replaced with a valid UTC timestamp."""
+        actual = placeholder_utils.resolve_individual_placeholder(
+            element='{{$.pipeline_job_schedule_time_utc}}',
+            executor_input_dict=EXECUTOR_INPUT_DICT,
+            pipeline_resource_name='my-pipeline-2023-10-10-13-32-59-420710',
+            task_resource_name='comp',
+            pipeline_root='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
+            pipeline_job_id='123456789',
+            pipeline_task_id='987654321',
+        )
+        # Verify that the result is a non-empty string in ISO 8601 format (YYYY-MM-DDTHH:MM:SS.sssZ)
+        import re
+        iso8601_pattern = r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z'
+        self.assertRegex(actual, iso8601_pattern)
 
 
 class TestGetValueUsingPath(unittest.TestCase):

--- a/sdk/python/kfp/local/placeholder_utils_test.py
+++ b/sdk/python/kfp/local/placeholder_utils_test.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 """Tests for placeholder_utils.py."""
 
+import datetime
 import json
 import os
+import re
 import tempfile
 from typing import List, Optional
 import unittest
@@ -299,22 +301,29 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
 
     def test_pipeline_job_create_time_utc_placeholder(self):
         """Test that PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER is replaced with a valid UTC timestamp."""
-        actual = placeholder_utils.resolve_individual_placeholder(
-            element='{{$.pipeline_job_create_time_utc}}',
+        utc_timestamp = datetime.datetime.now(
+            datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        iso8601_pattern = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$'
+        kwargs = dict(
             executor_input_dict=EXECUTOR_INPUT_DICT,
             pipeline_resource_name='my-pipeline-2023-10-10-13-32-59-420710',
             task_resource_name='comp',
             pipeline_root='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
             pipeline_job_id='123456789',
             pipeline_task_id='987654321',
+            utc_timestamp=utc_timestamp,
         )
-        # Verify that the result is a non-empty string in ISO 8601 format (YYYY-MM-DDTHH:MM:SS.sssZ)
-        import re
-        iso8601_pattern = r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z'
-        self.assertRegex(actual, iso8601_pattern)
+        actual_create = placeholder_utils.resolve_individual_placeholder(
+            element='{{$.pipeline_job_create_time_utc}}', **kwargs)
+        actual_schedule = placeholder_utils.resolve_individual_placeholder(
+            element='{{$.pipeline_job_schedule_time_utc}}', **kwargs)
+        self.assertRegex(actual_create, iso8601_pattern)
+        self.assertEqual(actual_create, actual_schedule)
 
     def test_pipeline_job_schedule_time_utc_placeholder(self):
         """Test that PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER is replaced with a valid UTC timestamp."""
+        utc_timestamp = datetime.datetime.now(
+            datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
         actual = placeholder_utils.resolve_individual_placeholder(
             element='{{$.pipeline_job_schedule_time_utc}}',
             executor_input_dict=EXECUTOR_INPUT_DICT,
@@ -323,10 +332,9 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
             pipeline_root='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
             pipeline_job_id='123456789',
             pipeline_task_id='987654321',
+            utc_timestamp=utc_timestamp,
         )
-        # Verify that the result is a non-empty string in ISO 8601 format (YYYY-MM-DDTHH:MM:SS.sssZ)
-        import re
-        iso8601_pattern = r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z'
+        iso8601_pattern = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$'
         self.assertRegex(actual, iso8601_pattern)
 
 

--- a/sdk/python/kfp/local/placeholder_utils_test.py
+++ b/sdk/python/kfp/local/placeholder_utils_test.py
@@ -16,7 +16,6 @@
 import datetime
 import json
 import os
-import re
 import tempfile
 from typing import List, Optional
 import unittest
@@ -300,7 +299,13 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
         self.assertEqual(actual, expected)
 
     def test_pipeline_job_create_time_utc_placeholder(self):
-        """Test that PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER is replaced with a valid UTC timestamp."""
+        """Test that create and schedule timestamps are stable and match for the same run context.
+        
+        Verifies that multiple calls to resolve create/schedule time placeholders
+        return the same timestamp value, ensuring the utc_timestamp is not regenerated
+        per call. This catches regressions where datetime.now() might be called
+        per placeholder resolution instead of using the stable utc_timestamp parameter.
+        """
         utc_timestamp = datetime.datetime.now(
             datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
         iso8601_pattern = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$'
@@ -313,19 +318,42 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
             pipeline_task_id='987654321',
             utc_timestamp=utc_timestamp,
         )
-        actual_create = placeholder_utils.resolve_individual_placeholder(
+        # Resolve create time multiple times
+        actual_create_1 = placeholder_utils.resolve_individual_placeholder(
             element='{{$.pipeline_job_create_time_utc}}', **kwargs)
-        actual_schedule = placeholder_utils.resolve_individual_placeholder(
+        actual_create_2 = placeholder_utils.resolve_individual_placeholder(
+            element='{{$.pipeline_job_create_time_utc}}', **kwargs)
+        # Resolve schedule time multiple times
+        actual_schedule_1 = placeholder_utils.resolve_individual_placeholder(
             element='{{$.pipeline_job_schedule_time_utc}}', **kwargs)
-        self.assertRegex(actual_create, iso8601_pattern)
-        self.assertEqual(actual_create, actual_schedule)
+        actual_schedule_2 = placeholder_utils.resolve_individual_placeholder(
+            element='{{$.pipeline_job_schedule_time_utc}}', **kwargs)
+        
+        # Verify format is valid
+        self.assertRegex(actual_create_1, iso8601_pattern)
+        self.assertRegex(actual_schedule_1, iso8601_pattern)
+        
+        # Verify stability: multiple calls to the same placeholder return the same value
+        self.assertEqual(actual_create_1, actual_create_2,
+                        'Multiple calls to create_time_utc should return identical values')
+        self.assertEqual(actual_schedule_1, actual_schedule_2,
+                        'Multiple calls to schedule_time_utc should return identical values')
+        
+        # Verify semantic equivalence: create and schedule times are the same
+        self.assertEqual(actual_create_1, actual_schedule_1,
+                        'Create and schedule timestamps must be identical for the same job context')
 
     def test_pipeline_job_schedule_time_utc_placeholder(self):
-        """Test that PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER is replaced with a valid UTC timestamp."""
+        """Test that schedule time placeholder returns stable timestamps across multiple calls.
+        
+        Verifies that multiple resolutions of the schedule_time_utc placeholder
+        return the same timestamp value within a single job context, ensuring
+        the timestamp does not change between placeholder resolutions.
+        """
         utc_timestamp = datetime.datetime.now(
             datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-        actual = placeholder_utils.resolve_individual_placeholder(
-            element='{{$.pipeline_job_schedule_time_utc}}',
+        iso8601_pattern = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$'
+        kwargs = dict(
             executor_input_dict=EXECUTOR_INPUT_DICT,
             pipeline_resource_name='my-pipeline-2023-10-10-13-32-59-420710',
             task_resource_name='comp',
@@ -334,8 +362,24 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
             pipeline_task_id='987654321',
             utc_timestamp=utc_timestamp,
         )
-        iso8601_pattern = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$'
-        self.assertRegex(actual, iso8601_pattern)
+        # Resolve schedule time multiple times to verify stability
+        actual_1 = placeholder_utils.resolve_individual_placeholder(
+            element='{{$.pipeline_job_schedule_time_utc}}', **kwargs)
+        actual_2 = placeholder_utils.resolve_individual_placeholder(
+            element='{{$.pipeline_job_schedule_time_utc}}', **kwargs)
+        actual_3 = placeholder_utils.resolve_individual_placeholder(
+            element='{{$.pipeline_job_schedule_time_utc}}', **kwargs)
+        
+        # Verify format is valid ISO8601
+        self.assertRegex(actual_1, iso8601_pattern)
+        self.assertRegex(actual_2, iso8601_pattern)
+        self.assertRegex(actual_3, iso8601_pattern)
+        
+        # Verify stability: all calls return the same timestamp
+        self.assertEqual(actual_1, actual_2,
+                        'Multiple calls to schedule_time_utc should return identical values')
+        self.assertEqual(actual_2, actual_3,
+                        'Multiple calls to schedule_time_utc should return identical values')
 
 
 class TestGetValueUsingPath(unittest.TestCase):

--- a/sdk/python/kfp/local/placeholder_utils_test.py
+++ b/sdk/python/kfp/local/placeholder_utils_test.py
@@ -123,6 +123,63 @@ class TestReplacePlaceholders(unittest.TestCase):
         ]
         self.assertEqual(actual, expected)
 
+    def test_replace_placeholders_with_utc_timestamps(self):
+        """Test that replace_placeholders() correctly resolves UTC timestamp
+        placeholders.
+
+        This test verifies the full path where utc_timestamp is
+        generated internally within replace_placeholders() and
+        propagated through the resolution hierarchy. Verifies that the
+        timestamps match the expected ISO8601 format and are identical
+        across different timestamp placeholders in the same command.
+        """
+        import re
+        
+        iso8601_pattern = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$'
+        
+        full_command = [
+            'task',
+            '--create-time={{$.pipeline_job_create_time_utc}}',
+            '--schedule-time={{$.pipeline_job_schedule_time_utc}}',
+            '--resource-name={{$.pipeline_job_resource_name}}',
+        ]
+        
+        actual = placeholder_utils.replace_placeholders(
+            full_command=full_command,
+            executor_input_dict=EXECUTOR_INPUT_DICT,
+            pipeline_resource_name='my-pipeline-2023-10-10-13-32-59-420710',
+            task_resource_name='comp',
+            pipeline_root='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
+            unique_pipeline_id='job-123',
+        )
+        
+        # Verify the command was resolved correctly
+        self.assertEqual(len(actual), 4)
+        self.assertEqual(actual[0], 'task')
+        
+        # Extract the timestamp values from the resolved command
+        create_time_match = re.search(r'--create-time=(.+)$', actual[1])
+        schedule_time_match = re.search(r'--schedule-time=(.+)$', actual[2])
+        
+        self.assertIsNotNone(create_time_match, f"Could not extract create-time from {actual[1]!r}")
+        self.assertIsNotNone(schedule_time_match, f"Could not extract schedule-time from {actual[2]!r}")
+        
+        create_timestamp = create_time_match.group(1)
+        schedule_timestamp = schedule_time_match.group(1)
+        
+        # Verify both timestamps are valid ISO8601 format
+        self.assertRegex(create_timestamp, iso8601_pattern,
+                        f"Create timestamp {create_timestamp!r} is not valid ISO8601")
+        self.assertRegex(schedule_timestamp, iso8601_pattern,
+                        f"Schedule timestamp {schedule_timestamp!r} is not valid ISO8601")
+        
+        # Verify both timestamps are identical (stability within replace_placeholders call)
+        self.assertEqual(create_timestamp, schedule_timestamp,
+                        'Create and schedule timestamps must be identical within same replace_placeholders() call')
+        
+        # Verify resource name is resolved
+        self.assertEqual(actual[3], '--resource-name=my-pipeline-2023-10-10-13-32-59-420710')
+
 
 class TestResolveIndividualPlaceholder(parameterized.TestCase):
 
@@ -299,12 +356,14 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
         self.assertEqual(actual, expected)
 
     def test_pipeline_job_create_time_utc_placeholder(self):
-        """Test that create and schedule timestamps are stable and match for the same run context.
-        
-        Verifies that multiple calls to resolve create/schedule time placeholders
-        return the same timestamp value, ensuring the utc_timestamp is not regenerated
-        per call. This catches regressions where datetime.now() might be called
-        per placeholder resolution instead of using the stable utc_timestamp parameter.
+        """Test that create and schedule timestamps are stable and match for
+        the same run context.
+
+        Verifies that multiple calls to resolve create/schedule time
+        placeholders return the same timestamp value, ensuring the
+        utc_timestamp is not regenerated per call. This catches
+        regressions where datetime.now() might be called per placeholder
+        resolution instead of using the stable utc_timestamp parameter.
         """
         utc_timestamp = datetime.datetime.now(
             datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
@@ -344,11 +403,13 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
                         'Create and schedule timestamps must be identical for the same job context')
 
     def test_pipeline_job_schedule_time_utc_placeholder(self):
-        """Test that schedule time placeholder returns stable timestamps across multiple calls.
-        
-        Verifies that multiple resolutions of the schedule_time_utc placeholder
-        return the same timestamp value within a single job context, ensuring
-        the timestamp does not change between placeholder resolutions.
+        """Test that schedule time placeholder returns stable timestamps across
+        multiple calls.
+
+        Verifies that multiple resolutions of the schedule_time_utc
+        placeholder return the same timestamp value within a single job
+        context, ensuring the timestamp does not change between
+        placeholder resolutions.
         """
         utc_timestamp = datetime.datetime.now(
             datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
@@ -380,6 +441,33 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
                         'Multiple calls to schedule_time_utc should return identical values')
         self.assertEqual(actual_2, actual_3,
                         'Multiple calls to schedule_time_utc should return identical values')
+
+    def test_utc_timestamp_placeholder_without_explicit_timestamp(self):
+        """Test behavior when UTC timestamp placeholders are resolved without
+        explicit utc_timestamp.
+
+        Documents the current behavior: when utc_timestamp parameter is not provided
+        (defaults to empty string), the placeholder is replaced with an empty string.
+        This is generally safe when called from replace_placeholders() which always
+        provides a utc_timestamp, but direct calls to resolve_individual_placeholder()
+        without utc_timestamp could produce unexpected empty values.
+
+        This test serves as a regression check and documents the current contract.
+        """
+        # When utc_timestamp is not provided (defaults to ''), the placeholder
+        # is replaced with an empty string
+        actual = placeholder_utils.resolve_individual_placeholder(
+            element='{{$.pipeline_job_create_time_utc}}',
+            executor_input_dict=EXECUTOR_INPUT_DICT,
+            pipeline_resource_name='my-pipeline-2023-10-10-13-32-59-420710',
+            task_resource_name='comp',
+            pipeline_root='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
+            pipeline_job_id='123456789',
+            pipeline_task_id='987654321',
+            # utc_timestamp is not provided, defaults to ''
+        )
+        # The placeholder is replaced with an empty string
+        self.assertEqual(actual, '')
 
 
 class TestGetValueUsingPath(unittest.TestCase):

--- a/sdk/python/kfp/local/placeholder_utils_test.py
+++ b/sdk/python/kfp/local/placeholder_utils_test.py
@@ -134,16 +134,16 @@ class TestReplacePlaceholders(unittest.TestCase):
         across different timestamp placeholders in the same command.
         """
         import re
-        
+
         iso8601_pattern = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$'
-        
+
         full_command = [
             'task',
             '--create-time={{$.pipeline_job_create_time_utc}}',
             '--schedule-time={{$.pipeline_job_schedule_time_utc}}',
             '--resource-name={{$.pipeline_job_resource_name}}',
         ]
-        
+
         actual = placeholder_utils.replace_placeholders(
             full_command=full_command,
             executor_input_dict=EXECUTOR_INPUT_DICT,
@@ -152,33 +152,42 @@ class TestReplacePlaceholders(unittest.TestCase):
             pipeline_root='/foo/bar/my-pipeline-2023-10-10-13-32-59-420710',
             unique_pipeline_id='job-123',
         )
-        
+
         # Verify the command was resolved correctly
         self.assertEqual(len(actual), 4)
         self.assertEqual(actual[0], 'task')
-        
+
         # Extract the timestamp values from the resolved command
         create_time_match = re.search(r'--create-time=(.+)$', actual[1])
         schedule_time_match = re.search(r'--schedule-time=(.+)$', actual[2])
-        
-        self.assertIsNotNone(create_time_match, f"Could not extract create-time from {actual[1]!r}")
-        self.assertIsNotNone(schedule_time_match, f"Could not extract schedule-time from {actual[2]!r}")
-        
+
+        self.assertIsNotNone(
+            create_time_match,
+            f"Could not extract create-time from {actual[1]!r}")
+        self.assertIsNotNone(
+            schedule_time_match,
+            f"Could not extract schedule-time from {actual[2]!r}")
+
         create_timestamp = create_time_match.group(1)
         schedule_timestamp = schedule_time_match.group(1)
-        
+
         # Verify both timestamps are valid ISO8601 format
-        self.assertRegex(create_timestamp, iso8601_pattern,
-                        f"Create timestamp {create_timestamp!r} is not valid ISO8601")
-        self.assertRegex(schedule_timestamp, iso8601_pattern,
-                        f"Schedule timestamp {schedule_timestamp!r} is not valid ISO8601")
-        
+        self.assertRegex(
+            create_timestamp, iso8601_pattern,
+            f"Create timestamp {create_timestamp!r} is not valid ISO8601")
+        self.assertRegex(
+            schedule_timestamp, iso8601_pattern,
+            f"Schedule timestamp {schedule_timestamp!r} is not valid ISO8601")
+
         # Verify both timestamps are identical (stability within replace_placeholders call)
-        self.assertEqual(create_timestamp, schedule_timestamp,
-                        'Create and schedule timestamps must be identical within same replace_placeholders() call')
-        
+        self.assertEqual(
+            create_timestamp, schedule_timestamp,
+            'Create and schedule timestamps must be identical within same replace_placeholders() call'
+        )
+
         # Verify resource name is resolved
-        self.assertEqual(actual[3], '--resource-name=my-pipeline-2023-10-10-13-32-59-420710')
+        self.assertEqual(
+            actual[3], '--resource-name=my-pipeline-2023-10-10-13-32-59-420710')
 
 
 class TestResolveIndividualPlaceholder(parameterized.TestCase):
@@ -387,20 +396,25 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
             element='{{$.pipeline_job_schedule_time_utc}}', **kwargs)
         actual_schedule_2 = placeholder_utils.resolve_individual_placeholder(
             element='{{$.pipeline_job_schedule_time_utc}}', **kwargs)
-        
+
         # Verify format is valid
         self.assertRegex(actual_create_1, iso8601_pattern)
         self.assertRegex(actual_schedule_1, iso8601_pattern)
-        
+
         # Verify stability: multiple calls to the same placeholder return the same value
-        self.assertEqual(actual_create_1, actual_create_2,
-                        'Multiple calls to create_time_utc should return identical values')
-        self.assertEqual(actual_schedule_1, actual_schedule_2,
-                        'Multiple calls to schedule_time_utc should return identical values')
-        
+        self.assertEqual(
+            actual_create_1, actual_create_2,
+            'Multiple calls to create_time_utc should return identical values')
+        self.assertEqual(
+            actual_schedule_1, actual_schedule_2,
+            'Multiple calls to schedule_time_utc should return identical values'
+        )
+
         # Verify semantic equivalence: create and schedule times are the same
-        self.assertEqual(actual_create_1, actual_schedule_1,
-                        'Create and schedule timestamps must be identical for the same job context')
+        self.assertEqual(
+            actual_create_1, actual_schedule_1,
+            'Create and schedule timestamps must be identical for the same job context'
+        )
 
     def test_pipeline_job_schedule_time_utc_placeholder(self):
         """Test that schedule time placeholder returns stable timestamps across
@@ -430,17 +444,21 @@ class TestResolveIndividualPlaceholder(parameterized.TestCase):
             element='{{$.pipeline_job_schedule_time_utc}}', **kwargs)
         actual_3 = placeholder_utils.resolve_individual_placeholder(
             element='{{$.pipeline_job_schedule_time_utc}}', **kwargs)
-        
+
         # Verify format is valid ISO8601
         self.assertRegex(actual_1, iso8601_pattern)
         self.assertRegex(actual_2, iso8601_pattern)
         self.assertRegex(actual_3, iso8601_pattern)
-        
+
         # Verify stability: all calls return the same timestamp
-        self.assertEqual(actual_1, actual_2,
-                        'Multiple calls to schedule_time_utc should return identical values')
-        self.assertEqual(actual_2, actual_3,
-                        'Multiple calls to schedule_time_utc should return identical values')
+        self.assertEqual(
+            actual_1, actual_2,
+            'Multiple calls to schedule_time_utc should return identical values'
+        )
+        self.assertEqual(
+            actual_2, actual_3,
+            'Multiple calls to schedule_time_utc should return identical values'
+        )
 
     def test_utc_timestamp_placeholder_without_explicit_timestamp(self):
         """Test behavior when UTC timestamp placeholders are resolved without


### PR DESCRIPTION
## Problem

Fixes #13424.

Three `dsl` placeholders were silently left unresolved when running pipelines locally via `kfp.local`. Components using these placeholders received the raw placeholder string instead of the actual runtime value.

### Affected placeholders

| Placeholder | Expected Runtime Value |
| --- | --- |
| `dsl.PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER` | Argo Workflow object name (pipeline run resource name) |
| `dsl.PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER` | UTC timestamp when the pipeline job was created |
| `dsl.PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER` | UTC timestamp for which the pipeline job was scheduled |

All other job/task placeholders were already resolved correctly:

- `PIPELINE_JOB_NAME`
- `PIPELINE_JOB_ID`
- `PIPELINE_TASK_NAME`
- `PIPELINE_TASK_ID`
- `PIPELINE_ROOT`

These three placeholders were simply missing from the local placeholder resolution map.

---

## Root Cause

`resolve_individual_placeholder()` in:

```text
sdk/python/kfp/local/placeholder_utils.py
```

maintains a `PLACEHOLDERS` mapping that resolves placeholder strings to runtime values.

Although the following placeholders were defined in `kfp.dsl`, they were never added to this mapping:

- `PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER`
- `PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER`
- `PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER`

As a result, local execution returned unresolved raw placeholder strings.

---

## Changes

### `sdk/python/kfp/local/placeholder_utils.py`

Added support for the following placeholders:

| Placeholder | Resolved Value |
| --- | --- |
| `PIPELINE_JOB_RESOURCE_NAME_PLACEHOLDER` | `pipeline_resource_name` |
| `PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER` | Current UTC timestamp in ISO 8601 format |
| `PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER` | Current UTC timestamp in ISO 8601 format |


---

## Tests

### `sdk/python/kfp/local/placeholder_utils_test.py`

Added coverage for the newly supported placeholders:

- Added `{{$.pipeline_job_resource_name}}` to `test_constant_placeholders`
- Added `test_pipeline_job_create_time_utc_placeholder`
- Added `test_pipeline_job_schedule_time_utc_placeholder`

The timestamp tests validate that resolved values match the expected ISO 8601 UTC format.

---
