### PR TITLE
feat(frontend): fix artifact cross namespace IDOR vuln

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -37,6 +37,9 @@ RUN npm install --global "$(node -p 'require("/tmp/frontend-package.json").packa
 
 COPY --from=build ./src/frontend/server /server
 COPY --from=build ./src/frontend/build /client
+# MLMD proto bundle for the runtime validator; marker forces CJS under type: module.
+COPY --from=build ./src/frontend/src/third_party/mlmd/generated /server/src/third_party/mlmd/generated
+RUN printf '{"type":"commonjs"}\n' > /server/src/third_party/mlmd/generated/package.json
 
 WORKDIR /server
 

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -168,6 +168,7 @@ function createUIServer(options: UIConfigs) {
     authorizeFn,
     options.auth.enabled,
     options.auth.kubeflowUserIdHeader,
+    envoyServiceAddress,
   );
 
   /** Artifact */

--- a/frontend/server/handlers/artifacts.test.ts
+++ b/frontend/server/handlers/artifacts.test.ts
@@ -1,0 +1,195 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import type { Request } from 'express';
+import { resolveArtifactCoordinates } from '../helpers/artifact-coordinates.js';
+
+function makeRequest(path: string, query: Record<string, unknown> = {}): Request {
+  return { path, query } as unknown as Request;
+}
+
+describe('resolveArtifactCoordinates', () => {
+  describe('path-based routes', () => {
+    it('extracts coordinates from /artifacts/:source/:bucket/* style URLs', () => {
+      const req = makeRequest('/artifacts/minio/ml-pipeline/hello/world.txt');
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 'minio',
+        bucket: 'ml-pipeline',
+        key: 'hello/world.txt',
+      });
+    });
+
+    it('extracts coordinates from /pipeline-prefixed routes', () => {
+      const req = makeRequest('/pipeline/artifacts/s3/my-bucket/path/to/file.csv');
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 's3',
+        bucket: 'my-bucket',
+        key: 'path/to/file.csv',
+      });
+    });
+
+    it('extracts coordinates from a non-/pipeline base path', () => {
+      const req = makeRequest('/foo/bar/artifacts/minio/my-bucket/some/key');
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 'minio',
+        bucket: 'my-bucket',
+        key: 'some/key',
+      });
+    });
+
+    it('decodes percent-encoded path segments once (matching Express req.params semantics)', () => {
+      const req = makeRequest('/artifacts/minio/ml-pipeline/hello%2Fworld.txt');
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 'minio',
+        bucket: 'ml-pipeline',
+        key: 'hello/world.txt',
+      });
+    });
+
+    it('preserves a literal %2F when the URL is double-encoded (%252F)', () => {
+      const req = makeRequest('/artifacts/minio/ml-pipeline/hello%252Fworld.txt');
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 'minio',
+        bucket: 'ml-pipeline',
+        key: 'hello%2Fworld.txt',
+      });
+    });
+
+    it('returns null on malformed percent-encoding (fail-closed)', () => {
+      const req = makeRequest('/artifacts/minio/ml-pipeline/bad%ZZkey');
+      expect(resolveArtifactCoordinates(req)).toBeNull();
+    });
+
+    it('handles keys that contain multiple slashes', () => {
+      const req = makeRequest('/artifacts/gcs/my-bucket/a/b/c/d.json');
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 'gcs',
+        bucket: 'my-bucket',
+        key: 'a/b/c/d.json',
+      });
+    });
+  });
+
+  describe('query-based fallback (/artifacts/get and unrecognized paths)', () => {
+    it('falls back to query when path is /artifacts/get', () => {
+      const req = makeRequest('/artifacts/get', {
+        source: 'minio',
+        bucket: 'ml-pipeline',
+        key: 'hello/world.txt',
+      });
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 'minio',
+        bucket: 'ml-pipeline',
+        key: 'hello/world.txt',
+      });
+    });
+
+    it('falls back to query when path is /pipeline/artifacts/get', () => {
+      const req = makeRequest('/pipeline/artifacts/get', {
+        source: 's3',
+        bucket: 'my-bucket',
+        key: 'data.csv',
+      });
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 's3',
+        bucket: 'my-bucket',
+        key: 'data.csv',
+      });
+    });
+
+    it('falls back to query when path does not match the artifact patterns', () => {
+      const req = makeRequest('/foo/bar', {
+        source: 'minio',
+        bucket: 'ml-pipeline',
+        key: 'k',
+      });
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 'minio',
+        bucket: 'ml-pipeline',
+        key: 'k',
+      });
+    });
+  });
+
+  describe('missing or non-string query values', () => {
+    it('returns empty strings when query params are absent', () => {
+      const req = makeRequest('/artifacts/get');
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: '',
+        bucket: '',
+        key: '',
+      });
+    });
+
+    it('rejects array-valued query params (treats them as missing)', () => {
+      const req = makeRequest('/artifacts/get', {
+        source: ['minio', 'sneaky'],
+        bucket: 'ml-pipeline',
+        key: 'k',
+      });
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: '',
+        bucket: 'ml-pipeline',
+        key: 'k',
+      });
+    });
+
+    it('rejects object-valued query params (treats them as missing)', () => {
+      const req = makeRequest('/artifacts/get', {
+        source: { nested: 'minio' },
+        bucket: 'ml-pipeline',
+        key: 'k',
+      });
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: '',
+        bucket: 'ml-pipeline',
+        key: 'k',
+      });
+    });
+  });
+
+  describe('coordinate-source spoofing defense', () => {
+    it('uses path coordinates when both path and query are present', () => {
+      // Attacker plants benign values in query, real values in path.
+      const req = makeRequest('/artifacts/minio/victim-bucket/secret.txt', {
+        source: 'minio',
+        bucket: 'safe-bucket',
+        key: 'safe-key',
+      });
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 'minio',
+        bucket: 'victim-bucket',
+        key: 'secret.txt',
+      });
+    });
+
+    it('treats /artifacts/get/x/y as a path-based route with source=get (not the get endpoint)', () => {
+      // Only an exact /artifacts/get path uses the query string; any other
+      // path that matches /:source/:bucket/* uses path values, even if the
+      // first segment happens to literally be "get". The downstream handler
+      // then rejects source="get" as an unknown storage source (500).
+      const req = makeRequest('/artifacts/get/some-bucket/some-key', {
+        source: 'minio',
+        bucket: 'safe-bucket',
+        key: 'safe-key',
+      });
+      expect(resolveArtifactCoordinates(req)).toEqual({
+        source: 'get',
+        bucket: 'some-bucket',
+        key: 'some-key',
+      });
+    });
+  });
+});

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -41,6 +41,8 @@ import { isAllowedDomain } from './domain-checker.js';
 import { getK8sSecret } from '../k8s-helper.js';
 import { CredentialBody } from 'google-auth-library';
 import { AuthorizeFn } from '../helpers/auth.js';
