### PR TITLE
fix(backend): skip zero-byte directory markers when downloading artifacts

### DIFF
--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -155,7 +155,17 @@ func isBlobKeyUnderPrefix(objKey, blobDir string) bool {
 	return objKey == blobDir || strings.HasPrefix(objKey, blobDir+"/")
 }
 
+func isZeroByteDirectoryMarker(obj *blob.ListObject, blobDir string) bool {
+	if obj.Size != 0 {
+		return false
+	}
+	blobDir = strings.TrimRight(blobDir, "/")
+	return strings.HasSuffix(obj.Key, "/") || obj.Key == blobDir
+}
+
 func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir string) error {
+	var exactPrefixMarker *blob.ListObject
+	downloadedChild := false
 	iter := bucket.List(&blob.ListOptions{Prefix: blobDir})
 	for {
 		obj, err := iter.Next(ctx)
@@ -172,6 +182,12 @@ func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir st
 			// there is no need to recursively list each folder.
 			continue
 		} else if isBlobKeyUnderPrefix(obj.Key, blobDir) {
+			if isZeroByteDirectoryMarker(obj, blobDir) {
+				if strings.TrimRight(obj.Key, "/") == strings.TrimRight(blobDir, "/") && !downloadedChild {
+					exactPrefixMarker = obj
+				}
+				continue
+			}
 			localPath, err := sanitizeDownloadPath(localDir, blobDir, obj.Key)
 			if err != nil {
 				return err
@@ -179,8 +195,20 @@ func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir st
 			if err := downloadFile(ctx, bucket, obj.Key, localPath); err != nil {
 				return err
 			}
+			if obj.Key != strings.TrimRight(blobDir, "/") {
+				downloadedChild = true
+			}
 		} else {
 			glog.V(4).Infof("DownloadBlob: skipping blob key %q not under expected prefix %q", obj.Key, blobDir)
+		}
+	}
+	if exactPrefixMarker != nil && !downloadedChild {
+		localPath, err := sanitizeDownloadPath(localDir, blobDir, exactPrefixMarker.Key)
+		if err != nil {
+			return err
+		}
+		if err := downloadFile(ctx, bucket, exactPrefixMarker.Key, localPath); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -155,15 +155,15 @@ func isBlobKeyUnderPrefix(objKey, blobDir string) bool {
 	return objKey == blobDir || strings.HasPrefix(objKey, blobDir+"/")
 }
 
-func isZeroByteDirectoryMarker(obj *blob.ListObject, blobDir string) bool {
+func isZeroByteDirectoryMarker(obj *blob.ListObject, trimmedBlobDir string) bool {
 	if obj.Size != 0 {
 		return false
 	}
-	blobDir = strings.TrimRight(blobDir, "/")
-	return strings.HasSuffix(obj.Key, "/") || obj.Key == blobDir
+	return strings.HasSuffix(obj.Key, "/") || obj.Key == trimmedBlobDir
 }
 
 func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir string) error {
+	trimmedBlobDir := strings.TrimRight(blobDir, "/")
 	var exactPrefixMarker *blob.ListObject
 	downloadedChild := false
 	iter := bucket.List(&blob.ListOptions{Prefix: blobDir})
@@ -182,8 +182,8 @@ func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir st
 			// there is no need to recursively list each folder.
 			continue
 		} else if isBlobKeyUnderPrefix(obj.Key, blobDir) {
-			if isZeroByteDirectoryMarker(obj, blobDir) {
-				if strings.TrimRight(obj.Key, "/") == strings.TrimRight(blobDir, "/") && !downloadedChild {
+			if isZeroByteDirectoryMarker(obj, trimmedBlobDir) {
+				if strings.TrimRight(obj.Key, "/") == trimmedBlobDir && !downloadedChild {
 					exactPrefixMarker = obj
 				}
 				continue
@@ -195,7 +195,7 @@ func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir st
 			if err := downloadFile(ctx, bucket, obj.Key, localPath); err != nil {
 				return err
 			}
-			if obj.Key != strings.TrimRight(blobDir, "/") {
+			if obj.Key != trimmedBlobDir {
 				downloadedChild = true
 			}
 		} else {
@@ -206,6 +206,11 @@ func DownloadBlob(ctx context.Context, bucket *blob.Bucket, localDir, blobDir st
 		localPath, err := sanitizeDownloadPath(localDir, blobDir, exactPrefixMarker.Key)
 		if err != nil {
 			return err
+		}
+		if info, err := os.Stat(localPath); err == nil && info.IsDir() {
+			return nil
+		} else if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to stat local download path %q: %w", localPath, err)
 		}
 		if err := downloadFile(ctx, bucket, exactPrefixMarker.Key, localPath); err != nil {
 			return err

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -428,6 +428,27 @@ func TestDownloadBlobKeepsSingleZeroByteFile(t *testing.T) {
 	assert.Zero(t, info.Size())
 }
 
+func TestDownloadBlobEmptyDirectoryMarker(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { require.NoError(t, bucket.Close()) }()
+
+	writeBlobToMemBucket(ctx, t, bucket, "artifacts/emptydir", "")
+
+	localDir := t.TempDir()
+
+	err := DownloadBlob(ctx, bucket, localDir, "artifacts/emptydir")
+	require.NoError(t, err)
+
+	info, err := os.Stat(localDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	entries, err := os.ReadDir(localDir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
 func TestDownloadBlobSkipsSiblingKeys(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -381,6 +381,53 @@ func TestDownloadBlobDirectory(t *testing.T) {
 	assert.Equal(t, "content2", string(content2))
 }
 
+func TestDownloadBlobDirectorySkipsZeroByteMarkers(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { require.NoError(t, bucket.Close()) }()
+
+	writeBlobToMemBucket(ctx, t, bucket, "artifacts/model", "")
+	writeBlobToMemBucket(ctx, t, bucket, "artifacts/model/saved_model.pb", "model")
+	writeBlobToMemBucket(ctx, t, bucket, "artifacts/model/variables/", "")
+	writeBlobToMemBucket(ctx, t, bucket, "artifacts/model/variables/variables.index", "index")
+
+	localDir := t.TempDir()
+
+	err := DownloadBlob(ctx, bucket, localDir, "artifacts/model")
+	require.NoError(t, err)
+
+	info, err := os.Stat(localDir)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	content, err := os.ReadFile(filepath.Join(localDir, "saved_model.pb"))
+	require.NoError(t, err)
+	assert.Equal(t, "model", string(content))
+
+	content, err = os.ReadFile(filepath.Join(localDir, "variables", "variables.index"))
+	require.NoError(t, err)
+	assert.Equal(t, "index", string(content))
+}
+
+func TestDownloadBlobKeepsSingleZeroByteFile(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { require.NoError(t, bucket.Close()) }()
+
+	writeBlobToMemBucket(ctx, t, bucket, "artifacts/empty.txt", "")
+
+	localDir := t.TempDir()
+	targetPath := filepath.Join(localDir, "empty.txt")
+
+	err := DownloadBlob(ctx, bucket, targetPath, "artifacts/empty.txt")
+	require.NoError(t, err)
+
+	info, err := os.Stat(targetPath)
+	require.NoError(t, err)
+	assert.False(t, info.IsDir())
+	assert.Zero(t, info.Size())
+}
+
 func TestDownloadBlobSkipsSiblingKeys(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)


### PR DESCRIPTION
Fixes #13476.

GCS and TensorFlow workflows can leave zero-byte objects that act as directory markers. The downloader currently treats an exact-prefix marker like a normal file, which can create the local output path as a file before child objects are downloaded.

This change skips zero-byte directory markers while preserving a legitimate single empty file at the exact artifact URI. The exact-prefix empty object is deferred until we know whether child objects exist.

Tested:
- go test ./backend/src/v2/objectstore