### PR TITLE
docs(backend): replace stale Testing section with pointer to AGENTS.md

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -16,21 +16,7 @@ Note that you may need to restart your shell after installing these resources in
 
 ## Testing
 
-To run all unittests for backend:
-
-```
-go test -v -cover ./backend/...
-```
-
-If running a [local API server](#run-the-kfp-backend-locally-with-a-kind-cluster), you can run the integration tests
-with:
-
-```bash
-LOCAL_API_SERVER=true go test -v ./backend/test/v2/integration/... -namespace kubeflow -args -runIntegrationTests=true
-```
-
-To run a specific test, you can use the `-run` flag. For example, to run the `TestCacheSingleRun` test in the
-`TestCache` suite, you can use the `-run 'TestCache/TestCacheSingleRun'` flag to the above command.
+See the [Local testing](../AGENTS.md#local-testing) section in AGENTS.md.
 
 ## Build
 


### PR DESCRIPTION
## Summary

- The `backend/README.md` Testing section contained outdated commands (`go test -v -cover ./backend/...`) that inadvertently ran integration/compiler/E2E tests alongside unit tests.
- The canonical, up-to-date testing reference is the **Local testing** section in `AGENTS.md`.
- This PR replaces the stale content with a single redirect line to keep a single source of truth.

## Test plan

- [ ] Verify `backend/README.md` renders correctly on GitHub with the link pointing to the right anchor in `AGENTS.md`.
- [ ] No code changes; no tests to run.