+import { validateArtifactNamespace, buildArtifactUri } from '../helpers/mlmd-validator.js';
+import { resolveArtifactCoordinates } from '../helpers/artifact-coordinates.js';
 import {
   AuthorizeRequestResources,
   AuthorizeRequestVerb,
@@ -121,11 +123,14 @@ export interface GCSProviderInfo {
  * @param authorizeFn The authorization function to validate permissions
  * @param authEnabled Whether authorization is enabled
  * @param kubeflowUserIdHeader The header name containing the user identity
+ * @param envoyAddress MLMD Envoy address used for namespace-ownership
+ *   validation (#9889). When omitted, the IDOR check is skipped.
  */
 export function getArtifactsAuthMiddleware(
   authorizeFn: AuthorizeFn,
   authEnabled: boolean,
   kubeflowUserIdHeader: string,
+  envoyAddress?: string,
 ): Handler {
   return async (request: Request, response: Response, next: NextFunction) => {
     if (!authEnabled) {
@@ -185,6 +190,36 @@ export function getArtifactsAuthMiddleware(
       );
       response.status(403).send(authError.message);
       return;
+    }
+
+    if (envoyAddress) {
+      const coords = resolveArtifactCoordinates(request);
+      if (coords === null) {
+        console.warn(
+          `[SECURITY] Malformed percent-encoding in artifact path. ` +
+            `User: ${userId}, Path: ${request.path}`,
+        );
+        response.status(400).send('Malformed URL encoding in artifact path');
+        return;
+      }
+      const mlmdTrackedSources = new Set(['minio', 's3', 'gcs', 'http', 'https']);
+      if (mlmdTrackedSources.has(coords.source) && coords.bucket && coords.key) {
+        const artifactUri = buildArtifactUri(coords.source, coords.bucket, coords.key);
+        const validation = await validateArtifactNamespace(envoyAddress, artifactUri, namespace);
+
+        if (!validation.valid) {
+          console.warn(
+            `[SECURITY] IDOR blocked: artifact namespace mismatch. ` +
+              `User: ${userId}, ` +
+              `Claimed namespace: ${namespace}, ` +
+              `Actual namespace: ${validation.actualNamespace}, ` +
+              `URI: ${artifactUri}, ` +
+              `Path: ${request.path}`,
+          );
+          response.status(403).send('Artifact does not belong to the requested namespace');
+          return;
+        }
+      }
     }
 
     next();

--- a/frontend/server/helpers/artifact-coordinates.ts
+++ b/frontend/server/helpers/artifact-coordinates.ts
@@ -1,0 +1,44 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Request } from 'express';
+
+export function resolveArtifactCoordinates(
+  request: Request,
+): { source: string; bucket: string; key: string } | null {
+  const artifactPathStart = request.path.indexOf('/artifacts/');
+  const artifactPath =
+    artifactPathStart >= 0 ? request.path.slice(artifactPathStart) : request.path;
+  const isExactGetEndpoint = artifactPath === '/artifacts/get';
+  if (!isExactGetEndpoint) {
+    const downloadPathMatch = artifactPath.match(/^\/artifacts\/([^/]+)\/([^/]+)\/(.+)$/);
+    if (downloadPathMatch) {
+      try {
+        return {
+          source: decodeURIComponent(downloadPathMatch[1]),
+          bucket: decodeURIComponent(downloadPathMatch[2]),
+          key: decodeURIComponent(downloadPathMatch[3]),
+        };
+      } catch {
+        return null;
+      }
+    }
+  }
+  const asString = (v: unknown): string => (typeof v === 'string' ? v : '');
+  return {
+    source: asString(request.query.source),
+    bucket: asString(request.query.bucket),
+    key: asString(request.query.key),
+  };
+}

--- a/frontend/server/helpers/mlmd-validator.test.ts
+++ b/frontend/server/helpers/mlmd-validator.test.ts
@@ -1,0 +1,256 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import {
+  decideFromContexts,
+  decodeGrpcWebResponse,
+  encodeGrpcWebRequest,
+} from './mlmd-validator.js';
+
+const PIPELINE_RUN = 'system.PipelineRun';
+
+function buildFrame(type: number, payload: Uint8Array): Uint8Array {
+  const frame = new Uint8Array(5 + payload.length);
+  frame[0] = type;
+  new DataView(frame.buffer).setUint32(1, payload.length, false);
+  frame.set(payload, 5);
+  return frame;
+}
+
+function concat(...arrs: Uint8Array[]): ArrayBuffer {
+  const len = arrs.reduce((s, a) => s + a.length, 0);
+  const out = new Uint8Array(len);
+  let pos = 0;
+  for (const a of arrs) {
+    out.set(a, pos);
+    pos += a.length;
+  }
+  return out.buffer;
+}
+
+describe('encodeGrpcWebRequest', () => {
+  it('prefixes payload with a 5-byte data-frame header (big-endian length)', () => {
+    const payload = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+    const frame = encodeGrpcWebRequest(payload);
+
+    expect(frame.length).toBe(9);
+    expect(frame[0]).toBe(0x00);
+    expect(new DataView(frame.buffer).getUint32(1, false)).toBe(4);
+    expect(Array.from(frame.slice(5))).toEqual(Array.from(payload));
+  });
+
+  it('handles empty payload', () => {
+    const frame = encodeGrpcWebRequest(new Uint8Array(0));
+    expect(frame.length).toBe(5);
+    expect(frame[0]).toBe(0x00);
+    expect(new DataView(frame.buffer).getUint32(1, false)).toBe(0);
+  });
+});
+
+describe('decodeGrpcWebResponse', () => {
+  const okTrailer = new TextEncoder().encode('grpc-status:0\r\n');
+  const errTrailer = new TextEncoder().encode('grpc-status:13\r\ngrpc-message:internal\r\n');
+
+  it('returns the data-frame body when followed by a status-0 trailer', () => {
+    const data = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const buf = concat(buildFrame(0x00, data), buildFrame(0x80, okTrailer));
+    expect(Array.from(decodeGrpcWebResponse(buf))).toEqual(Array.from(data));
+  });
+
+  it('returns the data-frame body when no trailer is present', () => {
+    const data = new Uint8Array([0x11, 0x22]);
+    const buf = concat(buildFrame(0x00, data));
+    expect(Array.from(decodeGrpcWebResponse(buf))).toEqual(Array.from(data));
+  });
+
+  it('throws on a non-zero grpc-status trailer', () => {
+    const data = new Uint8Array([0x01]);
+    const buf = concat(buildFrame(0x00, data), buildFrame(0x80, errTrailer));
+    expect(() => decodeGrpcWebResponse(buf)).toThrow(/gRPC error status 13/);
+  });
+
+  it('throws when a frame claims more bytes than the buffer holds (truncation)', () => {
+    const buf = new Uint8Array(9);
+    buf[0] = 0x00;
+    new DataView(buf.buffer).setUint32(1, 100, false);
+    expect(() => decodeGrpcWebResponse(buf.buffer)).toThrow(/claims length 100/);
+  });
+
+  it('throws on trailing bytes that do not form a complete frame header', () => {
+    const data = new Uint8Array([0xaa]);
+    const validFrame = buildFrame(0x00, data);
+    const out = new Uint8Array(validFrame.length + 3);
+    out.set(validFrame, 0);
+    out[validFrame.length] = 0xff;
+    out[validFrame.length + 1] = 0xff;
+    out[validFrame.length + 2] = 0xff;
+    expect(() => decodeGrpcWebResponse(out.buffer)).toThrow(/trailing bytes/);
+  });
+
+  it('accumulates multiple data frames into a single payload', () => {
+    const chunk1 = new Uint8Array([0x01, 0x02]);
+    const chunk2 = new Uint8Array([0x03, 0x04, 0x05]);
+    const buf = concat(buildFrame(0x00, chunk1), buildFrame(0x00, chunk2));
+    expect(Array.from(decodeGrpcWebResponse(buf))).toEqual([0x01, 0x02, 0x03, 0x04, 0x05]);
+  });
+
+  it('throws on an empty response (no data frame)', () => {
+    expect(() => decodeGrpcWebResponse(new ArrayBuffer(0))).toThrow(/no data frame/);
+  });
+
+  it('throws on an unknown frame type', () => {
+    const buf = new Uint8Array(5);
+    buf[0] = 0x42;
+    expect(() => decodeGrpcWebResponse(buf.buffer)).toThrow(/Unexpected gRPC-web frame type/);
+  });
+});
+
+describe('decideFromContexts', () => {
+  it('passes when the only PipelineRun context namespace matches the claim', () => {
+    expect(
+      decideFromContexts(
+        [{ artifactId: 1, contexts: [{ contextType: PIPELINE_RUN, namespace: 'ns-a' }] }],
+        'ns-a',
+      ),
+    ).toEqual({ valid: true });
+  });
+
+  it('rejects when a PipelineRun context namespace differs from the claim', () => {
+    expect(
+      decideFromContexts(
+        [{ artifactId: 1, contexts: [{ contextType: PIPELINE_RUN, namespace: 'ns-a' }] }],
+        'ns-b',
+      ),
+    ).toEqual({
+      valid: false,
+      actualNamespace: 'ns-a',
+      reason: 'namespace-mismatch',
+    });
+  });
+
+  it('a mismatch on a later artifact wins over an unavailable lookup on an earlier one', () => {
+    expect(
+      decideFromContexts(
+        [
+          { artifactId: 1, contexts: null },
+          { artifactId: 2, contexts: [{ contextType: PIPELINE_RUN, namespace: 'victim-ns' }] },
+        ],
+        'attacker-ns',
+      ),
+    ).toEqual({
+      valid: false,
+      actualNamespace: 'victim-ns',
+      reason: 'namespace-mismatch',
+    });
+  });
+
+  it('returns mlmd-unavailable when all results are unavailable', () => {
+    expect(
+      decideFromContexts(
+        [
+          { artifactId: 1, contexts: null },
+          { artifactId: 2, contexts: null },
+        ],
+        'ns-a',
+      ),
+    ).toEqual({ valid: true, reason: 'mlmd-unavailable' });
+  });
+
+  it('returns mlmd-unavailable when some lookups failed but others have no mismatch', () => {
+    expect(
+      decideFromContexts(
+        [
+          { artifactId: 1, contexts: [{ contextType: PIPELINE_RUN, namespace: 'ns-a' }] },
+          { artifactId: 2, contexts: null },
+        ],
+        'ns-a',
+      ),
+    ).toEqual({ valid: true, reason: 'mlmd-unavailable' });
+  });
+
+  it('returns no-evidence when contexts contain no PipelineRun entry at all', () => {
+    expect(
+      decideFromContexts(
+        [
+          {
+            artifactId: 1,
+            contexts: [{ contextType: 'system.Pipeline', namespace: 'ns-a' }],
+          },
+        ],
+        'ns-b',
+      ),
+    ).toEqual({ valid: true, reason: 'no-evidence' });
+  });
+
+  it('returns no-evidence when PipelineRun context has no namespace property', () => {
+    expect(
+      decideFromContexts(
+        [{ artifactId: 1, contexts: [{ contextType: PIPELINE_RUN, namespace: undefined }] }],
+        'ns-a',
+      ),
+    ).toEqual({ valid: true, reason: 'no-evidence' });
+  });
+
+  it('rejects when one artifact has multiple PipelineRun contexts and any mismatches', () => {
+    expect(
+      decideFromContexts(
+        [
+          {
+            artifactId: 1,
+            contexts: [
+              { contextType: PIPELINE_RUN, namespace: 'ns-a' },
+              { contextType: PIPELINE_RUN, namespace: 'ns-c' },
+            ],
+          },
+        ],
+        'ns-a',
+      ),
+    ).toEqual({
+      valid: false,
+      actualNamespace: 'ns-c',
+      reason: 'namespace-mismatch',
+    });
+  });
+
+  it('passes cleanly when many artifacts all match the claim', () => {
+    expect(
+      decideFromContexts(
+        [
+          { artifactId: 1, contexts: [{ contextType: PIPELINE_RUN, namespace: 'ns-a' }] },
+          { artifactId: 2, contexts: [{ contextType: PIPELINE_RUN, namespace: 'ns-a' }] },
+          { artifactId: 3, contexts: [{ contextType: PIPELINE_RUN, namespace: 'ns-a' }] },
+        ],
+        'ns-a',
+      ),
+    ).toEqual({ valid: true });
+  });
+
+  it('rejects when the only mismatching context is on the last artifact in the list', () => {
+    expect(
+      decideFromContexts(
+        [
+          { artifactId: 1, contexts: [{ contextType: PIPELINE_RUN, namespace: 'ns-a' }] },
+          { artifactId: 2, contexts: [{ contextType: PIPELINE_RUN, namespace: 'ns-a' }] },
+          { artifactId: 3, contexts: [{ contextType: PIPELINE_RUN, namespace: 'ns-b' }] },
+        ],
+        'ns-a',
+      ),
+    ).toEqual({
+      valid: false,
+      actualNamespace: 'ns-b',
+      reason: 'namespace-mismatch',
+    });
+  });
+});

--- a/frontend/server/helpers/mlmd-validator.ts
+++ b/frontend/server/helpers/mlmd-validator.ts
@@ -1,0 +1,344 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+// Lazy proto load — missing bundle (e.g. dev) fails open instead of crashing at import.
+let servicePb: any = null;
+let storePb: any = null;
+let protoLoadAttempted = false;
+
+function loadProtos(): boolean {
+  if (servicePb !== null && storePb !== null) {
+    return true;
+  }
+  const candidateBases = [
+    '../../src/third_party/mlmd/generated/ml_metadata/proto/',
+    '../../../src/third_party/mlmd/generated/ml_metadata/proto/',
+  ];
+  let lastError: unknown = null;
+  for (const base of candidateBases) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      servicePb = require(`${base}metadata_store_service_pb.js`);
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      storePb = require(`${base}metadata_store_pb.js`);
+      return true;
+    } catch (error) {
+      lastError = error;
+      servicePb = null;
+      storePb = null;
+    }
+  }
+  if (!protoLoadAttempted) {
+    console.warn(
+      `[SECURITY] MLMD proto bundle could not be loaded — namespace-ownership ` +
+        `validation will be disabled (IDOR check fails open). Error: ${lastError}`,
+    );
+    protoLoadAttempted = true;
+  }
+  return false;
+}
+
+const PIPELINE_RUN_CONTEXT_TYPE = 'system.PipelineRun';
+const NAMESPACE_PROPERTY_KEY = 'namespace';
+
+const GRPC_WEB_PROTO = 'application/grpc-web+proto';
+
+const DEFAULT_TIMEOUT_MS = (() => {
+  const raw = process.env.MLMD_VALIDATION_TIMEOUT_MS;
+  const parsed = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 5000;
+})();
+
+export function encodeGrpcWebRequest(serializedMessage: Uint8Array): Uint8Array {
+  const frame = new Uint8Array(5 + serializedMessage.length);
+  frame[0] = 0x00; // data frame
+  const view = new DataView(frame.buffer);
+  view.setUint32(1, serializedMessage.length, false); // big-endian length
+  frame.set(serializedMessage, 5);
+  return frame;
+}
+
+export function decodeGrpcWebResponse(buffer: ArrayBuffer): Uint8Array {
+  const view = new DataView(buffer);
+  const dataChunks: Uint8Array[] = [];
+  let offset = 0;
+
+  while (offset + 5 <= buffer.byteLength) {
+    const frameType = view.getUint8(offset);
+    const frameLength = view.getUint32(offset + 1, false);
+
+    if (offset + 5 + frameLength > buffer.byteLength) {
+      throw new Error(
+        `gRPC-web frame at offset ${offset} claims length ${frameLength} ` +
+          `but only ${buffer.byteLength - offset - 5} bytes remain`,
+      );
+    }
+
+    if (frameType === 0x00) {
+      dataChunks.push(new Uint8Array(buffer, offset + 5, frameLength));
+    } else if (frameType === 0x80) {
+      const trailerBytes = new Uint8Array(buffer, offset + 5, frameLength);
+      const trailerText = new TextDecoder().decode(trailerBytes);
+      const statusMatch = trailerText.match(/grpc-status:\s*(\d+)/);
+      const messageMatch = trailerText.match(/grpc-message:\s*([^\r\n]+)/);
+      const status = statusMatch ? parseInt(statusMatch[1], 10) : -1;
+      if (status !== 0) {
+        let message = 'unknown';
+        if (messageMatch) {
+          const raw = messageMatch[1].trim();
+          try {
+            message = decodeURIComponent(raw);
+          } catch {
+            message = raw;
+          }
+        }
+        throw new Error(`gRPC error status ${status}: ${message}`);
+      }
+    } else {
+      throw new Error(`Unexpected gRPC-web frame type: 0x${frameType.toString(16)}`);
+    }
+
+    offset += 5 + frameLength;
+  }
+
+  if (offset !== buffer.byteLength) {
+    throw new Error(
+      `gRPC-web response has ${
+        buffer.byteLength - offset
+      } trailing bytes that don't form a frame header`,
+    );
+  }
+
+  if (dataChunks.length === 0) {
+    throw new Error('gRPC-web response contained no data frame');
+  }
+  if (dataChunks.length === 1) {
+    return dataChunks[0];
+  }
+  const merged = new Uint8Array(dataChunks.reduce((sum, c) => sum + c.length, 0));
+  let pos = 0;
+  for (const chunk of dataChunks) {
+    merged.set(chunk, pos);
+    pos += chunk.length;
+  }
+  return merged;
+}
+
+async function grpcWebCall(
+  envoyAddress: string,
+  method: string,
+  requestBytes: Uint8Array,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<Uint8Array> {
+  const base = envoyAddress.replace(/\/+$/, '');
+  const url = `${base}/ml_metadata.MetadataStoreService/${method}`;
+  const body = encodeGrpcWebRequest(requestBytes);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': GRPC_WEB_PROTO,
+        Accept: GRPC_WEB_PROTO,
+        'x-grpc-web': '1',
+      },
+      body,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`MLMD gRPC-web call ${method} failed: HTTP ${response.status}`);
+    }
+
+    const responseBuffer = await response.arrayBuffer();
+    return decodeGrpcWebResponse(responseBuffer);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+interface ArtifactInfo {
+  id: number;
+}
+
+export interface ContextNamespace {
+  contextType: string;
+  namespace: string | undefined;
+}
+
+function getArtifactsByUri(envoyAddress: string, uris: string[]): Promise<ArtifactInfo[]> {
+  const request = new servicePb.GetArtifactsByURIRequest();
+  request.setUrisList(uris);
+
+  return grpcWebCall(envoyAddress, 'GetArtifactsByURI', request.serializeBinary()).then(
+    (responseBytes) => {
+      const response = servicePb.GetArtifactsByURIResponse.deserializeBinary(responseBytes);
+      const artifacts: ArtifactInfo[] = [];
+      for (const artifact of response.getArtifactsList()) {
+        artifacts.push({ id: artifact.getId() });
+      }
+      return artifacts;
+    },
+  );
+}
+
+function getContextsByArtifact(
+  envoyAddress: string,
+  artifactId: number,
+): Promise<ContextNamespace[]> {
+  const request = new servicePb.GetContextsByArtifactRequest();
+  request.setArtifactId(artifactId);
+
+  return grpcWebCall(envoyAddress, 'GetContextsByArtifact', request.serializeBinary()).then(
+    (responseBytes) => {
+      const response = servicePb.GetContextsByArtifactResponse.deserializeBinary(responseBytes);
+      const contexts: ContextNamespace[] = [];
+      for (const context of response.getContextsList()) {
+        const contextType = context.getType();
+        let namespace: string | undefined;
+        const customProps = context.getCustomPropertiesMap();
+        if (customProps) {
+          const nsValue = customProps.get(NAMESPACE_PROPERTY_KEY);
+          if (nsValue) {
+            const valueCase = nsValue.getValueCase();
+            if (valueCase === storePb.Value.ValueCase.STRING_VALUE) {
+              namespace = nsValue.getStringValue();
+            }
+          }
+        }
+        contexts.push({ contextType, namespace });
+      }
+      return contexts;
+    },
+  );
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  actualNamespace?: string;
+  reason?: string;
+}
+
+// A concrete mismatch on any artifact beats an unavailable context on another.
+export function decideFromContexts(
+  contextResults: { artifactId: number; contexts: ContextNamespace[] | null }[],
+  claimedNamespace: string,
+): ValidationResult {
+  let hasNamespaceEvidence = false;
+  let hadUnavailable = false;
+  for (const { contexts } of contextResults) {
+    if (contexts === null) {
+      hadUnavailable = true;
+      continue;
+    }
+    for (const ctx of contexts) {
+      if (ctx.contextType !== PIPELINE_RUN_CONTEXT_TYPE) continue;
+      if (!ctx.namespace) continue;
+      hasNamespaceEvidence = true;
+      if (ctx.namespace !== claimedNamespace) {
+        return {
+          valid: false,
+          actualNamespace: ctx.namespace,
+          reason: 'namespace-mismatch',
+        };
+      }
+    }
+  }
+  if (hadUnavailable) {
+    return { valid: true, reason: 'mlmd-unavailable' };
+  }
+  if (!hasNamespaceEvidence) {
+    return { valid: true, reason: 'no-evidence' };
+  }
+  return { valid: true };
+}
+
+export async function validateArtifactNamespace(
+  envoyAddress: string,
+  artifactUri: string,
+  claimedNamespace: string,
+): Promise<ValidationResult> {
+  if (!loadProtos()) {
+    return { valid: true, reason: 'protos-unavailable' };
+  }
+
+  let artifacts: ArtifactInfo[];
+  try {
+    artifacts = await getArtifactsByUri(envoyAddress, [artifactUri]);
+  } catch (error) {
+    console.warn(
+      `[SECURITY] MLMD artifact lookup failed for URI "${artifactUri}", ` +
+        `allowing access (fail-open). Error: ${error}`,
+    );
+    return { valid: true, reason: 'mlmd-unavailable' };
+  }
+
+  if (artifacts.length === 0) {
+    console.warn(
+      `[SECURITY] Artifact not found in MLMD for URI "${artifactUri}", ` +
+        `denying access (no namespace ownership evidence).`,
+    );
+    return { valid: false, reason: 'artifact-not-found' };
+  }
+
+  let contextResults: { artifactId: number; contexts: ContextNamespace[] | null }[];
+  try {
+    contextResults = await Promise.all(
+      artifacts.map(async (artifact) => {
+        try {
+          const contexts = await getContextsByArtifact(envoyAddress, artifact.id);
+          return { artifactId: artifact.id, contexts };
+        } catch (error) {
+          console.warn(
+            `[SECURITY] MLMD context lookup failed for artifact ${artifact.id}, ` +
+              `marking as unavailable. Error: ${error}`,
+          );
+          return { artifactId: artifact.id, contexts: null };
+        }
+      }),
+    );
+  } catch (error) {
+    console.warn(
+      `[SECURITY] MLMD batch context lookup failed, ` +
+        `allowing access (fail-open). Error: ${error}`,
+    );
+    return { valid: true, reason: 'mlmd-unavailable' };
+  }
+
+  const decision = decideFromContexts(contextResults, claimedNamespace);
+  if (decision.reason === 'mlmd-unavailable') {
+    console.warn(
+      `[SECURITY] At least one MLMD context lookup was unavailable for URI "${artifactUri}", ` +
+        `allowing access (fail-open after scanning available contexts).`,
+    );
+  } else if (decision.reason === 'no-evidence') {
+    console.warn(
+      `[SECURITY] No PipelineRun namespace evidence found in MLMD for URI "${artifactUri}", ` +
+        `allowing access (no ownership data to validate against).`,
+    );
+  }
+  return decision;
+}
+
+export function buildArtifactUri(source: string, bucket: string, key: string): string {
+  const scheme = source === 'gcs' ? 'gs' : source;
+  return `${scheme}://${bucket}/${key}`;
+}

--- a/frontend/server/integration-tests/artifact-auth.test.ts
+++ b/frontend/server/integration-tests/artifact-auth.test.ts
@@ -24,6 +24,28 @@ const MinioClient = minio.Client;
 vi.mock('minio');
 vi.mock('../k8s-helper.js');
 
+vi.mock('../gcs-helper.js', () => ({
+  getGCSClient: () => Promise.resolve({}),
+  listGCSObjectNames: ({ bucket, prefix }: { bucket: string; prefix: string }) =>
+    bucket === 'ml-pipeline' && prefix === 'hello/world.txt'
+      ? Promise.resolve(['hello/world.txt'])
+      : Promise.resolve([]),
+  downloadGCSObjectStream: () => {
+    const s = new PassThrough();
+    s.end('hello world');
+    return Promise.resolve(s);
+  },
+}));
+
+const mockedValidateArtifactNamespace = vi.fn();
+vi.mock('../helpers/mlmd-validator.js', () => ({
+  validateArtifactNamespace: (...args: unknown[]) => mockedValidateArtifactNamespace(...args),
+  buildArtifactUri: (source: string, bucket: string, key: string) => {
+    const scheme = source === 'gcs' ? 'gs' : source;
+    return `${scheme}://${bucket}/${key}`;
+  },
+}));
+
 const mockedFetch = vi.fn();
 vi.stubGlobal('fetch', mockedFetch);
 
@@ -34,6 +56,13 @@ describe('/artifacts authorization', () => {
   const artifactContent = 'hello world';
 
   beforeEach(() => {
+    // Isolate each test from prior call records.
+    mockedValidateArtifactNamespace.mockClear();
+    mockedFetch.mockClear();
+
+    // Default: MLMD validation passes (artifact belongs to claimed namespace)
+    mockedValidateArtifactNamespace.mockResolvedValue({ valid: true });
+
     const mockedMinioClient = MinioClient as any;
     mockedMinioClient.mockImplementation(function () {
       return {
@@ -381,11 +410,281 @@ describe('/artifacts authorization', () => {
       const request = requests(app.app);
       const response = await request
         .get(
-          `/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace&providerInfo=${encodeURIComponent(JSON.stringify(providerInfo))}`,
+          `/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace&providerInfo=${encodeURIComponent(
+            JSON.stringify(providerInfo),
+          )}`,
         )
         .set('kubeflow-userid', 'user@example.com')
         .expect(500);
       expect(response.text).toContain('Failed to initialize Minio Client');
+    });
+  });
+
+  describe('IDOR prevention (cross-namespace artifact access via namespace swap)', () => {
+    const authEnabledConfigs = () => {
+      const configurations = loadConfigs(argv, {
+        MINIO_ACCESS_KEY: 'minio',
+        MINIO_HOST: 'minio-service',
+        MINIO_NAMESPACE: 'kubeflow',
+        MINIO_PORT: '9000',
+        MINIO_SECRET_KEY: 'minio123',
+        MINIO_SSL: 'false',
+        ML_PIPELINE_SERVICE_HOST: 'localhost',
+        ML_PIPELINE_SERVICE_PORT: '8888',
+        KUBEFLOW_USERID_HEADER: 'kubeflow-userid',
+        KUBEFLOW_USERID_PREFIX: '',
+      });
+      configurations.auth.enabled = true;
+      return configurations;
+    };
+
+    // Mock auth to pass (user has access to the claimed namespace)
+    const mockAuthPass = () => {
+      mockedFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(''),
+      });
+    };
+
+    it('rejects artifact access when MLMD shows namespace mismatch', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({
+        valid: false,
+        actualNamespace: 'victim-namespace',
+        reason: 'namespace-mismatch',
+      });
+
+      app = new UIServer(authEnabledConfigs());
+
+      const request = requests(app.app);
+      const response = await request
+        .get(
+          '/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace',
+        )
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(403);
+      expect(response.text).toContain('does not belong to the requested namespace');
+    });
+
+    it('allows artifact access when MLMD confirms namespace matches', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({ valid: true });
+
+      app = new UIServer(authEnabledConfigs());
+
+      const request = requests(app.app);
+      await request
+        .get(
+          '/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace',
+        )
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(200, artifactContent);
+    });
+
+    it('rejects when any artifact with same URI belongs to different namespace', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({
+        valid: false,
+        actualNamespace: 'other-namespace',
+        reason: 'namespace-mismatch',
+      });
+
+      app = new UIServer(authEnabledConfigs());
+
+      const request = requests(app.app);
+      const response = await request
+        .get(
+          '/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace',
+        )
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(403);
+      expect(response.text).toContain('does not belong to the requested namespace');
+    });
+
+    it('rejects when artifact is not found in MLMD (no ownership evidence)', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({
+        valid: false,
+        reason: 'artifact-not-found',
+      });
+
+      app = new UIServer(authEnabledConfigs());
+
+      const request = requests(app.app);
+      const response = await request
+        .get(
+          '/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace',
+        )
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(403);
+      expect(response.text).toContain('does not belong to the requested namespace');
+    });
+
+    it('falls through (fail-open) when MLMD is unreachable', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({
+        valid: true,
+        reason: 'mlmd-unavailable',
+      });
+
+      app = new UIServer(authEnabledConfigs());
+
+      const request = requests(app.app);
+      await request
+        .get(
+          '/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace',
+        )
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(200, artifactContent);
+    });
+
+    it('rejects http source artifact when namespace ownership mismatches', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({
+        valid: false,
+        actualNamespace: 'victim-namespace',
+        reason: 'namespace-mismatch',
+      });
+
+      app = new UIServer(authEnabledConfigs());
+
+      const request = requests(app.app);
+      const response = await request
+        .get(
+          '/artifacts/get?source=http&bucket=internal.example.com&key=victim%2Fsecret.txt&namespace=my-namespace',
+        )
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(403);
+      expect(response.text).toContain('does not belong to the requested namespace');
+
+      expect(mockedValidateArtifactNamespace).toHaveBeenCalledWith(
+        expect.any(String),
+        'http://internal.example.com/victim/secret.txt',
+        'my-namespace',
+      );
+    });
+
+    it('passes correct URI to MLMD validation for s3 source', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({ valid: true });
+
+      app = new UIServer(authEnabledConfigs());
+
+      const request = requests(app.app);
+      await request
+        .get(
+          '/artifacts/get?source=s3&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace',
+        )
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(200);
+
+      expect(mockedValidateArtifactNamespace).toHaveBeenCalledWith(
+        expect.any(String),
+        's3://ml-pipeline/hello/world.txt',
+        'my-namespace',
+      );
+    });
+
+    it('passes correct URI to MLMD validation for gcs source', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({ valid: true });
+
+      app = new UIServer(authEnabledConfigs());
+
+      const request = requests(app.app);
+      await request
+        .get(
+          '/artifacts/get?source=gcs&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace',
+        )
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(200, `${artifactContent}\n`);
+
+      expect(mockedValidateArtifactNamespace).toHaveBeenCalledWith(
+        expect.any(String),
+        'gs://ml-pipeline/hello/world.txt',
+        'my-namespace',
+      );
+    });
+
+    it('validates path-based download route against MLMD, not query params', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({ valid: true });
+
+      app = new UIServer(authEnabledConfigs());
+
+      const request = requests(app.app);
+      await request
+        .get('/artifacts/minio/ml-pipeline/hello/world.txt?namespace=my-namespace')
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(200, artifactContent);
+
+      expect(mockedValidateArtifactNamespace).toHaveBeenCalledWith(
+        expect.any(String),
+        'minio://ml-pipeline/hello/world.txt',
+        'my-namespace',
+      );
+    });
+
+    it('rejects path-based route even if query params point to a valid artifact', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({
+        valid: false,
+        actualNamespace: 'victim-namespace',
+        reason: 'namespace-mismatch',
+      });
+
+      app = new UIServer(authEnabledConfigs());
+
+      const request = requests(app.app);
+      const response = await request
+        .get(
+          '/artifacts/minio/ml-pipeline/hello/world.txt?source=minio&bucket=safe-bucket&key=safe-key&namespace=my-namespace',
+        )
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(403);
+      expect(response.text).toContain('does not belong to the requested namespace');
+
+      expect(mockedValidateArtifactNamespace).toHaveBeenCalledWith(
+        expect.any(String),
+        'minio://ml-pipeline/hello/world.txt',
+        'my-namespace',
+      );
+    });
+
+    it('logs IDOR attempt with attacker and victim namespace details', async () => {
+      mockAuthPass();
+      mockedValidateArtifactNamespace.mockResolvedValue({
+        valid: false,
+        actualNamespace: 'secret-namespace',
+        reason: 'namespace-mismatch',
+      });
+
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        app = new UIServer(authEnabledConfigs());
+
+        const request = requests(app.app);
+        await request
+          .get(
+            '/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=attacker-namespace',
+          )
+          .set('kubeflow-userid', 'attacker@example.com')
+          .expect(403);
+
+        const idorLog = consoleSpy.mock.calls.find(
+          (call) => call[0] && call[0].includes('IDOR blocked'),
+        );
+        expect(idorLog).toBeDefined();
+        if (idorLog) {
+          expect(idorLog[0]).toContain('attacker@example.com');
+          expect(idorLog[0]).toContain('attacker-namespace');
+          expect(idorLog[0]).toContain('secret-namespace');
+        }
+      } finally {
+        consoleSpy.mockRestore();
+      }
     });
   });
 

