### PR TITLE
feat(backend,frontend): surface pod lifecycle failures in the KFP UI. Fixes #12843

### DIFF
--- a/backend/src/apiserver/model/task.go
+++ b/backend/src/apiserver/model/task.go
@@ -26,25 +26,29 @@ type Task struct {
 	// RunID is limited to varchar(191) to make it indexable as a foreign key.
 	// For details on type lengths and index safety, refer to comments in the Pipeline struct.
 	// nolint:staticcheck // [ST1003] Field name matches upstream legacy naming
-	RunID                   string           `gorm:"column:RunUUID; type:varchar(191); not null; index:tasks_RunUUID_run_details_UUID_foreign;"`                            // Note: field name (RunID) ≠ column name (RunUUID). The former should be the foreign key instead of the letter.
-	Run                     Run              `gorm:"foreignKey:RunID;references:UUID;constraint:tasks_RunUUID_run_details_UUID_foreign,OnDelete:CASCADE,OnUpdate:CASCADE;"` // A Task belongs to a Run.
-	PodName                 string           `gorm:"column:PodName; not null;"`
-	MLMDExecutionID         string           `gorm:"column:MLMDExecutionID; not null;"`
-	CreatedTimestamp        int64            `gorm:"column:CreatedTimestamp; not null;"`
-	StartedTimestamp        int64            `gorm:"column:StartedTimestamp; default:0;"`
-	FinishedTimestamp       int64            `gorm:"column:FinishedTimestamp; default:0;"`
-	Fingerprint             string           `gorm:"column:Fingerprint; not null;"`
-	Name                    string           `gorm:"column:Name; default:null"`
-	ParentTaskId            string           `gorm:"column:ParentTaskUUID; default:null"`
-	State                   RuntimeState     `gorm:"column:State; default:null;"`
-	StateHistoryString      LargeText        `gorm:"column:StateHistory; default:null;"`
-	MLMDInputs              LargeText        `gorm:"column:MLMDInputs; default:null;"`
-	MLMDOutputs             LargeText        `gorm:"column:MLMDOutputs; default:null;"`
-	ChildrenPodsString      LargeText        `gorm:"column:ChildrenPods; default:null;"`
-	StateHistory            []*RuntimeStatus `gorm:"-;"`
-	ChildrenPods            []string         `gorm:"-;"`
-	Payload                 LargeText        `gorm:"column:Payload; default:null;"`
-	LifecycleFailureMessage LargeText        `gorm:"column:LifecycleFailureMessage; default:null;"`
+	RunID              string           `gorm:"column:RunUUID; type:varchar(191); not null; index:tasks_RunUUID_run_details_UUID_foreign;"`                            // Note: field name (RunID) ≠ column name (RunUUID). The former should be the foreign key instead of the letter.
+	Run                Run              `gorm:"foreignKey:RunID;references:UUID;constraint:tasks_RunUUID_run_details_UUID_foreign,OnDelete:CASCADE,OnUpdate:CASCADE;"` // A Task belongs to a Run.
+	PodName            string           `gorm:"column:PodName; not null;"`
+	MLMDExecutionID    string           `gorm:"column:MLMDExecutionID; not null;"`
+	CreatedTimestamp   int64            `gorm:"column:CreatedTimestamp; not null;"`
+	StartedTimestamp   int64            `gorm:"column:StartedTimestamp; default:0;"`
+	FinishedTimestamp  int64            `gorm:"column:FinishedTimestamp; default:0;"`
+	Fingerprint        string           `gorm:"column:Fingerprint; not null;"`
+	Name               string           `gorm:"column:Name; default:null"`
+	ParentTaskId       string           `gorm:"column:ParentTaskUUID; default:null"`
+	State              RuntimeState     `gorm:"column:State; default:null;"`
+	StateHistoryString LargeText        `gorm:"column:StateHistory; default:null;"`
+	MLMDInputs         LargeText        `gorm:"column:MLMDInputs; default:null;"`
+	MLMDOutputs        LargeText        `gorm:"column:MLMDOutputs; default:null;"`
+	ChildrenPodsString LargeText        `gorm:"column:ChildrenPods; default:null;"`
+	StateHistory       []*RuntimeStatus `gorm:"-;"`
+	ChildrenPods       []string         `gorm:"-;"`
+	Payload            LargeText        `gorm:"column:Payload; default:null;"`
+
+	// LifecycleFailureMessage carries the pod lifecycle failure message (e.g. ImagePullBackOff,
+	// OOMKilled, Unschedulable) propagated from the underlying execution engine, so the UI can
+	// surface workload failures the same way it surfaces user-script failures.
+	LifecycleFailureMessage LargeText `gorm:"column:LifecycleFailureMessage; default:null;"`
 }
 
 func (t Task) ToString() string {

--- a/backend/src/apiserver/model/task.go
+++ b/backend/src/apiserver/model/task.go
@@ -26,24 +26,25 @@ type Task struct {
 	// RunID is limited to varchar(191) to make it indexable as a foreign key.
 	// For details on type lengths and index safety, refer to comments in the Pipeline struct.
 	// nolint:staticcheck // [ST1003] Field name matches upstream legacy naming
-	RunID              string           `gorm:"column:RunUUID; type:varchar(191); not null; index:tasks_RunUUID_run_details_UUID_foreign;"`                            // Note: field name (RunID) ≠ column name (RunUUID). The former should be the foreign key instead of the letter.
-	Run                Run              `gorm:"foreignKey:RunID;references:UUID;constraint:tasks_RunUUID_run_details_UUID_foreign,OnDelete:CASCADE,OnUpdate:CASCADE;"` // A Task belongs to a Run.
-	PodName            string           `gorm:"column:PodName; not null;"`
-	MLMDExecutionID    string           `gorm:"column:MLMDExecutionID; not null;"`
-	CreatedTimestamp   int64            `gorm:"column:CreatedTimestamp; not null;"`
-	StartedTimestamp   int64            `gorm:"column:StartedTimestamp; default:0;"`
-	FinishedTimestamp  int64            `gorm:"column:FinishedTimestamp; default:0;"`
-	Fingerprint        string           `gorm:"column:Fingerprint; not null;"`
-	Name               string           `gorm:"column:Name; default:null"`
-	ParentTaskId       string           `gorm:"column:ParentTaskUUID; default:null"`
-	State              RuntimeState     `gorm:"column:State; default:null;"`
-	StateHistoryString LargeText        `gorm:"column:StateHistory; default:null;"`
-	MLMDInputs         LargeText        `gorm:"column:MLMDInputs; default:null;"`
-	MLMDOutputs        LargeText        `gorm:"column:MLMDOutputs; default:null;"`
-	ChildrenPodsString LargeText        `gorm:"column:ChildrenPods; default:null;"`
-	StateHistory       []*RuntimeStatus `gorm:"-;"`
-	ChildrenPods       []string         `gorm:"-;"`
-	Payload            LargeText        `gorm:"column:Payload; default:null;"`
+	RunID                   string           `gorm:"column:RunUUID; type:varchar(191); not null; index:tasks_RunUUID_run_details_UUID_foreign;"`                            // Note: field name (RunID) ≠ column name (RunUUID). The former should be the foreign key instead of the letter.
+	Run                     Run              `gorm:"foreignKey:RunID;references:UUID;constraint:tasks_RunUUID_run_details_UUID_foreign,OnDelete:CASCADE,OnUpdate:CASCADE;"` // A Task belongs to a Run.
+	PodName                 string           `gorm:"column:PodName; not null;"`
+	MLMDExecutionID         string           `gorm:"column:MLMDExecutionID; not null;"`
+	CreatedTimestamp        int64            `gorm:"column:CreatedTimestamp; not null;"`
+	StartedTimestamp        int64            `gorm:"column:StartedTimestamp; default:0;"`
+	FinishedTimestamp       int64            `gorm:"column:FinishedTimestamp; default:0;"`
+	Fingerprint             string           `gorm:"column:Fingerprint; not null;"`
+	Name                    string           `gorm:"column:Name; default:null"`
+	ParentTaskId            string           `gorm:"column:ParentTaskUUID; default:null"`
+	State                   RuntimeState     `gorm:"column:State; default:null;"`
+	StateHistoryString      LargeText        `gorm:"column:StateHistory; default:null;"`
+	MLMDInputs              LargeText        `gorm:"column:MLMDInputs; default:null;"`
+	MLMDOutputs             LargeText        `gorm:"column:MLMDOutputs; default:null;"`
+	ChildrenPodsString      LargeText        `gorm:"column:ChildrenPods; default:null;"`
+	StateHistory            []*RuntimeStatus `gorm:"-;"`
+	ChildrenPods            []string         `gorm:"-;"`
+	Payload                 LargeText        `gorm:"column:Payload; default:null;"`
+	LifecycleFailureMessage LargeText        `gorm:"column:LifecycleFailureMessage; default:null;"`
 }
 
 func (t Task) ToString() string {

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -1722,6 +1722,7 @@ func toModelTask(t interface{}) (*model.Task, error) {
 	}
 	var taskId, nodeId, namespace, pipelineName, runId, mlmdExecId, fingerprint string
 	var name, parentTaskId, state, inputs, outputs string
+	var lifecycleFailureMessage string
 	var createTime, startTime, finishTime int64
 	var stateHistory []*model.RuntimeStatus
 	var children []string
@@ -1782,27 +1783,29 @@ func toModelTask(t interface{}) (*model.Task, error) {
 		createTime = wfStatus.CreateTime
 		finishTime = wfStatus.FinishTime
 		children = wfStatus.Children
+		lifecycleFailureMessage = nodeLifecycleFailureMessage(wfStatus)
 	default:
 		return nil, util.NewUnknownApiVersionError("Task", t)
 	}
 	return &model.Task{
-		UUID:              taskId,
-		PodName:           nodeId,
-		Namespace:         namespace,
-		PipelineName:      pipelineName,
-		RunID:             runId,
-		MLMDExecutionID:   mlmdExecId,
-		CreatedTimestamp:  createTime,
-		StartedTimestamp:  startTime,
-		FinishedTimestamp: finishTime,
-		Fingerprint:       fingerprint,
-		Name:              name,
-		ParentTaskId:      parentTaskId,
-		State:             model.RuntimeState(state).ToV2(),
-		StateHistory:      stateHistory,
-		MLMDInputs:        model.LargeText(inputs),
-		MLMDOutputs:       model.LargeText(outputs),
-		ChildrenPods:      children,
+		UUID:                    taskId,
+		PodName:                 nodeId,
+		Namespace:               namespace,
+		PipelineName:            pipelineName,
+		RunID:                   runId,
+		MLMDExecutionID:         mlmdExecId,
+		CreatedTimestamp:        createTime,
+		StartedTimestamp:        startTime,
+		FinishedTimestamp:       finishTime,
+		Fingerprint:             fingerprint,
+		Name:                    name,
+		ParentTaskId:            parentTaskId,
+		State:                   model.RuntimeState(state).ToV2(),
+		StateHistory:            stateHistory,
+		MLMDInputs:              model.LargeText(inputs),
+		MLMDOutputs:             model.LargeText(outputs),
+		ChildrenPods:            children,
+		LifecycleFailureMessage: model.LargeText(lifecycleFailureMessage),
 	}, nil
 }
 
@@ -1836,6 +1839,11 @@ func toModelTasks(t interface{}) ([]*model.Task, error) {
 			nodeNames = append(nodeNames, nodeName)
 		}
 		sort.Strings(nodeNames)
+		// Argo records pod-level lifecycle failures (e.g. ImagePullBackOff) on the executor Pod
+		// node, which is a child of the task node the UI renders. Resolve an effective message for
+		// each node by propagating a non-empty descendant message up to its ancestors, so the
+		// failure is associated with the pipeline task the user actually sees in the graph.
+		resolvedMessages := resolveNodeLifecycleMessages(nodes)
 		modelTasks := make([]*model.Task, 0)
 		for _, nodeName := range nodeNames {
 			node := nodes[nodeName]
@@ -1846,12 +1854,99 @@ func toModelTasks(t interface{}) ([]*model.Task, error) {
 			modelTask.RunID = runId
 			modelTask.Namespace = namespace
 			modelTask.CreatedTimestamp = createdAt
+			// resolveNodeLifecycleMessages already accounts for node state and bubbles a pod-level
+			// failure up from the executor child to the task node the UI renders, so it is the
+			// authoritative value. Recomputed every sync, so it clears once the node recovers.
+			modelTask.LifecycleFailureMessage = model.LargeText(resolvedMessages[nodeName])
 			modelTasks = append(modelTasks, modelTask)
 		}
 		return modelTasks, nil
 	default:
 		return nil, util.NewUnknownApiVersionError("[]Task", t)
 	}
+}
+
+// transientNodeMessages are benign Argo/Kubernetes node messages that appear during a pod's normal
+// startup and are cleared once the pod is running. They must NOT be treated as lifecycle failures;
+// otherwise healthy runs would be mislabeled (every KFP pod passes through PodInitializing because
+// of the launcher init container).
+var transientNodeMessages = map[string]bool{
+	"podinitializing":   true,
+	"containercreating": true,
+}
+
+// nonFailureNodeStates are terminal/benign Argo node phases that never represent a pod lifecycle
+// failure. Messages attached to nodes in these states (e.g. a skip reason such as
+// "when 'true != true' evaluated false") must not be surfaced as failures.
+var nonFailureNodeStates = map[string]bool{
+	"Succeeded": true,
+	"Skipped":   true,
+	"Omitted":   true,
+}
+
+// normalizeLifecycleFailureMessage normalizes an Argo node message into a pod lifecycle failure
+// message. It returns the message verbatim for genuine failures (e.g. ImagePullBackOff, OOMKilled,
+// Unschedulable) and an empty string for transient/benign startup states, so that only real
+// failures are surfaced to the UI.
+func normalizeLifecycleFailureMessage(message string) string {
+	if transientNodeMessages[strings.ToLower(strings.TrimSpace(message))] {
+		return ""
+	}
+	return message
+}
+
+// nodeLifecycleFailureMessage returns the pod lifecycle failure message for a single node, or an
+// empty string when the node is in a non-failure state or only carries a transient/benign message.
+func nodeLifecycleFailureMessage(node util.NodeStatus) string {
+	if nonFailureNodeStates[node.State] {
+		return ""
+	}
+	return normalizeLifecycleFailureMessage(node.Message)
+}
+
+// resolveNodeLifecycleMessages computes, for each workflow node, the lifecycle failure message to
+// surface. Nodes in a non-failure state (e.g. Succeeded/Skipped) resolve to an empty message. For
+// the rest, a node's own message takes precedence; if empty, the first non-empty message found
+// among its descendants is used. This lets pod-level failures recorded on a child executor node
+// (e.g. "ImagePullBackOff ...") be associated with the parent task node that the UI renders. The
+// keys and child references are Argo node IDs, matching the NodeStatuses map.
+func resolveNodeLifecycleMessages(nodes map[string]util.NodeStatus) map[string]string {
+	resolved := make(map[string]string, len(nodes))
+	var resolve func(nodeID string, visited map[string]bool) string
+	resolve = func(nodeID string, visited map[string]bool) string {
+		if message, ok := resolved[nodeID]; ok {
+			return message
+		}
+		if visited[nodeID] {
+			return ""
+		}
+		visited[nodeID] = true
+		node, ok := nodes[nodeID]
+		if !ok {
+			return ""
+		}
+		// A node in a non-failure state (e.g. Succeeded/Skipped) never carries a lifecycle failure,
+		// and must not inherit one from its descendants either.
+		if nonFailureNodeStates[node.State] {
+			resolved[nodeID] = ""
+			return ""
+		}
+		message := normalizeLifecycleFailureMessage(node.Message)
+		if message == "" {
+			for _, childID := range node.Children {
+				if childMessage := resolve(childID, visited); childMessage != "" {
+					message = childMessage
+					break
+				}
+			}
+		}
+		resolved[nodeID] = message
+		return message
+	}
+	for nodeID := range nodes {
+		resolve(nodeID, make(map[string]bool))
+	}
+	return resolved
 }
 
 // Converts internal task representation to its API counterpart.
