### PR TITLE
test: stabilize proxy CI setup

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -50,12 +50,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Deploy Squid
-      id: deploy-squid
-      if: ${{ inputs.proxy == 'true' }}
-      shell: bash
-      run: ./.github/resources/squid/deploy-squid.sh
-
     - name: Download Docker Images
       uses: actions/download-artifact@v7
       with:
@@ -93,12 +87,23 @@ runs:
     - name: Load Runtime Base Images Into Kind
       shell: bash
       run: |
+        docker pull docker.io/alpine:3.23
         docker pull python:3.11
         docker pull registry.access.redhat.com/ubi9/python-311:latest
+        kind load docker-image docker.io/alpine:3.23 --name ${{ inputs.cluster_name }}
         kind load docker-image python:3.11 --name ${{ inputs.cluster_name }}
         kind load docker-image registry.access.redhat.com/ubi9/python-311:latest --name ${{ inputs.cluster_name }}
+        docker image rm docker.io/alpine:3.23
         docker image rm python:3.11
         docker image rm registry.access.redhat.com/ubi9/python-311:latest
+
+    - name: Deploy Squid
+      id: deploy-squid
+      if: ${{ inputs.proxy == 'true' }}
+      shell: bash
+      env:
+        CLUSTER_NAME: ${{ inputs.cluster_name }}
+      run: ./.github/resources/squid/deploy-squid.sh
 
     - name: Configure Args
       shell: bash

--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -279,7 +279,10 @@ runs:
         echo "=== Current disk usage ==="
         df -h
         NAMESPACE="${{ inputs.default_namespace }}"
-        ./.github/resources/scripts/collect-logs.sh --ns $NAMESPACE --output /tmp/tmp_pod_log.txt
+        ./.github/resources/scripts/collect-logs.sh --ns "$NAMESPACE" --output /tmp/tmp_pod_log.txt
+        if [ "${{ inputs.proxy }}" = "true" ]; then
+          ./.github/resources/scripts/collect-logs.sh --ns squid --output /tmp/tmp_pod_log.txt
+        fi
       continue-on-error: true
 
     - name: Set up Python for reporting

--- a/.github/resources/manifests/standalone/cache-disabled-proxy/apiserver-env.yaml
+++ b/.github/resources/manifests/standalone/cache-disabled-proxy/apiserver-env.yaml
@@ -15,6 +15,6 @@ spec:
             - name: HTTPS_PROXY
               value: "http://squid.squid.svc.cluster.local:3128"
             - name: NO_PROXY
-              value: "localhost,127.0.0.1,.svc.cluster.local,kubernetes.default.svc,seaweedfs.kubeflow,metadata-grpc-service,metadata-grpc-service.kubeflow,ml-pipeline.kubeflow"
+              value: "localhost,127.0.0.1,10.96.0.0/12,.svc.cluster.local,kubernetes.default.svc,seaweedfs.kubeflow,metadata-grpc-service,metadata-grpc-service.kubeflow,ml-pipeline.kubeflow"
             - name: OBJECTSTORECONFIG_HOST
               value: "seaweedfs.kubeflow.svc.cluster.local"

--- a/.github/resources/manifests/standalone/cache-disabled-proxy/kustomization.yaml
+++ b/.github/resources/manifests/standalone/cache-disabled-proxy/kustomization.yaml
@@ -9,3 +9,7 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: ../proxy/wf-controller-env.yaml
+    target:
+      kind: Deployment
+      name: workflow-controller

--- a/.github/resources/manifests/standalone/proxy/apiserver-env.yaml
+++ b/.github/resources/manifests/standalone/proxy/apiserver-env.yaml
@@ -13,4 +13,4 @@ spec:
             - name: HTTPS_PROXY
               value: "http://squid.squid.svc.cluster.local:3128"
             - name: NO_PROXY
-              value: "localhost,127.0.0.1,.svc.cluster.local,kubernetes.default.svc,mysql,mysql.kubeflow,seaweedfs.kubeflow,metadata-grpc-service,metadata-grpc-service.kubeflow,ml-pipeline.kubeflow"
+              value: "localhost,127.0.0.1,10.96.0.0/12,.svc.cluster.local,kubernetes.default.svc,mysql,mysql.kubeflow,seaweedfs.kubeflow,metadata-grpc-service,metadata-grpc-service.kubeflow,ml-pipeline.kubeflow"

