### PR TITLE
feat: add Start Time, End Time and Schedule Status columns to recurring runs table

### DIFF
--- a/frontend/src/pages/RecurringRunList.test.tsx
+++ b/frontend/src/pages/RecurringRunList.test.tsx
@@ -23,7 +23,11 @@ import { range } from 'lodash';
 import * as Utils from 'src/lib/Utils';
 import TestUtils from 'src/TestUtils';
 import { Apis, JobSortKeys, ListRequest } from 'src/lib/Apis';
-import RecurringRunList, { RecurringRunListProps } from './RecurringRunList';
+import RecurringRunList, {
+  RecurringRunListProps,
+  getScheduleTimes,
+  getScheduleStatus,
+} from './RecurringRunList';
 import { V2beta1RecurringRun, V2beta1RecurringRunStatus } from 'src/apisv2beta1/recurringrun';
 import { color } from 'src/Css';
 
@@ -166,6 +170,9 @@ describe('RecurringRunList', () => {
           'recurring run with id: testrecurringrun1',
           undefined,
           undefined,
+          '-',
+          '-',
+          '-',
           undefined,
           '-',
         ],
@@ -322,7 +329,7 @@ describe('RecurringRunList', () => {
     await loadRecurringRuns({});
 
     expect(props.onError).not.toHaveBeenCalled();
-    expect(lastCustomTableProps.rows[0].otherFields[3]).toEqual({
+    expect(lastCustomTableProps.rows[0].otherFields[6]).toEqual({
       displayName: 'test experiment',
       id: 'test-experiment-id',
     });
@@ -349,7 +356,7 @@ describe('RecurringRunList', () => {
     expect(lastCustomTableProps.columns.map((column: any) => column.label)).not.toContain(
       'Experiment',
     );
-    expect(lastCustomTableProps.rows[0].otherFields).toHaveLength(4);
+    expect(lastCustomTableProps.rows[0].otherFields).toHaveLength(7);
   });
 
   it('renders recurring run trigger in seconds', () => {
@@ -438,5 +445,184 @@ describe('RecurringRunList', () => {
       }),
     );
     expect(getByText('Unknown Status')).toHaveStyle({ color: color.errorText });
+  });
+
+  it('shows start time and end time when configured (periodic)', async () => {
+    const startTime = new Date('2025-01-01T00:00:00Z');
+    const endTime = new Date('2025-12-31T23:59:59Z');
+    mockNRecurringRuns(1, {
+      trigger: {
+        periodic_schedule: {
+          interval_second: '3600',
+          start_time: startTime,
+          end_time: endTime,
+        },
+      },
+    });
+    renderRecurringRunList();
+    await loadRecurringRuns({});
+
+    expect(formatDateStringSpy.mock.calls.slice(0, 2)).toEqual([[startTime], [endTime]]);
+    expect(lastCustomTableProps.rows[0].otherFields[3]).toBe('1/2/2019, 12:34:56 PM');
+    expect(lastCustomTableProps.rows[0].otherFields[4]).toBe('1/2/2019, 12:34:56 PM');
+  });
+
+  it('shows start time and end time when configured (cron)', async () => {
+    const startTime = new Date('2025-01-01T00:00:00Z');
+    const endTime = new Date('2025-12-31T23:59:59Z');
+    mockNRecurringRuns(1, {
+      trigger: {
+        cron_schedule: {
+          cron: '0 * * * * ?',
+          start_time: startTime,
+          end_time: endTime,
+        },
+      },
+    });
+    renderRecurringRunList();
+    await loadRecurringRuns({});
+
+    expect(formatDateStringSpy.mock.calls.slice(0, 2)).toEqual([[startTime], [endTime]]);
+    expect(lastCustomTableProps.rows[0].otherFields[3]).toBe('1/2/2019, 12:34:56 PM');
+    expect(lastCustomTableProps.rows[0].otherFields[4]).toBe('1/2/2019, 12:34:56 PM');
+  });
+
+  it('shows dash for missing start time and end time', async () => {
+    mockNRecurringRuns(1, {
+      trigger: { periodic_schedule: { interval_second: '3600' } },
+    });
+    renderRecurringRunList();
+    await loadRecurringRuns({});
+
+    expect(lastCustomTableProps.rows[0].otherFields[3]).toBe('-');
+    expect(lastCustomTableProps.rows[0].otherFields[4]).toBe('-');
+  });
+
+  it('getScheduleTimes extracts from cron_schedule', () => {
+    const startTime = new Date('2025-01-01T00:00:00Z');
+    const endTime = new Date('2025-12-31T23:59:59Z');
+    const result = getScheduleTimes({
+      cron_schedule: { cron: '0 * * * *', start_time: startTime, end_time: endTime },
+    });
+    expect(result).toEqual({ startTime, endTime });
+  });
+
+  it('getScheduleTimes extracts from periodic_schedule', () => {
+    const startTime = new Date('2025-06-01T00:00:00Z');
+    const result = getScheduleTimes({
+      periodic_schedule: { interval_second: '60', start_time: startTime },
+    });
+    expect(result).toEqual({ startTime, endTime: undefined });
+  });
+
+  it('getScheduleTimes returns undefined for no trigger', () => {
+    expect(getScheduleTimes(undefined)).toEqual({ startTime: undefined, endTime: undefined });
+  });
+
+  it('getScheduleStatus returns Disabled for disabled runs', () => {
+    expect(
+      getScheduleStatus({
+        status: V2beta1RecurringRunStatus.DISABLED,
+        trigger: { periodic_schedule: { start_time: new Date('2020-01-01') } },
+      }),
+    ).toBe('Disabled');
+  });
+
+  it('getScheduleStatus returns dash for unknown/missing status', () => {
+    expect(getScheduleStatus({ recurring_run_id: 'err-row' } as V2beta1RecurringRun)).toBe('-');
+  });
+
+  it('getScheduleStatus returns Active for enabled run with no schedule times', () => {
+    expect(
+      getScheduleStatus({
+        status: V2beta1RecurringRunStatus.ENABLED,
+      }),
+    ).toBe('Active');
+  });
+
+  it('getScheduleStatus returns Active for enabled run within schedule window', () => {
+    expect(
+      getScheduleStatus({
+        status: V2beta1RecurringRunStatus.ENABLED,
+        trigger: {
+          periodic_schedule: {
+            start_time: new Date('2020-01-01'),
+            end_time: new Date('2099-12-31'),
+          },
+        },
+      }),
+    ).toBe('Active');
+  });
+
+  it('getScheduleStatus returns Scheduled for enabled run with future start_time', () => {
+    expect(
+      getScheduleStatus({
+        status: V2beta1RecurringRunStatus.ENABLED,
+        trigger: {
+          cron_schedule: {
+            cron: '0 * * * *',
+            start_time: new Date('2099-01-01'),
+          },
+        },
+      }),
+    ).toBe('Scheduled');
+  });
+
+  it('getScheduleStatus returns Expired for enabled run with past end_time', () => {
+    expect(
+      getScheduleStatus({
+        status: V2beta1RecurringRunStatus.ENABLED,
+        trigger: {
+          periodic_schedule: {
+            start_time: new Date('2020-01-01'),
+            end_time: new Date('2020-12-31'),
+          },
+        },
+      }),
+    ).toBe('Expired');
+  });
+
+  it('renders schedule status Active', () => {
+    renderRecurringRunList();
+    const { getByText } = render(
+      getInstance()._scheduleStatusCustomRenderer({
+        value: 'Active',
+        id: 'recurring run-id',
+      }),
+    );
+    expect(getByText('Active')).toHaveStyle({ color: color.success });
+  });
+
+  it('renders schedule status Scheduled', () => {
+    renderRecurringRunList();
+    const { getByText } = render(
+      getInstance()._scheduleStatusCustomRenderer({
+        value: 'Scheduled',
+        id: 'recurring run-id',
+      }),
+    );
+    expect(getByText('Scheduled')).toHaveStyle({ color: color.theme });
+  });
+
+  it('renders schedule status Expired', () => {
+    renderRecurringRunList();
+    const { getByText } = render(
+      getInstance()._scheduleStatusCustomRenderer({
+        value: 'Expired',
+        id: 'recurring run-id',
+      }),
+    );
+    expect(getByText('Expired')).toHaveStyle({ color: color.warningText });
+  });
+
+  it('renders schedule status Disabled', () => {
+    renderRecurringRunList();
+    const { getByText } = render(
+      getInstance()._scheduleStatusCustomRenderer({
+        value: 'Disabled',
+        id: 'recurring run-id',
+      }),
+    );
+    expect(getByText('Disabled')).toHaveStyle({ color: color.inactive });
   });
 });

--- a/frontend/src/pages/RecurringRunList.tsx
+++ b/frontend/src/pages/RecurringRunList.tsx
@@ -30,6 +30,35 @@ import {
 import { V2beta1ListExperimentsResponse } from 'src/apisv2beta1/experiment';
 import { Tooltip } from '@mui/material';
 
+/** Extracts start_time and end_time from the trigger's cron or periodic schedule. */
+export function getScheduleTimes(trigger?: V2beta1Trigger): { startTime?: Date; endTime?: Date } {
+  const schedule = trigger?.cron_schedule || trigger?.periodic_schedule;
+  return {
+    startTime: schedule?.start_time,
+    endTime: schedule?.end_time,
+  };
+}
+
+/** Derives schedule status (Active, Scheduled, Expired, Disabled) from run state and trigger times. */
+export function getScheduleStatus(recurringRun: V2beta1RecurringRun): string {
+  if (recurringRun.status === V2beta1RecurringRunStatus.DISABLED) {
+    return 'Disabled';
+  }
+  if (recurringRun.status !== V2beta1RecurringRunStatus.ENABLED) {
+    return '-';
+  }
+
+  const { startTime, endTime } = getScheduleTimes(recurringRun.trigger);
+  const now = new Date();
+  if (startTime && now < startTime) {
+    return 'Scheduled';
+  }
+  if (endTime && now > endTime) {
+    return 'Expired';
+  }
+  return 'Active';
+}
+
 interface DisplayRecurringRun {
   experiment?: ExperimentInfo;
   recurringRun: V2beta1RecurringRun;
@@ -88,11 +117,14 @@ class RecurringRunList extends React.PureComponent<RecurringRunListProps, Recurr
       },
       { customRenderer: this._statusCustomRenderer, label: 'Status', flex: 0.5 },
       { customRenderer: this._triggerCustomRenderer, label: 'Trigger', flex: 1 },
+      { label: 'Start Time', flex: 1 },
+      { label: 'End Time', flex: 1 },
+      { customRenderer: this._scheduleStatusCustomRenderer, label: 'Schedule Status', flex: 0.7 },
       { label: 'Created at', flex: 1, sortKey: JobSortKeys.CREATED_AT },
     ];
 
     if (!this.props.hideExperimentColumn) {
-      columns.splice(3, 0, {
+      columns.splice(6, 0, {
         customRenderer: this._experimentCustomRenderer,
         flex: 1,
         label: 'Experiment',
@@ -100,6 +132,7 @@ class RecurringRunList extends React.PureComponent<RecurringRunListProps, Recurr
     }
 
     const rows: Row[] = this.state.recurringRuns.map((j) => {
+      const { startTime, endTime } = getScheduleTimes(j.recurringRun.trigger);
       const row = {
         error: j.error,
         id: j.recurringRun.recurring_run_id!,
@@ -107,11 +140,14 @@ class RecurringRunList extends React.PureComponent<RecurringRunListProps, Recurr
           j.recurringRun!.display_name,
           j.recurringRun.status,
           j.recurringRun.trigger,
+          formatDateString(startTime),
+          formatDateString(endTime),
+          getScheduleStatus(j.recurringRun),
           formatDateString(j.recurringRun.created_at),
         ] as any,
       };
       if (!this.props.hideExperimentColumn) {
-        row.otherFields.splice(3, 0, j.experiment);
+        row.otherFields.splice(6, 0, j.experiment);
       }
 
       return row;
@@ -224,6 +260,32 @@ class RecurringRunList extends React.PureComponent<RecurringRunListProps, Recurr
         : props.value === V2beta1RecurringRunStatus.DISABLED
           ? color.inactive
           : color.errorText;
+    return <div style={{ color: textColor }}>{props.value}</div>;
+  };
+
+  public _scheduleStatusCustomRenderer: React.FC<CustomRendererProps<string>> = (
+    props: CustomRendererProps<string>,
+  ) => {
+    if (!props.value) {
+      return <div>-</div>;
+    }
+    let textColor: string;
+    switch (props.value) {
+      case 'Active':
+        textColor = color.success;
+        break;
+      case 'Scheduled':
+        textColor = color.theme;
+        break;
+      case 'Expired':
+        textColor = color.warningText;
+        break;
+      case 'Disabled':
+        textColor = color.inactive;
+        break;
+      default:
+        textColor = color.inactive;
+    }
     return <div style={{ color: textColor }}>{props.value}</div>;
   };
 


### PR DESCRIPTION
**Description of your changes:**
Adds Start Time, End Time, and Schedule Status columns to the recurring runs table. Currently, the recurring runs list shows only whether a job is enabled or disabled, but it's not immediately clear whether an enabled recurring run is still effectively active if an end_time was configured. Users must click into each run's details to check the schedule window.

**Changes**

**`RecurringRunList.tsx`**
- Added `getScheduleTimes()` helper to extract `start_time / end_time` from cron or periodic schedule triggers.
- Added `getScheduleStatus()` helper to derive a human-readable status from the run's enabled state and trigger time window:



          

    **Active (green)** — enabled, current time is within the schedule window
    **Scheduled (blue)** — enabled, but start_time is in the future
    **Expired (orange)** — enabled, but end_time has passed
    **Disabled (grey)** — manually disabled

- Added `_scheduleStatusCustomRenderer` with color-coded output.
- Added three new columns: `Start Time`, `End Time`, `Schedule Status`.
- Updated `Experiment` column splice index from 3 to 6 to account for new columns.

**`RecurringRunList.test.tsx`**

- Updated existing assertions for new `otherFields` indices and array length.
- Added 14 new tests covering all helpers and renderers.

**Before**
<img width="1900" height="887" alt="pipelines3" src="https://github.com/user-attachments/assets/75539988-6bec-4480-a29d-ca19117f3e37" />

**After**
<img width="1892" height="906" alt="pipelines4" src="https://github.com/user-attachments/assets/c9a4a955-b7ff-485b-929e-ffddce028c08" />

Closes #13406 




 