### PR TITLE
chore(deps): bump remaining backend Go builder images to golang:1.26.3

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/kubeflow/pipelines/api
 
 go 1.26
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250715232539-7130f93afb79

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # 1. Build api server application
-FROM golang:1.26.2-bookworm@sha256:47ce5636e9936b2c5cbf708925578ef386b4f8872aec74a67bd13a627d242b19 AS builder
+FROM golang:1.26.3-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b AS builder
 RUN apt-get update && apt-get install -y cmake clang musl-dev openssl
 WORKDIR /go/src/github.com/kubeflow/pipelines
 

--- a/backend/Dockerfile.cacheserver
+++ b/backend/Dockerfile.cacheserver
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for building the source code of cache_server
-FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 as builder
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d as builder
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh gcc musl-dev

--- a/backend/Dockerfile.conformance
+++ b/backend/Dockerfile.conformance
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Dockerfile for building the source code of conformance tests
-FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 as builder
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d as builder
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh gcc musl-dev

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 
 # Needed musl-dev for github.com/mattn/go-sqlite3
 RUN apk update && apk upgrade && \

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
 
 # Needed musl-dev for github.com/mattn/go-sqlite3
 RUN apk update && apk upgrade && \

--- a/backend/Dockerfile.viewercontroller
+++ b/backend/Dockerfile.viewercontroller
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 as builder
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d as builder
 
 RUN apk update && apk upgrade
 RUN apk add --no-cache git gcc musl-dev

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kubeflow/pipelines
 
 go 1.26
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/Masterminds/squirrel v0.0.0-20190107164353-fa735ea14f09

--- a/kubernetes_platform/go.mod
+++ b/kubernetes_platform/go.mod
@@ -2,7 +2,7 @@ module github.com/kubeflow/pipelines/kubernetes_platform
 
 go 1.26
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/kubeflow/pipelines/api v0.0.0-00010101000000-000000000000


### PR DESCRIPTION
## Summary

Extends the Go builder toolchain bump from #13451 to the remaining backend images and all three \`go.mod\` files.

**Files changed:**
| File | Before | After |
|---|---|---|
| \`backend/Dockerfile\` (API server) | \`golang:1.26.2-bookworm@sha256:47ce5636...\` | \`golang:1.26.3-bookworm@sha256:386d475a...\` |
| \`backend/Dockerfile.cacheserver\` | \`golang:1.26.2-alpine@sha256:f85330846...\` | \`golang:1.26.3-alpine@sha256:91eda9776...\` |
| \`backend/Dockerfile.conformance\` | \`golang:1.26.2-alpine@sha256:f85330846...\` | \`golang:1.26.3-alpine@sha256:91eda9776...\` |
| \`backend/Dockerfile.persistenceagent\` | \`golang:1.26.2-alpine@sha256:f85330846...\` | \`golang:1.26.3-alpine@sha256:91eda9776...\` |
| \`backend/Dockerfile.scheduledworkflow\` | \`golang:1.26.2-alpine@sha256:f85330846...\` | \`golang:1.26.3-alpine@sha256:91eda9776...\` |
| \`backend/Dockerfile.viewercontroller\` | \`golang:1.26.2-alpine@sha256:f85330846...\` | \`golang:1.26.3-alpine@sha256:91eda9776...\` |
| \`go.mod\` | \`toolchain go1.26.2\` | \`toolchain go1.26.3\` |
| \`kubernetes_platform/go.mod\` | \`toolchain go1.26.2\` | \`toolchain go1.26.3\` |
| \`api/go.mod\` | \`toolchain go1.26.2\` | \`toolchain go1.26.3\` |

## Context

This is part of #13449 (tracking Go stdlib and third-party module CVEs in the 2.16.1 \`kfp-driver\` and \`kfp-launcher\` images).

### Dependency PRs from #13449 — all resolved on master

| PR | Dependency | Status |
|---|---|---|
| #13200 | \`github.com/go-jose/go-jose/v4\` 4.1.3 → 4.1.4 | **Merged** |
| #13234 | \`aws/aws-sdk-go-v2/aws/protocol/eventstream\` | **Merged** |
| #13240 | \`go.opentelemetry.io/otel/exporters/otlp/otlpmetrichttp\` | **Merged** |
| #13241 | \`go.opentelemetry.io/otel/sdk\` 1.41.0 → 1.43.0 | **Merged** |
| #13460 | \`argo-workflows\` 3.7.11 → 3.7.14, \`aws-sdk-go-v2/service/s3\` → 1.97.3, \`moby/spdystream\` → 0.5.1 | **Merged** (superseded #13308, #13235, #13285) |

### Go toolchain PRs

| PR | Change | Status |
|---|---|---|
| #13451 | \`kfp-driver\` + \`kfp-launcher\` builder: \`golang:1.26.2\` → \`golang:1.26.3\` | **Open** |
| This PR | Remaining 5 backend images + API server + 3 \`go.mod\` toolchain directives | **This PR** |

The \`go.mod\` toolchain directive update was flagged by reviewer @hbelmiro on #13451. Keeping the \`toolchain\` directive in sync with the builder image ensures \`go mod\` and toolchain auto-selection behave consistently.

**Note on \`release-2.16\`:** The \`release-2.16\` branch still uses \`golang:1.24-alpine\`. Per the remediation strategy in #13449 — *master first, then decide on a 2.16.2 patch release after verification* — that backport is a separate, subsequent step for maintainers to decide on after master scans are clean.

## Verification

```bash
# Build each image and confirm no stdlib findings in Trivy
docker build -f backend/Dockerfile.cacheserver       -t kfp-cache:go1.26.3-test .
docker build -f backend/Dockerfile.persistenceagent  -t kfp-pa:go1.26.3-test .
docker build -f backend/Dockerfile.scheduledworkflow -t kfp-sw:go1.26.3-test .
docker build -f backend/Dockerfile.viewercontroller  -t kfp-vc:go1.26.3-test .
docker build -f backend/Dockerfile.conformance       -t kfp-conf:go1.26.3-test .
docker build -f backend/Dockerfile                   -t kfp-api:go1.26.3-test .

trivy image --scanners vuln --format table kfp-cache:go1.26.3-test
trivy image --scanners vuln --format table kfp-pa:go1.26.3-test
trivy image --scanners vuln --format table kfp-sw:go1.26.3-test
trivy image --scanners vuln --format table kfp-vc:go1.26.3-test
trivy image --scanners vuln --format table kfp-conf:go1.26.3-test
trivy image --scanners vuln --format table kfp-api:go1.26.3-test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)