### PR TITLE
fix(sdk): remove max duration limit on retries

### DIFF
--- a/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
+++ b/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
@@ -4321,8 +4321,7 @@ type PipelineTaskSpec_RetryPolicy struct {
 	// unspecified, will default to 2.
 	BackoffFactor float64 `protobuf:"fixed64,3,opt,name=backoff_factor,json=backoffFactor,proto3" json:"backoff_factor,omitempty"`
 	// The maximum duration during which the task will be retried according to
-	// the backoff strategy. Max allowed is 1 hour - higher value will be capped
-	// to this limit. If unspecified, will set to 1 hour.
+	// the backoff strategy. If unspecified, will set to 1 hour.
 	BackoffMaxDuration *durationpb.Duration `protobuf:"bytes,4,opt,name=backoff_max_duration,json=backoffMaxDuration,proto3" json:"backoff_max_duration,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache

--- a/api/v2alpha1/pipeline_spec.proto
+++ b/api/v2alpha1/pipeline_spec.proto
@@ -592,8 +592,7 @@ message PipelineTaskSpec {
     double backoff_factor = 3;
 
     // The maximum duration during which the task will be retried according to
-    // the backoff strategy. Max allowed is 1 hour - higher value will be capped
-    // to this limit. If unspecified, will set to 1 hour.
+    // the backoff strategy. If unspecified, will set to 1 hour.
     google.protobuf.Duration backoff_max_duration = 4;
   }
 

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -1816,7 +1816,7 @@ class TestSetRetryCompilation(unittest.TestCase):
         self.assertEqual(retry_policy.max_retry_count, 3)
         self.assertEqual(retry_policy.backoff_duration.seconds, 30)
         self.assertEqual(retry_policy.backoff_factor, 1.0)
-        self.assertEqual(retry_policy.backoff_max_duration.seconds, 3600)
+        self.assertEqual(retry_policy.backoff_max_duration.seconds, 10800)
 
 
 from google.protobuf import json_format

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -617,7 +617,7 @@ class PipelineTask:
             num_retries : Number of times to retry on failure.
             backoff_duration: Number of seconds to wait before triggering a retry. Defaults to ``'0s'`` (immediate retry).
             backoff_factor: Exponential backoff factor applied to ``backoff_duration``. For example, if ``backoff_duration="60"`` (60 seconds) and ``backoff_factor=2``, the first retry will happen after 60 seconds, then again after 120, 240, and so on. Defaults to ``2.0``.
-            backoff_max_duration: Maximum duration during which the task will be retried. Maximum duration is 1 hour (3600s). Defaults to ``'3600s'``.
+            backoff_max_duration: Maximum duration during which the task will be retried. Defaults to ``'3600s'``.
 
         Returns:
             Self return to allow chained setting calls.

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -380,9 +380,8 @@ class RetryPolicy:
         backoff_factor = self.backoff_factor or 2.0
         backoff_max_duration = self.backoff_max_duration or '3600s'
 
-        # include max duration seconds cap so that IR is more reflective of runtime behavior
         backoff_duration_seconds = f'{convert_duration_to_seconds(backoff_duration)}s'
-        backoff_max_duration_seconds = f'{min(convert_duration_to_seconds(backoff_max_duration), 3600)}s'
+        backoff_max_duration_seconds = f'{convert_duration_to_seconds(backoff_max_duration)}s'
 
         return json_format.ParseDict(
             {

--- a/sdk/python/kfp/dsl/structures_test.py
+++ b/sdk/python/kfp/dsl/structures_test.py
@@ -912,8 +912,8 @@ class TestRetryPolicy(unittest.TestCase):
         self.assertEqual(retry_policy_proto.max_retry_count, 10)
         self.assertEqual(retry_policy_proto.backoff_duration.seconds, 3600)
         self.assertEqual(retry_policy_proto.backoff_factor, 1.5)
-        # tests cap
-        self.assertEqual(retry_policy_proto.backoff_max_duration.seconds, 3600)
+        self.assertEqual(retry_policy_proto.backoff_max_duration.seconds,
+                         1209600)
 
 
 class TestDeserializeV1ComponentYamlDefaults(unittest.TestCase):


### PR DESCRIPTION
## Description of your changes:

Currently there is a hard cap of 1 hour on retries, regardless of user configuration. Importantly, this 1hr limit is cumulative across all retry attempts of the same component (Argo measures it from the first attempt's start). Due to the interaction with Argo Workflows, once this limit is reached the active pod will fail or no pod will be retried (if pod ran over 1hr before failing).

This PR is intended to be a quick fix. The default behavior is all still the same, but now users can override it to get around this issue for long-running components.

Further discussion/changes can be proposed to fix the issue where this time is taken from the total component time, but that will require much larger configuration changes.

## Live Cluster Evidence

### Before (2.16.1):

#### Compiled retryPolicy with `backoff_max_duration='4h'`
```yaml
retryPolicy:
  backoffMaxDuration: 3600s   # ← reduced from '4h'
  maxRetryCount: 1
```

#### 50 minute wait example:
<img width="1428" height="69" alt="Screenshot 2026-05-29 at 11 58 57 PM" src="https://github.com/user-attachments/assets/686f083b-56c1-4f17-9b6f-79e291cc8c12" />


Initial pod start time: `2026-05-30T02:51:40Z`:
```yaml
    state:
      terminated:
        containerID: containerd://62169eb1743a4d8e19fcc9663dfd5253396ff62714f698d64f476de6cfca1919
        exitCode: 1
        finishedAt: "2026-05-30T03:47:29Z"
        reason: Error
        startedAt: "2026-05-30T02:51:40Z"
```

Pod is retried, but fails prematurely
Retry pod deadline:
4 minutes after initial pod failure (56 mins in)
```yaml
    state:
      terminated:
        containerID: containerd://75afccb4eeb1ff6b2e3752dfa88398743048c00ac56e92d0beec4e8df9912b12
        exitCode: 143
        finishedAt: "2026-05-30T03:51:12Z"
        reason: Error
        startedAt: "2026-05-30T03:47:45Z"
```

Failure forced due to argo deadline:
```yaml
- name: ARGO_DEADLINE
  value: "2026-05-30T03:51:10Z"
```

#### >1hr wait example:
<img width="1420" height="52" alt="Screenshot 2026-05-30 at 12 13 03 AM" src="https://github.com/user-attachments/assets/f8c2205e-31c4-4d65-b3fb-b75e29d3f47e" />

Pod fails after 1 of executing, no pods are retried, the workflow fails immediately 


### After:

#### Compiled retryPolicy with `backoff_max_duration='4h'`
```yaml
retryPolicy:
  backoffMaxDuration: 14400s   # ← '4h' preserved
  maxRetryCount: 1
```

#### 50 minute wait example:
<img width="1420" height="72" alt="Screenshot 2026-05-31 at 10 34 19 AM" src="https://github.com/user-attachments/assets/07151559-90e9-493b-ba92-7200de2d9260" />

Initial pod fails after 1hr, retry pod is spun up as expected
argo deadline on retry pod (4hrs after initial execution time):
```yaml
    - name: ARGO_DEADLINE
      value: "2026-05-31T17:20:36Z"
```

#### 61 minute wait example:
<img width="1416" height="70" alt="Screenshot 2026-05-31 at 10 45 14 AM" src="https://github.com/user-attachments/assets/75d877d9-e01d-4bd3-9fb3-723d9d1fd95a" />
(initial pod ran past 1hr threshold, failed, pod was still retried due to the 4hr limit increase)
argo deadline on retry pod (4hrs after initial execution time):
```yaml
- name: ARGO_DEADLINE
  value: "2026-05-31T17:20:59Z"
```

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->


argoWF when my pod attempts to retry after an hour:
<img width="414" height="234" alt="Screenshot 2026-05-31 at 11 00 31 AM" src="https://github.com/user-attachments/assets/885eb36c-5c3e-45d8-b0d4-57ed4ceaff79" />

