### PR TITLE
fix(frontend): fix MetricsDropdown table cell borders

### DIFF
--- a/frontend/src/components/viewers/MetricsDropdown.tsx
+++ b/frontend/src/components/viewers/MetricsDropdown.tsx
@@ -46,18 +46,13 @@ import {
 import { CircularProgress } from '@mui/material';
 
 const css = stylesheet({
-  leftCell: {
-    borderRight: `3px solid ${color.divider}`,
+  table: {
+    borderCollapse: 'collapse',
   },
-  rightCell: {
+  divider: {
     borderLeft: `3px solid ${color.divider}`,
-  },
-  middleCell: {
-    borderLeft: `3px solid ${color.divider}`,
-    borderRight: `3px solid ${color.divider}`,
   },
   cell: {
-    borderCollapse: 'collapse',
     padding: '1rem',
     verticalAlign: 'top',
   },
@@ -124,19 +119,11 @@ export default function MetricsDropdown(props: MetricsDropdownProps) {
   }
 
   return (
-    <table>
+    <table className={css.table}>
       <tbody>
         <tr>
           {selectedArtifacts.map((selectedArtifact, panelIndex) => (
-            <td
-              key={panelIndex}
-              className={classes(
-                css.cell,
-                panelIndex === 0 && css.leftCell,
-                panelIndex === selectedArtifacts.length - 1 && css.rightCell,
-                panelIndex > 0 && panelIndex < selectedArtifacts.length - 1 && css.middleCell,
-              )}
-            >
+            <td key={panelIndex} className={classes(css.cell, panelIndex > 0 && css.divider)}>
               <TwoLevelDropdown
                 title={`Choose a ${panelIndex === 0 ? 'first' : panelIndex === 1 ? 'second' : `panel ${panelIndex + 1}`} ${metricsTabText} artifact`}
                 items={dropdownItems}


### PR DESCRIPTION
**Description of your changes:**

Fix two table-border issues in `MetricsDropdown`:

- Replace the `leftCell` / `rightCell` / `middleCell` classes with a single divider class applied to every panel except the first, ensuring a single divider between panels regardless of panel count.
- Move `borderCollapse: 'collapse'` from the `<td>` element (where it has no effect) to the `<table>` element.

Notes:
-  User-visible effect: the divider between the two compare panels now renders as a single line instead of a doubled border.
- No changes to selection behavior or component logic.

Closes #13370