@@ -1905,7 +2000,7 @@ func toApiPipelineTaskDetail(t *model.Task) *apiv2beta1.PipelineTaskDetail {
 			ChildTask: &apiv2beta1.PipelineTaskDetail_ChildTask_PodName{PodName: c},
 		})
 	}
-	return &apiv2beta1.PipelineTaskDetail{
+	taskDetail := &apiv2beta1.PipelineTaskDetail{
 		RunId:        t.RunID,
 		TaskId:       t.UUID,
 		DisplayName:  t.Name,
@@ -1920,6 +2015,13 @@ func toApiPipelineTaskDetail(t *model.Task) *apiv2beta1.PipelineTaskDetail {
 		StateHistory: toApiRuntimeStatuses(t.StateHistory),
 		ChildTasks:   children,
 	}
+	if t.LifecycleFailureMessage != "" {
+		taskDetail.Error = util.ToRpcStatus(util.NewInternalServerError(
+			fmt.Errorf("%s", string(t.LifecycleFailureMessage)),
+			"Pod lifecycle failure",
+		))
+	}
+	return taskDetail
 }
 
 // Converts and array of internal task representations to its API counterpart.

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -33,6 +33,8 @@ import (
 	swapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/pkg/errors"
 	"github.com/robfig/cron"
+	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -1912,19 +1914,24 @@ func nodeLifecycleFailureMessage(node util.NodeStatus) string {
 // keys and child references are Argo node IDs, matching the NodeStatuses map.
 func resolveNodeLifecycleMessages(nodes map[string]util.NodeStatus) map[string]string {
 	resolved := make(map[string]string, len(nodes))
-	var resolve func(nodeID string, visited map[string]bool) string
-	resolve = func(nodeID string, visited map[string]bool) string {
+	// onStack tracks nodes currently in the DFS recursion stack, so we only block recursion through
+	// true cycles. Once a node finishes resolving, it is removed from the stack and its answer is
+	// cached in `resolved`; sibling/shared-descendant paths then hit the cache, not the stack.
+	onStack := make(map[string]bool)
+	var resolve func(nodeID string) string
+	resolve = func(nodeID string) string {
 		if message, ok := resolved[nodeID]; ok {
 			return message
 		}
-		if visited[nodeID] {
+		if onStack[nodeID] {
 			return ""
 		}
-		visited[nodeID] = true
 		node, ok := nodes[nodeID]
 		if !ok {
 			return ""
 		}
+		onStack[nodeID] = true
+		defer delete(onStack, nodeID)
 		// A node in a non-failure state (e.g. Succeeded/Skipped) never carries a lifecycle failure,
 		// and must not inherit one from its descendants either.
 		if nonFailureNodeStates[node.State] {
@@ -1934,7 +1941,7 @@ func resolveNodeLifecycleMessages(nodes map[string]util.NodeStatus) map[string]s
 		message := normalizeLifecycleFailureMessage(node.Message)
 		if message == "" {
 			for _, childID := range node.Children {
-				if childMessage := resolve(childID, visited); childMessage != "" {
+				if childMessage := resolve(childID); childMessage != "" {
 					message = childMessage
 					break
 				}
@@ -1944,7 +1951,7 @@ func resolveNodeLifecycleMessages(nodes map[string]util.NodeStatus) map[string]s
 		return message
 	}
 	for nodeID := range nodes {
-		resolve(nodeID, make(map[string]bool))
+		resolve(nodeID)
 	}
 	return resolved
 }
@@ -2016,10 +2023,13 @@ func toApiPipelineTaskDetail(t *model.Task) *apiv2beta1.PipelineTaskDetail {
 		ChildTasks:   children,
 	}
 	if t.LifecycleFailureMessage != "" {
-		taskDetail.Error = util.ToRpcStatus(util.NewInternalServerError(
-			fmt.Errorf("%s", string(t.LifecycleFailureMessage)),
-			"Pod lifecycle failure",
-		))
+		// This is a workload failure surfaced from Argo, not an API server fault. Carry the actual
+		// Kubernetes/Argo message verbatim in the user-facing Status.Message so the UI can render
+		// it as-is, prefixed with a stable label that identifies the failure category.
+		taskDetail.Error = &rpcstatus.Status{
+			Code:    int32(codes.Internal),
+			Message: fmt.Sprintf("Pod lifecycle failure: %s", string(t.LifecycleFailureMessage)),
+		}
 	}
 	return taskDetail
 }

--- a/backend/src/apiserver/server/api_converter_test.go
+++ b/backend/src/apiserver/server/api_converter_test.go
@@ -6082,3 +6082,150 @@ func TestToApiRecurringRunPluginsInput(t *testing.T) {
 		assert.Nil(t, got.PluginsInput)
 	})
 }
+
+func TestResolveNodeLifecycleMessages(t *testing.T) {
+	t.Run("node keeps its own message", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"task": {ID: "task", Message: "task level failure"},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "task level failure", resolved["task"])
+	})
+
+	t.Run("empty parent inherits child message", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"task":     {ID: "task", Children: []string{"executor"}},
+			"executor": {ID: "executor", Message: "Pod failed before main container starts"},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "Pod failed before main container starts", resolved["task"])
+		assert.Equal(t, "Pod failed before main container starts", resolved["executor"])
+	})
+
+	t.Run("message propagates across multiple levels", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"dag":      {ID: "dag", Children: []string{"task"}},
+			"task":     {ID: "task", Children: []string{"executor"}},
+			"executor": {ID: "executor", Message: "ImagePullBackOff"},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "ImagePullBackOff", resolved["dag"])
+		assert.Equal(t, "ImagePullBackOff", resolved["task"])
+	})
+
+	t.Run("own message takes precedence over descendant", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"task":     {ID: "task", Message: "task message", Children: []string{"executor"}},
+			"executor": {ID: "executor", Message: "executor message"},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "task message", resolved["task"])
+	})
+
+	t.Run("no message anywhere resolves to empty", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"task":     {ID: "task", Children: []string{"executor"}},
+			"executor": {ID: "executor"},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "", resolved["task"])
+		assert.Equal(t, "", resolved["executor"])
+	})
+
+	t.Run("cyclic children do not cause infinite recursion", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"a": {ID: "a", Children: []string{"b"}},
+			"b": {ID: "b", Children: []string{"a"}, Message: "cycle failure"},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "cycle failure", resolved["a"])
+		assert.Equal(t, "cycle failure", resolved["b"])
+	})
+
+	t.Run("missing child reference is ignored", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"task": {ID: "task", Children: []string{"does-not-exist"}},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "", resolved["task"])
+	})
+
+	t.Run("transient startup messages are not treated as failures", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"task":     {ID: "task", Children: []string{"executor"}},
+			"executor": {ID: "executor", Message: "PodInitializing"},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "", resolved["task"])
+		assert.Equal(t, "", resolved["executor"])
+	})
+
+	t.Run("skipped node skip-reason is not a failure", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"executor": {ID: "executor", State: "Skipped", Message: "when 'true != true' evaluated false"},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "", resolved["executor"])
+	})
+
+	t.Run("succeeded node does not inherit a failed descendant message", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"task":     {ID: "task", State: "Succeeded", Children: []string{"executor"}},
+			"executor": {ID: "executor", State: "Failed", Message: "OOMKilled"},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "", resolved["task"])
+		assert.Equal(t, "OOMKilled", resolved["executor"])
+	})
+
+	t.Run("running parent inherits failed executor message", func(t *testing.T) {
+		nodes := map[string]util.NodeStatus{
+			"task":     {ID: "task", State: "Running", Children: []string{"executor"}},
+			"executor": {ID: "executor", State: "Pending", Message: "ImagePullBackOff"},
+		}
+		resolved := resolveNodeLifecycleMessages(nodes)
+		assert.Equal(t, "ImagePullBackOff", resolved["task"])
+	})
+}
+
+func TestNodeLifecycleFailureMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		node util.NodeStatus
+		want string
+	}{
+		{"failed node with failure message", util.NodeStatus{State: "Failed", Message: "OOMKilled"}, "OOMKilled"},
+		{"running node stuck on image pull", util.NodeStatus{State: "Running", Message: "ImagePullBackOff"}, "ImagePullBackOff"},
+		{"succeeded node is never a failure", util.NodeStatus{State: "Succeeded", Message: "ImagePullBackOff"}, ""},
+		{"skipped node is never a failure", util.NodeStatus{State: "Skipped", Message: "when 'true != true' evaluated false"}, ""},
+		{"omitted node is never a failure", util.NodeStatus{State: "Omitted", Message: "omitted"}, ""},
+		{"running node initializing is transient", util.NodeStatus{State: "Running", Message: "PodInitializing"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, nodeLifecycleFailureMessage(tt.node))
+		})
+	}
+}
+
+func TestNormalizeLifecycleFailureMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{"empty message", "", ""},
+		{"PodInitializing is transient", "PodInitializing", ""},
+		{"ContainerCreating is transient", "ContainerCreating", ""},
+		{"transient match is case-insensitive", "podinitializing", ""},
+		{"transient match trims whitespace", "  PodInitializing  ", ""},
+		{"ImagePullBackOff is a failure", "ImagePullBackOff: Back-off pulling image", "ImagePullBackOff: Back-off pulling image"},
+		{"OOMKilled is a failure", "OOMKilled", "OOMKilled"},
+		{"Unschedulable is a failure", "0/1 nodes are available: Unschedulable", "0/1 nodes are available: Unschedulable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeLifecycleFailureMessage(tt.message))
+		})
+	}
+}

