### PR TITLE
fix(backend): apply S3 checksum options for env-based credentials

### DIFF
--- a/backend/src/v2/objectstore/config.go
+++ b/backend/src/v2/objectstore/config.go
@@ -28,6 +28,23 @@ import (
 // https://kubernetes.io/docs/concepts/services-networking/service/#dns
 const DefaultEndpointInMultiUserMode = "seaweedfs.kubeflow:9000"
 
+// S3 session param keys shared by object store config parsing.
+//
+// If S3 session fields are added or renamed in the launcher/provider config
+// flow, update these constants and review the S3-related helpers in this file,
+// including StructuredS3Params and HasStructuredS3Settings.
+const (
+	S3ParamFromEnv        = "fromEnv"
+	S3ParamSecretName     = "secretName"
+	S3ParamAccessKeyKey   = "accessKeyKey"
+	S3ParamSecretKeyKey   = "secretKeyKey"
+	S3ParamRegion         = "region"
+	S3ParamEndpoint       = "endpoint"
+	S3ParamDisableSSL     = "disableSSL"
+	S3ParamForcePathStyle = "forcePathStyle"
+	S3ParamMaxRetries     = "maxRetries"
+)
+
 type Config struct {
 	Scheme      string
 	BucketName  string
@@ -175,37 +192,37 @@ func GetSessionInfoFromString(sessionInfoJSON string) (*SessionInfo, error) {
 
 func StructuredS3Params(p map[string]string) (*S3Params, error) {
 	sparams := &S3Params{}
-	if val, ok := p["fromEnv"]; ok {
+	if val, ok := p[S3ParamFromEnv]; ok {
 		boolVal, err := strconv.ParseBool(val)
 		if err != nil {
 			return nil, err
 		}
 		sparams.FromEnv = boolVal
 	}
-	if val, ok := p["secretName"]; ok {
+	if val, ok := p[S3ParamSecretName]; ok {
 		sparams.SecretName = val
 	}
 	// The k8s secret "Key" for "Artifact SecretKey" and "Artifact AccessKey"
-	if val, ok := p["accessKeyKey"]; ok {
+	if val, ok := p[S3ParamAccessKeyKey]; ok {
 		sparams.AccessKeyKey = val
 	}
-	if val, ok := p["secretKeyKey"]; ok {
+	if val, ok := p[S3ParamSecretKeyKey]; ok {
 		sparams.SecretKeyKey = val
 	}
-	if val, ok := p["region"]; ok {
+	if val, ok := p[S3ParamRegion]; ok {
 		sparams.Region = val
 	}
-	if val, ok := p["endpoint"]; ok {
+	if val, ok := p[S3ParamEndpoint]; ok {
 		sparams.Endpoint = val
 	}
-	if val, ok := p["disableSSL"]; ok {
+	if val, ok := p[S3ParamDisableSSL]; ok {
 		boolVal, err := strconv.ParseBool(val)
 		if err != nil {
 			return nil, err
 		}
 		sparams.DisableSSL = boolVal
 	}
-	if val, ok := p["forcePathStyle"]; ok {
+	if val, ok := p[S3ParamForcePathStyle]; ok {
 		boolVal, err := strconv.ParseBool(val)
 		if err != nil {
 			return nil, err
@@ -214,7 +231,7 @@ func StructuredS3Params(p map[string]string) (*S3Params, error) {
 	} else {
 		sparams.ForcePathStyle = true
 	}
-	if val, ok := p["maxRetries"]; ok {
+	if val, ok := p[S3ParamMaxRetries]; ok {
 		intVal, err := strconv.ParseInt(val, 10, 0)
 		if err != nil {
 			return nil, err
@@ -222,6 +239,23 @@ func StructuredS3Params(p map[string]string) (*S3Params, error) {
 		sparams.MaxRetries = int(intVal)
 	}
 	return sparams, nil
+}
+
+// HasStructuredS3Settings reports whether the session params include explicit
+// S3 client settings beyond credential-source metadata.
+func HasStructuredS3Settings(p map[string]string) bool {
+	for _, key := range []string{
+		S3ParamRegion,
+		S3ParamEndpoint,
+		S3ParamDisableSSL,
+		S3ParamForcePathStyle,
+		S3ParamMaxRetries,
+	} {
+		if _, ok := p[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func StructuredGCSParams(p map[string]string) (*GCSParams, error) {

--- a/backend/src/v2/objectstore/config_test.go
+++ b/backend/src/v2/objectstore/config_test.go
@@ -1,0 +1,49 @@
+// Copyright 2021 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasStructuredS3Settings(t *testing.T) {
+	assert.False(t, HasStructuredS3Settings(map[string]string{}))
+
+	assert.False(t, HasStructuredS3Settings(map[string]string{
+		S3ParamFromEnv:      "true",
+		S3ParamSecretName:   "secret",
+		S3ParamAccessKeyKey: "access",
+		S3ParamSecretKeyKey: "key",
+	}))
+
+	assert.True(t, HasStructuredS3Settings(map[string]string{
+		S3ParamFromEnv: "true",
+		S3ParamRegion:  "us-east-1",
+	}))
+
+	for _, key := range []string{
+		S3ParamRegion,
+		S3ParamEndpoint,
+		S3ParamDisableSSL,
+		S3ParamForcePathStyle,
+		S3ParamMaxRetries,
+	} {
+		t.Run(key, func(t *testing.T) {
+			assert.True(t, HasStructuredS3Settings(map[string]string{key: "x"}))
+		})
+	}
+}

--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
-	"github.com/aws/aws-sdk-go-v2/config"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/golang/glog"
@@ -49,19 +49,21 @@ func OpenBucket(ctx context.Context, k8sClient kubernetes.Interface, namespace s
 	if config.SessionInfo != nil {
 		switch config.SessionInfo.Provider {
 		case "minio", "s3":
-			s3Client, err1 := createS3BucketSession(ctx, namespace, config.SessionInfo, k8sClient)
-			if err1 != nil {
-				return nil, fmt.Errorf("Failed to retrieve credentials for bucket %s: %w", config.BucketName, err1)
-			}
-			if s3Client != nil {
-				// Use s3blob.OpenBucketV2 with the configured S3 client to leverage retry logic
-				openedBucket, err2 := s3blob.OpenBucketV2(ctx, s3Client, config.BucketName, nil)
-				if err2 != nil {
-					return nil, err2
+			if config.QueryString == "" {
+				s3Client, err1 := createS3BucketSession(ctx, namespace, config.SessionInfo, k8sClient)
+				if err1 != nil {
+					return nil, fmt.Errorf("failed to retrieve credentials for bucket %s: %w", config.BucketName, err1)
 				}
-				// Directly calling s3blob.OpenBucketV2 does not allow overriding prefix via bucketConfig.BucketURL().
-				// Therefore, we need to explicitly configure the prefixed bucket.
-				return blob.PrefixedBucket(openedBucket, config.Prefix), nil
+				if s3Client != nil {
+					// Use s3blob.OpenBucketV2 with the configured S3 client to leverage retry logic
+					openedBucket, err2 := s3blob.OpenBucketV2(ctx, s3Client, config.BucketName, nil)
+					if err2 != nil {
+						return nil, err2
+					}
+					// Directly calling s3blob.OpenBucketV2 does not allow overriding prefix via bucketConfig.BucketURL().
+					// Therefore, we need to explicitly configure the prefixed bucket.
+					return blob.PrefixedBucket(openedBucket, config.Prefix), nil
+				}
 			}
 		case "gs":
 			client, err1 := getGCSTokenClient(ctx, namespace, config.SessionInfo, k8sClient)
@@ -86,7 +88,23 @@ func OpenBucket(ctx context.Context, k8sClient kubernetes.Interface, namespace s
 		bucketURL = strings.Replace(bucketURL, "minio://", "s3://", 1)
 	}
 
-	// When no provider config is provided, or "FromEnv" is specified, use default credentials from the environment
+	// When no session info is provided for a plain s3:// or minio:// URL,
+	// build the S3 client directly so checksum options are applied.
+	useExplicitS3Client := strings.HasPrefix(bucketURL, "minio://") ||
+		(config.QueryString == "" && strings.HasPrefix(bucketURL, "s3://"))
+	if useExplicitS3Client {
+		s3Client, err1 := newS3Client(ctx, nil, nil)
+		if err1 != nil {
+			return nil, err1
+		}
+		openedBucket, err2 := s3blob.OpenBucketV2(ctx, s3Client, config.BucketName, nil)
+		if err2 != nil {
+			return nil, err2
+		}
+		return blob.PrefixedBucket(openedBucket, config.Prefix), nil
+	}
+
+	// Use gocloud's URL opener for the remaining cases, including query-string based S3 URLs.
 	return blob.OpenBucket(ctx, bucketURL)
 }
 
@@ -284,25 +302,41 @@ func createS3BucketSession(ctx context.Context, namespace string, sessionInfo *S
 	if err != nil {
 		return nil, err
 	}
-	if params.FromEnv {
+	if params.FromEnv && !HasStructuredS3Settings(sessionInfo.Params) {
 		return nil, nil
 	}
-	creds, err := getS3BucketCredential(ctx, client, namespace, params.SecretName, params.SecretKeyKey, params.AccessKeyKey)
-	if err != nil {
-		return nil, err
+	var creds *credentials.StaticCredentialsProvider
+	if !params.FromEnv {
+		creds, err = getS3BucketCredential(ctx, client, namespace, params.SecretName, params.SecretKeyKey, params.AccessKeyKey)
+		if err != nil {
+			return nil, err
+		}
 	}
-	s3Config, err := config.LoadDefaultConfig(ctx,
-		config.WithRetryer(func() aws.Retryer {
-			// Use standard retry logic with exponential backoff for transient S3 connection failures.
-			// The standard retryer implements exponential backoff with jitter, starting with a base delay
-			// and doubling the wait time between retries up to a maximum, helping to avoid thundering herd problems.
-			return retry.AddWithMaxAttempts(retry.NewStandard(), params.MaxRetries)
-		}),
-		config.WithCredentialsProvider(*creds),
-		config.WithRegion(*aws.String(params.Region)),
-		config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
-		config.WithResponseChecksumValidation(aws.ResponseChecksumValidationWhenRequired),
-	)
+	return newS3Client(ctx, params, creds)
+}
+
+func newS3Client(ctx context.Context, params *S3Params, creds *credentials.StaticCredentialsProvider) (*s3.Client, error) {
+	loadOptions := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
+		awsconfig.WithResponseChecksumValidation(aws.ResponseChecksumValidationWhenRequired),
+	}
+	if params != nil {
+		if params.MaxRetries > 0 {
+			loadOptions = append(loadOptions, awsconfig.WithRetryer(func() aws.Retryer {
+				// Use standard retry logic with exponential backoff for transient S3 connection failures.
+				// The standard retryer implements exponential backoff with jitter, starting with a base delay
+				// and doubling the wait time between retries up to a maximum, helping to avoid thundering herd problems.
+				return retry.AddWithMaxAttempts(retry.NewStandard(), params.MaxRetries)
+			}))
+		}
+		if params.Region != "" {
+			loadOptions = append(loadOptions, awsconfig.WithRegion(params.Region))
+		}
+	}
+	if creds != nil {
+		loadOptions = append(loadOptions, awsconfig.WithCredentialsProvider(*creds))
+	}
+	s3Config, err := awsconfig.LoadDefaultConfig(ctx, loadOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -313,11 +347,14 @@ func createS3BucketSession(ctx context.Context, namespace string, sessionInfo *S
 	// for (1) the endpoint is not required, thus we skip it, otherwise the writer will fail to close due to region mismatch.
 	// https://aws.amazon.com/blogs/infrastructure-and-automation/best-practices-for-using-amazon-s3-endpoints-in-aws-cloudformation-templates/
 	// https://docs.aws.amazon.com/sdk-for-go/api/aws/session/
-	awsEndpoint, _ := regexp.MatchString(`^(https://)?s3.amazonaws.com`, strings.ToLower(params.Endpoint))
 	s3Options := func(o *s3.Options) {
+		if params == nil {
+			return
+		}
+		awsEndpoint, _ := regexp.MatchString(`^(https://)?s3.amazonaws.com`, strings.ToLower(params.Endpoint))
 		o.UsePathStyle = *aws.Bool(params.ForcePathStyle)
 		o.EndpointOptions.DisableHTTPS = *aws.Bool(params.DisableSSL)
-		if !awsEndpoint {
+		if !awsEndpoint && params.Endpoint != "" {
 			// AWS SDK v2 requires BaseEndpoint to be a valid URI with scheme
 			endpoint := params.Endpoint
 			if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
@@ -332,7 +369,7 @@ func createS3BucketSession(ctx context.Context, namespace string, sessionInfo *S
 	}
 	s3Client := s3.NewFromConfig(s3Config, s3Options)
 	if s3Client == nil {
-		return nil, fmt.Errorf("Failed to create object store session, %v", err)
+		return nil, fmt.Errorf("failed to create object store session, %v", err)
 	}
 	return s3Client, nil
 }
@@ -348,7 +385,7 @@ func getS3BucketCredential(
 	defer func() {
 		if err != nil {
 			// wrap error before returning
-			err = fmt.Errorf("Failed to get Bucket credentials from secret name=%q namespace=%q: %w", secretName, namespace, err)
+			err = fmt.Errorf("failed to get Bucket credentials from secret name=%q namespace=%q: %w", secretName, namespace, err)
 		}
 	}()
 	secret, err := clientSet.CoreV1().Secrets(namespace).Get(

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -16,13 +16,14 @@ package objectstore
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gocloud.dev/blob"
@@ -534,6 +535,22 @@ func Test_createS3BucketSession(t *testing.T) {
 			expectValidClient: false,
 		},
 		{
+			msg: "Bucket with env-based credentials",
+			ns:  "testnamespace",
+			sessionInfo: &SessionInfo{
+				Provider: "s3",
+				Params: map[string]string{
+					"region":         "us-east-1",
+					"endpoint":       "s3.amazonaws.com",
+					"disableSSL":     "false",
+					"fromEnv":        "true",
+					"forcePathStyle": "true",
+				},
+			},
+			sessionSecret:     nil,
+			expectValidClient: true,
+		},
+		{
 			msg: "Bucket with session but secret doesn't exist",
 			ns:  "testnamespace",
 			sessionInfo: &SessionInfo{
@@ -583,12 +600,11 @@ func Test_createS3BucketSession(t *testing.T) {
 			ctx := context.Background()
 
 			if test.sessionSecret != nil {
-				testersecret, err := fakeKubernetesClientset.CoreV1().Secrets(test.ns).Create(
+				_, err := fakeKubernetesClientset.CoreV1().Secrets(test.ns).Create(
 					ctx,
 					test.sessionSecret,
 					metav1.CreateOptions{})
-				assert.Nil(t, err)
-				fmt.Printf("%s", testersecret.Namespace)
+				require.NoError(t, err)
 			}
 
 			actualSession, err := createS3BucketSession(ctx, test.ns, test.sessionInfo, fakeKubernetesClientset)
@@ -608,6 +624,182 @@ func Test_createS3BucketSession(t *testing.T) {
 			} else {
 				assert.Nil(t, actualSession)
 			}
+		})
+	}
+}
+
+func TestOpenBucketUsesExplicitS3ClientForEnvCredentials(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	tests := []struct {
+		name                 string
+		config               *Config
+		expectedRegion       string
+		expectedBaseEndpoint *string
+		expectedPathStyle    bool
+		expectedDisableHTTPS bool
+	}{
+		{
+			name: "Plain S3 URL without session info",
+			config: &Config{
+				Scheme:     "s3://",
+				BucketName: "test-bucket",
+				Prefix:     "artifacts/",
+			},
+			expectedRegion:       "us-east-1",
+			expectedBaseEndpoint: nil,
+			expectedPathStyle:    false,
+			expectedDisableHTTPS: false,
+		},
+		{
+			name: "Plain Minio URL without session info",
+			config: &Config{
+				Scheme:     "minio://",
+				BucketName: "test-bucket",
+				Prefix:     "artifacts/",
+			},
+			expectedRegion:       "us-east-1",
+			expectedBaseEndpoint: nil,
+			expectedPathStyle:    false,
+			expectedDisableHTTPS: false,
+		},
+		{
+			name: "Env-based S3 session info",
+			config: &Config{
+				Scheme:     "s3://",
+				BucketName: "test-bucket",
+				Prefix:     "artifacts/",
+				SessionInfo: &SessionInfo{
+					Provider: "s3",
+					Params: map[string]string{
+						"region":         "us-east-1",
+						"endpoint":       "s3.amazonaws.com",
+						"disableSSL":     "false",
+						"fromEnv":        "true",
+						"forcePathStyle": "true",
+						"maxRetries":     "5",
+					},
+				},
+			},
+			expectedRegion:       "us-east-1",
+			expectedBaseEndpoint: nil,
+			expectedPathStyle:    true,
+			expectedDisableHTTPS: false,
+		},
+		{
+			name: "Env-based S3 session info without structured params",
+			config: &Config{
+				Scheme:     "s3://",
+				BucketName: "test-bucket",
+				Prefix:     "artifacts/",
+				SessionInfo: &SessionInfo{
+					Provider: "s3",
+					Params: map[string]string{
+						"fromEnv": "true",
+					},
+				},
+			},
+			expectedRegion:       "us-east-1",
+			expectedBaseEndpoint: nil,
+			expectedPathStyle:    false,
+			expectedDisableHTTPS: false,
+		},
+		{
+			name: "Env-based Minio session info",
+			config: &Config{
+				Scheme:     "minio://",
+				BucketName: "test-bucket",
+				Prefix:     "artifacts/",
+				SessionInfo: &SessionInfo{
+					Provider: "minio",
+					Params: map[string]string{
+						"region":         "minio",
+						"endpoint":       "minio.example:9000",
+						"disableSSL":     "true",
+						"fromEnv":        "true",
+						"forcePathStyle": "true",
+						"maxRetries":     "5",
+					},
+				},
+			},
+			expectedRegion:       "minio",
+			expectedBaseEndpoint: aws.String("http://minio.example:9000"),
+			expectedPathStyle:    true,
+			expectedDisableHTTPS: true,
+		},
+		{
+			name: "Env-based Minio session info without structured params",
+			config: &Config{
+				Scheme:     "minio://",
+				BucketName: "test-bucket",
+				Prefix:     "artifacts/",
+				SessionInfo: &SessionInfo{
+					Provider: "minio",
+					Params: map[string]string{
+						"fromEnv": "true",
+					},
+				},
+			},
+			expectedRegion:       "us-east-1",
+			expectedBaseEndpoint: nil,
+			expectedPathStyle:    false,
+			expectedDisableHTTPS: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket, err := OpenBucket(context.Background(), nil, "", tt.config)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				require.NoError(t, bucket.Close())
+			})
+
+			var client *s3.Client
+			require.True(t, bucket.As(&client))
+			require.NotNil(t, client)
+			assert.Equal(t, tt.expectedRegion, client.Options().Region)
+			assert.Equal(t, tt.expectedBaseEndpoint, client.Options().BaseEndpoint)
+			assert.Equal(t, tt.expectedPathStyle, client.Options().UsePathStyle)
+			assert.Equal(t, tt.expectedDisableHTTPS, client.Options().EndpointOptions.DisableHTTPS)
+			assert.Equal(t, aws.RequestChecksumCalculationWhenRequired, client.Options().RequestChecksumCalculation)
+			assert.Equal(t, aws.ResponseChecksumValidationWhenRequired, client.Options().ResponseChecksumValidation)
+		})
+	}
+}
+
+func TestNewS3ClientRetryAttempts(t *testing.T) {
+	tests := []struct {
+		name                string
+		params              *S3Params
+		expectedMaxAttempts int
+	}{
+		{
+			name: "Structured params without maxRetries keep default retry cap",
+			params: &S3Params{
+				FromEnv:    true,
+				Region:     "us-east-1",
+				MaxRetries: 0,
+			},
+			expectedMaxAttempts: retry.NewStandard().MaxAttempts(),
+		},
+		{
+			name: "Structured params with maxRetries use configured retry cap",
+			params: &S3Params{
+				FromEnv:    true,
+				Region:     "us-east-1",
+				MaxRetries: 5,
+			},
+			expectedMaxAttempts: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := newS3Client(context.Background(), tt.params, nil)
+			require.NoError(t, err)
+			require.NotNil(t, client)
+			assert.Equal(t, tt.expectedMaxAttempts, client.Options().Retryer.MaxAttempts())
 		})
 	}
 }


### PR DESCRIPTION
Fix: [13314](https://github.com/kubeflow/pipelines/issues/13314) 
The existing [checksum fix](https://github.com/kubeflow/pipelines/pull/13315) only covered the S3 client built from secret-based credentials. This left a gap for env-based (like `AWS_PROFILE` or `IRSA`) object store access.

**Description of your changes:**
For plain `s3://` and `minio://` URLs without query parameters, `OpenBucket` now builds the S3 client directly and applies checksum settings.

For `SessionInfo` with `fromEnv=true` and structured S3 settings, `createS3BucketSession` now builds an S3 client from the default AWS credential chain and keeps the same S3 settings used by the secret-based path.

If `fromEnv=true` is set without structured S3 settings, the existing fallback behavior is kept.

Query-string based `s3://` and `minio://` URLs are left unchanged and still rely on gocloud URL parsing. 

Also, the config package import is aliased to awsconfig to avoid a name conflict with the config *Config parameter in OpenBucket.

Tests added:
- `createS3BucketSession` returns a valid client for `fromEnv=true` when structured S3 settings are present
- `OpenBucket` applies checksum settings for plain `s3://` and `minio://` URLs
- `OpenBucket` preserves the expected behavior for env-based session info both with and without structured S3 settings
- 
**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