--- a/frontend/server/package-lock.json
+++ b/frontend/server/package-lock.json
@@ -12,6 +12,7 @@
         "express": "^5.1.0",
         "form-data": "^2.5.6",
         "google-auth-library": "^7.14.1",
+        "google-protobuf": "^3.17.3",
         "gunzip-maybe": "^1.4.1",
         "http-proxy-middleware": "^2.0.7",
         "js-yaml": "^4.2.0",
@@ -1942,6 +1943,7 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -3413,6 +3415,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/google-protobuf": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.17.3.tgz",
+      "integrity": "sha512-OVPzcSWIAJ+d5yiHyeaLrdufQtrvaBrF4JQg+z8ynTkbO3uFcujqXszTumqg1cGsAsjkWnI+M5B1xZ19yR4Wyg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3900,6 +3908,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -5443,6 +5452,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5582,6 +5592,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5660,6 +5671,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5673,6 +5685,7 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -5814,6 +5827,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/frontend/server/package.json
+++ b/frontend/server/package.json
@@ -10,6 +10,7 @@
     "express": "^5.1.0",
     "form-data": "^2.5.6",
     "google-auth-library": "^7.14.1",
+    "google-protobuf": "^3.17.3",
     "gunzip-maybe": "^1.4.1",
     "http-proxy-middleware": "^2.0.7",
     "js-yaml": "^4.2.0",


