### PR TITLE
fix(backend): stub DNS resolver in pipeline URL validation tests

### DIFF
--- a/backend/src/apiserver/validation/pipeline_url.go
+++ b/backend/src/apiserver/validation/pipeline_url.go
@@ -74,6 +74,12 @@ var (
 	urlConfigInit  sync.Once
 )
 
+// lookupIPAddr resolves a host to its IP addresses. It is a package-level
+// variable (rather than a direct net.DefaultResolver.LookupIPAddr call) so
+// tests can substitute a fake resolver instead of performing real DNS
+// lookups.
+var lookupIPAddr = net.DefaultResolver.LookupIPAddr
+
 // initURLConfig initializes blocked networks and allowed domains
 func initURLConfig() {
 	urlConfigInit.Do(func() {
@@ -170,7 +176,7 @@ func validateResolvedIPs(host string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), dnsLookupTimeout)
 	defer cancel()
 
-	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	addrs, err := lookupIPAddr(ctx, host)
 	if err != nil {
 		return util.NewInvalidInputError("DNS resolution failed for %q: %v", host, err)
 	}
@@ -232,7 +238,7 @@ func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error
 
 	initURLConfig()
 
-	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	addrs, err := lookupIPAddr(ctx, host)
 	if err != nil {
 		return nil, fmt.Errorf("DNS resolution failed for %q: %v", host, err)
 	}

--- a/backend/src/apiserver/validation/pipeline_url_test.go
+++ b/backend/src/apiserver/validation/pipeline_url_test.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -34,9 +35,42 @@ func resetURLConfig() {
 	allowedDomains = nil
 }
 
+// fakeAddrs maps hostnames (and literal IPs) to the IPs a stubbed resolver
+// should return for them in tests, avoiding real DNS lookups.
+var fakeAddrs = map[string][]net.IP{
+	"storage.googleapis.com": {net.ParseIP("142.250.80.46")},
+	"s3.amazonaws.com":       {net.ParseIP("52.216.0.1")},
+	"github.com":             {net.ParseIP("140.82.112.3")},
+	"example.com":            {net.ParseIP("93.184.216.34")},
+	"evil.com":               {net.ParseIP("203.0.113.1")},
+	"localhost":              {net.ParseIP("127.0.0.1")},
+	"127.0.0.1":              {net.ParseIP("127.0.0.1")},
+	"169.254.169.254":        {net.ParseIP("169.254.169.254")},
+}
+
+// stubLookupIPAddr replaces the package's DNS resolver with a fake one backed
+// by fakeAddrs, so tests never perform a real network lookup, and restores
+// the original resolver when the test completes.
+func stubLookupIPAddr(t *testing.T) {
+	original := lookupIPAddr
+	lookupIPAddr = func(ctx context.Context, host string) ([]net.IPAddr, error) {
+		ips, ok := fakeAddrs[host]
+		if !ok {
+			return nil, fmt.Errorf("fakeAddrs: no stubbed addresses for %q", host)
+		}
+		addrs := make([]net.IPAddr, len(ips))
+		for i, ip := range ips {
+			addrs[i] = net.IPAddr{IP: ip}
+		}
+		return addrs, nil
+	}
+	t.Cleanup(func() { lookupIPAddr = original })
+}
+
 func TestValidatePipelineURL_AllowedDomains(t *testing.T) {
 	viper.Reset()
 	resetURLConfig()
+	stubLookupIPAddr(t)
 
 	// Default allowed domains should pass
 	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com/bucket/file.yaml"))
@@ -62,6 +96,7 @@ func TestValidatePipelineURL_BlockedDomain(t *testing.T) {
 func TestValidatePipelineURL_SchemeRestriction(t *testing.T) {
 	viper.Reset()
 	resetURLConfig()
+	stubLookupIPAddr(t)
 
 	// HTTP blocked by default
 	err := ValidatePipelineURL("http://storage.googleapis.com/bucket/file.yaml")
@@ -76,6 +111,7 @@ func TestValidatePipelineURL_HTTPAllowedWhenConfigured(t *testing.T) {
 	viper.Reset()
 	viper.Set("PIPELINE_URL_ALLOW_HTTP", "true")
 	resetURLConfig()
+	stubLookupIPAddr(t)
 
 	// HTTP allowed when configured
 	assert.NoError(t, ValidatePipelineURL("http://storage.googleapis.com/bucket/file.yaml"))
@@ -84,6 +120,7 @@ func TestValidatePipelineURL_HTTPAllowedWhenConfigured(t *testing.T) {
 func TestValidatePipelineURL_PortRestriction(t *testing.T) {
 	viper.Reset()
 	resetURLConfig()
+	stubLookupIPAddr(t)
 
 	// Default port (no port specified) should pass
 	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com/bucket/file.yaml"))
@@ -117,6 +154,7 @@ func TestValidatePipelineURL_UserConfiguredDomains(t *testing.T) {
 	viper.Reset()
 	viper.Set("PIPELINE_URL_ALLOWED_DOMAINS", "example.com")
 	resetURLConfig()
+	stubLookupIPAddr(t)
 
 	// User-configured domain should pass
 	assert.NoError(t, ValidatePipelineURL("https://example.com/test.yaml"))
@@ -197,6 +235,7 @@ func TestIsBlockedIP_IPv6Metadata(t *testing.T) {
 func TestValidatePipelineURL_HostnameNormalization(t *testing.T) {
 	viper.Reset()
 	resetURLConfig()
+	stubLookupIPAddr(t)
 
 	// Trailing dot (FQDN) should be normalized and pass
 	assert.NoError(t, ValidatePipelineURL("https://storage.googleapis.com./bucket/file.yaml"))
@@ -208,6 +247,7 @@ func TestValidatePipelineURL_HostnameNormalization(t *testing.T) {
 func TestSafePipelineHTTPClient_RedirectValidation(t *testing.T) {
 	viper.Reset()
 	resetURLConfig()
+	stubLookupIPAddr(t)
 
 	client := SafePipelineHTTPClient()
 
@@ -299,6 +339,7 @@ func TestSafeDialContext_BlocksPrivateIPs(t *testing.T) {
 	viper.Reset()
 	resetURLConfig()
 	initURLConfig()
+	stubLookupIPAddr(t)
 
 	ctx := context.Background()
 	// 127.0.0.1 is in the loopback blocked range
@@ -311,6 +352,7 @@ func TestSafeDialContext_BlocksMetadataIP(t *testing.T) {
 	viper.Reset()
 	resetURLConfig()
 	initURLConfig()
+	stubLookupIPAddr(t)
 
 	ctx := context.Background()
 	// 169.254.169.254 is the cloud metadata endpoint


### PR DESCRIPTION
## What this PR does

Makes `backend/src/apiserver/validation/pipeline_url_test.go` hermetic by removing its dependency on real DNS resolution.

## Background

`ValidatePipelineURL` and `safeDialContext` call `net.DefaultResolver.LookupIPAddr` to resolve a host and check the resolved IPs against a blocked-CIDR list (loopback/private/link-local/metadata), closing a DNS-rebinding gap. The existing tests exercised this code path directly against real hostnames (`storage.googleapis.com`, `s3.amazonaws.com`, `github.com`, `example.com`, etc.), which means every test run performed real outbound DNS lookups.

This is fine on a machine with unrestricted network access, but it makes the test suite flaky in network-restricted environments (sandboxed CI runners, offline dev environments): a real lookup can time out, e.g.

```
=== RUN   TestValidatePipelineURL_UserConfiguredDomains
    pipeline_url_test.go:122:
        Error: Received unexpected error:
               Invalid input error: DNS resolution failed for "example.com": lookup example.com: i/o timeout
--- FAIL: TestValidatePipelineURL_UserConfiguredDomains (5.00s)
```

This is a pre-existing test-design issue, unrelated to any particular feature branch — any network hiccup or restricted egress in CI can trip it.

## The change

- Extracted the resolver call into a package-level `lookupIPAddr` variable (`backend/src/apiserver/validation/pipeline_url.go`), defaulting to `net.DefaultResolver.LookupIPAddr`. Production behavior is unchanged.
- Added a `stubLookupIPAddr(t)` test helper that swaps in a fake resolver backed by a static hostname→IP map and restores the original via `t.Cleanup`.
- Applied the stub to every test that reaches the DNS-resolution step (allowed-domain checks, scheme/port checks that fall through to an allowed domain, hostname normalization, redirect validation, and the `safeDialContext` blocked-IP tests).

No assertions changed — same inputs, same expected errors/successes — only the source of IP resolution is now deterministic and offline.

## Testing

- `go test ./backend/src/apiserver/validation/...` — all tests pass, ~0.5s total (previously variable/slower due to real network round trips).
- `golangci-lint run ./backend/src/apiserver/validation/...` — 0 issues.
- `go build ./backend/...` — builds cleanly.
- `go test ./backend/src/apiserver/...` — full package suite passes, no regressions.