### PR TITLE
fix(backend): avoid bucket refresh on metadata retry. Fixes #13501

### DIFF
--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -890,6 +890,10 @@ func uploadOutputArtifactsWithRetry(
 		var uploadErr *outputArtifactUploadError
 		if errors.As(err, &uploadErr) {
 			glog.Info("Refreshing credentials before retrying artifacts upload.")
+			if openBucketConfig == nil {
+				finalErr = fmt.Errorf("failed to refresh credentials before retrying artifacts upload: open bucket config is nil: %w", err)
+				break
+			}
 			openBucket := objectstore.OpenBucket
 			if openBucketConfig.open != nil {
 				openBucket = openBucketConfig.open

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -172,6 +172,7 @@ type OpenBucketConfig struct {
 	k8sClient kubernetes.Interface
 	namespace string
 	config    *objectstore.Config
+	open      func(context.Context, kubernetes.Interface, string, *objectstore.Config) (*blob.Bucket, error)
 }
 
 // Execute calls executeV2, updates the cache, and publishes the results to MLMD.
@@ -775,6 +776,18 @@ type uploadOutputArtifactsOptions struct {
 	metadataClient metadata.ClientInterface
 }
 
+type outputArtifactUploadError struct {
+	err error
+}
+
+func (e *outputArtifactUploadError) Error() string {
+	return e.err.Error()
+}
+
+func (e *outputArtifactUploadError) Unwrap() error {
+	return e.err
+}
+
 func uploadOutputArtifacts(
 	ctx context.Context,
 	executorInput *pipelinespec.ExecutorInput,
@@ -831,7 +844,7 @@ func uploadOutputArtifacts(
 							continue
 						}
 					} else {
-						return nil, fmt.Errorf("failed to upload output artifact %q to remote storage URI %q: %w", name, outputArtifact.Uri, err)
+						return nil, &outputArtifactUploadError{err: fmt.Errorf("failed to upload output artifact %q to remote storage URI %q: %w", name, outputArtifact.Uri, err)}
 					}
 				}
 			}
@@ -874,21 +887,29 @@ func uploadOutputArtifactsWithRetry(
 
 	for retryCount := 1; retryCount < maxAttempts; retryCount++ {
 		glog.Warningf("Failed to upload output artifacts: %v", err)
-		glog.Info("Refreshing credentials before retrying artifacts upload.")
-		opts.bucket, err = objectstore.OpenBucket(
-			openBucketConfig.ctx,
-			openBucketConfig.k8sClient,
-			openBucketConfig.namespace,
-			openBucketConfig.config,
-		)
-		if err != nil {
-			glog.Infof("Failed to refresh credentials: %v", err)
-			finalErr = err
-			continue
+		var uploadErr *outputArtifactUploadError
+		if errors.As(err, &uploadErr) {
+			glog.Info("Refreshing credentials before retrying artifacts upload.")
+			openBucket := objectstore.OpenBucket
+			if openBucketConfig.open != nil {
+				openBucket = openBucketConfig.open
+			}
+			refreshedBucket, err := openBucket(
+				openBucketConfig.ctx,
+				openBucketConfig.k8sClient,
+				openBucketConfig.namespace,
+				openBucketConfig.config,
+			)
+			if err != nil {
+				glog.Infof("Failed to refresh credentials: %v", err)
+				finalErr = err
+				continue
+			}
+			opts.bucket = refreshedBucket
 		}
 
 		glog.Infof("Executing uploadOutputArtifacts attempt: %d", retryCount+1)
-		outputArtifacts, err := uploadOutputArtifacts(ctx, executorInput, executorOutput, opts, componentSucceeded)
+		outputArtifacts, err = uploadOutputArtifacts(ctx, executorInput, executorOutput, opts, componentSucceeded)
 
 		if err == nil {
 			return outputArtifacts, nil

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -394,6 +394,53 @@ func Test_uploadOutputArtifactsWithRetry_refreshesBucketAfterUploadFailure(t *te
 	assert.Equal(t, "dataset", string(uploaded))
 }
 
+func Test_uploadOutputArtifactsWithRetry_returnsErrorWhenUploadFailureCannotRefreshBucket(t *testing.T) {
+	ctx := context.Background()
+	bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket-refresh-missing-config/pipeline-root/", nil)
+	assert.Nil(t, err)
+
+	staleBucket, err := blob.OpenBucket(ctx, "mem://test-bucket-refresh-missing-config")
+	assert.Nil(t, err)
+	assert.Nil(t, staleBucket.Close())
+
+	tempDir := t.TempDir()
+	outputDataPath := filepath.Join(tempDir, "output-data")
+	assert.Nil(t, os.WriteFile(outputDataPath, []byte("dataset"), 0644))
+
+	executorInput := &pipelinespec.ExecutorInput{
+		Outputs: &pipelinespec.ExecutorInput_Outputs{
+			Artifacts: map[string]*pipelinespec.ArtifactList{
+				"output-data": {
+					Artifacts: []*pipelinespec.RuntimeArtifact{
+						{
+							Uri:        "mem://test-bucket-refresh-missing-config/pipeline-root/output-data",
+							Type:       &pipelinespec.ArtifactTypeSchema{Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{SchemaTitle: "system.Dataset"}},
+							CustomPath: &outputDataPath,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = uploadOutputArtifactsWithRetry(
+		ctx,
+		executorInput,
+		nil,
+		uploadOutputArtifactsOptions{
+			bucketConfig:   bucketConfig,
+			bucket:         staleBucket,
+			metadataClient: metadata.NewFakeClient(),
+		},
+		true,
+		nil,
+		2,
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "open bucket config is nil")
+}
+
 func Test_executeV2_publishLogs_skipsArtifactWhenSetupFailsBeforeLogsExist(t *testing.T) {
 	fakeKubernetesClientset := &fake.Clientset{}
 	fakeMetadataClient := metadata.NewFakeClient()

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	k8score "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -106,7 +107,7 @@ func Test_executeV2_Parameters(t *testing.T) {
 				fakeKubernetesClientset,
 				"false",
 				"",
-				&OpenBucketConfig{context.Background(), fakeKubernetesClientset, "namespace", bucketConfig},
+				&OpenBucketConfig{ctx: context.Background(), k8sClient: fakeKubernetesClientset, namespace: "namespace", config: bucketConfig},
 			)
 
 			if test.wantErr {
@@ -223,6 +224,14 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			assert.Nil(t, err)
 			bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket/pipeline-root/", nil)
 			assert.Nil(t, err)
+			bucketRefreshes := 0
+			openBucketConfig := &OpenBucketConfig{ctx: context.Background(), k8sClient: fakeKubernetesClientset, namespace: "namespace", config: bucketConfig}
+			if test.uploadFailure {
+				openBucketConfig.open = func(ctx context.Context, k8sClient kubernetes.Interface, namespace string, config *objectstore.Config) (*blob.Bucket, error) {
+					bucketRefreshes++
+					return nil, errors.New("bucket refresh should not run for metadata retry")
+				}
+			}
 			// Add executor-logs and output artifact to outputs
 			if test.executorInput.Outputs == nil {
 				test.executorInput.Outputs = &pipelinespec.ExecutorInput_Outputs{}
@@ -271,7 +280,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 				fakeKubernetesClientset,
 				"true",
 				"",
-				&OpenBucketConfig{context.Background(), fakeKubernetesClientset, "namespace", bucketConfig},
+				openBucketConfig,
 			)
 
 			if test.wantErr {
@@ -280,6 +289,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 				if test.uploadFailure {
 					// Only logs uploaded - first call fails, second call succeeds
 					assert.Equal(t, 2, countingFakeMetadataClient.RecordArtifactCalls)
+					assert.Equal(t, 0, bucketRefreshes)
 				}
 			} else {
 				assert.Nil(t, err)
@@ -287,6 +297,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 				if test.uploadFailure {
 					// First call fails and returns early, then both artifacts succeed on retry
 					assert.Equal(t, 3, countingFakeMetadataClient.RecordArtifactCalls)
+					assert.Equal(t, 0, bucketRefreshes)
 				}
 			}
 
@@ -313,6 +324,74 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			assert.Equal(t, "testoutput\n", string(outputLog))
 		})
 	}
+}
+
+func Test_uploadOutputArtifactsWithRetry_refreshesBucketAfterUploadFailure(t *testing.T) {
+	ctx := context.Background()
+	fakeKubernetesClientset := &fake.Clientset{}
+	bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket-refresh/pipeline-root/", nil)
+	assert.Nil(t, err)
+
+	staleBucket, err := blob.OpenBucket(ctx, "mem://test-bucket-refresh")
+	assert.Nil(t, err)
+	assert.Nil(t, staleBucket.Close())
+
+	refreshedBucket, err := blob.OpenBucket(ctx, "mem://test-bucket-refresh")
+	assert.Nil(t, err)
+	defer refreshedBucket.Close()
+
+	tempDir := t.TempDir()
+	outputDataPath := filepath.Join(tempDir, "output-data")
+	assert.Nil(t, os.WriteFile(outputDataPath, []byte("dataset"), 0644))
+
+	executorInput := &pipelinespec.ExecutorInput{
+		Outputs: &pipelinespec.ExecutorInput_Outputs{
+			Artifacts: map[string]*pipelinespec.ArtifactList{
+				"output-data": {
+					Artifacts: []*pipelinespec.RuntimeArtifact{
+						{
+							Uri:        "mem://test-bucket-refresh/pipeline-root/output-data",
+							Type:       &pipelinespec.ArtifactTypeSchema{Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{SchemaTitle: "system.Dataset"}},
+							CustomPath: &outputDataPath,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	bucketRefreshes := 0
+	openBucketConfig := &OpenBucketConfig{
+		ctx:       ctx,
+		k8sClient: fakeKubernetesClientset,
+		namespace: "namespace",
+		config:    bucketConfig,
+		open: func(ctx context.Context, k8sClient kubernetes.Interface, namespace string, config *objectstore.Config) (*blob.Bucket, error) {
+			bucketRefreshes++
+			return refreshedBucket, nil
+		},
+	}
+
+	outputArtifacts, err := uploadOutputArtifactsWithRetry(
+		ctx,
+		executorInput,
+		nil,
+		uploadOutputArtifactsOptions{
+			bucketConfig:   bucketConfig,
+			bucket:         staleBucket,
+			metadataClient: metadata.NewFakeClient(),
+		},
+		true,
+		openBucketConfig,
+		2,
+	)
+
+	assert.Nil(t, err)
+	assert.Len(t, outputArtifacts, 1)
+	assert.Equal(t, 1, bucketRefreshes)
+	uploaded, err := refreshedBucket.ReadAll(ctx, "output-data")
+	assert.Nil(t, err)
+	assert.Equal(t, "dataset", string(uploaded))
 }
 
 func Test_executeV2_publishLogs_skipsArtifactWhenSetupFailsBeforeLogsExist(t *testing.T) {
@@ -357,7 +436,7 @@ func Test_executeV2_publishLogs_skipsArtifactWhenSetupFailsBeforeLogsExist(t *te
 		fakeKubernetesClientset,
 		"true",
 		filepath.Join(tempDir, "missing-ca.pem"),
-		&OpenBucketConfig{context.Background(), fakeKubernetesClientset, "namespace", bucketConfig},
+		&OpenBucketConfig{ctx: context.Background(), k8sClient: fakeKubernetesClientset, namespace: "namespace", config: bucketConfig},
 	)
 
 	assert.Error(t, err)
@@ -420,7 +499,7 @@ EOF`, filepath.Dir(outputMetadataFile), outputMetadataFile)
 		fakeKubernetesClientset,
 		"true",
 		"",
-		&OpenBucketConfig{context.Background(), fakeKubernetesClientset, "namespace", bucketConfig},
+		&OpenBucketConfig{ctx: context.Background(), k8sClient: fakeKubernetesClientset, namespace: "namespace", config: bucketConfig},
 	)
 
 	assert.Nil(t, err)

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -37,6 +37,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	k8score "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -106,7 +107,7 @@ func Test_executeV2_Parameters(t *testing.T) {
 				fakeKubernetesClientset,
 				"false",
 				"",
-				&OpenBucketConfig{context.Background(), fakeKubernetesClientset, "namespace", bucketConfig},
+				&OpenBucketConfig{ctx: context.Background(), k8sClient: fakeKubernetesClientset, namespace: "namespace", config: bucketConfig},
 			)
 
 			if test.wantErr {
@@ -223,6 +224,14 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			assert.Nil(t, err)
 			bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket/pipeline-root/", nil)
 			assert.Nil(t, err)
+			bucketRefreshes := 0
+			openBucketConfig := &OpenBucketConfig{ctx: context.Background(), k8sClient: fakeKubernetesClientset, namespace: "namespace", config: bucketConfig}
+			if test.uploadFailure {
+				openBucketConfig.open = func(ctx context.Context, k8sClient kubernetes.Interface, namespace string, config *objectstore.Config) (*blob.Bucket, error) {
+					bucketRefreshes++
+					return nil, errors.New("bucket refresh should not run for metadata retry")
+				}
+			}
 			// Add executor-logs and output artifact to outputs
 			if test.executorInput.Outputs == nil {
 				test.executorInput.Outputs = &pipelinespec.ExecutorInput_Outputs{}
@@ -271,7 +280,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 				fakeKubernetesClientset,
 				"true",
 				"",
-				&OpenBucketConfig{context.Background(), fakeKubernetesClientset, "namespace", bucketConfig},
+				openBucketConfig,
 			)
 
 			if test.wantErr {
@@ -279,12 +288,18 @@ func Test_executeV2_publishLogs(t *testing.T) {
 				assert.Len(t, outputArtifacts, 1, "Expected 1 output artifact (executor-logs)")
 				if test.uploadFailure {
 					assert.Equal(t, 2, countingFakeMetadataClient.OutputNameCalls["executor-logs"])
+					// Only logs uploaded - first call fails, second call succeeds
+					assert.Equal(t, 2, countingFakeMetadataClient.RecordArtifactCalls)
+					assert.Equal(t, 0, bucketRefreshes)
 				}
 			} else {
 				assert.Nil(t, err)
 				assert.Len(t, outputArtifacts, 2, "Expected 2 output artifacts (executor-logs and output-data)")
 				if test.uploadFailure {
 					assert.Equal(t, 2, countingFakeMetadataClient.OutputNameCalls["executor-logs"])
+					// First call fails and returns early, then both artifacts succeed on retry
+					assert.Equal(t, 3, countingFakeMetadataClient.RecordArtifactCalls)
+					assert.Equal(t, 0, bucketRefreshes)
 				}
 			}
 
@@ -311,6 +326,74 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			assert.Equal(t, "testoutput\n", string(outputLog))
 		})
 	}
+}
+
+func Test_uploadOutputArtifactsWithRetry_refreshesBucketAfterUploadFailure(t *testing.T) {
+	ctx := context.Background()
+	fakeKubernetesClientset := &fake.Clientset{}
+	bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket-refresh/pipeline-root/", nil)
+	assert.Nil(t, err)
+
+	staleBucket, err := blob.OpenBucket(ctx, "mem://test-bucket-refresh")
+	assert.Nil(t, err)
+	assert.Nil(t, staleBucket.Close())
+
+	refreshedBucket, err := blob.OpenBucket(ctx, "mem://test-bucket-refresh")
+	assert.Nil(t, err)
+	defer refreshedBucket.Close()
+
+	tempDir := t.TempDir()
+	outputDataPath := filepath.Join(tempDir, "output-data")
+	assert.Nil(t, os.WriteFile(outputDataPath, []byte("dataset"), 0644))
+
+	executorInput := &pipelinespec.ExecutorInput{
+		Outputs: &pipelinespec.ExecutorInput_Outputs{
+			Artifacts: map[string]*pipelinespec.ArtifactList{
+				"output-data": {
+					Artifacts: []*pipelinespec.RuntimeArtifact{
+						{
+							Uri:        "mem://test-bucket-refresh/pipeline-root/output-data",
+							Type:       &pipelinespec.ArtifactTypeSchema{Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{SchemaTitle: "system.Dataset"}},
+							CustomPath: &outputDataPath,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	bucketRefreshes := 0
+	openBucketConfig := &OpenBucketConfig{
+		ctx:       ctx,
+		k8sClient: fakeKubernetesClientset,
+		namespace: "namespace",
+		config:    bucketConfig,
+		open: func(ctx context.Context, k8sClient kubernetes.Interface, namespace string, config *objectstore.Config) (*blob.Bucket, error) {
+			bucketRefreshes++
+			return refreshedBucket, nil
+		},
+	}
+
+	outputArtifacts, err := uploadOutputArtifactsWithRetry(
+		ctx,
+		executorInput,
+		nil,
+		uploadOutputArtifactsOptions{
+			bucketConfig:   bucketConfig,
+			bucket:         staleBucket,
+			metadataClient: metadata.NewFakeClient(),
+		},
+		true,
+		openBucketConfig,
+		2,
+	)
+
+	assert.Nil(t, err)
+	assert.Len(t, outputArtifacts, 1)
+	assert.Equal(t, 1, bucketRefreshes)
+	uploaded, err := refreshedBucket.ReadAll(ctx, "output-data")
+	assert.Nil(t, err)
+	assert.Equal(t, "dataset", string(uploaded))
 }
 
 func Test_executeV2_publishLogs_skipsArtifactWhenSetupFailsBeforeLogsExist(t *testing.T) {
@@ -355,7 +438,7 @@ func Test_executeV2_publishLogs_skipsArtifactWhenSetupFailsBeforeLogsExist(t *te
 		fakeKubernetesClientset,
 		"true",
 		filepath.Join(tempDir, "missing-ca.pem"),
-		&OpenBucketConfig{context.Background(), fakeKubernetesClientset, "namespace", bucketConfig},
+		&OpenBucketConfig{ctx: context.Background(), k8sClient: fakeKubernetesClientset, namespace: "namespace", config: bucketConfig},
 	)
 
 	assert.Error(t, err)
@@ -418,7 +501,7 @@ EOF`, filepath.Dir(outputMetadataFile), outputMetadataFile)
 		fakeKubernetesClientset,
 		"true",
 		"",
-		&OpenBucketConfig{context.Background(), fakeKubernetesClientset, "namespace", bucketConfig},
+		&OpenBucketConfig{ctx: context.Background(), k8sClient: fakeKubernetesClientset, namespace: "namespace", config: bucketConfig},
 	)
 
 	assert.Nil(t, err)

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -122,12 +122,12 @@ func Test_executeV2_Parameters(t *testing.T) {
 
 func Test_executeV2_publishLogs(t *testing.T) {
 	tests := []struct {
-		name          string
-		executorInput *pipelinespec.ExecutorInput
-		executorArgs  []string
-		retryIndex    string
-		wantErr       bool
-		uploadFailure bool
+		name            string
+		executorInput   *pipelinespec.ExecutorInput
+		executorArgs    []string
+		retryIndex      string
+		wantErr         bool
+		metadataFailure bool
 	}{
 		{
 			"happy pass",
@@ -214,7 +214,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			var countingFakeMetadataClient *metadata.RecordArtifactFailureFakeClient
 			// Use a fake client that will fail the executor-logs RecordArtifact call the first time,
 			// and succeed the second time, to test retry behavior without depending on map iteration order.
-			if test.uploadFailure {
+			if test.metadataFailure {
 				countingFakeMetadataClient = metadata.NewRecordArtifactFailureFakeClientForOutput("executor-logs", 1)
 				fakeMetadataClient = countingFakeMetadataClient
 			} else {
@@ -226,7 +226,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			assert.Nil(t, err)
 			bucketRefreshes := 0
 			openBucketConfig := &OpenBucketConfig{ctx: context.Background(), k8sClient: fakeKubernetesClientset, namespace: "namespace", config: bucketConfig}
-			if test.uploadFailure {
+			if test.metadataFailure {
 				openBucketConfig.open = func(ctx context.Context, k8sClient kubernetes.Interface, namespace string, config *objectstore.Config) (*blob.Bucket, error) {
 					bucketRefreshes++
 					return nil, errors.New("bucket refresh should not run for metadata retry")
@@ -286,7 +286,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			if test.wantErr {
 				assert.NotNil(t, err)
 				assert.Len(t, outputArtifacts, 1, "Expected 1 output artifact (executor-logs)")
-				if test.uploadFailure {
+				if test.metadataFailure {
 					assert.Equal(t, 2, countingFakeMetadataClient.OutputNameCalls["executor-logs"])
 					// Only logs uploaded - first call fails, second call succeeds
 					assert.Equal(t, 2, countingFakeMetadataClient.RecordArtifactCalls)
@@ -295,7 +295,7 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			} else {
 				assert.Nil(t, err)
 				assert.Len(t, outputArtifacts, 2, "Expected 2 output artifacts (executor-logs and output-data)")
-				if test.uploadFailure {
+				if test.metadataFailure {
 					assert.Equal(t, 2, countingFakeMetadataClient.OutputNameCalls["executor-logs"])
 					// First call fails and returns early, then both artifacts succeed on retry
 					assert.Equal(t, 3, countingFakeMetadataClient.RecordArtifactCalls)

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -396,6 +396,53 @@ func Test_uploadOutputArtifactsWithRetry_refreshesBucketAfterUploadFailure(t *te
 	assert.Equal(t, "dataset", string(uploaded))
 }
 
+func Test_uploadOutputArtifactsWithRetry_returnsErrorWhenUploadFailureCannotRefreshBucket(t *testing.T) {
+	ctx := context.Background()
+	bucketConfig, err := objectstore.ParseBucketConfig("mem://test-bucket-refresh-missing-config/pipeline-root/", nil)
+	assert.Nil(t, err)
+
+	staleBucket, err := blob.OpenBucket(ctx, "mem://test-bucket-refresh-missing-config")
+	assert.Nil(t, err)
+	assert.Nil(t, staleBucket.Close())
+
+	tempDir := t.TempDir()
+	outputDataPath := filepath.Join(tempDir, "output-data")
+	assert.Nil(t, os.WriteFile(outputDataPath, []byte("dataset"), 0644))
+
+	executorInput := &pipelinespec.ExecutorInput{
+		Outputs: &pipelinespec.ExecutorInput_Outputs{
+			Artifacts: map[string]*pipelinespec.ArtifactList{
+				"output-data": {
+					Artifacts: []*pipelinespec.RuntimeArtifact{
+						{
+							Uri:        "mem://test-bucket-refresh-missing-config/pipeline-root/output-data",
+							Type:       &pipelinespec.ArtifactTypeSchema{Kind: &pipelinespec.ArtifactTypeSchema_SchemaTitle{SchemaTitle: "system.Dataset"}},
+							CustomPath: &outputDataPath,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err = uploadOutputArtifactsWithRetry(
+		ctx,
+		executorInput,
+		nil,
+		uploadOutputArtifactsOptions{
+			bucketConfig:   bucketConfig,
+			bucket:         staleBucket,
+			metadataClient: metadata.NewFakeClient(),
+		},
+		true,
+		nil,
+		2,
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "open bucket config is nil")
+}
+
 func Test_executeV2_publishLogs_skipsArtifactWhenSetupFailsBeforeLogsExist(t *testing.T) {
 	fakeKubernetesClientset := &fake.Clientset{}
 	fakeMetadataClient := metadata.NewFakeClient()


### PR DESCRIPTION
## Summary
- distinguish object-store upload failures from MLMD `RecordArtifact` failures during output artifact retry
- avoid refreshing/replacing the bucket handle when only metadata registration failed
- keep refreshing the bucket for real upload failures and only swap the handle after refresh succeeds

## Verification
- `go test -v -run 'Test_uploadOutputArtifactsWithRetry_refreshesBucketAfterUploadFailure|Test_executeV2_publishLogs/retry_required_-_component_success|Test_executeV2_publishLogs/retry_required_-_component_failure' ./backend/src/v2/component`
- `go test ./backend/src/v2/component ./backend/src/v2/objectstore ./backend/src/v2/metadata`
- `autoreview --mode local --engine codex --model gpt-5.3-codex-spark` returned clean

Fixes #13501
