### PR TITLE
fix: use jq for artifact key lookup in proxy test

### DIFF
--- a/test/artifact-proxy/test-artifact-proxy.sh
+++ b/test/artifact-proxy/test-artifact-proxy.sh
@@ -71,7 +71,8 @@ if [[ "$WORKFLOW_PHASE" != "Succeeded" ]]; then
   exit 1
 fi
 
-KEY=$(kubectl -n "$NAMESPACE" get workflow "$WORKFLOW_NAME" -o jsonpath='{.status.nodes.*.outputs.artifacts[?(@.name=="out")].s3.key}')
+KEY=$(kubectl -n "$NAMESPACE" get workflow "$WORKFLOW_NAME" -o json | \
+  jq -r '[.status.nodes[].outputs.artifacts[]? | select(.name=="out") | .s3.key] | first')
 ART_URL="http://ml-pipeline-ui-artifact.${NAMESPACE}.svc.cluster.local/artifacts/get?source=minio&bucket=mlpipeline&key=${KEY}"
 if ! kubectl -n "$NAMESPACE" exec kfp-proxy-curl -- sh -c \
   "curl -fsS -H 'kubeflow-userid: user@example.com' '${ART_URL}' 2>/dev/null | grep -qx 'artifact-proxy-e2e-test-content'"; then


### PR DESCRIPTION
Fixes the `Test Artifact Proxy` failure on `proper-argo-retries`.

## Root Cause

`test-artifact-proxy.sh` line 74 uses kubectl jsonpath to extract the artifact S3 key:

```bash
kubectl ... -o jsonpath='{.status.nodes.*.outputs.artifacts[?(@.name=="out")].s3.key}'
```
With `templateDefaults.retryStrategy`, Argo wraps each template in a retry parent node that has no `outputs.artifacts` field. kubectl jsonpath returns empty when `nodes.*` matches nodes without the `outputs` field, causing the subsequent artifact fetch to fail with HTTP 404.

This is not a flake. CI history confirms 100% failure rate on branches with retryStrategy and 100% pass rate on branches without it.

## Changes

| File | Change |
|---|---|
| `test/artifact-proxy/test-artifact-proxy.sh` | Replace jsonpath with `jq` using the optional operator (`[]?`) to skip nodes without artifacts |

## Why jq

`jq` is already used in CI scripts (`configure-mlflow.sh`, `deploy-kfp.sh`, `upgrade-test.yml`) and is pre-installed on `ubuntu-latest` runners. The `[]?` try-operator silently skips nodes lacking `outputs.artifacts`, and `first` returns the first matching key from child execution nodes.

Signed-off-by: Siddhant Jain <siddhantjainofficial26@gmail.com>