--- a/backend/src/apiserver/storage/task_store.go
+++ b/backend/src/apiserver/storage/task_store.go
@@ -46,6 +46,7 @@ var taskColumns = []string{
 	"MLMDInputs",
 	"MLMDOutputs",
 	"ChildrenPods",
+	"LifecycleFailureMessage",
 }
 
 var taskColumnsWithPayload = append(taskColumns, "Payload")
@@ -116,24 +117,25 @@ func (s *TaskStore) CreateTask(task *model.Task) (*model.Task, error) {
 		Insert(table_name).
 		SetMap(
 			sq.Eq{
-				"UUID":              newTask.UUID,
-				"Namespace":         newTask.Namespace,
-				"PipelineName":      newTask.PipelineName,
-				"RunUUID":           newTask.RunID,
-				"PodName":           newTask.PodName,
-				"MLMDExecutionID":   newTask.MLMDExecutionID,
-				"CreatedTimestamp":  newTask.CreatedTimestamp,
-				"StartedTimestamp":  newTask.StartedTimestamp,
-				"FinishedTimestamp": newTask.FinishedTimestamp,
-				"Fingerprint":       newTask.Fingerprint,
-				"Name":              newTask.Name,
-				"ParentTaskUUID":    newTask.ParentTaskId,
-				"State":             newTask.State.ToString(),
-				"StateHistory":      stateHistoryString,
-				"MLMDInputs":        newTask.MLMDInputs,
-				"MLMDOutputs":       newTask.MLMDOutputs,
-				"ChildrenPods":      childrenPodsString,
-				"Payload":           newTask.ToString(),
+				"UUID":                    newTask.UUID,
+				"Namespace":               newTask.Namespace,
+				"PipelineName":            newTask.PipelineName,
+				"RunUUID":                 newTask.RunID,
+				"PodName":                 newTask.PodName,
+				"MLMDExecutionID":         newTask.MLMDExecutionID,
+				"CreatedTimestamp":        newTask.CreatedTimestamp,
+				"StartedTimestamp":        newTask.StartedTimestamp,
+				"FinishedTimestamp":       newTask.FinishedTimestamp,
+				"Fingerprint":             newTask.Fingerprint,
+				"Name":                    newTask.Name,
+				"ParentTaskUUID":          newTask.ParentTaskId,
+				"State":                   newTask.State.ToString(),
+				"StateHistory":            stateHistoryString,
+				"MLMDInputs":              newTask.MLMDInputs,
+				"MLMDOutputs":             newTask.MLMDOutputs,
+				"ChildrenPods":            childrenPodsString,
+				"LifecycleFailureMessage": newTask.LifecycleFailureMessage,
+				"Payload":                 newTask.ToString(),
 			},
 		).
 		ToSql()
@@ -154,6 +156,7 @@ func (s *TaskStore) scanRows(rows *sql.Rows) ([]*model.Task, error) {
 	for rows.Next() {
 		var uuid, namespace, pipelineName, runUUID, podName, mlmdExecutionID, fingerprint string
 		var name, parentTaskId, state, stateHistory, inputs, outputs, children sql.NullString
+		var lifecycleFailureMessage sql.NullString
 		var createdTimestamp, startedTimestamp, finishedTimestamp sql.NullInt64
 		err := rows.Scan(
 			&uuid,
@@ -173,6 +176,7 @@ func (s *TaskStore) scanRows(rows *sql.Rows) ([]*model.Task, error) {
 			&inputs,
 			&outputs,
 			&children,
+			&lifecycleFailureMessage,
 		)
 		if err != nil {
 			fmt.Printf("scan error is %v", err)
@@ -187,22 +191,23 @@ func (s *TaskStore) scanRows(rows *sql.Rows) ([]*model.Task, error) {
 			json.Unmarshal([]byte(children.String), &childrenPods)
 		}
 		task := &model.Task{
-			UUID:              uuid,
-			Namespace:         namespace,
-			PipelineName:      pipelineName,
-			RunID:             runUUID,
-			PodName:           podName,
-			MLMDExecutionID:   mlmdExecutionID,
-			CreatedTimestamp:  createdTimestamp.Int64,
-			StartedTimestamp:  startedTimestamp.Int64,
-			FinishedTimestamp: finishedTimestamp.Int64,
-			Fingerprint:       fingerprint,
-			Name:              name.String,
-			ParentTaskId:      parentTaskId.String,
-			StateHistory:      stateHistoryNew,
-			MLMDInputs:        model.LargeText(inputs.String),
-			MLMDOutputs:       model.LargeText(outputs.String),
-			ChildrenPods:      childrenPods,
+			UUID:                    uuid,
+			Namespace:               namespace,
+			PipelineName:            pipelineName,
+			RunID:                   runUUID,
+			PodName:                 podName,
+			MLMDExecutionID:         mlmdExecutionID,
+			CreatedTimestamp:        createdTimestamp.Int64,
+			StartedTimestamp:        startedTimestamp.Int64,
+			FinishedTimestamp:       finishedTimestamp.Int64,
+			Fingerprint:             fingerprint,
+			Name:                    name.String,
+			ParentTaskId:            parentTaskId.String,
+			StateHistory:            stateHistoryNew,
+			MLMDInputs:              model.LargeText(inputs.String),
+			MLMDOutputs:             model.LargeText(outputs.String),
+			ChildrenPods:            childrenPods,
+			LifecycleFailureMessage: model.LargeText(lifecycleFailureMessage.String),
 		}
 		tasks = append(tasks, task)
 	}
@@ -397,6 +402,7 @@ func (s *TaskStore) CreateOrUpdateTasks(tasks []*model.Task, runID string) ([]*m
 				t.MLMDInputs,
 				t.MLMDOutputs,
 				childrenPodsString,
+				t.LifecycleFailureMessage,
 				t.ToString(),
 			)
 		}
@@ -490,4 +496,7 @@ func patchTask(original *model.Task, patch *model.Task) {
 	if len(original.ChildrenPods) == 0 {
 		original.ChildrenPods = patch.ChildrenPods
 	}
+	// LifecycleFailureMessage is intentionally not preserved here. It is recomputed from the current
+	// workflow on every sync, so the latest value must win; otherwise a transient message captured
+	// mid-startup would stick even after the pod recovers or succeeds.
 }

--- a/backend/src/apiserver/storage/task_store.go
+++ b/backend/src/apiserver/storage/task_store.go
@@ -496,7 +496,8 @@ func patchTask(original *model.Task, patch *model.Task) {
 	if len(original.ChildrenPods) == 0 {
 		original.ChildrenPods = patch.ChildrenPods
 	}
-	// LifecycleFailureMessage is intentionally not preserved here. It is recomputed from the current
-	// workflow on every sync, so the latest value must win; otherwise a transient message captured
-	// mid-startup would stick even after the pod recovers or succeeds.
+	// LifecycleFailureMessage is deliberately omitted from this preserve-old-when-empty pattern.
+	// `original` is the freshly synced task and already holds the authoritative value computed from
+	// the current workflow (including an empty string when the pod has recovered or succeeded).
+	// Preserving the prior DB value here would let a transient mid-startup message stick forever.
 }

--- a/backend/src/common/util/execution_status.go
+++ b/backend/src/common/util/execution_status.go
@@ -26,6 +26,7 @@ type NodeStatus struct {
 	ID          string
 	DisplayName string
 	State       string
+	Message     string
 	StartTime   int64
 	CreateTime  int64
 	FinishTime  int64

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -872,6 +872,7 @@ func (w *Workflow) NodeStatuses() map[string]NodeStatus {
 			ID:          RetrievePodName(*w.Workflow, node),
 			DisplayName: node.DisplayName,
 			State:       string(node.Phase),
+			Message:     node.Message,
 			StartTime:   node.StartedAt.Unix(),
 			CreateTime:  node.StartedAt.Unix(),
 			FinishTime:  node.FinishedAt.Unix(),

--- a/frontend/src/components/graph/Constants.ts
+++ b/frontend/src/components/graph/Constants.ts
@@ -29,6 +29,7 @@ export type SubDagFlowElementData = FlowElementDataBase & {
 
 export type ExecutionFlowElementData = FlowElementDataBase & {
   state?: Execution.State;
+  lifecycleError?: string;
 };
 
 export type ArtifactFlowElementData = FlowElementDataBase & {

--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -29,6 +29,7 @@ import { Apis } from 'src/lib/Apis';
 import { KeyValue } from 'src/lib/StaticGraphParser';
 import { errorToMessage } from 'src/lib/Utils';
 import { getTaskKeyFromNodeKey, NodeTypeNames, PipelineFlowElement } from 'src/lib/v2/StaticFlow';
+import { ExecutionFlowElementData } from 'src/components/graph/Constants';
 import {
   EXECUTION_KEY_CACHED_EXECUTION_ID,
   getArtifactName,
@@ -179,8 +180,13 @@ function TaskNodeDetail({
 
   const [selectedTab, setSelectedTab] = useState(0);
 
+  const lifecycleError = (element?.data as ExecutionFlowElementData | undefined)?.lifecycleError;
+
   return (
     <div className={commonCss.page}>
+      {lifecycleError && (
+        <Banner message='Pod lifecycle failure' additionalInfo={lifecycleError} mode='error' />
+      )}
       <MD2Tabs
         tabs={['Input/Output', 'Task Details', 'Logs']}
         selectedTab={selectedTab}
@@ -192,6 +198,15 @@ function TaskNodeDetail({
           (() => {
             if (execution) {
               return <RuntimeInputOutputTab execution={execution} namespace={namespace} />;
+            }
+            if (lifecycleError) {
+              return (
+                <Banner
+                  message='No execution data available — the pod failed before the task could start.'
+                  additionalInfo={lifecycleError}
+                  mode='error'
+                />
+              );
             }
             return NODE_STATE_UNAVAILABLE;
           })()}

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -36,6 +36,7 @@ import {
 import { getArtifactNameFromEvent, LinkedArtifact, ExecutionHelpers } from 'src/mlmd/MlmdUtils';
 import { NodeMlmdInfo } from 'src/pages/RunDetailsV2';
 import { Artifact, Event, Execution, Value } from 'src/third_party/mlmd';
+import { V2beta1PipelineTaskDetail } from 'src/apisv2beta1/run';
 
 export const TASK_NAME_KEY = 'task_name';
 export const PARENT_DAG_ID_KEY = 'parent_dag_id';
@@ -221,10 +222,29 @@ export function updateFlowElementsState(
   executions: Execution[],
   events: Event[],
   artifacts: Artifact[],
+  taskDetails?: V2beta1PipelineTaskDetail[],
 ): PipelineFlowElement[] {
   const executionLayers = getExecutionLayers(layers, executions);
+
+  // Build a map from task display_name to lifecycle error message from the KFP API, so we can
+  // surface pod lifecycle failures (e.g. ImagePullBackOff) on nodes that have no MLMD execution.
+  const taskNameToLifecycleError = buildTaskNameToLifecycleError(taskDetails);
+
   if (executionLayers.length < layers.length) {
-    // This Sub DAG is not executed yet. There is no runtime information to update.
+    // This Sub DAG is not executed yet. There is no MLMD runtime information to update.
+    // However, individual tasks may already have lifecycle errors recorded in the KFP API.
+    if (taskNameToLifecycleError.size > 0) {
+      return elems.map((elem) => {
+        if (NodeTypeNames.EXECUTION !== elem.type) {
+          return elem;
+        }
+        const updatedElem = cloneFlowElement(elem);
+        const taskLabel = getTaskLabelByPipelineFlowElement(elem);
+        const lifecycleError = taskNameToLifecycleError.get(taskLabel);
+        (updatedElem.data as ExecutionFlowElementData).lifecycleError = lifecycleError;
+        return updatedElem;
+      });
+    }
     return elems;
   }
 
@@ -265,9 +285,10 @@ export function updateFlowElementsState(
   for (let elem of elems) {
     const updatedElem = cloneFlowElement(elem);
     if (NodeTypeNames.EXECUTION === elem.type) {
+      const taskLabel = getTaskLabelByPipelineFlowElement(elem);
       const executions = getExecutionsUnderDAG(
         taskNameToExecution,
-        getTaskLabelByPipelineFlowElement(elem),
+        taskLabel,
         executionLayers,
       );
       if (executions) {
@@ -277,6 +298,18 @@ export function updateFlowElementsState(
         (updatedElem.data as ExecutionFlowElementData).label = ExecutionHelpers.getName(
           executions[0],
         );
+      }
+      // Always reconcile the lifecycle error from the KFP API. A pod lifecycle failure (e.g.
+      // ImagePullBackOff) can occur even when an MLMD execution exists, because the driver
+      // registers the execution before the user container fails to start. Recompute every
+      // refresh so the error clears if the task later recovers.
+      const lifecycleError = taskNameToLifecycleError.get(taskLabel);
+      (updatedElem.data as ExecutionFlowElementData).lifecycleError = lifecycleError;
+      // When the pod never starts, MLMD keeps the execution stuck at RUNNING, leaving the node
+      // spinning forever. Render it as FAILED so the failure is visible in the graph, matching
+      // how pipeline script failures are surfaced.
+      if (lifecycleError) {
+        (updatedElem.data as ExecutionFlowElementData).state = Execution.State.FAILED;
       }
     } else if (NodeTypeNames.ARTIFACT === elem.type) {
       let linkedArtifact = artifactNodeKeyToArtifact.get(elem.id);
@@ -341,6 +374,26 @@ function cloneFlowElement(elem: PipelineFlowElement): PipelineFlowElement {
 function getTaskLabelByPipelineFlowElement(elem: PipelineFlowElement) {
   // Always use the original task name from the node ID for MLMD data lookups
   return getTaskKeyFromNodeKey(elem.id);
+}
+
+/**
+ * Builds a map from task display name to lifecycle error message.
+ * Lifecycle errors are pod-level failures (e.g. ImagePullBackOff, Unschedulable) that are
+ * recorded via the KFP API when no MLMD execution record exists for the task.
+ */
+function buildTaskNameToLifecycleError(
+  taskDetails?: V2beta1PipelineTaskDetail[],
+): Map<string, string> {
+  const result = new Map<string, string>();
+  if (!taskDetails) {
+    return result;
+  }
+  for (const task of taskDetails) {
+    if (task.display_name && task.error?.message) {
+      result.set(task.display_name, task.error.message);
+    }
+  }
+  return result;
 }
 
 function getExecutionsUnderDAG(

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -226,25 +226,15 @@ export function updateFlowElementsState(
 ): PipelineFlowElement[] {
   const executionLayers = getExecutionLayers(layers, executions);
 
-  // Build a map from task display_name to lifecycle error message from the KFP API, so we can
-  // surface pod lifecycle failures (e.g. ImagePullBackOff) on nodes that have no MLMD execution.
+  // Build a map from task name to lifecycle error message from the KFP API, so pod lifecycle
+  // failures (e.g. ImagePullBackOff) can be annotated even when the MLMD execution is stuck in
+  // RUNNING because the driver registered it before the user container failed to start.
+  // The backend sets PipelineTaskDetail.display_name from the Argo node DisplayName, which equals
+  // the pipeline task key the frontend extracts via getTaskKeyFromNodeKey(elem.id).
   const taskNameToLifecycleError = buildTaskNameToLifecycleError(taskDetails);
 
   if (executionLayers.length < layers.length) {
-    // This Sub DAG is not executed yet. There is no MLMD runtime information to update.
-    // However, individual tasks may already have lifecycle errors recorded in the KFP API.
-    if (taskNameToLifecycleError.size > 0) {
-      return elems.map((elem) => {
-        if (NodeTypeNames.EXECUTION !== elem.type) {
-          return elem;
-        }
-        const updatedElem = cloneFlowElement(elem);
-        const taskLabel = getTaskLabelByPipelineFlowElement(elem);
-        const lifecycleError = taskNameToLifecycleError.get(taskLabel);
-        (updatedElem.data as ExecutionFlowElementData).lifecycleError = lifecycleError;
-        return updatedElem;
-      });
-    }
+    // This Sub DAG is not executed yet. There is no runtime information to update.
     return elems;
   }
 
@@ -286,11 +276,7 @@ export function updateFlowElementsState(
     const updatedElem = cloneFlowElement(elem);
     if (NodeTypeNames.EXECUTION === elem.type) {
       const taskLabel = getTaskLabelByPipelineFlowElement(elem);
-      const executions = getExecutionsUnderDAG(
-        taskNameToExecution,
-        taskLabel,
-        executionLayers,
-      );
+      const executions = getExecutionsUnderDAG(taskNameToExecution, taskLabel, executionLayers);
       if (executions) {
         (updatedElem.data as ExecutionFlowElementData).state = executions[0]?.getLastKnownState();
         (updatedElem.data as ExecutionFlowElementData).mlmdId = executions[0]?.getId();

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -156,11 +156,8 @@ export function RunDetailsV2(props: RunDetailsV2Props) {
   );
 
   const dynamicFlowElements = useMemo(() => {
-    const taskDetails = run.run_details?.task_details;
-
     if (!isSuccess || !data) {
-      // MLMD not yet available, but we can still annotate nodes with lifecycle errors from the API.
-      return updateFlowElementsState(layers, flowElements, [], [], [], taskDetails);
+      return flowElements;
     }
 
     // Keep React Flow node references stable between unrelated rerenders after MLMD data arrives.
@@ -170,7 +167,7 @@ export function RunDetailsV2(props: RunDetailsV2Props) {
       data.executions,
       data.events,
       data.artifacts,
-      taskDetails,
+      run.run_details?.task_details,
     );
   }, [data, flowElements, isSuccess, layers, run.run_details?.task_details]);
 

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -156,8 +156,11 @@ export function RunDetailsV2(props: RunDetailsV2Props) {
   );
 
   const dynamicFlowElements = useMemo(() => {
+    const taskDetails = run.run_details?.task_details;
+
     if (!isSuccess || !data) {
-      return flowElements;
+      // MLMD not yet available, but we can still annotate nodes with lifecycle errors from the API.
+      return updateFlowElementsState(layers, flowElements, [], [], [], taskDetails);
     }
 
     // Keep React Flow node references stable between unrelated rerenders after MLMD data arrives.
@@ -167,8 +170,9 @@ export function RunDetailsV2(props: RunDetailsV2Props) {
       data.executions,
       data.events,
       data.artifacts,
+      taskDetails,
     );
-  }, [data, flowElements, isSuccess, layers]);
+  }, [data, flowElements, isSuccess, layers, run.run_details?.task_details]);
 
   const onElementSelection = (event: ReactMouseEvent, element: PipelineFlowElement) => {
     setSelectedNode(element);


### PR DESCRIPTION
**Description:**

When a pipeline task hits a pod lifecycle failure (e.g. `ImagePullBackOff`, `OOMKilled`, `Unschedulable`), the KFP UI previously showed the task node frozen in a spinning/running state with no error message. Users had to run `kubectl get pods` to understand what was happening, which breaks the Kubernetes abstraction KFP is meant to provide.

This PR fixes the visualization part of #12843. The failure message that Kubernetes reports is now captured, stored, and displayed in the UI exactly the way pipeline script failures are — with a red node and an error banner in the side panel.

**What changed:**

*Backend:*
- `util.NodeStatus` gains a `Message` field; `NodeStatuses()` populates it from Argo's `node.Message`
- Two new columns on the `tasks` table: `LifecycleFailureMessage` (persisted via GORM `AutoMigrate`, no manual migration needed)
- `toModelTasks()` calls `resolveNodeLifecycleMessages()` — a recursive helper that bubbles the pod-level failure message up to the parent task node the UI renders (Argo records the message on the executor child pod, not the task node itself)
- Transient startup messages (`PodInitializing`, `ContainerCreating`) and non-failure node states (`Succeeded`, `Skipped`, `Omitted`) are explicitly filtered so healthy runs produce no false positives
- `toApiPipelineTaskDetail()` exposes `LifecycleFailureMessage` via the existing `error` field on `PipelineTaskDetail`

*Frontend:*
- `ExecutionFlowElementData` gains a `lifecycleError` field
- `updateFlowElementsState()` reads `task_details[].error.message` from the KFP API and sets `lifecycleError` on the matching graph node; if set, the node state is forced to `FAILED` (overriding the MLMD `RUNNING` state that persists because the driver registers the execution before the user container fails)
- `RunDetailsV2` passes `task_details` into the graph even before MLMD data loads
- `RuntimeNodeDetailsV2` shows the "Pod lifecycle failure" banner whenever `lifecycleError` is present

---

**How to verify:**

1. Deploy the API server from this branch and run `npm run build` in `frontend/`

2. **Failure case** — create a pipeline with a non-existent image:
```python
from kfp import dsl, compiler

@dsl.component(base_image="python:99.99.99-nonexistent")
def will_fail(x: int) -> int:
    return x

@dsl.pipeline
def bad_pipeline():
    will_fail(x=1)

compiler.Compiler().compile(bad_pipeline, "bad.yaml")
```
Submit the run. Within ~30 seconds the task node should turn **red** and the side panel should show a `Pod lifecycle failure` banner with the full `ImagePullBackOff` message. No `kubectl` required.

3. **Success case** — submit any normal pipeline (e.g. the existing samples). All nodes should complete **green** with no lifecycle error banners anywhere, including on `SKIPPED` executor nodes.

4. **API check** (optional) — confirm the data is correct at the source:
```bash
curl http://<api-server>/apis/v2beta1/runs/<run-id> | \
  python3 -c "
import sys, json
d = json.load(sys.stdin)
for t in d['run_details']['task_details']:
    err = t.get('error')
    print(t['display_name'], '->', err['message'] if err else 'None')
"
```
For the failure run: only the failing task and its executor pod should have a non-None error. For the success run: every task should show `None`.