### PR TITLE
fix: use recursive child traversal for artifact lookup with retryStrategy

### DIFF
--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -776,8 +776,10 @@ func (w *Workflow) SetCannonicalLabels(name string, nextScheduledEpoch int64, in
 }
 
 // FindObjectStoreArtifactKeyOrEmpty looks up the first S3 artifact with the specified artifactName
-// on the specified nodeName. If the node has no outputs (e.g., a retry parent node), it also checks
-// the node's direct children. Returns empty string if nothing is found.
+// on the specified nodeName. If the node has no outputs (e.g., a retry parent or step group node),
+// it recursively checks the node's children up to a bounded depth. This handles the hierarchy
+// introduced by templateDefaults.retryStrategy: StepGroup → Retry → Pod.
+// Returns empty string if nothing is found.
 func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeName string, artifactName string) string {
 	if w.Status.Nodes == nil {
 		return ""
@@ -786,15 +788,22 @@ func (w *Workflow) FindObjectStoreArtifactKeyOrEmpty(nodeName string, artifactNa
 	if !found {
 		return ""
 	}
+	// maxDepth of 3 covers: StepGroup → Retry → Pod (deepest expected path).
+	return w.findArtifactKeyRecursive(node, artifactName, 3)
+}
+
+// findArtifactKeyRecursive searches the node and its children (up to maxDepth levels)
+// for an S3 artifact with the given name.
+func (w *Workflow) findArtifactKeyRecursive(node workflowapi.NodeStatus, artifactName string, maxDepth int) string {
 	if s3Key := findArtifactS3KeyFromNode(node, artifactName); s3Key != "" {
 		return s3Key
 	}
-	if node.Type != workflowapi.NodeTypeRetry {
+	if maxDepth <= 0 {
 		return ""
 	}
 	for _, childNodeID := range node.Children {
 		if childNode, childFound := w.Status.Nodes[childNodeID]; childFound {
-			if s3Key := findArtifactS3KeyFromNode(childNode, artifactName); s3Key != "" {
+			if s3Key := w.findArtifactKeyRecursive(childNode, artifactName, maxDepth-1); s3Key != "" {
 				return s3Key
 			}
 		}

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -2428,6 +2428,47 @@ func TestWorkflow_FindObjectStoreArtifactKeyOrEmpty_RetryParentNoChildren(t *tes
 	assert.Equal(t, "", workflow.FindObjectStoreArtifactKeyOrEmpty("retry-parent-node", "artifact1"))
 }
 
+func TestWorkflow_FindObjectStoreArtifactKeyOrEmpty_StepGroupToRetryToPod(t *testing.T) {
+	// With templateDefaults.retryStrategy, the hierarchy is:
+	// StepGroup → Retry parent → Pod (with artifacts).
+	// The test regex may capture the StepGroup node, so the function must
+	// traverse two levels to reach the Pod's artifacts.
+	workflow := NewWorkflow(&workflowapi.Workflow{
+		Status: workflowapi.WorkflowStatus{
+			Nodes: map[string]workflowapi.NodeStatus{
+				"step-group-node": {
+					ID:       "step-group-node",
+					Type:     workflowapi.NodeTypeStepGroup,
+					Children: []string{"retry-parent-node"},
+				},
+				"retry-parent-node": {
+					ID:       "retry-parent-node",
+					Type:     workflowapi.NodeTypeRetry,
+					Children: []string{"retry-parent-node(0)"},
+				},
+				"retry-parent-node(0)": {
+					ID:   "retry-parent-node(0)",
+					Type: workflowapi.NodeTypePod,
+					Outputs: &workflowapi.Outputs{
+						Artifacts: workflowapi.Artifacts{
+							{
+								Name: "artifact1",
+								ArtifactLocation: workflowapi.ArtifactLocation{
+									S3: &workflowapi.S3Artifact{
+										Key: "bucket/artifacts/deep-nested-key",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	assert.Equal(t, "bucket/artifacts/deep-nested-key",
+		workflow.FindObjectStoreArtifactKeyOrEmpty("step-group-node", "artifact1"))
+}
+
 // nonWorkflowExecution implements ExecutionSpec via embedding but is not *Workflow.
 // Used to test type assertion failures in WorkflowInterface methods.
 type nonWorkflowExecution struct {


### PR DESCRIPTION
## Description

Fixes the Integration v1 `TestArtifactAPI` 404 failure on `proper-argo-retries`.

### Root Cause

With `templateDefaults.retryStrategy`, the Argo workflow node hierarchy becomes:


The Integration v1 test regex captures `matches[0]` from `status.nodes`, which may be a **StepGroup** node (not a Retry node). The `NodeTypeRetry` guard added in `08fc835` blocks child traversal for non-Retry nodes, causing `FindObjectStoreArtifactKeyOrEmpty` to return empty → 404.

### Fix

- Replace the `NodeTypeRetry` type guard with **bounded recursive traversal** (`maxDepth=3`)
- Resolves artifacts regardless of which node in the hierarchy the test captures
- Covers: direct Pod, Retry → Pod, StepGroup → Retry → Pod

### Testing

All existing unit tests pass. New test added for the `StepGroup → Retry → Pod` path:


Signed-off-by: Siddhant Jain <siddhantjainofficial26@gmail.com>
