### PR TITLE
fix(sdk): serialize nested None pipeline parameters

### DIFF
--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -50,7 +50,8 @@ group_type_to_dsl_class = {
 }
 
 
-def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
+def to_protobuf_value(
+        value: Optional[type_utils.PARAMETER_TYPES]) -> struct_pb2.Value:
     """Creates a google.protobuf.struct_pb2.Value message out of a provide
     value.
 
@@ -64,7 +65,9 @@ def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
         ValueError if the given value is not one of the parameter types.
     """
     # bool check must be above (int, float) check because bool is a subclass of int so isinstance(True, int) == True
-    if isinstance(value, bool):
+    if value is None:
+        return struct_pb2.Value(null_value=struct_pb2.NULL_VALUE)
+    elif isinstance(value, bool):
         return struct_pb2.Value(bool_value=value)
     elif isinstance(value, str):
         return struct_pb2.Value(string_value=value)
@@ -81,7 +84,7 @@ def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
                 values=[to_protobuf_value(v) for v in value]))
     else:
         raise ValueError('Value must be one of the following types: '
-                         'str, int, float, bool, dict, and list. Got: '
+                         'str, int, float, bool, dict, list, and None. Got: '
                          f'"{value}" of type "{type(value)}".')
 
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
@@ -36,6 +36,12 @@ class PipelineSpecBuilderTest(parameterized.TestCase):
     def setUp(self):
         self.maxDiff = None
 
+    def test_to_protobuf_value_none(self):
+        self.assertEqual(
+            struct_pb2.Value(null_value=struct_pb2.NULL_VALUE),
+            pipeline_spec_builder.to_protobuf_value(None),
+        )
+
     @parameterized.parameters(
         {
             'parameter_type': pipeline_spec_pb2.ParameterType.NUMBER_INTEGER,

--- a/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
@@ -84,6 +84,33 @@ class PipelineSpecBuilderTest(parameterized.TestCase):
         },
         {
             'parameter_type':
+                pipeline_spec_pb2.ParameterType.STRUCT,
+            'default_value': {
+                'a': None,
+                'b': {
+                    'c': None,
+                },
+            },
+            'expected':
+                struct_pb2.Value(
+                    struct_value=struct_pb2.Struct(
+                        fields={
+                            'a':
+                                struct_pb2.Value(
+                                    null_value=struct_pb2.NULL_VALUE),
+                            'b':
+                                struct_pb2.Value(
+                                    struct_value=struct_pb2.Struct(
+                                        fields={
+                                            'c':
+                                                struct_pb2.Value(
+                                                    null_value=struct_pb2
+                                                    .NULL_VALUE),
+                                        })),
+                        })),
+        },
+        {
+            'parameter_type':
                 pipeline_spec_pb2.ParameterType.LIST,
             'default_value': ['a', 'b'],
             'expected':
@@ -91,6 +118,26 @@ class PipelineSpecBuilderTest(parameterized.TestCase):
                     list_value=struct_pb2.ListValue(values=[
                         struct_pb2.Value(string_value='a'),
                         struct_pb2.Value(string_value='b'),
+                    ])),
+        },
+        {
+            'parameter_type':
+                pipeline_spec_pb2.ParameterType.LIST,
+            'default_value': ['a', None, {
+                'b': None
+            }],
+            'expected':
+                struct_pb2.Value(
+                    list_value=struct_pb2.ListValue(values=[
+                        struct_pb2.Value(string_value='a'),
+                        struct_pb2.Value(null_value=struct_pb2.NULL_VALUE),
+                        struct_pb2.Value(
+                            struct_value=struct_pb2.Struct(
+                                fields={
+                                    'b':
+                                        struct_pb2.Value(
+                                            null_value=struct_pb2.NULL_VALUE),
+                                })),
                     ])),
         },
         {


### PR DESCRIPTION
Fixes #12240.

Nested Python None values inside pipeline parameter defaults currently fail during compilation because the recursive protobuf conversion only handles bool, int, float, string, dict, and list values.

This change serializes recursive None values as protobuf nulls. Top-level None defaults keep the existing behavior and are still skipped by the component input default handling.

Tested:
- PYTHONPATH='sdk\python;kubernetes_platform\python' .\.venv-kfp\Scripts\python.exe -m pytest sdk\python\kfp\compiler\pipeline_spec_builder_test.py -k fill_in_component_input_default_value
- .\.venv-kfp\Scripts\python.exe -m yapf --style .style.yapf -i sdk\python\kfp\compiler\pipeline_spec_builder.py sdk\python\kfp\compiler\pipeline_spec_builder_test.py
- git diff --check