### PR TITLE
fix(sdk): resolve symlinks when archiving embedded artifacts

### DIFF
--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import base64
 import dataclasses
+import errno
 import gzip
 import inspect
 import io
@@ -503,6 +504,73 @@ CONTAINERIZED_PYTHON_COMPONENT_COMMAND = [
 ]
 
 
+def _safe_add_to_tar(
+    tar: tarfile.TarFile,
+    root: pathlib.Path,
+    arcname: str = '.',
+) -> None:
+    """Add a file or directory to a tar archive with controlled symlink
+    resolution.
+
+    Resolves the top-level *root* path, then walks its contents:
+    - Regular files are added directly.
+    - In-tree file symlinks are dereferenced (archived as regular files).
+    - Dangling symlinks raise ``ValueError``.
+    - Files whose resolved path escapes the artifact tree raise
+      ``ValueError``.
+    - Directory symlinks are rejected unconditionally.
+
+    This helper operates on trusted local input and does not attempt to
+    enforce source-tree immutability against concurrent modification.
+    """
+    resolved_root = root.resolve()
+
+    if resolved_root.is_file():
+        tar.add(str(resolved_root), arcname=arcname)
+        return
+
+    if not resolved_root.is_dir():
+        raise ValueError(f'Embedded artifact path does not exist or is not a '
+                         f'file/directory: {root}')
+
+    def _walk(
+        current: pathlib.Path,
+        arc_prefix: str,
+    ) -> None:
+        try:
+            resolved = current.resolve(strict=True)
+        except RuntimeError:
+            raise ValueError(f'Symlink cycle detected at: {current}')
+        except OSError as e:
+            if e.errno == errno.ELOOP:
+                raise ValueError(f'Symlink cycle detected at: {current}')
+            if e.errno in (errno.ENOENT, errno.ENOTDIR):
+                raise ValueError(f'Dangling symlink: {current}')
+            raise
+
+        if resolved.is_dir():
+            if current != resolved:
+                raise ValueError(
+                    f'Directory symlinks are not supported: {current}')
+
+            tar.add(str(resolved), arcname=arc_prefix, recursive=False)
+            for child in sorted(resolved.iterdir()):
+                child_arc = (f'{arc_prefix}/{child.name}'
+                             if arc_prefix != '.' else child.name)
+                _walk(child, child_arc)
+        elif resolved.is_file():
+            try:
+                resolved.relative_to(resolved_root)
+            except ValueError:
+                raise ValueError(
+                    f'Path escapes artifact tree: {current} -> {resolved}')
+            tar.add(str(resolved), arcname=arc_prefix)
+        else:
+            raise ValueError(f'Unsupported file type: {current}')
+
+    _walk(resolved_root, arcname)
+
+
 def _get_command_and_args_for_lightweight_component(
     func: Callable,
     additional_funcs: Optional[List[Callable]] = None,
@@ -534,9 +602,9 @@ def _get_command_and_args_for_lightweight_component(
         buf = io.BytesIO()
         with tarfile.open(fileobj=buf, mode='w') as tar:
             if asset_path.is_dir():
-                tar.add(asset_path, arcname='.')
+                _safe_add_to_tar(tar, asset_path, arcname='.')
             else:
-                tar.add(asset_path, arcname=asset_path.name)
+                _safe_add_to_tar(tar, asset_path, arcname=asset_path.name)
 
         archive_bytes = buf.getvalue()
 

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -411,5 +411,259 @@ class TestPythonEOLWarning(unittest.TestCase):
                 pass
 
 
+def _get_archive(component_fn):
+    """Extract the raw tar bytes from a compiled component's embedded
+    archive."""
+    import base64
+    import gzip
+
+    source = component_fn.component_spec.implementation.container.command[-1]
+    match = re.search(r"__KFP_EMBEDDED_ARCHIVE_B64\s*=\s*'([^']+)'", source)
+    if not match:
+        raise ValueError(
+            'Could not locate __KFP_EMBEDDED_ARCHIVE_B64 in compiled '
+            'component source.')
+    archive_b64 = match.group(1)
+
+    compressed = base64.b64decode(archive_b64.encode('ascii'))
+    return gzip.decompress(compressed)
+
+
+class TestEmbeddedArtifactSymlinkResolution(unittest.TestCase):
+    """Tests for #13533: embedded artifacts should resolve symlinks."""
+
+    def test_symlinked_file_is_dereferenced_in_archive(self):
+        """A symlinked file should be archived as a regular file, not a
+        symlink."""
+        import io
+        import os
+        import tarfile
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real_dir = os.path.join(tmpdir, 'real')
+            os.makedirs(real_dir)
+            real_file = os.path.join(real_dir, 'data.txt')
+            with open(real_file, 'w') as f:
+                f.write('real content')
+
+            link_file = os.path.join(tmpdir, 'link.txt')
+            try:
+                os.symlink(real_file, link_file)
+            except OSError:
+                self.skipTest('Cannot create symlinks on this platform')
+
+            @component(
+                base_image='python:3.11',
+                embedded_artifact_path=link_file,
+                install_kfp_package=False,
+            )
+            def my_comp(cfg: dsl.EmbeddedInput[dsl.Dataset]):
+                pass
+
+            raw = _get_archive(my_comp)
+            with tarfile.open(fileobj=io.BytesIO(raw), mode='r') as tar:
+                members = tar.getmembers()
+                self.assertEqual(len(members), 1)
+                member = members[0]
+                self.assertFalse(member.issym(),
+                                 'Symlink was not dereferenced in archive')
+                self.assertFalse(member.islnk(),
+                                 'Hardlink was not dereferenced in archive')
+                self.assertTrue(member.isfile())
+                with tar.extractfile(member) as extracted:
+                    self.assertIsNotNone(extracted)
+                    self.assertEqual(extracted.read().decode(), 'real content')
+
+    def test_directory_with_symlinked_file_is_dereferenced(self):
+        """When a directory is embedded and it contains a symlinked file whose
+        target is inside the artifact tree, the archive should contain the real
+        file content."""
+        import io
+        import os
+        import tarfile
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            embed_dir = os.path.join(tmpdir, 'assets')
+            os.makedirs(embed_dir)
+
+            real_file = os.path.join(embed_dir, 'original.txt')
+            with open(real_file, 'w') as f:
+                f.write('original content')
+
+            link_in_dir = os.path.join(embed_dir, 'linked.txt')
+            try:
+                os.symlink(real_file, link_in_dir)
+            except OSError:
+                self.skipTest('Cannot create symlinks on this platform')
+
+            @component(
+                base_image='python:3.11',
+                embedded_artifact_path=embed_dir,
+                install_kfp_package=False,
+            )
+            def my_comp(cfg: dsl.EmbeddedInput[dsl.Dataset]):
+                pass
+
+            raw = _get_archive(my_comp)
+            with tarfile.open(fileobj=io.BytesIO(raw), mode='r') as tar:
+                members = tar.getmembers()
+                for member in members:
+                    self.assertFalse(
+                        member.issym(),
+                        f'Member {member.name} is still a symlink')
+                    self.assertFalse(
+                        member.islnk(),
+                        f'Member {member.name} is still a hardlink')
+                    self.assertTrue(
+                        member.isfile() or member.isdir(),
+                        f'Member {member.name} has unexpected type')
+                linked_member = next(
+                    (m for m in members if m.name.endswith('linked.txt')), None)
+                self.assertIsNotNone(linked_member,
+                                     'linked.txt not found in archive')
+                with tar.extractfile(linked_member) as extracted:
+                    self.assertIsNotNone(extracted)
+                    self.assertEqual(extracted.read().decode(),
+                                     'original content')
+
+    def test_directory_symlink_is_rejected(self):
+        """A directory symlink should be rejected."""
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            embed_dir = os.path.join(tmpdir, 'assets')
+            os.makedirs(embed_dir)
+            with open(os.path.join(embed_dir, 'file.txt'), 'w') as f:
+                f.write('hello')
+            cycle_link = os.path.join(embed_dir, 'loop')
+            try:
+                os.symlink(embed_dir, cycle_link)
+            except OSError:
+                self.skipTest('Cannot create symlinks on this platform')
+
+            with self.assertRaisesRegex(ValueError, r'[Dd]irectory symlinks'):
+
+                @component(
+                    base_image='python:3.11',
+                    embedded_artifact_path=embed_dir,
+                    install_kfp_package=False,
+                )
+                def my_comp(cfg: dsl.EmbeddedInput[dsl.Dataset]):
+                    pass
+
+    def test_escaping_symlink_raises_error(self):
+        """A nested symlink whose target is outside the artifact tree should be
+        rejected."""
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outside_file = os.path.join(tmpdir, 'secret.txt')
+            with open(outside_file, 'w') as f:
+                f.write('sensitive data')
+
+            embed_dir = os.path.join(tmpdir, 'assets')
+            sub_dir = os.path.join(embed_dir, 'nested')
+            os.makedirs(sub_dir)
+            escape_link = os.path.join(sub_dir, 'escaped.txt')
+            try:
+                os.symlink(outside_file, escape_link)
+            except OSError:
+                self.skipTest('Cannot create symlinks on this platform')
+
+            with self.assertRaisesRegex(ValueError, r'escapes'):
+
+                @component(
+                    base_image='python:3.11',
+                    embedded_artifact_path=embed_dir,
+                    install_kfp_package=False,
+                )
+                def my_comp(cfg: dsl.EmbeddedInput[dsl.Dataset]):
+                    pass
+
+    def test_dangling_symlink_raises_error(self):
+        """A symlink whose target does not exist should be rejected."""
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            embed_dir = os.path.join(tmpdir, 'assets')
+            os.makedirs(embed_dir)
+            dangling_link = os.path.join(embed_dir, 'broken.txt')
+            try:
+                os.symlink(
+                    os.path.join(tmpdir, 'nonexistent.txt'), dangling_link)
+            except OSError:
+                self.skipTest('Cannot create symlinks on this platform')
+
+            with self.assertRaisesRegex(ValueError, r'[Dd]angling'):
+
+                @component(
+                    base_image='python:3.11',
+                    embedded_artifact_path=embed_dir,
+                    install_kfp_package=False,
+                )
+                def my_comp(cfg: dsl.EmbeddedInput[dsl.Dataset]):
+                    pass
+
+    def test_sibling_directory_symlink_is_rejected(self):
+        """A symlink to a sibling directory should be rejected."""
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            embed_dir = os.path.join(tmpdir, 'assets')
+            sub_dir = os.path.join(embed_dir, 'sub')
+            os.makedirs(sub_dir)
+            with open(os.path.join(sub_dir, 'a.txt'), 'w') as f:
+                f.write('content A')
+
+            alias_link = os.path.join(embed_dir, 'alias')
+            try:
+                os.symlink(sub_dir, alias_link)
+            except OSError:
+                self.skipTest('Cannot create symlinks on this platform')
+
+            with self.assertRaisesRegex(ValueError, r'[Dd]irectory symlinks'):
+
+                @component(
+                    base_image='python:3.11',
+                    embedded_artifact_path=embed_dir,
+                    install_kfp_package=False,
+                )
+                def my_comp(cfg: dsl.EmbeddedInput[dsl.Dataset]):
+                    pass
+
+    def test_self_referential_symlink_raises_error(self):
+        """A self-referential symlink (a -> a) should be rejected as a cycle
+        consistently across Python versions."""
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            embed_dir = os.path.join(tmpdir, 'assets')
+            os.makedirs(embed_dir)
+            with open(os.path.join(embed_dir, 'file.txt'), 'w') as f:
+                f.write('hello')
+            self_link = os.path.join(embed_dir, 'self')
+            try:
+                os.symlink(self_link, self_link)
+            except OSError:
+                self.skipTest('Cannot create symlinks on this platform')
+
+            with self.assertRaisesRegex(ValueError, r'[Cc]ycle'):
+
+                @component(
+                    base_image='python:3.11',
+                    embedded_artifact_path=embed_dir,
+                    install_kfp_package=False,
+                )
+                def my_comp(cfg: dsl.EmbeddedInput[dsl.Dataset]):
+                    pass
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of your changes:**

Resolves symlinks when creating tar archives for embedded artifacts. Previously, `tarfile.open()` preserved symlinks in the archive, causing `RuntimeError: Failed to extract embedded archive` at runtime when the symlink target didn't exist inside the container.

Fixes #13533 
Changes:

- Added _safe_add_to_tar() helper that walks the artifact tree with controlled symlink resolution: Resolves the top-level `embedded_artifact_path`, Dereferences in-tree file symlinks and Rejects dangling, escaping, and cyclic symlinks (ancestor-based (`st_dev, st_ino`) cycle detection)


- Added `_get_archive()` test helper to extract and decompress the embedded archive from a compiled component
- Added regression tests: symlinked file, directory with in-tree symlink, cyclic symlink, nested escaping symlink, dangling symlink, and valid sibling symlink
- This fix only affects the SDK compile-time logic. The backend is unchanged

Note: The issue is labeled [backend] but the bug is in the Python SDK's archiving logic, not the backend API server.