### PR TITLE
fix(unit): stabilize backend unit tests

### DIFF
--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -211,10 +211,10 @@ func Test_executeV2_publishLogs(t *testing.T) {
 			fakeKubernetesClientset := &fake.Clientset{}
 			var fakeMetadataClient metadata.ClientInterface
 			var countingFakeMetadataClient *metadata.RecordArtifactFailureFakeClient
-			// Use a fake client that will fail the RecordArtifact call in uploadArtifactLogs the first time,
-			// and succeed the second time, to test retry behavior
+			// Use a fake client that will fail the executor-logs RecordArtifact call the first time,
+			// and succeed the second time, to test retry behavior without depending on map iteration order.
 			if test.uploadFailure {
-				countingFakeMetadataClient = metadata.NewRecordArtifactFailureFakeClient(1)
+				countingFakeMetadataClient = metadata.NewRecordArtifactFailureFakeClientForOutput("executor-logs", 1)
 				fakeMetadataClient = countingFakeMetadataClient
 			} else {
 				fakeMetadataClient = metadata.NewFakeClient()
@@ -278,15 +278,13 @@ func Test_executeV2_publishLogs(t *testing.T) {
 				assert.NotNil(t, err)
 				assert.Len(t, outputArtifacts, 1, "Expected 1 output artifact (executor-logs)")
 				if test.uploadFailure {
-					// Only logs uploaded - first call fails, second call succeeds
-					assert.Equal(t, 2, countingFakeMetadataClient.RecordArtifactCalls)
+					assert.Equal(t, 2, countingFakeMetadataClient.OutputNameCalls["executor-logs"])
 				}
 			} else {
 				assert.Nil(t, err)
 				assert.Len(t, outputArtifacts, 2, "Expected 2 output artifacts (executor-logs and output-data)")
 				if test.uploadFailure {
-					// First call fails and returns early, then both artifacts succeed on retry
-					assert.Equal(t, 3, countingFakeMetadataClient.RecordArtifactCalls)
+					assert.Equal(t, 2, countingFakeMetadataClient.OutputNameCalls["executor-logs"])
 				}
 			}
 

--- a/backend/src/v2/metadata/client_fake.go
+++ b/backend/src/v2/metadata/client_fake.go
@@ -20,6 +20,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 
@@ -118,18 +119,30 @@ type RecordArtifactFailureFakeClient struct {
 	*FakeClient
 	RecordArtifactCalls int
 	FailUntilCall       int
+	FailOutputName      string
+	OutputNameCalls     map[string]int
 }
 
-func NewRecordArtifactFailureFakeClient(failUntilCall int) *RecordArtifactFailureFakeClient {
+func NewRecordArtifactFailureFakeClientForOutput(outputName string, failUntilCall int) *RecordArtifactFailureFakeClient {
 	return &RecordArtifactFailureFakeClient{
-		FakeClient:    NewFakeClient(),
-		FailUntilCall: failUntilCall,
+		FakeClient:      NewFakeClient(),
+		FailUntilCall:   failUntilCall,
+		FailOutputName:  outputName,
+		OutputNameCalls: make(map[string]int),
 	}
 }
 
 func (c *RecordArtifactFailureFakeClient) RecordArtifact(ctx context.Context, outputName, schema string, runtimeArtifact *pipelinespec.RuntimeArtifact, state pb.Artifact_State, bucketConfig *objectstore.Config) (*OutputArtifact, error) {
 	c.RecordArtifactCalls++
-	if c.RecordArtifactCalls <= c.FailUntilCall {
+	if c.OutputNameCalls == nil {
+		return nil, fmt.Errorf("OutputNameCalls should be initialized; consider using `NewRecordArtifactFailureFakeClientForOutput`")
+	}
+	c.OutputNameCalls[outputName]++
+	if c.FailOutputName != "" {
+		if outputName == c.FailOutputName && c.OutputNameCalls[outputName] <= c.FailUntilCall {
+			return nil, errors.New("simulated error")
+		}
+	} else if c.RecordArtifactCalls <= c.FailUntilCall {
 		return nil, errors.New("simulated error")
 	}
 	return nil, nil


### PR DESCRIPTION
The `Test_executeV2_publishLogs/retry_required_-_component_success` case had an implicit dependency on artifact map iteration order. When `executor-logs` was not processed in the expected order, the retry path could miss uploading logs and fail randomly with: blob (key "executor-logs-0") (code=NotFound): blob not found

The fake metadata client now fails the `executor-logs` artifact explicitly, so the test no longer depends on which artifact is processed first.


failed tests:
```
testoutput
E0612 21:06:16.100891   27196 launcher_v2.go:449] Component failed to execute successfully: exit status 1
=== RUN   Test_executeV2_publishLogs/retry_required_-_component_success
testoutput
    launcher_v2_test.go:312: 
        	Error Trace:	/home/runner/work/pipelines/pipelines/backend/src/v2/component/launcher_v2_test.go:312
        	Error:      	Expected nil, but got: blob (key "executor-logs-0") (code=NotFound): blob not found
        	Test:       	Test_executeV2_publishLogs/retry_required_-_component_success
        	Messages:   	Expected executor-logs to be readable at key "executor-logs-0"
    launcher_v2_test.go:313: 
        	Error Trace:	/home/runner/work/pipelines/pipelines/backend/src/v2/component/launcher_v2_test.go:313
        	Error:      	Not equal: 
        	            	expected: "testoutput\n"
        	            	actual  : ""
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1 @@
        	            	-testoutput
        	            	 
        	Test:       	Test_executeV2_publishLogs/retry_required_-_component_success
```
https://github.com/kubeflow/pipelines/actions/runs/27442866956/job/81120877056?pr=13171
