### PR TITLE
fix: resolve artifact lookup and graph assertion for retry nodes

### DIFF
--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -777,6 +777,7 @@ func (w *Workflow) SetCannonicalLabels(name string, nextScheduledEpoch int64, in
 
 // FindObjectStoreArtifactKeyOrEmpty loops through all node running statuses and look up the first
 // S3 artifact with the specified nodeID and artifactName. Returns empty if nothing is found.
+// Also checks children nodes to handle retry parent nodes that have no artifacts themselves.
 func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeName string, artifactName string) string {
 	if w.Status.Nodes == nil {
 		return ""
@@ -785,17 +786,30 @@ func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeName string, artifactNa
 	if !found {
 		return ""
 	}
+	if s3Key := findArtifactS3KeyFromNode(node, artifactName); s3Key != "" {
+		return s3Key
+	}
+	for _, childNodeID := range node.Children {
+		if childNode, childFound := w.Status.Nodes[childNodeID]; childFound {
+			if s3Key := findArtifactS3KeyFromNode(childNode, artifactName); s3Key != "" {
+				return s3Key
+			}
+		}
+	}
+	return ""
+}
+
+// findArtifactS3KeyFromNode extracts the S3 key for a named artifact from a node's outputs.
+func findArtifactS3KeyFromNode(node workflowapi.NodeStatus, artifactName string) string {
 	if node.Outputs == nil || node.Outputs.Artifacts == nil {
 		return ""
 	}
-	var s3Key string
 	for _, artifact := range node.Outputs.Artifacts {
-		if artifact.Name != artifactName || artifact.S3 == nil || artifact.S3.Key == "" {
-			continue
+		if artifact.Name == artifactName && artifact.S3 != nil && artifact.S3.Key != "" {
+			return artifact.S3.Key
 		}
-		s3Key = artifact.S3.Key
 	}
-	return s3Key
+	return ""
 }
 
 // IsInFinalState whether the workflow is in a final state.

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -2381,6 +2381,53 @@ func TestWorkflow_FindObjectStoreArtifactKeyOrEmpty_NodeNotFound(t *testing.T) {
 	assert.Equal(t, "", workflow.FindObjectStoreArtifactKeyOrEmpty("node1", "artifact1"))
 }
 
+func TestWorkflow_FindObjectStoreArtifactKeyOrEmpty_RetryParentNode(t *testing.T) {
+	// Retry parent node (from global retryStrategy) delegates artifacts to child execution nodes.
+	workflow := NewWorkflow(&workflowapi.Workflow{
+		Status: workflowapi.WorkflowStatus{
+			Nodes: map[string]workflowapi.NodeStatus{
+				"retry-parent-node": {
+					ID:       "retry-parent-node",
+					Type:     workflowapi.NodeTypeRetry,
+					Children: []string{"retry-parent-node(0)"},
+				},
+				"retry-parent-node(0)": {
+					ID: "retry-parent-node(0)",
+					Outputs: &workflowapi.Outputs{
+						Artifacts: workflowapi.Artifacts{
+							{
+								Name: "artifact1",
+								ArtifactLocation: workflowapi.ArtifactLocation{
+									S3: &workflowapi.S3Artifact{
+										Key: "bucket/artifacts/retry-child-key",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	assert.Equal(t, "bucket/artifacts/retry-child-key",
+		workflow.FindObjectStoreArtifactKeyOrEmpty("retry-parent-node", "artifact1"))
+}
+
+func TestWorkflow_FindObjectStoreArtifactKeyOrEmpty_RetryParentNoChildren(t *testing.T) {
+	// Retry parent node with no children should return empty.
+	workflow := NewWorkflow(&workflowapi.Workflow{
+		Status: workflowapi.WorkflowStatus{
+			Nodes: map[string]workflowapi.NodeStatus{
+				"retry-parent-node": {
+					ID:   "retry-parent-node",
+					Type: workflowapi.NodeTypeRetry,
+				},
+			},
+		},
+	})
+	assert.Equal(t, "", workflow.FindObjectStoreArtifactKeyOrEmpty("retry-parent-node", "artifact1"))
+}
+
 // nonWorkflowExecution implements ExecutionSpec via embedding but is not *Workflow.
 // Used to test type assertion failures in WorkflowInterface methods.
 type nonWorkflowExecution struct {

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -193,7 +193,13 @@ describe('deploy helloworld sample run', () => {
   });
 
   it('has a 4-node graph', async () => {
-    await waitForGraphNodeCount(4, { timeout: uiTimeout });
+    await waitForCondition(
+      async () => (await $$('.graphNode')).length >= 4,
+      {
+        timeout: uiTimeout,
+        timeoutMsg: 'expected at least 4 graph node(s) to be visible',
+      },
+    );
   });
 
   it('opens the side panel when graph node is clicked', async () => {


### PR DESCRIPTION
Fixes CI failures introduced by the global `templateDefaults.retryStrategy` in #13485.

## Root Cause

When `templateDefaults.retryStrategy` is applied via `workflowDefaults`, Argo wraps each template execution in a retry parent node. This caused two failures:

1. `FindObjectStoreArtifactKeyOrEmpty` returned empty for retry parent nodes (no artifacts on parent), causing the ReadArtifact v1 API to return HTTP 404.
2. The helloworld frontend test expected exactly 4 runtime graph nodes, but retry wrappers increased the count.

## Changes

| File | Change |
|---|---|
| `backend/src/common/util/workflow.go` | Check children nodes when parent has no matching artifact. Extract `findArtifactS3KeyFromNode` helper. |
| `backend/src/common/util/workflow_test.go` | Add `RetryParentNode` and `RetryParentNoChildren` test cases. |
| `test/frontend-integration-test/helloworld.spec.js` | Accept `>= 4` runtime graph nodes instead of `=== 4`. |

## Verification

- Existing `FindObjectStoreArtifactKeyOrEmpty` unit tests pass unchanged.
- New unit tests cover retry parent with children and retry parent without children.

Signed-off-by: Siddhant Jain <siddhantjainofficial26@gmail.com>
