### PR TITLE
refactor(manifests): replace dbHost/dbPort relics with mysqlHost/mysqlPort

### DIFF
--- a/manifests/kustomize/base/cache/cache-deployment.yaml
+++ b/manifests/kustomize/base/cache/cache-deployment.yaml
@@ -63,12 +63,12 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: pipeline-install-config
-                key: dbHost
+                key: mysqlHost
           - name: DBCONFIG_PORT
             valueFrom:
               configMapKeyRef:
                 name: pipeline-install-config
-                key: dbPort
+                key: mysqlPort
           - name: DBCONFIG_USER
             valueFrom:
               secretKeyRef:

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -12,8 +12,6 @@ data:
     namespace: `kubectl rollout restart deployment -n <your-namespace>`.
   appName: pipeline
   appVersion: 2.16.1
-  dbHost: mysql # relic to be removed after release
-  dbPort: "3306" # relic to be removed after release
   dbType: mysql
   mysqlHost: mysql
   mysqlPort: "3306"

--- a/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
@@ -12,9 +12,7 @@ data:
     namespace: `kubectl rollout restart deployment -n <your-namespace>`.
   appName: pipeline
   appVersion: 2.0.0
-  dbHost: postgres  # relic to be removed after release
-  dbPort: "5432"    # relic to be removed after release
-  dbType: postgres  
+  dbType: postgres
   postgresHost: postgres
   postgresPort: "5432"
   mlmdDb: metadb
@@ -24,7 +22,7 @@ data:
   ## defaultPipelineRoot: Optional. Default pipeline root in v2 compatible mode.
   ## https://www.kubeflow.org/docs/components/pipelines/sdk/v2/v2-compatibility/
   ##
-  ## If the field is not set, kfp-launcher configmaps won't be created and 
+  ## If the field is not set, kfp-launcher configmaps won't be created and
   ## v2 compatible mode defaults to minio://mlpipeline/v2/artifacts as pipeline
   ## root.
   ##
@@ -61,20 +59,20 @@ data:
   ## [Alpha](https://github.com/kubeflow/pipelines/blob/master/docs/release/feature-stages.md#alpha)
   cronScheduleTimezone: "UTC"
   ## cacheImage is the image that the mutating webhook will use to patch
-  ## cached steps with. Will be used to echo a message announcing that 
-  ## the cached step result will be used. If not set it will default to 
+  ## cached steps with. Will be used to echo a message announcing that
+  ## the cached step result will be used. If not set it will default to
   ## 'ghcr.io/containerd/busybox'
   cacheImage: "ghcr.io/containerd/busybox"
   ## cacheNodeRestrictions the dummy container runing if output is cached
   ## will run with the same affinity and node selector as the default pipeline
-  ## step. This is defaulted to 'false' to allow the pod to be scheduled on 
+  ## step. This is defaulted to 'false' to allow the pod to be scheduled on
   ## any node and avoid defaulting to specific nodes. Allowed values are:
   ## 'false' and 'true'.
   cacheNodeRestrictions: "false"
   ## MAXIMUM_CACHE_STALENESS configures caching according to
   ## https://www.kubeflow.org/docs/components/pipelines/overview/caching/ and
   ## https://www.kubeflow.org/docs/components/pipelines/overview/caching-v2/.
-  ## Larger than MAXIMUM_CACHE_STALENESS per pipeline user set values are 
+  ## Larger than MAXIMUM_CACHE_STALENESS per pipeline user set values are
   ## reduced to MAXIMUM_CACHE_STALENESS.
   ## The administrator of the storage backend can rely on it to delete old cache
   ## artifacts.

--- a/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/base/metadata/base/metadata-grpc-deployment.yaml
@@ -44,12 +44,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
-              key: dbHost
+              key: mysqlHost
         - name: WAIT_PORT
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
-              key: dbPort
+              key: mysqlPort
         command: ["/bin/sh", "-ec"]
         args:
           - |
@@ -106,12 +106,12 @@ spec:
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
-              key: dbHost
+              key: mysqlHost
         - name: MYSQL_PORT
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
-              key: dbPort
+              key: mysqlPort
         command: ["/bin/metadata_store_server"]
         args: ["--grpc_port=8080",
                "--mysql_config_database=$(MYSQL_DATABASE)",

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -45,12 +45,12 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: pipeline-install-config
-                  key: dbHost
+                  key: mysqlHost
             - name: WAIT_PORT
               valueFrom:
                 configMapKeyRef:
                   name: pipeline-install-config
-                  key: dbPort
+                  key: mysqlPort
           command: ["/bin/sh", "-ec"]
           args:
             - |
@@ -160,12 +160,12 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: pipeline-install-config
-                  key: dbHost
+                  key: mysqlHost
             - name: DBCONFIG_PORT
               valueFrom:
                 configMapKeyRef:
                   name: pipeline-install-config
-                  key: dbPort
+                  key: mysqlPort
             # end of relic variables
             - name: DBCONFIG_CONMAXLIFETIME
               valueFrom:

--- a/manifests/kustomize/base/postgresql/pipeline/ml-pipeline-apiserver-deployment-patch.yaml
+++ b/manifests/kustomize/base/postgresql/pipeline/ml-pipeline-apiserver-deployment-patch.yaml
@@ -5,6 +5,20 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: wait-for-database
+        env:
+        - $patch: replace
+        - name: WAIT_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: postgresHost
+        - name: WAIT_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: postgresPort
       containers:
       - name: ml-pipeline-api-server
         env:

--- a/manifests/kustomize/env/cert-manager/platform-agnostic-standalone-tls/patches/metadata-grpc-deployment.yaml
+++ b/manifests/kustomize/env/cert-manager/platform-agnostic-standalone-tls/patches/metadata-grpc-deployment.yaml
@@ -72,12 +72,12 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   name: pipeline-install-config
-                  key: dbHost
+                  key: mysqlHost
             - name: MYSQL_PORT
               valueFrom:
                 configMapKeyRef:
                   name: pipeline-install-config
-                  key: dbPort
+                  key: mysqlPort
           volumeMounts:
             - name: tls-certs
               mountPath: /etc/pki/tls/certs


### PR DESCRIPTION
## Summary

- Three base deployments (`cache-deployment`, `metadata-grpc-deployment`, `ml-pipeline-apiserver-deployment`) were still reading from the legacy `dbHost`/`dbPort` ConfigMap keys; switched them to `mysqlHost`/`mysqlPort`
- The `cert-manager/platform-agnostic-standalone-tls` overlay patch for `metadata-grpc-deployment` had the same relic references; migrated in this follow-up
- Removed the `dbHost`/`dbPort` relic keys from both `pipeline-install-config` ConfigMaps (MySQL and PostgreSQL variants) now that all consumers have been migrated

## Tests

- [x] `kustomize build manifests/kustomize/env/platform-agnostic` — no unresolved ConfigMap key references
- [x] `kustomize build manifests/kustomize/env/cert-manager/platform-agnostic-standalone-tls` — no unresolved ConfigMap key references
- [x] `kustomize build manifests/kustomize/env/platform-agnostic-postgresql` — no unresolved ConfigMap key references
- [x] Verify no remaining `dbHost`/`dbPort` references in manifests: `grep -r "dbHost\|dbPort" manifests/` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)