### PR DESCRIPTION
**Description of your changes:**

Currently there is a minor issue in regarding cross namespace artifact IDOR: a user with access to namespace `B` can swap the `?namespace=` query param to view an artifact actually owned by namespace `A` when both share object storage credentials

This is a [follow up](https://github.com/kubeflow/pipelines/pull/12860#issuecomment-4189003892) from PR #12860 

This PR adds a new `mlmd-validator` helper that confirms the artifact actually belongs to the requested namespace via an MLMD lookup. The check runs in the artifact auth middleware after the existing `SubjectAccessReview` check passes, so the user still has to have access to the claimed namespace. The middleware returns `403 Artifact does not belong to the requested namespace` when the artifact is not associated with that namespace

Note: Default to a current behavior in situations when MLMD is unreachable, the artifact isn't tracked in MLMD, or when no PipelineRun namespace evidence exists

## Live Cluster Testing Evidence

### Before

NOTE: This testing is built from an image that has the existing logic from #12860. Currently this change is not released in any KFP versions, so the following before evidence will not reflect any environments on any currently released images

Artifact viewable with namespace access
<img width="1454" height="793" alt="Screenshot 2026-06-11 at 3 58 23 PM" src="https://github.com/user-attachments/assets/c7d05b64-c0e2-470b-a8f5-7da39686f541" />

Artifact viewable with namespace access

Artifact is blocked when namespace access is removed
<img width="1432" height="346" alt="Screenshot 2026-06-11 at 8 04 24 PM" src="https://github.com/user-attachments/assets/1fcf0d90-064a-4175-9d4f-aa45738a324a" />
Switching namespace in URL allows for artifact access again
<img width="1425" height="821" alt="Screenshot 2026-06-11 at 8 03 50 PM" src="https://github.com/user-attachments/assets/c453a4b3-833a-4bd9-8770-c4cd6a17daa9" />


### After

Artifact is blocked when namespace access is removed
<img width="1434" height="193" alt="Screenshot 2026-06-11 at 7 17 01 PM" src="https://github.com/user-attachments/assets/ee0ca354-f364-4f9b-a5e0-52d05aa3c9e2" />
Switching namespace in URL blocks access as well
<img width="1438" height="229" alt="Screenshot 2026-06-11 at 7 17 30 PM" src="https://github.com/user-attachments/assets/94871398-6ae6-4355-bde2-7fa8a0909edf" />


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
