### PR TITLE
fix(backend) stream metrics artifact extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -729,6 +729,7 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 - `TENSORBOARD_PROXY_SIGNING_SECRET=...`: Optional shared frontend-server secret for scoped TensorBoard proxy URLs; defaults to `MINIO_SECRET_KEY` when unset
 - `FRONTEND_SERVER_NAMESPACE=...`: Sets the namespace used by the local frontend Node server for Kubernetes lookups when it is not running inside a cluster pod. `npm run start:proxy-and-server` derives this from `NAMESPACE`.
 - `MINIO_ENDPOINT_REWRITE=from=to[,from=to]`: Rewrites explicit object-store endpoints for local proxy mode, for example from `seaweedfs.kubeflow:9000` to `localhost:9000`.
+- `MAX_METRICS_FILE_BYTES=...`: Maximum uncompressed size of the single metrics JSON file read from an `mlpipeline-metrics` archive; defaults to 1 MiB
 
 ## Troubleshooting and pitfalls
 

--- a/backend/src/agent/persistence/client/artifactclient/client_test.go
+++ b/backend/src/agent/persistence/client/artifactclient/client_test.go
@@ -76,7 +76,7 @@ func createTarGz(files map[string]string) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// extractTarGz extracts files from a tar.gz archive (like util.ExtractTgz but works with []byte)
+// extractTarGz extracts files from a tar.gz archive for test assertions.
 func extractTarGz(t *testing.T, tgzData []byte) map[string]string {
 	gr, err := gzip.NewReader(bytes.NewReader(tgzData))
 	require.NoError(t, err, "Failed to create gzip reader")

--- a/backend/src/common/util/consts.go
+++ b/backend/src/common/util/consts.go
@@ -31,6 +31,8 @@ const (
 
 	// MaxParameterBytesEnvVar is the environment variable name for configuring max parameter bytes.
 	MaxParameterBytesEnvVar = "MAX_PARAMETER_BYTES"
+	// MaxMetricsFileBytesEnvVar configures the maximum uncompressed metrics artifact size.
+	MaxMetricsFileBytesEnvVar = "MAX_METRICS_FILE_BYTES"
 
 	// LabelKeyWorkflowEpoch is a label on a Workflow.
 	// It captures the epoch at which the workflow was scheduled.
@@ -77,6 +79,19 @@ func GetMaxParameterBytes() int {
 		}
 	}
 	return defaultMaxParameterBytes
+}
+
+// GetMaxMetricsFileBytes returns the maximum uncompressed byte size of a
+// metrics artifact. One MiB comfortably exceeds the meaningful payload for 50
+// scalar metrics while bounding pathological JSON whitespace and encoding.
+func GetMaxMetricsFileBytes() int64 {
+	const defaultMaxMetricsFileBytes int64 = 1 << 20
+	if envValue := os.Getenv(MaxMetricsFileBytesEnvVar); envValue != "" {
+		if value, err := strconv.ParseInt(envValue, 10, 64); err == nil && value > 0 {
+			return value
+		}
+	}
+	return defaultMaxMetricsFileBytes
 }
 
 // MaxParameterBytes is the maximum byte size of the parameter column in package/pipeline DB.

--- a/backend/src/common/util/consts_test.go
+++ b/backend/src/common/util/consts_test.go
@@ -118,3 +118,25 @@ func TestMaxParameterBytes_EnvVarParsing(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMaxMetricsFileBytes(t *testing.T) {
+	const defaultMaxMetricsFileBytes int64 = 1 << 20
+	testCases := []struct {
+		name        string
+		envValue    string
+		expectValue int64
+	}{
+		{name: "default", expectValue: defaultMaxMetricsFileBytes},
+		{name: "valid positive integer", envValue: "2048", expectValue: 2048},
+		{name: "invalid string keeps default", envValue: "invalid", expectValue: defaultMaxMetricsFileBytes},
+		{name: "zero keeps default", envValue: "0", expectValue: defaultMaxMetricsFileBytes},
+		{name: "negative keeps default", envValue: "-1", expectValue: defaultMaxMetricsFileBytes},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv(MaxMetricsFileBytesEnvVar, testCase.envValue)
+			assert.Equal(t, testCase.expectValue, GetMaxMetricsFileBytes())
+		})
+	}
+}

