### PR TITLE
ci: stabilize SeaweedFS resource requests

### DIFF
--- a/.github/resources/manifests/base/seaweedfs-resources.yaml
+++ b/.github/resources/manifests/base/seaweedfs-resources.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seaweedfs
+spec:
+  template:
+    spec:
+      containers:
+        - name: seaweedfs
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi

--- a/.github/resources/manifests/multiuser/artifact-proxy/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/artifact-proxy/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-resources.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/cache-disabled/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/cache-disabled/kustomization.yaml
@@ -50,6 +50,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-resources.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/default/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/default/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-resources.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/cache-disabled/kustomization.yaml
+++ b/.github/resources/manifests/standalone/cache-disabled/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-resources.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/default/kustomization.yaml
+++ b/.github/resources/manifests/standalone/default/kustomization.yaml
@@ -42,6 +42,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-resources.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/proxy/kustomization.yaml
+++ b/.github/resources/manifests/standalone/proxy/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-resources.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/tls-enabled/kustomization.yaml
+++ b/.github/resources/manifests/standalone/tls-enabled/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-resources.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment


### PR DESCRIPTION
## Summary
- add a shared CI-only SeaweedFS resource request patch
- apply it to standalone and multi-user CI overlays that deploy SeaweedFS
- keep Ginkgo parallelism unchanged

## Context
PR #13451 exposed repeated Argo wait-container artifact/log upload failures to SeaweedFS, for example `failed to put file ... seaweedfs ... i/o timeout`.

Validated on PR #13451 before splitting this into a separate PR:
- `E2EParallelNested cacheEnabled=false argoVersion=v4.0.4` passed with normal 3-worker parallelism
- `E2ECritical pod_to_pod_tls_enabled=true` passed
- `Critical Scenario Multi User cacheEnabled=false` passed
- full test matrix was green except Tide pending

## Local verification
- `git diff --check`
- rendered standalone overlays: default, cache-disabled, cache-disabled-proxy, proxy, tls-enabled
- rendered multi-user overlays: default, cache-disabled, artifact-proxy
- verified rendered SeaweedFS requests are `cpu: 250m` and `memory: 256Mi`