### PR TITLE
chore(frontend): pin npm 11.17.0

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up npm
       working-directory: frontend
       run: |
-        npm install --global "$(node -p "require('./package.json').packageManager")"
+        npm install --global "$(node -p 'require("./package.json").packageManager')"
         npm --version
 
     - name: Check for toolchain version drift

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,6 +29,12 @@ jobs:
       with:
         node-version-file: frontend/.nvmrc
 
+    - name: Set up npm
+      working-directory: frontend
+      run: |
+        npm install --global "$(node -p "require('./package.json').packageManager")"
+        npm --version
+
     - name: Check for toolchain version drift
       if: github.event_name == 'pull_request'
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,7 +369,7 @@ The KFP frontend is a React TypeScript application that provides the web UI for 
 
 ```bash
 cd frontend
-npm install --global "$(node -p "require('./package.json').packageManager")"
+npm install --global "$(node -p 'require("./package.json").packageManager')"
 npm ci  # Install exact dependencies from package-lock.json
 ```
 
@@ -688,7 +688,7 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 - API client generation fails with Docker errors (for example permission denied to Docker socket): ensure Docker is running and your user can access the Docker daemon.
 - Frontend fails to start due to Node version mismatch: `nvm use $(cat frontend/.nvmrc)` or `fnm use`.
 - Frontend lockfile checks fail after a dependency update: from `frontend/`, install the pinned
-  npm with `npm install --global "$(node -p "require('./package.json').packageManager")"`,
+  npm with `npm install --global "$(node -p 'require("./package.json").packageManager')"`,
   regenerate `package-lock.json`, and commit the result.
 - Runtime component imports SDK-only modules: `_KFP_RUNTIME=true` disables many SDK imports; avoid importing SDK-only modules in task code.
 - Proxy CI jobs fail during `Deploy Squid` with `OOMKilled`, `CrashLoopBackOff`, endpoint readiness timeouts, or failed proxy tests: inspect the `squid` namespace logs/events and verify `.github/resources/squid/squid.conf` still disables caching for CI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-06-17
+- Last updated: 2026-06-18
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -354,6 +354,7 @@ The KFP frontend is a React TypeScript application that provides the web UI for 
 ### Prerequisites
 
 - Node.js version specified in `frontend/.nvmrc`
+- npm version specified by `packageManager` in `frontend/package.json`
 - Docker (required for frontend API client generation via OpenAPI Generator container)
 - Use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) for Node version management:
 
@@ -368,6 +369,7 @@ The KFP frontend is a React TypeScript application that provides the web UI for 
 
 ```bash
 cd frontend
+npm install --global "$(node -p "require('./package.json').packageManager")"
 npm ci  # Install exact dependencies from package-lock.json
 ```
 
@@ -589,7 +591,8 @@ KFP frontend supports feature flags for development:
 ### Troubleshooting
 
 - **Port conflicts**: Frontend uses 3000 (React), 3001 (Node server), 3002 (API proxy)
-- **Node version issues**: Ensure you're using the version in `.nvmrc`
+- **Node/npm version issues**: Use the Node version in `.nvmrc` and the npm version in
+  `package.json`'s `packageManager` field
 - **API generation failures**: Ensure Docker is running and `docker` CLI is available in PATH
 - **Proto generation**: Requires `protoc` and `protoc-gen-grpc-web` in PATH
 - **Mock backend**: Limited API support; use real cluster for full testing
@@ -674,7 +677,8 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 - Do not assume `pipeline_spec_pb2.py` exists in the repo; it must be generated.
 - Frontend API generation requires Docker (`openapitools/openapi-generator-cli:v7.19.0`).
 - Frontend proto generation requires `protoc` and `protoc-gen-grpc-web` binaries.
-- Node version must match `.nvmrc`; use nvm/fnm to manage versions.
+- Node version must match `.nvmrc`; use nvm/fnm to manage versions. npm must match the
+  `packageManager` version in `frontend/package.json`.
 - Frontend port conflicts: 3000 (Vite), 3001 (Node server), 3002 (API proxy), 6006 (Storybook).
 
 ### Common error patterns and quick fixes
@@ -683,5 +687,8 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 - Protobuf generation fails under SELinux enforcing: temporarily disable with `sudo setenforce 0`; re-enable after.
 - API client generation fails with Docker errors (for example permission denied to Docker socket): ensure Docker is running and your user can access the Docker daemon.
 - Frontend fails to start due to Node version mismatch: `nvm use $(cat frontend/.nvmrc)` or `fnm use`.
+- Frontend lockfile checks fail after a dependency update: from `frontend/`, install the pinned
+  npm with `npm install --global "$(node -p "require('./package.json').packageManager")"`,
+  regenerate `package-lock.json`, and commit the result.
 - Runtime component imports SDK-only modules: `_KFP_RUNTIME=true` disables many SDK imports; avoid importing SDK-only modules in task code.
 - Proxy CI jobs fail during `Deploy Squid` with `OOMKilled`, `CrashLoopBackOff`, endpoint readiness timeouts, or failed proxy tests: inspect the `squid` namespace logs/events and verify `.github/resources/squid/squid.conf` still disables caching for CI.