--- a/backend/src/common/util/metrics_artifact.go
+++ b/backend/src/common/util/metrics_artifact.go
@@ -1,0 +1,137 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+const (
+	// More than 50 metrics is not scalable with the current UI design.
+	maxMetricsCountLimit = 50
+	// This matches the metric-name validation in the v1 API server.
+	maxMetricNameLength = 64
+)
+
+func decodeRunMetrics(reader io.Reader) ([]*api.RunMetric, error) {
+	decoder := json.NewDecoder(reader)
+
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read metrics object: %w", err)
+	}
+	if delimiter, ok := token.(json.Delim); !ok || delimiter != '{' {
+		return nil, fmt.Errorf("metrics file must contain a JSON object")
+	}
+
+	var metrics []*api.RunMetric
+	metricsSeen := false
+	for decoder.More() {
+		fieldToken, err := decoder.Token()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read metrics field: %w", err)
+		}
+		fieldName, ok := fieldToken.(string)
+		if !ok {
+			return nil, fmt.Errorf("metrics field name must be a string")
+		}
+
+		switch fieldName {
+		case "metrics":
+			if metricsSeen {
+				return nil, fmt.Errorf("metrics field must not be repeated")
+			}
+			metricsSeen = true
+			metrics, err = decodeMetricsArray(decoder)
+			if err != nil {
+				return nil, err
+			}
+		case "runId", "run_id":
+			var ignoredRunID string
+			if err := decoder.Decode(&ignoredRunID); err != nil {
+				return nil, fmt.Errorf("failed to decode %s: %w", fieldName, err)
+			}
+		default:
+			return nil, fmt.Errorf("unknown metrics field %q", fieldName)
+		}
+	}
+
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("failed to finish metrics object: %w", err)
+	}
+	var trailing json.RawMessage
+	if err := decoder.Decode(&trailing); err == nil {
+		return nil, fmt.Errorf("unexpected content after metrics object")
+	} else if err != io.EOF {
+		return nil, fmt.Errorf("failed to finish metrics file: %w", err)
+	}
+	return metrics, nil
+}
+
+func decodeMetricsArray(decoder *json.Decoder) ([]*api.RunMetric, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read metrics array: %w", err)
+	}
+	if token == nil {
+		return nil, nil
+	}
+	if delimiter, ok := token.(json.Delim); !ok || delimiter != '[' {
+		return nil, fmt.Errorf("metrics field must be an array")
+	}
+
+	metrics := make([]*api.RunMetric, 0, maxMetricsCountLimit)
+	for decoder.More() {
+		if len(metrics) >= maxMetricsCountLimit {
+			return nil, fmt.Errorf("metrics file contains more than %d metrics", maxMetricsCountLimit)
+		}
+
+		var rawMetric json.RawMessage
+		if err := decoder.Decode(&rawMetric); err != nil {
+			return nil, fmt.Errorf("failed to decode metric: %w", err)
+		}
+		transformedMetric, err := transformJSONForBackwardCompatibility(string(rawMetric))
+		if err != nil {
+			return nil, err
+		}
+		metric := new(api.RunMetric)
+		if err := protojson.Unmarshal([]byte(transformedMetric), metric); err != nil {
+			return nil, fmt.Errorf("failed to decode metric: %w", err)
+		}
+		if len(metric.GetName()) > maxMetricNameLength {
+			return nil, fmt.Errorf("metric name cannot exceed %d characters", maxMetricNameLength)
+		}
+		metrics = append(metrics, metric)
+	}
+	if _, err := decoder.Token(); err != nil {
+		return nil, fmt.Errorf("failed to finish metrics array: %w", err)
+	}
+	return metrics, nil
+}
+
+// Previously number_value for RunMetrics in backend/api/v1beta1/run.proto
+// allowed camelCase field values in JSON. Keep accepting both forms.
+func transformJSONForBackwardCompatibility(jsonString string) (string, error) {
+	replacer := strings.NewReplacer(
+		`"numberValue":`, `"number_value":`,
+	)
+	return replacer.Replace(jsonString), nil
+}

--- a/backend/src/common/util/metrics_artifact.go
+++ b/backend/src/common/util/metrics_artifact.go
@@ -91,9 +91,6 @@ func decodeMetricsArray(decoder *json.Decoder) ([]*api.RunMetric, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read metrics array: %w", err)
 	}
-	if token == nil {
-		return nil, nil
-	}
 	if delimiter, ok := token.(json.Delim); !ok || delimiter != '[' {
 		return nil, fmt.Errorf("metrics field must be an array")
 	}

