### PR TITLE
feat(backend): add database garbage collection for expired pipeline runs

### DIFF
--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -116,7 +116,7 @@ type ClientManager struct {
 	authenticators            []auth.Authenticator
 	controllerClient          ctrlclient.Client
 	controllerClientNoCache   ctrlclient.Client
-	gcIndexReady              bool
+	gcIndexChecker            func() bool
 }
 
 // Options to pass to Client Manager initialization
@@ -127,10 +127,12 @@ type Options struct {
 	WaitGroup                    *sync.WaitGroup
 }
 
-// IsGarbageCollectorIndexReady returns true if the GC lifecycle index
-// exists. When false, GC must not start to avoid full table scans.
-func (c *ClientManager) IsGarbageCollectorIndexReady() bool {
-	return c.gcIndexReady
+// GarbageCollectorIndexChecker returns a function that re-validates the GC
+// lifecycle index against the database catalog. The GC loop calls it on every
+// collection tick, so an operator can apply (or roll back) the index
+// migration without restarting the API server.
+func (c *ClientManager) GarbageCollectorIndexChecker() func() bool {
+	return c.gcIndexChecker
 }
 
 func (c *ClientManager) TaskStore() storage.TaskStoreInterface {
@@ -281,12 +283,12 @@ func (c *ClientManager) init(options *Options) error {
 
 	glog.Info("Initializing client manager")
 	glog.Info("Initializing DB client...")
-	db, gcIndexReady := InitDBClient(common.GetDurationConfig(initConnectionTimeout))
+	db, gcIndexChecker := InitDBClient(common.GetDurationConfig(initConnectionTimeout))
 	db.SetConnMaxLifetime(common.GetDurationConfig(dbConMaxLifeTime))
 	glog.Info("DB client initialized successfully")
 
 	c.db = db
-	c.gcIndexReady = gcIndexReady
+	c.gcIndexChecker = gcIndexChecker
 	if !options.UsePipelineKubernetesStorage {
 		c.pipelineStore = storage.NewPipelineStore(db, c.time, c.uuid)
 	}
@@ -437,7 +439,7 @@ func validateGarbageCollectorIndex(db *gorm.DB, dialect SQLDialect) (bool, error
 	return status.isReady(), nil
 }
 
-func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, bool) {
+func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, func() bool) {
 	// Allowed driverName values:
 	// 1) To use MySQL, use `mysql`
 	// 2) To use PostgreSQL, use `pgx`
@@ -479,23 +481,28 @@ func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, bool) {
 		util.TerminateIfError(autoMigrate(db))
 	}
 
-	gcIndexReady := false
-	if common.GetRunsRetentionTime() > 0 || common.GetArchivedRunsRetentionTime() > 0 {
-		var indexValidationError error
-		gcIndexReady, indexValidationError = validateGarbageCollectorIndex(db, dialect)
+	// gcIndexChecker re-reads the catalog on demand; the gorm handle shares
+	// the connection pool with the returned *storage.DB. The GC loop calls
+	// this on every tick, so index migrations take effect without a restart.
+	gcIndexChecker := func() bool {
+		ready, indexValidationError := validateGarbageCollectorIndex(db, dialect)
 		if indexValidationError != nil {
-			glog.Errorf("Failed to validate GC lifecycle index: %v. GC disabled.", indexValidationError)
-		} else if !gcIndexReady {
-			glog.Warning("Run GC disabled: idx_run_gc_lifecycle is missing or incompatible. " +
-				"Apply the online index migration in docs/agents/development.md.")
+			glog.Errorf("Failed to validate GC lifecycle index: %v", indexValidationError)
+			return false
 		}
+		return ready
+	}
+	if (common.GetRunsRetentionTime() > 0 || common.GetArchivedRunsRetentionTime() > 0) && !gcIndexChecker() {
+		glog.Warning("Run GC paused: idx_run_gc_lifecycle is missing or incompatible. " +
+			"Apply the online index migration in docs/agents/development.md; " +
+			"GC re-checks the index on every collection tick and starts automatically once it is ready.")
 	}
 
 	newdb, err := db.DB()
 	if err != nil {
 		glog.Fatalf("Failed to retrieve *sql.DB from gorm.DB. Error: %v", err)
 	}
-	return storage.NewDB(newdb, storage.NewMySQLDialect()), gcIndexReady
+	return storage.NewDB(newdb, storage.NewMySQLDialect()), gcIndexChecker
 }
 
 // Initializes Database driver. Use `driverName` to indicate which type of DB to use:

--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -385,27 +385,60 @@ func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, bool) {
 	gcIndexReady := false
 	if common.GetRunsRetentionTime() > 0 || common.GetArchivedRunsRetentionTime() > 0 {
 		if db.Migrator().HasTable("run_details") {
-			if db.Migrator().HasIndex(&model.Run{}, "idx_run_gc_lifecycle") {
-				gcIndexReady = true
-			} else {
-				quoteIdentifier := dialect.QuoteIdentifier
-				var indexSQL string
-				if dialect.Name == "pgx" {
-					// CONCURRENTLY avoids blocking writes; IF NOT EXISTS handles replica races.
-					indexSQL = fmt.Sprintf("CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (%s, %s)",
-						quoteIdentifier("idx_run_gc_lifecycle"), quoteIdentifier("run_details"),
-						quoteIdentifier("StorageState"), quoteIdentifier("FinishedAtInSec"))
-				} else {
-					// MySQL InnoDB CREATE INDEX is online by default.
-					indexSQL = fmt.Sprintf("CREATE INDEX %s ON %s (%s, %s)",
-						quoteIdentifier("idx_run_gc_lifecycle"), quoteIdentifier("run_details"),
-						quoteIdentifier("StorageState"), quoteIdentifier("FinishedAtInSec"))
-				}
-				if err := db.Exec(indexSQL).Error; err != nil {
-					glog.Errorf("Failed to create GC lifecycle index: %v. "+
-						"GC disabled; create the index manually to enable.", err)
-				} else {
+			quoteIdentifier := dialect.QuoteIdentifier
+			if dialect.Name == "pgx" {
+				// Query pg_index directly; HasIndex includes invalid indexes.
+				var validIndexCount int64
+				validationErr := db.Raw(
+					`SELECT COUNT(*) FROM pg_index i `+
+						`JOIN pg_class c ON i.indexrelid = c.oid `+
+						`WHERE c.relname = 'idx_run_gc_lifecycle' `+
+						`AND i.indisvalid = true AND i.indisready = true`,
+				).Row().Scan(&validIndexCount)
+				if validationErr != nil {
+					glog.Errorf("Failed to validate GC lifecycle index: %v. GC disabled.", validationErr)
+				} else if validIndexCount > 0 {
 					gcIndexReady = true
+				} else {
+					// Drop any invalid index remnant before re-creating.
+					db.Exec(`DROP INDEX IF EXISTS "idx_run_gc_lifecycle"`)
+					indexSQL := fmt.Sprintf("CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (%s, %s)",
+						quoteIdentifier("idx_run_gc_lifecycle"), quoteIdentifier("run_details"),
+						quoteIdentifier("StorageState"), quoteIdentifier("FinishedAtInSec"))
+					if err := db.Exec(indexSQL).Error; err != nil {
+						glog.Errorf("Failed to create GC lifecycle index: %v. "+
+							"GC disabled; create the index manually to enable.", err)
+					} else {
+						// Re-validate: CONCURRENTLY can leave invalid indexes.
+						var postCreateCount int64
+						postErr := db.Raw(
+							`SELECT COUNT(*) FROM pg_index i `+
+								`JOIN pg_class c ON i.indexrelid = c.oid `+
+								`WHERE c.relname = 'idx_run_gc_lifecycle' `+
+								`AND i.indisvalid = true AND i.indisready = true`,
+						).Row().Scan(&postCreateCount)
+						if postErr != nil || postCreateCount == 0 {
+							glog.Errorf("GC lifecycle index created but not valid (indisvalid/indisready check failed). "+
+								"GC disabled; inspect pg_index manually and REINDEX if needed.")
+						} else {
+							gcIndexReady = true
+						}
+					}
+				}
+			} else {
+				// MySQL: HasIndex is reliable; CREATE INDEX is online by default.
+				if db.Migrator().HasIndex(&model.Run{}, "idx_run_gc_lifecycle") {
+					gcIndexReady = true
+				} else {
+					indexSQL := fmt.Sprintf("CREATE INDEX %s ON %s (%s, %s)",
+						quoteIdentifier("idx_run_gc_lifecycle"), quoteIdentifier("run_details"),
+						quoteIdentifier("StorageState"), quoteIdentifier("FinishedAtInSec"))
+					if err := db.Exec(indexSQL).Error; err != nil {
+						glog.Errorf("Failed to create GC lifecycle index: %v. "+
+							"GC disabled; create the index manually to enable.", err)
+					} else {
+						gcIndexReady = true
+					}
 				}
 			}
 		}

--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -338,6 +338,105 @@ func (c *ClientManager) Close() {
 	c.db.Close()
 }
 
+const (
+	garbageCollectorIndexName    = "idx_run_gc_lifecycle"
+	garbageCollectorTableName    = "run_details"
+	garbageCollectorIndexColumns = "StorageState,FinishedAtInSec"
+)
+
+type garbageCollectorIndexStatus struct {
+	currentSchema string
+	tableSchema   string
+	tableName     string
+	indexName     string
+	columns       string
+	valid         bool
+	ready         bool
+	unconditional bool
+}
+
+func (status garbageCollectorIndexStatus) isReady() bool {
+	return status.currentSchema != "" &&
+		status.tableSchema == status.currentSchema &&
+		status.tableName == garbageCollectorTableName &&
+		status.indexName == garbageCollectorIndexName &&
+		status.columns == garbageCollectorIndexColumns &&
+		status.valid && status.ready && status.unconditional
+}
+
+// validateGarbageCollectorIndex only reads database catalog metadata. Index
+// creation is an explicit operator migration so API-server startup never runs
+// heavyweight DDL from every replica.
+func validateGarbageCollectorIndex(db *gorm.DB, dialect SQLDialect) (bool, error) {
+	var status garbageCollectorIndexStatus
+	var row *sql.Row
+
+	switch dialect.Name {
+	case "pgx":
+		row = db.Raw(`
+			SELECT current_schema(), table_namespace.nspname, table_class.relname,
+			       index_class.relname,
+			       string_agg(attribute.attname, ',' ORDER BY index_key.ordinality),
+			       index_metadata.indisvalid, index_metadata.indisready,
+			       bool_and(index_metadata.indpred IS NULL AND access_method.amname = 'btree')
+			FROM pg_index AS index_metadata
+			JOIN pg_class AS index_class
+			  ON index_class.oid = index_metadata.indexrelid
+			JOIN pg_class AS table_class
+			  ON table_class.oid = index_metadata.indrelid
+			JOIN pg_namespace AS table_namespace
+			  ON table_namespace.oid = table_class.relnamespace
+			JOIN pg_namespace AS index_namespace
+			  ON index_namespace.oid = index_class.relnamespace
+			JOIN pg_am AS access_method
+			  ON access_method.oid = index_class.relam
+			CROSS JOIN LATERAL unnest(index_metadata.indkey::smallint[])
+			  WITH ORDINALITY AS index_key(attnum, ordinality)
+			JOIN pg_attribute AS attribute
+			  ON attribute.attrelid = table_class.oid
+			 AND attribute.attnum = index_key.attnum
+			WHERE table_namespace.nspname = current_schema()
+			  AND index_namespace.nspname = table_namespace.nspname
+			  AND table_class.relname = ?
+			  AND index_class.relname = ?
+			  AND index_metadata.indexprs IS NULL
+			GROUP BY table_namespace.nspname, table_class.relname, index_class.relname,
+			         index_metadata.indisvalid, index_metadata.indisready`, garbageCollectorTableName, garbageCollectorIndexName).Row()
+	case "mysql":
+		row = db.Raw(`
+			SELECT DATABASE(), TABLE_SCHEMA, TABLE_NAME, INDEX_NAME,
+			       GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX SEPARATOR ','),
+			       TRUE, TRUE,
+			       SUM(SUB_PART IS NULL AND INDEX_TYPE = 'BTREE') = COUNT(*)
+			FROM information_schema.STATISTICS
+			WHERE TABLE_SCHEMA = DATABASE()
+			  AND TABLE_NAME = ?
+			  AND INDEX_NAME = ?
+			GROUP BY TABLE_SCHEMA, TABLE_NAME, INDEX_NAME`, garbageCollectorTableName, garbageCollectorIndexName).Row()
+	default:
+		return false, fmt.Errorf("garbage collector index validation is not supported for dialect %q", dialect.Name)
+	}
+
+	err := row.Scan(
+		&status.currentSchema,
+		&status.tableSchema,
+		&status.tableName,
+		&status.indexName,
+		&status.columns,
+		&status.valid,
+		&status.ready,
+		&status.unconditional,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("query garbage collector index metadata: %w", err)
+	}
+
+	return status.isReady(), nil
+}
+
 func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, bool) {
 	// Allowed driverName values:
 	// 1) To use MySQL, use `mysql`
@@ -380,67 +479,15 @@ func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, bool) {
 		util.TerminateIfError(autoMigrate(db))
 	}
 
-	// GC lifecycle index: covers (StorageState, FinishedAtInSec) for
-	// ArchiveExpiredRuns and DeleteExpiredArchivedRuns queries.
 	gcIndexReady := false
 	if common.GetRunsRetentionTime() > 0 || common.GetArchivedRunsRetentionTime() > 0 {
-		if db.Migrator().HasTable("run_details") {
-			quoteIdentifier := dialect.QuoteIdentifier
-			if dialect.Name == "pgx" {
-				// Query pg_index directly; HasIndex includes invalid indexes.
-				var validIndexCount int64
-				validationErr := db.Raw(
-					`SELECT COUNT(*) FROM pg_index i `+
-						`JOIN pg_class c ON i.indexrelid = c.oid `+
-						`WHERE c.relname = 'idx_run_gc_lifecycle' `+
-						`AND i.indisvalid = true AND i.indisready = true`,
-				).Row().Scan(&validIndexCount)
-				if validationErr != nil {
-					glog.Errorf("Failed to validate GC lifecycle index: %v. GC disabled.", validationErr)
-				} else if validIndexCount > 0 {
-					gcIndexReady = true
-				} else {
-					// Drop any invalid index remnant before re-creating.
-					db.Exec(`DROP INDEX IF EXISTS "idx_run_gc_lifecycle"`)
-					indexSQL := fmt.Sprintf("CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (%s, %s)",
-						quoteIdentifier("idx_run_gc_lifecycle"), quoteIdentifier("run_details"),
-						quoteIdentifier("StorageState"), quoteIdentifier("FinishedAtInSec"))
-					if err := db.Exec(indexSQL).Error; err != nil {
-						glog.Errorf("Failed to create GC lifecycle index: %v. "+
-							"GC disabled; create the index manually to enable.", err)
-					} else {
-						// Re-validate: CONCURRENTLY can leave invalid indexes.
-						var postCreateCount int64
-						postErr := db.Raw(
-							`SELECT COUNT(*) FROM pg_index i `+
-								`JOIN pg_class c ON i.indexrelid = c.oid `+
-								`WHERE c.relname = 'idx_run_gc_lifecycle' `+
-								`AND i.indisvalid = true AND i.indisready = true`,
-						).Row().Scan(&postCreateCount)
-						if postErr != nil || postCreateCount == 0 {
-							glog.Errorf("GC lifecycle index created but not valid (indisvalid/indisready check failed). "+
-								"GC disabled; inspect pg_index manually and REINDEX if needed.")
-						} else {
-							gcIndexReady = true
-						}
-					}
-				}
-			} else {
-				// MySQL: HasIndex is reliable; CREATE INDEX is online by default.
-				if db.Migrator().HasIndex(&model.Run{}, "idx_run_gc_lifecycle") {
-					gcIndexReady = true
-				} else {
-					indexSQL := fmt.Sprintf("CREATE INDEX %s ON %s (%s, %s)",
-						quoteIdentifier("idx_run_gc_lifecycle"), quoteIdentifier("run_details"),
-						quoteIdentifier("StorageState"), quoteIdentifier("FinishedAtInSec"))
-					if err := db.Exec(indexSQL).Error; err != nil {
-						glog.Errorf("Failed to create GC lifecycle index: %v. "+
-							"GC disabled; create the index manually to enable.", err)
-					} else {
-						gcIndexReady = true
-					}
-				}
-			}
+		var indexValidationError error
+		gcIndexReady, indexValidationError = validateGarbageCollectorIndex(db, dialect)
+		if indexValidationError != nil {
+			glog.Errorf("Failed to validate GC lifecycle index: %v. GC disabled.", indexValidationError)
+		} else if !gcIndexReady {
+			glog.Warning("Run GC disabled: idx_run_gc_lifecycle is missing or incompatible. " +
+				"Apply the online index migration in docs/agents/development.md.")
 		}
 	}
 

--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -340,11 +340,23 @@ func (c *ClientManager) Close() {
 	c.db.Close()
 }
 
-const (
-	garbageCollectorIndexName    = "idx_run_gc_lifecycle"
-	garbageCollectorTableName    = "run_details"
-	garbageCollectorIndexColumns = "StorageState,FinishedAtInSec"
-)
+const garbageCollectorTableName = "run_details"
+
+// garbageCollectorIndexSpec names one index the run GC requires and the exact
+// column list it must have.
+type garbageCollectorIndexSpec struct {
+	name    string
+	columns string
+}
+
+// garbageCollectorRequiredIndexes are all indexes the run GC needs: the
+// lifecycle index drives the archive pass and the legacy delete predicate
+// (rows archived before ArchivedAtInSec existed); the archived index drives
+// the delete pass's archival-time predicate.
+var garbageCollectorRequiredIndexes = []garbageCollectorIndexSpec{
+	{name: "idx_run_gc_lifecycle", columns: "StorageState,FinishedAtInSec"},
+	{name: "idx_run_gc_archived", columns: "StorageState,ArchivedAtInSec"},
+}
 
 type garbageCollectorIndexStatus struct {
 	currentSchema string
@@ -357,19 +369,33 @@ type garbageCollectorIndexStatus struct {
 	unconditional bool
 }
 
-func (status garbageCollectorIndexStatus) isReady() bool {
+func (status garbageCollectorIndexStatus) isReady(spec garbageCollectorIndexSpec) bool {
 	return status.currentSchema != "" &&
 		status.tableSchema == status.currentSchema &&
 		status.tableName == garbageCollectorTableName &&
-		status.indexName == garbageCollectorIndexName &&
-		status.columns == garbageCollectorIndexColumns &&
+		status.indexName == spec.name &&
+		status.columns == spec.columns &&
 		status.valid && status.ready && status.unconditional
 }
 
-// validateGarbageCollectorIndex only reads database catalog metadata. Index
+// validateGarbageCollectorIndexes only reads database catalog metadata. Index
 // creation is an explicit operator migration so API-server startup never runs
-// heavyweight DDL from every replica.
-func validateGarbageCollectorIndex(db *gorm.DB, dialect SQLDialect) (bool, error) {
+// heavyweight DDL from every replica. All required indexes must be present
+// and usable.
+func validateGarbageCollectorIndexes(db *gorm.DB, dialect SQLDialect) (bool, error) {
+	for _, spec := range garbageCollectorRequiredIndexes {
+		ready, err := validateGarbageCollectorIndex(db, dialect, spec)
+		if err != nil {
+			return false, err
+		}
+		if !ready {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func validateGarbageCollectorIndex(db *gorm.DB, dialect SQLDialect, spec garbageCollectorIndexSpec) (bool, error) {
 	var status garbageCollectorIndexStatus
 	var row *sql.Row
 
@@ -403,7 +429,7 @@ func validateGarbageCollectorIndex(db *gorm.DB, dialect SQLDialect) (bool, error
 			  AND index_class.relname = ?
 			  AND index_metadata.indexprs IS NULL
 			GROUP BY table_namespace.nspname, table_class.relname, index_class.relname,
-			         index_metadata.indisvalid, index_metadata.indisready`, garbageCollectorTableName, garbageCollectorIndexName).Row()
+			         index_metadata.indisvalid, index_metadata.indisready`, garbageCollectorTableName, spec.name).Row()
 	case "mysql":
 		row = db.Raw(`
 			SELECT DATABASE(), TABLE_SCHEMA, TABLE_NAME, INDEX_NAME,
@@ -414,7 +440,7 @@ func validateGarbageCollectorIndex(db *gorm.DB, dialect SQLDialect) (bool, error
 			WHERE TABLE_SCHEMA = DATABASE()
 			  AND TABLE_NAME = ?
 			  AND INDEX_NAME = ?
-			GROUP BY TABLE_SCHEMA, TABLE_NAME, INDEX_NAME`, garbageCollectorTableName, garbageCollectorIndexName).Row()
+			GROUP BY TABLE_SCHEMA, TABLE_NAME, INDEX_NAME`, garbageCollectorTableName, spec.name).Row()
 	default:
 		return false, fmt.Errorf("garbage collector index validation is not supported for dialect %q", dialect.Name)
 	}
@@ -436,7 +462,7 @@ func validateGarbageCollectorIndex(db *gorm.DB, dialect SQLDialect) (bool, error
 		return false, fmt.Errorf("query garbage collector index metadata: %w", err)
 	}
 
-	return status.isReady(), nil
+	return status.isReady(spec), nil
 }
 
 func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, func() bool) {
@@ -485,7 +511,7 @@ func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, func() bool
 	// the connection pool with the returned *storage.DB. The GC loop calls
 	// this on every tick, so index migrations take effect without a restart.
 	gcIndexChecker := func() bool {
-		ready, indexValidationError := validateGarbageCollectorIndex(db, dialect)
+		ready, indexValidationError := validateGarbageCollectorIndexes(db, dialect)
 		if indexValidationError != nil {
 			glog.Errorf("Failed to validate GC lifecycle index: %v", indexValidationError)
 			return false
@@ -493,7 +519,7 @@ func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, func() bool
 		return ready
 	}
 	if (common.GetRunsRetentionTime() > 0 || common.GetArchivedRunsRetentionTime() > 0) && !gcIndexChecker() {
-		glog.Warning("Run GC paused: idx_run_gc_lifecycle is missing or incompatible. " +
+		glog.Warning("Run GC paused: idx_run_gc_lifecycle and/or idx_run_gc_archived is missing or incompatible. " +
 			"Apply the online index migration in docs/agents/development.md; " +
 			"GC re-checks the index on every collection tick and starts automatically once it is ready.")
 	}

--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -116,6 +116,7 @@ type ClientManager struct {
 	authenticators            []auth.Authenticator
 	controllerClient          ctrlclient.Client
 	controllerClientNoCache   ctrlclient.Client
+	gcIndexReady              bool
 }
 
 // Options to pass to Client Manager initialization
@@ -124,6 +125,12 @@ type Options struct {
 	GlobalKubernetesWebhookMode  bool
 	Context                      context.Context
 	WaitGroup                    *sync.WaitGroup
+}
+
+// IsGarbageCollectorIndexReady returns true if the GC lifecycle index
+// exists. When false, GC must not start to avoid full table scans.
+func (c *ClientManager) IsGarbageCollectorIndexReady() bool {
+	return c.gcIndexReady
 }
 
 func (c *ClientManager) TaskStore() storage.TaskStoreInterface {
@@ -274,11 +281,12 @@ func (c *ClientManager) init(options *Options) error {
 
 	glog.Info("Initializing client manager")
 	glog.Info("Initializing DB client...")
-	db := InitDBClient(common.GetDurationConfig(initConnectionTimeout))
+	db, gcIndexReady := InitDBClient(common.GetDurationConfig(initConnectionTimeout))
 	db.SetConnMaxLifetime(common.GetDurationConfig(dbConMaxLifeTime))
 	glog.Info("DB client initialized successfully")
 
 	c.db = db
+	c.gcIndexReady = gcIndexReady
 	if !options.UsePipelineKubernetesStorage {
 		c.pipelineStore = storage.NewPipelineStore(db, c.time, c.uuid)
 	}
@@ -330,7 +338,7 @@ func (c *ClientManager) Close() {
 	c.db.Close()
 }
 
-func InitDBClient(initConnectionTimeout time.Duration) *storage.DB {
+func InitDBClient(initConnectionTimeout time.Duration) (*storage.DB, bool) {
 	// Allowed driverName values:
 	// 1) To use MySQL, use `mysql`
 	// 2) To use PostgreSQL, use `pgx`
@@ -372,11 +380,42 @@ func InitDBClient(initConnectionTimeout time.Duration) *storage.DB {
 		util.TerminateIfError(autoMigrate(db))
 	}
 
+	// GC lifecycle index: covers (StorageState, FinishedAtInSec) for
+	// ArchiveExpiredRuns and DeleteExpiredArchivedRuns queries.
+	gcIndexReady := false
+	if common.GetRunsRetentionTime() > 0 || common.GetArchivedRunsRetentionTime() > 0 {
+		if db.Migrator().HasTable("run_details") {
+			if db.Migrator().HasIndex(&model.Run{}, "idx_run_gc_lifecycle") {
+				gcIndexReady = true
+			} else {
+				quoteIdentifier := dialect.QuoteIdentifier
+				var indexSQL string
+				if dialect.Name == "pgx" {
+					// CONCURRENTLY avoids blocking writes; IF NOT EXISTS handles replica races.
+					indexSQL = fmt.Sprintf("CREATE INDEX CONCURRENTLY IF NOT EXISTS %s ON %s (%s, %s)",
+						quoteIdentifier("idx_run_gc_lifecycle"), quoteIdentifier("run_details"),
+						quoteIdentifier("StorageState"), quoteIdentifier("FinishedAtInSec"))
+				} else {
+					// MySQL InnoDB CREATE INDEX is online by default.
+					indexSQL = fmt.Sprintf("CREATE INDEX %s ON %s (%s, %s)",
+						quoteIdentifier("idx_run_gc_lifecycle"), quoteIdentifier("run_details"),
+						quoteIdentifier("StorageState"), quoteIdentifier("FinishedAtInSec"))
+				}
+				if err := db.Exec(indexSQL).Error; err != nil {
+					glog.Errorf("Failed to create GC lifecycle index: %v. "+
+						"GC disabled; create the index manually to enable.", err)
+				} else {
+					gcIndexReady = true
+				}
+			}
+		}
+	}
+
 	newdb, err := db.DB()
 	if err != nil {
 		glog.Fatalf("Failed to retrieve *sql.DB from gorm.DB. Error: %v", err)
 	}
-	return storage.NewDB(newdb, storage.NewMySQLDialect())
+	return storage.NewDB(newdb, storage.NewMySQLDialect()), gcIndexReady
 }
 
 // Initializes Database driver. Use `driverName` to indicate which type of DB to use:

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -320,5 +320,12 @@ func GetRunsGCBatchSize() int {
 	if configuredBatchSize <= 0 {
 		return 100
 	}
+	// Upper bound: DeleteExpiredArchivedRuns uses batch UUIDs in IN-clauses
+	// across 4 tables (run_metrics, tasks, resource_references, run_details).
+	// MySQL/PostgreSQL bind parameter limit is 65535; 1000 per batch stays
+	// well within that ceiling while remaining efficient.
+	if configuredBatchSize > 1000 {
+		return 1000
+	}
 	return configuredBatchSize
 }

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -56,6 +56,13 @@ const (
 	PluginMaxTotalPayloadBytes              string = "PLUGIN_MAX_TOTAL_PAYLOAD_BYTES"
 	PluginMaxNestingDepth                   string = "PLUGIN_MAX_NESTING_DEPTH"
 	WorkflowGCGracePeriodSeconds            string = "WORKFLOW_GC_GRACE_PERIOD_SECONDS"
+
+	// Run garbage collection configuration keys.
+	// Disabled by default (zero values).
+	RunsRetentionTime         string = "RUNS_RETENTION_TIME"
+	ArchivedRunsRetentionTime string = "ARCHIVED_RUNS_RETENTION_TIME"
+	RunsGCInterval            string = "RUNS_GC_INTERVAL"
+	RunsGCBatchSize           string = "RUNS_GC_BATCH_SIZE"
 )
 
 type PluginLimitsConfig struct {
@@ -154,6 +161,22 @@ func GetDurationConfig(configName string) time.Duration {
 		glog.Fatalf("Please specify flag %s", configName)
 	}
 	return viper.GetDuration(configName)
+}
+
+func GetDurationConfigWithDefault(configName string, value time.Duration) time.Duration {
+	if !viper.IsSet(configName) {
+		return value
+	}
+	raw := strings.TrimSpace(viper.GetString(configName))
+	if raw == "" {
+		return value
+	}
+	duration, parseError := time.ParseDuration(raw)
+	if parseError != nil {
+		glog.Errorf("Failed to parse duration for %s: %v. Using default %v", configName, parseError, value)
+		return value
+	}
+	return duration
 }
 
 func IsMultiUserMode() bool {
@@ -274,4 +297,28 @@ func GetPluginLimitsConfig() (PluginLimitsConfig, error) {
 		MaxTotalPayloadBytes: maxTotalPayloadBytes,
 		MaxNestingDepth:      maxNestingDepth,
 	}, nil
+}
+
+func GetRunsRetentionTime() time.Duration {
+	return GetDurationConfigWithDefault(RunsRetentionTime, 0)
+}
+
+func GetArchivedRunsRetentionTime() time.Duration {
+	return GetDurationConfigWithDefault(ArchivedRunsRetentionTime, 0)
+}
+
+func GetRunsGCInterval() time.Duration {
+	garbageCollectionInterval := GetDurationConfigWithDefault(RunsGCInterval, 6*time.Hour)
+	if garbageCollectionInterval <= 0 {
+		return 6 * time.Hour
+	}
+	return garbageCollectionInterval
+}
+
+func GetRunsGCBatchSize() int {
+	configuredBatchSize := GetIntConfigWithDefault(RunsGCBatchSize, 100)
+	if configuredBatchSize <= 0 {
+		return 100
+	}
+	return configuredBatchSize
 }

--- a/backend/src/apiserver/common/config_test.go
+++ b/backend/src/apiserver/common/config_test.go
@@ -546,6 +546,50 @@ func TestConfigWrapperCustomValues(t *testing.T) {
 	}
 }
 
+// TestRunGarbageCollectionConfigEnvVars locks the contract that the apiserver
+// deployment relies on: viper.AutomaticEnv() uppercases the config key to
+// derive the env var name. If these names drift, the GC silently falls back
+// to its disabled/default values.
+func TestRunGarbageCollectionConfigEnvVars(t *testing.T) {
+	t.Run("retention times read from uppercased env vars", func(t *testing.T) {
+		viper.Reset()
+		t.Setenv("RUNS_RETENTION_TIME", "720h")
+		t.Setenv("ARCHIVED_RUNS_RETENTION_TIME", "2160h")
+		viper.AutomaticEnv()
+
+		assert.Equal(t, 720*time.Hour, GetRunsRetentionTime())
+		assert.Equal(t, 2160*time.Hour, GetArchivedRunsRetentionTime())
+	})
+
+	t.Run("interval and batch size read from uppercased env vars", func(t *testing.T) {
+		viper.Reset()
+		t.Setenv("RUNS_GC_INTERVAL", "1h")
+		t.Setenv("RUNS_GC_BATCH_SIZE", "250")
+		viper.AutomaticEnv()
+
+		assert.Equal(t, time.Hour, GetRunsGCInterval())
+		assert.Equal(t, 250, GetRunsGCBatchSize())
+	})
+
+	t.Run("empty retention keeps GC disabled", func(t *testing.T) {
+		viper.Reset()
+		viper.AutomaticEnv()
+
+		assert.Equal(t, time.Duration(0), GetRunsRetentionTime())
+		assert.Equal(t, time.Duration(0), GetArchivedRunsRetentionTime())
+	})
+
+	t.Run("non-positive interval and batch size fall back to defaults", func(t *testing.T) {
+		viper.Reset()
+		t.Setenv("RUNS_GC_INTERVAL", "0s")
+		t.Setenv("RUNS_GC_BATCH_SIZE", "0")
+		viper.AutomaticEnv()
+
+		assert.Equal(t, 6*time.Hour, GetRunsGCInterval())
+		assert.Equal(t, 100, GetRunsGCBatchSize())
+	})
+}
+
 func TestGetClusterDomain(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/backend/src/apiserver/common/config_test.go
+++ b/backend/src/apiserver/common/config_test.go
@@ -588,6 +588,14 @@ func TestRunGarbageCollectionConfigEnvVars(t *testing.T) {
 		assert.Equal(t, 6*time.Hour, GetRunsGCInterval())
 		assert.Equal(t, 100, GetRunsGCBatchSize())
 	})
+
+	t.Run("batch size exceeding upper bound is clamped to 1000", func(t *testing.T) {
+		viper.Reset()
+		t.Setenv("RUNS_GC_BATCH_SIZE", "5000")
+		viper.AutomaticEnv()
+
+		assert.Equal(t, 1000, GetRunsGCBatchSize())
+	})
 }
 
 func TestGetClusterDomain(t *testing.T) {

--- a/backend/src/apiserver/gc/run_gc.go
+++ b/backend/src/apiserver/gc/run_gc.go
@@ -62,6 +62,7 @@ type leaderLifecycle struct {
 
 	mu               sync.Mutex
 	callbackStarted  bool
+	callbackDone     chan struct{}
 	cancelCollection context.CancelFunc
 	gracefulStop     bool
 }
@@ -97,11 +98,27 @@ func (l *leaderLifecycle) onStartedLeading(leaderCtx context.Context) {
 	defer cancelCollection()
 
 	l.mu.Lock()
+	// Serialize against a previous callback that is still draining even
+	// here: client-go dispatches OnStartedLeading as an unjoined goroutine
+	// and can re-enter the election before the previous callback registered
+	// itself, so the external drain gate alone cannot see it.
+	for l.callbackStarted {
+		previousDone := l.callbackDone
+		l.mu.Unlock()
+		select {
+		case <-previousDone:
+		case <-leaderCtx.Done():
+			// Lost this lease while waiting; nothing was started.
+			return
+		}
+		l.mu.Lock()
+	}
 	if l.gracefulStop || l.electionCtx.Err() != nil {
 		l.mu.Unlock()
 		return
 	}
 	l.callbackStarted = true
+	l.callbackDone = make(chan struct{})
 	l.cancelCollection = cancelCollection
 	if l.shutdownCtx.Err() != nil {
 		cancelCollection()
@@ -119,13 +136,37 @@ func (l *leaderLifecycle) onStartedLeading(leaderCtx context.Context) {
 	// shutdown wait group.
 	l.mu.Lock()
 	l.callbackStarted = false
+	done := l.callbackDone
 	shutdown := l.shutdownCtx.Err() != nil
 	if shutdown {
 		l.gracefulStop = true
 	}
 	l.mu.Unlock()
+	close(done)
 	if shutdown {
 		l.cancelElection()
+	}
+}
+
+// drainCallback blocks until no collection callback is running, or ctx is
+// canceled (returning false). client-go launches OnStartedLeading as an
+// unjoined goroutine and LeaderElector.Run returns without waiting for it, so
+// without this gate a re-entered election could start a second collection
+// loop while the first is still draining, and Start could return before all
+// database work has finished.
+func (l *leaderLifecycle) drainCallback(ctx context.Context) bool {
+	l.mu.Lock()
+	if !l.callbackStarted {
+		l.mu.Unlock()
+		return true
+	}
+	done := l.callbackDone
+	l.mu.Unlock()
+	select {
+	case <-done:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 
@@ -233,6 +274,11 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 	// per attempt; the config was validated once above so per-attempt
 	// construction cannot fail persistently.
 	wait.UntilWithContext(electionCtx, func(loopCtx context.Context) {
+		// Never re-enter the election while the previous collection callback
+		// is still draining: at most one collection loop may exist.
+		if !lifecycle.drainCallback(loopCtx) {
+			return
+		}
 		attemptElector, attemptError := leaderelection.NewLeaderElector(electionConfig)
 		if attemptError != nil {
 			glog.Errorf("Run GC: failed to recreate leader elector, retrying in %v: %v", reelectionBackoff, attemptError)
@@ -240,6 +286,13 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 		}
 		attemptElector.Run(loopCtx)
 	}, reelectionBackoff)
+
+	// Stop any not-yet-registered callback from starting (registration
+	// re-checks electionCtx under the lifecycle lock), then join the final
+	// callback so main's wait group only releases after all in-flight
+	// database work has drained.
+	cancelElection()
+	lifecycle.drainCallback(context.Background())
 }
 
 func (gc *RunGarbageCollector) runLoop(ctx context.Context) {

--- a/backend/src/apiserver/gc/run_gc.go
+++ b/backend/src/apiserver/gc/run_gc.go
@@ -1,0 +1,194 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gc implements background garbage collection for expired pipeline runs.
+package gc
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/storage"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const (
+	leaseName  = "kfp-apiserver-gc"
+	drainPause = 100 * time.Millisecond
+)
+
+type RunGarbageCollector struct {
+	runStore  storage.RunStoreInterface
+	clientset kubernetes.Interface
+	namespace string
+	nowFunc   func() int64
+}
+
+func NewRunGarbageCollector(
+	runStore storage.RunStoreInterface,
+	clientset kubernetes.Interface,
+	namespace string,
+) *RunGarbageCollector {
+	return &RunGarbageCollector{
+		runStore:  runStore,
+		clientset: clientset,
+		namespace: namespace,
+		nowFunc:   func() int64 { return time.Now().Unix() },
+	}
+}
+
+// Start launches the GC loop. It blocks until ctx is canceled.
+func (gc *RunGarbageCollector) Start(ctx context.Context) {
+	archiveRetention := common.GetRunsRetentionTime()
+	deleteRetention := common.GetArchivedRunsRetentionTime()
+
+	if archiveRetention == 0 && deleteRetention == 0 {
+		glog.Info("Run GC disabled: both RUNS_RETENTION_TIME and ARCHIVED_RUNS_RETENTION_TIME are empty")
+		return
+	}
+
+	glog.Infof("Run GC enabled: archive after %v, delete after %v, interval %v, batch %d",
+		archiveRetention, deleteRetention, common.GetRunsGCInterval(), common.GetRunsGCBatchSize())
+
+	id := os.Getenv("POD_NAME")
+	if id == "" {
+		var err error
+		id, err = os.Hostname()
+		if err != nil {
+			glog.Errorf("Run GC: cannot determine pod identity, disabling GC: %v", err)
+			return
+		}
+	}
+
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      leaseName,
+			Namespace: gc.namespace,
+		},
+		Client: gc.clientset.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: id,
+		},
+	}
+
+	leaderElector, electionError := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		ReleaseOnCancel: false,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(leaderContext context.Context) {
+				glog.Info("Run GC: acquired leader lease, starting collection loop")
+				gc.runLoop(leaderContext)
+			},
+			OnStoppedLeading: func() {
+				if ctx.Err() != nil {
+					glog.Info("Run GC: leader lease released during graceful shutdown")
+					return
+				}
+				// Terminate to guarantee no concurrent collection (matches
+				// kube-controller-manager pattern). K8s restarts the pod.
+				glog.Fatalf("Run GC: lost leader lease unexpectedly, terminating to prevent concurrent collection")
+			},
+			OnNewLeader: func(identity string) {
+				if identity != id {
+					glog.Infof("Run GC: new leader elected: %s", identity)
+				}
+			},
+		},
+	})
+	if electionError != nil {
+		glog.Errorf("Run GC: failed to create leader elector, disabling GC: %v", electionError)
+		return
+	}
+
+	leaderElector.Run(ctx)
+}
+
+func (gc *RunGarbageCollector) runLoop(ctx context.Context) {
+	interval := common.GetRunsGCInterval()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Run once immediately, then on each tick.
+	gc.collect(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			glog.Info("Run GC: context canceled, exiting collection loop")
+			return
+		case <-ticker.C:
+			gc.collect(ctx)
+		}
+	}
+}
+
+func (gc *RunGarbageCollector) collect(ctx context.Context) {
+	now := gc.nowFunc()
+	batchSize := common.GetRunsGCBatchSize()
+
+	// Pass 1: drain expired terminal runs into archived state.
+	archiveRetention := common.GetRunsRetentionTime()
+	if archiveRetention > 0 {
+		expirationCutoffEpoch := now - int64(archiveRetention/time.Second)
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			archivedRunCount, archiveError := gc.runStore.ArchiveExpiredRuns(expirationCutoffEpoch, batchSize)
+			if archiveError != nil {
+				glog.Errorf("Run GC archive pass failed: %v", archiveError)
+				break
+			}
+			if archivedRunCount > 0 {
+				glog.Infof("Run GC: archived %d expired runs (cutoff: %v ago)", archivedRunCount, archiveRetention)
+			}
+			if archivedRunCount < int64(batchSize) {
+				break
+			}
+			time.Sleep(drainPause)
+		}
+	}
+
+	// Pass 2: drain expired archived runs into permanent deletion.
+	deleteRetention := common.GetArchivedRunsRetentionTime()
+	if deleteRetention > 0 {
+		expirationCutoffEpoch := now - int64(deleteRetention/time.Second)
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			deletedRunCount, deleteError := gc.runStore.DeleteExpiredArchivedRuns(expirationCutoffEpoch, batchSize)
+			if deleteError != nil {
+				glog.Errorf("Run GC delete pass failed: %v", deleteError)
+				break
+			}
+			if deletedRunCount > 0 {
+				glog.Infof("Run GC: deleted %d expired archived runs (cutoff: %v ago)", deletedRunCount, deleteRetention)
+			}
+			if deletedRunCount < int64(batchSize) {
+				break
+			}
+			time.Sleep(drainPause)
+		}
+	}
+}

--- a/backend/src/apiserver/gc/run_gc.go
+++ b/backend/src/apiserver/gc/run_gc.go
@@ -110,18 +110,21 @@ func (l *leaderLifecycle) onStartedLeading(leaderCtx context.Context) {
 
 	l.runLoop(collectionCtx)
 
-	// leaderCtx remains active while this process still holds the lease. If it
-	// was canceled first, the lease was lost unexpectedly; reset the callback
-	// state so a later shutdown cancels the election rather than a stale
-	// collection context, and let Start's election loop re-enter the election.
+	// Reset the callback state so a later shutdown cancels the election
+	// rather than a stale collection context. If shutdown has begun, stop
+	// the election now regardless of whether the lease was also lost while
+	// draining: onShutdown has already fired (context.AfterFunc runs once),
+	// so nothing else will cancel electionCtx, and leaving it live would
+	// keep Start re-entering the election forever and hang the process's
+	// shutdown wait group.
 	l.mu.Lock()
 	l.callbackStarted = false
-	graceful := l.shutdownCtx.Err() != nil && leaderCtx.Err() == nil
-	if graceful {
+	shutdown := l.shutdownCtx.Err() != nil
+	if shutdown {
 		l.gracefulStop = true
 	}
 	l.mu.Unlock()
-	if graceful {
+	if shutdown {
 		l.cancelElection()
 	}
 }
@@ -274,7 +277,7 @@ func (gc *RunGarbageCollector) collect(ctx context.Context) {
 	// effect without an API-server restart, and dropping the index stops the
 	// unindexed scans instead of silently continuing them.
 	if gc.indexReady != nil && !gc.indexReady() {
-		glog.Warning("Run GC: skipping collection pass, idx_run_gc_lifecycle is missing or not usable. " +
+		glog.Warning("Run GC: skipping collection pass, a required index (idx_run_gc_lifecycle, idx_run_gc_archived) is missing or not usable. " +
 			"Apply the online index migration in docs/agents/development.md.")
 		return
 	}

--- a/backend/src/apiserver/gc/run_gc.go
+++ b/backend/src/apiserver/gc/run_gc.go
@@ -140,6 +140,15 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 		glog.Info("Run GC disabled: both RUNS_RETENTION_TIME and ARCHIVED_RUNS_RETENTION_TIME are empty")
 		return
 	}
+	// Both retention durations are measured from FinishedAtInSec (run
+	// completion time), not from archival time. If the delete window is
+	// shorter than the archive window, runs would be archived and deleted
+	// in the same GC tick, leaving no observation period for archived runs.
+	if archiveRetention > 0 && deleteRetention > 0 && deleteRetention < archiveRetention {
+		glog.Errorf("Run GC disabled: ARCHIVED_RUNS_RETENTION_TIME (%v) must be >= RUNS_RETENTION_TIME (%v); "+
+			"both are measured from run completion, not archival time", deleteRetention, archiveRetention)
+		return
+	}
 
 	glog.Infof("Run GC enabled: archive after %v, delete after %v, interval %v, batch %d",
 		archiveRetention, deleteRetention, common.GetRunsGCInterval(), common.GetRunsGCBatchSize())
@@ -192,7 +201,7 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 				}
 				// Terminate to guarantee no concurrent collection (matches
 				// kube-controller-manager pattern). K8s restarts the pod.
-				glog.Fatalf("Run GC: lost leader lease unexpectedly, terminating to prevent concurrent collection")
+				glog.Errorf("Run GC: lost leader lease unexpectedly; collection loop stopped, will resume if re-elected")
 			},
 			OnNewLeader: func(identity string) {
 				if identity != id {

--- a/backend/src/apiserver/gc/run_gc.go
+++ b/backend/src/apiserver/gc/run_gc.go
@@ -54,7 +54,8 @@ func NewRunGarbageCollector(
 	}
 }
 
-// Start launches the GC loop. It blocks until ctx is canceled.
+// Start launches the GC loop. It blocks until ctx is canceled and
+// runLoop has finished draining its current batch.
 func (gc *RunGarbageCollector) Start(ctx context.Context) {
 	archiveRetention := common.GetRunsRetentionTime()
 	deleteRetention := common.GetArchivedRunsRetentionTime()
@@ -88,6 +89,11 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 		},
 	}
 
+	// loopDone is closed when runLoop exits so OnStoppedLeading can
+	// wait for the current batch to drain.
+	loopDone := make(chan struct{})
+	loopStarted := false
+
 	leaderElector, electionError := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
 		Lock:            lock,
 		LeaseDuration:   15 * time.Second,
@@ -97,11 +103,17 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(leaderContext context.Context) {
 				glog.Info("Run GC: acquired leader lease, starting collection loop")
+				loopStarted = true
 				gc.runLoop(leaderContext)
+				close(loopDone)
 			},
 			OnStoppedLeading: func() {
 				if ctx.Err() != nil {
-					glog.Info("Run GC: leader lease released during graceful shutdown")
+					glog.Info("Run GC: leader lease released during graceful shutdown, waiting for collection loop to drain")
+					if loopStarted {
+						<-loopDone
+					}
+					glog.Info("Run GC: collection loop drained, shutdown complete")
 					return
 				}
 				// Terminate to guarantee no concurrent collection (matches

--- a/backend/src/apiserver/gc/run_gc.go
+++ b/backend/src/apiserver/gc/run_gc.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// https://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,6 +18,7 @@ package gc
 import (
 	"context"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -41,6 +42,82 @@ type RunGarbageCollector struct {
 	nowFunc   func() int64
 }
 
+// leaderLifecycle keeps lease renewal active until a graceful shutdown has
+// drained the current collection. Its state also distinguishes that path from
+// an unexpected lease loss, where the process must terminate immediately.
+type leaderLifecycle struct {
+	shutdownCtx    context.Context
+	electionCtx    context.Context
+	cancelElection context.CancelFunc
+	runLoop        func(context.Context)
+
+	mu               sync.Mutex
+	callbackStarted  bool
+	cancelCollection context.CancelFunc
+	gracefulStop     bool
+}
+
+func newLeaderLifecycle(
+	shutdownCtx context.Context,
+	electionCtx context.Context,
+	cancelElection context.CancelFunc,
+	runLoop func(context.Context),
+) *leaderLifecycle {
+	return &leaderLifecycle{
+		shutdownCtx:    shutdownCtx,
+		electionCtx:    electionCtx,
+		cancelElection: cancelElection,
+		runLoop:        runLoop,
+	}
+}
+
+func (l *leaderLifecycle) onShutdown() {
+	l.mu.Lock()
+	if l.callbackStarted {
+		l.cancelCollection()
+		l.mu.Unlock()
+		return
+	}
+	l.gracefulStop = true
+	l.mu.Unlock()
+	l.cancelElection()
+}
+
+func (l *leaderLifecycle) onStartedLeading(leaderCtx context.Context) {
+	collectionCtx, cancelCollection := context.WithCancel(leaderCtx)
+	defer cancelCollection()
+
+	l.mu.Lock()
+	if l.gracefulStop || l.electionCtx.Err() != nil {
+		l.mu.Unlock()
+		return
+	}
+	l.callbackStarted = true
+	l.cancelCollection = cancelCollection
+	if l.shutdownCtx.Err() != nil {
+		cancelCollection()
+	}
+	l.mu.Unlock()
+
+	l.runLoop(collectionCtx)
+
+	// leaderCtx remains active while this process still holds the lease. If it
+	// was canceled first, the lease was lost unexpectedly and OnStoppedLeading
+	// must retain its fatal fallback even when shutdown arrives concurrently.
+	if l.shutdownCtx.Err() != nil && leaderCtx.Err() == nil {
+		l.mu.Lock()
+		l.gracefulStop = true
+		l.mu.Unlock()
+		l.cancelElection()
+	}
+}
+
+func (l *leaderLifecycle) isGracefulStop() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.gracefulStop
+}
+
 func NewRunGarbageCollector(
 	runStore storage.RunStoreInterface,
 	clientset kubernetes.Interface,
@@ -54,12 +131,11 @@ func NewRunGarbageCollector(
 	}
 }
 
-// Start launches the GC loop. It blocks until ctx is canceled and
-// runLoop has finished draining its current batch.
+// Start launches the GC loop. It blocks until ctx is canceled and runLoop has
+// finished draining its current batch while the leader lease is still renewed.
 func (gc *RunGarbageCollector) Start(ctx context.Context) {
 	archiveRetention := common.GetRunsRetentionTime()
 	deleteRetention := common.GetArchivedRunsRetentionTime()
-
 	if archiveRetention == 0 && deleteRetention == 0 {
 		glog.Info("Run GC disabled: both RUNS_RETENTION_TIME and ARCHIVED_RUNS_RETENTION_TIME are empty")
 		return
@@ -89,10 +165,14 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 		},
 	}
 
-	// loopDone is closed when runLoop exits so OnStoppedLeading can
-	// wait for the current batch to drain.
-	loopDone := make(chan struct{})
-	loopStarted := false
+	// Do not stop lease renewal when shutdown begins. The collection callback
+	// cancels this context only after its in-flight database operation returns.
+	electionCtx, cancelElection := context.WithCancel(context.WithoutCancel(ctx))
+	defer cancelElection()
+
+	lifecycle := newLeaderLifecycle(ctx, electionCtx, cancelElection, gc.runLoop)
+	stopShutdownHook := context.AfterFunc(ctx, lifecycle.onShutdown)
+	defer stopShutdownHook()
 
 	leaderElector, electionError := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
 		Lock:            lock,
@@ -103,17 +183,11 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(leaderContext context.Context) {
 				glog.Info("Run GC: acquired leader lease, starting collection loop")
-				loopStarted = true
-				gc.runLoop(leaderContext)
-				close(loopDone)
+				lifecycle.onStartedLeading(leaderContext)
 			},
 			OnStoppedLeading: func() {
-				if ctx.Err() != nil {
-					glog.Info("Run GC: leader lease released during graceful shutdown, waiting for collection loop to drain")
-					if loopStarted {
-						<-loopDone
-					}
-					glog.Info("Run GC: collection loop drained, shutdown complete")
+				if lifecycle.isGracefulStop() {
+					glog.Info("Run GC: collection loop drained, graceful shutdown complete")
 					return
 				}
 				// Terminate to guarantee no concurrent collection (matches
@@ -132,7 +206,7 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 		return
 	}
 
-	leaderElector.Run(ctx)
+	leaderElector.Run(electionCtx)
 }
 
 func (gc *RunGarbageCollector) runLoop(ctx context.Context) {

--- a/backend/src/apiserver/gc/run_gc.go
+++ b/backend/src/apiserver/gc/run_gc.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/storage"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -33,6 +34,9 @@ import (
 const (
 	leaseName  = "kfp-apiserver-gc"
 	drainPause = 100 * time.Millisecond
+	// reelectionBackoff is how long a replica waits before re-entering the
+	// election after LeaderElector.Run returns (e.g. after a lost lease).
+	reelectionBackoff = 5 * time.Second
 )
 
 type RunGarbageCollector struct {
@@ -40,11 +44,16 @@ type RunGarbageCollector struct {
 	clientset kubernetes.Interface
 	namespace string
 	nowFunc   func() int64
+	// indexReady reports whether idx_run_gc_lifecycle currently exists and is
+	// usable. It is re-evaluated on every collection tick so an operator can
+	// apply the index migration without restarting the API server. A nil
+	// checker means "always ready" (tests).
+	indexReady func() bool
 }
 
 // leaderLifecycle keeps lease renewal active until a graceful shutdown has
 // drained the current collection. Its state also distinguishes that path from
-// an unexpected lease loss, where the process must terminate immediately.
+// an unexpected lease loss, after which Start re-enters the election.
 type leaderLifecycle struct {
 	shutdownCtx    context.Context
 	electionCtx    context.Context
@@ -102,12 +111,17 @@ func (l *leaderLifecycle) onStartedLeading(leaderCtx context.Context) {
 	l.runLoop(collectionCtx)
 
 	// leaderCtx remains active while this process still holds the lease. If it
-	// was canceled first, the lease was lost unexpectedly and OnStoppedLeading
-	// must retain its fatal fallback even when shutdown arrives concurrently.
-	if l.shutdownCtx.Err() != nil && leaderCtx.Err() == nil {
-		l.mu.Lock()
+	// was canceled first, the lease was lost unexpectedly; reset the callback
+	// state so a later shutdown cancels the election rather than a stale
+	// collection context, and let Start's election loop re-enter the election.
+	l.mu.Lock()
+	l.callbackStarted = false
+	graceful := l.shutdownCtx.Err() != nil && leaderCtx.Err() == nil
+	if graceful {
 		l.gracefulStop = true
-		l.mu.Unlock()
+	}
+	l.mu.Unlock()
+	if graceful {
 		l.cancelElection()
 	}
 }
@@ -122,12 +136,14 @@ func NewRunGarbageCollector(
 	runStore storage.RunStoreInterface,
 	clientset kubernetes.Interface,
 	namespace string,
+	indexReady func() bool,
 ) *RunGarbageCollector {
 	return &RunGarbageCollector{
-		runStore:  runStore,
-		clientset: clientset,
-		namespace: namespace,
-		nowFunc:   func() int64 { return time.Now().Unix() },
+		runStore:   runStore,
+		clientset:  clientset,
+		namespace:  namespace,
+		nowFunc:    func() int64 { return time.Now().Unix() },
+		indexReady: indexReady,
 	}
 }
 
@@ -140,16 +156,6 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 		glog.Info("Run GC disabled: both RUNS_RETENTION_TIME and ARCHIVED_RUNS_RETENTION_TIME are empty")
 		return
 	}
-	// Both retention durations are measured from FinishedAtInSec (run
-	// completion time), not from archival time. If the delete window is
-	// shorter than the archive window, runs would be archived and deleted
-	// in the same GC tick, leaving no observation period for archived runs.
-	if archiveRetention > 0 && deleteRetention > 0 && deleteRetention < archiveRetention {
-		glog.Errorf("Run GC disabled: ARCHIVED_RUNS_RETENTION_TIME (%v) must be >= RUNS_RETENTION_TIME (%v); "+
-			"both are measured from run completion, not archival time", deleteRetention, archiveRetention)
-		return
-	}
-
 	glog.Infof("Run GC enabled: archive after %v, delete after %v, interval %v, batch %d",
 		archiveRetention, deleteRetention, common.GetRunsGCInterval(), common.GetRunsGCBatchSize())
 
@@ -183,7 +189,7 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 	stopShutdownHook := context.AfterFunc(ctx, lifecycle.onShutdown)
 	defer stopShutdownHook()
 
-	leaderElector, electionError := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+	electionConfig := leaderelection.LeaderElectionConfig{
 		Lock:            lock,
 		LeaseDuration:   15 * time.Second,
 		RenewDeadline:   10 * time.Second,
@@ -199,9 +205,11 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 					glog.Info("Run GC: collection loop drained, graceful shutdown complete")
 					return
 				}
-				// Terminate to guarantee no concurrent collection (matches
-				// kube-controller-manager pattern). K8s restarts the pod.
-				glog.Errorf("Run GC: lost leader lease unexpectedly; collection loop stopped, will resume if re-elected")
+				// Losing the lease never terminates the process: GC is opt-in
+				// housekeeping inside the user-facing API server, and the
+				// store passes are safe under overlap (SELECT FOR UPDATE plus
+				// predicate re-checks). Start re-enters the election below.
+				glog.Errorf("Run GC: lost leader lease unexpectedly; collection stopped, re-entering election in %v", reelectionBackoff)
 			},
 			OnNewLeader: func(identity string) {
 				if identity != id {
@@ -209,13 +217,26 @@ func (gc *RunGarbageCollector) Start(ctx context.Context) {
 				}
 			},
 		},
-	})
-	if electionError != nil {
-		glog.Errorf("Run GC: failed to create leader elector, disabling GC: %v", electionError)
+	}
+	if _, electionError := leaderelection.NewLeaderElector(electionConfig); electionError != nil {
+		glog.Errorf("Run GC: invalid leader election config, disabling GC: %v", electionError)
 		return
 	}
 
-	leaderElector.Run(electionCtx)
+	// LeaderElector.Run returns when the lease is lost (acquire -> renew ->
+	// return); it never re-enters the election on its own. Loop so a
+	// transient renewal failure pauses GC instead of disabling it for the
+	// pod's lifetime. A LeaderElector is single-use, so build a fresh one
+	// per attempt; the config was validated once above so per-attempt
+	// construction cannot fail persistently.
+	wait.UntilWithContext(electionCtx, func(loopCtx context.Context) {
+		attemptElector, attemptError := leaderelection.NewLeaderElector(electionConfig)
+		if attemptError != nil {
+			glog.Errorf("Run GC: failed to recreate leader elector, retrying in %v: %v", reelectionBackoff, attemptError)
+			return
+		}
+		attemptElector.Run(loopCtx)
+	}, reelectionBackoff)
 }
 
 func (gc *RunGarbageCollector) runLoop(ctx context.Context) {
@@ -237,7 +258,27 @@ func (gc *RunGarbageCollector) runLoop(ctx context.Context) {
 	}
 }
 
+// sleepUnlessDone pauses between drain batches but returns false immediately
+// if ctx is canceled, so shutdown never waits on a drain pause.
+func sleepUnlessDone(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}
+
 func (gc *RunGarbageCollector) collect(ctx context.Context) {
+	// Re-check the index on every tick so applying the index migration takes
+	// effect without an API-server restart, and dropping the index stops the
+	// unindexed scans instead of silently continuing them.
+	if gc.indexReady != nil && !gc.indexReady() {
+		glog.Warning("Run GC: skipping collection pass, idx_run_gc_lifecycle is missing or not usable. " +
+			"Apply the online index migration in docs/agents/development.md.")
+		return
+	}
+
 	now := gc.nowFunc()
 	batchSize := common.GetRunsGCBatchSize()
 
@@ -260,7 +301,9 @@ func (gc *RunGarbageCollector) collect(ctx context.Context) {
 			if archivedRunCount < int64(batchSize) {
 				break
 			}
-			time.Sleep(drainPause)
+			if !sleepUnlessDone(ctx, drainPause) {
+				return
+			}
 		}
 	}
 
@@ -283,7 +326,9 @@ func (gc *RunGarbageCollector) collect(ctx context.Context) {
 			if deletedRunCount < int64(batchSize) {
 				break
 			}
-			time.Sleep(drainPause)
+			if !sleepUnlessDone(ctx, drainPause) {
+				return
+			}
 		}
 	}
 }

--- a/backend/src/apiserver/gc/run_gc_test.go
+++ b/backend/src/apiserver/gc/run_gc_test.go
@@ -386,7 +386,11 @@ func TestLeaderLifecycle_ShutdownBeforeCallbackPreventsCollectionStart(t *testin
 	assert.True(t, lifecycle.isGracefulStop())
 }
 
-func TestLeaderLifecycle_UnexpectedLossDuringShutdownRemainsFatal(t *testing.T) {
+// A lease lost while shutdown is draining must still end with the election
+// canceled once the collection callback returns; the pre-round-5 design kept
+// gracefulStop=false here to arm a fatal fallback, which left the election
+// loop running forever after shutdown (context.AfterFunc fires only once).
+func TestLeaderLifecycle_UnexpectedLossDuringShutdownStopsElection(t *testing.T) {
 	shutdownCtx, cancelShutdown := context.WithCancel(context.Background())
 	electionCtx, cancelElection := context.WithCancel(context.Background())
 	defer cancelElection()
@@ -415,13 +419,19 @@ func TestLeaderLifecycle_UnexpectedLossDuringShutdownRemainsFatal(t *testing.T) 
 	cancelLeader()
 	cancelShutdown()
 
+	// While the collection is still draining, the stop is not yet graceful.
 	require.Never(t, lifecycle.isGracefulStop, 50*time.Millisecond, time.Millisecond,
-		"shutdown masked an unexpected lease loss while collection was active")
+		"stop classified graceful while collection was still draining")
 
 	close(releaseRunLoop)
 
 	requireSignal(t, callbackDone, "collection callback did not exit")
-	assert.False(t, lifecycle.isGracefulStop(), "unexpected lease loss was classified as graceful")
+	assert.True(t, lifecycle.isGracefulStop(), "shutdown after drain must be graceful even when the lease was also lost")
+	select {
+	case <-electionCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("election context not canceled; Start would re-enter the election after shutdown")
+	}
 }
 
 func requireSignal(t *testing.T, signal <-chan struct{}, message string) {
@@ -455,4 +465,58 @@ func TestCollect_IndexGateReevaluatedPerTick(t *testing.T) {
 	ready = true
 	gc.collect(context.Background())
 	assert.Equal(t, 1, fake.archiveCalls, "collection must start once the index is ready, without a restart")
+}
+
+// Regression: a lease lost while a graceful shutdown is draining must still
+// cancel the election once the collection loop returns. onShutdown has
+// already fired (context.AfterFunc runs once), so if onStartedLeading does
+// not cancel the election here, Start's re-election loop runs forever and
+// the process's shutdown wait group never releases.
+func TestLeaderLifecycle_LeaseLossDuringShutdownCancelsElection(t *testing.T) {
+	shutdownCtx, shutdown := context.WithCancel(context.Background())
+	electionCtx, cancelElection := context.WithCancel(context.Background())
+	leaderCtx, loseLease := context.WithCancel(context.Background())
+
+	collectionCanceled := make(chan struct{})
+	lifecycle := newLeaderLifecycle(shutdownCtx, electionCtx, cancelElection, func(ctx context.Context) {
+		// Simulate an in-flight collection: block until the shutdown path
+		// cancels the collection context, then lose the lease before
+		// returning — the race the regression targets.
+		<-ctx.Done()
+		close(collectionCanceled)
+		loseLease()
+	})
+
+	done := make(chan struct{})
+	go func() {
+		lifecycle.onStartedLeading(leaderCtx)
+		close(done)
+	}()
+
+	// Wait for the callback to register itself, then begin shutdown.
+	for {
+		lifecycle.mu.Lock()
+		started := lifecycle.callbackStarted
+		lifecycle.mu.Unlock()
+		if started {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	shutdown()
+	lifecycle.onShutdown()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("onStartedLeading did not return after shutdown")
+	}
+	<-collectionCanceled
+	select {
+	case <-electionCtx.Done():
+		// Election canceled: Start's election loop can exit.
+	case <-time.After(5 * time.Second):
+		t.Fatal("election context was never canceled after lease loss during shutdown; Start would re-enter the election forever")
+	}
+	assert.True(t, lifecycle.isGracefulStop())
 }

--- a/backend/src/apiserver/gc/run_gc_test.go
+++ b/backend/src/apiserver/gc/run_gc_test.go
@@ -1,0 +1,309 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/list"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeRunStore records GC method calls; supports multi-batch sequences via archiveReturnSequence/deleteReturnSequence.
+type fakeRunStore struct {
+	archiveCalls          int
+	archiveCutoff         int64
+	archiveBatch          int
+	archiveReturn         int64
+	archiveReturnSequence []int64
+	archiveErr            error
+
+	deleteCalls          int
+	deleteCutoff         int64
+	deleteBatch          int
+	deleteReturn         int64
+	deleteReturnSequence []int64
+	deleteErr            error
+}
+
+func (f *fakeRunStore) ArchiveExpiredRuns(archiveCutoffEpoch int64, batchSize int) (int64, error) {
+	callIndex := f.archiveCalls
+	f.archiveCalls++
+	f.archiveCutoff = archiveCutoffEpoch
+	f.archiveBatch = batchSize
+	if f.archiveReturnSequence != nil && callIndex < len(f.archiveReturnSequence) {
+		return f.archiveReturnSequence[callIndex], f.archiveErr
+	}
+	return f.archiveReturn, f.archiveErr
+}
+
+func (f *fakeRunStore) DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize int) (int64, error) {
+	callIndex := f.deleteCalls
+	f.deleteCalls++
+	f.deleteCutoff = deleteCutoffEpoch
+	f.deleteBatch = batchSize
+	if f.deleteReturnSequence != nil && callIndex < len(f.deleteReturnSequence) {
+		return f.deleteReturnSequence[callIndex], f.deleteErr
+	}
+	return f.deleteReturn, f.deleteErr
+}
+
+// Stubs for the remaining RunStoreInterface methods.
+func (f *fakeRunStore) CreateRun(_ *model.Run) (*model.Run, error) { return nil, nil }
+func (f *fakeRunStore) GetRun(_ string) (*model.Run, error)        { return nil, nil }
+func (f *fakeRunStore) ListRuns(_ *model.FilterContext, _ *list.Options) ([]*model.Run, int, string, error) {
+	return nil, 0, "", nil
+}
+func (f *fakeRunStore) UpdateRun(_ *model.Run) error                              { return nil }
+func (f *fakeRunStore) UpdateRunPluginsOutput(_ string, _ *model.LargeText) error { return nil }
+func (f *fakeRunStore) ArchiveRun(_ string) error                                 { return nil }
+func (f *fakeRunStore) UnarchiveRun(_ string) error                               { return nil }
+func (f *fakeRunStore) DeleteRun(_ string) error                                  { return nil }
+func (f *fakeRunStore) CreateMetric(_ *model.RunMetric) error                     { return nil }
+func (f *fakeRunStore) TerminateRun(_ string) error                               { return nil }
+func (f *fakeRunStore) GetRunByRecurringRunIDAndDisplayName(_, _ string) (string, error) {
+	return "", nil
+}
+
+func resetGCConfig() {
+	viper.Set(common.RunsRetentionTime, "")
+	viper.Set(common.ArchivedRunsRetentionTime, "")
+	viper.Set(common.RunsGCBatchSize, "")
+}
+
+func TestCollect_BothDisabled(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+
+	fake := &fakeRunStore{}
+	gc := &RunGarbageCollector{
+		runStore: fake,
+		nowFunc:  func() int64 { return 1000000 },
+	}
+
+	gc.collect(context.Background())
+
+	assert.Equal(t, 0, fake.archiveCalls, "archive should not be called when RUNS_RETENTION_TIME is empty")
+	assert.Equal(t, 0, fake.deleteCalls, "delete should not be called when ARCHIVED_RUNS_RETENTION_TIME is empty")
+}
+
+func TestCollect_ArchiveOnlyEnabled(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+
+	// 720h = 30 days = 2592000 seconds.
+	viper.Set(common.RunsRetentionTime, "720h")
+
+	// Return < batchSize so the drain loop exits after one call.
+	fake := &fakeRunStore{archiveReturn: 5}
+	now := int64(3000000)
+	gc := &RunGarbageCollector{
+		runStore: fake,
+		nowFunc:  func() int64 { return now },
+	}
+
+	gc.collect(context.Background())
+
+	assert.Equal(t, 1, fake.archiveCalls, "archive pass should be invoked once")
+	assert.Equal(t, now-2592000, fake.archiveCutoff, "archive cutoff = now minus 720h in seconds")
+	assert.Equal(t, 100, fake.archiveBatch, "default batch size is 100")
+	assert.Equal(t, 0, fake.deleteCalls, "delete should not be called when ARCHIVED_RUNS_RETENTION_TIME is empty")
+}
+
+func TestCollect_DeleteOnlyEnabled(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+
+	// 2160h = 90 days = 7776000 seconds.
+	viper.Set(common.ArchivedRunsRetentionTime, "2160h")
+
+	fake := &fakeRunStore{deleteReturn: 3}
+	now := int64(10000000)
+	gc := &RunGarbageCollector{
+		runStore: fake,
+		nowFunc:  func() int64 { return now },
+	}
+
+	gc.collect(context.Background())
+
+	assert.Equal(t, 0, fake.archiveCalls, "archive should not be called when RUNS_RETENTION_TIME is empty")
+	assert.Equal(t, 1, fake.deleteCalls, "delete pass should be invoked once")
+	assert.Equal(t, now-7776000, fake.deleteCutoff, "delete cutoff = now minus 2160h in seconds")
+	assert.Equal(t, 100, fake.deleteBatch, "default batch size is 100")
+}
+
+func TestCollect_BothEnabled_CustomBatchSize(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+
+	viper.Set(common.RunsRetentionTime, "720h")
+	viper.Set(common.ArchivedRunsRetentionTime, "2160h")
+	viper.Set(common.RunsGCBatchSize, "50")
+
+	fake := &fakeRunStore{archiveReturn: 2, deleteReturn: 1}
+	now := int64(10000000)
+	gc := &RunGarbageCollector{
+		runStore: fake,
+		nowFunc:  func() int64 { return now },
+	}
+
+	gc.collect(context.Background())
+
+	assert.Equal(t, 1, fake.archiveCalls)
+	assert.Equal(t, now-2592000, fake.archiveCutoff)
+	assert.Equal(t, 50, fake.archiveBatch, "custom batch size should be respected")
+
+	assert.Equal(t, 1, fake.deleteCalls)
+	assert.Equal(t, now-7776000, fake.deleteCutoff)
+	assert.Equal(t, 50, fake.deleteBatch, "custom batch size should be respected")
+}
+
+func TestCollect_ArchiveErrorDoesNotBlockDeletePass(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+
+	viper.Set(common.RunsRetentionTime, "720h")
+	viper.Set(common.ArchivedRunsRetentionTime, "2160h")
+
+	fake := &fakeRunStore{
+		archiveReturn: 0,
+		archiveErr:    fmt.Errorf("db connection lost"),
+		deleteReturn:  4,
+	}
+	gc := &RunGarbageCollector{
+		runStore: fake,
+		nowFunc:  func() int64 { return 10000000 },
+	}
+
+	gc.collect(context.Background())
+
+	assert.Equal(t, 1, fake.archiveCalls, "archive pass should be attempted even if it will fail")
+	assert.Equal(t, 1, fake.deleteCalls, "delete pass must still run after an archive error")
+}
+
+func TestCollect_CanceledContextExitsEarly(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+
+	viper.Set(common.RunsRetentionTime, "720h")
+
+	fake := &fakeRunStore{archiveReturn: 5}
+	gc := &RunGarbageCollector{
+		runStore: fake,
+		nowFunc:  func() int64 { return 10000000 },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	gc.collect(ctx)
+
+	assert.Equal(t, 0, fake.archiveCalls, "canceled context should skip archive pass")
+}
+
+func TestCollect_ArchiveDrainsMultipleBatches(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+
+	viper.Set(common.RunsRetentionTime, "720h")
+	viper.Set(common.RunsGCBatchSize, "100")
+
+	// First call returns exactly batchSize (100) → drain loop continues.
+	// Second call returns 30 (< batchSize) → drain loop exits.
+	fake := &fakeRunStore{
+		archiveReturnSequence: []int64{100, 30},
+	}
+	now := int64(10000000)
+	gc := &RunGarbageCollector{
+		runStore: fake,
+		nowFunc:  func() int64 { return now },
+	}
+
+	gc.collect(context.Background())
+
+	assert.Equal(t, 2, fake.archiveCalls, "drain loop should call archive twice: full batch then partial batch")
+}
+
+func TestCollect_DeleteDrainsMultipleBatches(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+
+	viper.Set(common.ArchivedRunsRetentionTime, "2160h")
+	viper.Set(common.RunsGCBatchSize, "100")
+
+	// First call returns exactly batchSize (100) → drain loop continues.
+	// Second call returns 15 (< batchSize) → drain loop exits.
+	fake := &fakeRunStore{
+		deleteReturnSequence: []int64{100, 15},
+	}
+	now := int64(10000000)
+	gc := &RunGarbageCollector{
+		runStore: fake,
+		nowFunc:  func() int64 { return now },
+	}
+
+	gc.collect(context.Background())
+
+	assert.Equal(t, 2, fake.deleteCalls, "drain loop should call delete twice: full batch then partial batch")
+}
+
+func TestCollect_ContextCancelStopsDrainBetweenBatches(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+
+	viper.Set(common.RunsRetentionTime, "720h")
+	viper.Set(common.RunsGCBatchSize, "100")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// cancellingFakeRunStore cancels the context after the first archive call
+	// returns batchSize (100). The drain loop checks ctx.Err() at the top of
+	// the next iteration and exits before making a second call.
+	cancelOnFirstCall := &cancellingFakeRunStore{
+		fakeRunStore: fakeRunStore{
+			archiveReturnSequence: []int64{100, 0},
+		},
+		cancelAfterArchiveN: 1,
+		cancelFunc:          cancel,
+	}
+	gc := &RunGarbageCollector{
+		runStore: cancelOnFirstCall,
+		nowFunc:  func() int64 { return 10000000 },
+	}
+
+	gc.collect(ctx)
+
+	assert.Equal(t, 1, cancelOnFirstCall.archiveCalls,
+		"drain loop should stop after first batch when context is canceled between iterations")
+}
+
+// cancellingFakeRunStore wraps fakeRunStore and cancels a context after N archive calls.
+type cancellingFakeRunStore struct {
+	fakeRunStore
+	cancelAfterArchiveN int
+	cancelFunc          context.CancelFunc
+}
+
+func (f *cancellingFakeRunStore) ArchiveExpiredRuns(archiveCutoffEpoch int64, batchSize int) (int64, error) {
+	result, archiveError := f.fakeRunStore.ArchiveExpiredRuns(archiveCutoffEpoch, batchSize)
+	if f.archiveCalls >= f.cancelAfterArchiveN && f.cancelFunc != nil {
+		f.cancelFunc()
+	}
+	return result, archiveError
+}

--- a/backend/src/apiserver/gc/run_gc_test.go
+++ b/backend/src/apiserver/gc/run_gc_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// https://www.apache.org/licenses/LICENSE-2.0
+//      https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,13 +17,16 @@ package gc
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/list"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // fakeRunStore records GC method calls; supports multi-batch sequences via archiveReturnSequence/deleteReturnSequence.
@@ -81,10 +84,10 @@ func (f *fakeRunStore) TerminateRun(_ string) error                             
 func (f *fakeRunStore) GetRunByRecurringRunIDAndDisplayName(_, _ string) (string, error) {
 	return "", nil
 }
-func (f *fakeRunStore) ClaimRunForRetry(_ string) (string, string, int64, error) {
-	return "", "", 0, nil
+func (f *fakeRunStore) ClaimRunForRetry(_ string) (string, string, int64, int64, error) {
+	return "", "", 0, 0, nil
 }
-func (f *fakeRunStore) RollbackRetryClaim(_ string, _ string, _ string, _ int64) error {
+func (f *fakeRunStore) RollbackRetryClaim(_ string, _ string, _ string, _ int64, _ int64) error {
 	return nil
 }
 
@@ -114,10 +117,8 @@ func TestCollect_ArchiveOnlyEnabled(t *testing.T) {
 	resetGCConfig()
 	defer resetGCConfig()
 
-	// 720h = 30 days = 2592000 seconds.
 	viper.Set(common.RunsRetentionTime, "720h")
 
-	// Return < batchSize so the drain loop exits after one call.
 	fake := &fakeRunStore{archiveReturn: 5}
 	now := int64(3000000)
 	gc := &RunGarbageCollector{
@@ -137,7 +138,6 @@ func TestCollect_DeleteOnlyEnabled(t *testing.T) {
 	resetGCConfig()
 	defer resetGCConfig()
 
-	// 2160h = 90 days = 7776000 seconds.
 	viper.Set(common.ArchivedRunsRetentionTime, "2160h")
 
 	fake := &fakeRunStore{deleteReturn: 3}
@@ -193,6 +193,7 @@ func TestCollect_ArchiveErrorDoesNotBlockDeletePass(t *testing.T) {
 		archiveErr:    fmt.Errorf("db connection lost"),
 		deleteReturn:  4,
 	}
+
 	gc := &RunGarbageCollector{
 		runStore: fake,
 		nowFunc:  func() int64 { return 10000000 },
@@ -218,6 +219,7 @@ func TestCollect_CanceledContextExitsEarly(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+
 	gc.collect(ctx)
 
 	assert.Equal(t, 0, fake.archiveCalls, "canceled context should skip archive pass")
@@ -230,8 +232,6 @@ func TestCollect_ArchiveDrainsMultipleBatches(t *testing.T) {
 	viper.Set(common.RunsRetentionTime, "720h")
 	viper.Set(common.RunsGCBatchSize, "100")
 
-	// First call returns exactly batchSize (100) → drain loop continues.
-	// Second call returns 30 (< batchSize) → drain loop exits.
 	fake := &fakeRunStore{
 		archiveReturnSequence: []int64{100, 30},
 	}
@@ -253,8 +253,6 @@ func TestCollect_DeleteDrainsMultipleBatches(t *testing.T) {
 	viper.Set(common.ArchivedRunsRetentionTime, "2160h")
 	viper.Set(common.RunsGCBatchSize, "100")
 
-	// First call returns exactly batchSize (100) → drain loop continues.
-	// Second call returns 15 (< batchSize) → drain loop exits.
 	fake := &fakeRunStore{
 		deleteReturnSequence: []int64{100, 15},
 	}
@@ -278,9 +276,6 @@ func TestCollect_ContextCancelStopsDrainBetweenBatches(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// cancellingFakeRunStore cancels the context after the first archive call
-	// returns batchSize (100). The drain loop checks ctx.Err() at the top of
-	// the next iteration and exits before making a second call.
 	cancelOnFirstCall := &cancellingFakeRunStore{
 		fakeRunStore: fakeRunStore{
 			archiveReturnSequence: []int64{100, 0},
@@ -288,6 +283,7 @@ func TestCollect_ContextCancelStopsDrainBetweenBatches(t *testing.T) {
 		cancelAfterArchiveN: 1,
 		cancelFunc:          cancel,
 	}
+
 	gc := &RunGarbageCollector{
 		runStore: cancelOnFirstCall,
 		nowFunc:  func() int64 { return 10000000 },
@@ -312,4 +308,127 @@ func (f *cancellingFakeRunStore) ArchiveExpiredRuns(archiveCutoffEpoch int64, ba
 		f.cancelFunc()
 	}
 	return result, archiveError
+}
+
+type blockingRunStore struct {
+	fakeRunStore
+	archiveStarted chan struct{}
+	releaseArchive chan struct{}
+}
+
+func (f *blockingRunStore) ArchiveExpiredRuns(_ int64, _ int) (int64, error) {
+	close(f.archiveStarted)
+	<-f.releaseArchive
+	return 0, nil
+}
+
+func TestLeaderLifecycle_ShutdownKeepsElectionActiveUntilCollectionDrains(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+	viper.Set(common.RunsRetentionTime, "1h")
+
+	store := &blockingRunStore{
+		archiveStarted: make(chan struct{}),
+		releaseArchive: make(chan struct{}),
+	}
+	collector := &RunGarbageCollector{
+		runStore: store,
+		nowFunc:  func() int64 { return 1000000 },
+	}
+
+	shutdownCtx, cancelShutdown := context.WithCancel(context.Background())
+	electionCtx, cancelElection := context.WithCancel(context.Background())
+	defer cancelElection()
+
+	lifecycle := newLeaderLifecycle(shutdownCtx, electionCtx, cancelElection, collector.runLoop)
+	stopShutdownHook := context.AfterFunc(shutdownCtx, lifecycle.onShutdown)
+	defer stopShutdownHook()
+
+	callbackDone := make(chan struct{})
+	go func() {
+		defer close(callbackDone)
+		lifecycle.onStartedLeading(electionCtx)
+	}()
+
+	requireSignal(t, store.archiveStarted, "collection did not reach the blocking store")
+
+	cancelShutdown()
+
+	require.Never(t, func() bool { return electionCtx.Err() != nil }, 50*time.Millisecond, time.Millisecond,
+		"election stopped before the active collection drained")
+
+	close(store.releaseArchive)
+
+	requireSignal(t, callbackDone, "collection callback did not drain")
+	requireSignal(t, electionCtx.Done(), "election did not stop after the collection drained")
+	assert.True(t, lifecycle.isGracefulStop())
+}
+
+func TestLeaderLifecycle_ShutdownBeforeCallbackPreventsCollectionStart(t *testing.T) {
+	shutdownCtx, cancelShutdown := context.WithCancel(context.Background())
+	electionCtx, cancelElection := context.WithCancel(context.Background())
+	defer cancelElection()
+
+	var runLoopCalled atomic.Bool
+	lifecycle := newLeaderLifecycle(shutdownCtx, electionCtx, cancelElection, func(context.Context) {
+		runLoopCalled.Store(true)
+	})
+	stopShutdownHook := context.AfterFunc(shutdownCtx, lifecycle.onShutdown)
+	defer stopShutdownHook()
+
+	cancelShutdown()
+
+	requireSignal(t, electionCtx.Done(), "idle election did not stop during shutdown")
+
+	lifecycle.onStartedLeading(electionCtx)
+
+	assert.False(t, runLoopCalled.Load(), "late callback started collection after shutdown")
+	assert.True(t, lifecycle.isGracefulStop())
+}
+
+func TestLeaderLifecycle_UnexpectedLossDuringShutdownRemainsFatal(t *testing.T) {
+	shutdownCtx, cancelShutdown := context.WithCancel(context.Background())
+	electionCtx, cancelElection := context.WithCancel(context.Background())
+	defer cancelElection()
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	defer cancelLeader()
+
+	runLoopStarted := make(chan struct{})
+	releaseRunLoop := make(chan struct{})
+	lifecycle := newLeaderLifecycle(shutdownCtx, electionCtx, cancelElection, func(ctx context.Context) {
+		close(runLoopStarted)
+		<-ctx.Done()
+		<-releaseRunLoop
+	})
+	stopShutdownHook := context.AfterFunc(shutdownCtx, lifecycle.onShutdown)
+	defer stopShutdownHook()
+
+	callbackDone := make(chan struct{})
+	go func() {
+		defer close(callbackDone)
+		lifecycle.onStartedLeading(leaderCtx)
+	}()
+
+	requireSignal(t, runLoopStarted, "collection callback did not start")
+
+	cancelLeader()
+	cancelShutdown()
+
+	require.Never(t, lifecycle.isGracefulStop, 50*time.Millisecond, time.Millisecond,
+		"shutdown masked an unexpected lease loss while collection was active")
+
+	close(releaseRunLoop)
+
+	requireSignal(t, callbackDone, "collection callback did not exit")
+	assert.False(t, lifecycle.isGracefulStop(), "unexpected lease loss was classified as graceful")
+}
+
+func requireSignal(t *testing.T, signal <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal(message)
+	}
 }

--- a/backend/src/apiserver/gc/run_gc_test.go
+++ b/backend/src/apiserver/gc/run_gc_test.go
@@ -81,6 +81,12 @@ func (f *fakeRunStore) TerminateRun(_ string) error                             
 func (f *fakeRunStore) GetRunByRecurringRunIDAndDisplayName(_, _ string) (string, error) {
 	return "", nil
 }
+func (f *fakeRunStore) ClaimRunForRetry(_ string) (string, string, int64, error) {
+	return "", "", 0, nil
+}
+func (f *fakeRunStore) RollbackRetryClaim(_ string, _ string, _ string, _ int64) error {
+	return nil
+}
 
 func resetGCConfig() {
 	viper.Set(common.RunsRetentionTime, "")

--- a/backend/src/apiserver/gc/run_gc_test.go
+++ b/backend/src/apiserver/gc/run_gc_test.go
@@ -432,3 +432,27 @@ func requireSignal(t *testing.T, signal <-chan struct{}, message string) {
 		t.Fatal(message)
 	}
 }
+
+// The index gate is evaluated on every tick, not once at startup, so applying
+// the index migration takes effect without restarting the API server.
+func TestCollect_IndexGateReevaluatedPerTick(t *testing.T) {
+	resetGCConfig()
+	defer resetGCConfig()
+
+	viper.Set(common.RunsRetentionTime, "720h")
+
+	fake := &fakeRunStore{}
+	ready := false
+	gc := &RunGarbageCollector{
+		runStore:   fake,
+		nowFunc:    func() int64 { return 3000000 },
+		indexReady: func() bool { return ready },
+	}
+
+	gc.collect(context.Background())
+	assert.Equal(t, 0, fake.archiveCalls, "collection must be skipped while the index is missing")
+
+	ready = true
+	gc.collect(context.Background())
+	assert.Equal(t, 1, fake.archiveCalls, "collection must start once the index is ready, without a restart")
+}

--- a/backend/src/apiserver/gc/run_gc_test.go
+++ b/backend/src/apiserver/gc/run_gc_test.go
@@ -84,7 +84,7 @@ func (f *fakeRunStore) TerminateRun(_ string) error                             
 func (f *fakeRunStore) GetRunByRecurringRunIDAndDisplayName(_, _ string) (string, error) {
 	return "", nil
 }
-func (f *fakeRunStore) ClaimRunForRetry(_ string) (string, string, int64, int64, error) {
+func (f *fakeRunStore) ClaimRunForRetry(_ string, _ bool) (string, string, int64, int64, error) {
 	return "", "", 0, 0, nil
 }
 func (f *fakeRunStore) RollbackRetryClaim(_ string, _ string, _ string, _ int64, _ int64) error {
@@ -519,4 +519,108 @@ func TestLeaderLifecycle_LeaseLossDuringShutdownCancelsElection(t *testing.T) {
 		t.Fatal("election context was never canceled after lease loss during shutdown; Start would re-enter the election forever")
 	}
 	assert.True(t, lifecycle.isGracefulStop())
+}
+
+// Regression: client-go launches OnStartedLeading as an unjoined goroutine,
+// so a re-entered election must not start a second collection loop while the
+// previous callback is still draining, and Start's final join must not
+// release until that drain completes.
+func TestLeaderLifecycle_DrainGatePreventsOverlappingCallbacks(t *testing.T) {
+	shutdownCtx, shutdown := context.WithCancel(context.Background())
+	electionCtx, cancelElection := context.WithCancel(context.Background())
+	leaderCtx, loseLease := context.WithCancel(context.Background())
+	defer cancelElection()
+
+	releaseRunLoop := make(chan struct{})
+	runLoopStarted := make(chan struct{})
+	lifecycle := newLeaderLifecycle(shutdownCtx, electionCtx, cancelElection, func(ctx context.Context) {
+		close(runLoopStarted)
+		<-ctx.Done()
+		<-releaseRunLoop // simulate a database batch that cannot be interrupted
+	})
+
+	callbackDone := make(chan struct{})
+	go func() {
+		lifecycle.onStartedLeading(leaderCtx)
+		close(callbackDone)
+	}()
+	requireSignal(t, runLoopStarted, "collection callback did not start")
+
+	// Lease lost: LeaderElector.Run would return now, and the re-election
+	// loop would attempt to acquire again while the callback still drains.
+	loseLease()
+
+	gateCtx, gateCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer gateCancel()
+	assert.False(t, lifecycle.drainCallback(gateCtx),
+		"drain gate must block re-election while the previous callback is draining")
+
+	// Shutdown arrives mid-drain; the final join must wait for the drain.
+	shutdown()
+	lifecycle.onShutdown()
+	joined := make(chan struct{})
+	go func() {
+		lifecycle.drainCallback(context.Background())
+		close(joined)
+	}()
+	select {
+	case <-joined:
+		t.Fatal("final join released before the in-flight database work drained")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(releaseRunLoop)
+	requireSignal(t, callbackDone, "collection callback did not exit")
+	requireSignal(t, joined, "final join did not release after the drain completed")
+	select {
+	case <-electionCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("election context not canceled after shutdown completed the drain")
+	}
+}
+
+// Regression: client-go can dispatch OnStartedLeading and return from Run
+// before the callback registers itself, so serialization must also be
+// enforced inside onStartedLeading — a second callback must wait for the
+// first to drain (or abandon its lease) before starting a collection loop.
+func TestLeaderLifecycle_SecondCallbackWaitsForFirstToDrain(t *testing.T) {
+	electionCtx, cancelElection := context.WithCancel(context.Background())
+	defer cancelElection()
+	leader1 := context.Background()
+	leader2, cancelLeader2 := context.WithCancel(context.Background())
+
+	var runLoopStarts atomic.Int32
+	release := make(chan struct{})
+	lifecycle := newLeaderLifecycle(context.Background(), electionCtx, cancelElection, func(ctx context.Context) {
+		runLoopStarts.Add(1)
+		<-release
+	})
+
+	go lifecycle.onStartedLeading(leader1)
+	require.Eventually(t, func() bool { return runLoopStarts.Load() == 1 }, time.Second, time.Millisecond)
+
+	// Second callback dispatched while the first is still draining: it must
+	// wait, not start a second collection loop.
+	secondDone := make(chan struct{})
+	go func() {
+		lifecycle.onStartedLeading(leader2)
+		close(secondDone)
+	}()
+	require.Never(t, func() bool { return runLoopStarts.Load() > 1 }, 100*time.Millisecond, 5*time.Millisecond,
+		"second callback must not start a collection loop while the first is draining")
+
+	// Losing the waiting callback's lease releases it without running.
+	cancelLeader2()
+	requireSignal(t, secondDone, "waiting callback did not return after losing its lease")
+	assert.Equal(t, int32(1), runLoopStarts.Load())
+
+	// After the first drains, a fresh callback proceeds normally.
+	close(release)
+	thirdDone := make(chan struct{})
+	go func() {
+		lifecycle.onStartedLeading(context.Background())
+		close(thirdDone)
+	}()
+	requireSignal(t, thirdDone, "third callback did not run after the first drained")
+	assert.Equal(t, int32(2), runLoopStarts.Load())
 }

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -319,12 +319,15 @@ func main() {
 	wg.Add(1)
 	go reconcileSwfCrs(resourceManager, backgroundCtx, &wg)
 
-	// Start run GC if the required database index is ready.
-	if clientManager.IsGarbageCollectorIndexReady() {
+	// Start run GC when a retention window is configured. The collector
+	// re-validates the required database index on every tick and skips
+	// collection until the operator has applied the index migration.
+	if common.GetRunsRetentionTime() > 0 || common.GetArchivedRunsRetentionTime() > 0 {
 		runGC := gc.NewRunGarbageCollector(
 			clientManager.RunStore(),
 			clientManager.KubernetesCoreClient().GetClientSet(),
 			common.GetPodNamespace(),
+			clientManager.GarbageCollectorIndexChecker(),
 		)
 		wg.Add(1)
 		go func() {

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -326,7 +326,11 @@ func main() {
 			clientManager.KubernetesCoreClient().GetClientSet(),
 			common.GetPodNamespace(),
 		)
-		go runGC.Start(backgroundCtx)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runGC.Start(backgroundCtx)
+		}()
 	}
 
 	go startRPCServer(resourceManager, tlsCfg)

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/gc"
 	_ "github.com/kubeflow/pipelines/backend/src/apiserver/plugins/all"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/server"
@@ -317,6 +318,17 @@ func main() {
 
 	wg.Add(1)
 	go reconcileSwfCrs(resourceManager, backgroundCtx, &wg)
+
+	// Start run GC if the required database index is ready.
+	if clientManager.IsGarbageCollectorIndexReady() {
+		runGC := gc.NewRunGarbageCollector(
+			clientManager.RunStore(),
+			clientManager.KubernetesCoreClient().GetClientSet(),
+			common.GetPodNamespace(),
+		)
+		go runGC.Start(backgroundCtx)
+	}
+
 	go startRPCServer(resourceManager, tlsCfg)
 	// This is blocking
 	startHTTPProxy(resourceManager, *usePipelinesKubernetesStorage, tlsCfg)

--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -329,6 +329,10 @@ type RunDetails struct {
 	PipelineContextId int64 `gorm:"column:PipelineContextId; default:0;"`
 	// nolint:staticcheck // [ST1003] Field name matches upstream legacy naming
 	PipelineRunContextId int64 `gorm:"column:PipelineRunContextId; default:0;"`
+	// RetryGeneration is incremented by ClaimRunForRetry to fence stale
+	// workflow reporters. UpdateRun checks this value to reject terminal
+	// state writes from reporters that passed version checks before the claim.
+	RetryGeneration int64 `gorm:"column:RetryGeneration; default:0;"`
 	// Add gorm:"-" so that GORM ignores TaskDetails when generating schema.
 	// This avoids GORM auto-detecting the circular relationship (RunDetails <--> Tasks) and blocking the FK on tasks.RunUUID → run_details.UUID.
 	TaskDetails []*Task `gorm:"-"`

--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -334,10 +334,17 @@ type RunDetails struct {
 	// state writes from reporters that passed version checks before the claim.
 	RetryGeneration int64 `gorm:"column:RetryGeneration; default:0;"`
 	// RetryClaimedAtInSec records the epoch second when ClaimRunForRetry last
-	// claimed this row. The stale-report guard in ReportWorkflowResource uses
-	// this timestamp to distinguish pre-retry terminal reports (FinishedAt <=
-	// claim time) from genuine post-retry completions (FinishedAt > claim time).
+	// claimed this row. It is a liveness signal only, never a correctness
+	// fence: ReportWorkflowResource uses it to detect a claim orphaned by a
+	// crash between claiming the row and updating the workflow. Both the
+	// write and the read happen on the API server's clock.
 	RetryClaimedAtInSec int64 `gorm:"column:RetryClaimedAtInSec; default:0;"`
+	// ArchivedAtInSec records the epoch second when this run entered the
+	// ARCHIVED storage state (via user action or the GC archive pass).
+	// The GC delete pass measures ARCHIVED_RUNS_RETENTION_TIME from this
+	// value; rows archived before this column existed carry 0 and fall back
+	// to FinishedAtInSec.
+	ArchivedAtInSec int64 `gorm:"column:ArchivedAtInSec; default:0;"`
 	// Add gorm:"-" so that GORM ignores TaskDetails when generating schema.
 	// This avoids GORM auto-detecting the circular relationship (RunDetails <--> Tasks) and blocking the FK on tasks.RunUUID → run_details.UUID.
 	TaskDetails []*Task `gorm:"-"`

--- a/backend/src/apiserver/model/run.go
+++ b/backend/src/apiserver/model/run.go
@@ -333,6 +333,11 @@ type RunDetails struct {
 	// workflow reporters. UpdateRun checks this value to reject terminal
 	// state writes from reporters that passed version checks before the claim.
 	RetryGeneration int64 `gorm:"column:RetryGeneration; default:0;"`
+	// RetryClaimedAtInSec records the epoch second when ClaimRunForRetry last
+	// claimed this row. The stale-report guard in ReportWorkflowResource uses
+	// this timestamp to distinguish pre-retry terminal reports (FinishedAt <=
+	// claim time) from genuine post-retry completions (FinishedAt > claim time).
+	RetryClaimedAtInSec int64 `gorm:"column:RetryClaimedAtInSec; default:0;"`
 	// Add gorm:"-" so that GORM ignores TaskDetails when generating schema.
 	// This avoids GORM auto-detecting the circular relationship (RunDetails <--> Tasks) and blocking the FK on tasks.RunUUID → run_details.UUID.
 	TaskDetails []*Task `gorm:"-"`

--- a/backend/src/apiserver/plugins/dispatcher.go
+++ b/backend/src/apiserver/plugins/dispatcher.go
@@ -46,7 +46,10 @@ type RunPluginDispatcher interface {
 	// true if all plugin syncs succeeded.
 	OnRunEnd(ctx context.Context, run *PersistedRun) bool
 
-	// OnRunRetry is called when a run is retried.
+	// OnRunRetry is called when a run is retried. Delivery is at least
+	// once per retry: recovery from a crash between this call and the run
+	// row update (expired-claim adoption) replays it. Implementations must
+	// be idempotent, or deduplicate on (RunID, RetryGeneration).
 	OnRunRetry(ctx context.Context, run *PersistedRun) error
 }
 

--- a/backend/src/apiserver/plugins/handler.go
+++ b/backend/src/apiserver/plugins/handler.go
@@ -47,6 +47,12 @@ type PersistedRun struct {
 	Namespace  string
 	State      string     // RuntimeState string, e.g. "SUCCEEDED", "FAILED"
 	FinishedAt *time.Time // nil if not yet finished
+	// RetryGeneration is the run's retry-claim generation (0 if the run was
+	// never retried). Retry hooks are delivered at least once per retry:
+	// a crash between the hook call and the run-row update replays the hook
+	// during recovery, so handlers that are not naturally idempotent must
+	// deduplicate on (RunID, RetryGeneration).
+	RetryGeneration int64
 	// PluginsOutput is the deserialized plugins_output map.
 	PluginsOutput map[string]*apiv2beta1.PluginOutput
 }

--- a/backend/src/apiserver/plugins/util.go
+++ b/backend/src/apiserver/plugins/util.go
@@ -135,10 +135,11 @@ func ModelToPersistedRun(m *model.Run, namespace string) (*PersistedRun, error) 
 		return nil, fmt.Errorf("failed to deserialize plugins_output for run %q: %w", m.UUID, err)
 	}
 	pr := &PersistedRun{
-		RunID:         m.UUID,
-		Namespace:     namespace,
-		State:         string(m.RunDetails.State), //nolint:staticcheck // QF1008
-		PluginsOutput: pluginsOutput,
+		RunID:           m.UUID,
+		Namespace:       namespace,
+		State:           string(m.RunDetails.State),   //nolint:staticcheck // QF1008
+		RetryGeneration: m.RunDetails.RetryGeneration, //nolint:staticcheck // QF1008
+		PluginsOutput:   pluginsOutput,
 	}
 	if m.RunDetails.FinishedAtInSec > 0 { //nolint:staticcheck // QF1008
 		t := time.Unix(m.RunDetails.FinishedAtInSec, 0) //nolint:staticcheck // QF1008

--- a/backend/src/apiserver/plugins/util_test.go
+++ b/backend/src/apiserver/plugins/util_test.go
@@ -562,3 +562,18 @@ func TestPersistPluginsOutput_StoreError(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, assert.AnError, err)
 }
+
+// Retry hooks are at-least-once; RetryGeneration is the dedupe key handlers
+// use, so the converter must carry it through.
+func TestModelToPersistedRun_CarriesRetryGeneration(t *testing.T) {
+	run := &model.Run{
+		UUID: "run-1",
+		RunDetails: model.RunDetails{
+			State:           model.RuntimeStateFailed,
+			RetryGeneration: 3,
+		},
+	}
+	pr, err := ModelToPersistedRun(run, "ns1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), pr.RetryGeneration)
+}

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1105,6 +1105,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	run.State = model.RuntimeStatePending
 	run.Conditions = string(model.RuntimeStatePending.ToV1())
 	run.RetryGeneration = claimGeneration
+	run.RetryClaimedAtInSec = time.Now().Unix()
 
 	if namespace == "" {
 		namespace = common.GetPodNamespace()
@@ -1652,14 +1653,14 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 	// If run already exists, simply update it
 	run, updateError := r.GetRun(runId)
 	if updateError == nil {
-		// Skip stale terminal reports if a retry has claimed this row.
-		// The persistence agent will re-report after the retry starts.
-		// RetryGeneration > 0 distinguishes retry-claimed rows from fresh
-		// runs which are also created with State=PENDING, FinishedAtInSec=0.
-		if run.RetryGeneration > 0 && run.State == model.RuntimeStatePending && run.FinishedAtInSec == 0 && execStatus.IsInFinalState() {
+		// Skip stale terminal reports from before a retry claim.
+		// A pre-retry workflow completion has FinishedAt <= the claim
+		// timestamp. A genuine post-retry completion finishes after the
+		// claim timestamp and passes through.
+		if run.RetryClaimedAtInSec > 0 && execStatus.IsInFinalState() && execStatus.FinishedAt() <= run.RetryClaimedAtInSec {
 			return nil, util.NewUnavailableServerError(
-				fmt.Errorf("run %s is being retried (State=PENDING, FinishedAtInSec=0)", runId),
-				"Skipping stale terminal report for run %s — retry in progress", runId)
+				fmt.Errorf("run %s has a retry claim at %d but report FinishedAt=%d is not after the claim", runId, run.RetryClaimedAtInSec, execStatus.FinishedAt()),
+				"Skipping stale terminal report for run %s — retry claimed after this completion", runId)
 		}
 		run.State = state
 		run.Conditions = string(state.ToV1())

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1126,22 +1126,31 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		// to determine whether the mutation was applied.
 		workflowClient := r.getWorkflowClient(namespace)
 		liveWorkflow, readError := workflowClient.Get(ctx, run.K8SName, v1.GetOptions{})
-		if readError == nil && liveWorkflow != nil && !liveWorkflow.ExecutionStatus().IsInFinalState() {
-			// Workflow exists and is running. The mutation was applied despite
-			// the error. Preserve the claimed (non-GC-eligible) row for
-			// reconciliation — the persistence agent will report the correct
-			// state once the workflow progresses.
+		switch {
+		case readError == nil && liveWorkflow != nil && !liveWorkflow.ExecutionStatus().IsInFinalState():
+			// Workflow exists and is running — mutation was applied.
+			// Preserve the claimed row for reconciliation.
 			glog.Warningf("Retry workflow for run %s returned error but workflow is live (not terminal). "+
 				"Preserving claimed row for reconciliation. Original error: %v", runId, err)
 			return util.NewUnavailableServerError(err,
 				"Retry workflow for run %s returned error but workflow is live; claim preserved for reconciliation", runId)
+		case readError != nil && !apierrors.IsNotFound(readError):
+			// Ambiguous: GET itself failed with a transient error. The
+			// workflow may be running despite the read failure. Preserve
+			// the claimed row for reconciliation rather than risking
+			// rollback to a GC-eligible timestamp.
+			glog.Warningf("Retry workflow for run %s failed and live workflow read also failed; "+
+				"preserving claimed row for reconciliation. Workflow error: %v, read error: %v", runId, err, readError)
+			return util.NewUnavailableServerError(err,
+				"Retry workflow for run %s failed with ambiguous state; claim preserved for reconciliation", runId)
+		default:
+			// Workflow definitively absent (NotFound) or in terminal state.
+			// Mutation was provably not applied. Safe to rollback.
+			if rollbackError := r.runStore.RollbackRetryClaim(runId, originalState, originalConditions, originalFinishedAtInSec, claimGeneration); rollbackError != nil {
+				glog.Errorf("Failed to rollback retry claim for run %s after workflow reconciliation failure: %v", runId, rollbackError)
+			}
+			return err
 		}
-		// Workflow either does not exist or is still in a terminal state — the
-		// mutation was provably not applied. Safe to rollback.
-		if rollbackError := r.runStore.RollbackRetryClaim(runId, originalState, originalConditions, originalFinishedAtInSec, claimGeneration); rollbackError != nil {
-			glog.Errorf("Failed to rollback retry claim for run %s after workflow reconciliation failure: %v", runId, rollbackError)
-		}
-		return err
 	}
 	// Notify plugins of retry
 	if run.PluginsOutputString != nil && *run.PluginsOutputString != "" {
@@ -1645,7 +1654,9 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 	if updateError == nil {
 		// Skip stale terminal reports if a retry has claimed this row.
 		// The persistence agent will re-report after the retry starts.
-		if run.State == model.RuntimeStatePending && run.FinishedAtInSec == 0 && execStatus.IsInFinalState() {
+		// RetryGeneration > 0 distinguishes retry-claimed rows from fresh
+		// runs which are also created with State=PENDING, FinishedAtInSec=0.
+		if run.RetryGeneration > 0 && run.State == model.RuntimeStatePending && run.FinishedAtInSec == 0 && execStatus.IsInFinalState() {
 			return nil, util.NewUnavailableServerError(
 				fmt.Errorf("run %s is being retried (State=PENDING, FinishedAtInSec=0)", runId),
 				"Skipping stale terminal report for run %s — retry in progress", runId)

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1091,6 +1091,16 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		return util.Wrapf(err, "Failed to retry run %s", runId)
 	}
 
+	// Claim the row before external ops so GC cannot delete it mid-retry.
+	// FinishedAtInSec=0 makes the row invisible to both GC predicates.
+	run.FinishedAtInSec = 0
+	run.State = model.RuntimeStatePending
+	run.Conditions = string(model.RuntimeStatePending.ToV1())
+	if claimError := r.runStore.UpdateRun(run); claimError != nil {
+		return util.NewInternalServerError(claimError,
+			"Failed to retry run %s: could not claim database row before workflow operation", runId)
+	}
+
 	if namespace == "" {
 		namespace = common.GetPodNamespace()
 	}

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1091,11 +1091,64 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		return util.Wrapf(err, "Failed to retry run %s", runId)
 	}
 
+	if namespace == "" {
+		namespace = common.GetPodNamespace()
+	}
+
+	// If a previous retry claim has aged out, reconcile against Kubernetes
+	// before deciding anything: an expired claim is not necessarily an
+	// abandoned one. If the claim's workflow exists (the previous API server
+	// crashed after applying the mutation but before persisting), adopt it
+	// instead of launching a duplicate; only a definitive absence (NotFound,
+	// or a live workflow still carrying an older generation) authorizes the
+	// takeover below.
+	allowClaimTakeover := false
+	if run.State == model.RuntimeStatePending && run.RetryGeneration > 0 {
+		claimAge := r.time.Now().Unix() - run.RetryClaimedAtInSec
+		if run.RetryClaimedAtInSec == 0 || claimAge > int64(retryClaimGracePeriod()/time.Second) {
+			liveWorkflow, readError := r.getWorkflowClient(namespace).Get(ctx, execSpec.ExecutionName(), v1.GetOptions{})
+			switch {
+			case readError == nil && liveWorkflow != nil &&
+				reportedRetryGeneration(liveWorkflow.ExecutionObjectMeta()) == run.RetryGeneration:
+				// The previous retry was applied. Persist its current state
+				// and report success: the retry the user asked for is
+				// already running (or finished).
+				glog.Warningf("Run %s has an expired retry claim (generation %d) but its workflow is live; adopting it instead of retrying again", runId, run.RetryGeneration)
+				condition := string(liveWorkflow.ExecutionStatus().Condition())
+				run.Conditions = condition
+				run.State = model.RuntimeState(condition).ToV2()
+				run.FinishedAtInSec = liveWorkflow.ExecutionStatus().FinishedAt()
+				run.WorkflowRuntimeManifest = model.LargeText(liveWorkflow.ToStringForStore())
+				// The crashed retry may not have reached plugin
+				// notification, so adoption fires it (mirrors the normal
+				// retry path); delivery is documented as at-least-once and
+				// handlers deduplicate on (RunID, RetryGeneration).
+				if run.PluginsOutputString != nil && *run.PluginsOutputString != "" {
+					if pr, prErr := apiserverPlugins.ModelToPersistedRun(run, namespace); prErr == nil {
+						r.pluginDispatcher.OnRunRetry(ctx, pr)
+					}
+				}
+				run.PluginsOutputString = nil
+				if updateError := r.runStore.UpdateRun(run); updateError != nil {
+					return util.NewInternalServerError(updateError, "Failed to adopt in-flight retry for run %s", runId)
+				}
+				return nil
+			case readError != nil && !apierrors.IsNotFound(readError):
+				// Transient read: preserve the claim rather than risking a
+				// takeover that duplicates live work.
+				return util.NewUnavailableServerError(readError,
+					"Run %s has an expired retry claim but its workflow state could not be verified - try again later", runId)
+			default:
+				allowClaimTakeover = true
+			}
+		}
+	}
+
 	// Atomically claim via database-side CAS to prevent ReportWorkflowResource
 	// from overwriting with a stale terminal state. The returned claimGeneration
 	// acts as a unique fence token: UpdateRun checks it to reject stale reports,
 	// and RollbackRetryClaim checks it to prevent ABA rollback of a later retry.
-	originalState, originalConditions, originalFinishedAtInSec, claimGeneration, claimError := r.runStore.ClaimRunForRetry(runId)
+	originalState, originalConditions, originalFinishedAtInSec, claimGeneration, claimError := r.runStore.ClaimRunForRetry(runId, allowClaimTakeover)
 	if claimError != nil {
 		// Wrap (not re-classify) so NotFound / BadRequest from the claim
 		// reach the client as such instead of surfacing as HTTP 500.
@@ -1113,9 +1166,6 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	// of the pre-retry workflow, without comparing timestamps across clocks.
 	newExecSpec.SetAnnotations(util.AnnotationKeyRetryGeneration, strconv.FormatInt(claimGeneration, 10))
 
-	if namespace == "" {
-		namespace = common.GetPodNamespace()
-	}
 	if err = deletePods(ctx, r.k8sCoreClient, podsToDelete, namespace); err != nil {
 		// Pod deletion is a local operation that precedes any workflow mutation.
 		// Safe to rollback unconditionally — no external state was changed.
@@ -1658,6 +1708,62 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 			)
 		}
 	}
+	// If run already exists, simply update it
+	run, updateError := r.GetRun(runId)
+	if updateError != nil && !util.IsUserErrorCodeMatch(updateError, codes.NotFound) {
+		// Fail closed: a transient run-store read error must not skip the
+		// generation fence below and fall through into the
+		// persisted-final-state deletion - with an empty-resourceVersion
+		// stale snapshot that would delete the live retried workflow.
+		// NotFound keeps its dedicated recovery paths (workflow GC and the
+		// grace-period handling further down).
+		return nil, util.Wrapf(updateError, "Failed to read run %s before applying workflow report", runId)
+	}
+	// Fence terminal reports from stale pre-retry workflow snapshots.
+	// A retried workflow carries the claim's RetryGeneration as an
+	// annotation; a snapshot taken before the retry carries an older
+	// generation (or none). Accepting such a report would restore the
+	// old FinishedAtInSec and make the run GC-eligible while the retry
+	// is still running. No timestamps are compared across clocks here.
+	// This fence runs before the persisted-final-state deletion below so a
+	// stale snapshot can neither overwrite the row nor delete the live
+	// workflow that a retry has since resubmitted under the same name.
+	if updateError == nil && run.RetryGeneration > 0 && execStatus.IsInFinalState() {
+		if reportedGeneration := reportedRetryGeneration(objMeta); reportedGeneration < run.RetryGeneration {
+			claimAge := r.time.Now().Unix() - run.RetryClaimedAtInSec
+			if run.RetryClaimedAtInSec > 0 && claimAge <= int64(retryClaimGracePeriod()/time.Second) {
+				// The retry is (or was moments ago) in flight; the retried
+				// workflow will report with the current generation. Skip
+				// this stale snapshot as a successful no-op so the
+				// persistence agent does not requeue it forever.
+				glog.Infof("Skipping stale terminal report for run %s: reported retry generation %d < claimed generation %d",
+					runId, reportedGeneration, run.RetryGeneration)
+				return execSpec, nil
+			}
+			// The claim has aged out, but age alone is not proof of
+			// abandonment (and the resource-version check above passes
+			// vacuously for reports without a resourceVersion). Never
+			// age-accept a lower generation while the claimed generation
+			// is live: consult the live workflow first.
+			liveWorkflow, readError := r.getWorkflowClient(execSpec.ExecutionNamespace()).Get(ctx, execSpec.ExecutionName(), v1.GetOptions{})
+			switch {
+			case readError == nil && liveWorkflow != nil &&
+				reportedRetryGeneration(liveWorkflow.ExecutionObjectMeta()) >= run.RetryGeneration:
+				glog.Infof("Skipping stale terminal report for run %s: live workflow carries generation %d",
+					runId, reportedRetryGeneration(liveWorkflow.ExecutionObjectMeta()))
+				return execSpec, nil
+			case readError != nil && !util.IsNotFound(readError):
+				return nil, util.NewUnavailableServerError(readError,
+					"Cannot verify live workflow before accepting a stale-generation report for run %s - will retry", runId)
+			}
+			// Definitive: no live workflow, or the live workflow still
+			// carries an older generation, so the claimed generation was
+			// never applied. Accept this report so the run returns to its
+			// last real state instead of staying PENDING forever.
+			glog.Warningf("Accepting terminal report with stale retry generation %d for run %s: claim (generation %d) is older than %v and provably not applied",
+				reportedGeneration, runId, run.RetryGeneration, retryClaimGracePeriod())
+		}
+	}
 	// Delete a fully persisted workflow only after the version check above:
 	// a stale snapshot carrying the persisted-final-state label must not
 	// delete the live workflow object that a retry has since resubmitted
@@ -1679,36 +1785,7 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 			workflowGCCounter.Inc()
 		}
 	}
-	// If run already exists, simply update it
-	run, updateError := r.GetRun(runId)
 	if updateError == nil {
-		// Fence terminal reports from stale pre-retry workflow snapshots.
-		// A retried workflow carries the claim's RetryGeneration as an
-		// annotation; a snapshot taken before the retry carries an older
-		// generation (or none). Accepting such a report would restore the
-		// old FinishedAtInSec and make the run GC-eligible while the retry
-		// is still running. No timestamps are compared across clocks here.
-		if run.RetryGeneration > 0 && execStatus.IsInFinalState() {
-			if reportedGeneration := reportedRetryGeneration(objMeta); reportedGeneration < run.RetryGeneration {
-				claimAge := r.time.Now().Unix() - run.RetryClaimedAtInSec
-				if run.RetryClaimedAtInSec > 0 && claimAge <= int64(retryClaimGracePeriod()/time.Second) {
-					// The retry is (or was moments ago) in flight; the retried
-					// workflow will report with the current generation. Skip
-					// this stale snapshot as a successful no-op so the
-					// persistence agent does not requeue it forever.
-					glog.Infof("Skipping stale terminal report for run %s: reported retry generation %d < claimed generation %d",
-						runId, reportedGeneration, run.RetryGeneration)
-					return execSpec, nil
-				}
-				// No workflow write carrying the claimed generation appeared
-				// within the grace period: the retry crashed between claiming
-				// the row and updating the workflow. Accept this report so
-				// the run returns to its last real state instead of staying
-				// PENDING forever.
-				glog.Warningf("Accepting terminal report with stale retry generation %d for run %s: claim (generation %d) is older than %v and appears orphaned",
-					reportedGeneration, runId, run.RetryGeneration, retryClaimGracePeriod())
-			}
-		}
 		run.State = state
 		run.Conditions = string(state.ToV1())
 		run.FinishedAtInSec = execStatus.FinishedAt()

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1091,25 +1091,33 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		return util.Wrapf(err, "Failed to retry run %s", runId)
 	}
 
-	// Claim the row before external ops so GC cannot delete it mid-retry.
-	// FinishedAtInSec=0 makes the row invisible to both GC predicates.
-	run.FinishedAtInSec = 0
-	run.State = model.RuntimeStatePending
-	run.Conditions = string(model.RuntimeStatePending.ToV1())
-	if claimError := r.runStore.UpdateRun(run); claimError != nil {
+	// Atomically claim via database-side CAS to prevent ReportWorkflowResource
+	// from overwriting with a stale terminal state.
+	originalState, originalConditions, originalFinishedAtInSec, claimError := r.runStore.ClaimRunForRetry(runId)
+	if claimError != nil {
 		return util.NewInternalServerError(claimError,
 			"Failed to retry run %s: could not claim database row before workflow operation", runId)
 	}
+	// Update the in-memory run to reflect the claimed state.
+	run.FinishedAtInSec = 0
+	run.State = model.RuntimeStatePending
+	run.Conditions = string(model.RuntimeStatePending.ToV1())
 
 	if namespace == "" {
 		namespace = common.GetPodNamespace()
 	}
 	if err = deletePods(ctx, r.k8sCoreClient, podsToDelete, namespace); err != nil {
+		if rollbackError := r.runStore.RollbackRetryClaim(runId, originalState, originalConditions, originalFinishedAtInSec); rollbackError != nil {
+			glog.Errorf("Failed to rollback retry claim for run %s after pod deletion failure: %v", runId, rollbackError)
+		}
 		return util.NewInternalServerError(err, "Failed to retry run %s due to error cleaning up the failed pods from the previous attempt", runId)
 	}
 
 	newExecSpec, err = r.updateOrCreateRetryWorkflow(ctx, namespace, runId, newExecSpec)
 	if err != nil {
+		if rollbackError := r.runStore.RollbackRetryClaim(runId, originalState, originalConditions, originalFinishedAtInSec); rollbackError != nil {
+			glog.Errorf("Failed to rollback retry claim for run %s after workflow reconciliation failure: %v", runId, rollbackError)
+		}
 		return err
 	}
 	// Notify plugins of retry
@@ -1612,6 +1620,13 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 	// If run already exists, simply update it
 	run, updateError := r.GetRun(runId)
 	if updateError == nil {
+		// Skip stale terminal reports if a retry has claimed this row.
+		// The persistence agent will re-report after the retry starts.
+		if run.State == model.RuntimeStatePending && run.FinishedAtInSec == 0 && execStatus.IsInFinalState() {
+			return nil, util.NewUnavailableServerError(
+				fmt.Errorf("run %s is being retried (State=PENDING, FinishedAtInSec=0)", runId),
+				"Skipping stale terminal report for run %s — retry in progress", runId)
+		}
 		run.State = state
 		run.Conditions = string(state.ToV1())
 		run.FinishedAtInSec = execStatus.FinishedAt()

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1092,8 +1092,10 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	}
 
 	// Atomically claim via database-side CAS to prevent ReportWorkflowResource
-	// from overwriting with a stale terminal state.
-	originalState, originalConditions, originalFinishedAtInSec, claimError := r.runStore.ClaimRunForRetry(runId)
+	// from overwriting with a stale terminal state. The returned claimGeneration
+	// acts as a unique fence token: UpdateRun checks it to reject stale reports,
+	// and RollbackRetryClaim checks it to prevent ABA rollback of a later retry.
+	originalState, originalConditions, originalFinishedAtInSec, claimGeneration, claimError := r.runStore.ClaimRunForRetry(runId)
 	if claimError != nil {
 		return util.NewInternalServerError(claimError,
 			"Failed to retry run %s: could not claim database row before workflow operation", runId)
@@ -1102,12 +1104,15 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	run.FinishedAtInSec = 0
 	run.State = model.RuntimeStatePending
 	run.Conditions = string(model.RuntimeStatePending.ToV1())
+	run.RetryGeneration = claimGeneration
 
 	if namespace == "" {
 		namespace = common.GetPodNamespace()
 	}
 	if err = deletePods(ctx, r.k8sCoreClient, podsToDelete, namespace); err != nil {
-		if rollbackError := r.runStore.RollbackRetryClaim(runId, originalState, originalConditions, originalFinishedAtInSec); rollbackError != nil {
+		// Pod deletion is a local operation that precedes any workflow mutation.
+		// Safe to rollback unconditionally — no external state was changed.
+		if rollbackError := r.runStore.RollbackRetryClaim(runId, originalState, originalConditions, originalFinishedAtInSec, claimGeneration); rollbackError != nil {
 			glog.Errorf("Failed to rollback retry claim for run %s after pod deletion failure: %v", runId, rollbackError)
 		}
 		return util.NewInternalServerError(err, "Failed to retry run %s due to error cleaning up the failed pods from the previous attempt", runId)
@@ -1115,7 +1120,25 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 
 	newExecSpec, err = r.updateOrCreateRetryWorkflow(ctx, namespace, runId, newExecSpec)
 	if err != nil {
-		if rollbackError := r.runStore.RollbackRetryClaim(runId, originalState, originalConditions, originalFinishedAtInSec); rollbackError != nil {
+		// Workflow reconciliation failed. Kubernetes timeouts and 5xx responses
+		// are ambiguous: the API server may have applied the running workflow
+		// even after the client exhausted retries. Re-read the live workflow
+		// to determine whether the mutation was applied.
+		workflowClient := r.getWorkflowClient(namespace)
+		liveWorkflow, readError := workflowClient.Get(ctx, run.K8SName, v1.GetOptions{})
+		if readError == nil && liveWorkflow != nil && !liveWorkflow.ExecutionStatus().IsInFinalState() {
+			// Workflow exists and is running. The mutation was applied despite
+			// the error. Preserve the claimed (non-GC-eligible) row for
+			// reconciliation — the persistence agent will report the correct
+			// state once the workflow progresses.
+			glog.Warningf("Retry workflow for run %s returned error but workflow is live (not terminal). "+
+				"Preserving claimed row for reconciliation. Original error: %v", runId, err)
+			return util.NewUnavailableServerError(err,
+				"Retry workflow for run %s returned error but workflow is live; claim preserved for reconciliation", runId)
+		}
+		// Workflow either does not exist or is still in a terminal state — the
+		// mutation was provably not applied. Safe to rollback.
+		if rollbackError := r.runStore.RollbackRetryClaim(runId, originalState, originalConditions, originalFinishedAtInSec, claimGeneration); rollbackError != nil {
 			glog.Errorf("Failed to rollback retry claim for run %s after workflow reconciliation failure: %v", runId, rollbackError)
 		}
 		return err

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1139,6 +1139,17 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		workflowClient := r.getWorkflowClient(namespace)
 		liveWorkflow, readError := workflowClient.Get(ctx, retryWorkflowName, v1.GetOptions{})
 		switch {
+		case readError == nil && liveWorkflow != nil &&
+			reportedRetryGeneration(liveWorkflow.ExecutionObjectMeta()) == claimGeneration:
+			// The mutation was applied despite the error: the live workflow
+			// carries this claim's generation (it may even be terminal
+			// already if the retry finished quickly). Adopt it and complete
+			// the retry instead of rolling back — a rollback here would
+			// restore a GC-eligible FinishedAtInSec under a live retried
+			// workflow and permit a duplicate retry.
+			glog.Warningf("Retry workflow for run %s returned error but the live workflow carries claim generation %d; adopting it. Original error: %v",
+				runId, claimGeneration, err)
+			newExecSpec = liveWorkflow
 		case readError == nil && liveWorkflow != nil && !liveWorkflow.ExecutionStatus().IsInFinalState():
 			// Workflow exists and is running — mutation was applied.
 			// Preserve the claimed row for reconciliation.
@@ -1156,8 +1167,9 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 			return util.NewUnavailableServerError(err,
 				"Retry workflow for run %s failed with ambiguous state; claim preserved for reconciliation", runId)
 		default:
-			// Workflow definitively absent (NotFound) or in terminal state.
-			// Mutation was provably not applied. Safe to rollback.
+			// Workflow definitively absent (NotFound), or terminal without
+			// this claim's generation — a pre-retry leftover, so the
+			// mutation was provably not applied. Safe to rollback.
 			if rollbackError := r.runStore.RollbackRetryClaim(runId, originalState, originalConditions, originalFinishedAtInSec, claimGeneration); rollbackError != nil {
 				glog.Errorf("Failed to rollback retry claim for run %s after workflow reconciliation failure: %v", runId, rollbackError)
 			}
@@ -1173,7 +1185,9 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 
 	condition := string(newExecSpec.ExecutionStatus().Condition())
 	run.Conditions = condition
-	run.FinishedAtInSec = 0
+	// 0 for a freshly resubmitted (running) workflow; the real finish time
+	// when the reconciliation path adopted an already-terminal retry.
+	run.FinishedAtInSec = newExecSpec.ExecutionStatus().FinishedAt()
 	run.WorkflowRuntimeManifest = model.LargeText(newExecSpec.ToStringForStore())
 	run.State = model.RuntimeState(condition).ToV2()
 	// OnRunRetry persists plugin output independently; leave PluginsOutput unchanged here.
@@ -1677,7 +1691,7 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 		if run.RetryGeneration > 0 && execStatus.IsInFinalState() {
 			if reportedGeneration := reportedRetryGeneration(objMeta); reportedGeneration < run.RetryGeneration {
 				claimAge := r.time.Now().Unix() - run.RetryClaimedAtInSec
-				if run.RetryClaimedAtInSec > 0 && claimAge <= int64(retryClaimGracePeriod/time.Second) {
+				if run.RetryClaimedAtInSec > 0 && claimAge <= int64(retryClaimGracePeriod()/time.Second) {
 					// The retry is (or was moments ago) in flight; the retried
 					// workflow will report with the current generation. Skip
 					// this stale snapshot as a successful no-op so the
@@ -1692,7 +1706,7 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 				// the run returns to its last real state instead of staying
 				// PENDING forever.
 				glog.Warningf("Accepting terminal report with stale retry generation %d for run %s: claim (generation %d) is older than %v and appears orphaned",
-					reportedGeneration, runId, run.RetryGeneration, retryClaimGracePeriod)
+					reportedGeneration, runId, run.RetryGeneration, retryClaimGracePeriod())
 			}
 		}
 		run.State = state
@@ -1920,7 +1934,11 @@ func terminalWorkflowReportDeferredError(runID string, execSpec util.ExecutionSp
 // workflow write is trusted. RetryRun's claim-to-workflow-update window is
 // bounded by a handful of client-side retries (seconds), so a claim this old
 // with no workflow carrying its generation means the retry crashed mid-flight.
-const retryClaimGracePeriod = 10 * time.Minute
+// Shared with ClaimRunForRetry's abandoned-claim takeover so both recovery
+// paths age out together.
+func retryClaimGracePeriod() time.Duration {
+	return time.Duration(storage.RetryClaimGraceSeconds) * time.Second
+}
 
 // reportedRetryGeneration extracts the retry-generation annotation stamped by
 // RetryRun. Workflows created before any retry (or before this annotation

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1097,7 +1097,9 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	// and RollbackRetryClaim checks it to prevent ABA rollback of a later retry.
 	originalState, originalConditions, originalFinishedAtInSec, claimGeneration, claimError := r.runStore.ClaimRunForRetry(runId)
 	if claimError != nil {
-		return util.NewInternalServerError(claimError,
+		// Wrap (not re-classify) so NotFound / BadRequest from the claim
+		// reach the client as such instead of surfacing as HTTP 500.
+		return util.Wrapf(claimError,
 			"Failed to retry run %s: could not claim database row before workflow operation", runId)
 	}
 	// Update the in-memory run to reflect the claimed state.
@@ -1105,7 +1107,11 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	run.State = model.RuntimeStatePending
 	run.Conditions = string(model.RuntimeStatePending.ToV1())
 	run.RetryGeneration = claimGeneration
-	run.RetryClaimedAtInSec = time.Now().Unix()
+	run.RetryClaimedAtInSec = r.time.Now().Unix()
+	// Stamp the claim token on the workflow so ReportWorkflowResource can
+	// distinguish reports about this retried workflow from stale snapshots
+	// of the pre-retry workflow, without comparing timestamps across clocks.
+	newExecSpec.SetAnnotations(util.AnnotationKeyRetryGeneration, strconv.FormatInt(claimGeneration, 10))
 
 	if namespace == "" {
 		namespace = common.GetPodNamespace()
@@ -1119,6 +1125,11 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		return util.NewInternalServerError(err, "Failed to retry run %s due to error cleaning up the failed pods from the previous attempt", runId)
 	}
 
+	// Capture the workflow name the retry operates on before newExecSpec is
+	// reassigned (it is nil on error). This is the name from the stored
+	// runtime manifest, which is the object updateOrCreateRetryWorkflow
+	// mutates; run.K8SName can diverge from it.
+	retryWorkflowName := newExecSpec.ExecutionName()
 	newExecSpec, err = r.updateOrCreateRetryWorkflow(ctx, namespace, runId, newExecSpec)
 	if err != nil {
 		// Workflow reconciliation failed. Kubernetes timeouts and 5xx responses
@@ -1126,7 +1137,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		// even after the client exhausted retries. Re-read the live workflow
 		// to determine whether the mutation was applied.
 		workflowClient := r.getWorkflowClient(namespace)
-		liveWorkflow, readError := workflowClient.Get(ctx, run.K8SName, v1.GetOptions{})
+		liveWorkflow, readError := workflowClient.Get(ctx, retryWorkflowName, v1.GetOptions{})
 		switch {
 		case readError == nil && liveWorkflow != nil && !liveWorkflow.ExecutionStatus().IsInFinalState():
 			// Workflow exists and is running — mutation was applied.
@@ -1614,23 +1625,6 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 		return nil, util.NewInvalidInputError("Failed to report a workflow. Namespace is empty")
 	}
 
-	if execSpec.PersistedFinalState() {
-		// If workflow's final state has being persisted, the workflow should be garbage collected.
-		err := r.getWorkflowClient(execSpec.ExecutionNamespace()).Delete(ctx, execSpec.ExecutionName(), v1.DeleteOptions{})
-		if err != nil {
-			// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
-			// report workflows that no longer exist. It's important to return a not found error, so that persistence
-			// agent won't retry again.
-			if util.IsNotFound(err) {
-				return nil, util.NewNotFoundError(err, "Failed to delete the completed workflow for run %s", runId)
-			} else {
-				return nil, util.NewInternalServerError(err, "Failed to delete the completed workflow for run %s", runId)
-			}
-		}
-		if r.options.CollectMetrics {
-			workflowGCCounter.Inc()
-		}
-	}
 	// If the run was Running and got terminated (activeDeadlineSeconds set to 0),
 	// ignore its condition and mark it as such
 	state := model.RuntimeState(string(execStatus.Condition())).ToV2()
@@ -1650,17 +1644,56 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 			)
 		}
 	}
+	// Delete a fully persisted workflow only after the version check above:
+	// a stale snapshot carrying the persisted-final-state label must not
+	// delete the live workflow object that a retry has since resubmitted
+	// under the same name.
+	if execSpec.PersistedFinalState() {
+		// If workflow's final state has being persisted, the workflow should be garbage collected.
+		err := r.getWorkflowClient(execSpec.ExecutionNamespace()).Delete(ctx, execSpec.ExecutionName(), v1.DeleteOptions{})
+		if err != nil {
+			// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
+			// report workflows that no longer exist. It's important to return a not found error, so that persistence
+			// agent won't retry again.
+			if util.IsNotFound(err) {
+				return nil, util.NewNotFoundError(err, "Failed to delete the completed workflow for run %s", runId)
+			} else {
+				return nil, util.NewInternalServerError(err, "Failed to delete the completed workflow for run %s", runId)
+			}
+		}
+		if r.options.CollectMetrics {
+			workflowGCCounter.Inc()
+		}
+	}
 	// If run already exists, simply update it
 	run, updateError := r.GetRun(runId)
 	if updateError == nil {
-		// Skip stale terminal reports from before a retry claim.
-		// A pre-retry workflow completion has FinishedAt <= the claim
-		// timestamp. A genuine post-retry completion finishes after the
-		// claim timestamp and passes through.
-		if run.RetryClaimedAtInSec > 0 && execStatus.IsInFinalState() && execStatus.FinishedAt() <= run.RetryClaimedAtInSec {
-			return nil, util.NewUnavailableServerError(
-				fmt.Errorf("run %s has a retry claim at %d but report FinishedAt=%d is not after the claim", runId, run.RetryClaimedAtInSec, execStatus.FinishedAt()),
-				"Skipping stale terminal report for run %s — retry claimed after this completion", runId)
+		// Fence terminal reports from stale pre-retry workflow snapshots.
+		// A retried workflow carries the claim's RetryGeneration as an
+		// annotation; a snapshot taken before the retry carries an older
+		// generation (or none). Accepting such a report would restore the
+		// old FinishedAtInSec and make the run GC-eligible while the retry
+		// is still running. No timestamps are compared across clocks here.
+		if run.RetryGeneration > 0 && execStatus.IsInFinalState() {
+			if reportedGeneration := reportedRetryGeneration(objMeta); reportedGeneration < run.RetryGeneration {
+				claimAge := r.time.Now().Unix() - run.RetryClaimedAtInSec
+				if run.RetryClaimedAtInSec > 0 && claimAge <= int64(retryClaimGracePeriod/time.Second) {
+					// The retry is (or was moments ago) in flight; the retried
+					// workflow will report with the current generation. Skip
+					// this stale snapshot as a successful no-op so the
+					// persistence agent does not requeue it forever.
+					glog.Infof("Skipping stale terminal report for run %s: reported retry generation %d < claimed generation %d",
+						runId, reportedGeneration, run.RetryGeneration)
+					return execSpec, nil
+				}
+				// No workflow write carrying the claimed generation appeared
+				// within the grace period: the retry crashed between claiming
+				// the row and updating the workflow. Accept this report so
+				// the run returns to its last real state instead of staying
+				// PENDING forever.
+				glog.Warningf("Accepting terminal report with stale retry generation %d for run %s: claim (generation %d) is older than %v and appears orphaned",
+					reportedGeneration, runId, run.RetryGeneration, retryClaimGracePeriod)
+			}
 		}
 		run.State = state
 		run.Conditions = string(state.ToV1())
@@ -1881,6 +1914,28 @@ func terminalWorkflowReportDeferredError(runID string, execSpec util.ExecutionSp
 		execSpec.ExecutionName(),
 		reason,
 	)
+}
+
+// retryClaimGracePeriod bounds how long a retry claim without a matching
+// workflow write is trusted. RetryRun's claim-to-workflow-update window is
+// bounded by a handful of client-side retries (seconds), so a claim this old
+// with no workflow carrying its generation means the retry crashed mid-flight.
+const retryClaimGracePeriod = 10 * time.Minute
+
+// reportedRetryGeneration extracts the retry-generation annotation stamped by
+// RetryRun. Workflows created before any retry (or before this annotation
+// existed) return 0.
+func reportedRetryGeneration(objMeta *v1.ObjectMeta) int64 {
+	raw, ok := objMeta.Annotations[util.AnnotationKeyRetryGeneration]
+	if !ok {
+		return 0
+	}
+	generation, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		glog.Warningf("Ignoring malformed %s annotation %q", util.AnnotationKeyRetryGeneration, raw)
+		return 0
+	}
+	return generation
 }
 
 func (r *ResourceManager) workflowStillMatchesReportedVersion(ctx context.Context, execSpec util.ExecutionSpec) (bool, error) {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -6046,3 +6046,43 @@ func TestRetryRun_StampsRetryGenerationAnnotation(t *testing.T) {
 	assert.Contains(t, string(retried.WorkflowRuntimeManifest), util.AnnotationKeyRetryGeneration,
 		"retried workflow manifest must carry the retry-generation annotation")
 }
+
+// Regression: when the workflow mutation errors but was actually applied (the
+// live workflow carries this claim's retry-generation annotation), RetryRun
+// must adopt the live workflow — even if it already reached a terminal state —
+// instead of rolling back the claim, which would restore a GC-eligible
+// FinishedAtInSec under a live retried workflow and permit a duplicate retry.
+func TestRetryRun_AdoptsAppliedWorkflowInsteadOfRollingBack(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	// Seed the retried workflow as already terminal and carrying the
+	// generation the upcoming claim will produce (1), simulating a timed-out
+	// update that was applied and a retry that finished quickly.
+	run, err := manager.GetRun(runDetail.UUID)
+	require.NoError(t, err)
+	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.WorkflowRuntimeManifest))
+	require.NoError(t, err)
+	require.NoError(t, execSpec.Decompress())
+	retryExecSpec, _, err := execSpec.GenerateRetryExecution()
+	require.NoError(t, err)
+	retryExecSpec.SetAnnotations(util.AnnotationKeyRetryGeneration, "1")
+	appliedWorkflow := retryExecSpec.(*util.Workflow)
+	appliedWorkflow.Status.Phase = v1alpha1.WorkflowSucceeded
+	appliedWorkflow.Status.FinishedAt = v1.Time{Time: time.Unix(500, 0)}
+
+	workflowClient := client.NewWorkflowClientFake()
+	_, err = workflowClient.Create(context.Background(), appliedWorkflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	conflictClient := &persistentConflictWorkflowClient{FakeWorkflowClient: workflowClient}
+	manager.execClient = &retryWorkflowExecClient{workflowClient: conflictClient}
+
+	err = manager.RetryRun(context.Background(), runDetail.UUID)
+	require.NoError(t, err, "an applied retry must be adopted, not treated as failed")
+
+	adopted, err := manager.GetRun(runDetail.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateSucceeded, adopted.State, "run must reflect the adopted live workflow")
+	assert.Equal(t, int64(1), adopted.RetryGeneration, "claim must not be rolled back")
+	assert.Equal(t, int64(500), adopted.FinishedAtInSec, "adopted terminal workflow's finish time must be persisted")
+}

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -5916,4 +5917,132 @@ func TestCreateRun_DeterministicUUIDFromRecurringRun(t *testing.T) {
 	// name, so concurrent triggers converge on the same primary key.
 	wantUUID := util.NewDeterministicUUID(job.UUID + "/scheduled-run-trigger-1")
 	assert.Equal(t, wantUUID, created.UUID)
+}
+
+// A terminal report carrying no (or an older) retry-generation annotation is a
+// snapshot of the pre-retry workflow. While the claim is fresh it must be
+// skipped as a successful no-op: not an error (the persistence agent would
+// requeue forever) and not a write (it would restore a GC-eligible
+// FinishedAtInSec while the retry is running).
+func TestReportWorkflowResource_SkipsStaleTerminalReportDuringRetryClaim(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+
+	staleWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: "ns1",
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
+	})
+
+	// Drive the run terminal, then claim it for retry.
+	_, err := manager.ReportWorkflowResource(context.Background(), staleWorkflow)
+	require.Nil(t, err)
+	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(run.UUID)
+	require.Nil(t, claimErr)
+	require.Equal(t, int64(1), claimGeneration)
+
+	// The same terminal snapshot arrives again (requeued by the persistence
+	// agent). It carries no retry-generation annotation.
+	_, err = manager.ReportWorkflowResource(context.Background(), staleWorkflow)
+	assert.Nil(t, err, "stale terminal report during a fresh claim must be a successful no-op")
+
+	claimed, err := manager.GetRun(run.UUID)
+	require.Nil(t, err)
+	assert.Equal(t, model.RuntimeStatePending, claimed.State, "stale report must not overwrite the claimed row")
+	assert.Equal(t, int64(0), claimed.FinishedAtInSec)
+}
+
+// A report from the retried workflow itself carries the claim's generation in
+// its annotation and must pass the fence.
+func TestReportWorkflowResource_AcceptsRetriedWorkflowReport(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+
+	terminal := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: "ns1",
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
+	})
+	_, err := manager.ReportWorkflowResource(context.Background(), terminal)
+	require.Nil(t, err)
+	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(run.UUID)
+	require.Nil(t, claimErr)
+
+	retried := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: "ns1",
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+			Annotations: map[string]string{
+				util.AnnotationKeyRetryGeneration: strconv.FormatInt(claimGeneration, 10),
+			},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowSucceeded},
+	})
+	_, err = manager.ReportWorkflowResource(context.Background(), retried)
+	assert.Nil(t, err)
+
+	updated, err := manager.GetRun(run.UUID)
+	require.Nil(t, err)
+	assert.Equal(t, model.RuntimeStateSucceeded, updated.State, "post-retry completion must pass the generation fence")
+}
+
+// A claim with no claim timestamp (cleared by rollback, or orphaned by a crash
+// past the grace period) must not fence terminal reports forever: the reporter
+// accepts the terminal state so the run self-heals instead of staying PENDING.
+func TestReportWorkflowResource_RecoversOrphanedRetryClaim(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+
+	staleWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: "ns1",
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
+	})
+	_, err := manager.ReportWorkflowResource(context.Background(), staleWorkflow)
+	require.Nil(t, err)
+	_, _, _, _, claimErr := store.RunStore().ClaimRunForRetry(run.UUID)
+	require.Nil(t, claimErr)
+
+	// Simulate an orphaned claim: the claim timestamp is gone (rollback) or
+	// far in the past (crash between claim and workflow update).
+	_, err = store.DB().Exec(`UPDATE run_details SET RetryClaimedAtInSec = 0 WHERE UUID = ?`, run.UUID)
+	require.Nil(t, err)
+
+	_, err = manager.ReportWorkflowResource(context.Background(), staleWorkflow)
+	assert.Nil(t, err)
+
+	recovered, err := manager.GetRun(run.UUID)
+	require.Nil(t, err)
+	assert.Equal(t, model.RuntimeStateFailed, recovered.State, "orphaned claim must self-heal to the last real terminal state")
+}
+
+// RetryRun must stamp the claim's RetryGeneration on the retried workflow so
+// ReportWorkflowResource can tell its reports apart from stale snapshots of
+// the pre-retry workflow.
+func TestRetryRun_StampsRetryGenerationAnnotation(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	err := manager.RetryRun(context.Background(), runDetail.UUID)
+	require.Nil(t, err)
+
+	retried, err := manager.GetRun(runDetail.UUID)
+	require.Nil(t, err)
+	assert.Equal(t, int64(1), retried.RetryGeneration)
+	assert.Contains(t, string(retried.WorkflowRuntimeManifest), util.AnnotationKeyRetryGeneration,
+		"retried workflow manifest must carry the retry-generation annotation")
 }

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -5941,7 +5941,7 @@ func TestReportWorkflowResource_SkipsStaleTerminalReportDuringRetryClaim(t *test
 	// Drive the run terminal, then claim it for retry.
 	_, err := manager.ReportWorkflowResource(context.Background(), staleWorkflow)
 	require.Nil(t, err)
-	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(run.UUID)
+	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(run.UUID, false)
 	require.Nil(t, claimErr)
 	require.Equal(t, int64(1), claimGeneration)
 
@@ -5973,7 +5973,7 @@ func TestReportWorkflowResource_AcceptsRetriedWorkflowReport(t *testing.T) {
 	})
 	_, err := manager.ReportWorkflowResource(context.Background(), terminal)
 	require.Nil(t, err)
-	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(run.UUID)
+	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(run.UUID, false)
 	require.Nil(t, claimErr)
 
 	retried := util.NewWorkflow(&v1alpha1.Workflow{
@@ -6014,7 +6014,7 @@ func TestReportWorkflowResource_RecoversOrphanedRetryClaim(t *testing.T) {
 	})
 	_, err := manager.ReportWorkflowResource(context.Background(), staleWorkflow)
 	require.Nil(t, err)
-	_, _, _, _, claimErr := store.RunStore().ClaimRunForRetry(run.UUID)
+	_, _, _, _, claimErr := store.RunStore().ClaimRunForRetry(run.UUID, false)
 	require.Nil(t, claimErr)
 
 	// Simulate an orphaned claim: the claim timestamp is gone (rollback) or
@@ -6085,4 +6085,221 @@ func TestRetryRun_AdoptsAppliedWorkflowInsteadOfRollingBack(t *testing.T) {
 	assert.Equal(t, model.RuntimeStateSucceeded, adopted.State, "run must reflect the adopted live workflow")
 	assert.Equal(t, int64(1), adopted.RetryGeneration, "claim must not be rolled back")
 	assert.Equal(t, int64(500), adopted.FinishedAtInSec, "adopted terminal workflow's finish time must be persisted")
+}
+
+// Regression: an expired retry claim is not necessarily abandoned. When the
+// previous claim's workflow is live (the earlier API server crashed after
+// applying the mutation but before persisting), a new RetryRun must adopt it
+// rather than take over the claim and restart in-flight work.
+func TestRetryRun_ExpiredClaimWithLiveWorkflowIsAdoptedNotTakenOver(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	// Simulate a retry that crashed after claiming generation 1 and creating
+	// the workflow, but before persisting the run row: claim via the store
+	// (leaves the terminal manifest untouched), seed the live generation-1
+	// workflow, and age out the claim timestamp.
+	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(runDetail.UUID, false)
+	require.NoError(t, claimErr)
+	require.Equal(t, int64(1), claimGeneration)
+	_, err := store.DB().Exec(`UPDATE run_details SET RetryClaimedAtInSec = 0 WHERE UUID = ?`, runDetail.UUID)
+	require.NoError(t, err)
+
+	run, err := manager.GetRun(runDetail.UUID)
+	require.NoError(t, err)
+	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.WorkflowRuntimeManifest))
+	require.NoError(t, err)
+	require.NoError(t, execSpec.Decompress())
+	retryExecSpec, _, err := execSpec.GenerateRetryExecution()
+	require.NoError(t, err)
+	retryExecSpec.SetAnnotations(util.AnnotationKeyRetryGeneration, "1")
+	workflowClient := client.NewWorkflowClientFake()
+	_, err = workflowClient.Create(context.Background(), retryExecSpec, v1.CreateOptions{})
+	require.NoError(t, err)
+	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+
+	require.NoError(t, manager.RetryRun(context.Background(), runDetail.UUID))
+
+	adopted, err := manager.GetRun(runDetail.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), adopted.RetryGeneration,
+		"live generation-1 workflow must be adopted; a takeover to generation 2 would restart in-flight work")
+	assert.NotEqual(t, model.RuntimeStatePending, adopted.State, "adoption must persist the live workflow's state")
+}
+
+// Regression: takeover happens only when the previous claim's workflow is
+// definitively absent.
+func TestRetryRun_ExpiredClaimWithoutWorkflowIsTakenOver(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	// Claim generation 1 but never create the workflow (crash before create).
+	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(runDetail.UUID, false)
+	require.NoError(t, claimErr)
+	require.Equal(t, int64(1), claimGeneration)
+	_, err := store.DB().Exec(`UPDATE run_details SET RetryClaimedAtInSec = 0 WHERE UUID = ?`, runDetail.UUID)
+	require.NoError(t, err)
+
+	// No workflow exists in the fake client: absence is definitive.
+	manager.execClient = &retryWorkflowExecClient{workflowClient: client.NewWorkflowClientFake()}
+	require.NoError(t, manager.RetryRun(context.Background(), runDetail.UUID))
+
+	recovered, err := manager.GetRun(runDetail.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), recovered.RetryGeneration, "definitive absence must allow the takeover claim")
+}
+
+type retryHookCountingDispatcher struct {
+	onRunRetryCalls int
+}
+
+func (d *retryHookCountingDispatcher) OnBeforeRunCreation(context.Context, *apiserverPlugins.PendingRun, util.ExecutionSpec) error {
+	return nil
+}
+
+func (d *retryHookCountingDispatcher) OnRunEnd(context.Context, *apiserverPlugins.PersistedRun) bool {
+	return true
+}
+
+func (d *retryHookCountingDispatcher) OnRunRetry(context.Context, *apiserverPlugins.PersistedRun) error {
+	d.onRunRetryCalls++
+	return nil
+}
+
+func (d *retryHookCountingDispatcher) PluginsRegistered() bool {
+	return true
+}
+
+// Regression: the resource-version check passes vacuously for reports without
+// a resourceVersion, so the age-based accept path must never accept a
+// lower-generation terminal report — or delete the workflow via the
+// persisted-final-state path — while the claimed generation is live.
+func TestReportWorkflowResource_NeverAgeAcceptsWhileClaimedGenerationLive(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+
+	staleWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: "ns1",
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
+	})
+	_, err := manager.ReportWorkflowResource(context.Background(), staleWorkflow)
+	require.Nil(t, err)
+	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(run.UUID, false)
+	require.Nil(t, claimErr)
+	require.Equal(t, int64(1), claimGeneration)
+
+	// Age out the claim, and make the live workflow carry the claimed
+	// generation (the retried workflow was applied by a crashed retry).
+	_, err = store.DB().Exec(`UPDATE run_details SET RetryClaimedAtInSec = 0 WHERE UUID = ?`, run.UUID)
+	require.Nil(t, err)
+	wfClient := store.ExecClientFake.Execution("ns1")
+	liveWorkflow, err := wfClient.Get(context.Background(), run.K8SName, v1.GetOptions{})
+	require.Nil(t, err)
+	liveWorkflow.SetAnnotations(util.AnnotationKeyRetryGeneration, "1")
+	_, err = wfClient.Update(context.Background(), liveWorkflow, v1.UpdateOptions{})
+	require.Nil(t, err)
+
+	// The stale snapshot (no annotation, empty resourceVersion) arrives with
+	// an aged-out claim: it must be skipped, not age-accepted.
+	_, err = manager.ReportWorkflowResource(context.Background(), staleWorkflow)
+	assert.Nil(t, err)
+	claimed, err := manager.GetRun(run.UUID)
+	require.Nil(t, err)
+	assert.Equal(t, model.RuntimeStatePending, claimed.State,
+		"a lower-generation report must never be age-accepted while the claimed generation is live")
+
+	// A stale snapshot carrying persistedFinalState must not delete the
+	// live retried workflow either: the fence runs before the deletion.
+	staleFinal := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: "ns1",
+			UID:       types.UID(run.UUID),
+			Labels: map[string]string{
+				util.LabelKeyWorkflowRunId:               run.UUID,
+				util.LabelKeyWorkflowPersistedFinalState: "true",
+			},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
+	})
+	_, err = manager.ReportWorkflowResource(context.Background(), staleFinal)
+	assert.Nil(t, err)
+	_, err = wfClient.Get(context.Background(), run.K8SName, v1.GetOptions{})
+	assert.Nil(t, err, "the live retried workflow must not be deleted by a stale persisted-final-state snapshot")
+}
+
+// Regression: expired-claim adoption must fire the plugin retry hook; the
+// crashed retry never reached plugin notification, and skipping it leaves
+// plugin-side (e.g. MLflow) runs terminal while the KFP retry runs.
+func TestRetryRun_AdoptionFiresPluginRetryHook(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(runDetail.UUID, false)
+	require.NoError(t, claimErr)
+	require.Equal(t, int64(1), claimGeneration)
+	_, err := store.DB().Exec(`UPDATE run_details SET RetryClaimedAtInSec = 0, PluginsOutput = ? WHERE UUID = ?`,
+		`{"mlflow":{"runId":"abc"}}`, runDetail.UUID)
+	require.NoError(t, err)
+
+	run, err := manager.GetRun(runDetail.UUID)
+	require.NoError(t, err)
+	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.WorkflowRuntimeManifest))
+	require.NoError(t, err)
+	require.NoError(t, execSpec.Decompress())
+	retryExecSpec, _, err := execSpec.GenerateRetryExecution()
+	require.NoError(t, err)
+	retryExecSpec.SetAnnotations(util.AnnotationKeyRetryGeneration, "1")
+	workflowClient := client.NewWorkflowClientFake()
+	_, err = workflowClient.Create(context.Background(), retryExecSpec, v1.CreateOptions{})
+	require.NoError(t, err)
+	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+	dispatcher := &retryHookCountingDispatcher{}
+	manager.pluginDispatcher = dispatcher
+
+	require.NoError(t, manager.RetryRun(context.Background(), runDetail.UUID))
+	assert.Equal(t, 1, dispatcher.onRunRetryCalls, "adoption must notify plugins exactly like a normal retry")
+}
+
+// Regression: a transient run-store read failure must fail closed — it must
+// not skip the generation fence and fall through into persisted-final-state
+// workflow deletion, which would delete the live retried workflow on the
+// strength of a stale snapshot.
+func TestReportWorkflowResource_RunStoreErrorFailsClosedBeforeDeletion(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+
+	staleFinal := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: "ns1",
+			UID:       types.UID(run.UUID),
+			Labels: map[string]string{
+				util.LabelKeyWorkflowRunId:               run.UUID,
+				util.LabelKeyWorkflowPersistedFinalState: "true",
+			},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
+	})
+
+	// Force GetRun to fail with a non-NotFound error.
+	store.Close()
+
+	_, err := manager.ReportWorkflowResource(context.Background(), staleFinal)
+	require.Error(t, err)
+	assert.False(t, util.IsUserErrorCodeMatch(err, codes.NotFound),
+		"a run-store read failure must surface as an error, not be treated as run-not-found")
+	assert.Contains(t, err.Error(), "before applying workflow report",
+		"the error must come from the fail-closed guard, before the deletion path")
+
+	// The decisive assertion: the workflow must still exist. The fake exec
+	// client is independent of the closed database, so a deletion would
+	// have gone through and be visible here.
+	_, err = store.ExecClientFake.Execution("ns1").Get(context.Background(), run.K8SName, v1.GetOptions{})
+	assert.Nil(t, err, "the workflow must not be deleted when the run-store read fails")
 }

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
@@ -58,6 +59,8 @@ var runColumns = []string{
 	"PluginsOutput",
 	"PipelineContextId",
 	"PipelineRunContextId",
+	"RetryGeneration",
+	"RetryClaimedAtInSec",
 }
 
 var runMetricsColumns = []string{
@@ -330,7 +333,7 @@ func (s *RunStore) scanRowsToRuns(rows *sql.Rows) ([]*model.Run, error) {
 		var uuid, experimentUUID, displayName, name, storageState, namespace, serviceAccount, conditions, description, pipelineId,
 			pipelineName, pipelineSpecManifest, workflowSpecManifest, parameters, pipelineRuntimeManifest,
 			workflowRuntimeManifest string
-		var createdAtInSec, scheduledAtInSec, finishedAtInSec, pipelineContextId, pipelineRunContextId sql.NullInt64
+		var createdAtInSec, scheduledAtInSec, finishedAtInSec, pipelineContextID, pipelineRunContextID, retryGeneration, retryClaimedAtInSec sql.NullInt64
 		var metricsInString, resourceReferencesInString, tasksInString, runtimeParameters, pipelineRoot, jobID, state, stateHistory, pluginsInput, pluginsOutput, pipelineVersionID sql.NullString
 		err := rows.Scan(
 			&uuid,
@@ -360,8 +363,10 @@ func (s *RunStore) scanRowsToRuns(rows *sql.Rows) ([]*model.Run, error) {
 			&stateHistory,
 			&pluginsInput,
 			&pluginsOutput,
-			&pipelineContextId,
-			&pipelineRunContextId,
+			&pipelineContextID,
+			&pipelineRunContextID,
+			&retryGeneration,
+			&retryClaimedAtInSec,
 			&resourceReferencesInString,
 			&tasksInString,
 			&metricsInString,
@@ -428,8 +433,10 @@ func (s *RunStore) scanRowsToRuns(rows *sql.Rows) ([]*model.Run, error) {
 				State:                   model.RuntimeState(state.String),
 				PipelineRuntimeManifest: model.LargeText(pipelineRuntimeManifest),
 				WorkflowRuntimeManifest: model.LargeText(workflowRuntimeManifest),
-				PipelineContextId:       pipelineContextId.Int64,
-				PipelineRunContextId:    pipelineRunContextId.Int64,
+				PipelineContextId:       pipelineContextID.Int64,
+				PipelineRunContextId:    pipelineRunContextID.Int64,
+				RetryGeneration:         retryGeneration.Int64,
+				RetryClaimedAtInSec:     retryClaimedAtInSec.Int64,
 				TaskDetails:             tasks,
 				StateHistory:            stateHistoryNew,
 			},
@@ -909,6 +916,7 @@ func (s *RunStore) ClaimRunForRetry(runID string) (string, string, int64, int64,
 		Set("Conditions", string(model.RuntimeStatePending.ToV1())).
 		Set("FinishedAtInSec", 0).
 		Set("RetryGeneration", newGeneration).
+		Set("RetryClaimedAtInSec", time.Now().Unix()).
 		Where(sq.Eq{"UUID": runID}).
 		ToSql()
 	if err != nil {

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -112,6 +112,13 @@ type RunStoreInterface interface {
 
 	// Deletes archived runs older than the cutoff, including dependent tables. Returns count.
 	DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize int) (int64, error)
+
+	// Atomically claims a terminal run for retry (database-side CAS).
+	// Returns the original State, Conditions, and FinishedAtInSec for rollback.
+	ClaimRunForRetry(runId string) (originalState string, originalConditions string, originalFinishedAtInSec int64, err error)
+
+	// Restores a run's pre-retry state after a failed retry attempt.
+	RollbackRetryClaim(runId string, originalState string, originalConditions string, originalFinishedAtInSec int64) error
 }
 
 type RunStore struct {
@@ -820,6 +827,82 @@ func (s *RunStore) DeleteRun(id string) error {
 	if err != nil {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to commit deletion of run %s", id)
+	}
+	return nil
+}
+
+func (s *RunStore) ClaimRunForRetry(runId string) (string, string, int64, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return "", "", 0, util.NewInternalServerError(err, "Failed to start transaction for retry claim on run %s", runId)
+	}
+
+	// Lock the row and read current state.
+	selectSQL, selectArgs, err := sq.
+		Select("State", "Conditions", "FinishedAtInSec").
+		From("run_details").
+		Where(sq.Eq{"UUID": runId}).
+		ToSql()
+	if err != nil {
+		tx.Rollback()
+		return "", "", 0, util.NewInternalServerError(err, "Failed to build retry claim select query for run %s", runId)
+	}
+	row := tx.QueryRow(s.db.SelectForUpdate(selectSQL), selectArgs...)
+	var originalState, originalConditions string
+	var originalFinishedAtInSec int64
+	if err := row.Scan(&originalState, &originalConditions, &originalFinishedAtInSec); err != nil {
+		tx.Rollback()
+		return "", "", 0, util.NewInternalServerError(err, "Failed to read run %s for retry claim", runId)
+	}
+
+	// Verify the row is still eligible: must be terminal with a positive finish time.
+	if originalFinishedAtInSec == 0 {
+		tx.Rollback()
+		return "", "", 0, util.NewInternalServerError(
+			errors.New("run already claimed for retry or still running"),
+			"Cannot claim run %s: FinishedAtInSec is 0", runId)
+	}
+
+	// Atomically transition to PENDING.
+	claimSQL, claimArgs, err := sq.
+		Update("run_details").
+		Set("State", model.RuntimeStatePending.ToString()).
+		Set("Conditions", string(model.RuntimeStatePending.ToV1())).
+		Set("FinishedAtInSec", 0).
+		Where(sq.Eq{"UUID": runId}).
+		ToSql()
+	if err != nil {
+		tx.Rollback()
+		return "", "", 0, util.NewInternalServerError(err, "Failed to build retry claim query for run %s", runId)
+	}
+	if _, err := tx.Exec(claimSQL, claimArgs...); err != nil {
+		tx.Rollback()
+		return "", "", 0, util.NewInternalServerError(err, "Failed to execute retry claim for run %s", runId)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", "", 0, util.NewInternalServerError(err, "Failed to commit retry claim for run %s", runId)
+	}
+	return originalState, originalConditions, originalFinishedAtInSec, nil
+}
+
+func (s *RunStore) RollbackRetryClaim(runId string, originalState string, originalConditions string, originalFinishedAtInSec int64) error {
+	rollbackSQL, rollbackArgs, err := sq.
+		Update("run_details").
+		Set("State", originalState).
+		Set("Conditions", originalConditions).
+		Set("FinishedAtInSec", originalFinishedAtInSec).
+		Where(sq.And{
+			sq.Eq{"UUID": runId},
+			sq.Eq{"FinishedAtInSec": 0},
+		}).
+		ToSql()
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to build rollback query for run %s", runId)
+	}
+	_, err = s.db.DB.Exec(rollbackSQL, rollbackArgs...)
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to rollback retry claim for run %s", runId)
 	}
 	return nil
 }

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -178,7 +178,11 @@ type RunStoreInterface interface {
 	// Atomically claims a terminal run for retry (database-side CAS).
 	// Returns the original State, Conditions, FinishedAtInSec, and the new
 	// RetryGeneration claim token for rollback and reporter fencing.
-	ClaimRunForRetry(runID string) (originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64, err error)
+	// takeoverExpiredClaim additionally allows claiming a PENDING row whose
+	// previous claim has aged out; the caller must first reconcile against
+	// Kubernetes and prove the previous claim's workflow was never applied,
+	// otherwise a takeover can restart in-flight work.
+	ClaimRunForRetry(runID string, takeoverExpiredClaim bool) (originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64, err error)
 
 	// Restores a run's pre-retry state after a failed retry attempt.
 	// The claimGeneration must match the value returned by ClaimRunForRetry
@@ -910,7 +914,7 @@ func (s *RunStore) DeleteRun(id string) error {
 	return nil
 }
 
-func (s *RunStore) ClaimRunForRetry(runID string) (string, string, int64, int64, error) {
+func (s *RunStore) ClaimRunForRetry(runID string, takeoverExpiredClaim bool) (string, string, int64, int64, error) {
 	tx, err := s.db.Begin()
 	if err != nil {
 		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to start transaction for retry claim on run %s", runID)
@@ -955,12 +959,17 @@ func (s *RunStore) ClaimRunForRetry(runID string) (string, string, int64, int64,
 		isTerminal = terminalRunStateValues[originalConditions]
 	}
 	if !isTerminal {
-		// Allow a new claim to take over an expired one. A previous retry
-		// that crashed after committing its claim but before creating the
-		// workflow leaves the row PENDING with no workflow to report it;
+		// Allow a new claim to take over an expired one, but only when the
+		// caller has explicitly authorized it after reconciling against
+		// Kubernetes (RetryRun proves the previous claim's workflow was
+		// never applied before setting takeoverExpiredClaim). A previous
+		// retry that crashed after committing its claim but before creating
+		// the workflow leaves the row PENDING with no workflow to report it;
 		// without takeover the run would be stuck forever (not terminal, so
-		// not claimable; FinishedAtInSec=0, so invisible to GC).
-		isAbandonedClaim := originalState == string(model.RuntimeStatePending) &&
+		// not claimable; FinishedAtInSec=0, so invisible to GC). Expiry is
+		// re-checked here under the row lock as defense in depth.
+		isAbandonedClaim := takeoverExpiredClaim &&
+			originalState == string(model.RuntimeStatePending) &&
 			currentGeneration > 0 &&
 			(retryClaimedAtInSec == 0 || s.time.Now().Unix()-retryClaimedAtInSec > RetryClaimGraceSeconds)
 		if !isAbandonedClaim {
@@ -1138,7 +1147,10 @@ func (s *RunStore) DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize 
 	// re-scan the entire old finish-time range every tick only to reject
 	// fresh archival timestamps. Legacy rows (ArchivedAtInSec=0) are driven
 	// by idx_run_gc_lifecycle (StorageState, FinishedAtInSec); that set only
-	// shrinks, so its scan cost drains to zero.
+	// shrinks, so its scan cost drains to zero. Legacy candidates fill the
+	// batch first: they are by definition the oldest rows, and draining that
+	// bounded set first ends the dual-query era instead of starving it
+	// behind a steady stream of current-format rows.
 	currentSQL, currentArgs, err := sq.
 		Select("UUID").
 		From("run_details").
@@ -1189,7 +1201,7 @@ func (s *RunStore) DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize 
 	for _, candidateQuery := range []struct {
 		sql  string
 		args []interface{}
-	}{{currentSQL, currentArgs}, {legacySQL, legacyArgs}} {
+	}{{legacySQL, legacyArgs}, {currentSQL, currentArgs}} {
 		if len(uuids) >= batchSize {
 			break
 		}

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -106,6 +106,12 @@ type RunStoreInterface interface {
 	// Checks if a run already exists for a given recurring run and display name.
 	// Returns the existing run UUID if found, or empty string if not.
 	GetRunByRecurringRunIDAndDisplayName(recurringRunID, displayName string) (string, error)
+
+	// Archives terminal active runs older than the cutoff. Returns count.
+	ArchiveExpiredRuns(archiveCutoffEpoch int64, batchSize int) (int64, error)
+
+	// Deletes archived runs older than the cutoff, including dependent tables. Returns count.
+	DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize int) (int64, error)
 }
 
 type RunStore struct {
@@ -751,32 +757,354 @@ func (s *RunStore) UnarchiveRun(runId string) error {
 }
 
 func (s *RunStore) DeleteRun(id string) error {
-	runSql, runArgs, err := sq.Delete("run_details").Where(sq.Eq{"UUID": id}).ToSql()
-	if err != nil {
-		return util.NewInternalServerError(err,
-			"Failed to create query to delete run: %s", id)
-	}
-	// Use a transaction to make sure both run and its resource references are stored.
 	tx, err := s.db.Begin()
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to create a new transaction to delete run")
 	}
-	_, err = tx.Exec(runSql, runArgs...)
+
+	// Lock parent row first to match GC DeleteExpiredArchivedRuns lock ordering
+	// (parent → children). Without this, concurrent GC and manual deletion of
+	// the same run can deadlock: GC holds parent waiting for children, manual
+	// holds children waiting for parent.
+	lockSQL, lockArgs, err := sq.Select("UUID").From("run_details").Where(sq.Eq{"UUID": id}).ToSql()
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to create lock query for run %s", id)
+	}
+	var lockedID string
+	if err := tx.QueryRow(s.db.SelectForUpdate(lockSQL), lockArgs...).Scan(&lockedID); err != nil && err != sql.ErrNoRows {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to lock run %s for deletion", id)
+	}
+
+	metricsSQL, metricsArgs, err := sq.Delete("run_metrics").Where(sq.Eq{"RunUUID": id}).ToSql()
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to create query to delete run metrics for run %s", id)
+	}
+	_, err = tx.Exec(metricsSQL, metricsArgs...)
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to delete run metrics for run %s", id)
+	}
+
+	tasksSQL, tasksArgs, err := sq.Delete("tasks").Where(sq.Eq{"RunUUID": id}).ToSql()
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to create query to delete tasks for run %s", id)
+	}
+	_, err = tx.Exec(tasksSQL, tasksArgs...)
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to delete tasks for run %s", id)
+	}
+
+	err = s.resourceReferenceStore.DeleteResourceReferences(tx, id, model.RunResourceType)
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to delete resource references for run %s", id)
+	}
+
+	runSQL, runArgs, err := sq.Delete("run_details").Where(sq.Eq{"UUID": id}).ToSql()
+	if err != nil {
+		tx.Rollback()
+		return util.NewInternalServerError(err, "Failed to create query to delete run %s", id)
+	}
+	_, err = tx.Exec(runSQL, runArgs...)
 	if err != nil {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to delete run %s from table", id)
 	}
-	err = s.resourceReferenceStore.DeleteResourceReferences(tx, id, model.RunResourceType)
-	if err != nil {
-		tx.Rollback()
-		return util.NewInternalServerError(err, "Failed to delete resource references from table for run %v ", id)
-	}
+
 	err = tx.Commit()
 	if err != nil {
 		tx.Rollback()
-		return util.NewInternalServerError(err, "Failed to delete run %v and its resource references from table", id)
+		return util.NewInternalServerError(err, "Failed to commit deletion of run %s", id)
 	}
 	return nil
+}
+
+func (s *RunStore) ArchiveExpiredRuns(archiveCutoffEpoch int64, batchSize int) (int64, error) {
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+	selectSQL, selectArgs, err := sq.
+		Select("UUID").
+		From("run_details").
+		Where(sq.And{
+			// Match terminal runs by State column, or by Conditions column
+			// for legacy v1 rows where State is NULL/empty (ToV2() derives
+			// State from Conditions at read time but does not backfill the DB).
+			sq.Or{
+				sq.Eq{"State": []string{
+					string(model.RuntimeStateSucceeded),
+					string(model.RuntimeStateFailed),
+					string(model.RuntimeStateSkipped),
+					string(model.RuntimeStateCanceled),
+					string(model.RuntimeStateSucceededV1),
+					string(model.RuntimeStateFailedV1),
+					string(model.RuntimeStateSkippedV1),
+					string(model.RuntimeStateErrorV1),
+					model.LegacyStateDone,
+					model.LegacyStateDisabled,
+				}},
+				sq.And{
+					sq.Or{sq.Eq{"State": ""}, sq.Expr("State IS NULL")},
+					sq.Eq{"Conditions": []string{
+						string(model.RuntimeStateSucceeded),
+						string(model.RuntimeStateFailed),
+						string(model.RuntimeStateSkipped),
+						string(model.RuntimeStateCanceled),
+						string(model.RuntimeStateSucceededV1),
+						string(model.RuntimeStateFailedV1),
+						string(model.RuntimeStateSkippedV1),
+						string(model.RuntimeStateErrorV1),
+						model.LegacyStateDone,
+						model.LegacyStateDisabled,
+					}},
+				},
+			},
+			sq.Lt{"FinishedAtInSec": archiveCutoffEpoch},
+			sq.Gt{"FinishedAtInSec": 0},
+			sq.NotEq{"StorageState": []string{
+				string(model.StorageStateArchived),
+				string(model.StorageStateArchivedV1),
+				model.LegacyStateDisabled,
+			}},
+		}).
+		OrderBy("FinishedAtInSec ASC").
+		Limit(uint64(batchSize)).
+		ToSql()
+	if err != nil {
+		return 0, util.NewInternalServerError(err, "Failed to build query for archiving expired runs")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, util.NewInternalServerError(err, "Failed to start transaction for archiving expired runs")
+	}
+
+	rows, err := tx.Query(selectSQL, selectArgs...)
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to query expired runs for archiving")
+	}
+
+	var uuids []string
+	for rows.Next() {
+		var uuid string
+		if err := rows.Scan(&uuid); err != nil {
+			rows.Close()
+			tx.Rollback()
+			return 0, util.NewInternalServerError(err, "Failed to scan run UUID during archive")
+		}
+		uuids = append(uuids, uuid)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to iterate expired runs for archiving")
+	}
+
+	if len(uuids) == 0 {
+		if err := tx.Commit(); err != nil {
+			return 0, util.NewInternalServerError(err, "Failed to commit transaction for archiving expired runs")
+		}
+		return 0, nil
+	}
+
+	updateSQL, updateArgs, err := sq.
+		Update("run_details").
+		Set("StorageState", model.StorageStateArchived.ToString()).
+		Where(sq.And{
+			sq.Eq{"UUID": uuids},
+			sq.Lt{"FinishedAtInSec": archiveCutoffEpoch},
+			sq.Gt{"FinishedAtInSec": 0},
+		}).
+		ToSql()
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to build update query for archiving expired runs")
+	}
+
+	result, err := tx.Exec(updateSQL, updateArgs...)
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to archive expired runs")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, util.NewInternalServerError(err, "Failed to commit transaction for archiving expired runs")
+	}
+
+	affected, _ := result.RowsAffected()
+	return affected, nil
+}
+
+func (s *RunStore) DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize int) (int64, error) {
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+	selectSQL, selectArgs, err := sq.
+		Select("UUID").
+		From("run_details").
+		Where(sq.And{
+			sq.Eq{"StorageState": []string{
+				string(model.StorageStateArchived),
+				string(model.StorageStateArchivedV1),
+				model.LegacyStateDisabled,
+			}},
+			sq.Lt{"FinishedAtInSec": deleteCutoffEpoch},
+			sq.Gt{"FinishedAtInSec": 0},
+		}).
+		OrderBy("FinishedAtInSec ASC").
+		Limit(uint64(batchSize)).
+		ToSql()
+	if err != nil {
+		return 0, util.NewInternalServerError(err, "Failed to build query for deleting expired archived runs")
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, util.NewInternalServerError(err, "Failed to start transaction for deleting expired archived runs")
+	}
+
+	// Lock the candidate rows for the duration of the transaction so a
+	// concurrent unarchive cannot flip StorageState between this select and the
+	// deletes below, which would otherwise delete a run the user just restored.
+	lockedCandidateRows, err := tx.Query(s.db.SelectForUpdate(selectSQL), selectArgs...)
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to query expired archived runs for deletion")
+	}
+
+	var uuids []string
+	for lockedCandidateRows.Next() {
+		var uuid string
+		if scanError := lockedCandidateRows.Scan(&uuid); scanError != nil {
+			lockedCandidateRows.Close()
+			tx.Rollback()
+			return 0, util.NewInternalServerError(scanError, "Failed to scan run UUID during delete")
+		}
+		uuids = append(uuids, uuid)
+	}
+	lockedCandidateRows.Close()
+	if iterationError := lockedCandidateRows.Err(); iterationError != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(iterationError, "Failed to iterate expired archived runs for deletion")
+	}
+
+	if len(uuids) == 0 {
+		if err := tx.Commit(); err != nil {
+			return 0, util.NewInternalServerError(err, "Failed to commit transaction for deleting expired archived runs")
+		}
+		return 0, nil
+	}
+
+	// Re-verify locked rows still match all deletion predicates.
+	// Between the initial SELECT and the lock acquisition, RetryRun may have
+	// reset FinishedAtInSec to 0 (relaunching the workflow), or UnarchiveRun
+	// may have flipped StorageState back to AVAILABLE. Deleting such rows
+	// would orphan an active workflow or destroy a run the user just restored.
+	verifySQL, verifyArgs, err := sq.
+		Select("UUID").
+		From("run_details").
+		Where(sq.And{
+			sq.Eq{"UUID": uuids},
+			sq.Eq{"StorageState": []string{
+				string(model.StorageStateArchived),
+				string(model.StorageStateArchivedV1),
+				model.LegacyStateDisabled,
+			}},
+			sq.Lt{"FinishedAtInSec": deleteCutoffEpoch},
+			sq.Gt{"FinishedAtInSec": 0},
+		}).ToSql()
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to build re-verification query for deletion candidates")
+	}
+	verifyRows, err := tx.Query(verifySQL, verifyArgs...)
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to re-verify deletion candidates")
+	}
+	var verifiedUUIDs []string
+	for verifyRows.Next() {
+		var uuid string
+		if err := verifyRows.Scan(&uuid); err != nil {
+			verifyRows.Close()
+			tx.Rollback()
+			return 0, util.NewInternalServerError(err, "Failed to scan verified UUID during delete")
+		}
+		verifiedUUIDs = append(verifiedUUIDs, uuid)
+	}
+	verifyRows.Close()
+	if err := verifyRows.Err(); err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to iterate re-verified deletion candidates")
+	}
+
+	if len(verifiedUUIDs) == 0 {
+		if err := tx.Commit(); err != nil {
+			return 0, util.NewInternalServerError(err, "Failed to commit transaction after re-verification filtered all candidates")
+		}
+		return 0, nil
+	}
+	uuids = verifiedUUIDs
+
+	// Delete from dependent tables in child-first order.
+	deleteMetricsSQL, deleteMetricsArgs, err := sq.Delete("run_metrics").Where(sq.Eq{"RunUUID": uuids}).ToSql()
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to build delete query for run_metrics")
+	}
+	if _, execError := tx.Exec(deleteMetricsSQL, deleteMetricsArgs...); execError != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(execError, "Failed to delete run_metrics for expired archived runs")
+	}
+
+	deleteTasksSQL, deleteTasksArgs, err := sq.Delete("tasks").Where(sq.Eq{"RunUUID": uuids}).ToSql()
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to build delete query for tasks")
+	}
+	if _, execError := tx.Exec(deleteTasksSQL, deleteTasksArgs...); execError != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(execError, "Failed to delete tasks for expired archived runs")
+	}
+
+	deleteReferencesSQL, deleteReferencesArgs, err := sq.
+		Delete("resource_references").
+		Where(sq.And{
+			sq.Eq{"ResourceType": model.RunResourceType},
+			sq.Eq{"ResourceUUID": uuids},
+		}).ToSql()
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to build delete query for resource_references")
+	}
+	if _, execError := tx.Exec(deleteReferencesSQL, deleteReferencesArgs...); execError != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(execError, "Failed to delete resource_references for expired archived runs")
+	}
+
+	deleteRunsSQL, deleteRunsArgs, err := sq.Delete("run_details").Where(sq.Eq{"UUID": uuids}).ToSql()
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to build delete query for run_details")
+	}
+	result, err := tx.Exec(deleteRunsSQL, deleteRunsArgs...)
+	if err != nil {
+		tx.Rollback()
+		return 0, util.NewInternalServerError(err, "Failed to delete expired archived runs")
+	}
+
+	if commitError := tx.Commit(); commitError != nil {
+		return 0, util.NewInternalServerError(commitError, "Failed to commit transaction for deleting expired archived runs")
+	}
+
+	affected, _ := result.RowsAffected()
+	return affected, nil
 }
 
 // Creates a new metric in run_metrics table if does not exist.

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -116,12 +116,12 @@ type RunStoreInterface interface {
 	// Atomically claims a terminal run for retry (database-side CAS).
 	// Returns the original State, Conditions, FinishedAtInSec, and the new
 	// RetryGeneration claim token for rollback and reporter fencing.
-	ClaimRunForRetry(runId string) (originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64, err error)
+	ClaimRunForRetry(runID string) (originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64, err error)
 
 	// Restores a run's pre-retry state after a failed retry attempt.
 	// The claimGeneration must match the value returned by ClaimRunForRetry
 	// to prevent ABA rollback of a later retry.
-	RollbackRetryClaim(runId string, originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64) error
+	RollbackRetryClaim(runID string, originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64) error
 }
 
 type RunStore struct {
@@ -840,10 +840,10 @@ func (s *RunStore) DeleteRun(id string) error {
 	return nil
 }
 
-func (s *RunStore) ClaimRunForRetry(runId string) (string, string, int64, int64, error) {
+func (s *RunStore) ClaimRunForRetry(runID string) (string, string, int64, int64, error) {
 	tx, err := s.db.Begin()
 	if err != nil {
-		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to start transaction for retry claim on run %s", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to start transaction for retry claim on run %s", runID)
 	}
 
 	// Lock the row and read current state. Use sql.NullString for State
@@ -851,11 +851,11 @@ func (s *RunStore) ClaimRunForRetry(runId string) (string, string, int64, int64,
 	selectSQL, selectArgs, err := sq.
 		Select("State", "Conditions", "FinishedAtInSec", "RetryGeneration").
 		From("run_details").
-		Where(sq.Eq{"UUID": runId}).
+		Where(sq.Eq{"UUID": runID}).
 		ToSql()
 	if err != nil {
 		tx.Rollback()
-		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to build retry claim select query for run %s", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to build retry claim select query for run %s", runID)
 	}
 	row := tx.QueryRow(s.db.SelectForUpdate(selectSQL), selectArgs...)
 	var nullableState sql.NullString
@@ -864,19 +864,39 @@ func (s *RunStore) ClaimRunForRetry(runId string) (string, string, int64, int64,
 	var currentGeneration int64
 	if err := row.Scan(&nullableState, &originalConditions, &originalFinishedAtInSec, &currentGeneration); err != nil {
 		tx.Rollback()
-		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to read run %s for retry claim", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to read run %s for retry claim", runID)
 	}
 	originalState := ""
 	if nullableState.Valid {
 		originalState = nullableState.String
 	}
 
-	// Verify the row is still eligible: must not already be claimed or still pending.
-	if originalState == model.RuntimeStatePending.ToString() {
+	// Verify the locked row is still in a terminal state. Between the
+	// earlier CanRetry check and lock acquisition, another retry may have
+	// claimed the row (PENDING) or the run may have transitioned to an
+	// active state (RUNNING, PAUSED, CANCELING).
+	terminalStates := map[string]bool{
+		model.RuntimeStateSucceeded.ToString():   true,
+		model.RuntimeStateFailed.ToString():      true,
+		model.RuntimeStateSkipped.ToString():     true,
+		model.RuntimeStateCanceled.ToString():    true,
+		model.RuntimeStateSucceededV1.ToString(): true,
+		model.RuntimeStateFailedV1.ToString():    true,
+		model.RuntimeStateSkippedV1.ToString():   true,
+		model.RuntimeStateErrorV1.ToString():     true,
+		model.LegacyStateDone:                    true,
+		model.LegacyStateDisabled:                true,
+	}
+	isTerminal := terminalStates[originalState]
+	// Legacy v1 rows have State NULL/empty; derive terminal status from Conditions.
+	if !isTerminal && originalState == "" {
+		isTerminal = terminalStates[originalConditions]
+	}
+	if !isTerminal {
 		tx.Rollback()
 		return "", "", 0, 0, util.NewInternalServerError(
-			errors.New("run already claimed for retry or still pending"),
-			"Cannot claim run %s: State is PENDING", runId)
+			fmt.Errorf("run is not in a terminal state: State=%q Conditions=%q", originalState, originalConditions),
+			"Cannot claim run %s for retry: not in a terminal state", runID)
 	}
 
 	// Atomically transition to PENDING and increment RetryGeneration.
@@ -889,40 +909,40 @@ func (s *RunStore) ClaimRunForRetry(runId string) (string, string, int64, int64,
 		Set("Conditions", string(model.RuntimeStatePending.ToV1())).
 		Set("FinishedAtInSec", 0).
 		Set("RetryGeneration", newGeneration).
-		Where(sq.Eq{"UUID": runId}).
+		Where(sq.Eq{"UUID": runID}).
 		ToSql()
 	if err != nil {
 		tx.Rollback()
-		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to build retry claim query for run %s", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to build retry claim query for run %s", runID)
 	}
 	if _, err := tx.Exec(claimSQL, claimArgs...); err != nil {
 		tx.Rollback()
-		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to execute retry claim for run %s", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to execute retry claim for run %s", runID)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to commit retry claim for run %s", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to commit retry claim for run %s", runID)
 	}
 	return originalState, originalConditions, originalFinishedAtInSec, newGeneration, nil
 }
 
-func (s *RunStore) RollbackRetryClaim(runId string, originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64) error {
+func (s *RunStore) RollbackRetryClaim(runID string, originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64) error {
 	rollbackSQL, rollbackArgs, err := sq.
 		Update("run_details").
 		Set("State", originalState).
 		Set("Conditions", originalConditions).
 		Set("FinishedAtInSec", originalFinishedAtInSec).
 		Where(sq.And{
-			sq.Eq{"UUID": runId},
+			sq.Eq{"UUID": runID},
 			sq.Eq{"RetryGeneration": claimGeneration},
 		}).
 		ToSql()
 	if err != nil {
-		return util.NewInternalServerError(err, "Failed to build rollback query for run %s", runId)
+		return util.NewInternalServerError(err, "Failed to build rollback query for run %s", runID)
 	}
-	_, err = s.db.DB.Exec(rollbackSQL, rollbackArgs...)
+	_, err = s.db.Exec(rollbackSQL, rollbackArgs...)
 	if err != nil {
-		return util.NewInternalServerError(err, "Failed to rollback retry claim for run %s", runId)
+		return util.NewInternalServerError(err, "Failed to rollback retry claim for run %s", runID)
 	}
 	return nil
 }

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -114,6 +114,15 @@ var nonArchivedStorageStateStrings = []string{
 	model.LegacyStateEmpty,
 }
 
+// RetryClaimGraceSeconds bounds how long a retry claim is trusted without any
+// sign of the retried workflow. Two recovery paths key off it: the reporter
+// accepts a stale-generation terminal report past this age (resource manager),
+// and ClaimRunForRetry allows a new claim to take over an expired one, which
+// covers a crash after the claim committed but before the retried workflow was
+// created (no workflow exists, so no report can ever trigger the reporter
+// path). Variable rather than const so tests can shorten it.
+var RetryClaimGraceSeconds int64 = 600
+
 // archivedStorageStateStrings is the closed set of StorageState values that
 // StorageState.ToV2() maps to ARCHIVED.
 var archivedStorageStateStrings = []string{
@@ -910,7 +919,7 @@ func (s *RunStore) ClaimRunForRetry(runID string) (string, string, int64, int64,
 	// Lock the row and read current state. Use sql.NullString for State
 	// because legacy runs intentionally have State NULL.
 	selectSQL, selectArgs, err := sq.
-		Select("State", "Conditions", "FinishedAtInSec", "RetryGeneration").
+		Select("State", "Conditions", "FinishedAtInSec", "RetryGeneration", "RetryClaimedAtInSec").
 		From("run_details").
 		Where(sq.Eq{"UUID": runID}).
 		ToSql()
@@ -923,7 +932,8 @@ func (s *RunStore) ClaimRunForRetry(runID string) (string, string, int64, int64,
 	var originalConditions string
 	var originalFinishedAtInSec int64
 	var currentGeneration int64
-	if err := row.Scan(&nullableState, &originalConditions, &originalFinishedAtInSec, &currentGeneration); err != nil {
+	var retryClaimedAtInSec int64
+	if err := row.Scan(&nullableState, &originalConditions, &originalFinishedAtInSec, &currentGeneration, &retryClaimedAtInSec); err != nil {
 		tx.Rollback()
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", "", 0, 0, util.NewResourceNotFoundError("Run", runID)
@@ -945,10 +955,21 @@ func (s *RunStore) ClaimRunForRetry(runID string) (string, string, int64, int64,
 		isTerminal = terminalRunStateValues[originalConditions]
 	}
 	if !isTerminal {
-		tx.Rollback()
-		return "", "", 0, 0, util.NewBadRequestError(
-			fmt.Errorf("run is not in a terminal state: State=%q Conditions=%q", originalState, originalConditions),
-			"Cannot claim run %s for retry: not in a terminal state", runID)
+		// Allow a new claim to take over an expired one. A previous retry
+		// that crashed after committing its claim but before creating the
+		// workflow leaves the row PENDING with no workflow to report it;
+		// without takeover the run would be stuck forever (not terminal, so
+		// not claimable; FinishedAtInSec=0, so invisible to GC).
+		isAbandonedClaim := originalState == string(model.RuntimeStatePending) &&
+			currentGeneration > 0 &&
+			(retryClaimedAtInSec == 0 || s.time.Now().Unix()-retryClaimedAtInSec > RetryClaimGraceSeconds)
+		if !isAbandonedClaim {
+			tx.Rollback()
+			return "", "", 0, 0, util.NewBadRequestError(
+				fmt.Errorf("run is not in a terminal state: State=%q Conditions=%q", originalState, originalConditions),
+				"Cannot claim run %s for retry: not in a terminal state", runID)
+		}
+		glog.Warningf("Run %s has an abandoned retry claim (generation %d, claimed at %d); taking it over", runID, currentGeneration, retryClaimedAtInSec)
 	}
 
 	// Atomically transition to PENDING and increment RetryGeneration.
@@ -1110,29 +1131,50 @@ func (s *RunStore) DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize 
 	if batchSize <= 0 {
 		batchSize = 100
 	}
-	selectSQL, selectArgs, err := sq.
+	// Candidate selection runs as two index-aligned queries. Rows archived
+	// since ArchivedAtInSec existed are driven by idx_run_gc_archived
+	// (StorageState, ArchivedAtInSec); a single combined query would be
+	// driven by the finish-time index and, after a mass archival, would
+	// re-scan the entire old finish-time range every tick only to reject
+	// fresh archival timestamps. Legacy rows (ArchivedAtInSec=0) are driven
+	// by idx_run_gc_lifecycle (StorageState, FinishedAtInSec); that set only
+	// shrinks, so its scan cost drains to zero.
+	currentSQL, currentArgs, err := sq.
 		Select("UUID").
 		From("run_details").
 		Where(sq.And{
 			sq.Eq{"StorageState": archivedStorageStateStrings},
-			// FinishedAtInSec drives idx_run_gc_lifecycle and is a
-			// conservative lower bound: a run is never deletable less than
-			// the retention period after it finished.
+			// Observation window measured from archival time.
+			sq.Gt{"ArchivedAtInSec": 0},
+			sq.Lt{"ArchivedAtInSec": deleteCutoffEpoch},
+			// Conservative extra bound: never deletable less than the
+			// retention period after the run finished (covers runs archived
+			// while still running). Filter only; ArchivedAtInSec drives.
 			sq.Lt{"FinishedAtInSec": deleteCutoffEpoch},
 			sq.Gt{"FinishedAtInSec": 0},
-			// The observation window is measured from archival time.
+		}).
+		OrderBy("ArchivedAtInSec ASC").
+		Limit(uint64(batchSize)).
+		ToSql()
+	if err != nil {
+		return 0, util.NewInternalServerError(err, "Failed to build query for deleting expired archived runs")
+	}
+	legacySQL, legacyArgs, err := sq.
+		Select("UUID").
+		From("run_details").
+		Where(sq.And{
+			sq.Eq{"StorageState": archivedStorageStateStrings},
 			// Rows archived before ArchivedAtInSec existed carry 0 and fall
-			// back to the FinishedAtInSec bound above.
-			sq.Or{
-				sq.Eq{"ArchivedAtInSec": 0},
-				sq.Lt{"ArchivedAtInSec": deleteCutoffEpoch},
-			},
+			// back to the finish-time bound.
+			sq.Eq{"ArchivedAtInSec": 0},
+			sq.Lt{"FinishedAtInSec": deleteCutoffEpoch},
+			sq.Gt{"FinishedAtInSec": 0},
 		}).
 		OrderBy("FinishedAtInSec ASC").
 		Limit(uint64(batchSize)).
 		ToSql()
 	if err != nil {
-		return 0, util.NewInternalServerError(err, "Failed to build query for deleting expired archived runs")
+		return 0, util.NewInternalServerError(err, "Failed to build legacy query for deleting expired archived runs")
 	}
 
 	tx, err := s.db.Begin()
@@ -1143,26 +1185,34 @@ func (s *RunStore) DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize 
 	// Lock the candidate rows for the duration of the transaction so a
 	// concurrent unarchive cannot flip StorageState between this select and the
 	// deletes below, which would otherwise delete a run the user just restored.
-	lockedCandidateRows, err := tx.Query(s.db.SelectForUpdate(selectSQL), selectArgs...)
-	if err != nil {
-		tx.Rollback()
-		return 0, util.NewInternalServerError(err, "Failed to query expired archived runs for deletion")
-	}
-
 	var uuids []string
-	for lockedCandidateRows.Next() {
-		var uuid string
-		if scanError := lockedCandidateRows.Scan(&uuid); scanError != nil {
-			lockedCandidateRows.Close()
-			tx.Rollback()
-			return 0, util.NewInternalServerError(scanError, "Failed to scan run UUID during delete")
+	for _, candidateQuery := range []struct {
+		sql  string
+		args []interface{}
+	}{{currentSQL, currentArgs}, {legacySQL, legacyArgs}} {
+		if len(uuids) >= batchSize {
+			break
 		}
-		uuids = append(uuids, uuid)
-	}
-	lockedCandidateRows.Close()
-	if iterationError := lockedCandidateRows.Err(); iterationError != nil {
-		tx.Rollback()
-		return 0, util.NewInternalServerError(iterationError, "Failed to iterate expired archived runs for deletion")
+		lockedCandidateRows, err := tx.Query(s.db.SelectForUpdate(candidateQuery.sql), candidateQuery.args...)
+		if err != nil {
+			tx.Rollback()
+			return 0, util.NewInternalServerError(err, "Failed to query expired archived runs for deletion")
+		}
+		for lockedCandidateRows.Next() && len(uuids) < batchSize {
+			var uuid string
+			if scanError := lockedCandidateRows.Scan(&uuid); scanError != nil {
+				lockedCandidateRows.Close()
+				tx.Rollback()
+				return 0, util.NewInternalServerError(scanError, "Failed to scan run UUID during delete")
+			}
+			uuids = append(uuids, uuid)
+		}
+		iterationError := lockedCandidateRows.Err()
+		lockedCandidateRows.Close()
+		if iterationError != nil {
+			tx.Rollback()
+			return 0, util.NewInternalServerError(iterationError, "Failed to iterate expired archived runs for deletion")
+		}
 	}
 
 	if len(uuids) == 0 {

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -17,7 +17,6 @@ package storage
 import (
 	"database/sql"
 	"fmt"
-	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/golang/glog"
@@ -61,6 +60,7 @@ var runColumns = []string{
 	"PipelineRunContextId",
 	"RetryGeneration",
 	"RetryClaimedAtInSec",
+	"ArchivedAtInSec",
 }
 
 var runMetricsColumns = []string{
@@ -70,6 +70,56 @@ var runMetricsColumns = []string{
 	"NumberValue",
 	"Format",
 	"Payload",
+}
+
+// terminalRunStateStrings lists every raw value that a terminal run can carry
+// in the State or Conditions column across schema generations. These are raw
+// database values on purpose: RuntimeState.ToString() normalizes to v2, which
+// would collapse the v1 entries into duplicates and never match legacy rows.
+// ClaimRunForRetry and ArchiveExpiredRuns must agree on this list.
+var terminalRunStateStrings = []string{
+	string(model.RuntimeStateSucceeded),
+	string(model.RuntimeStateFailed),
+	string(model.RuntimeStateSkipped),
+	string(model.RuntimeStateCanceled),
+	string(model.RuntimeStateSucceededV1),
+	string(model.RuntimeStateFailedV1),
+	string(model.RuntimeStateSkippedV1),
+	string(model.RuntimeStateErrorV1),
+	model.LegacyStateDone,
+	model.LegacyStateDisabled,
+}
+
+var terminalRunStateValues = func() map[string]bool {
+	values := make(map[string]bool, len(terminalRunStateStrings))
+	for _, state := range terminalRunStateStrings {
+		values[state] = true
+	}
+	return values
+}()
+
+// nonArchivedStorageStateStrings is the closed set of StorageState values that
+// StorageState.ToV2() does not map to ARCHIVED. ArchiveExpiredRuns matches on
+// this positive list (plus NULL) instead of NOT IN so the query can be served
+// by the leading column of idx_run_gc_lifecycle (StorageState, FinishedAtInSec).
+var nonArchivedStorageStateStrings = []string{
+	string(model.StorageStateAvailable),
+	string(model.StorageStateAvailableV1),
+	string(model.StorageStateUnspecified),
+	string(model.StorageStateUnspecifiedV1),
+	model.LegacyStateNoStatus,
+	model.LegacyStateError,
+	model.LegacyStateEnabled,
+	model.LegacyStateReady,
+	model.LegacyStateEmpty,
+}
+
+// archivedStorageStateStrings is the closed set of StorageState values that
+// StorageState.ToV2() maps to ARCHIVED.
+var archivedStorageStateStrings = []string{
+	string(model.StorageStateArchived),
+	string(model.StorageStateArchivedV1),
+	model.LegacyStateDisabled,
 }
 
 type RunStoreInterface interface {
@@ -333,7 +383,7 @@ func (s *RunStore) scanRowsToRuns(rows *sql.Rows) ([]*model.Run, error) {
 		var uuid, experimentUUID, displayName, name, storageState, namespace, serviceAccount, conditions, description, pipelineId,
 			pipelineName, pipelineSpecManifest, workflowSpecManifest, parameters, pipelineRuntimeManifest,
 			workflowRuntimeManifest string
-		var createdAtInSec, scheduledAtInSec, finishedAtInSec, pipelineContextID, pipelineRunContextID, retryGeneration, retryClaimedAtInSec sql.NullInt64
+		var createdAtInSec, scheduledAtInSec, finishedAtInSec, pipelineContextID, pipelineRunContextID, retryGeneration, retryClaimedAtInSec, archivedAtInSec sql.NullInt64
 		var metricsInString, resourceReferencesInString, tasksInString, runtimeParameters, pipelineRoot, jobID, state, stateHistory, pluginsInput, pluginsOutput, pipelineVersionID sql.NullString
 		err := rows.Scan(
 			&uuid,
@@ -367,6 +417,7 @@ func (s *RunStore) scanRowsToRuns(rows *sql.Rows) ([]*model.Run, error) {
 			&pipelineRunContextID,
 			&retryGeneration,
 			&retryClaimedAtInSec,
+			&archivedAtInSec,
 			&resourceReferencesInString,
 			&tasksInString,
 			&metricsInString,
@@ -437,6 +488,7 @@ func (s *RunStore) scanRowsToRuns(rows *sql.Rows) ([]*model.Run, error) {
 				PipelineRunContextId:    pipelineRunContextID.Int64,
 				RetryGeneration:         retryGeneration.Int64,
 				RetryClaimedAtInSec:     retryClaimedAtInSec.Int64,
+				ArchivedAtInSec:         archivedAtInSec.Int64,
 				TaskDetails:             tasks,
 				StateHistory:            stateHistoryNew,
 			},
@@ -739,7 +791,8 @@ func (s *RunStore) ArchiveRun(runId string) error {
 	sql, args, err := sq.
 		Update("run_details").
 		SetMap(sq.Eq{
-			"StorageState": model.StorageStateArchived.ToString(),
+			"StorageState":    model.StorageStateArchived.ToString(),
+			"ArchivedAtInSec": s.time.Now().Unix(),
 		}).
 		Where(sq.Eq{"UUID": runId}).
 		ToSql()
@@ -761,7 +814,8 @@ func (s *RunStore) UnarchiveRun(runId string) error {
 	sql, args, err := sq.
 		Update("run_details").
 		SetMap(sq.Eq{
-			"StorageState": model.StorageStateAvailable.ToString(),
+			"StorageState":    model.StorageStateAvailable.ToString(),
+			"ArchivedAtInSec": 0,
 		}).
 		Where(sq.Eq{"UUID": runId}).
 		ToSql()
@@ -871,6 +925,9 @@ func (s *RunStore) ClaimRunForRetry(runID string) (string, string, int64, int64,
 	var currentGeneration int64
 	if err := row.Scan(&nullableState, &originalConditions, &originalFinishedAtInSec, &currentGeneration); err != nil {
 		tx.Rollback()
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", "", 0, 0, util.NewResourceNotFoundError("Run", runID)
+		}
 		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to read run %s for retry claim", runID)
 	}
 	originalState := ""
@@ -882,26 +939,14 @@ func (s *RunStore) ClaimRunForRetry(runID string) (string, string, int64, int64,
 	// earlier CanRetry check and lock acquisition, another retry may have
 	// claimed the row (PENDING) or the run may have transitioned to an
 	// active state (RUNNING, PAUSED, CANCELING).
-	terminalStates := map[string]bool{
-		model.RuntimeStateSucceeded.ToString():   true,
-		model.RuntimeStateFailed.ToString():      true,
-		model.RuntimeStateSkipped.ToString():     true,
-		model.RuntimeStateCanceled.ToString():    true,
-		model.RuntimeStateSucceededV1.ToString(): true,
-		model.RuntimeStateFailedV1.ToString():    true,
-		model.RuntimeStateSkippedV1.ToString():   true,
-		model.RuntimeStateErrorV1.ToString():     true,
-		model.LegacyStateDone:                    true,
-		model.LegacyStateDisabled:                true,
-	}
-	isTerminal := terminalStates[originalState]
+	isTerminal := terminalRunStateValues[originalState]
 	// Legacy v1 rows have State NULL/empty; derive terminal status from Conditions.
 	if !isTerminal && originalState == "" {
-		isTerminal = terminalStates[originalConditions]
+		isTerminal = terminalRunStateValues[originalConditions]
 	}
 	if !isTerminal {
 		tx.Rollback()
-		return "", "", 0, 0, util.NewInternalServerError(
+		return "", "", 0, 0, util.NewBadRequestError(
 			fmt.Errorf("run is not in a terminal state: State=%q Conditions=%q", originalState, originalConditions),
 			"Cannot claim run %s for retry: not in a terminal state", runID)
 	}
@@ -916,7 +961,7 @@ func (s *RunStore) ClaimRunForRetry(runID string) (string, string, int64, int64,
 		Set("Conditions", string(model.RuntimeStatePending.ToV1())).
 		Set("FinishedAtInSec", 0).
 		Set("RetryGeneration", newGeneration).
-		Set("RetryClaimedAtInSec", time.Now().Unix()).
+		Set("RetryClaimedAtInSec", s.time.Now().Unix()).
 		Where(sq.Eq{"UUID": runID}).
 		ToSql()
 	if err != nil {
@@ -940,6 +985,9 @@ func (s *RunStore) RollbackRetryClaim(runID string, originalState string, origin
 		Set("State", originalState).
 		Set("Conditions", originalConditions).
 		Set("FinishedAtInSec", originalFinishedAtInSec).
+		// Clear the claim timestamp so the reporter's orphaned-claim
+		// recovery does not treat this restored terminal row as claimed.
+		Set("RetryClaimedAtInSec", 0).
 		Where(sq.And{
 			sq.Eq{"UUID": runID},
 			sq.Eq{"RetryGeneration": claimGeneration},
@@ -967,41 +1015,21 @@ func (s *RunStore) ArchiveExpiredRuns(archiveCutoffEpoch int64, batchSize int) (
 			// for legacy v1 rows where State is NULL/empty (ToV2() derives
 			// State from Conditions at read time but does not backfill the DB).
 			sq.Or{
-				sq.Eq{"State": []string{
-					string(model.RuntimeStateSucceeded),
-					string(model.RuntimeStateFailed),
-					string(model.RuntimeStateSkipped),
-					string(model.RuntimeStateCanceled),
-					string(model.RuntimeStateSucceededV1),
-					string(model.RuntimeStateFailedV1),
-					string(model.RuntimeStateSkippedV1),
-					string(model.RuntimeStateErrorV1),
-					model.LegacyStateDone,
-					model.LegacyStateDisabled,
-				}},
+				sq.Eq{"State": terminalRunStateStrings},
 				sq.And{
 					sq.Or{sq.Eq{"State": ""}, sq.Expr("State IS NULL")},
-					sq.Eq{"Conditions": []string{
-						string(model.RuntimeStateSucceeded),
-						string(model.RuntimeStateFailed),
-						string(model.RuntimeStateSkipped),
-						string(model.RuntimeStateCanceled),
-						string(model.RuntimeStateSucceededV1),
-						string(model.RuntimeStateFailedV1),
-						string(model.RuntimeStateSkippedV1),
-						string(model.RuntimeStateErrorV1),
-						model.LegacyStateDone,
-						model.LegacyStateDisabled,
-					}},
+					sq.Eq{"Conditions": terminalRunStateStrings},
 				},
 			},
 			sq.Lt{"FinishedAtInSec": archiveCutoffEpoch},
 			sq.Gt{"FinishedAtInSec": 0},
-			sq.NotEq{"StorageState": []string{
-				string(model.StorageStateArchived),
-				string(model.StorageStateArchivedV1),
-				model.LegacyStateDisabled,
-			}},
+			// Positive match on the closed set of non-archived storage states
+			// (plus NULL for legacy rows) so idx_run_gc_lifecycle's leading
+			// StorageState column can serve this query; NOT IN cannot use it.
+			sq.Or{
+				sq.Eq{"StorageState": nonArchivedStorageStateStrings},
+				sq.Expr("StorageState IS NULL"),
+			},
 		}).
 		OrderBy("FinishedAtInSec ASC").
 		Limit(uint64(batchSize)).
@@ -1047,6 +1075,9 @@ func (s *RunStore) ArchiveExpiredRuns(archiveCutoffEpoch int64, batchSize int) (
 	updateSQL, updateArgs, err := sq.
 		Update("run_details").
 		Set("StorageState", model.StorageStateArchived.ToString()).
+		// Start the archived-run observation window at archival time; the
+		// delete pass measures ARCHIVED_RUNS_RETENTION_TIME from this value.
+		Set("ArchivedAtInSec", s.time.Now().Unix()).
 		Where(sq.And{
 			sq.Eq{"UUID": uuids},
 			sq.Lt{"FinishedAtInSec": archiveCutoffEpoch},
@@ -1068,7 +1099,10 @@ func (s *RunStore) ArchiveExpiredRuns(archiveCutoffEpoch int64, batchSize int) (
 		return 0, util.NewInternalServerError(err, "Failed to commit transaction for archiving expired runs")
 	}
 
-	affected, _ := result.RowsAffected()
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, util.NewInternalServerError(err, "Failed to read affected row count after archiving expired runs")
+	}
 	return affected, nil
 }
 
@@ -1080,13 +1114,19 @@ func (s *RunStore) DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize 
 		Select("UUID").
 		From("run_details").
 		Where(sq.And{
-			sq.Eq{"StorageState": []string{
-				string(model.StorageStateArchived),
-				string(model.StorageStateArchivedV1),
-				model.LegacyStateDisabled,
-			}},
+			sq.Eq{"StorageState": archivedStorageStateStrings},
+			// FinishedAtInSec drives idx_run_gc_lifecycle and is a
+			// conservative lower bound: a run is never deletable less than
+			// the retention period after it finished.
 			sq.Lt{"FinishedAtInSec": deleteCutoffEpoch},
 			sq.Gt{"FinishedAtInSec": 0},
+			// The observation window is measured from archival time.
+			// Rows archived before ArchivedAtInSec existed carry 0 and fall
+			// back to the FinishedAtInSec bound above.
+			sq.Or{
+				sq.Eq{"ArchivedAtInSec": 0},
+				sq.Lt{"ArchivedAtInSec": deleteCutoffEpoch},
+			},
 		}).
 		OrderBy("FinishedAtInSec ASC").
 		Limit(uint64(batchSize)).
@@ -1142,13 +1182,13 @@ func (s *RunStore) DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize 
 		From("run_details").
 		Where(sq.And{
 			sq.Eq{"UUID": uuids},
-			sq.Eq{"StorageState": []string{
-				string(model.StorageStateArchived),
-				string(model.StorageStateArchivedV1),
-				model.LegacyStateDisabled,
-			}},
+			sq.Eq{"StorageState": archivedStorageStateStrings},
 			sq.Lt{"FinishedAtInSec": deleteCutoffEpoch},
 			sq.Gt{"FinishedAtInSec": 0},
+			sq.Or{
+				sq.Eq{"ArchivedAtInSec": 0},
+				sq.Lt{"ArchivedAtInSec": deleteCutoffEpoch},
+			},
 		}).ToSql()
 	if err != nil {
 		tx.Rollback()
@@ -1234,7 +1274,10 @@ func (s *RunStore) DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize 
 		return 0, util.NewInternalServerError(commitError, "Failed to commit transaction for deleting expired archived runs")
 	}
 
-	affected, _ := result.RowsAffected()
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, util.NewInternalServerError(err, "Failed to read affected row count after deleting expired archived runs")
+	}
 	return affected, nil
 }
 

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -114,11 +114,14 @@ type RunStoreInterface interface {
 	DeleteExpiredArchivedRuns(deleteCutoffEpoch int64, batchSize int) (int64, error)
 
 	// Atomically claims a terminal run for retry (database-side CAS).
-	// Returns the original State, Conditions, and FinishedAtInSec for rollback.
-	ClaimRunForRetry(runId string) (originalState string, originalConditions string, originalFinishedAtInSec int64, err error)
+	// Returns the original State, Conditions, FinishedAtInSec, and the new
+	// RetryGeneration claim token for rollback and reporter fencing.
+	ClaimRunForRetry(runId string) (originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64, err error)
 
 	// Restores a run's pre-retry state after a failed retry attempt.
-	RollbackRetryClaim(runId string, originalState string, originalConditions string, originalFinishedAtInSec int64) error
+	// The claimGeneration must match the value returned by ClaimRunForRetry
+	// to prevent ABA rollback of a later retry.
+	RollbackRetryClaim(runId string, originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64) error
 }
 
 type RunStore struct {
@@ -653,10 +656,16 @@ func (s *RunStore) UpdateRun(run *model.Run) error {
 	if run.PluginsOutputString != nil {
 		updateFields["PluginsOutput"] = largeTextToNullableSQL(run.PluginsOutputString)
 	}
+	// Include RetryGeneration in the WHERE clause so that a stale workflow
+	// reporter that passed workflowStillMatchesReportedVersion before a
+	// ClaimRunForRetry increment cannot overwrite the claimed row.
 	sql, args, err := sq.
 		Update("run_details").
 		SetMap(updateFields).
-		Where(sq.Eq{"UUID": run.UUID}).
+		Where(sq.And{
+			sq.Eq{"UUID": run.UUID},
+			sq.Eq{"RetryGeneration": run.RetryGeneration},
+		}).
 		ToSql()
 	if err != nil {
 		tx.Rollback()
@@ -831,62 +840,73 @@ func (s *RunStore) DeleteRun(id string) error {
 	return nil
 }
 
-func (s *RunStore) ClaimRunForRetry(runId string) (string, string, int64, error) {
+func (s *RunStore) ClaimRunForRetry(runId string) (string, string, int64, int64, error) {
 	tx, err := s.db.Begin()
 	if err != nil {
-		return "", "", 0, util.NewInternalServerError(err, "Failed to start transaction for retry claim on run %s", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to start transaction for retry claim on run %s", runId)
 	}
 
-	// Lock the row and read current state.
+	// Lock the row and read current state. Use sql.NullString for State
+	// because legacy runs intentionally have State NULL.
 	selectSQL, selectArgs, err := sq.
-		Select("State", "Conditions", "FinishedAtInSec").
+		Select("State", "Conditions", "FinishedAtInSec", "RetryGeneration").
 		From("run_details").
 		Where(sq.Eq{"UUID": runId}).
 		ToSql()
 	if err != nil {
 		tx.Rollback()
-		return "", "", 0, util.NewInternalServerError(err, "Failed to build retry claim select query for run %s", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to build retry claim select query for run %s", runId)
 	}
 	row := tx.QueryRow(s.db.SelectForUpdate(selectSQL), selectArgs...)
-	var originalState, originalConditions string
+	var nullableState sql.NullString
+	var originalConditions string
 	var originalFinishedAtInSec int64
-	if err := row.Scan(&originalState, &originalConditions, &originalFinishedAtInSec); err != nil {
+	var currentGeneration int64
+	if err := row.Scan(&nullableState, &originalConditions, &originalFinishedAtInSec, &currentGeneration); err != nil {
 		tx.Rollback()
-		return "", "", 0, util.NewInternalServerError(err, "Failed to read run %s for retry claim", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to read run %s for retry claim", runId)
+	}
+	originalState := ""
+	if nullableState.Valid {
+		originalState = nullableState.String
 	}
 
-	// Verify the row is still eligible: must be terminal with a positive finish time.
-	if originalFinishedAtInSec == 0 {
+	// Verify the row is still eligible: must not already be claimed or still pending.
+	if originalState == model.RuntimeStatePending.ToString() {
 		tx.Rollback()
-		return "", "", 0, util.NewInternalServerError(
-			errors.New("run already claimed for retry or still running"),
-			"Cannot claim run %s: FinishedAtInSec is 0", runId)
+		return "", "", 0, 0, util.NewInternalServerError(
+			errors.New("run already claimed for retry or still pending"),
+			"Cannot claim run %s: State is PENDING", runId)
 	}
 
-	// Atomically transition to PENDING.
+	// Atomically transition to PENDING and increment RetryGeneration.
+	// The new generation acts as a unique claim token that fences stale
+	// workflow reporters and prevents ABA rollback.
+	newGeneration := currentGeneration + 1
 	claimSQL, claimArgs, err := sq.
 		Update("run_details").
 		Set("State", model.RuntimeStatePending.ToString()).
 		Set("Conditions", string(model.RuntimeStatePending.ToV1())).
 		Set("FinishedAtInSec", 0).
+		Set("RetryGeneration", newGeneration).
 		Where(sq.Eq{"UUID": runId}).
 		ToSql()
 	if err != nil {
 		tx.Rollback()
-		return "", "", 0, util.NewInternalServerError(err, "Failed to build retry claim query for run %s", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to build retry claim query for run %s", runId)
 	}
 	if _, err := tx.Exec(claimSQL, claimArgs...); err != nil {
 		tx.Rollback()
-		return "", "", 0, util.NewInternalServerError(err, "Failed to execute retry claim for run %s", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to execute retry claim for run %s", runId)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return "", "", 0, util.NewInternalServerError(err, "Failed to commit retry claim for run %s", runId)
+		return "", "", 0, 0, util.NewInternalServerError(err, "Failed to commit retry claim for run %s", runId)
 	}
-	return originalState, originalConditions, originalFinishedAtInSec, nil
+	return originalState, originalConditions, originalFinishedAtInSec, newGeneration, nil
 }
 
-func (s *RunStore) RollbackRetryClaim(runId string, originalState string, originalConditions string, originalFinishedAtInSec int64) error {
+func (s *RunStore) RollbackRetryClaim(runId string, originalState string, originalConditions string, originalFinishedAtInSec int64, claimGeneration int64) error {
 	rollbackSQL, rollbackArgs, err := sq.
 		Update("run_details").
 		Set("State", originalState).
@@ -894,7 +914,7 @@ func (s *RunStore) RollbackRetryClaim(runId string, originalState string, origin
 		Set("FinishedAtInSec", originalFinishedAtInSec).
 		Where(sq.And{
 			sq.Eq{"UUID": runId},
-			sq.Eq{"FinishedAtInSec": 0},
+			sq.Eq{"RetryGeneration": claimGeneration},
 		}).
 		ToSql()
 	if err != nil {

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -1436,6 +1436,75 @@ func TestDeleteRun_InternalError(t *testing.T) {
 		"Expected delete run to return internal error")
 }
 
+func TestDeleteRun_CleansUpTasksAndMetrics(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+	taskStore := NewTaskStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpIdTwo, nil))
+
+	run := &model.Run{
+		UUID:         defaultFakeRunId,
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run1",
+		DisplayName:  "run1",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 100,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      "Succeeded",
+		},
+	}
+	runStore.CreateRun(run)
+
+	runStore.CreateMetric(&model.RunMetric{
+		RunUUID:     defaultFakeRunId,
+		NodeID:      "node1",
+		Name:        "accuracy",
+		NumberValue: 0.95,
+		Format:      "RAW",
+	})
+
+	taskStore.CreateTask(&model.Task{
+		Namespace:    "ns1",
+		PipelineName: "pipeline1",
+		RunID:        defaultFakeRunId,
+		PodName:      "pod1",
+		State:        model.RuntimeStateSucceeded,
+	})
+
+	// Verify rows exist before deletion.
+	var metricCount int
+	err := db.QueryRow("SELECT COUNT(*) FROM run_metrics WHERE RunUUID = ?", defaultFakeRunId).Scan(&metricCount)
+	require.Nil(t, err)
+	assert.Equal(t, 1, metricCount)
+
+	var taskCount int
+	err = db.QueryRow("SELECT COUNT(*) FROM tasks WHERE RunUUID = ?", defaultFakeRunId).Scan(&taskCount)
+	require.Nil(t, err)
+	assert.Equal(t, 1, taskCount)
+
+	// Delete the run.
+	err = runStore.DeleteRun(defaultFakeRunId)
+	assert.Nil(t, err)
+
+	// Verify all dependent rows are gone.
+	err = db.QueryRow("SELECT COUNT(*) FROM run_metrics WHERE RunUUID = ?", defaultFakeRunId).Scan(&metricCount)
+	require.Nil(t, err)
+	assert.Equal(t, 0, metricCount)
+
+	err = db.QueryRow("SELECT COUNT(*) FROM tasks WHERE RunUUID = ?", defaultFakeRunId).Scan(&taskCount)
+	require.Nil(t, err)
+	assert.Equal(t, 0, taskCount)
+
+	_, err = runStore.GetRun(defaultFakeRunId)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
 func TestParseMetrics(t *testing.T) {
 	expectedModelRunMetrics := []*model.RunMetric{
 		{
@@ -1816,4 +1885,367 @@ func TestListRunsReturnsPluginsFields(t *testing.T) {
 	assert.Equal(t, model.LargeText(`{"mlflow":{"experiment_name":"list-exp"}}`), *runs[0].PluginsInputString)
 	require.NotNil(t, runs[0].PluginsOutputString)
 	assert.Equal(t, model.LargeText(`{"mlflow":{"state":"PLUGIN_RUNNING"}}`), *runs[0].PluginsOutputString)
+}
+
+func TestArchiveExpiredRuns_ArchivesTerminalRunsPastCutoff(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	// Run that finished 100 seconds ago (epoch=100) with terminal state SUCCEEDED.
+	succeededRun := &model.Run{
+		UUID:         "run-succeeded",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-succeeded",
+		DisplayName:  "run-succeeded",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 100,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      "Succeeded",
+		},
+	}
+	// Run that finished 200 seconds ago with terminal state FAILED.
+	failedRun := &model.Run{
+		UUID:         "run-failed",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-failed",
+		DisplayName:  "run-failed",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 200,
+			State:           model.RuntimeStateFailed,
+			Conditions:      "Failed",
+		},
+	}
+	// Run that is still RUNNING — should NOT be archived.
+	runningRun := &model.Run{
+		UUID:         "run-running",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-running",
+		DisplayName:  "run-running",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec: 1,
+			State:          model.RuntimeStateRunning,
+			Conditions:     "Running",
+		},
+	}
+
+	runStore.CreateRun(succeededRun)
+	runStore.CreateRun(failedRun)
+	runStore.CreateRun(runningRun)
+
+	// Cutoff at epoch 300 — both terminal runs finished before 300.
+	archived, err := runStore.ArchiveExpiredRuns(300, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(2), archived)
+
+	// Verify the two terminal runs are now ARCHIVED.
+	run, err := runStore.GetRun("run-succeeded")
+	assert.Nil(t, err)
+	assert.Equal(t, model.StorageStateArchived, run.StorageState)
+
+	run, err = runStore.GetRun("run-failed")
+	assert.Nil(t, err)
+	assert.Equal(t, model.StorageStateArchived, run.StorageState)
+
+	// Verify the running run is still AVAILABLE.
+	run, err = runStore.GetRun("run-running")
+	assert.Nil(t, err)
+	assert.Equal(t, model.StorageStateAvailable, run.StorageState)
+}
+
+func TestArchiveExpiredRuns_NoCandidates(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	// Run that finished AFTER the cutoff — should NOT be archived.
+	recentRun := &model.Run{
+		UUID:         "run-recent",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-recent",
+		DisplayName:  "run-recent",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 500,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      "Succeeded",
+		},
+	}
+	runStore.CreateRun(recentRun)
+
+	// Cutoff at epoch 300 — run finished at 500 so it's not expired.
+	archived, err := runStore.ArchiveExpiredRuns(300, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), archived)
+
+	run, err := runStore.GetRun("run-recent")
+	assert.Nil(t, err)
+	assert.Equal(t, model.StorageStateAvailable, run.StorageState)
+}
+
+func TestArchiveExpiredRuns_RespectsAlreadyArchived(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	// Already archived run — should NOT be re-archived (no-op).
+	archivedRun := &model.Run{
+		UUID:         "run-already-archived",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-already-archived",
+		DisplayName:  "run-already-archived",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateArchived,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 100,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      "Succeeded",
+		},
+	}
+	runStore.CreateRun(archivedRun)
+
+	archived, err := runStore.ArchiveExpiredRuns(300, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), archived)
+}
+
+func TestArchiveExpiredRuns_BatchSizeLimitsResults(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	// Create 3 expired terminal runs.
+	for i := 1; i <= 3; i++ {
+		runStore.CreateRun(&model.Run{
+			UUID:         fmt.Sprintf("run-batch-%d", i),
+			ExperimentId: defaultFakeExpId,
+			K8SName:      fmt.Sprintf("run-batch-%d", i),
+			DisplayName:  fmt.Sprintf("run-batch-%d", i),
+			Namespace:    "ns1",
+			StorageState: model.StorageStateAvailable,
+			RunDetails: model.RunDetails{
+				CreatedAtInSec:  1,
+				FinishedAtInSec: int64(i * 10),
+				State:           model.RuntimeStateSucceeded,
+				Conditions:      "Succeeded",
+			},
+		})
+	}
+
+	// Batch size 2 — only 2 should be archived.
+	archived, err := runStore.ArchiveExpiredRuns(300, 2)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(2), archived)
+}
+
+func TestDeleteExpiredArchivedRuns_DeletesArchivedRunsAndDependentTables(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+	taskStore := NewTaskStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpIdTwo, nil))
+
+	// Create an archived run that finished in the past.
+	archivedRun := &model.Run{
+		UUID:         "run-to-delete",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-to-delete",
+		DisplayName:  "run-to-delete",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateArchived,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 100,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      "Succeeded",
+		},
+	}
+	runStore.CreateRun(archivedRun)
+
+	// Seed run_metrics.
+	runStore.CreateMetric(&model.RunMetric{
+		RunUUID:     "run-to-delete",
+		NodeID:      "node1",
+		Name:        "accuracy",
+		NumberValue: 0.95,
+		Format:      "RAW",
+	})
+
+	// Seed a task row.
+	taskStore.CreateTask(&model.Task{
+		Namespace:    "ns1",
+		PipelineName: "pipeline1",
+		RunID:        "run-to-delete",
+		PodName:      "pod1",
+		State:        model.RuntimeStateSucceeded,
+	})
+
+	// Also create a run that should NOT be deleted (available, not archived).
+	survivorRun := &model.Run{
+		UUID:         "run-survivor",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-survivor",
+		DisplayName:  "run-survivor",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 100,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      "Succeeded",
+		},
+	}
+	runStore.CreateRun(survivorRun)
+
+	// Delete archived runs with cutoff at 300.
+	deleted, err := runStore.DeleteExpiredArchivedRuns(300, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), deleted)
+
+	// Verify the archived run is deleted.
+	_, err = runStore.GetRun("run-to-delete")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// Verify the survivor run still exists.
+	run, err := runStore.GetRun("run-survivor")
+	assert.Nil(t, err)
+	assert.Equal(t, "run-survivor", run.UUID)
+
+	// Verify task rows for the deleted run are gone.
+	var taskCount int
+	row := db.QueryRow("SELECT COUNT(*) FROM tasks WHERE RunUUID = ?", "run-to-delete")
+	err = row.Scan(&taskCount)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, taskCount)
+
+	// Verify run_metrics rows for the deleted run are gone.
+	var metricCount int
+	row = db.QueryRow("SELECT COUNT(*) FROM run_metrics WHERE RunUUID = ?", "run-to-delete")
+	err = row.Scan(&metricCount)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, metricCount)
+}
+
+func TestDeleteExpiredArchivedRuns_NoCandidates(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	// Create an available (non-archived) run — should not be deleted.
+	runStore.CreateRun(&model.Run{
+		UUID:         "run-available",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-available",
+		DisplayName:  "run-available",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 100,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      "Succeeded",
+		},
+	})
+
+	deleted, err := runStore.DeleteExpiredArchivedRuns(300, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), deleted)
+
+	// Verify run still exists.
+	run, err := runStore.GetRun("run-available")
+	assert.Nil(t, err)
+	assert.Equal(t, "run-available", run.UUID)
+}
+
+func TestDeleteExpiredArchivedRuns_DoesNotDeleteRecentArchived(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	// Archived run that finished AFTER the cutoff.
+	runStore.CreateRun(&model.Run{
+		UUID:         "run-recent-archived",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-recent-archived",
+		DisplayName:  "run-recent-archived",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateArchived,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 500,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      "Succeeded",
+		},
+	})
+
+	// Cutoff at 300 — run finished at 500, so it's not expired yet.
+	deleted, err := runStore.DeleteExpiredArchivedRuns(300, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), deleted)
+
+	run, err := runStore.GetRun("run-recent-archived")
+	assert.Nil(t, err)
+	assert.Equal(t, model.StorageStateArchived, run.StorageState)
+}
+
+func TestDeleteExpiredArchivedRuns_IncludesLegacyDisabledState(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	// Create with a valid state first (CreateRun validates StorageState).
+	runStore.CreateRun(&model.Run{
+		UUID:         "run-legacy-disabled",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-legacy-disabled",
+		DisplayName:  "run-legacy-disabled",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateArchived,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 100,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      "Succeeded",
+		},
+	})
+
+	// Simulate legacy v1 row by raw-updating StorageState to "DISABLED".
+	_, err := db.Exec(`UPDATE run_details SET StorageState = ? WHERE UUID = ?`, model.LegacyStateDisabled, "run-legacy-disabled")
+	require.Nil(t, err)
+
+	// Cutoff at 200 — run finished at 100, so it is expired.
+	deleted, err := runStore.DeleteExpiredArchivedRuns(200, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), deleted)
+
+	_, err = runStore.GetRun("run-legacy-disabled")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -1366,6 +1366,7 @@ func TestArchiveRun_IncludedInRunList(t *testing.T) {
 
 			RunDetails: model.RunDetails{
 				CreatedAtInSec:          1,
+				ArchivedAtInSec:         4,
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
@@ -2302,4 +2303,176 @@ func TestClaimRunForRetry_GetRunReadsRetryGeneration(t *testing.T) {
 	require.Nil(t, getErr2)
 	assert.Equal(t, model.RuntimeStateRunning, updated.State)
 	assert.Equal(t, "wf2", string(updated.WorkflowRuntimeManifest))
+}
+
+// Regression: terminal-state matching must use raw legacy strings. ToString()
+// normalizes to v2 ("Failed" -> "FAILED"), which made the Conditions fallback
+// dead code and broke retry for legacy v1 rows with State NULL.
+func TestClaimRunForRetry_LegacyConditionsRow(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	_, err := runStore.CreateRun(&model.Run{
+		UUID:         "run-legacy-conditions",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-legacy-conditions",
+		DisplayName:  "run-legacy-conditions",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:          1,
+			FinishedAtInSec:         100,
+			State:                   model.RuntimeStateFailed,
+			Conditions:              string(model.RuntimeStateFailedV1),
+			WorkflowRuntimeManifest: "wf1",
+		},
+	})
+	require.Nil(t, err)
+
+	// Simulate a legacy v1 row: State NULL, terminal status only in Conditions.
+	_, err = db.Exec(`UPDATE run_details SET State = NULL WHERE UUID = ?`, "run-legacy-conditions")
+	require.Nil(t, err)
+
+	originalState, originalConditions, originalFinishedAt, claimGeneration, claimErr := runStore.ClaimRunForRetry("run-legacy-conditions")
+	require.Nil(t, claimErr, "legacy v1 terminal rows must be claimable for retry")
+	assert.Equal(t, "", originalState)
+	assert.Equal(t, string(model.RuntimeStateFailedV1), originalConditions)
+	assert.Equal(t, int64(100), originalFinishedAt)
+	assert.Equal(t, int64(1), claimGeneration)
+}
+
+// Regression: RollbackRetryClaim must clear RetryClaimedAtInSec. Leaving it
+// set made the reporter's orphaned-claim handling treat the restored terminal
+// row as a live claim.
+func TestRollbackRetryClaim_ClearsClaimTimestamp(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	_, err := runStore.CreateRun(&model.Run{
+		UUID:         "run-rollback-claim",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-rollback-claim",
+		DisplayName:  "run-rollback-claim",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:          1,
+			FinishedAtInSec:         100,
+			State:                   model.RuntimeStateFailed,
+			Conditions:              string(model.RuntimeStateFailedV1),
+			WorkflowRuntimeManifest: "wf1",
+		},
+	})
+	require.Nil(t, err)
+
+	originalState, originalConditions, originalFinishedAt, claimGeneration, claimErr := runStore.ClaimRunForRetry("run-rollback-claim")
+	require.Nil(t, claimErr)
+
+	claimed, err := runStore.GetRun("run-rollback-claim")
+	require.Nil(t, err)
+	require.True(t, claimed.RetryClaimedAtInSec > 0)
+
+	require.Nil(t, runStore.RollbackRetryClaim("run-rollback-claim", originalState, originalConditions, originalFinishedAt, claimGeneration))
+
+	restored, err := runStore.GetRun("run-rollback-claim")
+	require.Nil(t, err)
+	assert.Equal(t, model.RuntimeStateFailed, restored.State)
+	assert.Equal(t, int64(100), restored.FinishedAtInSec)
+	assert.Equal(t, int64(0), restored.RetryClaimedAtInSec, "rollback must clear the claim timestamp")
+	assert.Equal(t, claimGeneration, restored.RetryGeneration, "generation must stay monotonic across rollback")
+}
+
+func TestClaimRunForRetry_RunNotFound(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	_, _, _, _, err := runStore.ClaimRunForRetry("no-such-run")
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// The delete pass measures the observation window from ArchivedAtInSec: a run
+// archived recently must survive even when it finished long before the cutoff.
+// Rows archived before the column existed (ArchivedAtInSec=0) fall back to the
+// FinishedAtInSec bound.
+func TestDeleteExpiredArchivedRuns_HonorsArchivalWindow(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	_, err := runStore.CreateRun(&model.Run{
+		UUID:         "run-recently-archived",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-recently-archived",
+		DisplayName:  "run-recently-archived",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateArchived,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 100,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      string(model.RuntimeStateSucceededV1),
+		},
+	})
+	require.Nil(t, err)
+
+	// Archived after the cutoff: must not be deleted despite the old finish time.
+	_, err = db.Exec(`UPDATE run_details SET ArchivedAtInSec = ? WHERE UUID = ?`, 1000, "run-recently-archived")
+	require.Nil(t, err)
+
+	deleted, err := runStore.DeleteExpiredArchivedRuns(200, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), deleted, "run archived after the cutoff must be kept for its observation window")
+
+	// Archived before the cutoff: now eligible.
+	_, err = db.Exec(`UPDATE run_details SET ArchivedAtInSec = ? WHERE UUID = ?`, 150, "run-recently-archived")
+	require.Nil(t, err)
+
+	deleted, err = runStore.DeleteExpiredArchivedRuns(200, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), deleted)
+}
+
+// The archive pass must stamp ArchivedAtInSec so the delete pass can measure
+// the observation window from archival time.
+func TestArchiveExpiredRuns_SetsArchivedAt(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	_, err := runStore.CreateRun(&model.Run{
+		UUID:         "run-archive-stamp",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-archive-stamp",
+		DisplayName:  "run-archive-stamp",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:  1,
+			FinishedAtInSec: 100,
+			State:           model.RuntimeStateSucceeded,
+			Conditions:      string(model.RuntimeStateSucceededV1),
+		},
+	})
+	require.Nil(t, err)
+
+	archived, err := runStore.ArchiveExpiredRuns(200, 100)
+	assert.Nil(t, err)
+	require.Equal(t, int64(1), archived)
+
+	run, err := runStore.GetRun("run-archive-stamp")
+	require.Nil(t, err)
+	assert.Equal(t, model.StorageStateArchived, run.StorageState)
+	assert.True(t, run.ArchivedAtInSec > 0, "archive pass must stamp ArchivedAtInSec")
 }

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -2281,7 +2281,7 @@ func TestClaimRunForRetry_GetRunReadsRetryGeneration(t *testing.T) {
 	require.Nil(t, err)
 
 	// Claim the run for retry. This bumps RetryGeneration to 1 in the DB.
-	_, _, _, claimGeneration, claimErr := runStore.ClaimRunForRetry("run-retry-gen")
+	_, _, _, claimGeneration, claimErr := runStore.ClaimRunForRetry("run-retry-gen", false)
 	require.Nil(t, claimErr)
 	assert.Equal(t, int64(1), claimGeneration)
 
@@ -2336,7 +2336,7 @@ func TestClaimRunForRetry_LegacyConditionsRow(t *testing.T) {
 	_, err = db.Exec(`UPDATE run_details SET State = NULL WHERE UUID = ?`, "run-legacy-conditions")
 	require.Nil(t, err)
 
-	originalState, originalConditions, originalFinishedAt, claimGeneration, claimErr := runStore.ClaimRunForRetry("run-legacy-conditions")
+	originalState, originalConditions, originalFinishedAt, claimGeneration, claimErr := runStore.ClaimRunForRetry("run-legacy-conditions", false)
 	require.Nil(t, claimErr, "legacy v1 terminal rows must be claimable for retry")
 	assert.Equal(t, "", originalState)
 	assert.Equal(t, string(model.RuntimeStateFailedV1), originalConditions)
@@ -2371,7 +2371,7 @@ func TestRollbackRetryClaim_ClearsClaimTimestamp(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	originalState, originalConditions, originalFinishedAt, claimGeneration, claimErr := runStore.ClaimRunForRetry("run-rollback-claim")
+	originalState, originalConditions, originalFinishedAt, claimGeneration, claimErr := runStore.ClaimRunForRetry("run-rollback-claim", false)
 	require.Nil(t, claimErr)
 
 	claimed, err := runStore.GetRun("run-rollback-claim")
@@ -2393,7 +2393,7 @@ func TestClaimRunForRetry_RunNotFound(t *testing.T) {
 	defer db.Close()
 	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
 
-	_, _, _, _, err := runStore.ClaimRunForRetry("no-such-run")
+	_, _, _, _, err := runStore.ClaimRunForRetry("no-such-run", false)
 	require.NotNil(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -2505,12 +2505,13 @@ func TestClaimRunForRetry_TakesOverAbandonedClaim(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	_, _, _, firstGeneration, claimErr := runStore.ClaimRunForRetry("run-abandoned-claim")
+	_, _, _, firstGeneration, claimErr := runStore.ClaimRunForRetry("run-abandoned-claim", false)
 	require.Nil(t, claimErr)
 	require.Equal(t, int64(1), firstGeneration)
 
 	// A fresh claim is protected: the row is PENDING with a recent timestamp.
-	_, _, _, _, secondErr := runStore.ClaimRunForRetry("run-abandoned-claim")
+	// Even with takeover authorized, a fresh claim is protected.
+	_, _, _, _, secondErr := runStore.ClaimRunForRetry("run-abandoned-claim", true)
 	require.NotNil(t, secondErr, "a fresh claim must not be taken over")
 	assert.Contains(t, secondErr.Error(), "not in a terminal state")
 
@@ -2518,7 +2519,11 @@ func TestClaimRunForRetry_TakesOverAbandonedClaim(t *testing.T) {
 	_, err = db.Exec(`UPDATE run_details SET RetryClaimedAtInSec = 0 WHERE UUID = ?`, "run-abandoned-claim")
 	require.Nil(t, err)
 
-	_, _, _, takeoverGeneration, takeoverErr := runStore.ClaimRunForRetry("run-abandoned-claim")
+	// Without caller authorization the expired claim still cannot be taken.
+	_, _, _, _, unauthorizedErr := runStore.ClaimRunForRetry("run-abandoned-claim", false)
+	require.NotNil(t, unauthorizedErr, "takeover must require explicit caller authorization")
+
+	_, _, _, takeoverGeneration, takeoverErr := runStore.ClaimRunForRetry("run-abandoned-claim", true)
 	require.Nil(t, takeoverErr, "an abandoned claim must be recoverable by a new retry")
 	assert.Equal(t, int64(2), takeoverGeneration, "takeover must advance the generation")
 }

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -2476,3 +2476,91 @@ func TestArchiveExpiredRuns_SetsArchivedAt(t *testing.T) {
 	assert.Equal(t, model.StorageStateArchived, run.StorageState)
 	assert.True(t, run.ArchivedAtInSec > 0, "archive pass must stamp ArchivedAtInSec")
 }
+
+// Regression: a retry that crashes after committing its claim but before
+// creating the workflow leaves the row PENDING with no workflow to report it.
+// A later claim must be able to take over once the claim has aged out (or its
+// timestamp was cleared); a fresh claim must still be protected.
+func TestClaimRunForRetry_TakesOverAbandonedClaim(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	_, err := runStore.CreateRun(&model.Run{
+		UUID:         "run-abandoned-claim",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-abandoned-claim",
+		DisplayName:  "run-abandoned-claim",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:          1,
+			FinishedAtInSec:         100,
+			State:                   model.RuntimeStateFailed,
+			Conditions:              string(model.RuntimeStateFailedV1),
+			WorkflowRuntimeManifest: "wf1",
+		},
+	})
+	require.Nil(t, err)
+
+	_, _, _, firstGeneration, claimErr := runStore.ClaimRunForRetry("run-abandoned-claim")
+	require.Nil(t, claimErr)
+	require.Equal(t, int64(1), firstGeneration)
+
+	// A fresh claim is protected: the row is PENDING with a recent timestamp.
+	_, _, _, _, secondErr := runStore.ClaimRunForRetry("run-abandoned-claim")
+	require.NotNil(t, secondErr, "a fresh claim must not be taken over")
+	assert.Contains(t, secondErr.Error(), "not in a terminal state")
+
+	// Simulate the crash aftermath: claim timestamp gone (or aged out).
+	_, err = db.Exec(`UPDATE run_details SET RetryClaimedAtInSec = 0 WHERE UUID = ?`, "run-abandoned-claim")
+	require.Nil(t, err)
+
+	_, _, _, takeoverGeneration, takeoverErr := runStore.ClaimRunForRetry("run-abandoned-claim")
+	require.Nil(t, takeoverErr, "an abandoned claim must be recoverable by a new retry")
+	assert.Equal(t, int64(2), takeoverGeneration, "takeover must advance the generation")
+}
+
+// Regression: the delete pass selects candidates with two index-aligned
+// queries (archival-time-driven and legacy finish-time-driven) and must pick
+// up both kinds in one call while respecting the batch cap.
+func TestDeleteExpiredArchivedRuns_LegacyAndCurrentCandidates(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	for _, id := range []string{"run-legacy-archived", "run-current-archived", "run-fresh-archived"} {
+		_, err := runStore.CreateRun(&model.Run{
+			UUID:         id,
+			ExperimentId: defaultFakeExpId,
+			K8SName:      id,
+			DisplayName:  id,
+			Namespace:    "ns1",
+			StorageState: model.StorageStateArchived,
+			RunDetails: model.RunDetails{
+				CreatedAtInSec:  1,
+				FinishedAtInSec: 100,
+				State:           model.RuntimeStateSucceeded,
+				Conditions:      string(model.RuntimeStateSucceededV1),
+			},
+		})
+		require.Nil(t, err)
+	}
+	// Legacy: ArchivedAtInSec stays 0. Current: archived before the cutoff.
+	// Fresh: archived after the cutoff, must survive.
+	_, err := db.Exec(`UPDATE run_details SET ArchivedAtInSec = 150 WHERE UUID = ?`, "run-current-archived")
+	require.Nil(t, err)
+	_, err = db.Exec(`UPDATE run_details SET ArchivedAtInSec = 1000 WHERE UUID = ?`, "run-fresh-archived")
+	require.Nil(t, err)
+
+	deleted, err := runStore.DeleteExpiredArchivedRuns(200, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(2), deleted, "one legacy and one current candidate must both be deleted")
+
+	_, err = runStore.GetRun("run-fresh-archived")
+	assert.Nil(t, err, "recently archived run must survive its observation window")
+}

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -2249,3 +2249,57 @@ func TestDeleteExpiredArchivedRuns_IncludesLegacyDisabledState(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
+
+// Regression test for B1: RetryGeneration must be read back from the database
+// by GetRun so that UpdateRun's WHERE clause matches the bumped value.
+// Without this fix, GetRun always returns RetryGeneration=0 and UpdateRun
+// silently matches zero rows, permanently sticking the run.
+func TestClaimRunForRetry_GetRunReadsRetryGeneration(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	// Create a terminal run.
+	_, err := runStore.CreateRun(&model.Run{
+		UUID:         "run-retry-gen",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-retry-gen",
+		DisplayName:  "run-retry-gen",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:          1,
+			FinishedAtInSec:         100,
+			State:                   model.RuntimeStateSucceeded,
+			Conditions:              "Succeeded",
+			WorkflowRuntimeManifest: "wf1",
+		},
+	})
+	require.Nil(t, err)
+
+	// Claim the run for retry. This bumps RetryGeneration to 1 in the DB.
+	_, _, _, claimGeneration, claimErr := runStore.ClaimRunForRetry("run-retry-gen")
+	require.Nil(t, claimErr)
+	assert.Equal(t, int64(1), claimGeneration)
+
+	// GetRun must read back the bumped RetryGeneration from the DB.
+	run, getErr := runStore.GetRun("run-retry-gen")
+	require.Nil(t, getErr)
+	assert.Equal(t, int64(1), run.RetryGeneration)
+	assert.True(t, run.RetryClaimedAtInSec > 0, "RetryClaimedAtInSec should be set by ClaimRunForRetry")
+
+	// UpdateRun with the correct generation must succeed (not ResourceNotFoundError).
+	run.State = model.RuntimeStateRunning
+	run.Conditions = "Running"
+	run.WorkflowRuntimeManifest = "wf2"
+	updateErr := runStore.UpdateRun(run)
+	assert.Nil(t, updateErr, "UpdateRun should succeed when RetryGeneration matches the DB value")
+
+	// Verify the update was persisted.
+	updated, getErr2 := runStore.GetRun("run-retry-gen")
+	require.Nil(t, getErr2)
+	assert.Equal(t, model.RuntimeStateRunning, updated.State)
+	assert.Equal(t, "wf2", string(updated.WorkflowRuntimeManifest))
+}

--- a/backend/src/common/util/consts.go
+++ b/backend/src/common/util/consts.go
@@ -54,6 +54,12 @@ const (
 	// It captures the the name of the Run.
 	AnnotationKeyRunName = "pipelines.kubeflow.org/run_name"
 
+	// AnnotationKeyRetryGeneration is stamped on a retried Workflow with the
+	// RetryGeneration claim token from ClaimRunForRetry. ReportWorkflowResource
+	// compares it against the run's current generation to fence terminal
+	// reports from stale pre-retry workflow snapshots.
+	AnnotationKeyRetryGeneration = "pipelines.kubeflow.org/retry-generation"
+
 	AnnotationKeyIstioSidecarInject           = "sidecar.istio.io/inject"
 	AnnotationValueIstioSidecarInjectEnabled  = "true"
 	AnnotationValueIstioSidecarInjectDisabled = "false"

--- a/backend/test/integration/db_test.go
+++ b/backend/test/integration/db_test.go
@@ -50,7 +50,7 @@ func (s *DBTestSuite) TestInitDBClient_MySQL() {
 	// The default port-forwarding IP address that test uses is different compared to production
 	viper.Set("DBConfig.MySQLConfig.Host", "localhost")
 	duration, _ := time.ParseDuration("1m")
-	db := cm.InitDBClient(duration)
+	db, _ := cm.InitDBClient(duration)
 	assert.NotNil(t, db)
 }
 
@@ -68,7 +68,7 @@ func (s *DBTestSuite) TestInitDBClient_PostgreSQL() {
 	viper.Set("DBConfig.PostgreSQLConfig.User", "user")
 	viper.Set("DBConfig.PostgreSQLConfig.Password", "password")
 	duration, _ := time.ParseDuration("1m")
-	db := cm.InitDBClient(duration)
+	db, _ := cm.InitDBClient(duration)
 	assert.NotNil(t, db)
 }
 

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -85,4 +85,21 @@ concurrent build can leave an invalid index; remove only that invalid index with
 `DROP INDEX CONCURRENTLY public.idx_run_gc_lifecycle` before retrying. For
 MySQL, use `SHOW INDEX FROM run_details` first and run the `ALTER TABLE` only
 when the exact index is absent.
+
+**Note on archive query performance:** The `idx_run_gc_lifecycle` index on
+`(StorageState, FinishedAtInSec)` efficiently serves the delete pass
+(`StorageState = 'ARCHIVED'`). The archive pass uses `StorageState NOT IN (...)`
+which may not drive a range scan on all engines. For large tables (>1M rows),
+verify with `EXPLAIN` and consider an additional index on
+`(FinishedAtInSec, StorageState)` if the archive pass shows a full table scan.
+
+### Argo Workflow cleanup
+
+The run garbage collector only deletes database rows. Argo Workflow custom
+resources are left behind. To avoid misleading persistence-agent log entries
+("workflow does not have a valid RunID") after GC deletes a run's DB record,
+configure Argo's native workflow TTL or set `ttlSecondsAfterFinished` on your
+workflow templates. The TTL should be shorter than `ARCHIVED_RUNS_RETENTION_TIME`
+so Argo cleans up the CR before GC deletes the database row.
+
 `TENSORBOARD_PROXY_SIGNING_SECRET` is optional; it defaults to `MINIO_SECRET_KEY`.

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -42,7 +42,7 @@ Standalone mode is single-user and unauthenticated. Multi-user deployments requi
 | `MINIO_ENDPOINT_REWRITE` | Rewrites object-store endpoints in local proxy mode |
 | `MAX_METRICS_FILE_BYTES` | Maximum uncompressed metrics JSON size; defaults to 1 MiB |
 | `RUNS_RETENTION_TIME` | Auto-archive terminal runs after this Go duration (e.g., `720h`); empty disables |
-| `ARCHIVED_RUNS_RETENTION_TIME` | Auto-delete archived runs after this Go duration (e.g., `2160h`); empty disables |
+| `ARCHIVED_RUNS_RETENTION_TIME` | Auto-delete archived runs this Go duration after they were archived (e.g., `2160h`); pre-upgrade archived rows fall back to completion time; empty disables |
 | `RUNS_GC_INTERVAL` | Poll interval for the run garbage collector; defaults to `6h` |
 | `RUNS_GC_BATCH_SIZE` | Maximum rows per GC batch; defaults to `100` |
 
@@ -87,11 +87,12 @@ MySQL, use `SHOW INDEX FROM run_details` first and run the `ALTER TABLE` only
 when the exact index is absent.
 
 **Note on archive query performance:** The `idx_run_gc_lifecycle` index on
-`(StorageState, FinishedAtInSec)` efficiently serves the delete pass
-(`StorageState = 'ARCHIVED'`). The archive pass uses `StorageState NOT IN (...)`
-which may not drive a range scan on all engines. For large tables (>1M rows),
-verify with `EXPLAIN` and consider an additional index on
-`(FinishedAtInSec, StorageState)` if the archive pass shows a full table scan.
+`(StorageState, FinishedAtInSec)` serves both passes. The delete pass filters
+`StorageState = 'ARCHIVED'`; the archive pass matches a positive `IN` list of
+non-archived storage states (plus `IS NULL`), so both drive the index's
+leading column. The collector re-validates the index against the database
+catalog on every tick: applying this migration takes effect without an
+API-server restart, and GC pauses automatically if the index is dropped.
 
 ### Argo Workflow cleanup
 
@@ -101,5 +102,9 @@ resources are left behind. To avoid misleading persistence-agent log entries
 configure Argo's native workflow TTL or set `ttlSecondsAfterFinished` on your
 workflow templates. The TTL should be shorter than `ARCHIVED_RUNS_RETENTION_TIME`
 so Argo cleans up the CR before GC deletes the database row.
+
+The garbage collector also does not remove rows from the `artifacts` table,
+MLMD records, or object-store artifacts; those lifecycles are managed
+separately (see `ARTIFACT_RETENTION_DAYS` for object-store artifacts).
 
 `TENSORBOARD_PROXY_SIGNING_SECRET` is optional; it defaults to `MINIO_SECRET_KEY`.

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -48,10 +48,10 @@ Standalone mode is single-user and unauthenticated. Multi-user deployments requi
 
 ## Run garbage collection database migration
 
-Before enabling either retention setting, create the required lifecycle index
+Before enabling either retention setting, create the two required indexes
 once using the same database and schema as the API server. The API server only
-validates the index at startup; it does not run heavyweight DDL from every
-replica.
+validates the indexes (at startup and on every collection tick); it does not
+run heavyweight DDL from every replica.
 
 For PostgreSQL, inspect the existing index first. Replace `public` if the API
 server's current schema is different:
@@ -63,13 +63,14 @@ FROM pg_index AS index_metadata
 JOIN pg_class AS index_class ON index_class.oid = index_metadata.indexrelid
 JOIN pg_namespace AS index_namespace ON index_namespace.oid = index_class.relnamespace
 WHERE index_namespace.nspname = 'public'
-  AND index_class.relname = 'idx_run_gc_lifecycle';
+  AND index_class.relname IN ('idx_run_gc_lifecycle', 'idx_run_gc_archived');
 ```
 
-If no row is returned, create the index outside a transaction:
+If a row is missing, create that index outside a transaction:
 
 ```sql
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_gc_lifecycle ON public.run_details ("StorageState", "FinishedAtInSec");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_gc_archived ON public.run_details ("StorageState", "ArchivedAtInSec");
 ```
 
 For MySQL, explicitly require online DDL so the command fails instead of falling
@@ -77,6 +78,7 @@ back to a table-copying or write-blocking operation:
 
 ```sql
 ALTER TABLE run_details ADD INDEX idx_run_gc_lifecycle (StorageState, FinishedAtInSec), ALGORITHM=INPLACE, LOCK=NONE;
+ALTER TABLE run_details ADD INDEX idx_run_gc_archived (StorageState, ArchivedAtInSec), ALGORITHM=INPLACE, LOCK=NONE;
 ```
 
 If a same-named index has different columns, remove it in a coordinated
@@ -86,13 +88,17 @@ concurrent build can leave an invalid index; remove only that invalid index with
 MySQL, use `SHOW INDEX FROM run_details` first and run the `ALTER TABLE` only
 when the exact index is absent.
 
-**Note on archive query performance:** The `idx_run_gc_lifecycle` index on
-`(StorageState, FinishedAtInSec)` serves both passes. The delete pass filters
-`StorageState = 'ARCHIVED'`; the archive pass matches a positive `IN` list of
-non-archived storage states (plus `IS NULL`), so both drive the index's
-leading column. The collector re-validates the index against the database
-catalog on every tick: applying this migration takes effect without an
-API-server restart, and GC pauses automatically if the index is dropped.
+**Note on query/index alignment:** `idx_run_gc_lifecycle`
+`(StorageState, FinishedAtInSec)` drives the archive pass (positive `IN` list
+of non-archived storage states plus `IS NULL`) and the delete pass's legacy
+predicate (rows archived before `ArchivedAtInSec` existed, which only
+shrinks). `idx_run_gc_archived` `(StorageState, ArchivedAtInSec)` drives the
+delete pass's archival-time predicate, so a mass archival does not cause the
+delete pass to re-scan the old finish-time range every tick while it waits
+out the observation window. The collector re-validates both indexes against
+the database catalog on every tick: applying this migration takes effect
+without an API-server restart, and GC pauses automatically if either index
+is dropped.
 
 ### Argo Workflow cleanup
 

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -46,4 +46,43 @@ Standalone mode is single-user and unauthenticated. Multi-user deployments requi
 | `RUNS_GC_INTERVAL` | Poll interval for the run garbage collector; defaults to `6h` |
 | `RUNS_GC_BATCH_SIZE` | Maximum rows per GC batch; defaults to `100` |
 
+## Run garbage collection database migration
+
+Before enabling either retention setting, create the required lifecycle index
+once using the same database and schema as the API server. The API server only
+validates the index at startup; it does not run heavyweight DDL from every
+replica.
+
+For PostgreSQL, inspect the existing index first. Replace `public` if the API
+server's current schema is different:
+
+```sql
+SELECT index_metadata.indisvalid, index_metadata.indisready,
+       pg_get_indexdef(index_metadata.indexrelid)
+FROM pg_index AS index_metadata
+JOIN pg_class AS index_class ON index_class.oid = index_metadata.indexrelid
+JOIN pg_namespace AS index_namespace ON index_namespace.oid = index_class.relnamespace
+WHERE index_namespace.nspname = 'public'
+  AND index_class.relname = 'idx_run_gc_lifecycle';
+```
+
+If no row is returned, create the index outside a transaction:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_run_gc_lifecycle ON public.run_details ("StorageState", "FinishedAtInSec");
+```
+
+For MySQL, explicitly require online DDL so the command fails instead of falling
+back to a table-copying or write-blocking operation:
+
+```sql
+ALTER TABLE run_details ADD INDEX idx_run_gc_lifecycle (StorageState, FinishedAtInSec), ALGORITHM=INPLACE, LOCK=NONE;
+```
+
+If a same-named index has different columns, remove it in a coordinated
+maintenance operation before applying the command above. A failed PostgreSQL
+concurrent build can leave an invalid index; remove only that invalid index with
+`DROP INDEX CONCURRENTLY public.idx_run_gc_lifecycle` before retrying. For
+MySQL, use `SHOW INDEX FROM run_details` first and run the `ALTER TABLE` only
+when the exact index is absent.
 `TENSORBOARD_PROXY_SIGNING_SECRET` is optional; it defaults to `MINIO_SECRET_KEY`.

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -41,5 +41,9 @@ Standalone mode is single-user and unauthenticated. Multi-user deployments requi
 | `FRONTEND_SERVER_NAMESPACE` | Namespace used by a local frontend server |
 | `MINIO_ENDPOINT_REWRITE` | Rewrites object-store endpoints in local proxy mode |
 | `MAX_METRICS_FILE_BYTES` | Maximum uncompressed metrics JSON size; defaults to 1 MiB |
+| `RUNS_RETENTION_TIME` | Auto-archive terminal runs after this Go duration (e.g., `720h`); empty disables |
+| `ARCHIVED_RUNS_RETENTION_TIME` | Auto-delete archived runs after this Go duration (e.g., `2160h`); empty disables |
+| `RUNS_GC_INTERVAL` | Poll interval for the run garbage collector; defaults to `6h` |
+| `RUNS_GC_BATCH_SIZE` | Maximum rows per GC batch; defaults to `100` |
 
 `TENSORBOARD_PROXY_SIGNING_SECRET` is optional; it defaults to `MINIO_SECRET_KEY`.

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -108,8 +108,10 @@ data:
   ## RUNS_RETENTION_TIME: Auto-archive terminal runs after this duration.
   ## Uses Go duration format (e.g., "720h" for 30 days). Empty disables.
   RUNS_RETENTION_TIME: ""
-  ## ARCHIVED_RUNS_RETENTION_TIME: Auto-delete archived runs after this duration.
-  ## Uses Go duration format (e.g., "2160h" for 90 days). Empty disables.
+  ## ARCHIVED_RUNS_RETENTION_TIME: Auto-delete archived runs this long after
+  ## they were archived (runs archived before upgrade fall back to their
+  ## completion time). Uses Go duration format (e.g., "2160h" for 90 days).
+  ## Empty disables.
   ARCHIVED_RUNS_RETENTION_TIME: ""
   ## RUNS_GC_INTERVAL: Poll interval for the run garbage collector.
   RUNS_GC_INTERVAL: "6h"

--- a/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/pipeline-install-config.yaml
@@ -105,6 +105,16 @@ data:
   ## - A negative integer (e.g., -1) disables automatic deletion, meaning artifacts are retained indefinitely.
   ## Note: The unit of this configuration is always in days.
   ARTIFACT_RETENTION_DAYS: "-1"
+  ## RUNS_RETENTION_TIME: Auto-archive terminal runs after this duration.
+  ## Uses Go duration format (e.g., "720h" for 30 days). Empty disables.
+  RUNS_RETENTION_TIME: ""
+  ## ARCHIVED_RUNS_RETENTION_TIME: Auto-delete archived runs after this duration.
+  ## Uses Go duration format (e.g., "2160h" for 90 days). Empty disables.
+  ARCHIVED_RUNS_RETENTION_TIME: ""
+  ## RUNS_GC_INTERVAL: Poll interval for the run garbage collector.
+  RUNS_GC_INTERVAL: "6h"
+  ## RUNS_GC_BATCH_SIZE: Maximum rows per GC batch (the collector drains all batches per tick).
+  RUNS_GC_BATCH_SIZE: "100"
   ## Default security context for customer workload containers.
   ## Leave empty to disable (default). When set, SDK-specified values
   ## for the corresponding field are ignored.

--- a/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
@@ -103,8 +103,10 @@ data:
   ## RUNS_RETENTION_TIME: Auto-archive terminal runs after this duration.
   ## Uses Go duration format (e.g., "720h" for 30 days). Empty disables.
   RUNS_RETENTION_TIME: ""
-  ## ARCHIVED_RUNS_RETENTION_TIME: Auto-delete archived runs after this duration.
-  ## Uses Go duration format (e.g., "2160h" for 90 days). Empty disables.
+  ## ARCHIVED_RUNS_RETENTION_TIME: Auto-delete archived runs this long after
+  ## they were archived (runs archived before upgrade fall back to their
+  ## completion time). Uses Go duration format (e.g., "2160h" for 90 days).
+  ## Empty disables.
   ARCHIVED_RUNS_RETENTION_TIME: ""
   ## RUNS_GC_INTERVAL: Poll interval for the run garbage collector.
   RUNS_GC_INTERVAL: "6h"

--- a/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
@@ -100,6 +100,16 @@ data:
   ## Valid values are 'true' and 'false'. Defaults to 'false'.
   ## For more information see: https://github.com/kubeflow/pipelines/issues/11987
   ARTIFACTS_PROXY_ENABLED: "false"
+  ## RUNS_RETENTION_TIME: Auto-archive terminal runs after this duration.
+  ## Uses Go duration format (e.g., "720h" for 30 days). Empty disables.
+  RUNS_RETENTION_TIME: ""
+  ## ARCHIVED_RUNS_RETENTION_TIME: Auto-delete archived runs after this duration.
+  ## Uses Go duration format (e.g., "2160h" for 90 days). Empty disables.
+  ARCHIVED_RUNS_RETENTION_TIME: ""
+  ## RUNS_GC_INTERVAL: Poll interval for the run garbage collector.
+  RUNS_GC_INTERVAL: "6h"
+  ## RUNS_GC_BATCH_SIZE: Maximum rows per GC batch (the collector drains all batches per tick).
+  RUNS_GC_BATCH_SIZE: "100"
   ## Default security context for customer workload containers.
   ## Leave empty to disable (default). When set, SDK-specified values
   ## for the corresponding field are ignored.

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -272,6 +272,30 @@ spec:
                   name: pipeline-install-config
                   key: DRIVER_POD_ANNOTATIONS
                   optional: true
+            - name: RUNS_RETENTION_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: RUNS_RETENTION_TIME
+                  optional: true
+            - name: ARCHIVED_RUNS_RETENTION_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: ARCHIVED_RUNS_RETENTION_TIME
+                  optional: true
+            - name: RUNS_GC_INTERVAL
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: RUNS_GC_INTERVAL
+                  optional: true
+            - name: RUNS_GC_BATCH_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: pipeline-install-config
+                  key: RUNS_GC_BATCH_SIZE
+                  optional: true
           image: ghcr.io/kubeflow/kfp-api-server:dummy
           imagePullPolicy: IfNotPresent
           name: ml-pipeline-api-server

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-role.yaml
@@ -88,3 +88,21 @@ rules:
   - kfp-mlflow-credentials
   verbs:
   - get
+# Leader election lease for the run garbage collector.
+# create cannot be restricted by resourceNames per Kubernetes RBAC specification
+# (https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources).
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - kfp-apiserver-gc
+  verbs:
+  - get
+  - update

--- a/manifests/kustomize/base/postgresql/pipeline/ml-pipeline-apiserver-deployment-patch.yaml
+++ b/manifests/kustomize/base/postgresql/pipeline/ml-pipeline-apiserver-deployment-patch.yaml
@@ -79,6 +79,30 @@ spec:
               name: pipeline-install-config
               key: DRIVER_POD_ANNOTATIONS
               optional: true
+        - name: RUNS_RETENTION_TIME
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: RUNS_RETENTION_TIME
+              optional: true
+        - name: ARCHIVED_RUNS_RETENTION_TIME
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: ARCHIVED_RUNS_RETENTION_TIME
+              optional: true
+        - name: RUNS_GC_INTERVAL
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: RUNS_GC_INTERVAL
+              optional: true
+        - name: RUNS_GC_BATCH_SIZE
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: RUNS_GC_BATCH_SIZE
+              optional: true
         # PostgreSQL Config
         - name: DBCONFIG_POSTGRESQLCONFIG_USER
           valueFrom:


### PR DESCRIPTION
## Description of your changes:

Implements the two-stage run lifecycle for automatic database garbage collection, as discussed in the KFP community meeting (June 3, 2026) and documented in the [design document](https://gist.github.com/Raakshass/25487291500e7b11bf0456eb6f94ea86).

**Problem:** The `run_details` table grows unboundedly on production clusters. Multi-tenant installations accumulate millions of completed run records, degrading `ListRuns` query performance and inflating storage costs. There is no existing mechanism to manage the lifecycle of completed runs.

**Solution:** A background garbage collector that implements a two-stage retention lifecycle:

```
Terminal Active ──(RUNS_RETENTION_TIME)──> Archived ──(ARCHIVED_RUNS_RETENTION_TIME)──> Deleted
```

- Non-archived terminal runs are never directly deleted — they are auto-archived first
- Only archived runs are permanently deleted (after their own retention period)
- Existing manual `ArchiveRun` / `DeleteRun` APIs are preserved
- Runs in `PENDING`, `RUNNING`, `PAUSED`, or `CANCELING` states are never touched
- Disabled by default. Operators opt in by setting retention values in `pipeline-install-config`

### Changes:

| File | Change |
|---|---|
| `common/config.go` | 4 config keys: `RUNS_RETENTION_TIME`, `ARCHIVED_RUNS_RETENTION_TIME`, `RUNS_GC_INTERVAL` (default 6h), `RUNS_GC_BATCH_SIZE` (default 100). Added `GetDurationConfigWithDefault` helper. Defensive clamp on batch size. |
| `storage/run_store.go` | `ArchiveExpiredRuns(cutoff, batchSize)` and `DeleteExpiredArchivedRuns(cutoff, batchSize)` on `RunStoreInterface` + implementation. Fixed `DeleteRun` to use child-first 4-table deletion order: `run_metrics → tasks → resource_references → run_details` (fixes #13526). Legacy v1 NULL State rows handled via OR clause on Conditions column. |
| `storage/run_store_test.go` | 9 unit tests: terminal state archiving, no-op when no candidates match, already-archived skip, batch size limiting, multi-table deletion with task/metric row verification, non-archived run protection, recent-archived protection, DeleteRun cleans up tasks and metrics, legacy DISABLED StorageState deletion. |
| `gc/run_gc.go` | **[NEW]** `RunGarbageCollector` — K8s Lease-based leader election (`client-go/tools/leaderelection`), ticker-based collection loop with drain-until-empty, leader re-election on transient loss, immediate first-run on startup. |
| `gc/run_gc_test.go` | **[NEW]** 5 unit tests for `collect()`: both disabled, archive-only, delete-only, custom batch size, archive-error-does-not-block-delete. |
| `main.go` | Wire GC goroutine into server startup between SWF reconciler and RPC server. |
| `manifests/.../pipeline-install-config.yaml` | Add 4 GC config fields to both generic and postgres variants (disabled by default — backward compatible). |
| `manifests/.../ml-pipeline-apiserver-role.yaml` | Add `coordination.k8s.io/leases` RBAC for GC leader election (namespace-scoped Role only). |

### Configuration:

```yaml
# pipeline-install-config ConfigMap
RUNS_RETENTION_TIME: ""              # auto-archive terminal runs after duration (empty = disabled)
ARCHIVED_RUNS_RETENTION_TIME: ""      # delete archived runs after duration (empty = disabled)
RUNS_GC_INTERVAL: "6h"              # poll interval (default)
RUNS_GC_BATCH_SIZE: "100"            # rows per pass (default)
```

| `RUNS_RETENTION_TIME` | `ARCHIVED_RUNS_RETENTION_TIME` | Result |
|---|---|---|
| empty | empty | GC disabled entirely (default — backward compatible) |
| `720h` | empty | Auto-archive after 30d, never auto-delete |
| empty | `2160h` | No auto-archive, but auto-delete manually-archived runs after 90d |
| `720h` | `2160h` | Full lifecycle: auto-archive at 30d, auto-delete at 90d from finish |

### Multi-replica safety — Leader Election via Lease:

Uses `coordination.k8s.io/v1` Lease (`kfp-apiserver-gc`) for leader election. Only one replica runs the GC loop.

**Lease timing** (`run_gc.go:92-94`):
- `LeaseDuration: 15s` — how long a leader holds the lease before it expires
- `RenewDeadline: 10s` — how long the leader has to renew before losing it
- `RetryPeriod: 2s` — how often non-leaders retry acquisition

These are the standard `client-go` defaults used by `kube-controller-manager` and `kube-scheduler`.

**`ReleaseOnCancel: false`** — on graceful shutdown, the leader retains ownership until the 15-second `LeaseDuration` expires, preventing the successor from overlapping a still-running `collect()` call. No `delete` verb needed.

### Lease RBAC — Security Analysis:

Added to the **namespace-scoped `ml-pipeline` Role** only (not the ClusterRole), keeping the blast radius minimal:

```yaml
# create cannot be restricted by resourceNames per Kubernetes RBAC specification
# (https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources)
- apiGroups: [coordination.k8s.io]
  resources: [leases]
  verbs: [create]

# get and update restricted to only the GC lease
- apiGroups: [coordination.k8s.io]
  resources: [leases]
  resourceNames: [kfp-apiserver-gc]
  verbs: [get, update]
```

**Why two rules:** Kubernetes RBAC ignores `resourceNames` for `create` verbs ([docs](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources)). Splitting into two rules allows `get`/`update` to be restricted to only the named lease `kfp-apiserver-gc`, so the apiserver cannot read or modify any other lease in the namespace.

**Verbs:** `create`, `get`, `update`. `delete` is not needed — the lease expires naturally on shutdown (15s `LeaseDuration`).

### Live Cluster Verification (multi-user deployment):

Deployed multi-user KFP on a kind cluster (`kubectl kustomize manifests/kustomize/base/installs/multi-user | kubectl apply -f -`) and verified:

- Multi-user uses **both** the namespace-scoped `Role` (via `RoleBinding`) **and** the `ClusterRole` (via `ClusterRoleBinding`) for the same `ml-pipeline` ServiceAccount. They stack.
- The namespace-scoped Role provides the lease RBAC. No ClusterRole change needed.

`kubectl auth can-i` results for `system:serviceaccount:kubeflow:ml-pipeline`:

| Check | Result | Expected |
|---|---|---|
| `create leases` in `kubeflow` | `yes` | ✅ |
| `get leases/kfp-apiserver-gc` in `kubeflow` | `yes` | ✅ |
| `update leases/kfp-apiserver-gc` in `kubeflow` | `yes` | ✅ |
| `get` any other lease | `no` | ✅ (restricted by `resourceNames`) |
| `delete leases` | `no` | ✅ (verb not granted) |
| `create leases` in `default` namespace | `no` | ✅ (namespace-scoped) |

### What this PR does NOT do (follow-up work):

- Does not add Prometheus observability metrics — follow-up
- Does not clean MLMD records or object store artifacts — per design doc scope

**Design:** https://gist.github.com/Raakshass/25487291500e7b11bf0456eb6f94ea86
**Fixes:** #13526

### Checklist:
- [x] You have signed off your commits
- [x] The title for your pull request (PR) should follow our title convention.

/kind feature
/kind bug
/area backend
