### PR TITLE
test(e2e): poll MLflow status after retry run failure

### DIFF
--- a/backend/test/end2end/mlflow_e2e_test.go
+++ b/backend/test/end2end/mlflow_e2e_test.go
@@ -518,7 +518,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 				"Retried pipeline run should still be FAILED (fail_v2 always fails)")
 
 			// Verify the MLflow parent run reflects the retry
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FAILED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FAILED", &timeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify plugins_output is still populated after retry

--- a/backend/test/end2end/utils/mlflow_utils.go
+++ b/backend/test/end2end/utils/mlflow_utils.go
@@ -317,9 +317,40 @@ func VerifyMLflowRunStatus(endpoint, runID, experimentID, expectedStatus string)
 		return err
 	}
 	if mlflowRun.Info.Status != expectedStatus {
-		return fmt.Errorf("MLflow run %s should have status %s", runID, expectedStatus)
+		return fmt.Errorf("MLflow run %s should have status %s, got %s", runID, expectedStatus, mlflowRun.Info.Status)
 	}
 	return nil
+}
+
+// WaitForMLflowRunStatus polls until the MLflow run reaches expectedStatus or timeout expires.
+func WaitForMLflowRunStatus(endpoint, runID, experimentID, expectedStatus string, timeout *time.Duration) error {
+	ginkgo.GinkgoHelper()
+	logger.Log("Waiting for MLflow run %s to reach status %s", runID, expectedStatus)
+	maxTimeToWait := time.Duration(300)
+	pollTime := time.Duration(5)
+	if timeout != nil {
+		maxTimeToWait = *timeout
+	}
+	deadline := time.Now().Add(maxTimeToWait * time.Second)
+	ticker := time.NewTicker(pollTime * time.Second)
+	defer ticker.Stop()
+	for {
+		err := VerifyMLflowRunStatus(endpoint, runID, experimentID, expectedStatus)
+		if err == nil {
+			logger.Log("MLflow run %s reached expected status %s", runID, expectedStatus)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return err
+		}
+		mlflowRun, queryErr := QueryMLflowRunByID(endpoint, runID, experimentID)
+		if queryErr == nil {
+			logger.Log("MLflow run %s is in %s status, waiting for %s...", runID, mlflowRun.Info.Status, expectedStatus)
+		} else {
+			logger.Log("MLflow run %s status check failed, retrying: %v", runID, queryErr)
+		}
+		<-ticker.C
+	}
 }
 
 func VerifyMLflowRunTags(endpoint, runID, experimentID string, expectedTags map[string]string) error {


### PR DESCRIPTION
**Description of your changes:**

This PR fixes the intermittent failures observed in MLflow retry run Integration test. Here is a recent test [failure](https://github.com/kubeflow/pipelines/actions/runs/26760360864/job/78887213801?pr=13441).

Fixes the race in the MLflow retry E2E test where the test asserted MLflow parent run status immediately after KFP reached a terminal state. This PR adds WaitForMLflowRunStatus, and uses it in the retry test instead of  VerifyMLflowRunStatus.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
