### PR TITLE
chore(ci): rotate tested Kubernetes versions

### DIFF
--- a/.github/workflows/api-server-tests.yml
+++ b/.github/workflows/api-server-tests.yml
@@ -63,23 +63,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.34.0" ]
+        k8s_version: [ "v1.35.0" ]
         cache_enabled: [ "true", "false" ]
         proxy: [ "true", "false" ]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         pipeline_store: [ "database" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.29.2"
+          - k8s_version: "v1.31.14"
             cache_enabled: "true"
             argo_version: "v3.7.3"
-          - k8s_version: "v1.29.2"
+          - k8s_version: "v1.31.14"
             cache_enabled: "true"
             argo_version: "v3.5.14"
-          - k8s_version: "v1.29.2"
+          - k8s_version: "v1.31.14"
             cache_enabled: "true"
             argo_version: "v4.0.4"
-          - k8s_version: "v1.34.0"
+          - k8s_version: "v1.35.0"
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
       fail-fast: false # So that failure in 1 type of parameterized job does not cause other jobs to terminate prematurely
@@ -167,14 +167,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.34.0", "v1.29.2" ]
+        k8s_version: [ "v1.35.0", "v1.31.14" ]
         cache_enabled: [ "true" ]
         uploadPipelinesWithKubernetesClient: [ "true", "false" ]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         pipeline_store: [ "kubernetes" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.34.0"
+          - k8s_version: "v1.35.0"
             cache_enabled: "true"
             # Pod to Pod TLS manifests are not yet implemented for Kubernetes Native API mode
             pipeline_store: "database"
@@ -226,7 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.34.0"]
+        k8s_version: [ "v1.35.0"]
         cache_enabled: [ "true", "false" ]
         multi_user: [ "true" ]
       fail-fast: false # So that failure in 1 type of parameterized job does not cause other jobs to terminate prematurely

--- a/.github/workflows/e2e-test-frontend.yml
+++ b/.github/workflows/e2e-test-frontend.yml
@@ -26,7 +26,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.34.0" ]
+        k8s_version: [ "v1.31.14", "v1.35.0" ]
         pod_to_pod_tls_enabled: [ "true", "false" ]
     name: Frontend Integration Tests - K8s ${{ matrix.k8s_version }} pod_to_pod_tls_enabled=${{ matrix.pod_to_pod_tls_enabled }}
     steps:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,25 +61,25 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.34.0"]
+        k8s_version: ["v1.35.0"]
         cache_enabled: ["true", "false"]
         argo_version: [ "v3.7.3", "v3.5.14", "v4.0.4" ]
         proxy: [ "false" ]
         test_label: [ "E2ECritical", "E2EEssential", "E2EParallelNested" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.29.2"
+          - k8s_version: "v1.31.14"
             cache_enabled: "false"
             argo_version: "v3.5.14"
             test_label: "E2ECritical"
-          - k8s_version: "v1.34.0"
+          - k8s_version: "v1.35.0"
             cache_enabled: "false"
             proxy: "true"
             test_label: "E2EProxy"
-          - k8s_version: "v1.34.0"
+          - k8s_version: "v1.35.0"
             cache_enabled: "false"
             test_label: "E2EFailure"
-          - k8s_version: "v1.34.0"
+          - k8s_version: "v1.35.0"
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
             test_label: "E2ECritical"
@@ -168,14 +168,14 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.34.0"]
+        k8s_version: ["v1.35.0"]
         cache_enabled: ["true", "false"]
         multi_user: [ "true" ]
         test_label: [ "E2ECritical" ]
         include:
         - multi_user: "true"
           artifact_proxy: "true"
-          k8s_version: "v1.34.0"
+          k8s_version: "v1.35.0"
           cache_enabled: "true"
           test_label: "E2ECritical"
       fail-fast: false

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.34.0" ]
+        k8s_version: [ "v1.31.14", "v1.35.0" ]
     name: Initialization & Integration tests v1 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
+++ b/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.29.2", "v1.34.0"]
+        k8s_version: ["v1.31.14", "v1.35.0"]
     name: KFP Kubernetes Native Migration Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-sdk-client-tests.yml
+++ b/.github/workflows/kfp-sdk-client-tests.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.34.0" ]
+        k8s_version: [ "v1.31.14", "v1.35.0" ]
     name: KFP SDK Client Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-webhooks.yml
+++ b/.github/workflows/kfp-webhooks.yml
@@ -24,7 +24,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.29.2", "v1.34.0" ]
+        k8s_version: [ "v1.31.14", "v1.35.0" ]
     name: KFP Webhooks - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/.github/workflows/legacy-v2-api-integration-tests.yml
+++ b/.github/workflows/legacy-v2-api-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         pipeline_store: [ "database", "kubernetes" ]
-        k8s_version: [ "v1.34.0" ]
+        k8s_version: [ "v1.35.0" ]
         pod_to_pod_tls_enabled: [ "true", "false" ]
         exclude:
           # Pod to Pod TLS manifests are not yet implemented for Kubernetes Native API mode

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.34.0" ]
+        k8s_version: [ "v1.35.0" ]
     name: KFP upgrade tests - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-04-25
+- Last updated: 2026-05-31
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -521,7 +521,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 ### Test matrices and variants (Kubernetes, stores, proxy, cache)
 
-- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.29.2` and `v1.31.0`.
+- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.31.14` and `v1.35.0`.
   - Examples: `e2e-test.yml`, `sdk-execution.yml`, `upgrade-test.yml`, `kfp-kubernetes-execution-tests.yml`, `kfp-webhooks.yml`, `api-server-tests.yml`, `compiler-tests.yml`, `legacy-v2-api-integration-tests.yml`, `integration-tests-v1.yml`, and frontend integration in `e2e-test-frontend.yml`.
 - Pipeline store variants (v2 engine): tests run with `database` and `kubernetes` stores, and a dedicated job compiles pipelines to Kubernetes-native manifests.
   - Example: `e2e-test.yml` job "API integration tests v2 - K8s with ${pipeline_store}" and "compile pipelines with Kubernetes".

--- a/proposals/12147-mlmd-removal/test_plan.md
+++ b/proposals/12147-mlmd-removal/test_plan.md
@@ -160,13 +160,13 @@ This is a **breaking architectural change** that affects:
 - **Python Version**: 3.9+
 - **Database**: MySQL 8.0 or compatible
 - **Container Runtime**: Docker or Podman
-- **Kubernetes**: Kind cluster (v1.29.2 or v1.31.0)
+- **Kubernetes**: Kind cluster (v1.31.14 or v1.35.0)
 
 ### Test Cluster Configurations
 
 #### 1. Local Development Cluster
 ```yaml
-Kubernetes: Kind v1.29.2
+Kubernetes: Kind v1.31.14
 KFP Mode: Standalone
 Database: MySQL 8.0
 Storage: MinIO (local S3-compatible)
@@ -176,7 +176,7 @@ Purpose: Unit test validation, quick smoke tests
 
 #### 2. Standard KFP Cluster
 ```yaml
-Kubernetes: Kind v1.31.0
+Kubernetes: Kind v1.35.0
 KFP Mode: Standalone with RBAC
 Database: MySQL 8.0
 Storage: MinIO
@@ -187,7 +187,7 @@ Purpose: Main integration testing, regression tests
 
 #### 3. Multi-Tenant Cluster
 ```yaml
-Kubernetes: Kind v1.31.0
+Kubernetes: Kind v1.35.0
 KFP Mode: Multi-tenant
 Database: MySQL 8.0
 Storage: MinIO with namespace isolation
@@ -198,7 +198,7 @@ Purpose: Security testing, RBAC validation
 
 #### 4. Performance Testing Cluster
 ```yaml
-Kubernetes: Kind v1.31.0 (or GKE/EKS for realistic perf)
+Kubernetes: Kind v1.35.0 (or GKE/EKS for realistic perf)
 KFP Mode: Standalone
 Database: MySQL 8.0 (optimized)
 Storage: MinIO (or cloud storage)


### PR DESCRIPTION
## Summary

- rotate the current CI-tested Kubernetes low/high pair from `v1.29.2` / `v1.34.0` to `v1.31.14` / `v1.35.0`
- update `AGENTS.md` and the stale Kind version examples in `proposals/12147-mlmd-removal/test_plan.md`
- keep the existing `pipelines` low/high CI policy rather than broadening the matrix in this PR

## Rationale

This repo currently validates Kubernetes compatibility with a low/high spot-check model rather than a contiguous rolling range.

As of May 31, 2026, the practical endpoints under the current Kind constraint are:

- low: `v1.31.14`
- high: `v1.35.0`

Why these versions:

- `v1.31.14` is the oldest prebuilt node image in Kind `v0.31.0`, which is what our current `helm/kind-action@v1.13.0` setup uses.
- `v1.35.0` is the newest prebuilt node image in Kind `v0.31.0`.
- We are intentionally using the pinned Kind release's **release-matched prebuilt image set**, not "latest patch in the Kubernetes minor if a tag happens to exist in the registry".
- Upstream latest is already `1.36.x`, but Kind has not caught up yet.
- Major cloud providers still extend support lower than this, but Kind also does not provide a release-matched prebuilt image for `1.30.x`.

So this PR updates the repo to the current **feasible CI-tested** endpoints without changing the broader support policy.

For the broader future policy discussion, see:
- #13457

This effectively replaces the earlier closed attempt in #12978 with current version rationale.

## Verification

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/api-server-tests.yml .github/workflows/e2e-test-frontend.yml .github/workflows/e2e-test.yml .github/workflows/integration-tests-v1.yml .github/workflows/kfp-kubernetes-native-migration-tests.yaml .github/workflows/kfp-sdk-client-tests.yml .github/workflows/kfp-webhooks.yml .github/workflows/legacy-v2-api-integration-tests.yml .github/workflows/upgrade-test.yml`
- `git diff --check`
- `gh release view v0.31.0 --repo kubernetes-sigs/kind` (verified prebuilt images for `v1.31.14` and `v1.35.0`)