--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -25,7 +25,7 @@ nvm use "$(cat .nvmrc)"
 Install the npm version declared in [`package.json`](package.json):
 
 ```bash
-npm install --global "$(node -p "require('./package.json').packageManager")"
+npm install --global "$(node -p 'require("./package.json").packageManager')"
 ```
 
 ## Manage dev environment with npm

--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -22,6 +22,12 @@ nvm install "$(cat .nvmrc)"
 nvm use "$(cat .nvmrc)"
 ```
 
+Install the npm version declared in [`package.json`](package.json):
+
+```bash
+npm install --global "$(node -p "require('./package.json').packageManager")"
+```
+
 ## Manage dev environment with npm
 
 ### Pre-requisites

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,6 +16,8 @@ COPY . .
 
 WORKDIR ./frontend
 
+RUN npm install --global "$(node -p "require('./package.json').packageManager")"
+
 # Retry with cache clean as a workaround for an intermittent npm EEXIST/ENOENT
 # race condition where parallel download workers collide on the same cache entry.
 RUN npm ci && npm run postinstall || (npm cache clean --force && npm ci && npm run postinstall)
@@ -27,6 +29,10 @@ RUN mkdir -p ./server/dist && \
     echo ${TAG_NAME} > ./server/dist/TAG_NAME
 
 FROM node:${NODE_VERSION}-${BASE_IMAGE}
+
+COPY --from=build ./src/frontend/package.json /tmp/frontend-package.json
+RUN npm install --global "$(node -p "require('/tmp/frontend-package.json').packageManager")" && \
+    rm /tmp/frontend-package.json
 
 COPY --from=build ./src/frontend/server /server
 COPY --from=build ./src/frontend/build /client

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 
 WORKDIR ./frontend
 
-RUN npm install --global "$(node -p "require('./package.json').packageManager")"
+RUN npm install --global "$(node -p 'require("./package.json").packageManager')"
 
 # Retry with cache clean as a workaround for an intermittent npm EEXIST/ENOENT
 # race condition where parallel download workers collide on the same cache entry.
@@ -31,7 +31,7 @@ RUN mkdir -p ./server/dist && \
 FROM node:${NODE_VERSION}-${BASE_IMAGE}
 
 COPY --from=build ./src/frontend/package.json /tmp/frontend-package.json
-RUN npm install --global "$(node -p "require('/tmp/frontend-package.json').packageManager")" && \
+RUN npm install --global "$(node -p 'require("/tmp/frontend-package.json").packageManager')" && \
     rm /tmp/frontend-package.json
 
 COPY --from=build ./src/frontend/server /server

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -70,7 +70,7 @@ Now navigate to the KFP frontend folder, install and build your NPM dependencies
 
 ```bash
 cd ${WORKING_DIRECTORY}/frontend
-npm install --global "$(node -p "require('./package.json').packageManager")"
+npm install --global "$(node -p 'require("./package.json").packageManager')"
 npm ci
 npm run build
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,6 +25,7 @@ You will need the following installed in your environment:
 * [Kind] 
 * [Kustomize] 
 * [Node] version specified in the [.nvmrc]
+* npm version specified in [package.json]
 
 > [!Note]
 > MAC users have reported positive experiences using [Docker + Colima] when using Kind environments. Consider
@@ -69,6 +70,7 @@ Now navigate to the KFP frontend folder, install and build your NPM dependencies
 
 ```bash
 cd ${WORKING_DIRECTORY}/frontend
+npm install --global "$(node -p "require('./package.json').packageManager")"
 npm ci
 npm run build
 ```
@@ -149,6 +151,7 @@ For a more comprehensive guide on contributing, please read [CONTRIBUTING.md].
 [Kustomize]: https://kustomize.io
 [Node]: https://www.npmjs.com/package/node
 [.nvmrc]: .nvmrc
+[package.json]: package.json
 [CONTRIBUTING.md]: CONTRIBUTING.md
 [scripts/ui-smoke-test/README.md]: scripts/ui-smoke-test/README.md
 [http://127.0.0.1:3000]: http://127.0.0.1:3000

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "private": true,
+  "packageManager": "npm@11.17.0",
   "engines": {
     "node": "24.14.0"
   },


### PR DESCRIPTION
## Summary

- declare npm 11.17.0 as the frontend package manager
- install the declared npm version before frontend CI lockfile validation
- use the declared npm version in both frontend container build stages
- document the local npm bootstrap command and lockfile troubleshooting flow

## Why

The frontend currently pins Node but inherits whichever npm version ships with that Node
distribution. This caused the lockfile check on #13548 to fail before tests: npm 11.9.0
rewrote lockfile metadata that is stable under current npm releases.

Pinning npm independently makes lockfile generation and validation deterministic across CI,
container builds, and local development.

## Impact

There is no frontend runtime behavior change. Developers need to install the npm version
declared by `frontend/package.json` after selecting the pinned Node version.

## Verification

- Node 24.14.0 + npm 11.17.0: `npm ci`
- `node scripts/check-lockfile-drift.mjs --base-ref origin/master`
- `npm run build`
- UI coverage suite: 148 files and 2,021 tests passed
- server coverage suite: 16 files and 272 tests passed, with 2 existing TODOs
- workflow YAML parse and `git diff --check`

The frontend Docker build was not run locally because the configured Docker daemon was not
available. The npm installation and frontend build commands used by the image were verified
directly.
