### PR TITLE
fix(frontend): re-check redirects against artifact domain allowlist

### DIFF
--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -346,11 +346,34 @@ function getHttpArtifactsHandler(
         req.headers[auth.key] || req.headers[auth.key.toLowerCase()] || auth.defaultValue;
       headers[auth.key] = Array.isArray(headerValue) ? headerValue[0] : headerValue;
     }
-    if (!isAllowedDomain(url, allowedDomain)) {
-      res.status(500).send(`Domain not allowed.`);
-      return;
+    // Follow redirects manually so every hop is re-checked against the
+    // allowlist. Letting fetch auto-follow only validates the first URL, so an
+    // allowed host could 3xx the request to an internal address (link-local
+    // metadata, cluster services) and exfiltrate the response plus any auth
+    // header.
+    const maxRedirects = 5;
+    let currentUrl = url;
+    let response: Awaited<ReturnType<typeof fetch>>;
+    for (let hop = 0; ; hop++) {
+      if (!isAllowedDomain(currentUrl, allowedDomain)) {
+        res.status(500).send(`Domain not allowed.`);
+        return;
+      }
+      response = await fetch(currentUrl, { headers, redirect: 'manual' });
+      const status = response.status ?? 200;
+      if (status < 300 || status >= 400) {
+        break;
+      }
+      const location = response.headers?.get('location');
+      if (!location) {
+        break;
+      }
+      if (hop >= maxRedirects) {
+        res.status(500).send('Too many redirects while retrieving artifact');
+        return;
+      }
+      currentUrl = new URL(location, currentUrl).toString();
     }
-    const response = await fetch(url, { headers });
     if (!response.body) {
       res.status(500).send('Unable to retrieve artifact: empty response body');
       return;

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -372,7 +372,15 @@ function getHttpArtifactsHandler(
         res.status(500).send('Too many redirects while retrieving artifact');
         return;
       }
-      currentUrl = new URL(location, currentUrl).toString();
+      // An allowed host can hand back a malformed Location header; resolve it
+      // defensively so a bad value turns into a controlled 500 rather than an
+      // unhandled exception escaping the handler.
+      try {
+        currentUrl = new URL(location, currentUrl).toString();
+      } catch {
+        res.status(500).send('Invalid redirect location while retrieving artifact');
+        return;
+      }
     }
     if (!response.body) {
       res.status(500).send('Unable to retrieve artifact: empty response body');

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -368,6 +368,12 @@ function getHttpArtifactsHandler(
       if (!location) {
         break;
       }
+      // We are not streaming this redirect response, so release its body.
+      // Node's fetch keeps the connection tied up until GC if the body is left
+      // unconsumed, which shows up under redirect-heavy artifact traffic.
+      if (response.body) {
+        await response.body.cancel().catch(() => undefined);
+      }
       if (hop >= maxRedirects) {
         res.status(500).send('Too many redirects while retrieving artifact');
         return;

--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -565,6 +565,98 @@ describe('/artifacts', () => {
       expect(mockedFetch).not.toHaveBeenCalledWith(internalUrl, expect.anything());
     });
 
+    it('follows an http redirect that stays within the allowlist', async () => {
+      // Artifact stores that hand out signed URLs / CDN links rely on 3xx. A
+      // redirect whose target is still on an allowed host must be followed and
+      // its body streamed back.
+      mockedFetch.mockClear();
+      const firstUrl = 'http://allowed.host/ml-pipeline/hello/world.txt';
+      const redirectedUrl = 'http://allowed.host/signed/hello/world.txt';
+      const artifactContent = 'redirected body';
+      mockedFetch.mockImplementation((url: string) => {
+        if (url === firstUrl) {
+          return Promise.resolve({
+            status: 302,
+            headers: new Map([['location', redirectedUrl]]),
+            body: toWebStream(''),
+          });
+        }
+        if (url === redirectedUrl) {
+          return Promise.resolve({
+            status: 200,
+            headers: new Map(),
+            body: toWebStream(artifactContent),
+          });
+        }
+        return Promise.reject(`unexpected fetch to ${url}`);
+      });
+      const configs = loadConfigs(argv, {
+        ALLOWED_ARTIFACT_DOMAIN_REGEX: '^allowed\\.host$',
+        HTTP_BASE_URL: 'allowed.host/',
+      });
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      await request
+        .get('/artifacts/get?source=http&bucket=ml-pipeline&key=hello%2Fworld.txt')
+        .expect(200, artifactContent);
+      expect(mockedFetch).toHaveBeenCalledWith(redirectedUrl, {
+        headers: {},
+        redirect: 'manual',
+      });
+    });
+
+    it('stops after too many http redirects within the allowlist', async () => {
+      // Redirect loop that never leaves the allowlist must still be bounded.
+      mockedFetch.mockClear();
+      mockedFetch.mockImplementation(() =>
+        Promise.resolve({
+          status: 302,
+          headers: new Map([['location', 'http://allowed.host/loop/next']]),
+          body: toWebStream(''),
+        }),
+      );
+      const configs = loadConfigs(argv, {
+        ALLOWED_ARTIFACT_DOMAIN_REGEX: '^allowed\\.host$',
+        HTTP_BASE_URL: 'allowed.host/',
+      });
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      const res = await request
+        .get('/artifacts/get?source=http&bucket=ml-pipeline&key=hello%2Fworld.txt')
+        .expect(500);
+      expect(res.text).toBe('Too many redirects while retrieving artifact');
+    });
+
+    it('returns a controlled error when a redirect location is malformed', async () => {
+      // An allowed host can answer with an unparseable Location header; that
+      // must surface as a 500, not an unhandled exception.
+      mockedFetch.mockClear();
+      const firstUrl = 'http://allowed.host/ml-pipeline/hello/world.txt';
+      mockedFetch.mockImplementation((url: string) => {
+        if (url === firstUrl) {
+          return Promise.resolve({
+            status: 302,
+            headers: new Map([['location', 'http://[']]),
+            body: toWebStream(''),
+          });
+        }
+        return Promise.reject(`unexpected fetch to ${url}`);
+      });
+      const configs = loadConfigs(argv, {
+        ALLOWED_ARTIFACT_DOMAIN_REGEX: '^allowed\\.host$',
+        HTTP_BASE_URL: 'allowed.host/',
+      });
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      const res = await request
+        .get('/artifacts/get?source=http&bucket=ml-pipeline&key=hello%2Fworld.txt')
+        .expect(500);
+      expect(res.text).toBe('Invalid redirect location while retrieving artifact');
+    });
+
     it('responds with a https artifact if source=https', async () => {
       const artifactContent = 'hello world';
       mockedFetch.mockImplementationOnce((url: string, opts: any) =>

--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -497,6 +497,7 @@ describe('/artifacts', () => {
         .expect(200, artifactContent);
       expect(mockedFetch).toBeCalledWith('http://foo.bar/ml-pipeline/hello/world.txt', {
         headers: {},
+        redirect: 'manual',
       });
     });
 
@@ -522,7 +523,46 @@ describe('/artifacts', () => {
         .expect(200, artifactContent.slice(0, 5));
       expect(mockedFetch).toBeCalledWith('http://foo.bar/ml-pipeline/hello/world.txt', {
         headers: {},
+        redirect: 'manual',
       });
+    });
+
+    it('does not follow an http redirect that leaves the allowlist', async () => {
+      // The allowed host answers with a 3xx pointing at the link-local
+      // metadata service. fetch auto-follows redirects, so without per-hop
+      // re-validation the handler would fetch the internal target and stream
+      // its response back. Model real fetch semantics: a non-manual call
+      // follows the redirect, a manual call surfaces the 3xx instead.
+      const allowedUrl = 'http://allowed.host/ml-pipeline/hello/world.txt';
+      const internalUrl = 'http://169.254.169.254/latest/meta-data/';
+      mockedFetch.mockImplementation((url: string, opts: any) => {
+        if (url === allowedUrl) {
+          if (opts?.redirect === 'manual') {
+            return Promise.resolve({
+              status: 302,
+              headers: new Map([['location', internalUrl]]),
+              body: toWebStream(''),
+            });
+          }
+          // Auto-follow: real fetch would end up at the internal target.
+          return Promise.resolve({ status: 200, headers: new Map(), body: toWebStream('SECRET') });
+        }
+        return Promise.resolve({ status: 200, headers: new Map(), body: toWebStream('SECRET') });
+      });
+      const configs = loadConfigs(argv, {
+        ALLOWED_ARTIFACT_DOMAIN_REGEX: '^allowed\\.host$',
+        HTTP_BASE_URL: 'allowed.host/',
+      });
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      const res = await request
+        .get('/artifacts/get?source=http&bucket=ml-pipeline&key=hello%2Fworld.txt')
+        .expect(500);
+      expect(res.text).toBe('Domain not allowed.');
+      expect(res.text).not.toContain('SECRET');
+      // The internal target is never fetched.
+      expect(mockedFetch).not.toHaveBeenCalledWith(internalUrl, expect.anything());
     });
 
     it('responds with a https artifact if source=https', async () => {
@@ -551,6 +591,7 @@ describe('/artifacts', () => {
         headers: {
           Authorization: 'someToken',
         },
+        redirect: 'manual',
       });
     });
 
@@ -579,6 +620,7 @@ describe('/artifacts', () => {
         headers: {
           Authorization: 'inheritedToken',
         },
+        redirect: 'manual',
       });
     });
 


### PR DESCRIPTION
**Description of your changes:**

The http/https artifact handler checks the requested URL against `ALLOWED_ARTIFACT_DOMAIN_REGEX` once and then calls `fetch()`, which auto-follows redirects, so only the first hop is validated. An allowed host that answers with a 3xx to an internal address (link-local metadata, in-cluster services) gets followed without re-checking, and the configured auth header rides along to the redirect target. `getHttpArtifactsHandler` now follows redirects manually and re-validates each hop against the allowlist, bounded by a max redirect count. The added test models real fetch redirect semantics and asserts the internal target is never fetched.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
