### PR TITLE
feat(backend): enable create and schedule time placeholders

### DIFF
--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -20,9 +20,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/spf13/viper"
+	argoclient "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
+	workflowcommon "github.com/argoproj/argo-workflows/v3/workflow/common"
 	"google.golang.org/protobuf/encoding/protojson"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -57,16 +62,18 @@ const (
 
 var (
 	// inputs
-	driverType        = flag.String(driverTypeArg, "", "task driver type, one of ROOT_DAG, DAG, CONTAINER")
-	pipelineName      = flag.String("pipeline_name", "", "pipeline context name")
-	runID             = flag.String("run_id", "", "pipeline run uid")
-	runName           = flag.String("run_name", "", "pipeline run name (Kubernetes object name)")
-	runDisplayName    = flag.String("run_display_name", "", "pipeline run display name")
-	componentSpecJson = flag.String("component", "{}", "component spec")
-	taskSpecJson      = flag.String("task", "", "task spec")
-	runtimeConfigJson = flag.String("runtime_config", "", "jobruntime config")
-	iterationIndex    = flag.Int("iteration_index", -1, "iteration index, -1 means not an interation")
-	taskName          = flag.String("task_name", "", "original task name, used for proper input resolution in the container/dag driver")
+	driverType                      = flag.String(driverTypeArg, "", "task driver type, one of ROOT_DAG, DAG, CONTAINER")
+	pipelineName                    = flag.String("pipeline_name", "", "pipeline context name")
+	runID                           = flag.String("run_id", "", "pipeline run uid")
+	runName                         = flag.String("run_name", "", "pipeline run name (Kubernetes object name)")
+	runDisplayName                  = flag.String("run_display_name", "", "pipeline run display name")
+	pipelineJobCreateTimeUTCArg     = flag.String("pipeline_job_create_time_utc", "", "pipeline job creation time in UTC")
+	pipelineJobScheduleTimeEpochArg = flag.String("pipeline_job_schedule_time_epoch_seconds", "", "pipeline job scheduled time as Unix epoch seconds")
+	componentSpecJSON               = flag.String("component", "{}", "component spec")
+	taskSpecJSON                    = flag.String("task", "", "task spec")
+	runtimeConfigJSON               = flag.String("runtime_config", "", "jobruntime config")
+	iterationIndex                  = flag.Int("iteration_index", -1, "iteration index, -1 means not an interation")
+	taskName                        = flag.String("task_name", "", "original task name, used for proper input resolution in the container/dag driver")
 
 	// container inputs
 	dagExecutionID    = flag.Int64("dag_execution_id", 0, "DAG execution ID")
@@ -145,6 +152,94 @@ func validate() error {
 	return nil
 }
 
+// getCurrentWorkflowMetadata returns the owning Argo Workflow metadata for the
+// current driver pod.
+//
+// The compiler can safely pass workflow creation time directly via
+// {{workflow.creationTimestamp}}, but recurring-run schedule time is stored in
+// the workflowEpoch label and that label is absent for ad hoc runs. Referencing
+// the label directly from the compiled template causes Argo to reject manual
+// runs before the driver starts, so the driver resolves the label at runtime
+// from the Workflow object instead.
+func getCurrentWorkflowMetadata(ctx context.Context, namespace string) (*metav1.ObjectMeta, error) {
+	restConfig, err := util.GetKubernetesConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize kubernetes config for workflow metadata: %w", err)
+	}
+	k8sClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize kubernetes client for workflow metadata: %w", err)
+	}
+	podName, err := config.InPodName()
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine driver pod name: %w", err)
+	}
+	pod, err := k8sClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve driver pod %q: %w", podName, err)
+	}
+	workflowName := pod.Labels[workflowcommon.LabelKeyWorkflow]
+	if workflowName == "" {
+		return nil, nil
+	}
+	argoClient, err := argoclient.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize argo client for workflow metadata: %w", err)
+	}
+	workflow, err := argoClient.ArgoprojV1alpha1().Workflows(namespace).Get(ctx, workflowName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve workflow %q: %w", workflowName, err)
+	}
+	return &workflow.ObjectMeta, nil
+}
+
+// resolvePipelineJobScheduleTimeUTCFromWorkflow returns the exact recurring-run
+// schedule time when workflowEpoch is present and otherwise falls back to the
+// workflow creation time for manual runs.
+func resolvePipelineJobScheduleTimeUTCFromWorkflow(
+	workflowMeta *metav1.ObjectMeta,
+	fallbackCreateTimeUTC string,
+) string {
+	if workflowMeta == nil {
+		return fallbackCreateTimeUTC
+	}
+	createTimeUTC := fallbackCreateTimeUTC
+	if createTimeUTC == "" {
+		createTimeUTC = workflowMeta.CreationTimestamp.Time.UTC().Format(time.RFC3339)
+	}
+	value, ok := workflowMeta.Labels[util.LabelKeyWorkflowEpoch]
+	if !ok {
+		return createTimeUTC
+	}
+	scheduledEpochSeconds, err := util.RetrieveInt64FromLabel(value)
+	if err != nil {
+		return createTimeUTC
+	}
+	return time.Unix(scheduledEpochSeconds, 0).UTC().Format(time.RFC3339)
+}
+
+// resolvePipelineJobTimes normalizes the placeholder inputs into the UTC values
+// consumed by driver.Options. Schedule time may come from the compiled flag
+// when explicitly provided, or from workflow metadata when manual runs would
+// otherwise have no workflowEpoch label to resolve.
+func resolvePipelineJobTimes(
+	createTimeUTC string,
+	scheduleTimeEpochSeconds string,
+	workflowMeta *metav1.ObjectMeta,
+) (string, string, error) {
+	if createTimeUTC == "" && workflowMeta != nil {
+		createTimeUTC = workflowMeta.CreationTimestamp.Time.UTC().Format(time.RFC3339)
+	}
+	if scheduleTimeEpochSeconds == "" {
+		return createTimeUTC, resolvePipelineJobScheduleTimeUTCFromWorkflow(workflowMeta, createTimeUTC), nil
+	}
+	scheduleTimeEpoch, err := strconv.ParseInt(scheduleTimeEpochSeconds, 10, 64)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid pipeline job schedule time epoch seconds %q: %w", scheduleTimeEpochSeconds, err)
+	}
+	return createTimeUTC, time.Unix(scheduleTimeEpoch, 0).UTC().Format(time.RFC3339), nil
+}
+
 func drive() (err error) {
 	defer func() {
 		if err != nil {
@@ -158,28 +253,28 @@ func drive() (err error) {
 
 	// Support reading component spec from a file if value starts with @
 	// This bypasses exec() argument size limits for large workflows
-	if strings.HasPrefix(*componentSpecJson, "@") {
-		filePath := (*componentSpecJson)[1:] // Remove the "@" prefix
+	if strings.HasPrefix(*componentSpecJSON, "@") {
+		filePath := (*componentSpecJSON)[1:] // Remove the "@" prefix
 		data, err := os.ReadFile(filePath)
 		if err != nil {
 			return fmt.Errorf("failed to read component spec from file %s: %w", filePath, err)
 		}
-		*componentSpecJson = string(data)
+		*componentSpecJSON = string(data)
 		glog.Infof("Read component spec from file: %s (%d bytes)", filePath, len(data))
 	}
 
 	proxy.InitializeConfig(*httpProxy, *httpsProxy, *noProxy)
-	glog.Infof("input ComponentSpec:%s\n", prettyPrint(*componentSpecJson))
+	glog.Infof("input ComponentSpec:%s\n", prettyPrint(*componentSpecJSON))
 	componentSpec := &pipelinespec.ComponentSpec{}
-	if err := util.UnmarshalString(*componentSpecJson, componentSpec); err != nil {
-		return fmt.Errorf("failed to unmarshal component spec, error: %w\ncomponentSpec: %v", err, prettyPrint(*componentSpecJson))
+	if err := util.UnmarshalString(*componentSpecJSON, componentSpec); err != nil {
+		return fmt.Errorf("failed to unmarshal component spec, error: %w\ncomponentSpec: %v", err, prettyPrint(*componentSpecJSON))
 	}
 	var taskSpec *pipelinespec.PipelineTaskSpec
-	if *taskSpecJson != "" {
-		glog.Infof("input TaskSpec:%s\n", prettyPrint(*taskSpecJson))
+	if *taskSpecJSON != "" {
+		glog.Infof("input TaskSpec:%s\n", prettyPrint(*taskSpecJSON))
 		taskSpec = &pipelinespec.PipelineTaskSpec{}
-		if err := util.UnmarshalString(*taskSpecJson, taskSpec); err != nil {
-			return fmt.Errorf("failed to unmarshal task spec, error: %w\ntask: %v", err, taskSpecJson)
+		if err := util.UnmarshalString(*taskSpecJSON, taskSpec); err != nil {
+			return fmt.Errorf("failed to unmarshal task spec, error: %w\ntask: %v", err, taskSpecJSON)
 		}
 	}
 	glog.Infof("input ContainerSpec:%s\n", prettyPrint(*containerSpecJson))
@@ -188,11 +283,11 @@ func drive() (err error) {
 		return fmt.Errorf("failed to unmarshal container spec, error: %w\ncontainerSpec: %v", err, containerSpecJson)
 	}
 	var runtimeConfig *pipelinespec.PipelineJob_RuntimeConfig
-	if *runtimeConfigJson != "" {
-		glog.Infof("input RuntimeConfig:%s\n", prettyPrint(*runtimeConfigJson))
+	if *runtimeConfigJSON != "" {
+		glog.Infof("input RuntimeConfig:%s\n", prettyPrint(*runtimeConfigJSON))
 		runtimeConfig = &pipelinespec.PipelineJob_RuntimeConfig{}
-		if err := util.UnmarshalString(*runtimeConfigJson, runtimeConfig); err != nil {
-			return fmt.Errorf("failed to unmarshal runtime config, error: %w\nruntimeConfig: %v", err, runtimeConfigJson)
+		if err := util.UnmarshalString(*runtimeConfigJSON, runtimeConfig); err != nil {
+			return fmt.Errorf("failed to unmarshal runtime config, error: %w\nruntimeConfig: %v", err, runtimeConfigJSON)
 		}
 	}
 	k8sExecCfg, err := parseExecConfigJson(k8sExecConfigJson)
@@ -218,6 +313,7 @@ func drive() (err error) {
 	if err != nil {
 		return err
 	}
+<<<<<<< HEAD
 	// pluginDispatcher executes task-level plugin lifecycle hooks
 	pluginDispatcher, err := plugins.GetPluginDispatcher()
 	if err != nil {
@@ -246,6 +342,47 @@ func drive() (err error) {
 		MLMDTLSEnabled:          *metadataTLSEnabled,
 		CaCertPath:              *caCertPath,
 		PluginDispatcher:        pluginDispatcher,
+=======
+	var workflowMeta *metav1.ObjectMeta
+	if *pipelineJobCreateTimeUTCArg == "" || *pipelineJobScheduleTimeEpochArg == "" {
+		workflowMeta, err = getCurrentWorkflowMetadata(context.Background(), namespace)
+		if err != nil {
+			return err
+		}
+	}
+	resolvedPipelineJobCreateTimeUTC, resolvedPipelineJobScheduleTimeUTC, err := resolvePipelineJobTimes(
+		*pipelineJobCreateTimeUTCArg,
+		*pipelineJobScheduleTimeEpochArg,
+		workflowMeta,
+	)
+	if err != nil {
+		return err
+	}
+	options := driver.Options{
+		PipelineName:               *pipelineName,
+		RunID:                      *runID,
+		RunName:                    *runName,
+		RunDisplayName:             *runDisplayName,
+		PipelineJobCreateTimeUTC:   resolvedPipelineJobCreateTimeUTC,
+		PipelineJobScheduleTimeUTC: resolvedPipelineJobScheduleTimeUTC,
+		Namespace:                  namespace,
+		Component:                  componentSpec,
+		Task:                       taskSpec,
+		DAGExecutionID:             *dagExecutionID,
+		IterationIndex:             *iterationIndex,
+		PipelineLogLevel:           *logLevel,
+		PublishLogs:                *publishLogs,
+		CacheDisabled:              *cacheDisabledFlag,
+		DriverType:                 *driverType,
+		TaskName:                   *taskName,
+		MLPipelineServerAddress:    *mlPipelineServerAddress,
+		MLPipelineServerPort:       *mlPipelineServerPort,
+		MLMDServerAddress:          *mlmdServerAddress,
+		MLMDServerPort:             *mlmdServerPort,
+		MLPipelineTLSEnabled:       *mlPipelineTLSEnabled,
+		MLMDTLSEnabled:             *metadataTLSEnabled,
+		CaCertPath:                 *caCertPath,
+>>>>>>> 647b51dba (feat(backend): enable create and schedule time placeholders)
 	}
 	var execution *driver.Execution
 	var driverErr error

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -48,14 +48,16 @@ import (
 )
 
 const (
-	driverTypeArg      = "type"
-	httpProxyArg       = "http_proxy"
-	httpsProxyArg      = "https_proxy"
-	noProxyArg         = "no_proxy"
-	unsetProxyArgValue = "unset"
-	ROOT_DAG           = "ROOT_DAG"
-	DAG                = "DAG"
-	CONTAINER          = "CONTAINER"
+	driverTypeArg                         = "type"
+	httpProxyArg                          = "http_proxy"
+	httpsProxyArg                         = "https_proxy"
+	noProxyArg                            = "no_proxy"
+	unsetProxyArgValue                    = "unset"
+	ROOT_DAG                              = "ROOT_DAG" //nolint
+	DAG                                   = "DAG"
+	CONTAINER                             = "CONTAINER"
+	pipelineJobCreateTimeUTCPlaceholder   = "{{$.pipeline_job_create_time_utc}}"
+	pipelineJobScheduleTimeUTCPlaceholder = "{{$.pipeline_job_schedule_time_utc}}"
 )
 
 var (
@@ -182,24 +184,69 @@ func getCurrentWorkflowMetadata(ctx context.Context, namespace string, workflowN
 
 type workflowMetadataGetter func(ctx context.Context, namespace string, workflowName string) (*metav1.ObjectMeta, error)
 
-// getWorkflowMetadataForPipelineJobTimes loads Workflow metadata only when a
-// placeholder still needs runtime metadata. If create time is already available,
-// schedule-time lookup is best-effort so clusters without Workflow read RBAC
-// still resolve placeholders by falling back to create time.
+type pipelineJobTimePlaceholderUsage struct {
+	needsCreateTime   bool
+	needsScheduleTime bool
+}
+
+// getPipelineJobTimePlaceholderUsage reports whether the current driver can
+// resolve pipeline job time placeholders from task input runtime values.
+//
+// Only DAG and CONTAINER drivers call resolveInputs for the current task, and
+// the resolver substitutes pipeline job time placeholders only when a task
+// input parameter is a runtime-value constant matching the placeholder.
+func getPipelineJobTimePlaceholderUsage(
+	driverType string,
+	taskSpec *pipelinespec.PipelineTaskSpec,
+) pipelineJobTimePlaceholderUsage {
+	usage := pipelineJobTimePlaceholderUsage{}
+	if driverType == ROOT_DAG || taskSpec == nil {
+		return usage
+	}
+	for _, inputParamSpec := range taskSpec.GetInputs().GetParameters() {
+		runtimeValue := inputParamSpec.GetRuntimeValue()
+		if runtimeValue == nil {
+			continue
+		}
+		constant := runtimeValue.GetConstant()
+		if constant == nil {
+			continue
+		}
+		switch constant.GetStringValue() {
+		case pipelineJobCreateTimeUTCPlaceholder:
+			usage.needsCreateTime = true
+		case pipelineJobScheduleTimeUTCPlaceholder:
+			usage.needsScheduleTime = true
+		}
+		if usage.needsCreateTime && usage.needsScheduleTime {
+			return usage
+		}
+	}
+	return usage
+}
+
+// getWorkflowMetadataForPipelineJobTimes loads Workflow metadata only when the
+// current driver still needs unresolved pipeline job time placeholders. If
+// create time is already available and only schedule time still needs runtime
+// metadata, lookup is best-effort so clusters without Workflow read RBAC still
+// resolve schedule time by falling back to create time.
 func getWorkflowMetadataForPipelineJobTimes(
 	ctx context.Context,
 	namespace string,
 	workflowName string,
+	placeholderUsage pipelineJobTimePlaceholderUsage,
 	createTimeUTC string,
 	scheduleTimeEpochSeconds string,
 	getMetadata workflowMetadataGetter,
 ) (*metav1.ObjectMeta, error) {
-	if createTimeUTC != "" && scheduleTimeEpochSeconds != "" {
+	needsCreateTimeMetadata := placeholderUsage.needsCreateTime && createTimeUTC == ""
+	needsScheduleTimeMetadata := placeholderUsage.needsScheduleTime && scheduleTimeEpochSeconds == ""
+	if !needsCreateTimeMetadata && !needsScheduleTimeMetadata {
 		return nil, nil
 	}
 	workflowMeta, err := getMetadata(ctx, namespace, workflowName)
 	if err != nil {
-		if createTimeUTC != "" && scheduleTimeEpochSeconds == "" {
+		if !needsCreateTimeMetadata && needsScheduleTimeMetadata && createTimeUTC != "" {
 			glog.Warningf(
 				"Failed to retrieve workflow metadata for pipeline job schedule time for workflow %q, falling back to create time: %v",
 				workflowName,
@@ -293,7 +340,7 @@ func drive() (err error) {
 		glog.Infof("input TaskSpec:%s\n", prettyPrint(*taskSpecJSON))
 		taskSpec = &pipelinespec.PipelineTaskSpec{}
 		if err := util.UnmarshalString(*taskSpecJSON, taskSpec); err != nil {
-			return fmt.Errorf("failed to unmarshal task spec, error: %w\ntask: %v", err, taskSpecJSON)
+			return fmt.Errorf("failed to unmarshal task spec, error: %w\ntask: %v", err, prettyPrint(*taskSpecJSON))
 		}
 	}
 	glog.Infof("input ContainerSpec:%s\n", prettyPrint(*containerSpecJson))
@@ -337,10 +384,12 @@ func drive() (err error) {
 	if err != nil {
 		glog.Errorf("Failed to initialize plugin dispatcher: %v", err)
 	}
+	placeholderUsage := getPipelineJobTimePlaceholderUsage(*driverType, taskSpec)
 	workflowMeta, err := getWorkflowMetadataForPipelineJobTimes(
 		ctx,
 		namespace,
 		*runName,
+		placeholderUsage,
 		*pipelineJobCreateTimeUTCArg,
 		*pipelineJobScheduleTimeEpochArg,
 		getCurrentWorkflowMetadata,

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -22,9 +22,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/spf13/viper"
 	argoclient "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
 	workflowcommon "github.com/argoproj/argo-workflows/v3/workflow/common"
+	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -313,39 +313,14 @@ func drive() (err error) {
 	if err != nil {
 		return err
 	}
-<<<<<<< HEAD
 	// pluginDispatcher executes task-level plugin lifecycle hooks
 	pluginDispatcher, err := plugins.GetPluginDispatcher()
 	if err != nil {
 		glog.Errorf("Failed to initialize plugin dispatcher: %v", err)
 	}
-	options := driver.Options{
-		PipelineName:            *pipelineName,
-		RunID:                   *runID,
-		RunName:                 *runName,
-		RunDisplayName:          *runDisplayName,
-		Namespace:               namespace,
-		Component:               componentSpec,
-		Task:                    taskSpec,
-		DAGExecutionID:          *dagExecutionID,
-		IterationIndex:          *iterationIndex,
-		PipelineLogLevel:        *logLevel,
-		PublishLogs:             *publishLogs,
-		CacheDisabled:           *cacheDisabledFlag,
-		DriverType:              *driverType,
-		TaskName:                *taskName,
-		MLPipelineServerAddress: *mlPipelineServerAddress,
-		MLPipelineServerPort:    *mlPipelineServerPort,
-		MLMDServerAddress:       *mlmdServerAddress,
-		MLMDServerPort:          *mlmdServerPort,
-		MLPipelineTLSEnabled:    *mlPipelineTLSEnabled,
-		MLMDTLSEnabled:          *metadataTLSEnabled,
-		CaCertPath:              *caCertPath,
-		PluginDispatcher:        pluginDispatcher,
-=======
 	var workflowMeta *metav1.ObjectMeta
 	if *pipelineJobCreateTimeUTCArg == "" || *pipelineJobScheduleTimeEpochArg == "" {
-		workflowMeta, err = getCurrentWorkflowMetadata(context.Background(), namespace)
+		workflowMeta, err = getCurrentWorkflowMetadata(ctx, namespace)
 		if err != nil {
 			return err
 		}
@@ -382,7 +357,7 @@ func drive() (err error) {
 		MLPipelineTLSEnabled:       *mlPipelineTLSEnabled,
 		MLMDTLSEnabled:             *metadataTLSEnabled,
 		CaCertPath:                 *caCertPath,
->>>>>>> 647b51dba (feat(backend): enable create and schedule time placeholders)
+		PluginDispatcher:           pluginDispatcher,
 	}
 	var execution *driver.Execution
 	var driverErr error

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	argoclient "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
+	argoclient "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned"
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -23,11 +23,9 @@ import (
 	"time"
 
 	argoclient "github.com/argoproj/argo-workflows/v3/pkg/client/clientset/versioned"
-	workflowcommon "github.com/argoproj/argo-workflows/v3/workflow/common"
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -152,35 +150,24 @@ func validate() error {
 	return nil
 }
 
-// getCurrentWorkflowMetadata returns the owning Argo Workflow metadata for the
-// current driver pod.
+// getCurrentWorkflowMetadata returns metadata for the Argo Workflow backing the
+// current run.
 //
 // The compiler can safely pass workflow creation time directly via
 // {{workflow.creationTimestamp}}, but recurring-run schedule time is stored in
 // the workflowEpoch label and that label is absent for ad hoc runs. Referencing
 // the label directly from the compiled template causes Argo to reject manual
 // runs before the driver starts, so the driver resolves the label at runtime
-// from the Workflow object instead.
-func getCurrentWorkflowMetadata(ctx context.Context, namespace string) (*metav1.ObjectMeta, error) {
+// from the Workflow object instead. The driver already receives --run_name as
+// {{workflow.name}}, so it can read the Workflow directly without first looking
+// up its own Pod.
+func getCurrentWorkflowMetadata(ctx context.Context, namespace string, workflowName string) (*metav1.ObjectMeta, error) {
+	if workflowName == "" {
+		return nil, fmt.Errorf("workflow name is empty")
+	}
 	restConfig, err := util.GetKubernetesConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize kubernetes config for workflow metadata: %w", err)
-	}
-	k8sClient, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize kubernetes client for workflow metadata: %w", err)
-	}
-	podName, err := config.InPodName()
-	if err != nil {
-		return nil, fmt.Errorf("failed to determine driver pod name: %w", err)
-	}
-	pod, err := k8sClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve driver pod %q: %w", podName, err)
-	}
-	workflowName := pod.Labels[workflowcommon.LabelKeyWorkflow]
-	if workflowName == "" {
-		return nil, nil
 	}
 	argoClient, err := argoclient.NewForConfig(restConfig)
 	if err != nil {
@@ -191,6 +178,38 @@ func getCurrentWorkflowMetadata(ctx context.Context, namespace string) (*metav1.
 		return nil, fmt.Errorf("failed to retrieve workflow %q: %w", workflowName, err)
 	}
 	return &workflow.ObjectMeta, nil
+}
+
+type workflowMetadataGetter func(ctx context.Context, namespace string, workflowName string) (*metav1.ObjectMeta, error)
+
+// getWorkflowMetadataForPipelineJobTimes loads Workflow metadata only when a
+// placeholder still needs runtime metadata. If create time is already available,
+// schedule-time lookup is best-effort so clusters without Workflow read RBAC
+// still resolve placeholders by falling back to create time.
+func getWorkflowMetadataForPipelineJobTimes(
+	ctx context.Context,
+	namespace string,
+	workflowName string,
+	createTimeUTC string,
+	scheduleTimeEpochSeconds string,
+	getMetadata workflowMetadataGetter,
+) (*metav1.ObjectMeta, error) {
+	if createTimeUTC != "" && scheduleTimeEpochSeconds != "" {
+		return nil, nil
+	}
+	workflowMeta, err := getMetadata(ctx, namespace, workflowName)
+	if err != nil {
+		if createTimeUTC != "" && scheduleTimeEpochSeconds == "" {
+			glog.Warningf(
+				"Failed to retrieve workflow metadata for pipeline job schedule time for workflow %q, falling back to create time: %v",
+				workflowName,
+				err,
+			)
+			return nil, nil
+		}
+		return nil, err
+	}
+	return workflowMeta, nil
 }
 
 // resolvePipelineJobScheduleTimeUTCFromWorkflow returns the exact recurring-run
@@ -318,12 +337,16 @@ func drive() (err error) {
 	if err != nil {
 		glog.Errorf("Failed to initialize plugin dispatcher: %v", err)
 	}
-	var workflowMeta *metav1.ObjectMeta
-	if *pipelineJobCreateTimeUTCArg == "" || *pipelineJobScheduleTimeEpochArg == "" {
-		workflowMeta, err = getCurrentWorkflowMetadata(ctx, namespace)
-		if err != nil {
-			return err
-		}
+	workflowMeta, err := getWorkflowMetadataForPipelineJobTimes(
+		ctx,
+		namespace,
+		*runName,
+		*pipelineJobCreateTimeUTCArg,
+		*pipelineJobScheduleTimeEpochArg,
+		getCurrentWorkflowMetadata,
+	)
+	if err != nil {
+		return err
 	}
 	resolvedPipelineJobCreateTimeUTC, resolvedPipelineJobScheduleTimeUTC, err := resolvePipelineJobTimes(
 		*pipelineJobCreateTimeUTCArg,

--- a/backend/src/v2/cmd/driver/main_test.go
+++ b/backend/src/v2/cmd/driver/main_test.go
@@ -6,16 +6,30 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/v2/driver"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func strPtr(s string) *string {
 	return &s
+}
+
+func runtimeValueConstant(value string) *pipelinespec.TaskInputsSpec_InputParameterSpec {
+	return &pipelinespec.TaskInputsSpec_InputParameterSpec{
+		Kind: &pipelinespec.TaskInputsSpec_InputParameterSpec_RuntimeValue{
+			RuntimeValue: &pipelinespec.ValueOrRuntimeParameter{
+				Value: &pipelinespec.ValueOrRuntimeParameter_Constant{
+					Constant: structpb.NewStringValue(value),
+				},
+			},
+		},
+	}
 }
 
 func TestSpecParsing(t *testing.T) {
@@ -52,6 +66,66 @@ func TestSpecParsing(t *testing.T) {
 		cfg, err := parseExecConfigJson(tc.input)
 		assert.Equal(t, tc.wantErr, err != nil)
 		assert.True(t, proto.Equal(tc.expected, cfg))
+	}
+}
+
+func TestGetPipelineJobTimePlaceholderUsage(t *testing.T) {
+	tests := []struct {
+		name       string
+		driverType string
+		taskSpec   *pipelinespec.PipelineTaskSpec
+		want       pipelineJobTimePlaceholderUsage
+	}{
+		{
+			name:       "root dag skips placeholder lookup",
+			driverType: ROOT_DAG,
+			taskSpec: &pipelinespec.PipelineTaskSpec{
+				Inputs: &pipelinespec.TaskInputsSpec{
+					Parameters: map[string]*pipelinespec.TaskInputsSpec_InputParameterSpec{
+						"create_time": runtimeValueConstant(pipelineJobCreateTimeUTCPlaceholder),
+						"schedule_time": runtimeValueConstant(
+							pipelineJobScheduleTimeUTCPlaceholder,
+						),
+					},
+				},
+			},
+		},
+		{
+			name:       "nil task spec has no placeholder usage",
+			driverType: DAG,
+		},
+		{
+			name:       "tracks create and schedule placeholder usage from task inputs",
+			driverType: CONTAINER,
+			taskSpec: &pipelinespec.PipelineTaskSpec{
+				Inputs: &pipelinespec.TaskInputsSpec{
+					Parameters: map[string]*pipelinespec.TaskInputsSpec_InputParameterSpec{
+						"create_time":   runtimeValueConstant(pipelineJobCreateTimeUTCPlaceholder),
+						"schedule_time": runtimeValueConstant(pipelineJobScheduleTimeUTCPlaceholder),
+						"literal":       runtimeValueConstant("literal-value"),
+						"component_input": {
+							Kind: &pipelinespec.TaskInputsSpec_InputParameterSpec_ComponentInputParameter{
+								ComponentInputParameter: "pipeline-input",
+							},
+						},
+					},
+				},
+			},
+			want: pipelineJobTimePlaceholderUsage{
+				needsCreateTime:   true,
+				needsScheduleTime: true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(
+				t,
+				tc.want,
+				getPipelineJobTimePlaceholderUsage(tc.driverType, tc.taskSpec),
+			)
+		})
 	}
 }
 
@@ -140,6 +214,7 @@ func TestGetWorkflowMetadataForPipelineJobTimes(t *testing.T) {
 
 	tests := []struct {
 		name                     string
+		placeholderUsage         pipelineJobTimePlaceholderUsage
 		createTimeUTC            string
 		scheduleTimeEpochSeconds string
 		getterResult             *metav1.ObjectMeta
@@ -149,29 +224,49 @@ func TestGetWorkflowMetadataForPipelineJobTimes(t *testing.T) {
 		wantGetterCalls          int
 	}{
 		{
-			name:                     "skips lookup when both values are already provided",
-			createTimeUTC:            "2026-01-02T03:04:05Z",
+			name:            "skips lookup when current task does not use placeholders",
+			wantGetterCalls: 0,
+		},
+		{
+			name:             "skips lookup when create placeholder already has compiled value",
+			placeholderUsage: pipelineJobTimePlaceholderUsage{needsCreateTime: true},
+			createTimeUTC:    "2026-01-02T03:04:05Z",
+			wantGetterCalls:  0,
+		},
+		{
+			name:                     "skips lookup when schedule placeholder already has compiled value",
+			placeholderUsage:         pipelineJobTimePlaceholderUsage{needsScheduleTime: true},
 			scheduleTimeEpochSeconds: "1767225600",
 			wantGetterCalls:          0,
 		},
 		{
-			name:            "returns workflow metadata when schedule time needs lookup",
-			createTimeUTC:   "2026-01-02T03:04:05Z",
-			getterResult:    workflowMeta,
-			wantMetadata:    workflowMeta,
-			wantGetterCalls: 1,
+			name:             "returns workflow metadata when schedule time needs lookup",
+			placeholderUsage: pipelineJobTimePlaceholderUsage{needsScheduleTime: true},
+			createTimeUTC:    "2026-01-02T03:04:05Z",
+			getterResult:     workflowMeta,
+			wantMetadata:     workflowMeta,
+			wantGetterCalls:  1,
 		},
 		{
-			name:            "falls back when schedule-time lookup fails",
-			createTimeUTC:   "2026-01-02T03:04:05Z",
-			getterErr:       lookupErr,
-			wantGetterCalls: 1,
+			name:             "falls back when only schedule-time lookup fails",
+			placeholderUsage: pipelineJobTimePlaceholderUsage{needsScheduleTime: true},
+			createTimeUTC:    "2026-01-02T03:04:05Z",
+			getterErr:        lookupErr,
+			wantGetterCalls:  1,
 		},
 		{
-			name:            "fails when create time also requires lookup",
-			getterErr:       lookupErr,
-			wantErr:         true,
-			wantGetterCalls: 1,
+			name:             "fails when create time still needs lookup",
+			placeholderUsage: pipelineJobTimePlaceholderUsage{needsCreateTime: true},
+			getterErr:        lookupErr,
+			wantErr:          true,
+			wantGetterCalls:  1,
+		},
+		{
+			name:             "fails when schedule time needs lookup without create time fallback",
+			placeholderUsage: pipelineJobTimePlaceholderUsage{needsScheduleTime: true},
+			getterErr:        lookupErr,
+			wantErr:          true,
+			wantGetterCalls:  1,
 		},
 	}
 
@@ -182,6 +277,7 @@ func TestGetWorkflowMetadataForPipelineJobTimes(t *testing.T) {
 				context.Background(),
 				"kubeflow",
 				"workflow-name",
+				tc.placeholderUsage,
 				tc.createTimeUTC,
 				tc.scheduleTimeEpochSeconds,
 				func(ctx context.Context, namespace string, workflowName string) (*metav1.ObjectMeta, error) {

--- a/backend/src/v2/cmd/driver/main_test.go
+++ b/backend/src/v2/cmd/driver/main_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"os"
 	"testing"
+	"time"
 
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/v2/driver"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func strPtr(s string) *string {
@@ -48,6 +51,85 @@ func TestSpecParsing(t *testing.T) {
 		cfg, err := parseExecConfigJson(tc.input)
 		assert.Equal(t, tc.wantErr, err != nil)
 		assert.True(t, proto.Equal(tc.expected, cfg))
+	}
+}
+
+func TestResolvePipelineJobTimes(t *testing.T) {
+	workflowCreationTime := metav1.NewTime(time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+	tt := []struct {
+		name                     string
+		createTimeUTC            string
+		scheduleTimeEpochSeconds string
+		workflowMeta             *metav1.ObjectMeta
+		expectedCreateTimeUTC    string
+		expectedScheduleTimeUTC  string
+		wantErr                  bool
+	}{
+		{
+			name:                    "falls back to create time when schedule label is absent",
+			createTimeUTC:           "2026-01-02T03:04:05Z",
+			expectedCreateTimeUTC:   "2026-01-02T03:04:05Z",
+			expectedScheduleTimeUTC: "2026-01-02T03:04:05Z",
+		},
+		{
+			name:                    "uses workflow creation time when create time arg is absent",
+			workflowMeta:            &metav1.ObjectMeta{CreationTimestamp: workflowCreationTime},
+			expectedCreateTimeUTC:   "2026-01-02T03:04:05Z",
+			expectedScheduleTimeUTC: "2026-01-02T03:04:05Z",
+		},
+		{
+			name:          "uses workflow epoch label for schedule time when present",
+			createTimeUTC: "2026-01-02T03:04:05Z",
+			workflowMeta: &metav1.ObjectMeta{
+				CreationTimestamp: workflowCreationTime,
+				Labels: map[string]string{
+					util.LabelKeyWorkflowEpoch: util.FormatInt64ForLabel(1767225600),
+				},
+			},
+			expectedCreateTimeUTC:   "2026-01-02T03:04:05Z",
+			expectedScheduleTimeUTC: "2026-01-01T00:00:00Z",
+		},
+		{
+			name:          "falls back to workflow creation time when workflow epoch label is invalid",
+			createTimeUTC: "2026-01-02T03:04:05Z",
+			workflowMeta: &metav1.ObjectMeta{
+				CreationTimestamp: workflowCreationTime,
+				Labels: map[string]string{
+					util.LabelKeyWorkflowEpoch: "invalid",
+				},
+			},
+			expectedCreateTimeUTC:   "2026-01-02T03:04:05Z",
+			expectedScheduleTimeUTC: "2026-01-02T03:04:05Z",
+		},
+		{
+			name:                     "converts schedule epoch seconds to UTC",
+			createTimeUTC:            "2026-01-02T03:04:05Z",
+			scheduleTimeEpochSeconds: "1767225600",
+			expectedCreateTimeUTC:    "2026-01-02T03:04:05Z",
+			expectedScheduleTimeUTC:  "2026-01-01T00:00:00Z",
+		},
+		{
+			name:                     "rejects invalid schedule epoch seconds",
+			createTimeUTC:            "2026-01-02T03:04:05Z",
+			scheduleTimeEpochSeconds: "not-an-int",
+			wantErr:                  true,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			actualCreateTimeUTC, actualScheduleTimeUTC, err := resolvePipelineJobTimes(
+				tc.createTimeUTC,
+				tc.scheduleTimeEpochSeconds,
+				tc.workflowMeta,
+			)
+			assert.Equal(t, tc.wantErr, err != nil)
+			if tc.wantErr {
+				return
+			}
+			assert.Equal(t, tc.expectedCreateTimeUTC, actualCreateTimeUTC)
+			assert.Equal(t, tc.expectedScheduleTimeUTC, actualScheduleTimeUTC)
+		})
 	}
 }
 

--- a/backend/src/v2/cmd/driver/main_test.go
+++ b/backend/src/v2/cmd/driver/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -129,6 +130,70 @@ func TestResolvePipelineJobTimes(t *testing.T) {
 			}
 			assert.Equal(t, tc.expectedCreateTimeUTC, actualCreateTimeUTC)
 			assert.Equal(t, tc.expectedScheduleTimeUTC, actualScheduleTimeUTC)
+		})
+	}
+}
+
+func TestGetWorkflowMetadataForPipelineJobTimes(t *testing.T) {
+	workflowMeta := &metav1.ObjectMeta{Name: "workflow-name"}
+	lookupErr := assert.AnError
+
+	tests := []struct {
+		name                     string
+		createTimeUTC            string
+		scheduleTimeEpochSeconds string
+		getterResult             *metav1.ObjectMeta
+		getterErr                error
+		wantMetadata             *metav1.ObjectMeta
+		wantErr                  bool
+		wantGetterCalls          int
+	}{
+		{
+			name:                     "skips lookup when both values are already provided",
+			createTimeUTC:            "2026-01-02T03:04:05Z",
+			scheduleTimeEpochSeconds: "1767225600",
+			wantGetterCalls:          0,
+		},
+		{
+			name:            "returns workflow metadata when schedule time needs lookup",
+			createTimeUTC:   "2026-01-02T03:04:05Z",
+			getterResult:    workflowMeta,
+			wantMetadata:    workflowMeta,
+			wantGetterCalls: 1,
+		},
+		{
+			name:            "falls back when schedule-time lookup fails",
+			createTimeUTC:   "2026-01-02T03:04:05Z",
+			getterErr:       lookupErr,
+			wantGetterCalls: 1,
+		},
+		{
+			name:            "fails when create time also requires lookup",
+			getterErr:       lookupErr,
+			wantErr:         true,
+			wantGetterCalls: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			getterCalls := 0
+			actualMetadata, err := getWorkflowMetadataForPipelineJobTimes(
+				context.Background(),
+				"kubeflow",
+				"workflow-name",
+				tc.createTimeUTC,
+				tc.scheduleTimeEpochSeconds,
+				func(ctx context.Context, namespace string, workflowName string) (*metav1.ObjectMeta, error) {
+					getterCalls++
+					assert.Equal(t, "kubeflow", namespace)
+					assert.Equal(t, "workflow-name", workflowName)
+					return tc.getterResult, tc.getterErr
+				},
+			)
+			assert.Equal(t, tc.wantErr, err != nil)
+			assert.Equal(t, tc.wantGetterCalls, getterCalls)
+			assert.Same(t, tc.wantMetadata, actualMetadata)
 		})
 	}
 }

--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -517,6 +517,10 @@ func runResourceName() string {
 	return "{{workflow.name}}"
 }
 
+func runCreationTimeUTC() string {
+	return "{{workflow.creationTimestamp}}"
+}
+
 func workflowParameter(name string) string {
 	return fmt.Sprintf("{{workflow.parameters.%s}}", name)
 }

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -196,6 +196,7 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 		"--run_id", runID(),
 		"--run_name", runResourceName(),
 		"--run_display_name", c.job.DisplayName,
+		"--pipeline_job_create_time_utc", runCreationTimeUTC(),
 		"--dag_execution_id", inputValue(paramParentDagID),
 		"--component", inputValue(paramComponent),
 		"--task", inputValue(paramTask),

--- a/backend/src/v2/compiler/argocompiler/container_test.go
+++ b/backend/src/v2/compiler/argocompiler/container_test.go
@@ -107,6 +107,31 @@ func TestContainerDriverTemplate_IncludesKFPPodNameEnv(t *testing.T) {
 		"system-container-driver template must include KFP_POD_NAME env var to avoid hostname truncation for long pod names")
 }
 
+func TestContainerDriverTemplate_IncludesPipelineJobCreateTimeArg(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+	c := &workflowCompiler{
+		templates: make(map[string]*wfapi.Template),
+		wf: &wfapi.Workflow{
+			Spec: wfapi.WorkflowSpec{
+				Templates: []wfapi.Template{},
+			},
+		},
+		spec: &pipelinespec.PipelineSpec{
+			PipelineInfo: &pipelinespec.PipelineInfo{Name: "test-pipeline"},
+		},
+		job: &pipelinespec.PipelineJob{},
+	}
+
+	name := c.addContainerDriverTemplate()
+	tmpl, exists := c.templates[name]
+	require.True(t, exists, "system-container-driver template should exist")
+	require.NotNil(t, tmpl.Container, "template should have a container")
+	assert.Contains(t, tmpl.Container.Args, "--pipeline_job_create_time_utc")
+	assert.Contains(t, tmpl.Container.Args, runCreationTimeUTC())
+	assert.Contains(t, tmpl.Container.Args, runCreationTimeUTC())
+	assert.NotContains(t, tmpl.Container.Args, "--pipeline_job_schedule_time_epoch_seconds")
+}
+
 func Test_extendPodMetadata(t *testing.T) {
 	tests := []struct {
 		name                     string

--- a/backend/src/v2/compiler/argocompiler/container_test.go
+++ b/backend/src/v2/compiler/argocompiler/container_test.go
@@ -128,7 +128,6 @@ func TestContainerDriverTemplate_IncludesPipelineJobCreateTimeArg(t *testing.T) 
 	require.NotNil(t, tmpl.Container, "template should have a container")
 	assert.Contains(t, tmpl.Container.Args, "--pipeline_job_create_time_utc")
 	assert.Contains(t, tmpl.Container.Args, runCreationTimeUTC())
-	assert.Contains(t, tmpl.Container.Args, runCreationTimeUTC())
 	assert.NotContains(t, tmpl.Container.Args, "--pipeline_job_schedule_time_epoch_seconds")
 }
 

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -575,6 +575,7 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 		"--run_id", runID(),
 		"--run_name", runResourceName(),
 		"--run_display_name", c.job.DisplayName,
+		"--pipeline_job_create_time_utc", runCreationTimeUTC(),
 		"--dag_execution_id", inputValue(paramParentDagID),
 		"--component", inputValue(paramComponent),
 		"--task", inputValue(paramTask),

--- a/backend/src/v2/compiler/argocompiler/dag_test.go
+++ b/backend/src/v2/compiler/argocompiler/dag_test.go
@@ -184,6 +184,5 @@ func TestDAGDriverTemplate_IncludesPipelineJobCreateTimeArg(t *testing.T) {
 	require.NotNil(t, tmpl.Container, "template should have a container")
 	assert.Contains(t, tmpl.Container.Args, "--pipeline_job_create_time_utc")
 	assert.Contains(t, tmpl.Container.Args, runCreationTimeUTC())
-	assert.Contains(t, tmpl.Container.Args, runCreationTimeUTC())
 	assert.NotContains(t, tmpl.Container.Args, "--pipeline_job_schedule_time_epoch_seconds")
 }

--- a/backend/src/v2/compiler/argocompiler/dag_test.go
+++ b/backend/src/v2/compiler/argocompiler/dag_test.go
@@ -151,3 +151,39 @@ func TestDagDriverTask_TaskNameIncludedInArguments(t *testing.T) {
 	assert.Equal(t, "parent-dag-123", paramMap[paramParentDagID])
 	assert.Equal(t, `{"taskInfo": {"name": "for-loop-task"}}`, paramMap[paramTask])
 }
+
+func TestDAGDriverTemplate_IncludesPipelineJobCreateTimeArg(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+
+	c := &workflowCompiler{
+		templates: make(map[string]*wfapi.Template),
+		wf: &wfapi.Workflow{
+			Spec: wfapi.WorkflowSpec{
+				Templates: []wfapi.Template{},
+			},
+		},
+		spec: &pipelinespec.PipelineSpec{
+			PipelineInfo: &pipelinespec.PipelineInfo{
+				Name: "test-pipeline",
+			},
+		},
+		job: &pipelinespec.PipelineJob{
+			DisplayName: "test-pipeline-run",
+		},
+	}
+
+	name := c.addDAGDriverTemplate()
+	var tmpl *wfapi.Template
+	for index := range c.wf.Spec.Templates {
+		if c.wf.Spec.Templates[index].Name == name {
+			tmpl = &c.wf.Spec.Templates[index]
+			break
+		}
+	}
+	require.NotNil(t, tmpl, "system-dag-driver template should exist")
+	require.NotNil(t, tmpl.Container, "template should have a container")
+	assert.Contains(t, tmpl.Container.Args, "--pipeline_job_create_time_utc")
+	assert.Contains(t, tmpl.Container.Args, runCreationTimeUTC())
+	assert.Contains(t, tmpl.Container.Args, runCreationTimeUTC())
+	assert.NotContains(t, tmpl.Container.Args, "--pipeline_job_schedule_time_epoch_seconds")
+}

--- a/test_data/compiled-workflows/add_numbers.yaml
+++ b/test_data/compiled-workflows/add_numbers.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -294,6 +296,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/arguments_parameters.yaml
+++ b/test_data/compiled-workflows/arguments_parameters.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -285,6 +287,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/artifact_cache.yaml
+++ b/test_data/compiled-workflows/artifact_cache.yaml
@@ -63,6 +63,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -313,6 +315,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/artifact_crust.yaml
+++ b/test_data/compiled-workflows/artifact_crust.yaml
@@ -63,6 +63,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -313,6 +315,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/artifacts_complex.yaml
+++ b/test_data/compiled-workflows/artifacts_complex.yaml
@@ -89,6 +89,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -420,6 +422,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/artifacts_simple.yaml
+++ b/test_data/compiled-workflows/artifacts_simple.yaml
@@ -74,6 +74,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -324,6 +326,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/collected_artifacts.yaml
+++ b/test_data/compiled-workflows/collected_artifacts.yaml
@@ -155,6 +155,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -405,6 +407,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/collected_parameters.yaml
+++ b/test_data/compiled-workflows/collected_parameters.yaml
@@ -90,6 +90,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -365,6 +367,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/component_with_env_variable.yaml
+++ b/test_data/compiled-workflows/component_with_env_variable.yaml
@@ -45,6 +45,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -295,6 +297,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/component_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/component_with_metadata_fields.yaml
@@ -59,6 +59,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -309,6 +311,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/component_with_optional_inputs.yaml
+++ b/test_data/compiled-workflows/component_with_optional_inputs.yaml
@@ -48,6 +48,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -298,6 +300,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/component_with_pip_index_urls.yaml
+++ b/test_data/compiled-workflows/component_with_pip_index_urls.yaml
@@ -46,6 +46,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -296,6 +298,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/component_with_pip_install.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install.yaml
@@ -46,6 +46,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -296,6 +298,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
@@ -47,6 +47,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -297,6 +299,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/components_with_optional_artifacts.yaml
+++ b/test_data/compiled-workflows/components_with_optional_artifacts.yaml
@@ -60,6 +60,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -413,6 +415,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/concat_message.yaml
+++ b/test_data/compiled-workflows/concat_message.yaml
@@ -45,6 +45,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -295,6 +297,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
+++ b/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
@@ -66,6 +66,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -348,6 +350,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/container_component_with_no_inputs.yaml
+++ b/test_data/compiled-workflows/container_component_with_no_inputs.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -285,6 +287,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/container_io.yaml
+++ b/test_data/compiled-workflows/container_io.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -285,6 +287,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/container_no_input.yaml
+++ b/test_data/compiled-workflows/container_no_input.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -285,6 +287,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/container_with_artifact_output.yaml
+++ b/test_data/compiled-workflows/container_with_artifact_output.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -285,6 +287,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/container_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_concat_placeholder.yaml
@@ -36,6 +36,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -286,6 +288,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/container_with_if_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder.yaml
@@ -38,6 +38,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -288,6 +290,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
+++ b/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -285,6 +287,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/containerized_python_component.yaml
+++ b/test_data/compiled-workflows/containerized_python_component.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -285,6 +287,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/create_pod_metadata_complex.yaml
+++ b/test_data/compiled-workflows/create_pod_metadata_complex.yaml
@@ -88,6 +88,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -676,6 +678,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/cross_loop_after_topology.yaml
+++ b/test_data/compiled-workflows/cross_loop_after_topology.yaml
@@ -65,6 +65,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -347,6 +349,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/dict_input.yaml
+++ b/test_data/compiled-workflows/dict_input.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -294,6 +296,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/embedded_artifact.yaml
+++ b/test_data/compiled-workflows/embedded_artifact.yaml
@@ -85,6 +85,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -359,6 +361,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/env-var.yaml
+++ b/test_data/compiled-workflows/env-var.yaml
@@ -46,6 +46,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -296,6 +298,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/fail_v2.yaml
+++ b/test_data/compiled-workflows/fail_v2.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -294,6 +296,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/flip_coin.yaml
+++ b/test_data/compiled-workflows/flip_coin.yaml
@@ -101,6 +101,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -387,6 +389,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/hello_world.yaml
+++ b/test_data/compiled-workflows/hello_world.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -285,6 +287,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/identity.yaml
+++ b/test_data/compiled-workflows/identity.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -294,6 +296,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/if_elif_else_complex.yaml
+++ b/test_data/compiled-workflows/if_elif_else_complex.yaml
@@ -135,6 +135,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -386,6 +388,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
@@ -90,6 +90,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -406,6 +408,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
@@ -81,6 +81,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -363,6 +365,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
@@ -68,6 +68,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -352,6 +354,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/input_artifact.yaml
+++ b/test_data/compiled-workflows/input_artifact.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -294,6 +296,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/iris_pipeline_compiled.yaml
+++ b/test_data/compiled-workflows/iris_pipeline_compiled.yaml
@@ -97,6 +97,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -397,6 +399,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
@@ -99,6 +99,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -374,6 +376,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
@@ -91,6 +91,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -415,6 +417,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/local_execution_pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_exit_handler.yaml
@@ -59,6 +59,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -341,6 +343,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/local_execution_pipeline_with_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_ignore_upstream_failure.yaml
@@ -58,6 +58,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -347,6 +349,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/local_execution_pipeline_with_k8s_only_methods.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_k8s_only_methods.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -294,6 +296,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/local_execution_pipeline_with_oneof.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_oneof.yaml
@@ -78,6 +78,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -360,6 +362,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/local_execution_pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_retry.yaml
@@ -48,6 +48,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -334,6 +336,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/log_streaming_compiled.yaml
+++ b/test_data/compiled-workflows/log_streaming_compiled.yaml
@@ -48,6 +48,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -298,6 +300,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/long-running.yaml
+++ b/test_data/compiled-workflows/long-running.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -310,6 +312,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/loop_consume_upstream.yaml
+++ b/test_data/compiled-workflows/loop_consume_upstream.yaml
@@ -92,6 +92,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -369,6 +371,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/metrics_visualization_v2.yaml
+++ b/test_data/compiled-workflows/metrics_visualization_v2.yaml
@@ -136,6 +136,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -482,6 +484,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
+++ b/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
@@ -47,6 +47,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -300,6 +302,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/mixed_parameters.yaml
+++ b/test_data/compiled-workflows/mixed_parameters.yaml
@@ -61,6 +61,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -311,6 +313,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/modelcar.yaml
+++ b/test_data/compiled-workflows/modelcar.yaml
@@ -69,6 +69,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -427,6 +429,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -305,6 +307,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/mounted_cabundle_secret.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_secret.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -305,6 +307,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
@@ -65,6 +65,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -315,6 +317,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
@@ -64,6 +64,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -314,6 +316,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/nested_parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/nested_parallel_for_secret.yaml
@@ -65,6 +65,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -317,6 +319,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
@@ -124,6 +124,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -494,6 +496,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
@@ -75,6 +75,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -373,6 +375,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
@@ -127,6 +127,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -505,6 +507,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/nested_return.yaml
+++ b/test_data/compiled-workflows/nested_return.yaml
@@ -45,6 +45,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -295,6 +297,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/nested_with_parameters.yaml
+++ b/test_data/compiled-workflows/nested_with_parameters.yaml
@@ -77,6 +77,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -376,6 +378,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/notebook_component_mixed.yaml
+++ b/test_data/compiled-workflows/notebook_component_mixed.yaml
@@ -273,6 +273,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -573,6 +575,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/notebook_component_simple.yaml
+++ b/test_data/compiled-workflows/notebook_component_simple.yaml
@@ -142,6 +142,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -392,6 +394,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/output_metrics.yaml
+++ b/test_data/compiled-workflows/output_metrics.yaml
@@ -46,6 +46,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -296,6 +298,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/parallel_for_after_dependency.yaml
+++ b/test_data/compiled-workflows/parallel_for_after_dependency.yaml
@@ -47,6 +47,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -297,6 +299,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
+++ b/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
@@ -71,6 +71,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -323,6 +325,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/parallel_for_secret.yaml
@@ -51,6 +51,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -303,6 +305,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/parameter_cache.yaml
+++ b/test_data/compiled-workflows/parameter_cache.yaml
@@ -61,6 +61,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -311,6 +313,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/parameter_oneof.yaml
+++ b/test_data/compiled-workflows/parameter_oneof.yaml
@@ -100,6 +100,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -384,6 +386,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/parameters_complex.yaml
+++ b/test_data/compiled-workflows/parameters_complex.yaml
@@ -94,6 +94,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -344,6 +346,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/parameters_simple.yaml
+++ b/test_data/compiled-workflows/parameters_simple.yaml
@@ -65,6 +65,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -315,6 +317,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_as_exit_task.yaml
+++ b/test_data/compiled-workflows/pipeline_as_exit_task.yaml
@@ -81,6 +81,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -332,6 +334,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_in_pipeline.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline.yaml
@@ -50,6 +50,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -325,6 +327,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
@@ -59,6 +59,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -341,6 +343,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
@@ -66,6 +66,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -341,6 +343,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_producer_consumer.yaml
+++ b/test_data/compiled-workflows/pipeline_producer_consumer.yaml
@@ -97,6 +97,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -347,6 +349,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_after.yaml
+++ b/test_data/compiled-workflows/pipeline_with_after.yaml
@@ -38,6 +38,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -341,6 +343,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
@@ -66,6 +66,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -341,6 +343,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
@@ -65,6 +65,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -340,6 +342,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_caching.yaml
+++ b/test_data/compiled-workflows/pipeline_with_caching.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -294,6 +296,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_collected_artifacts.yaml
+++ b/test_data/compiled-workflows/pipeline_with_collected_artifacts.yaml
@@ -63,6 +63,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -313,6 +315,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
@@ -37,6 +37,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -287,6 +289,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_condition.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition.yaml
@@ -63,6 +63,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -362,6 +364,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
@@ -160,6 +160,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -410,6 +412,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
@@ -123,6 +123,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -397,6 +399,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
@@ -122,6 +122,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -445,6 +447,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_env.yaml
@@ -50,6 +50,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -324,6 +326,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
@@ -62,6 +62,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -370,6 +372,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
+++ b/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
@@ -141,6 +141,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -428,6 +430,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_importer.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer.yaml
@@ -131,6 +131,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -394,6 +396,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
@@ -39,6 +39,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -373,6 +375,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
@@ -205,6 +205,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -505,6 +507,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
+++ b/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
@@ -62,6 +62,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -344,6 +346,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops.yaml
@@ -78,6 +78,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -488,6 +490,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
@@ -124,6 +124,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -438,6 +440,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
@@ -75,6 +75,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -350,6 +352,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
@@ -49,6 +49,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -299,6 +301,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
+++ b/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
@@ -68,6 +68,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -506,6 +508,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
@@ -65,6 +65,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -340,6 +342,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
@@ -77,6 +77,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -363,6 +365,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
@@ -55,6 +55,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -305,6 +307,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -285,6 +287,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_outputs.yaml
@@ -51,6 +51,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -326,6 +328,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
@@ -142,6 +142,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -392,6 +394,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
@@ -67,6 +67,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -381,6 +383,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
+++ b/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
@@ -64,6 +64,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -315,6 +317,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_placeholders.yaml
+++ b/test_data/compiled-workflows/pipeline_with_placeholders.yaml
@@ -51,6 +51,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -301,6 +303,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
@@ -166,6 +166,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -1160,6 +1162,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -330,6 +332,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_reused_component.yaml
+++ b/test_data/compiled-workflows/pipeline_with_reused_component.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -344,6 +346,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
@@ -63,6 +63,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -340,6 +342,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
@@ -51,6 +51,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -303,6 +305,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
@@ -44,6 +44,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -294,6 +296,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
@@ -71,7 +71,7 @@ spec:
         kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
         sum_numbers(a: int, b: int) -\u003e int:\n    return a + b\n\n"],"image":"python:3.11","resources":{"accelerator":{"resourceCount":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}","resourceType":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"},"resourceCpuLimit":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}","resourceMemoryLimit":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}}'
     - name: components-root
-      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["cpu-limit","accelerator-limit","accelerator-type","memory-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
+      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","memory-limit","accelerator-limit","cpu-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
   entrypoint: entrypoint
   podMetadata:
     annotations:
@@ -96,6 +96,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -405,15 +407,15 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["cpu-limit","accelerator-limit","accelerator-type","memory-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","memory-limit","accelerator-limit","cpu-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
           - name: container
             value: '{{workflow.parameters.implementations-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task-name
             value: sum-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
-        depends: cpu-limit.Succeeded && accelerator-limit.Succeeded && accelerator-type.Succeeded
-          && memory-limit.Succeeded
+        depends: accelerator-type.Succeeded && memory-limit.Succeeded && accelerator-limit.Succeeded
+          && cpu-limit.Succeeded
         name: sum-numbers-driver
         template: system-container-driver
       - arguments:
@@ -444,6 +446,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_submit_request.yaml
+++ b/test_data/compiled-workflows/pipeline_with_submit_request.yaml
@@ -55,6 +55,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -329,6 +331,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
@@ -78,6 +78,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -385,6 +387,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
@@ -43,6 +43,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -325,6 +327,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -58,6 +58,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -347,6 +349,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_utils.yaml
+++ b/test_data/compiled-workflows/pipeline_with_utils.yaml
@@ -48,6 +48,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -298,6 +300,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
@@ -39,6 +39,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -314,6 +316,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume.yaml
@@ -92,6 +92,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -401,6 +403,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
@@ -66,6 +66,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -330,6 +332,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
@@ -92,6 +92,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -401,6 +403,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pipeline_with_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_workspace.yaml
@@ -68,6 +68,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -343,6 +345,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
+++ b/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
@@ -38,6 +38,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -288,6 +290,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/preprocess.yaml
+++ b/test_data/compiled-workflows/preprocess.yaml
@@ -66,6 +66,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -316,6 +318,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
+++ b/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
@@ -42,6 +42,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -317,6 +319,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pvc_mount.yaml
+++ b/test_data/compiled-workflows/pvc_mount.yaml
@@ -62,6 +62,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -341,6 +343,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
+++ b/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
@@ -126,6 +126,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -389,6 +391,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
@@ -63,6 +63,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -338,6 +340,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
@@ -64,6 +64,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -314,6 +316,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
@@ -69,6 +69,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -319,6 +321,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/ray_integration_compiled.yaml
+++ b/test_data/compiled-workflows/ray_integration_compiled.yaml
@@ -109,6 +109,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -359,6 +361,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
@@ -36,6 +36,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -290,6 +292,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
@@ -36,6 +36,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -290,6 +292,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/sequential_v1.yaml
+++ b/test_data/compiled-workflows/sequential_v1.yaml
@@ -35,6 +35,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -309,6 +311,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/sequential_v2.yaml
+++ b/test_data/compiled-workflows/sequential_v2.yaml
@@ -39,6 +39,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -314,6 +316,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/take_nap_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_compiled.yaml
@@ -60,6 +60,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -335,6 +337,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
@@ -60,6 +60,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -335,6 +337,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/two_step_pipeline.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline.yaml
@@ -40,6 +40,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -315,6 +317,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
@@ -41,6 +41,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -316,6 +318,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/upload_download_compiled.yaml
+++ b/test_data/compiled-workflows/upload_download_compiled.yaml
@@ -99,6 +99,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -399,6 +401,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component

--- a/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
+++ b/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
@@ -303,6 +303,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component
@@ -729,6 +731,8 @@ spec:
       - '{{workflow.name}}'
       - --run_display_name
       - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
       - --dag_execution_id
       - '{{inputs.parameters.parent-dag-id}}'
       - --component


### PR DESCRIPTION
## Summary

As currently opened, this PR contains two sets of changes:

1. **Backend fix for #13424**
   - Populates `dsl.PIPELINE_JOB_CREATE_TIME_UTC_PLACEHOLDER` and `dsl.PIPELINE_JOB_SCHEDULE_TIME_UTC_PLACEHOLDER` in the Kubernetes-backed v2 runtime.
   - Passes `{{workflow.creationTimestamp}}` into the DAG and container drivers as `--pipeline_job_create_time_utc`.
   - Resolves schedule time from Argo Workflow metadata at runtime when needed, using `scheduledworkflows.kubeflow.org/workflowEpoch` when present and falling back to workflow creation time for manual runs.
   - Limits Workflow metadata reads to DAG/container tasks that actually use these placeholders. Root DAG drivers and tasks that do not use the placeholders skip the lookup entirely.
   - Keeps schedule-time lookup best-effort when create time is already available, so reduced-RBAC clusters fall back to create time instead of failing.
   - Avoids regressing older compiled workflows that do not include the new create-time arg unless they actually rely on these placeholders.

2. **Release process docs / automation updates already in the branch**
   - Refreshes `RELEASE.md`.
   - Adds `gh` CLI examples for running release workflows and cutting releases.
   - Updates `test/release/release.sh` to bump the public version ConfigMap during release prep.

## Validation

- `go test ./backend/src/v2/compiler/argocompiler ./backend/src/v2/cmd/driver ./backend/src/v2/driver`
- Compiler goldens refreshed under `test_data/compiled-workflows/`

## Notes

- The backend placeholder change is scoped to the Kubernetes-backed v2 runtime. It does not change local execution.
- Exact recurring-run schedule time still depends on Workflow metadata availability. When the metadata cannot be read after create time is already known, the driver falls back to create time.

## Fixes

Fixes #13424.
