### PR TITLE
 Fix workflow compiler tests by ignoring .files

### DIFF
--- a/backend/test/testutil/file_utils.go
+++ b/backend/test/testutil/file_utils.go
@@ -85,7 +85,7 @@ func GetListOfFilesInADir(directoryPath string) []string {
 
 	for _, file := range files {
 		if !file.IsDir() {
-			if !strings.Contains(file.Name(), ".py") && (file.Name() != "Dockerfile") && !strings.Contains(file.Name(), ".md") && !strings.Contains(file.Name(), ".ipynb") {
+			if isPipelineTestFile(file.Name()) {
 				fileNames = append(fileNames, file.Name())
 			}
 		}
@@ -104,7 +104,7 @@ func GetListOfAllFilesInDir(directoryPath string) []string {
 
 		// Check if it's a regular file (not a directory)
 		if !d.IsDir() {
-			if !strings.Contains(d.Name(), ".py") && (d.Name() != "Dockerfile") && !strings.Contains(d.Name(), ".md") && !strings.Contains(d.Name(), ".ipynb") {
+			if isPipelineTestFile(d.Name()) {
 				filePaths = append(filePaths, path)
 			}
 		}
@@ -114,6 +114,14 @@ func GetListOfAllFilesInDir(directoryPath string) []string {
 		fmt.Printf("Error walking the directory tree: %v\n", err)
 	}
 	return filePaths
+}
+
+func isPipelineTestFile(fileName string) bool {
+	return !strings.HasPrefix(fileName, ".") &&
+		!strings.Contains(fileName, ".py") &&
+		fileName != "Dockerfile" &&
+		!strings.Contains(fileName, ".md") &&
+		!strings.Contains(fileName, ".ipynb")
 }
 
 func ProtoToBytes(objectToConvert proto.Message) []byte {
@@ -138,7 +146,7 @@ func ToBytes(objectToConvert any) []byte {
 
 // ParseFileToSpecs - Read a file and unmarshall it into a template.V2Spec
 func ParseFileToSpecs(pipelineFilePath string, cacheDisabled bool, defaultWorkspace *v1.PersistentVolumeClaimSpec) *template.V2Spec {
-	specFromFile, err := os.OpenFile(pipelineFilePath, os.O_RDWR, 0o644)
+	specFromFile, err := os.Open(pipelineFilePath)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to read pipeline file")
 	defer specFromFile.Close()
 	pipelineSpecBytes, pipelineUnmarshallError := server.ReadPipelineFile(pipelineFilePath, specFromFile, common.MaxFileLength)


### PR DESCRIPTION
macOS can create `.DS_Store` files when a directory is opened in Finder (see https://en.wikipedia.org/wiki/.DS_Store). The workflow compiler test helper collected all files from test_data so these hidden files could be treated as pipeline specs and break the tests.

 This change adds dotfiles to the existing file filter and extracts the filter into a shared helper to avoid duplicating.

**Description of your changes:**


**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