--- a/.github/resources/manifests/standalone/proxy/kustomization.yaml
+++ b/.github/resources/manifests/standalone/proxy/kustomization.yaml
@@ -46,6 +46,10 @@ patches:
     target:
       kind: Deployment
       name: ml-pipeline
+  - path: wf-controller-env.yaml
+    target:
+      kind: Deployment
+      name: workflow-controller
   - path: ../../base/grpc-specs.yaml
     target:
       kind: Deployment

--- a/.github/resources/manifests/standalone/proxy/wf-controller-env.yaml
+++ b/.github/resources/manifests/standalone/proxy/wf-controller-env.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflow-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: workflow-controller
+          env:
+            - name: NO_PROXY
+              value: "localhost,127.0.0.1,10.96.0.0/12,.svc.cluster.local,kubernetes.default.svc"

--- a/.github/resources/scripts/collect-logs.sh
+++ b/.github/resources/scripts/collect-logs.sh
@@ -14,12 +14,18 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-mkdir -p /tmp/tmp.log
-
 if [[ -z "$NS" ]]; then
-    echo "Both --ns parameters are required."
+    echo "--ns parameter is required."
     exit 1
 fi
+
+if [[ -z "$OUTPUT_FILE" ]]; then
+    echo "--output parameter is required."
+    exit 1
+fi
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+touch "$OUTPUT_FILE"
 
 function check_namespace {
     if ! kubectl get namespace "$1" &>/dev/null; then
@@ -43,7 +49,7 @@ function display_pod_info {
         return
     fi
 
-    echo "Pod Information for Namespace: ${NAMESPACE}" > "$OUTPUT_FILE"
+    echo "Pod Information for Namespace: ${NAMESPACE}" | tee -a "$OUTPUT_FILE"
 
     for POD_NAME in ${POD_NAMES}; do
         {

--- a/.github/resources/squid/Containerfile
+++ b/.github/resources/squid/Containerfile
@@ -7,4 +7,5 @@ COPY squid.conf /etc/squid/squid.conf
 
 EXPOSE 3128
 
-CMD ["squid", "-N", "-d", "1"]
+# Runtime EmptyDir mounts hide any cache/log directories initialized at build time.
+CMD ["sh", "-c", "mkdir -p /var/cache/squid /var/log/squid /run/squid && chown -R squid:squid /var/cache/squid /var/log/squid /run/squid && squid -z -f /etc/squid/squid.conf && rm -f /run/squid.pid && exec squid -N -d 1 -f /etc/squid/squid.conf"]

--- a/.github/resources/squid/deploy-squid.sh
+++ b/.github/resources/squid/deploy-squid.sh
@@ -4,13 +4,44 @@ set -e
 
 C_DIR="${BASH_SOURCE%/*}"
 NAMESPACE="squid"
+CLUSTER_NAME="${CLUSTER_NAME:-kfp}"
 
-docker build --progress=plain -t "registry.domain.local/squid:test" -f ${C_DIR}/Containerfile ${C_DIR}
-kind --name kfp load docker-image registry.domain.local/squid:test
+function dump_squid_state {
+    kubectl -n "${NAMESPACE}" get pods -l app=squid -o wide || true
+    kubectl -n "${NAMESPACE}" describe deployment/squid || true
+    for pod in $(kubectl -n "${NAMESPACE}" get pods -l app=squid -o name 2>/dev/null); do
+        kubectl -n "${NAMESPACE}" describe "${pod}" || true
+        kubectl -n "${NAMESPACE}" logs "${pod}" --all-containers=true --tail=200 || true
+        kubectl -n "${NAMESPACE}" logs "${pod}" --all-containers=true --previous --tail=200 || true
+    done
+}
 
-kubectl apply -k ${C_DIR}/manifests
+docker build --progress=plain -t "registry.domain.local/squid:test" -f "${C_DIR}/Containerfile" "${C_DIR}"
+kind --name "${CLUSTER_NAME}" load docker-image registry.domain.local/squid:test
 
-if ! kubectl -n ${NAMESPACE} wait --for=condition=available deployment/squid --timeout=60s; then
+kubectl apply -k "${C_DIR}/manifests"
+
+if ! kubectl -n "${NAMESPACE}" wait --for=condition=available deployment/squid --timeout=60s; then
     echo "Timeout occurred while waiting for the Squid deployment."
+    dump_squid_state
     exit 1
 fi
+
+echo "Waiting for the Squid service to publish a ready endpoint."
+end_time=$((SECONDS + 60))
+while true; do
+    endpoint_ip="$(kubectl -n "${NAMESPACE}" get endpoints squid -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null || true)"
+    if [[ -n "${endpoint_ip}" ]]; then
+        echo "Squid endpoint is ready: ${endpoint_ip}"
+        break
+    fi
+
+    if (( SECONDS >= end_time )); then
+        echo "Timeout occurred while waiting for the Squid service endpoint."
+        dump_squid_state
+        kubectl -n "${NAMESPACE}" get endpoints squid -o yaml || true
+        exit 1
+    fi
+
+    sleep 2
+done

--- a/.github/resources/squid/manifests/deployment.yaml
+++ b/.github/resources/squid/manifests/deployment.yaml
@@ -18,6 +18,28 @@ spec:
           image: registry.domain.local/squid:test
           ports:
             - containerPort: 3128
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          startupProbe:
+            tcpSocket:
+              port: 3128
+            periodSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            tcpSocket:
+              port: 3128
+            periodSeconds: 2
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 3128
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
           volumeMounts:
             - name: squid-cache
               mountPath: /var/cache/squid

--- a/.github/resources/squid/squid.conf
+++ b/.github/resources/squid/squid.conf
@@ -1,8 +1,11 @@
-# Define an access control list (ACL) for all source IP addresses
-acl all src all
-
 # Allow HTTP access from all sources
 http_access allow all
 
 # Define the port Squid will listen on
 http_port 3128
+
+# CI only needs a pass-through forward proxy. Disable caching so Squid stays
+# small enough for memory-constrained GitHub Actions Kind nodes.
+cache deny all
+cache_mem 0 bytes
+maximum_object_size 0 bytes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-06-09
+- Last updated: 2026-06-14
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -533,6 +533,9 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 - Kind-based clusters are provisioned via the `kfp-cluster` composite action, parameterized by `k8s_version`, `pipeline_store`, `proxy`, `cache_enabled`, and optional `argo_version`.
 - The `create-cluster` and `deploy` actions are used by newer suites; `kfp-k8s` installs SDK components from source inside jobs that execute Python-based tests.
+- The `deploy` action downloads and loads CI-built images before deploying optional Squid proxy support, preloads runtime base images used by test pods and init containers, and waits for Squid readiness/endpoints in proxy lanes.
+- Proxy test failures collect both the KFP namespace and `squid` namespace logs/events to diagnose proxy-service readiness separately from pipeline failures.
+- The CI proxy runs Squid as a no-cache forward proxy under the historical `squid` namespace/service names.
 - The `protobuf` composite action prepares `protoc` and related dependencies when compiling Python protobufs.
 - The `create-cluster` action caches Kind node images by Kubernetes version to reduce Docker Hub pulls.
 - Python workflows use `actions/cache@v5` for pip cache to reduce repeated dependency installs.
@@ -679,3 +682,4 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 - API client generation fails with Docker errors (for example permission denied to Docker socket): ensure Docker is running and your user can access the Docker daemon.
 - Frontend fails to start due to Node version mismatch: `nvm use $(cat frontend/.nvmrc)` or `fnm use`.
 - Runtime component imports SDK-only modules: `_KFP_RUNTIME=true` disables many SDK imports; avoid importing SDK-only modules in task code.
+- Proxy CI jobs fail during `Deploy Squid` with `OOMKilled`, `CrashLoopBackOff`, endpoint readiness timeouts, or failed proxy tests: inspect the `squid` namespace logs/events and verify `.github/resources/squid/squid.conf` still disables caching for CI.


### PR DESCRIPTION
**Description of your changes:**

This PR keeps the existing `squid.squid.svc.cluster.local:3128` proxy fixture, but makes the proxy CI lanes less fragile.

Changes:
- load Docker image artifacts and runtime base images before deploying Squid, including `docker.io/alpine:3.23`
- run Squid as a no-cache forward proxy with small memory requests/limits and TCP probes
- wait for the Squid Deployment and Service endpoint before continuing
- keep Kubernetes service traffic out of the proxy path with `NO_PROXY` on `ml-pipeline` and `workflow-controller`
- collect `squid` namespace logs when proxy jobs fail

This is CI/test infrastructure only. It does not change KFP product code, public APIs, CRDs, or Kubernetes version matrices.

Validation:
- parsed changed YAML files with `yaml.safe_load_all`
- ran `kubectl kustomize` for Squid and both proxy overlays
- ran `bash -n` for changed shell scripts
- ran `git diff --check`
- built the Squid image locally and confirmed it starts and listens on port `3128`


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
