### PR TITLE
test: update tested Kubernetes versions to 1.33-1.36

### DIFF
--- a/.github/actions/create-cluster/action.yml
+++ b/.github/actions/create-cluster/action.yml
@@ -41,7 +41,7 @@ runs:
       with:
         cluster_name: ${{ inputs.cluster_name }}
         kubectl_version: ${{ inputs.k8s_version }}
-        version: v0.31.0
+        version: v0.32.0
         node_image: kindest/node:${{ inputs.k8s_version }}
 
     - name: Retry Create k8s Kind Cluster
@@ -50,5 +50,5 @@ runs:
       with:
         cluster_name: ${{ inputs.cluster_name }}
         kubectl_version: ${{ inputs.k8s_version }}
-        version: v0.31.0
+        version: v0.32.0
         node_image: kindest/node:${{ inputs.k8s_version }}

--- a/.github/workflows/api-server-tests.yml
+++ b/.github/workflows/api-server-tests.yml
@@ -63,20 +63,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.0" ]
+        k8s_version: [ "v1.36.1" ]
         cache_enabled: [ "true", "false" ]
         proxy: [ "true", "false" ]
         argo_version: [ "v3.7.14", "v4.0.5" ]
         pipeline_store: [ "database" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.31.14"
+          - k8s_version: "v1.33.12"
             cache_enabled: "true"
             argo_version: "v3.7.14"
-          - k8s_version: "v1.31.14"
+          - k8s_version: "v1.33.12"
             cache_enabled: "true"
             argo_version: "v4.0.5"
-          - k8s_version: "v1.35.0"
+          - k8s_version: "v1.36.1"
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
       fail-fast: false # So that failure in 1 type of parameterized job does not cause other jobs to terminate prematurely
@@ -146,7 +146,7 @@ jobs:
         if: ${{ steps.configure.outcome == 'success' }}
         id: test-run
         env:
-          ARGO_COMPATIBILITY_TESTS: ${{ matrix.argo_version == 'v4.0.5' && matrix.k8s_version == 'v1.35.0' && matrix.cache_enabled == 'true' && matrix.proxy == 'false' && matrix.pod_to_pod_tls_enabled == 'false' }}
+          ARGO_COMPATIBILITY_TESTS: ${{ matrix.argo_version == 'v4.0.5' && matrix.k8s_version == 'v1.36.1' && matrix.cache_enabled == 'true' && matrix.proxy == 'false' && matrix.pod_to_pod_tls_enabled == 'false' }}
         with:
           pipeline_store: ${{ matrix.pipeline_store }}
           cache_enabled: ${{ matrix.cache_enabled }}
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.0", "v1.31.14" ]
+        k8s_version: [ "v1.36.1", "v1.33.12" ]
         cache_enabled: [ "true" ]
         uploadPipelinesWithKubernetesClient: [ "true", "false" ]
         argo_version: [ "v3.7.14", "v4.0.5" ]
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.0"]
+        k8s_version: [ "v1.36.1"]
         cache_enabled: [ "true", "false" ]
         multi_user: [ "true" ]
       fail-fast: false # So that failure in 1 type of parameterized job does not cause other jobs to terminate prematurely

--- a/.github/workflows/e2e-test-frontend.yml
+++ b/.github/workflows/e2e-test-frontend.yml
@@ -32,7 +32,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.31.14", "v1.35.0" ]
+        k8s_version: [ "v1.33.12", "v1.36.1" ]
         pod_to_pod_tls_enabled: [ "true", "false" ]
     name: Frontend Integration Tests - K8s ${{ matrix.k8s_version }} pod_to_pod_tls_enabled=${{ matrix.pod_to_pod_tls_enabled }}
     steps:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -66,25 +66,25 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.35.0"]
+        k8s_version: ["v1.36.1"]
         cache_enabled: ["true", "false"]
         argo_version: [ "v3.7.14", "v4.0.5" ]
         proxy: [ "false" ]
         test_label: [ "E2ECritical", "E2EEssential", "E2EParallelNested" ]
         pod_to_pod_tls_enabled: [ "false" ]
         include:
-          - k8s_version: "v1.31.14"
+          - k8s_version: "v1.33.12"
             cache_enabled: "false"
             argo_version: "v3.7.14"
             test_label: "E2ECritical"
-          - k8s_version: "v1.35.0"
+          - k8s_version: "v1.36.1"
             cache_enabled: "false"
             proxy: "true"
             test_label: "E2EProxy"
-          - k8s_version: "v1.35.0"
+          - k8s_version: "v1.36.1"
             cache_enabled: "false"
             test_label: "E2EFailure"
-          - k8s_version: "v1.35.0"
+          - k8s_version: "v1.36.1"
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
             test_label: "E2ECritical"
@@ -173,14 +173,14 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.35.0"]
+        k8s_version: ["v1.36.1"]
         cache_enabled: ["true", "false"]
         multi_user: [ "true" ]
         test_label: [ "E2ECritical" ]
         include:
         - multi_user: "true"
           artifact_proxy: "true"
-          k8s_version: "v1.35.0"
+          k8s_version: "v1.36.1"
           cache_enabled: "true"
           test_label: "E2ECritical"
       fail-fast: false
@@ -275,7 +275,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.34.0" ]
+        k8s_version: [ "v1.36.1" ]
         cache_enabled: [ "true", "false" ]
         argo_version: [ "v3.7.3" ]
         proxy: [ "false" ]

--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.31.14", "v1.35.0" ]
+        k8s_version: [ "v1.33.12", "v1.36.1" ]
     name: Initialization & Integration tests v1 - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
+++ b/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: ["v1.31.14", "v1.35.0"]
+        k8s_version: ["v1.33.12", "v1.36.1"]
     name: KFP Kubernetes Native Migration Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-sdk-client-tests.yml
+++ b/.github/workflows/kfp-sdk-client-tests.yml
@@ -33,7 +33,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.31.14", "v1.35.0" ]
+        k8s_version: [ "v1.33.12", "v1.36.1" ]
     name: KFP SDK Client Tests - K8s ${{ matrix.k8s_version }}
     steps:
       - name: Checkout code

--- a/.github/workflows/kfp-webhooks.yml
+++ b/.github/workflows/kfp-webhooks.yml
@@ -29,7 +29,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        k8s_version: [ "v1.31.14", "v1.35.0" ]
+        k8s_version: [ "v1.33.12", "v1.36.1" ]
     name: KFP Webhooks - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/.github/workflows/legacy-v2-api-integration-tests.yml
+++ b/.github/workflows/legacy-v2-api-integration-tests.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         pipeline_store: [ "database", "kubernetes" ]
-        k8s_version: [ "v1.35.0" ]
+        k8s_version: [ "v1.36.1" ]
         pod_to_pod_tls_enabled: [ "true", "false" ]
         exclude:
           # Pod to Pod TLS manifests are not yet implemented for Kubernetes Native API mode

--- a/.github/workflows/upgrade-test.yml
+++ b/.github/workflows/upgrade-test.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8s_version: [ "v1.35.0" ]
+        k8s_version: [ "v1.36.1" ]
     name: KFP upgrade tests - K8s ${{ matrix.k8s_version }}
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -523,12 +523,12 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 ### Test matrices and variants (Kubernetes, stores, proxy, cache)
 
-- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.31.14` and `v1.35.0`.
+- Kubernetes versions: CI runs a matrix across a low and high supported version, commonly `v1.33.12` and `v1.36.1`.
   - Examples: `e2e-test.yml`, `sdk-execution.yml`, `upgrade-test.yml`, `kfp-kubernetes-execution-tests.yml`, `kfp-webhooks.yml`, `api-server-tests.yml`, `compiler-tests.yml`, `legacy-v2-api-integration-tests.yml`, `integration-tests-v1.yml`, and frontend integration in `e2e-test-frontend.yml`.
 - Pipeline store variants (v2 engine): tests run with `database` and `kubernetes` stores, and a dedicated job compiles pipelines to Kubernetes-native manifests.
   - Example: `e2e-test.yml` job "API integration tests v2 - K8s with ${pipeline_store}" and "compile pipelines with Kubernetes".
 - Argo Workflows version matrix for compatibility (where relevant): `e2e-test.yml` exercises `v3.7.14` and `v4.0.5` across the standard cache/test-label matrix, while `api-server-tests.yml` covers standalone and Kubernetes-native Argo compatibility across the standard matrices (with standalone low-Kubernetes spot lanes per supported Argo version).
-- Focused Argo runtime compatibility API tests run only in the canonical standalone `v4.0.5` / Kubernetes `v1.35.0` job via `ARGO_COMPATIBILITY_TESTS`; this covers recurring-run creation, run retry, task metadata/artifacts, and archived logs without adding another E2E lane.
+- Focused Argo runtime compatibility API tests run only in the canonical standalone `v4.0.5` / Kubernetes `v1.36.1` job via `ARGO_COMPATIBILITY_TESTS`; this covers recurring-run creation, run retry, task metadata/artifacts, and archived logs without adding another E2E lane.
 - Proxy / cache toggles: dedicated jobs run with HTTP proxy enabled and with execution cache disabled to validate those modes.
 - Artifacts: failing logs and test outputs are uploaded as workflow artifacts for debugging.
 

--- a/proposals/12147-mlmd-removal/test_plan.md
+++ b/proposals/12147-mlmd-removal/test_plan.md
@@ -160,13 +160,13 @@ This is a **breaking architectural change** that affects:
 - **Python Version**: 3.9+
 - **Database**: MySQL 8.0 or compatible
 - **Container Runtime**: Docker or Podman
-- **Kubernetes**: Kind cluster (v1.31.14 or v1.35.0)
+- **Kubernetes**: Kubernetes v1.33.12 or v1.36.1 (Kind node image)
 
 ### Test Cluster Configurations
 
 #### 1. Local Development Cluster
 ```yaml
-Kubernetes: Kind v1.31.14
+Kubernetes: v1.33.12 (Kind node image)
 KFP Mode: Standalone
 Database: MySQL 8.0
 Storage: MinIO (local S3-compatible)
@@ -176,7 +176,7 @@ Purpose: Unit test validation, quick smoke tests
 
 #### 2. Standard KFP Cluster
 ```yaml
-Kubernetes: Kind v1.35.0
+Kubernetes: v1.36.1 (Kind node image)
 KFP Mode: Standalone with RBAC
 Database: MySQL 8.0
 Storage: MinIO
@@ -187,7 +187,7 @@ Purpose: Main integration testing, regression tests
 
 #### 3. Multi-Tenant Cluster
 ```yaml
-Kubernetes: Kind v1.35.0
+Kubernetes: v1.36.1 (Kind node image)
 KFP Mode: Multi-tenant
 Database: MySQL 8.0
 Storage: MinIO with namespace isolation
@@ -198,7 +198,7 @@ Purpose: Security testing, RBAC validation
 
 #### 4. Performance Testing Cluster
 ```yaml
-Kubernetes: Kind v1.35.0 (or GKE/EKS for realistic perf)
+Kubernetes: v1.36.1 (Kind node image, or GKE/EKS for realistic perf)
 KFP Mode: Standalone
 Database: MySQL 8.0 (optimized)
 Storage: MinIO (or cloud storage)


### PR DESCRIPTION
**Description of your changes:**

This rebases the Kubernetes CI version bump on current `master` and keeps the PR version-only.

Changes:
- rotate the tested low/high Kubernetes pair from `v1.31.14` / `v1.35.0` to `v1.33.12` / `v1.36.1`
- update the shared Kind binary version from `v0.31.0` to `v0.32.0`
- update `AGENTS.md` and the MLMD removal test plan to match the new CI versions
- clarify the test-plan wording so it says Kubernetes versions running through Kind node images

The proxy CI robustness work was split out and merged in #13523, so this PR no longer carries proxy fixture or diagnostic changes. The broader Kubernetes version policy discussion remains in #13457.

Validation:
- parsed changed workflow/action YAML files
- ran `git diff --check`
- confirmed Kind `v0.32.0` release notes include `kindest/node:v1.33.12` and `kindest/node:v1.36.1`
- confirmed both `kindest/node` manifests resolve with `docker manifest inspect`

Local Kind validation was skipped because this machine does not have enough RAM for a KFP CI deployment.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
