### PR TITLE
chore: remove double-quote-string-fixer from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
       - id: debug-statements
       - id: check-merge-conflict
       - id: name-tests-test
-      - id: double-quote-string-fixer
       - id: no-commit-to-branch
         args: [--branch, master]
   - repo: https://github.com/PyCQA/flake8


### PR DESCRIPTION
## Summary

- Removes the `double-quote-string-fixer` hook from `.pre-commit-config.yaml`
- This hook silently reformats single quotes to double quotes across **all Python files touched in a commit**, including lines unrelated to the actual change
- There is no corresponding CI check for this rule (`sdk-yapf.yml`, `sdk-isort.yml`, `sdk-docformatter.yml` all run but none enforce quote style), so it generates noisy diffs with zero enforcement value

## Test plan

- [x] Verify `.pre-commit-config.yaml` no longer triggers quote reformatting on unrelated files
- [x] Verify all existing CI checks (`sdk-yapf`, `sdk-isort`, `sdk-docformatter`, `pre-commit`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)