### PR TITLE
ci: use GHCR SeaweedFS image in CI manifests

### DIFF
--- a/.github/resources/manifests/base/seaweedfs-image.yaml
+++ b/.github/resources/manifests/base/seaweedfs-image.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: seaweedfs
+spec:
+  template:
+    spec:
+      containers:
+        # Use upstream GHCR in CI to reduce Docker Hub pull-rate pressure.
+        - name: seaweedfs
+          image: ghcr.io/chrislusf/seaweedfs:4.18

--- a/.github/resources/manifests/kubernetes-native/default/kustomization.yaml
+++ b/.github/resources/manifests/kubernetes-native/default/kustomization.yaml
@@ -42,6 +42,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-image.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/artifact-proxy/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/artifact-proxy/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-image.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/seaweedfs-resources.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/cache-disabled/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/cache-disabled/kustomization.yaml
@@ -50,6 +50,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-image.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/seaweedfs-resources.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/multiuser/default/kustomization.yaml
+++ b/.github/resources/manifests/multiuser/default/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-image.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/seaweedfs-resources.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/cache-disabled/kustomization.yaml
+++ b/.github/resources/manifests/standalone/cache-disabled/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-image.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/seaweedfs-resources.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/default/kustomization.yaml
+++ b/.github/resources/manifests/standalone/default/kustomization.yaml
@@ -42,6 +42,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-image.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/seaweedfs-resources.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/proxy/kustomization.yaml
+++ b/.github/resources/manifests/standalone/proxy/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-image.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/seaweedfs-resources.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/tls-enabled/kustomization.yaml
+++ b/.github/resources/manifests/standalone/tls-enabled/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../../base/seaweedfs-image.yaml
+    target:
+      kind: Deployment
+      name: seaweedfs
   - path: ../../base/seaweedfs-resources.yaml
     target:
       kind: Deployment


### PR DESCRIPTION
## Summary
- Add a shared CI kustomize patch that renders SeaweedFS as `ghcr.io/chrislusf/seaweedfs:4.18`.
- Apply the patch to the standalone, multi-user, and Kubernetes-native CI install overlays.
- Leave the product/base install manifests unchanged.

## Why
CI hit Docker Hub unauthenticated pull-rate limiting while pulling `chrislusf/seaweedfs:4.18`. Pulling SeaweedFS from upstream GHCR reduces Docker Hub rate-limit pressure in CI without changing the SeaweedFS version.

## Upstream image evidence
- SeaweedFS tag `4.18` uses the release workflow on tag pushes and derives `RELEASE_TAG` from `github.ref_name`: https://github.com/seaweedfs/seaweedfs/blob/4.18/.github/workflows/container_release_unified.yml#L3-L34
- The release build pushes the image to `ghcr.io/chrislusf/seaweedfs:${RELEASE_TAG}`: https://github.com/seaweedfs/seaweedfs/blob/4.18/.github/workflows/container_release_unified.yml#L151-L163
- The `copy-to-dockerhub` job copies the multi-arch image from GHCR to Docker Hub with `crane copy`: https://github.com/seaweedfs/seaweedfs/blob/4.18/.github/workflows/container_release_unified.yml#L179-L257
- The upstream GitHub Actions run for tag `4.18` completed successfully, including `copy-to-dockerhub (normal)`: https://github.com/seaweedfs/seaweedfs/actions/runs/23878806737
- I also verified with `docker manifest inspect` that the Linux child digests match between `ghcr.io/chrislusf/seaweedfs:4.18` and `chrislusf/seaweedfs:4.18` for `amd64`, `arm64`, `arm`, and `386`.

## Verification
- `git diff --check`
- Rendered all CI overlays under `.github/resources/manifests` with `kubectl kustomize --load-restrictor LoadRestrictionsNone`; 10 overlays rendered `ghcr.io/chrislusf/seaweedfs:4.18` and none rendered `chrislusf/seaweedfs:4.18`.
