### PR TITLE
fix(swf): Enforce V1 pipeline blocking with expanded test cases

### DIFF
--- a/backend/src/crd/controller/scheduledworkflow/controller.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller.go
@@ -727,8 +727,8 @@ func isV1PipelineBlocked(namespace string) bool {
 	return true
 }
 
-// shouldEnforceV1Block checks if the V1 pipeline block should be enforced for the given ScheduledWorkflow.
-// v2 ScheduledWorkflows can also have embedded workflow spec, but should not be blocked with this feature flag.
+// shouldEnforceV1Block Returns true allowing V2 workflows when key V2 component or pipeline labels
+// are present on the pod metadata. Returns false if the workflow is v1.
 func shouldEnforceV1Block(swf *util.ScheduledWorkflow) bool {
 	if swf == nil || !isV1PipelineBlocked(swf.Namespace) {
 		return false
@@ -746,14 +746,14 @@ func shouldEnforceV1Block(swf *util.ScheduledWorkflow) bool {
 		var err error
 		raw, err = json.Marshal(v)
 		if err != nil {
-			log.WithError(err).Warnf("Failed to marshal SWF spec to JSON: %v", err)
+			log.Warnf("Failed to marshal SWF spec to JSON: %v", err)
 			return true
 		}
 	}
 
 	var wf workflowapi.Workflow
 	if err := json.Unmarshal(raw, &wf); err != nil {
-		log.WithError(err).Warnf("Failed to unmarshal SWF spec to JSON: %v", err)
+		log.Warnf("Failed to unmarshal SWF spec to JSON: %v", err)
 		return true
 	}
 
@@ -769,7 +769,7 @@ func shouldEnforceV1Block(swf *util.ScheduledWorkflow) bool {
 	// the top-level Workflow wrapper.
 	var workflowSpec workflowapi.WorkflowSpec
 	if err := json.Unmarshal(raw, &workflowSpec); err != nil {
-		log.WithError(err).Warnf("Failed to unmarshal SWF spec to JSON: %v", err)
+		log.Warnf("Failed to unmarshal SWF spec to JSON: %v", err)
 		return true
 	}
 

--- a/backend/src/crd/controller/scheduledworkflow/controller.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -582,7 +583,6 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 	if swf.Spec.Workflow != nil && swf.Spec.Workflow.Spec != nil {
 		// V1 recurring runs bypass the API server by embedding the workflow spec directly in the ScheduledWorkflow CRD,
 		// so the V1 pipeline block needs to be enforced at the controller level as well.
-
 		if shouldEnforceV1Block(swf) {
 			return false, "", fmt.Errorf(
 				"namespace %s is not allowed to run v1 pipelines; please migrate to KFP v2 pipelines", swf.Namespace)
@@ -703,7 +703,7 @@ func (c *Controller) updateStatus(
 // isV1PipelineBlocked checks if the given namespace is blocked from running V1 pipelines
 // based on the BLOCK_V1_PIPELINES and V1_ALLOWED_NAMESPACES environment variables.
 func isV1PipelineBlocked(namespace string) bool {
-	blockV1Value := viper.GetString("BLOCK_V1_PIPELINES")
+	blockV1Value := viper.GetString(util.BlockV1Pipelines)
 	blockV1, err := strconv.ParseBool(blockV1Value)
 	if err != nil {
 		log.WithError(err).Warnf("Invalid BLOCK_V1_PIPELINES value %q; V1 pipelines are not blocked", blockV1Value)
@@ -713,7 +713,7 @@ func isV1PipelineBlocked(namespace string) bool {
 		return false
 	}
 
-	allowedNamespaces := viper.GetString("V1_ALLOWED_NAMESPACES")
+	allowedNamespaces := viper.GetString(util.AllowedNamespaces)
 	if allowedNamespaces == "" {
 		return true
 	}
@@ -730,5 +730,64 @@ func isV1PipelineBlocked(namespace string) bool {
 // shouldEnforceV1Block checks if the V1 pipeline block should be enforced for the given ScheduledWorkflow.
 // v2 ScheduledWorkflows can also have embedded workflow spec, but should not be blocked with this feature flag.
 func shouldEnforceV1Block(swf *util.ScheduledWorkflow) bool {
-	return strings.HasPrefix(swf.APIVersion, commonutil.ApiVersionV1) && isV1PipelineBlocked(swf.Namespace)
+	if swf == nil || !isV1PipelineBlocked(swf.Namespace) {
+		return false
+	}
+
+	if swf.Spec.Workflow == nil || swf.Spec.Workflow.Spec == nil {
+		return false
+	}
+
+	var raw []byte
+	switch v := swf.Spec.Workflow.Spec.(type) {
+	case string:
+		raw = []byte(v)
+	default:
+		var err error
+		raw, err = json.Marshal(v)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to marshal SWF spec to JSON: %v", err)
+			return true
+		}
+	}
+
+	var wf workflowapi.Workflow
+	if err := json.Unmarshal(raw, &wf); err != nil {
+		log.WithError(err).Warnf("Failed to unmarshal SWF spec to JSON: %v", err)
+		return true
+	}
+
+	if hasV2PipelineMarker(wf.GetLabels(), wf.GetAnnotations()) {
+		return false
+	}
+
+	if hasV2ComponentMarker(wf.Spec.PodMetadata) {
+		return false
+	}
+
+	// Fall back because older ScheduledWorkflow specs may embed a WorkflowSpec without
+	// the top-level Workflow wrapper.
+	var workflowSpec workflowapi.WorkflowSpec
+	if err := json.Unmarshal(raw, &workflowSpec); err != nil {
+		log.WithError(err).Warnf("Failed to unmarshal SWF spec to JSON: %v", err)
+		return true
+	}
+
+	if hasV2ComponentMarker(workflowSpec.PodMetadata) {
+		return false
+	}
+
+	return true
+}
+
+func hasV2ComponentMarker(podMetadata *workflowapi.Metadata) bool {
+	if podMetadata == nil {
+		return false
+	}
+
+	return podMetadata.Labels[util.V2Key] == "true" || podMetadata.Annotations[util.V2Key] == "true"
+}
+
+func hasV2PipelineMarker(labels, annotations map[string]string) bool {
+	return labels[util.V2PipelineKey] == "true" || annotations[util.V2PipelineKey] == "true"
 }

--- a/backend/src/crd/controller/scheduledworkflow/controller_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_test.go
@@ -15,15 +15,22 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"
+	"github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/client"
 	util "github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/util"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestIsV1PipelineBlocked(t *testing.T) {
@@ -98,53 +105,341 @@ func TestIsV1PipelineBlocked(t *testing.T) {
 }
 
 func TestShouldEnforceV1Block(t *testing.T) {
+	v1WorkflowSpec := map[string]interface{}{
+		"entrypoint": "main",
+		"templates": []interface{}{
+			map[string]interface{}{
+				"name": "main",
+				"container": map[string]interface{}{
+					"image": "alpine",
+				},
+			},
+		},
+	}
+	v1Workflow := map[string]interface{}{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Workflow",
+		"spec":       v1WorkflowSpec,
+	}
+	v2WorkflowSpec := map[string]interface{}{
+		"podMetadata": map[string]interface{}{
+			"labels": map[string]interface{}{
+				"pipelines.kubeflow.org/v2_component": "true",
+			},
+		},
+		"entrypoint": "main",
+		"templates": []interface{}{
+			map[string]interface{}{
+				"name": "main",
+				"container": map[string]interface{}{
+					"image": "alpine",
+				},
+			},
+		},
+	}
+	v2Workflow := map[string]interface{}{
+		"apiVersion": "argoproj.io/v1alpha1",
+		"kind":       "Workflow",
+		"spec":       v2WorkflowSpec,
+	}
+
 	tests := []struct {
-		name       string
-		apiVersion string
-		blockV1    string
-		namespace  string
-		expected   bool
+		name              string
+		spec              interface{}
+		blockV1           string
+		allowedNamespaces string
+		namespace         string
+		expected          bool
 	}{
 		{
-			name:       "V1 SWF, blocking enabled - blocked",
-			apiVersion: commonutil.ApiVersionV1,
-			blockV1:    "true",
-			namespace:  "ns1",
-			expected:   true,
+			name:      "V1 workflow spec, blocking enabled - blocked",
+			spec:      v1WorkflowSpec,
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  true,
 		},
 		{
-			name:       "V1 SWF, blocking disabled - not blocked",
-			apiVersion: commonutil.ApiVersionV1,
-			blockV1:    "false",
-			namespace:  "ns1",
-			expected:   false,
+			name:      "V1 full workflow, blocking enabled - blocked",
+			spec:      v1Workflow,
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  true,
 		},
 		{
-			name:       "V2 SWF, blocking enabled - not blocked",
-			apiVersion: commonutil.ApiVersionV2,
-			blockV1:    "true",
-			namespace:  "ns1",
-			expected:   false,
+			name:      "V1 workflow spec string, blocking enabled - blocked",
+			spec:      `{"entrypoint":"main","templates":[{"name":"main","container":{"image":"alpine"}}]}`,
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  true,
 		},
 		{
-			name:       "V2 SWF, blocking disabled - not blocked",
-			apiVersion: commonutil.ApiVersionV2,
-			blockV1:    "false",
-			namespace:  "ns1",
-			expected:   false,
+			name:      "V1 full workflow string, blocking enabled - blocked",
+			spec:      `{"apiVersion":"argoproj.io/v1alpha1","kind":"Workflow","spec":{"entrypoint":"main","templates":[{"name":"main","container":{"image":"alpine"}}]}}`,
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  true,
+		},
+		{
+			name:      "V2 full workflow on v1beta1 ScheduledWorkflow, blocking enabled - not blocked",
+			spec:      v2Workflow,
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  false,
+		},
+		{
+			name:      "V2 workflow spec on v1beta1 ScheduledWorkflow, blocking enabled - not blocked",
+			spec:      v2WorkflowSpec,
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  false,
+		},
+		{
+			name:      "V2 marker in annotation, blocking enabled - not blocked",
+			spec:      `{"spec":{"podMetadata":{"annotations":{"pipelines.kubeflow.org/v2_component":"true"}},"entrypoint":"main"}}`,
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  false,
+		},
+		{
+			name:      "V2 compatible workflow marker, blocking enabled - not blocked",
+			spec:      `{"metadata":{"annotations":{"pipelines.kubeflow.org/v2_pipeline":"true"}},"spec":{"entrypoint":"main"}}`,
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  false,
+		},
+		{
+			name:      "V2 marker false, blocking enabled - blocked",
+			spec:      `{"spec":{"podMetadata":{"labels":{"pipelines.kubeflow.org/v2_component":"false"}},"entrypoint":"main"}}`,
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  true,
+		},
+		{
+			name:      "V1 workflow spec, blocking disabled - not blocked",
+			spec:      v1WorkflowSpec,
+			blockV1:   "false",
+			namespace: "ns1",
+			expected:  false,
+		},
+		{
+			name:              "V1 workflow spec, namespace allowed - not blocked",
+			spec:              v1WorkflowSpec,
+			blockV1:           "true",
+			allowedNamespaces: "ns1",
+			namespace:         "ns1",
+			expected:          false,
+		},
+		{
+			name:      "Missing workflow spec, blocking enabled - not blocked",
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  false,
+		},
+		{
+			name:      "Malformed embedded workflow, blocking enabled - blocked",
+			spec:      `not valid json`,
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			viper.Set(common.BlockV1Pipelines, tt.blockV1)
-			defer viper.Set(common.BlockV1Pipelines, "")
+			viper.Set(common.V1NamespaceWhitelist, tt.allowedNamespaces)
+			defer func() {
+				viper.Set(common.BlockV1Pipelines, "")
+				viper.Set(common.V1NamespaceWhitelist, "")
+			}()
 
 			swf := util.NewScheduledWorkflow(&swfapi.ScheduledWorkflow{
-				TypeMeta:   metav1.TypeMeta{APIVersion: tt.apiVersion},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubeflow.org/v1beta1",
+					Kind:       "ScheduledWorkflow",
+				},
 				ObjectMeta: metav1.ObjectMeta{Namespace: tt.namespace},
+				Spec: swfapi.ScheduledWorkflowSpec{
+					Workflow: &swfapi.WorkflowResource{
+						Spec: tt.spec,
+					},
+				},
 			})
 			assert.Equal(t, tt.expected, shouldEnforceV1Block(swf))
 		})
 	}
+
+	t.Run("Nil ScheduledWorkflow - not blocked", func(t *testing.T) {
+		viper.Set(common.BlockV1Pipelines, "true")
+		defer viper.Set(common.BlockV1Pipelines, "")
+
+		assert.False(t, shouldEnforceV1Block(nil))
+	})
 }
+
+func TestSubmitNewWorkflowIfNotAlreadySubmitted_BlockV1AllowsV2(t *testing.T) {
+	tests := []struct {
+		name          string
+		workflowSpec  interface{}
+		expectCreated bool
+		expectError   string
+	}{
+		{
+			name: "blocks v1 embedded workflow",
+			workflowSpec: `{
+				"apiVersion": "argoproj.io/v1alpha1",
+				"kind": "Workflow",
+				"spec": {
+					"entrypoint": "main",
+					"templates": [
+						{"name": "main", "container": {"image": "alpine"}}
+					]
+				}
+			}`,
+			expectCreated: false,
+			expectError:   "not allowed to run v1 pipelines",
+		},
+		{
+			name: "allows v2 embedded workflow",
+			workflowSpec: `{
+				"apiVersion": "argoproj.io/v1alpha1",
+				"kind": "Workflow",
+				"spec": {
+					"podMetadata": {
+						"labels": {
+							"pipelines.kubeflow.org/v2_component": "true"
+						}
+					},
+					"entrypoint": "main",
+					"templates": [
+						{"name": "main", "container": {"image": "alpine"}}
+					]
+				}
+			}`,
+			expectCreated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Set(common.BlockV1Pipelines, "true")
+			viper.Set(common.V1NamespaceWhitelist, "")
+			defer func() {
+				viper.Set(common.BlockV1Pipelines, "")
+				viper.Set(common.V1NamespaceWhitelist, "")
+			}()
+
+			executionClient := &fakeExecutionClient{}
+			controller := &Controller{
+				workflowClient: client.NewWorkflowClient(executionClient, &fakeExecutionInformer{}),
+			}
+			swf := util.NewScheduledWorkflow(&swfapi.ScheduledWorkflow{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "kubeflow.org/v1beta1",
+					Kind:       "ScheduledWorkflow",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "scheduled-workflow",
+					Namespace: "blocked-namespace",
+					UID:       "scheduled-workflow-uid",
+				},
+				Spec: swfapi.ScheduledWorkflowSpec{
+					Workflow: &swfapi.WorkflowResource{
+						Spec: tt.workflowSpec,
+					},
+				},
+			})
+
+			submitted, workflowName, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
+				context.Background(), swf, 100, 200)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				assert.False(t, submitted)
+				assert.Empty(t, workflowName)
+			} else {
+				require.NoError(t, err)
+				assert.True(t, submitted)
+				assert.NotEmpty(t, workflowName)
+			}
+			assert.Equal(t, tt.expectCreated, executionClient.createdWorkflow != nil)
+		})
+	}
+}
+
+type fakeExecutionClient struct {
+	createdWorkflow commonutil.ExecutionSpec
+}
+
+func (f *fakeExecutionClient) Execution(namespace string) commonutil.ExecutionInterface {
+	return &fakeExecutionInterface{client: f}
+}
+
+func (f *fakeExecutionClient) Compare(old, new interface{}) bool {
+	return false
+}
+
+type fakeExecutionInterface struct {
+	client *fakeExecutionClient
+}
+
+func (f *fakeExecutionInterface) Create(ctx context.Context, execution commonutil.ExecutionSpec,
+	opts metav1.CreateOptions) (commonutil.ExecutionSpec, error) {
+	f.client.createdWorkflow = execution
+	return execution, nil
+}
+
+func (f *fakeExecutionInterface) Update(ctx context.Context, execution commonutil.ExecutionSpec,
+	opts metav1.UpdateOptions) (commonutil.ExecutionSpec, error) {
+	return execution, nil
+}
+
+func (f *fakeExecutionInterface) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
+	return nil
+}
+
+func (f *fakeExecutionInterface) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions,
+	listOpts metav1.ListOptions) error {
+	return nil
+}
+
+func (f *fakeExecutionInterface) Get(ctx context.Context, name string,
+	opts metav1.GetOptions) (commonutil.ExecutionSpec, error) {
+	return nil, nil
+}
+
+func (f *fakeExecutionInterface) List(ctx context.Context,
+	opts metav1.ListOptions) (*commonutil.ExecutionSpecList, error) {
+	return &commonutil.ExecutionSpecList{}, nil
+}
+
+func (f *fakeExecutionInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte,
+	opts metav1.PatchOptions, subresources ...string) (commonutil.ExecutionSpec, error) {
+	return nil, nil
+}
+
+type fakeExecutionInformer struct{}
+
+func (f *fakeExecutionInformer) AddEventHandler(funcs cache.ResourceEventHandler) (
+	cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (f *fakeExecutionInformer) HasSynced() func() bool {
+	return func() bool { return true }
+}
+
+func (f *fakeExecutionInformer) Get(namespace string, name string) (commonutil.ExecutionSpec, bool, error) {
+	return nil, true, errors.New("not found")
+}
+
+func (f *fakeExecutionInformer) List(labels *labels.Selector) (commonutil.ExecutionSpecList, error) {
+	return commonutil.ExecutionSpecList{}, nil
+}
+
+func (f *fakeExecutionInformer) InformerFactoryStart(stopCh <-chan struct{}) {}
+
+var _ commonutil.ExecutionClient = &fakeExecutionClient{}
+var _ commonutil.ExecutionInterface = &fakeExecutionInterface{}
+var _ commonutil.ExecutionInformer = &fakeExecutionInformer{}

--- a/backend/src/crd/controller/scheduledworkflow/controller_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_test.go
@@ -431,7 +431,7 @@ func (f *fakeExecutionInformer) HasSynced() func() bool {
 }
 
 func (f *fakeExecutionInformer) Get(namespace string, name string) (commonutil.ExecutionSpec, bool, error) {
-	return nil, false, errors.New("not found")
+	return nil, true, errors.New("not found")
 }
 
 func (f *fakeExecutionInformer) List(labels *labels.Selector) (commonutil.ExecutionSpecList, error) {

--- a/backend/src/crd/controller/scheduledworkflow/controller_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_test.go
@@ -124,7 +124,7 @@ func TestShouldEnforceV1Block(t *testing.T) {
 	v2WorkflowSpec := map[string]interface{}{
 		"podMetadata": map[string]interface{}{
 			"labels": map[string]interface{}{
-				"pipelines.kubeflow.org/v2_component": "true",
+				util.V2Key: "true",
 			},
 		},
 		"entrypoint": "main",
@@ -431,7 +431,7 @@ func (f *fakeExecutionInformer) HasSynced() func() bool {
 }
 
 func (f *fakeExecutionInformer) Get(namespace string, name string) (commonutil.ExecutionSpec, bool, error) {
-	return nil, true, errors.New("not found")
+	return nil, false, errors.New("not found")
 }
 
 func (f *fakeExecutionInformer) List(labels *labels.Selector) (commonutil.ExecutionSpecList, error) {

--- a/backend/src/crd/controller/scheduledworkflow/util/const.go
+++ b/backend/src/crd/controller/scheduledworkflow/util/const.go
@@ -23,6 +23,10 @@ import (
 const (
 	ControllerAgentName string = "scheduled-workflow-controller" // ControllerAgentName is the name of the controller.
 	TimeZone            string = "CRON_SCHEDULE_TIMEZONE"        // TimeZone is the name of the cron schedule timezone env parameter
+	V2Key               string = "pipelines.kubeflow.org/v2_component"
+	V2PipelineKey       string = "pipelines.kubeflow.org/v2_pipeline"
+	BlockV1Pipelines    string = "BLOCK_V1_PIPELINES"
+	AllowedNamespaces   string = "V1_ALLOWED_NAMESPACES"
 )
 
 func GetLocation() (*time.Location, error) {

--- a/backend/src/crd/controller/scheduledworkflow/util/const.go
+++ b/backend/src/crd/controller/scheduledworkflow/util/const.go
@@ -21,12 +21,12 @@ import (
 )
 
 const (
-	ControllerAgentName string = "scheduled-workflow-controller" // ControllerAgentName is the name of the controller.
-	TimeZone            string = "CRON_SCHEDULE_TIMEZONE"        // TimeZone is the name of the cron schedule timezone env parameter
-	V2Key               string = "pipelines.kubeflow.org/v2_component"
-	V2PipelineKey       string = "pipelines.kubeflow.org/v2_pipeline"
-	BlockV1Pipelines    string = "BLOCK_V1_PIPELINES"
-	AllowedNamespaces   string = "V1_ALLOWED_NAMESPACES"
+	ControllerAgentName string = "scheduled-workflow-controller"       // ControllerAgentName is the name of the controller.
+	TimeZone            string = "CRON_SCHEDULE_TIMEZONE"              // TimeZone is the name of the cron schedule timezone env parameter
+	V2Key               string = "pipelines.kubeflow.org/v2_component" // V2Key is the name of the v2 component labels
+	V2PipelineKey       string = "pipelines.kubeflow.org/v2_pipeline"  // V2PipelineKey is the name of the v2 pipeline label
+	BlockV1Pipelines    string = "BLOCK_V1_PIPELINES"                  // BlockV1Pipelines is the name of the env parameter to block v1 pipelines
+	AllowedNamespaces   string = "V1_ALLOWED_NAMESPACES"               // AllowedNamespaces is the name of the env parameter to specify allowed namespaces for v1 pipelines
 )
 
 func GetLocation() (*time.Location, error) {


### PR DESCRIPTION
**Description of your changes:**

This PR updates the logic for identifying v1 vs v2 pipelines in the scheduled workflow controller responsible for creating recurring runs in Kubeflow pipelines. Previously the logic looked at the API version for determining if a pipeline was v1 or v2:

```go
ApiVersionV1 = "kubeflow.org/v1beta1"
ApiVersionV2 = "kubeflow.org/v2beta1"
```

However, this introduced problems when v2 pipelines use a v1 API version. This PR addresses this by identifying key v2 labels on components and workflows in the pod metadata instead of relying solely on API versions. 

Additional unit tests were added to cover both the new methods and the logic for submitting workflows in `controller.go`.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->