### PR TITLE
chore:  proper argo retries for transient and argo errors

### DIFF
--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -776,8 +776,10 @@ func (w *Workflow) SetCannonicalLabels(name string, nextScheduledEpoch int64, in
 }
 
 // FindObjectStoreArtifactKeyOrEmpty looks up the first S3 artifact with the specified artifactName
-// on the specified nodeName. If the node has no outputs (e.g., a retry parent node), it also checks
-// the node's direct children. Returns empty string if nothing is found.
+// on the specified nodeName. If the node has no outputs (e.g., a retry parent or step group node),
+// it recursively checks the node's children up to a bounded depth. This handles the hierarchy
+// introduced by templateDefaults.retryStrategy: StepGroup → Retry → Pod.
+// Returns empty string if nothing is found.
 func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeName string, artifactName string) string {
 	if w.Status.Nodes == nil {
 		return ""
@@ -786,15 +788,22 @@ func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeName string, artifactNa
 	if !found {
 		return ""
 	}
+	// maxDepth of 3 covers: StepGroup → Retry → Pod (deepest expected path).
+	return w.findArtifactKeyRecursive(node, artifactName, 3)
+}
+
+// findArtifactKeyRecursive searches the node and its children (up to maxDepth levels)
+// for an S3 artifact with the given name.
+func (w *Workflow) findArtifactKeyRecursive(node workflowapi.NodeStatus, artifactName string, maxDepth int) string {
 	if s3Key := findArtifactS3KeyFromNode(node, artifactName); s3Key != "" {
 		return s3Key
 	}
-	if node.Type != workflowapi.NodeTypeRetry {
+	if maxDepth <= 0 {
 		return ""
 	}
 	for _, childNodeID := range node.Children {
 		if childNode, childFound := w.Status.Nodes[childNodeID]; childFound {
-			if s3Key := findArtifactS3KeyFromNode(childNode, artifactName); s3Key != "" {
+			if s3Key := w.findArtifactKeyRecursive(childNode, artifactName, maxDepth-1); s3Key != "" {
 				return s3Key
 			}
 		}

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -789,6 +789,9 @@ func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeName string, artifactNa
 	if s3Key := findArtifactS3KeyFromNode(node, artifactName); s3Key != "" {
 		return s3Key
 	}
+	if node.Type != workflowapi.NodeTypeRetry {
+		return ""
+	}
 	for _, childNodeID := range node.Children {
 		if childNode, childFound := w.Status.Nodes[childNodeID]; childFound {
 			if s3Key := findArtifactS3KeyFromNode(childNode, artifactName); s3Key != "" {

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -775,9 +775,9 @@ func (w *Workflow) SetCannonicalLabels(name string, nextScheduledEpoch int64, in
 	w.SetLabels(LabelKeyWorkflowIsOwnedByScheduledWorkflow, "true")
 }
 
-// FindObjectStoreArtifactKeyOrEmpty loops through all node running statuses and look up the first
-// S3 artifact with the specified nodeID and artifactName. Returns empty if nothing is found.
-// Also checks children nodes to handle retry parent nodes that have no artifacts themselves.
+// FindObjectStoreArtifactKeyOrEmpty looks up the first S3 artifact with the specified artifactName
+// on the specified nodeName. If the node has no outputs (e.g., a retry parent node), it also checks
+// the node's direct children. Returns empty string if nothing is found.
 func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeName string, artifactName string) string {
 	if w.Status.Nodes == nil {
 		return ""

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -777,6 +777,7 @@ func (w *Workflow) SetCannonicalLabels(name string, nextScheduledEpoch int64, in
 
 // FindObjectStoreArtifactKeyOrEmpty loops through all node running statuses and look up the first
 // S3 artifact with the specified nodeID and artifactName. Returns empty if nothing is found.
+// Also checks children nodes to handle retry parent nodes that have no artifacts themselves.
 func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeName string, artifactName string) string {
 	if w.Status.Nodes == nil {
 		return ""
@@ -785,17 +786,30 @@ func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeName string, artifactNa
 	if !found {
 		return ""
 	}
+	if s3Key := findArtifactS3KeyFromNode(node, artifactName); s3Key != "" {
+		return s3Key
+	}
+	for _, childNodeID := range node.Children {
+		if childNode, childFound := w.Status.Nodes[childNodeID]; childFound {
+			if s3Key := findArtifactS3KeyFromNode(childNode, artifactName); s3Key != "" {
+				return s3Key
+			}
+		}
+	}
+	return ""
+}
+
+// findArtifactS3KeyFromNode extracts the S3 key for a named artifact from a node's outputs.
+func findArtifactS3KeyFromNode(node workflowapi.NodeStatus, artifactName string) string {
 	if node.Outputs == nil || node.Outputs.Artifacts == nil {
 		return ""
 	}
-	var s3Key string
 	for _, artifact := range node.Outputs.Artifacts {
-		if artifact.Name != artifactName || artifact.S3 == nil || artifact.S3.Key == "" {
-			continue
+		if artifact.Name == artifactName && artifact.S3 != nil && artifact.S3.Key != "" {
+			return artifact.S3.Key
 		}
-		s3Key = artifact.S3.Key
 	}
-	return s3Key
+	return ""
 }
 
 // IsInFinalState whether the workflow is in a final state.

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -2428,6 +2428,47 @@ func TestWorkflow_FindObjectStoreArtifactKeyOrEmpty_RetryParentNoChildren(t *tes
 	assert.Equal(t, "", workflow.FindObjectStoreArtifactKeyOrEmpty("retry-parent-node", "artifact1"))
 }
 
+func TestWorkflow_FindObjectStoreArtifactKeyOrEmpty_StepGroupToRetryToPod(t *testing.T) {
+	// With templateDefaults.retryStrategy, the hierarchy is:
+	// StepGroup → Retry parent → Pod (with artifacts).
+	// The test regex may capture the StepGroup node, so the function must
+	// traverse two levels to reach the Pod's artifacts.
+	workflow := NewWorkflow(&workflowapi.Workflow{
+		Status: workflowapi.WorkflowStatus{
+			Nodes: map[string]workflowapi.NodeStatus{
+				"step-group-node": {
+					ID:       "step-group-node",
+					Type:     workflowapi.NodeTypeStepGroup,
+					Children: []string{"retry-parent-node"},
+				},
+				"retry-parent-node": {
+					ID:       "retry-parent-node",
+					Type:     workflowapi.NodeTypeRetry,
+					Children: []string{"retry-parent-node(0)"},
+				},
+				"retry-parent-node(0)": {
+					ID:   "retry-parent-node(0)",
+					Type: workflowapi.NodeTypePod,
+					Outputs: &workflowapi.Outputs{
+						Artifacts: workflowapi.Artifacts{
+							{
+								Name: "artifact1",
+								ArtifactLocation: workflowapi.ArtifactLocation{
+									S3: &workflowapi.S3Artifact{
+										Key: "bucket/artifacts/deep-nested-key",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	assert.Equal(t, "bucket/artifacts/deep-nested-key",
+		workflow.FindObjectStoreArtifactKeyOrEmpty("step-group-node", "artifact1"))
+}
+
 // nonWorkflowExecution implements ExecutionSpec via embedding but is not *Workflow.
 // Used to test type assertion failures in WorkflowInterface methods.
 type nonWorkflowExecution struct {

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -2381,6 +2381,53 @@ func TestWorkflow_FindObjectStoreArtifactKeyOrEmpty_NodeNotFound(t *testing.T) {
 	assert.Equal(t, "", workflow.FindObjectStoreArtifactKeyOrEmpty("node1", "artifact1"))
 }
 
+func TestWorkflow_FindObjectStoreArtifactKeyOrEmpty_RetryParentNode(t *testing.T) {
+	// Retry parent node (from global retryStrategy) delegates artifacts to child execution nodes.
+	workflow := NewWorkflow(&workflowapi.Workflow{
+		Status: workflowapi.WorkflowStatus{
+			Nodes: map[string]workflowapi.NodeStatus{
+				"retry-parent-node": {
+					ID:       "retry-parent-node",
+					Type:     workflowapi.NodeTypeRetry,
+					Children: []string{"retry-parent-node(0)"},
+				},
+				"retry-parent-node(0)": {
+					ID: "retry-parent-node(0)",
+					Outputs: &workflowapi.Outputs{
+						Artifacts: workflowapi.Artifacts{
+							{
+								Name: "artifact1",
+								ArtifactLocation: workflowapi.ArtifactLocation{
+									S3: &workflowapi.S3Artifact{
+										Key: "bucket/artifacts/retry-child-key",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	assert.Equal(t, "bucket/artifacts/retry-child-key",
+		workflow.FindObjectStoreArtifactKeyOrEmpty("retry-parent-node", "artifact1"))
+}
+
+func TestWorkflow_FindObjectStoreArtifactKeyOrEmpty_RetryParentNoChildren(t *testing.T) {
+	// Retry parent node with no children should return empty.
+	workflow := NewWorkflow(&workflowapi.Workflow{
+		Status: workflowapi.WorkflowStatus{
+			Nodes: map[string]workflowapi.NodeStatus{
+				"retry-parent-node": {
+					ID:   "retry-parent-node",
+					Type: workflowapi.NodeTypeRetry,
+				},
+			},
+		},
+	})
+	assert.Equal(t, "", workflow.FindObjectStoreArtifactKeyOrEmpty("retry-parent-node", "artifact1"))
+}
+
 // nonWorkflowExecution implements ExecutionSpec via embedding but is not *Workflow.
 // Used to test type assertion failures in WorkflowInterface methods.
 type nonWorkflowExecution struct {

--- a/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml
+++ b/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml
@@ -7,10 +7,9 @@ metadata:
   name: workflow-controller-configmap
 data:
   # References:
-  # * https://github.com/argoproj/argo-workflows/blob/v3.7.3/config/config.go
-  # * https://github.com/argoproj/argo-workflows/blob/v3.7.3/docs/workflow-controller-configmap.md
-  # * https://github.com/argoproj/argo-workflows/blob/v3.7.3/docs/workflow-controller-configmap.yaml
-
+  # * https://github.com/argoproj/argo-workflows/blob/v3.7.14/config/config.go
+  # * https://github.com/argoproj/argo-workflows/blob/v3.7.14/docs/workflow-controller-configmap.md
+  # * https://github.com/argoproj/argo-workflows/blob/v3.7.14/docs/workflow-controller-configmap.yaml
 
   # In artifactRepository.s3.endpoint, $(kfp-namespace) is needed, because in multi-user mode, pipelines may run in other namespaces.
   artifactRepository: |
@@ -48,3 +47,39 @@ data:
           - ALL
       seccompProfile:
         type: RuntimeDefault
+  workflowDefaults: |
+    spec:
+      ttlStrategy:
+        secondsAfterCompletion: 3600
+        secondsAfterSuccess: 3600
+        secondsAfterFailure: 3600
+      metrics:
+        prometheus:
+        - counter:
+            value: '1'
+          help: Kubeflow pipeline status
+          labels:
+          - key: namespace
+            value: '{{workflow.namespace}}'
+          - key: status
+            value: '{{workflow.status}}'
+          - key: pipeline
+            value: '{{=jsonpath(workflow.annotations.pipelines.kubeflow[''org/pipeline_spec''], ''$.name'')}}'
+          name: pipeline_info
+      templateDefaults:
+        retryStrategy:
+          limit: '2'
+          retryPolicy: OnError
+        metrics:
+          prometheus:
+          - gauge:
+              value: '1'
+            help: Kubeflow pipelines pod information
+            labels:
+            - key: namespace
+              value: '{{workflow.namespace}}'
+            - key: pipeline
+              value: '{{=jsonpath(workflow.annotations.pipelines.kubeflow[''org/pipeline_spec''], ''$.name'')}}'
+            - key: run
+              value: '{{workflow.annotations.pipelines.kubeflow.org/run_name}}'
+            name: pipeline_pod_info

--- a/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml
+++ b/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml
@@ -53,33 +53,7 @@ data:
         secondsAfterCompletion: 3600
         secondsAfterSuccess: 3600
         secondsAfterFailure: 3600
-      metrics:
-        prometheus:
-        - counter:
-            value: '1'
-          help: Kubeflow pipeline status
-          labels:
-          - key: namespace
-            value: '{{workflow.namespace}}'
-          - key: status
-            value: '{{workflow.status}}'
-          - key: pipeline
-            value: '{{=jsonpath(workflow.annotations.pipelines.kubeflow[''org/pipeline_spec''], ''$.name'')}}'
-          name: pipeline_info
       templateDefaults:
         retryStrategy:
           limit: '2'
           retryPolicy: OnError
-        metrics:
-          prometheus:
-          - gauge:
-              value: '1'
-            help: Kubeflow pipelines pod information
-            labels:
-            - key: namespace
-              value: '{{workflow.namespace}}'
-            - key: pipeline
-              value: '{{=jsonpath(workflow.annotations.pipelines.kubeflow[''org/pipeline_spec''], ''$.name'')}}'
-            - key: run
-              value: '{{workflow.annotations.pipelines.kubeflow.org/run_name}}'
-            name: pipeline_pod_info

--- a/test/artifact-proxy/test-artifact-proxy.sh
+++ b/test/artifact-proxy/test-artifact-proxy.sh
@@ -71,8 +71,14 @@ if [[ "$WORKFLOW_PHASE" != "Succeeded" ]]; then
   exit 1
 fi
 
-KEY=$(kubectl -n "$NAMESPACE" get workflow "$WORKFLOW_NAME" -o json | \
-  jq -r '[.status.nodes[].outputs.artifacts[]? | select(.name=="out") | .s3.key] | first')
+KEY=$(
+  kubectl -n "$NAMESPACE" get workflow "$WORKFLOW_NAME" -o json |
+    jq -r '[.status.nodes[].outputs.artifacts[]? | select(.name=="out") | .s3.key] | first // empty'
+)
+if [[ -z "$KEY" ]]; then
+  echo "ERROR: Could not locate S3 key for artifact 'out' in workflow status"
+  exit 1
+fi
 ARTIFACT_URL="http://ml-pipeline-ui-artifact.${NAMESPACE}.svc.cluster.local/artifacts/get?source=minio&bucket=mlpipeline&key=${KEY}"
 if ! kubectl -n "$NAMESPACE" exec kfp-proxy-curl -- sh -c \
   "curl -fsS -H 'kubeflow-userid: user@example.com' '${ARTIFACT_URL}' 2>/dev/null | grep -qx 'artifact-proxy-e2e-test-content'"; then

--- a/test/artifact-proxy/test-artifact-proxy.sh
+++ b/test/artifact-proxy/test-artifact-proxy.sh
@@ -71,7 +71,8 @@ if [[ "$WORKFLOW_PHASE" != "Succeeded" ]]; then
   exit 1
 fi
 
-KEY=$(kubectl -n "$NAMESPACE" get workflow "$WORKFLOW_NAME" -o jsonpath='{.status.nodes.*.outputs.artifacts[?(@.name=="out")].s3.key}')
+KEY=$(kubectl -n "$NAMESPACE" get workflow "$WORKFLOW_NAME" -o json | \
+  jq -r '[.status.nodes[].outputs.artifacts[]? | select(.name=="out") | .s3.key] | first')
 ART_URL="http://ml-pipeline-ui-artifact.${NAMESPACE}.svc.cluster.local/artifacts/get?source=minio&bucket=mlpipeline&key=${KEY}"
 if ! kubectl -n "$NAMESPACE" exec kfp-proxy-curl -- sh -c \
   "curl -fsS -H 'kubeflow-userid: user@example.com' '${ART_URL}' 2>/dev/null | grep -qx 'artifact-proxy-e2e-test-content'"; then

--- a/test/artifact-proxy/test-artifact-proxy.sh
+++ b/test/artifact-proxy/test-artifact-proxy.sh
@@ -73,9 +73,9 @@ fi
 
 KEY=$(kubectl -n "$NAMESPACE" get workflow "$WORKFLOW_NAME" -o json | \
   jq -r '[.status.nodes[].outputs.artifacts[]? | select(.name=="out") | .s3.key] | first')
-ART_URL="http://ml-pipeline-ui-artifact.${NAMESPACE}.svc.cluster.local/artifacts/get?source=minio&bucket=mlpipeline&key=${KEY}"
+ARTIFACT_URL="http://ml-pipeline-ui-artifact.${NAMESPACE}.svc.cluster.local/artifacts/get?source=minio&bucket=mlpipeline&key=${KEY}"
 if ! kubectl -n "$NAMESPACE" exec kfp-proxy-curl -- sh -c \
-  "curl -fsS -H 'kubeflow-userid: user@example.com' '${ART_URL}' 2>/dev/null | grep -qx 'artifact-proxy-e2e-test-content'"; then
+  "curl -fsS -H 'kubeflow-userid: user@example.com' '${ARTIFACT_URL}' 2>/dev/null | grep -qx 'artifact-proxy-e2e-test-content'"; then
   echo "ERROR: Artifact content validation failed"
   kubectl -n "$NAMESPACE" logs deploy/ml-pipeline-ui-artifact -c ml-pipeline-ui-artifact --tail=50 || true
   exit 1

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -193,7 +193,13 @@ describe('deploy helloworld sample run', () => {
   });
 
   it('has a 4-node graph', async () => {
-    await waitForGraphNodeCount(4, { timeout: uiTimeout });
+    await waitForCondition(
+      async () => (await $$('.graphNode')).length >= 4,
+      {
+        timeout: uiTimeout,
+        timeoutMsg: 'expected at least 4 graph node(s) to be visible',
+      },
+    );
   });
 
   it('opens the side panel when graph node is clicked', async () => {

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -192,7 +192,7 @@ describe('deploy helloworld sample run', () => {
     await $('button=Graph').click();
   });
 
-  it('has a 4-node graph', async () => {
+  it('has at least 4 graph nodes', async () => {
     await waitForCondition(
       async () => (await $$('.graphNode')).length >= 4,
       {


### PR DESCRIPTION
Updated Argo workflow controller configmap references and added workflow defaults for retry strategies.

**Description of your changes:**
proper argo retries for transient and argo errors for enterprise readiness and customer experience.
@ntny @droctothorpe 

see also https://github.com/kubeflow/pipelines/pull/13386 and https://argo-workflows.readthedocs.io/en/latest/retries/

I did provide a proper expression for transient errors (espescially cluster autoscaler) here https://github.com/kubeflow/pipelines/blob/63dac612a3d8ce4f45b7113dba41701ebe1df811/manifests/kustomize/third-party/argo/base/workflow-controller-deployment-patch.yaml#L20-L25 and have to switch soon the Argo default workflow template configuration to OnError which includes transient. We also need to expose all the retry policy options in the sdk. Default OnError is good via argo, but we must be able to opt out via the SDK (always, onfailure, transient)

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