--- a/backend/src/common/util/metrics_artifact.go
+++ b/backend/src/common/util/metrics_artifact.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -44,6 +45,7 @@ func decodeRunMetrics(reader io.Reader) ([]*api.RunMetric, error) {
 
 	var metrics []*api.RunMetric
 	metricsSeen := false
+	runIDSeen := false
 	for decoder.More() {
 		fieldToken, err := decoder.Token()
 		if err != nil {
@@ -65,6 +67,10 @@ func decodeRunMetrics(reader io.Reader) ([]*api.RunMetric, error) {
 				return nil, err
 			}
 		case "runId", "run_id":
+			if runIDSeen {
+				return nil, fmt.Errorf("run ID field must not be repeated")
+			}
+			runIDSeen = true
 			var ignoredRunID string
 			if err := decoder.Decode(&ignoredRunID); err != nil {
 				return nil, fmt.Errorf("failed to decode %s: %w", fieldName, err)
@@ -91,6 +97,9 @@ func decodeMetricsArray(decoder *json.Decoder) ([]*api.RunMetric, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read metrics array: %w", err)
 	}
+	if token == nil {
+		return nil, nil
+	}
 	if delimiter, ok := token.(json.Delim); !ok || delimiter != '[' {
 		return nil, fmt.Errorf("metrics field must be an array")
 	}
@@ -109,7 +118,7 @@ func decodeMetricsArray(decoder *json.Decoder) ([]*api.RunMetric, error) {
 		if err := protojson.Unmarshal([]byte(transformedMetric), metric); err != nil {
 			return nil, fmt.Errorf("failed to decode metric: %w", err)
 		}
-		if len(metric.GetName()) > maxMetricNameLength {
+		if utf8.RuneCountInString(metric.GetName()) > maxMetricNameLength {
 			return nil, fmt.Errorf("metric name cannot exceed %d characters", maxMetricNameLength)
 		}
 		if len(metrics) < maxMetricsCountLimit {

--- a/backend/src/common/util/metrics_artifact.go
+++ b/backend/src/common/util/metrics_artifact.go
@@ -97,10 +97,6 @@ func decodeMetricsArray(decoder *json.Decoder) ([]*api.RunMetric, error) {
 
 	metrics := make([]*api.RunMetric, 0, maxMetricsCountLimit)
 	for decoder.More() {
-		if len(metrics) >= maxMetricsCountLimit {
-			return nil, fmt.Errorf("metrics file contains more than %d metrics", maxMetricsCountLimit)
-		}
-
 		var rawMetric json.RawMessage
 		if err := decoder.Decode(&rawMetric); err != nil {
 			return nil, fmt.Errorf("failed to decode metric: %w", err)
@@ -116,7 +112,9 @@ func decodeMetricsArray(decoder *json.Decoder) ([]*api.RunMetric, error) {
 		if len(metric.GetName()) > maxMetricNameLength {
 			return nil, fmt.Errorf("metric name cannot exceed %d characters", maxMetricNameLength)
 		}
-		metrics = append(metrics, metric)
+		if len(metrics) < maxMetricsCountLimit {
+			metrics = append(metrics, metric)
+		}
 	}
 	if _, err := decoder.Token(); err != nil {
 		return nil, fmt.Errorf("failed to finish metrics array: %w", err)

--- a/backend/src/common/util/metrics_artifact_test.go
+++ b/backend/src/common/util/metrics_artifact_test.go
@@ -99,6 +99,11 @@ func TestDecodeRunMetrics_RejectsUnknownFieldsAndTrailingJSON(t *testing.T) {
 		errorContains string
 	}{
 		{
+			name:          "null metrics",
+			input:         `{"metrics":null}`,
+			errorContains: "metrics field must be an array",
+		},
+		{
 			name:          "unknown top-level field",
 			input:         `{"metrics":[],"unknown":true}`,
 			errorContains: `unknown metrics field "unknown"`,

--- a/backend/src/common/util/metrics_artifact_test.go
+++ b/backend/src/common/util/metrics_artifact_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeRunMetrics_StreamsCompatibleMetrics(t *testing.T) {
+	metrics, err := decodeRunMetrics(strings.NewReader(`{
+		"runId": "ignored",
+		"metrics": [
+			{"name": "accuracy", "numberValue": 0.95},
+			{"name": "loss", "number_value": 1.25, "format": "RAW"}
+		]
+	}`))
+
+	require.NoError(t, err)
+	require.Len(t, metrics, 2)
+	assert.Equal(t, "accuracy", metrics[0].GetName())
+	assert.Equal(t, 0.95, metrics[0].GetNumberValue())
+	assert.Equal(t, "loss", metrics[1].GetName())
+	assert.Equal(t, 1.25, metrics[1].GetNumberValue())
+}
+
+func TestDecodeRunMetrics_EnforcesMetricCount(t *testing.T) {
+	var input strings.Builder
+	input.WriteString(`{"metrics":[`)
+	for index := 0; index <= maxMetricsCountLimit; index++ {
+		if index > 0 {
+			input.WriteByte(',')
+		}
+		fmt.Fprintf(&input, `{"name":"metric-%d","numberValue":%d}`, index, index)
+	}
+	input.WriteString(`]}`)
+
+	metrics, err := decodeRunMetrics(strings.NewReader(input.String()))
+
+	assert.Nil(t, metrics)
+	assert.ErrorContains(t, err, "metrics file contains more than 50 metrics")
+}
+
+func TestDecodeRunMetrics_EnforcesMetricNameLength(t *testing.T) {
+	testCases := []struct {
+		name          string
+		metricName    string
+		errorContains string
+	}{
+		{name: "exact limit", metricName: strings.Repeat("a", maxMetricNameLength)},
+		{
+			name:          "over limit",
+			metricName:    strings.Repeat("a", maxMetricNameLength+1),
+			errorContains: "metric name cannot exceed 64 characters",
+		},
+		{
+			name:       "pattern validation remains downstream",
+			metricName: "log loss",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			input := fmt.Sprintf(`{"metrics":[{"name":%q,"numberValue":1}]}`, testCase.metricName)
+			metrics, err := decodeRunMetrics(strings.NewReader(input))
+
+			if testCase.errorContains == "" {
+				require.NoError(t, err)
+				require.Len(t, metrics, 1)
+				assert.Equal(t, testCase.metricName, metrics[0].GetName())
+			} else {
+				assert.Nil(t, metrics)
+				assert.ErrorContains(t, err, testCase.errorContains)
+			}
+		})
+	}
+}
+
+func TestDecodeRunMetrics_RejectsUnknownFieldsAndTrailingJSON(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         string
+		errorContains string
+	}{
+		{
+			name:          "unknown top-level field",
+			input:         `{"metrics":[],"unknown":true}`,
+			errorContains: `unknown metrics field "unknown"`,
+		},
+		{
+			name:          "unknown metric field",
+			input:         `{"metrics":[{"name":"accuracy","unknown":true}]}`,
+			errorContains: "unknown field",
+		},
+		{
+			name:          "trailing JSON value",
+			input:         `{"metrics":[]} {}`,
+			errorContains: "unexpected content after metrics object",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			metrics, err := decodeRunMetrics(strings.NewReader(testCase.input))
+
+			assert.Nil(t, metrics)
+			assert.ErrorContains(t, err, testCase.errorContains)
+		})
+	}
+}

--- a/backend/src/common/util/metrics_artifact_test.go
+++ b/backend/src/common/util/metrics_artifact_test.go
@@ -66,9 +66,15 @@ func TestDecodeRunMetrics_EnforcesMetricNameLength(t *testing.T) {
 		errorContains string
 	}{
 		{name: "exact limit", metricName: strings.Repeat("a", maxMetricNameLength)},
+		{name: "exact Unicode limit", metricName: strings.Repeat("é", maxMetricNameLength)},
 		{
 			name:          "over limit",
 			metricName:    strings.Repeat("a", maxMetricNameLength+1),
+			errorContains: "metric name cannot exceed 64 characters",
+		},
+		{
+			name:          "over Unicode limit",
+			metricName:    strings.Repeat("é", maxMetricNameLength+1),
 			errorContains: "metric name cannot exceed 64 characters",
 		},
 		{
@@ -94,17 +100,44 @@ func TestDecodeRunMetrics_EnforcesMetricNameLength(t *testing.T) {
 	}
 }
 
+func TestDecodeRunMetrics_AcceptsNullMetrics(t *testing.T) {
+	metrics, err := decodeRunMetrics(strings.NewReader(`{"metrics":null}`))
+
+	require.NoError(t, err)
+	assert.Nil(t, metrics)
+}
+
+func TestDecodeRunMetrics_RejectsDuplicateRunIDFields(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "same spelling",
+			input: `{"runId":"first","runId":"second","metrics":[]}`,
+		},
+		{
+			name:  "JSON name and proto name aliases",
+			input: `{"runId":"first","run_id":"second","metrics":[]}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			metrics, err := decodeRunMetrics(strings.NewReader(testCase.input))
+
+			assert.Nil(t, metrics)
+			assert.ErrorContains(t, err, "run ID field must not be repeated")
+		})
+	}
+}
+
 func TestDecodeRunMetrics_RejectsUnknownFieldsAndTrailingJSON(t *testing.T) {
 	testCases := []struct {
 		name          string
 		input         string
 		errorContains string
 	}{
-		{
-			name:          "null metrics",
-			input:         `{"metrics":null}`,
-			errorContains: "metrics field must be an array",
-		},
 		{
 			name:          "unknown top-level field",
 			input:         `{"metrics":[],"unknown":true}`,

--- a/backend/src/common/util/metrics_artifact_test.go
+++ b/backend/src/common/util/metrics_artifact_test.go
@@ -40,7 +40,7 @@ func TestDecodeRunMetrics_StreamsCompatibleMetrics(t *testing.T) {
 	assert.Equal(t, 1.25, metrics[1].GetNumberValue())
 }
 
-func TestDecodeRunMetrics_EnforcesMetricCount(t *testing.T) {
+func TestDecodeRunMetrics_CapsMetricCount(t *testing.T) {
 	var input strings.Builder
 	input.WriteString(`{"metrics":[`)
 	for index := 0; index <= maxMetricsCountLimit; index++ {
@@ -53,8 +53,10 @@ func TestDecodeRunMetrics_EnforcesMetricCount(t *testing.T) {
 
 	metrics, err := decodeRunMetrics(strings.NewReader(input.String()))
 
-	assert.Nil(t, metrics)
-	assert.ErrorContains(t, err, "metrics file contains more than 50 metrics")
+	require.NoError(t, err)
+	require.Len(t, metrics, maxMetricsCountLimit)
+	assert.Equal(t, "metric-0", metrics[0].GetName())
+	assert.Equal(t, "metric-49", metrics[maxMetricsCountLimit-1].GetName())
 }
 
 func TestDecodeRunMetrics_EnforcesMetricNameLength(t *testing.T) {

--- a/backend/src/common/util/tgz.go
+++ b/backend/src/common/util/tgz.go
@@ -74,7 +74,7 @@ func readSingleFileFromTgz(tgzContent []byte, maxFileSize int64, consume func(io
 	if err != nil {
 		return err
 	}
-	if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeRegA {
+	if hdr.Typeflag != tar.TypeReg {
 		return fmt.Errorf("metrics archive entry %q must be a regular file", hdr.Name)
 	}
 	if hdr.Size < 0 {
@@ -93,7 +93,7 @@ func readSingleFileFromTgz(tgzContent []byte, maxFileSize int64, consume func(io
 	}
 
 	if _, err := tr.Next(); err == nil {
-		return fmt.Errorf("metrics archive must contain exactly one file")
+		return fmt.Errorf("metrics archive must contain exactly one regular file")
 	} else if err != io.EOF {
 		return err
 	}

--- a/backend/src/common/util/tgz.go
+++ b/backend/src/common/util/tgz.go
@@ -18,8 +18,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
-	"strings"
 )
 
 // Utils to archive and extract tgz (tar.gz) file.
@@ -53,34 +53,49 @@ func ArchiveTgz(files map[string]string) (string, error) {
 	return buf.String(), nil
 }
 
-// ExtractTgz extracts a list of files from a tgz content. The output is a map
-// with file name as key and content as value. Nested files and directories are
-// not supported.
-func ExtractTgz(tgzContent string) (map[string]string, error) {
-	sr := strings.NewReader(tgzContent)
-	gr, err := gzip.NewReader(sr)
-	if err != nil {
-		return nil, err
+// readSingleFileFromTgz streams the only regular file in a tar.gz archive to
+// consume. The caller provides the maximum uncompressed file size.
+func readSingleFileFromTgz(tgzContent []byte, maxFileSize int64, consume func(io.Reader) error) error {
+	if maxFileSize <= 0 {
+		return fmt.Errorf("maximum metrics file size must be positive")
 	}
+
+	gr, err := gzip.NewReader(bytes.NewReader(tgzContent))
+	if err != nil {
+		return err
+	}
+	defer gr.Close()
 	tr := tar.NewReader(gr)
 
-	files := make(map[string]string)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-		if hdr == nil {
-			continue
-		}
-		fileContent, err := io.ReadAll(tr)
-		if err != nil {
-			return nil, err
-		}
-		files[hdr.Name] = string(fileContent)
+	hdr, err := tr.Next()
+	if err == io.EOF {
+		return fmt.Errorf("metrics archive must contain exactly one regular file")
 	}
-	return files, nil
+	if err != nil {
+		return err
+	}
+	if hdr.Typeflag != tar.TypeReg && hdr.Typeflag != tar.TypeRegA {
+		return fmt.Errorf("metrics archive entry %q must be a regular file", hdr.Name)
+	}
+	if hdr.Size < 0 {
+		return fmt.Errorf("metrics archive entry %q has invalid negative size %d", hdr.Name, hdr.Size)
+	}
+	if hdr.Size > maxFileSize {
+		return fmt.Errorf("metrics archive entry %q exceeds maximum size of %d bytes", hdr.Name, maxFileSize)
+	}
+
+	limitedReader := &io.LimitedReader{R: tr, N: maxFileSize}
+	if err := consume(limitedReader); err != nil {
+		return err
+	}
+	if _, err := io.Copy(io.Discard, limitedReader); err != nil {
+		return err
+	}
+
+	if _, err := tr.Next(); err == nil {
+		return fmt.Errorf("metrics archive must contain exactly one file")
+	} else if err != io.EOF {
+		return err
+	}
+	return nil
 }

--- a/backend/src/common/util/tgz_test.go
+++ b/backend/src/common/util/tgz_test.go
@@ -15,47 +15,145 @@
 package util
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestArchiveTgzAndExtractTgz_Roundtrip(t *testing.T) {
-	expectedFiles := map[string]string{
-		"README":         "Hello, World",
-		"hello_world.sh": "echo 'Hello, World'",
+type testTgzEntry struct {
+	name     string
+	content  string
+	typeflag byte
+}
+
+func createTestTgz(t *testing.T, entries []testTgzEntry) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for _, entry := range entries {
+		err := tarWriter.WriteHeader(&tar.Header{
+			Typeflag: entry.typeflag,
+			Name:     entry.name,
+			Size:     int64(len(entry.content)),
+		})
+		require.NoError(t, err)
+		_, err = tarWriter.Write([]byte(entry.content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+
+	return buf.Bytes()
+}
+
+func TestArchiveTgzAndReadSingleFileFromTgz_Roundtrip(t *testing.T) {
+	tgzContent, err := ArchiveTgz(map[string]string{"metrics.json": "content"})
+	require.NoError(t, err)
+
+	var content []byte
+	err = readSingleFileFromTgz([]byte(tgzContent), 7, func(reader io.Reader) error {
+		content, err = io.ReadAll(reader)
+		return err
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+}
+
+func TestReadSingleFileFromTgz_RejectsInvalidArchive(t *testing.T) {
+	err := readSingleFileFromTgz([]byte("not a valid tgz"), 1024, func(io.Reader) error {
+		return nil
+	})
+
+	assert.Error(t, err)
+}
+
+func TestReadSingleFileFromTgz_RequiresOneEntry(t *testing.T) {
+	testCases := []struct {
+		name          string
+		entries       []testTgzEntry
+		errorContains string
+	}{
+		{
+			name:          "empty archive",
+			entries:       nil,
+			errorContains: "metrics archive must contain exactly one regular file",
+		},
+		{
+			name: "multiple files",
+			entries: []testTgzEntry{
+				{name: "first.json", content: "first"},
+				{name: "second.json", content: "second"},
+			},
+			errorContains: "metrics archive must contain exactly one file",
+		},
 	}
 
-	tgzContent, err := ArchiveTgz(expectedFiles)
-	assert.Nil(t, err)
-	assert.NotEmpty(t, tgzContent)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tgzContent := createTestTgz(t, testCase.entries)
+			err := readSingleFileFromTgz(tgzContent, 1024, func(reader io.Reader) error {
+				_, err := io.Copy(io.Discard, reader)
+				return err
+			})
 
-	actualFiles, err := ExtractTgz(tgzContent)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedFiles, actualFiles)
+			assert.ErrorContains(t, err, testCase.errorContains)
+		})
+	}
 }
 
-func TestArchiveTgz_EmptyFiles(t *testing.T) {
-	tgzContent, err := ArchiveTgz(map[string]string{})
-	assert.Nil(t, err)
-	assert.NotEmpty(t, tgzContent)
+func TestReadSingleFileFromTgz_RejectsNonRegularEntry(t *testing.T) {
+	tgzContent := createTestTgz(t, []testTgzEntry{{name: "metrics", typeflag: tar.TypeDir}})
 
-	files, err := ExtractTgz(tgzContent)
-	assert.Nil(t, err)
-	assert.Empty(t, files)
+	err := readSingleFileFromTgz(tgzContent, 1024, func(io.Reader) error {
+		return nil
+	})
+
+	assert.ErrorContains(t, err, `metrics archive entry "metrics" must be a regular file`)
 }
 
-func TestExtractTgz_InvalidContent(t *testing.T) {
-	files, err := ExtractTgz("not a valid tgz")
-	assert.NotNil(t, err)
-	assert.Nil(t, files)
+func TestReadSingleFileFromTgz_EnforcesConfigurableByteLimit(t *testing.T) {
+	testCases := []struct {
+		name          string
+		maxBytes      int64
+		errorContains string
+	}{
+		{name: "exact limit", maxBytes: 7},
+		{name: "over limit", maxBytes: 6, errorContains: `metrics archive entry "metrics.json" exceeds maximum size of 6 bytes`},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tgzContent := createTestTgz(t, []testTgzEntry{{name: "metrics.json", content: "content"}})
+			err := readSingleFileFromTgz(tgzContent, testCase.maxBytes, func(reader io.Reader) error {
+				_, err := io.Copy(io.Discard, reader)
+				return err
+			})
+
+			if testCase.errorContains == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, testCase.errorContains)
+			}
+		})
+	}
 }
 
-func TestArchiveTgz_SingleFile(t *testing.T) {
-	tgzContent, err := ArchiveTgz(map[string]string{"file.txt": "content"})
-	assert.Nil(t, err)
+func TestReadSingleFileFromTgz_PropagatesConsumerError(t *testing.T) {
+	tgzContent := createTestTgz(t, []testTgzEntry{{name: "metrics.json", content: "content"}})
+	expectedError := errors.New("decode failed")
 
-	files, err := ExtractTgz(tgzContent)
-	assert.Nil(t, err)
-	assert.Equal(t, "content", files["file.txt"])
+	err := readSingleFileFromTgz(tgzContent, 1024, func(io.Reader) error {
+		return expectedError
+	})
+
+	assert.ErrorIs(t, err, expectedError)
 }

--- a/backend/src/common/util/tgz_test.go
+++ b/backend/src/common/util/tgz_test.go
@@ -93,7 +93,7 @@ func TestReadSingleFileFromTgz_RequiresOneEntry(t *testing.T) {
 				{name: "first.json", content: "first"},
 				{name: "second.json", content: "second"},
 			},
-			errorContains: "metrics archive must contain exactly one file",
+			errorContains: "metrics archive must contain exactly one regular file",
 		},
 	}
 

--- a/backend/src/common/util/tgz_test.go
+++ b/backend/src/common/util/tgz_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
@@ -52,6 +53,40 @@ func createTestTgz(t *testing.T, entries []testTgzEntry) []byte {
 	require.NoError(t, gzipWriter.Close())
 
 	return buf.Bytes()
+}
+
+func rewriteFirstTarEntryTypeflag(t *testing.T, tgzContent []byte, typeflag byte) []byte {
+	t.Helper()
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(tgzContent))
+	require.NoError(t, err)
+	tarContent, err := io.ReadAll(gzipReader)
+	require.NoError(t, err)
+	require.NoError(t, gzipReader.Close())
+
+	const (
+		tarBlockSize   = 512
+		checksumOffset = 148
+		checksumLength = 8
+		typeflagOffset = 156
+	)
+	require.GreaterOrEqual(t, len(tarContent), tarBlockSize)
+	tarContent[typeflagOffset] = typeflag
+	for index := checksumOffset; index < checksumOffset+checksumLength; index++ {
+		tarContent[index] = ' '
+	}
+	checksum := 0
+	for _, value := range tarContent[:tarBlockSize] {
+		checksum += int(value)
+	}
+	copy(tarContent[checksumOffset:checksumOffset+checksumLength], fmt.Sprintf("%06o\x00 ", checksum))
+
+	var rewritten bytes.Buffer
+	gzipWriter := gzip.NewWriter(&rewritten)
+	_, err = gzipWriter.Write(tarContent)
+	require.NoError(t, err)
+	require.NoError(t, gzipWriter.Close())
+	return rewritten.Bytes()
 }
 
 func TestArchiveTgzAndReadSingleFileFromTgz_Roundtrip(t *testing.T) {
@@ -118,6 +153,25 @@ func TestReadSingleFileFromTgz_RejectsNonRegularEntry(t *testing.T) {
 	})
 
 	assert.ErrorContains(t, err, `metrics archive entry "metrics" must be a regular file`)
+}
+
+func TestReadSingleFileFromTgz_AcceptsLegacyRegularEntry(t *testing.T) {
+	tgzContent := createTestTgz(t, []testTgzEntry{{
+		name:     "metrics.json",
+		content:  "content",
+		typeflag: tar.TypeReg,
+	}})
+	tgzContent = rewriteFirstTarEntryTypeflag(t, tgzContent, tar.TypeRegA)
+
+	var content []byte
+	err := readSingleFileFromTgz(tgzContent, 7, func(reader io.Reader) error {
+		var readError error
+		content, readError = io.ReadAll(reader)
+		return readError
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
 }
 
 func TestReadSingleFileFromTgz_EnforcesConfigurableByteLimit(t *testing.T) {

--- a/backend/src/common/util/tgz_test.go
+++ b/backend/src/common/util/tgz_test.go
@@ -156,12 +156,14 @@ func TestReadSingleFileFromTgz_RejectsNonRegularEntry(t *testing.T) {
 }
 
 func TestReadSingleFileFromTgz_AcceptsLegacyRegularEntry(t *testing.T) {
+	const legacyRegularFileTypeflag byte = '\x00'
+
 	tgzContent := createTestTgz(t, []testTgzEntry{{
 		name:     "metrics.json",
 		content:  "content",
 		typeflag: tar.TypeReg,
 	}})
-	tgzContent = rewriteFirstTarEntryTypeflag(t, tgzContent, tar.TypeRegA)
+	tgzContent = rewriteFirstTarEntryTypeflag(t, tgzContent, legacyRegularFileTypeflag)
 
 	var content []byte
 	err := readSingleFileFromTgz(tgzContent, 7, func(reader io.Reader) error {

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -563,8 +563,7 @@ func readNodeMetricsOrNil(runID string, nodeStatus *workflowapi.NodeStatus,
 		return decodeError
 	})
 	if err != nil {
-		// Invalid tgz file. This should never happen unless there is a bug in the system and
-		// it is a unrecoverable error.
+		// Contract violations and malformed metrics artifacts are permanent for this completed node.
 		return nil, NewCustomError(err, CUSTOM_CODE_PERMANENT,
 			"Unable to read metrics tgz file from (%+v): %v", artifactRequest, err)
 	}

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -18,10 +18,9 @@ package util
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
-
-	"google.golang.org/protobuf/encoding/protojson"
 
 	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	argoclient "github.com/argoproj/argo-workflows/v4/pkg/client/clientset/versioned"
@@ -481,8 +480,6 @@ func (w *Workflow) StartedAtTime() metav1.Time {
 
 const (
 	metricsArtifactName = "mlpipeline-metrics"
-	// More than 50 metrics is not scalable with current UI design.
-	maxMetricsCountLimit = 50
 )
 
 func (w *Workflow) CollectionMetrics(readArtifact func(*artifactclient.ReadArtifactRequest) (*artifactclient.ReadArtifactResponse, error)) ([]*api.RunMetric, []error) {
@@ -515,63 +512,24 @@ func collectNodeMetricsOrNil(runID string, nodeStatus *workflowapi.NodeStatus, r
 	if !nodeStatus.Completed() {
 		return nil, nil
 	}
-	metricsJSON, err := readNodeMetricsJSONOrEmpty(runID, nodeStatus, readArtifact, &wf)
-	if err != nil || metricsJSON == "" {
+	metrics, err := readNodeMetricsOrNil(runID, nodeStatus, readArtifact, &wf)
+	if err != nil || metrics == nil {
 		return nil, err
 	}
 
 	retrievedNodeID := nodeStatus.ID
-	// Proto json lib requires a proto message before unmarshal data from JSON. We use
-	// ReportRunMetricsRequest as a workaround to hold user's metrics, which is a superset of what
-	// user can provide.
-	reportMetricsRequest := new(api.ReportRunMetricsRequest)
-	transformedJSON, err := transformJSONForBackwardCompatibility(metricsJSON)
-	if err != nil {
-		fmt.Printf("Failed to transform JSON: %v\n", err)
-		return nil, err
-	}
-
-	err = protojson.Unmarshal([]byte(transformedJSON), reportMetricsRequest)
-	if err != nil {
-		// User writes invalid metrics JSON.
-		// TODO(#1426): report the error back to api server to notify user
-		log.WithFields(log.Fields{
-			"run":         runID,
-			"node":        retrievedNodeID,
-			"raw_content": metricsJSON,
-			"error":       err.Error(),
-		}).Warning("Failed to unmarshal metrics file.")
-		return nil, NewCustomError(err, CUSTOM_CODE_PERMANENT,
-			"failed to unmarshal metrics file from (%s, %s).", runID, retrievedNodeID)
-	}
-	if reportMetricsRequest.GetMetrics() == nil {
-		return nil, nil
-	}
-	for _, metric := range reportMetricsRequest.GetMetrics() {
+	for _, metric := range metrics {
 		// User metrics just have name and value but no NodeId.
 		metric.NodeId = retrievedNodeID
 	}
-	return reportMetricsRequest.GetMetrics(), nil
+	return metrics, nil
 }
 
-// Previously number_value for RunMetrics in backend/api/v1beta1/run.proto
-// allowed camelCase field values in JSON, to be consistent with the
-// rest of the API (as well as with KFP api docs); this value was switched
-// to support snake case. This function will convert old values to the
-// newer snakecase so we can continue to support camelcase Metric Values for
-// backwards compatibility for the end user.
-func transformJSONForBackwardCompatibility(jsonStr string) (string, error) {
-	replacer := strings.NewReplacer(
-		`"numberValue":`, `"number_value":`,
-	)
-	return replacer.Replace(jsonStr), nil
-}
-
-func readNodeMetricsJSONOrEmpty(runID string, nodeStatus *workflowapi.NodeStatus,
+func readNodeMetricsOrNil(runID string, nodeStatus *workflowapi.NodeStatus,
 	readArtifact func(*artifactclient.ReadArtifactRequest) (*artifactclient.ReadArtifactResponse, error), wf *workflowapi.Workflow,
-) (string, error) {
+) ([]*api.RunMetric, error) {
 	if nodeStatus.Outputs == nil || nodeStatus.Outputs.Artifacts == nil {
-		return "", nil // No output artifacts, skip the reporting
+		return nil, nil // No output artifacts, skip the reporting
 	}
 
 	var foundMetricsArtifact bool = false
@@ -581,7 +539,7 @@ func readNodeMetricsJSONOrEmpty(runID string, nodeStatus *workflowapi.NodeStatus
 		}
 	}
 	if !foundMetricsArtifact {
-		return "", nil // No metrics artifact, skip the reporting
+		return nil, nil // No metrics artifact, skip the reporting
 	}
 
 	artifactRequest := &artifactclient.ReadArtifactRequest{
@@ -591,27 +549,26 @@ func readNodeMetricsJSONOrEmpty(runID string, nodeStatus *workflowapi.NodeStatus
 	}
 	artifactResponse, err := readArtifact(artifactRequest)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if artifactResponse == nil || artifactResponse.Data == nil || len(artifactResponse.Data) == 0 {
 		// If artifact is not found or empty content, skip the reporting.
-		return "", nil
+		return nil, nil
 	}
-	archivedFiles, err := ExtractTgz(string(artifactResponse.Data))
+
+	var metrics []*api.RunMetric
+	err = readSingleFileFromTgz(artifactResponse.Data, GetMaxMetricsFileBytes(), func(reader io.Reader) error {
+		var decodeError error
+		metrics, decodeError = decodeRunMetrics(reader)
+		return decodeError
+	})
 	if err != nil {
 		// Invalid tgz file. This should never happen unless there is a bug in the system and
 		// it is a unrecoverable error.
-		return "", NewCustomError(err, CUSTOM_CODE_PERMANENT,
-			"Unable to extract metrics tgz file read from (%+v): %v", artifactRequest, err)
+		return nil, NewCustomError(err, CUSTOM_CODE_PERMANENT,
+			"Unable to read metrics tgz file from (%+v): %v", artifactRequest, err)
 	}
-	// There needs to be exactly one metrics file in the artifact archive. We load that file.
-	if len(archivedFiles) == 1 {
-		for _, value := range archivedFiles {
-			return value, nil
-		}
-	}
-	return "", NewCustomErrorf(CUSTOM_CODE_PERMANENT,
-		"There needs to be exactly one metrics file in the artifact archive, but zero or multiple files were found.")
+	return metrics, nil
 }
 
 func (w *Workflow) HasMetrics() bool {

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -1934,14 +1934,14 @@ func TestTransformJSONForBackwardCompatibility(t *testing.T) {
 	assert.Equal(t, input, result)
 }
 
-func TestReadNodeMetricsJSONOrEmpty(t *testing.T) {
+func TestReadNodeMetricsOrNil(t *testing.T) {
 	// No outputs → empty
 	nodeStatus := &workflowapi.NodeStatus{
 		ID:      "node-1",
 		Outputs: nil,
 	}
 	wf := &workflowapi.Workflow{ObjectMeta: metav1.ObjectMeta{Name: "test-wf"}}
-	result, err := readNodeMetricsJSONOrEmpty("run-1", nodeStatus, nil, wf)
+	result, err := readNodeMetricsOrNil("run-1", nodeStatus, nil, wf)
 	assert.Nil(t, err)
 	assert.Empty(t, result)
 
@@ -1952,7 +1952,7 @@ func TestReadNodeMetricsJSONOrEmpty(t *testing.T) {
 			Artifacts: nil,
 		},
 	}
-	result, err = readNodeMetricsJSONOrEmpty("run-1", nodeStatus, nil, wf)
+	result, err = readNodeMetricsOrNil("run-1", nodeStatus, nil, wf)
 	assert.Nil(t, err)
 	assert.Empty(t, result)
 
@@ -1965,7 +1965,7 @@ func TestReadNodeMetricsJSONOrEmpty(t *testing.T) {
 			},
 		},
 	}
-	result, err = readNodeMetricsJSONOrEmpty("run-1", nodeStatus, nil, wf)
+	result, err = readNodeMetricsOrNil("run-1", nodeStatus, nil, wf)
 	assert.Nil(t, err)
 	assert.Empty(t, result)
 
@@ -1981,7 +1981,7 @@ func TestReadNodeMetricsJSONOrEmpty(t *testing.T) {
 	mockReadArtifactError := func(request *artifactclient.ReadArtifactRequest) (*artifactclient.ReadArtifactResponse, error) {
 		return nil, fmt.Errorf("connection refused")
 	}
-	result, err = readNodeMetricsJSONOrEmpty("run-1", nodeStatus, mockReadArtifactError, wf)
+	result, err = readNodeMetricsOrNil("run-1", nodeStatus, mockReadArtifactError, wf)
 	assert.NotNil(t, err)
 	assert.Empty(t, result)
 
@@ -1989,7 +1989,7 @@ func TestReadNodeMetricsJSONOrEmpty(t *testing.T) {
 	mockReadArtifactNil := func(request *artifactclient.ReadArtifactRequest) (*artifactclient.ReadArtifactResponse, error) {
 		return nil, nil
 	}
-	result, err = readNodeMetricsJSONOrEmpty("run-1", nodeStatus, mockReadArtifactNil, wf)
+	result, err = readNodeMetricsOrNil("run-1", nodeStatus, mockReadArtifactNil, wf)
 	assert.Nil(t, err)
 	assert.Empty(t, result)
 
@@ -1997,7 +1997,7 @@ func TestReadNodeMetricsJSONOrEmpty(t *testing.T) {
 	mockReadArtifactEmpty := func(request *artifactclient.ReadArtifactRequest) (*artifactclient.ReadArtifactResponse, error) {
 		return &artifactclient.ReadArtifactResponse{Data: []byte{}}, nil
 	}
-	result, err = readNodeMetricsJSONOrEmpty("run-1", nodeStatus, mockReadArtifactEmpty, wf)
+	result, err = readNodeMetricsOrNil("run-1", nodeStatus, mockReadArtifactEmpty, wf)
 	assert.Nil(t, err)
 	assert.Empty(t, result)
 
@@ -2005,7 +2005,7 @@ func TestReadNodeMetricsJSONOrEmpty(t *testing.T) {
 	mockReadArtifactBadTgz := func(request *artifactclient.ReadArtifactRequest) (*artifactclient.ReadArtifactResponse, error) {
 		return &artifactclient.ReadArtifactResponse{Data: []byte("not a tgz file")}, nil
 	}
-	result, err = readNodeMetricsJSONOrEmpty("run-1", nodeStatus, mockReadArtifactBadTgz, wf)
+	result, err = readNodeMetricsOrNil("run-1", nodeStatus, mockReadArtifactBadTgz, wf)
 	assert.NotNil(t, err)
 	assert.Empty(t, result)
 
@@ -2016,9 +2016,11 @@ func TestReadNodeMetricsJSONOrEmpty(t *testing.T) {
 	mockReadArtifactSuccess := func(request *artifactclient.ReadArtifactRequest) (*artifactclient.ReadArtifactResponse, error) {
 		return &artifactclient.ReadArtifactResponse{Data: []byte(tgzContent)}, nil
 	}
-	result, err = readNodeMetricsJSONOrEmpty("run-1", nodeStatus, mockReadArtifactSuccess, wf)
-	assert.Nil(t, err)
-	assert.Equal(t, metricsJSON, result)
+	result, err = readNodeMetricsOrNil("run-1", nodeStatus, mockReadArtifactSuccess, wf)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "accuracy", result[0].GetName())
+	assert.Equal(t, 0.95, result[0].GetNumberValue())
 }
 
 func TestCollectNodeMetricsOrNil(t *testing.T) {
@@ -2262,7 +2264,7 @@ func TestCollectionMetrics_MetricsCountLimit(t *testing.T) {
 	assert.Empty(t, partialFailures)
 }
 
-func TestReadNodeMetricsJSONOrEmpty_MultipleTgzFiles(t *testing.T) {
+func TestReadNodeMetricsOrNil_MultipleTgzFiles(t *testing.T) {
 	// Multiple files in tgz → error
 	tgzContent, err := ArchiveTgz(map[string]string{
 		"file1.json": "content1",
@@ -2283,9 +2285,32 @@ func TestReadNodeMetricsJSONOrEmpty_MultipleTgzFiles(t *testing.T) {
 	mockReadArtifact := func(request *artifactclient.ReadArtifactRequest) (*artifactclient.ReadArtifactResponse, error) {
 		return &artifactclient.ReadArtifactResponse{Data: []byte(tgzContent)}, nil
 	}
-	result, err := readNodeMetricsJSONOrEmpty("run-1", nodeStatus, mockReadArtifact, wf)
+	result, err := readNodeMetricsOrNil("run-1", nodeStatus, mockReadArtifact, wf)
 	assert.NotNil(t, err)
 	assert.Empty(t, result)
+}
+
+func TestReadNodeMetricsOrNil_UsesConfiguredByteLimit(t *testing.T) {
+	t.Setenv(MaxMetricsFileBytesEnvVar, "32")
+	metricsJSON := `{"metrics":[{"name":"accuracy","number_value":0.95}]}`
+	tgzContent, err := ArchiveTgz(map[string]string{"metrics.json": metricsJSON})
+	require.NoError(t, err)
+
+	nodeStatus := &workflowapi.NodeStatus{
+		ID: "node-1",
+		Outputs: &workflowapi.Outputs{
+			Artifacts: []workflowapi.Artifact{{Name: metricsArtifactName}},
+		},
+	}
+	workflow := &workflowapi.Workflow{ObjectMeta: metav1.ObjectMeta{Name: "test-wf"}}
+	readArtifact := func(request *artifactclient.ReadArtifactRequest) (*artifactclient.ReadArtifactResponse, error) {
+		return &artifactclient.ReadArtifactResponse{Data: []byte(tgzContent)}, nil
+	}
+
+	metrics, err := readNodeMetricsOrNil("run-1", nodeStatus, readArtifact, workflow)
+
+	assert.Nil(t, metrics)
+	assert.ErrorContains(t, err, "exceeds maximum size of 32 bytes")
 }
 
 func TestWorkflow_SetExecutionName(t *testing.T) {


### PR DESCRIPTION
## Summary

- require `mlpipeline-metrics` archives to contain exactly one regular tar entry
- stream that entry directly into incremental JSON decoding instead of materializing a file map and full decompressed string
- retain the first 50 metrics while continuing to validate the complete bounded input stream
- enforce the existing 64-character metric-name contract while decoding
- add configurable `MAX_METRICS_FILE_BYTES` protection, defaulting to 1 MiB

## Why

ADA-KUBEFL-06 identified that metrics tar extraction used an unbounded `io.ReadAll`, allowing a small compressed artifact to cause excessive memory consumption. Generic archive entry and aggregate quotas are unnecessary here because the metrics artifact already has a stricter one-file contract.

This change applies that semantic contract first, retains only bounded metric data, and keeps a configurable decompressed-byte ceiling for pathological JSON whitespace or encoding.

Valid metrics continue to accept both `numberValue` and `number_value`. Inputs with more than 50 metrics preserve the existing behavior of reporting the first 50. Invalid metric-name patterns continue through the existing API reporting path; only contract-breaking lengths are rejected during decoding.

## Validation

- `go test -count=1 ./backend/src/common/...`
- `go test -count=1 ./backend/src/agent/persistence/worker`
- `go vet ./backend/src/common/util`
- `git diff --check origin/master..HEAD`

## Residual scope

The artifact client still materializes the compressed response before tar processing. This change bounds decompressed metrics processing but does not add a compressed-object download limit.
