### PR TITLE
fix(backend): Add handling for zero-byte blob directory markers, fixes #13476

### DIFF
--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -156,7 +156,7 @@ func isBlobKeyUnderPrefix(objKey, blobDir string) bool {
 }
 
 func isDirectoryMarkerBlob(obj *blob.ListObject, blobDir string) bool {
-	return obj.Size == 0 && (obj.Key == blobDir || strings.HasSuffix(obj.Key, "/"))
+	return obj.Size == 0 && (obj.Key == strings.TrimRight(blobDir, "/") || strings.HasSuffix(obj.Key, "/"))
 }
 
 func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir string) error {
@@ -171,7 +171,7 @@ func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir st
 		}
 
 		// Skip directories including marker blobs.
-		// GCS clients (including TensorFlow's gfile) create markers as placeholders
+		// Some cloud storage clients create markers as placeholders
 		if obj.IsDir || isDirectoryMarkerBlob(obj, blobDir) {
 			// Object stores list all files with the same prefix,
 			// there is no need to recursively list each folder.

--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -155,6 +155,10 @@ func isBlobKeyUnderPrefix(objKey, blobDir string) bool {
 	return objKey == blobDir || strings.HasPrefix(objKey, blobDir+"/")
 }
 
+func isDirectoryMarkerBlob(obj *blob.ListObject, blobDir string) bool {
+	return obj.Size == 0 && (obj.Key == blobDir || strings.HasSuffix(obj.Key, "/"))
+}
+
 func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir string) error {
 	iter := bucket.List(&blob.ListOptions{Prefix: blobDir})
 	for {
@@ -165,13 +169,16 @@ func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir st
 			}
 			return fmt.Errorf("failed to list objects in remote storage %q: %w", blobDir, err)
 		}
-		if obj.IsDir {
-			// TODO: is this branch possible?
 
+		// Skip directories including marker blobs.
+		// GCS clients (including TensorFlow's gfile) create markers as placeholders
+		if obj.IsDir || isDirectoryMarkerBlob(obj, blobDir) {
 			// Object stores list all files with the same prefix,
 			// there is no need to recursively list each folder.
 			continue
-		} else if isBlobKeyUnderPrefix(obj.Key, blobDir) {
+		}
+
+		if isBlobKeyUnderPrefix(obj.Key, blobDir) {
 			localPath, err := sanitizeDownloadPath(localDir, blobDir, obj.Key)
 			if err != nil {
 				return err

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -422,26 +422,23 @@ func TestDownloadBlobSkipsZeroByteDirectoryMarkers(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	defer func() { require.NoError(t, bucket.Close()) }()
 
-	// Simulate zero-byte blob directory marker.
-	writeBlobToMemBucket(ctx, t, bucket, "artifacts/model", "")
-	writeBlobToMemBucket(ctx, t, bucket, "artifacts/model/saved_model.pb", "saved model data")
+	blobDir := "artifacts/model"
+	blobDirWithTrailingSlash := blobDir + "/"
+
+	writeBlobToMemBucket(ctx, t, bucket, blobDir, "")
+	writeBlobToMemBucket(ctx, t, bucket, blobDirWithTrailingSlash, "")
 
 	localDir := t.TempDir()
-
-	err := DownloadBlob(ctx, bucket, localDir, "artifacts/model")
-	require.NoError(t, err)
-
-	// File containing content should still be downloaded
-	content, err := os.ReadFile(filepath.Join(localDir, "saved_model.pb"))
-	require.NoError(t, err)
-	assert.Equal(t, "saved model data", string(content))
-
-	// The zero-byte prefix-match marker "artifacts/model" resolves to localDir
-	// itself. If downloaded, it would make localDir a zero-byte file.
-	// Verify localDir was not overwritten and is still a directory.
+	require.NoError(t, DownloadBlob(ctx, bucket, localDir, blobDir))
 	localDirInfo, err := os.Stat(localDir)
 	require.NoError(t, err)
-	assert.True(t, localDirInfo.IsDir(), "prefix-match marker should not have clobbered localDir into a file")
+	assert.True(t, localDirInfo.IsDir(), "marker without slash")
+
+	localDir2 := t.TempDir()
+	require.NoError(t, DownloadBlob(ctx, bucket, localDir2, blobDirWithTrailingSlash))
+	localDirInfo2, err := os.Stat(localDir2)
+	require.NoError(t, err)
+	assert.True(t, localDirInfo2.IsDir(), "marker with slash")
 }
 
 func TestIsBlobKeyUnderPrefix(t *testing.T) {

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -417,6 +417,33 @@ func TestDownloadBlobRejectsTraversalKey(t *testing.T) {
 	assert.Contains(t, err.Error(), "path traversal detected")
 }
 
+func TestDownloadBlobSkipsZeroByteDirectoryMarkers(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { require.NoError(t, bucket.Close()) }()
+
+	// Simulate zero-byte blob directory marker.
+	writeBlobToMemBucket(ctx, t, bucket, "artifacts/model", "")
+	writeBlobToMemBucket(ctx, t, bucket, "artifacts/model/saved_model.pb", "saved model data")
+
+	localDir := t.TempDir()
+
+	err := DownloadBlob(ctx, bucket, localDir, "artifacts/model")
+	require.NoError(t, err)
+
+	// File containing content should still be downloaded
+	content, err := os.ReadFile(filepath.Join(localDir, "saved_model.pb"))
+	require.NoError(t, err)
+	assert.Equal(t, "saved model data", string(content))
+
+	// The zero-byte prefix-match marker "artifacts/model" resolves to localDir
+	// itself. If downloaded, it would make localDir a zero-byte file.
+	// Verify localDir was not overwritten and is still a directory.
+	localDirInfo, err := os.Stat(localDir)
+	require.NoError(t, err)
+	assert.True(t, localDirInfo.IsDir(), "prefix-match marker should not have clobbered localDir into a file")
+}
+
 func TestIsBlobKeyUnderPrefix(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -430,15 +430,15 @@ func TestDownloadBlobSkipsZeroByteDirectoryMarkers(t *testing.T) {
 
 	localDir := t.TempDir()
 	require.NoError(t, DownloadBlob(ctx, bucket, localDir, blobDir))
-	localDirInfo, err := os.Stat(localDir)
+	localDirInfoNoSlash, err := os.Stat(localDir)
 	require.NoError(t, err)
-	assert.True(t, localDirInfo.IsDir(), "marker without slash")
+	assert.True(t, localDirInfoNoSlash.IsDir(), "marker without slash")
 
-	localDir2 := t.TempDir()
-	require.NoError(t, DownloadBlob(ctx, bucket, localDir2, blobDirWithTrailingSlash))
-	localDirInfo2, err := os.Stat(localDir2)
+	localDir = t.TempDir()
+	require.NoError(t, DownloadBlob(ctx, bucket, localDir, blobDirWithTrailingSlash))
+	localDirInfoWithSlash, err := os.Stat(localDir)
 	require.NoError(t, err)
-	assert.True(t, localDirInfo2.IsDir(), "marker with slash")
+	assert.True(t, localDirInfoWithSlash.IsDir(), "marker with slash")
 }
 
 func TestIsBlobKeyUnderPrefix(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**

closes #13476 

Adds handling of zero-byte blob directory markers when downloading artifacts. It skips the directory markers as it would if it were a directory using the same logic. These markers are used by GCS when using tensorflow, but is only one of many potential setups that could cause this issue.


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
