### PR TITLE
feat(backend): add MLflow basic-auth and optional auth

### DIFF
--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -116,6 +116,21 @@ runs:
         sleep 5
       continue-on-error: true
 
+    - name: Re-establish MLflow port-forward for tests
+      id: port-forward-mlflow
+      if: (!cancelled())
+      shell: bash
+      run: |
+        if [ -z "${MLFLOW_PORT_FORWARD_NS:-}" ] || [ -z "${MLFLOW_PORT_FORWARD_SVC:-}" ]; then
+          echo "No MLflow port-forward metadata exported for this job"
+          exit 0
+        fi
+        REMOTE_PORT="${MLFLOW_PORT_FORWARD_REMOTE_PORT:-5000}"
+        pkill -f "kubectl port-forward.*${MLFLOW_PORT_FORWARD_SVC}.*8080:${REMOTE_PORT}" || true
+        kubectl port-forward -n "$MLFLOW_PORT_FORWARD_NS" "svc/$MLFLOW_PORT_FORWARD_SVC" "8080:$REMOTE_PORT" > /dev/null 2>&1 &
+        sleep 5
+      continue-on-error: true
+
     - name: Configure API Access
       id: configure-api
       if: ${{ inputs.skip_api_config != 'true' }}

--- a/.github/resources/mlflow-direct/manifests/kustomization.yaml
+++ b/.github/resources/mlflow-direct/manifests/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: opendatahub
+
+resources:
+- namespace.yaml
+- postgres.yaml
+- mlflow.yaml

--- a/.github/resources/mlflow-direct/manifests/mlflow.yaml
+++ b/.github/resources/mlflow-direct/manifests/mlflow.yaml
@@ -1,0 +1,139 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mlflow
+  labels:
+    app: mlflow
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mlflow
+  template:
+    metadata:
+      labels:
+        app: mlflow
+    spec:
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: mlflow
+        image: ghcr.io/mlflow/mlflow:v3.13.0-full
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - |
+          set -e
+          auth_args=""
+          if [ "${MLFLOW_AUTH_TYPE}" = "basic-auth" ]; then
+            python -m pip install --no-cache-dir --target /mlflow/python-packages \
+              "mlflow[auth]==$(python -c 'import mlflow; print(mlflow.__version__)')"
+            export PYTHONPATH="/mlflow/python-packages${PYTHONPATH:+:${PYTHONPATH}}"
+            python -m mlflow.server.auth db upgrade --url sqlite:////mlflow/basic_auth.db
+            cd /mlflow
+            auth_args="--app-name basic-auth --disable-security-middleware"
+          fi
+          exec mlflow server \
+            --host 0.0.0.0 \
+            --port 5000 \
+            --workers 2 \
+            --static-prefix /mlflow \
+            --backend-store-uri "${BACKEND_STORE_URI}" \
+            --registry-store-uri "${REGISTRY_STORE_URI}" \
+            --artifacts-destination "${ARTIFACTS_DESTINATION}" \
+            --serve-artifacts \
+            ${auth_args}
+        ports:
+        - containerPort: 5000
+        env:
+        - name: BACKEND_STORE_URI
+          valueFrom:
+            secretKeyRef:
+              name: mlflow-db-credentials
+              key: backend-store-uri
+        - name: REGISTRY_STORE_URI
+          valueFrom:
+            secretKeyRef:
+              name: mlflow-db-credentials
+              key: registry-store-uri
+        - name: MLFLOW_AUTH_TYPE
+          valueFrom:
+            configMapKeyRef:
+              name: mlflow-direct-config
+              key: MLFLOW_AUTH_TYPE
+        - name: ARTIFACTS_DESTINATION
+          valueFrom:
+            configMapKeyRef:
+              name: mlflow-direct-config
+              key: ARTIFACTS_DESTINATION
+        - name: MLFLOW_S3_ENDPOINT_URL
+          valueFrom:
+            configMapKeyRef:
+              name: mlflow-direct-config
+              key: MLFLOW_S3_ENDPOINT_URL
+              optional: true
+        - name: MLFLOW_FLASK_SERVER_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: mlflow-direct-auth
+              key: flask-secret-key
+        - name: MLFLOW_SERVER_DISABLE_SECURITY_MIDDLEWARE
+          valueFrom:
+            configMapKeyRef:
+              name: mlflow-direct-config
+              key: MLFLOW_SERVER_DISABLE_SECURITY_MIDDLEWARE
+              optional: true
+        envFrom:
+        - secretRef:
+            name: aws-credentials
+            optional: true
+        readinessProbe:
+          httpGet:
+            path: /mlflow/health
+            port: 5000
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 24
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 2Gi
+        volumeMounts:
+        - name: mlflow-data
+          mountPath: /mlflow
+      volumes:
+      - name: mlflow-data
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mlflow
+  labels:
+    app: mlflow
+spec:
+  selector:
+    app: mlflow
+  ports:
+  - name: http
+    port: 5000
+    targetPort: 5000

--- a/.github/resources/mlflow-direct/manifests/namespace.yaml
+++ b/.github/resources/mlflow-direct/manifests/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: opendatahub
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/.github/resources/mlflow-direct/manifests/postgres.yaml
+++ b/.github/resources/mlflow-direct/manifests/postgres.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mlflow-db-credentials
+stringData:
+  backend-store-uri: postgresql://postgres:mysecretpassword@postgres-service.opendatahub.svc.cluster.local:5432/mydatabase?sslmode=disable
+  registry-store-uri: postgresql://postgres:mysecretpassword@postgres-service.opendatahub.svc.cluster.local:5432/mydatabase?sslmode=disable
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-deployment
+  labels:
+    app: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      securityContext:
+        fsGroup: 999
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: postgres
+        image: postgres:15
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 999
+          runAsGroup: 999
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_USER
+          value: postgres
+        - name: POSTGRES_PASSWORD
+          value: mysecretpassword
+        - name: POSTGRES_DB
+          value: mydatabase
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        readinessProbe:
+          exec:
+            command:
+            - pg_isready
+            - -U
+            - postgres
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 12
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            memory: 512Mi
+        volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: postgres-data
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+  labels:
+    app: postgres
+spec:
+  selector:
+    app: postgres
+  ports:
+  - name: postgres
+    port: 5432
+    targetPort: 5432

--- a/.github/resources/scripts/configure-mlflow.sh
+++ b/.github/resources/scripts/configure-mlflow.sh
@@ -21,13 +21,18 @@
 # port-forward the API server and MLflow so E2E tests can reach both.
 # It also exports workspace/auth variables used by MLflow test helpers.
 #
-# Usage: configure-mlflow.sh <KFP_NAMESPACE> <MLFLOW_NAMESPACE> <CONFIG_JSON_PATH>
+# Usage: configure-mlflow.sh <KFP_NAMESPACE> <MLFLOW_NAMESPACE> <CONFIG_JSON_PATH> [AUTH_TYPE]
 
 set -e
 
 KFP_NAMESPACE="${1:?KFP namespace required}"
 MLFLOW_NAMESPACE="${2:?MLflow namespace required}"
 CONFIG_JSON_PATH="${3:?Path to source config.json required}"
+MLFLOW_AUTH_TYPE="${4:-kubernetes}"
+
+MLFLOW_CREDENTIALS_SECRET_NAME="kfp-mlflow-credentials"
+MLFLOW_BASIC_AUTH_USERNAME="admin"
+MLFLOW_BASIC_AUTH_PASSWORD="password1234"
 
 echo "Services in ${MLFLOW_NAMESPACE} namespace:"
 kubectl get svc -n "$MLFLOW_NAMESPACE" --no-headers
@@ -39,14 +44,57 @@ fi
 MLFLOW_PORT=$(kubectl get svc -n "$MLFLOW_NAMESPACE" "$MLFLOW_SVC" -o jsonpath='{.spec.ports[0].port}')
 MLFLOW_HOST="${MLFLOW_SVC}.${MLFLOW_NAMESPACE}.svc.cluster.local"
 MLFLOW_STATIC_PREFIX="/mlflow"
-MLFLOW_ENDPOINT="https://${MLFLOW_HOST}:${MLFLOW_PORT}${MLFLOW_STATIC_PREFIX}"
+MLFLOW_SCHEME="https"
+if [ "$MLFLOW_AUTH_TYPE" != "kubernetes" ]; then
+  MLFLOW_SCHEME="http"
+fi
+MLFLOW_ENDPOINT="${MLFLOW_SCHEME}://${MLFLOW_HOST}:${MLFLOW_PORT}${MLFLOW_STATIC_PREFIX}"
 echo "MLflow service: $MLFLOW_SVC port=$MLFLOW_PORT endpoint=$MLFLOW_ENDPOINT"
 
-MLFLOW_PATCH=$(jq -n --arg endpoint "$MLFLOW_ENDPOINT" '{
-  endpoint: $endpoint,
-  tls: { insecureSkipVerify: true },
-  settings: { workspacesEnabled: true }
-}')
+case "$MLFLOW_AUTH_TYPE" in
+  kubernetes)
+    MLFLOW_PATCH=$(jq -n --arg endpoint "$MLFLOW_ENDPOINT" '{
+      endpoint: $endpoint,
+      tls: { insecureSkipVerify: true },
+      settings: {
+        authType: "kubernetes",
+        workspacesEnabled: true
+      }
+    }')
+    ;;
+  basic-auth)
+    kubectl create secret generic "$MLFLOW_CREDENTIALS_SECRET_NAME" -n "$KFP_NAMESPACE" \
+      --from-literal=username="$MLFLOW_BASIC_AUTH_USERNAME" \
+      --from-literal=password="$MLFLOW_BASIC_AUTH_PASSWORD" \
+      --dry-run=client -o yaml | kubectl apply -f -
+    MLFLOW_PATCH=$(jq -n --arg endpoint "$MLFLOW_ENDPOINT" '{
+      endpoint: $endpoint,
+      tls: { insecureSkipVerify: true },
+      settings: {
+        authType: "basic-auth",
+        workspacesEnabled: false,
+        credentialSecretRef: {
+          usernameKey: "username",
+          passwordKey: "password"
+        }
+      }
+    }')
+    ;;
+  none)
+    MLFLOW_PATCH=$(jq -n --arg endpoint "$MLFLOW_ENDPOINT" '{
+      endpoint: $endpoint,
+      tls: { insecureSkipVerify: true },
+      settings: {
+        authType: "none",
+        workspacesEnabled: false
+      }
+    }')
+    ;;
+  *)
+    echo "ERROR: Unsupported MLflow auth type: $MLFLOW_AUTH_TYPE"
+    exit 1
+    ;;
+esac
 
 jq --argjson mlflow "$MLFLOW_PATCH" '. + { plugins: { mlflow: $mlflow } }' \
   "$CONFIG_JSON_PATH" > /tmp/kfp-config.json
@@ -79,42 +127,99 @@ curl -sf http://localhost:8888/apis/v1beta1/healthz > /dev/null 2>&1 || {
   exit 1
 }
 
-SA_TOKEN=$(kubectl create token ml-pipeline -n "$KFP_NAMESPACE" --duration=1h 2>/dev/null || true)
+SA_TOKEN=""
+if [ "$MLFLOW_AUTH_TYPE" = "kubernetes" ]; then
+  SA_TOKEN=$(kubectl create token ml-pipeline -n "$KFP_NAMESPACE" --duration=1h 2>/dev/null || true)
+fi
 if [ -n "${GITHUB_ENV:-}" ]; then
-  echo "MLFLOW_WORKSPACE=$KFP_NAMESPACE" >> "$GITHUB_ENV"
+  echo "MLFLOW_TRACKING_URI=${MLFLOW_SCHEME}://localhost:8080${MLFLOW_STATIC_PREFIX}" >> "$GITHUB_ENV"
+  echo "MLFLOW_BEARER_TOKEN=" >> "$GITHUB_ENV"
+  echo "MLFLOW_TRACKING_USERNAME=" >> "$GITHUB_ENV"
+  echo "MLFLOW_TRACKING_PASSWORD=" >> "$GITHUB_ENV"
+  echo "MLFLOW_WORKSPACE=" >> "$GITHUB_ENV"
   # Later workflow steps need these to re-establish port-forward: background jobs from this step
   # are terminated when the step exits, so test-and-report starts kubectl port-forward again.
   echo "MLFLOW_PORT_FORWARD_NS=$MLFLOW_NAMESPACE" >> "$GITHUB_ENV"
   echo "MLFLOW_PORT_FORWARD_SVC=$MLFLOW_SVC" >> "$GITHUB_ENV"
   echo "MLFLOW_PORT_FORWARD_REMOTE_PORT=$MLFLOW_PORT" >> "$GITHUB_ENV"
-  if [ -n "$SA_TOKEN" ]; then
-    echo "MLFLOW_BEARER_TOKEN=$SA_TOKEN" >> "$GITHUB_ENV"
-    echo "Exported MLFLOW_BEARER_TOKEN and MLFLOW_WORKSPACE for test helpers"
-  else
-    echo "WARNING: Could not create SA token; MLflow requests may be unauthenticated"
-    echo "Exported MLFLOW_WORKSPACE only"
-  fi
+  case "$MLFLOW_AUTH_TYPE" in
+    kubernetes)
+      echo "MLFLOW_WORKSPACE=$KFP_NAMESPACE" >> "$GITHUB_ENV"
+      if [ -n "$SA_TOKEN" ]; then
+        echo "MLFLOW_BEARER_TOKEN=$SA_TOKEN" >> "$GITHUB_ENV"
+        echo "Exported MLFLOW_BEARER_TOKEN and MLFLOW_WORKSPACE for test helpers"
+      else
+        echo "WARNING: Could not create SA token; MLflow requests may be unauthenticated"
+        echo "Exported MLFLOW_WORKSPACE only"
+      fi
+      ;;
+    basic-auth)
+      echo "MLFLOW_TRACKING_USERNAME=$MLFLOW_BASIC_AUTH_USERNAME" >> "$GITHUB_ENV"
+      echo "MLFLOW_TRACKING_PASSWORD=$MLFLOW_BASIC_AUTH_PASSWORD" >> "$GITHUB_ENV"
+      echo "Exported MLFLOW_TRACKING_USERNAME and MLFLOW_TRACKING_PASSWORD for test helpers"
+      ;;
+    none)
+      echo "Exported no MLflow auth credentials for test helpers"
+      ;;
+  esac
 fi
 
 kubectl port-forward -n "$MLFLOW_NAMESPACE" "svc/$MLFLOW_SVC" "8080:$MLFLOW_PORT" &
 sleep 3
 
-HEALTH_URL="https://localhost:8080${MLFLOW_STATIC_PREFIX}/health"
-CURL_HEADERS=(-H "X-MLflow-Workspace: $KFP_NAMESPACE")
-[ -n "$SA_TOKEN" ] && CURL_HEADERS+=(-H "Authorization: Bearer $SA_TOKEN")
+HEALTH_URL="${MLFLOW_SCHEME}://localhost:8080${MLFLOW_STATIC_PREFIX}/health"
+CURL_ARGS=()
+CURL_HEADERS=()
+case "$MLFLOW_AUTH_TYPE" in
+  kubernetes)
+    CURL_HEADERS=(-H "X-MLflow-Workspace: $KFP_NAMESPACE")
+    [ -n "$SA_TOKEN" ] && CURL_HEADERS+=(-H "Authorization: Bearer $SA_TOKEN")
+    ;;
+  basic-auth)
+    CURL_ARGS=(-u "${MLFLOW_BASIC_AUTH_USERNAME}:${MLFLOW_BASIC_AUTH_PASSWORD}")
+    ;;
+  none)
+    ;;
+esac
 
 STATUS=000
 for i in $(seq 1 30); do
   STATUS=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 10 \
-    "${CURL_HEADERS[@]}" "$HEALTH_URL" 2>/dev/null || echo "000")
-  if [ "$STATUS" != "000" ] && [ "$STATUS" -lt 500 ] 2>/dev/null; then
-    echo "MLflow backend is healthy on localhost:8080 (HTTPS, status=$STATUS)"
+    "${CURL_ARGS[@]}" "${CURL_HEADERS[@]}" "$HEALTH_URL" 2>/dev/null || echo "000")
+  if [ "$STATUS" = "200" ]; then
+    echo "MLflow backend is healthy on localhost:8080 (${MLFLOW_SCHEME}, status=$STATUS)"
     break
   fi
   echo "Waiting for MLflow backend... ($i/30, status=$STATUS)"
   sleep 5
 done
-if [ "$STATUS" = "000" ] || { [ "$STATUS" -ge 500 ] 2>/dev/null; }; then
+if [ "$STATUS" != "200" ]; then
   echo "ERROR: MLflow backend not healthy after 30 attempts (last status=$STATUS)"
   exit 1
+fi
+
+verify_mlflow_api_auth() {
+  local api_url="${MLFLOW_SCHEME}://localhost:8080${MLFLOW_STATIC_PREFIX}/api/2.0/mlflow/experiments/search"
+  local api_status
+
+  api_status=$(curl -sk -o /dev/null -w '%{http_code}' --connect-timeout 5 --max-time 15 \
+    -X POST \
+    -H "Content-Type: application/json" \
+    "${CURL_ARGS[@]}" "${CURL_HEADERS[@]}" \
+    -d '{"max_results":1}' \
+    "$api_url" 2>/dev/null || echo "000")
+
+  if [ "$api_status" = "200" ]; then
+    echo "MLflow API auth verified for authType=$MLFLOW_AUTH_TYPE (status=$api_status)"
+    return 0
+  fi
+
+  echo "ERROR: MLflow API auth verification failed for authType=$MLFLOW_AUTH_TYPE (status=$api_status)"
+  kubectl get deployment mlflow -n "$MLFLOW_NAMESPACE" -o jsonpath='{.spec.template.spec.containers[0].command}{" "}{.spec.template.spec.containers[0].args}{"\n"}' || true
+  kubectl get deployment mlflow -n "$MLFLOW_NAMESPACE" -o jsonpath='{range .spec.template.spec.containers[0].env[*]}{.name}={.value}{"\n"}{end}' || true
+  exit 1
+}
+
+if [ "$MLFLOW_AUTH_TYPE" != "kubernetes" ]; then
+  verify_mlflow_api_auth
 fi

--- a/.github/resources/scripts/deploy-direct-mlflow.sh
+++ b/.github/resources/scripts/deploy-direct-mlflow.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+MLFLOW_NAMESPACE="${1:?MLflow namespace required}"
+MLFLOW_AUTH_TYPE="${2:?MLflow auth type required}"
+ARTIFACT_STORAGE="${3:?MLflow artifact storage required}"
+DEFAULT_MLFLOW_IMAGE="ghcr.io/mlflow/mlflow:v3.13.0-full"
+MLFLOW_IMAGE="${4:-$DEFAULT_MLFLOW_IMAGE}"
+
+AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-minio}"
+AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-minio123}"
+AWS_S3_BUCKET="${AWS_S3_BUCKET:-mlpipeline}"
+
+case "$MLFLOW_AUTH_TYPE" in
+  basic-auth|none)
+    ;;
+  *)
+    echo "ERROR: deploy-direct-mlflow.sh only supports basic-auth and none, got $MLFLOW_AUTH_TYPE"
+    exit 1
+    ;;
+esac
+
+C_DIR="${BASH_SOURCE%/*}"
+MANIFESTS_DIR="${C_DIR}/../mlflow-direct/manifests"
+
+ARTIFACTS_DESTINATION="file:///mlflow/artifacts"
+MLFLOW_S3_ENDPOINT_URL=""
+if [ "$ARTIFACT_STORAGE" = "s3" ]; then
+  ARTIFACTS_DESTINATION="s3://${AWS_S3_BUCKET}/artifacts"
+  MLFLOW_S3_ENDPOINT_URL="http://seaweedfs.kubeflow.svc.cluster.local:9000"
+fi
+
+kubectl create namespace "$MLFLOW_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+CONFIGMAP_ARGS=(
+  --from-literal=MLFLOW_AUTH_TYPE="$MLFLOW_AUTH_TYPE"
+  --from-literal=ARTIFACTS_DESTINATION="$ARTIFACTS_DESTINATION"
+  --from-literal=MLFLOW_S3_ENDPOINT_URL="$MLFLOW_S3_ENDPOINT_URL"
+)
+if [ "$MLFLOW_AUTH_TYPE" = "none" ]; then
+  CONFIGMAP_ARGS+=(--from-literal=MLFLOW_SERVER_DISABLE_SECURITY_MIDDLEWARE=true)
+fi
+
+kubectl create configmap mlflow-direct-config -n "$MLFLOW_NAMESPACE" \
+  "${CONFIGMAP_ARGS[@]}" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic mlflow-direct-auth -n "$MLFLOW_NAMESPACE" \
+  --from-literal=flask-secret-key=mlflow-ci-secret-key \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl create secret generic aws-credentials -n "$MLFLOW_NAMESPACE" \
+  --from-literal=AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+  --from-literal=AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl kustomize "$MANIFESTS_DIR" \
+  | sed "s#ghcr.io/mlflow/mlflow:v3.13.0-full#${MLFLOW_IMAGE}#g" \
+  | kubectl apply -f -
+
+kubectl -n "$MLFLOW_NAMESPACE" wait --for=condition=available deployment/postgres-deployment --timeout=180s
+kubectl -n "$MLFLOW_NAMESPACE" wait --for=condition=available deployment/mlflow --timeout=300s
+kubectl -n "$MLFLOW_NAMESPACE" get pods -l app=mlflow -o wide

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -286,8 +286,14 @@ jobs:
         artifact_storage: [ "file", "s3" ]
         backend_store: [ "postgres" ]
         registry_store: [ "postgres" ]
+        mlflow_auth_type: [ "kubernetes", "basic-auth", "none" ]
+        exclude:
+          - artifact_storage: "s3"
+            mlflow_auth_type: "basic-auth"
+          - artifact_storage: "s3"
+            mlflow_auth_type: "none"
       fail-fast: false
-    name: End to End Critical Scenario MLflow Tests - K8s ${{ matrix.k8s_version }} cacheEnabled=${{ matrix.cache_enabled }} artifactStorage=${{ matrix.artifact_storage }}
+    name: End to End Critical Scenario MLflow Tests - K8s ${{ matrix.k8s_version }} cacheEnabled=${{ matrix.cache_enabled }} artifactStorage=${{ matrix.artifact_storage }} authType=${{ matrix.mlflow_auth_type }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -313,10 +319,10 @@ jobs:
           image_tag: ${{ needs.build.outputs.IMAGE_TAG }}
           image_registry: ${{ needs.build.outputs.IMAGE_REGISTRY }}
 
-      - name: Deploy MLflow
+      - name: Deploy MLflow with Kubernetes auth
         id: deploy-mlflow        
         uses: opendatahub-io/mlflow-operator/.github/actions/deploy@b55bcb6aa528ccecf8904745bb0218350b1ff453
-        if: ${{ steps.create-cluster.outcome == 'success' }}
+        if: ${{ steps.create-cluster.outcome == 'success' && matrix.mlflow_auth_type == 'kubernetes' }}
         with:
           namespace: 'opendatahub'
           mlflow_image: quay.io/${{ github.repository_owner == 'red-hat-data-services' && 'rhoai' || 'opendatahub' }}/mlflow:odh-stable
@@ -327,9 +333,20 @@ jobs:
           s3_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
           s3_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
 
+      - name: Deploy MLflow directly
+        id: deploy_direct_mlflow
+        shell: bash
+        if: ${{ steps.create-cluster.outcome == 'success' && matrix.mlflow_auth_type != 'kubernetes' }}
+        env:
+          # The direct optional-auth lane uses upstream MLflow. The kubernetes-auth
+          # lane above still uses the ODH operator because upstream MLflow does not
+          # provide the ODH kubernetes-auth app.
+          MLFLOW_IMAGE: ghcr.io/mlflow/mlflow:v3.13.0-full
+        run: ./.github/resources/scripts/deploy-direct-mlflow.sh opendatahub "${{ matrix.mlflow_auth_type }}" "${{ matrix.artifact_storage }}" "$MLFLOW_IMAGE"
+
       - name: Wait for MLflow stack readiness
         shell: bash
-        if: ${{ steps.deploy-mlflow.outcome == 'success' }}
+        if: ${{ steps.deploy-mlflow.outcome == 'success' || steps.deploy_direct_mlflow.outcome == 'success' }}
         run: |
           kubectl wait --for=condition=Ready pods --field-selector=status.phase=Running -n opendatahub --timeout=180s
           echo "All running pods in opendatahub are Ready"
@@ -337,8 +354,8 @@ jobs:
       - name: Configure MLflow Plugin and Forward Ports
         shell: bash
         id: configure-mlflow-plugin
-        if: ${{ steps.deploy.outcome == 'success' && steps.deploy-mlflow.outcome == 'success' }}
-        run: ./.github/resources/scripts/configure-mlflow.sh kubeflow opendatahub backend/src/apiserver/config/config.json
+        if: ${{ steps.deploy.outcome == 'success' && (steps.deploy-mlflow.outcome == 'success' || steps.deploy_direct_mlflow.outcome == 'success') }}
+        run: ./.github/resources/scripts/configure-mlflow.sh kubeflow opendatahub backend/src/apiserver/config/config.json "${{ matrix.mlflow_auth_type }}"
 
       - name: Configure Input Variables
         shell: bash
@@ -371,7 +388,7 @@ jobs:
       - name: Run Tests
         uses: ./.github/actions/test-and-report
         id: test-run
-        if: ${{ steps.configure.outcome == 'success' && steps.deploy-mlflow.outcome == 'success' && steps.configure-mlflow-plugin.outcome == 'success'}}
+        if: ${{ steps.configure.outcome == 'success' && (steps.deploy-mlflow.outcome == 'success' || steps.deploy_direct_mlflow.outcome == 'success') && steps.configure-mlflow-plugin.outcome == 'success'}}
         with:
           cache_enabled: ${{ matrix.cache_enabled }}
           test_directory: ${{ env.E2E_TESTS_DIR }}
@@ -379,7 +396,7 @@ jobs:
           num_parallel_nodes: ${{ steps.configure.outputs.NUMBER_OF_NODES }}
           default_namespace: ${{ steps.configure.outputs.NAMESPACE }}
           python_version: ${{ env.PYTHON_VERSION }}
-          report_name: "MLflowTests_K8s=${{ matrix.k8s_version }}_cacheEnabled=${{ matrix.cache_enabled }}_artifactStorage=${{ matrix.artifact_storage }}"
+          report_name: "MLflowTests_K8s=${{ matrix.k8s_version }}_cacheEnabled=${{ matrix.cache_enabled }}_artifactStorage=${{ matrix.artifact_storage }}_authType=${{ matrix.mlflow_auth_type }}"
           tls_enabled: ${{ matrix.pod_to_pod_tls_enabled }}
           ca_cert_path: ${{ env.CA_CERT_PATH }}
           mlflow_enabled: 'true'

--- a/backend/src/apiserver/plugins/mlflow/config.go
+++ b/backend/src/apiserver/plugins/mlflow/config.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
+	"time"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
@@ -27,6 +29,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -54,9 +57,10 @@ type LauncherNamespaceConfig struct {
 // LauncherNamespaceSettings lists the only MLflow settings that a namespace may
 // override through the kfp-launcher ConfigMap.
 type LauncherNamespaceSettings struct {
-	ExperimentDescription *string `json:"experimentDescription,omitempty"`
-	DefaultExperimentName string  `json:"defaultExperimentName,omitempty"`
-	InjectUserEnvVars     *bool   `json:"injectUserEnvVars,omitempty"`
+	ExperimentDescription *string                           `json:"experimentDescription,omitempty"`
+	DefaultExperimentName string                            `json:"defaultExperimentName,omitempty"`
+	InjectUserEnvVars     *bool                             `json:"injectUserEnvVars,omitempty"`
+	CredentialSecretRef   *commonmlflow.CredentialSecretRef `json:"credentialSecretRef,omitempty"`
 }
 
 // ApplySettingsDefaults applies default values to a parsed MLflowPluginSettings.
@@ -64,8 +68,11 @@ func ApplySettingsDefaults(settings *commonmlflow.MLflowPluginSettings) *commonm
 	if settings == nil {
 		settings = &commonmlflow.MLflowPluginSettings{}
 	}
+	if settings.AuthType == "" {
+		settings.AuthType = commonmlflow.AuthTypeKubernetes
+	}
 	if settings.WorkspacesEnabled == nil {
-		defaultEnabled := true
+		defaultEnabled := settings.AuthType == commonmlflow.AuthTypeKubernetes
 		settings.WorkspacesEnabled = &defaultEnabled
 	}
 	if settings.DefaultExperimentName == "" {
@@ -78,10 +85,30 @@ func ApplySettingsDefaults(settings *commonmlflow.MLflowPluginSettings) *commonm
 	return settings
 }
 
-// ResolvedConfig bundles the merged plugin configuration and its parsed settings.
+// ResolvedConfig bundles the merged, defaulted plugin configuration and its
+// resolved credentials.
 type ResolvedConfig struct {
-	Settings *commonmlflow.MLflowPluginSettings
-	Config   *commonmlflow.PluginConfig
+	Config      *commonmlflow.PluginConfig
+	Credentials commonmlflow.MLflowCredentials
+}
+
+func newResolvedConfig(config *commonmlflow.PluginConfig, credentials commonmlflow.MLflowCredentials) (*ResolvedConfig, error) {
+	if config == nil {
+		return nil, util.NewInternalServerError(errors.New("MLflow config is nil"), "resolved MLflow config requires plugin config")
+	}
+	if config.Settings == nil {
+		return nil, util.NewInternalServerError(errors.New("MLflow plugin settings are nil"), "resolved MLflow config requires plugin settings")
+	}
+	if credentials.AuthType == "" {
+		return nil, util.NewInternalServerError(
+			fmt.Errorf("missing resolved credentials for auth type %q", config.Settings.AuthType),
+			"resolved MLflow config requires credentials",
+		)
+	}
+	return &ResolvedConfig{
+		Config:      config,
+		Credentials: credentials,
+	}, nil
 }
 
 // MLflowPluginInput represents the user-facing plugins_input.mlflow schema.
@@ -216,6 +243,9 @@ func mergeLauncherNamespaceSettings(base *commonmlflow.MLflowPluginSettings, ove
 	if overrides.InjectUserEnvVars != nil {
 		merged.InjectUserEnvVars = overrides.InjectUserEnvVars
 	}
+	if overrides.CredentialSecretRef != nil {
+		merged.CredentialSecretRef = overrides.CredentialSecretRef
+	}
 	return &merged
 }
 
@@ -231,18 +261,29 @@ func ResolveMLflowRequestConfig(ctx context.Context, kubeClients KubeClientProvi
 		return nil, nil
 	}
 
+	var clientSet kubernetes.Interface
+	if kubeClients != nil {
+		clientSet = kubeClients.GetClientSet()
+	}
+
 	mergedCfg := globalCfg
+	var launcherNamespaceCfg *LauncherNamespaceConfig
 	if common.IsMultiUserMode() {
 		serverSideNamespaceCfg, err := GetServerSideNamespaceMLflowConfig(namespace)
 		if err != nil {
 			return nil, err
 		}
 		mergedCfg = commonmlflow.MergePluginConfig(mergedCfg, serverSideNamespaceCfg)
+		if mergedCfg.Settings != nil {
+			// In multi-user mode, secret refs are namespace-owned: clear inherited refs so
+			// only the namespace launcher ConfigMap can opt back in.
+			mergedCfg.Settings.CredentialSecretRef = nil
+		}
 
 		if kubeClients == nil {
 			return nil, util.NewInternalServerError(fmt.Errorf("kubeClients is nil"), "Kubernetes clients must be provided when reading MLflow namespace config")
 		}
-		launcherNamespaceCfg, err := GetLauncherNamespaceMLflowConfig(ctx, kubeClients.GetClientSet(), namespace)
+		launcherNamespaceCfg, err = GetLauncherNamespaceMLflowConfig(ctx, clientSet, namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -252,10 +293,12 @@ func ResolveMLflowRequestConfig(ctx context.Context, kubeClients KubeClientProvi
 		mergedCfg.Timeout = DefaultTimeout
 	}
 	settings := ApplySettingsDefaults(mergedCfg.Settings)
-	return &ResolvedConfig{
-		Settings: settings,
-		Config:   &mergedCfg,
-	}, nil
+	mergedCfg.Settings = settings
+	credentials, err := resolveConfiguredCredentials(ctx, clientSet, namespace, settings)
+	if err != nil {
+		return nil, err
+	}
+	return newResolvedConfig(&mergedCfg, credentials)
 }
 
 // BuildMLflowRunRequestContext constructs a fully initialized RequestContext by
@@ -268,19 +311,19 @@ func BuildMLflowRunRequestContext(ctx context.Context, namespace string, request
 	if requestCfg.Config.Endpoint == "" {
 		return nil, util.NewInvalidInputError("plugins.mlflow endpoint must be set")
 	}
-	settings := requestCfg.Settings
+	settings := requestCfg.Config.Settings
 	if settings == nil {
 		return nil, util.NewInternalServerError(errors.New("MLflow plugin settings are nil"), "BuildMLflowRequestContext requires resolved settings")
 	}
 	workspacesEnabled := settings.WorkspacesEnabled != nil && *settings.WorkspacesEnabled
-	return commonmlflow.BuildMLflowRequestContext(*requestCfg.Config, namespace, workspacesEnabled)
+	return commonmlflow.BuildMLflowRequestContext(*requestCfg.Config, requestCfg.Credentials, namespace, workspacesEnabled)
 }
 
 // ResolveMLflowPluginInput parses the plugins_input.mlflow JSON from a run model,
-// validates it against the MLflowPluginInput schema, and applies defaults.
+// and validates it against the MLflowPluginInput schema.
 func ResolveMLflowPluginInput(pluginsInputString *string) (*MLflowPluginInput, error) {
 	if pluginsInputString == nil || *pluginsInputString == "" {
-		return &MLflowPluginInput{ExperimentName: DefaultExperimentName}, nil
+		return &MLflowPluginInput{}, nil
 	}
 
 	var pluginInputs apiserverPlugins.PluginsInputMap
@@ -289,7 +332,7 @@ func ResolveMLflowPluginInput(pluginsInputString *string) (*MLflowPluginInput, e
 	}
 	mlflowRaw, ok := pluginInputs["mlflow"]
 	if !ok || len(mlflowRaw) == 0 {
-		return &MLflowPluginInput{ExperimentName: DefaultExperimentName}, nil
+		return &MLflowPluginInput{}, nil
 	}
 
 	decoder := json.NewDecoder(bytes.NewReader(mlflowRaw))
@@ -303,15 +346,6 @@ func ResolveMLflowPluginInput(pluginsInputString *string) (*MLflowPluginInput, e
 		return nil, util.NewInvalidInputError("plugins_input.mlflow must be a single JSON object")
 	}
 
-	if input.Disabled {
-		return input, nil
-	}
-	if input.ExperimentID != "" {
-		return input, nil
-	}
-	if input.ExperimentName == "" {
-		input.ExperimentName = DefaultExperimentName
-	}
 	return input, nil
 }
 
@@ -333,13 +367,168 @@ func SelectMLflowExperiment(input *MLflowPluginInput, settings *commonmlflow.MLf
 	return "", DefaultExperimentName
 }
 
+func resolveConfiguredCredentials(
+	ctx context.Context,
+	clientSet kubernetes.Interface,
+	namespace string,
+	settings *commonmlflow.MLflowPluginSettings,
+) (commonmlflow.MLflowCredentials, error) {
+	if settings == nil {
+		return commonmlflow.MLflowCredentials{}, util.NewInternalServerError(
+			fmt.Errorf("settings are nil"),
+			"MLflow settings must be provided when resolving credentials",
+		)
+	}
+	switch settings.AuthType {
+	case commonmlflow.AuthTypeKubernetes:
+		return commonmlflow.ResolveMLflowCredentials()
+	case commonmlflow.AuthTypeBearer:
+		if settings.CredentialSecretRef == nil {
+			return commonmlflow.MLflowCredentials{}, util.NewInvalidInputError(
+				"plugins.mlflow.settings.credentialSecretRef is required for authType %q",
+				commonmlflow.AuthTypeBearer,
+			)
+		}
+		return resolveBearerSecretCredentials(ctx, clientSet, namespace, settings.CredentialSecretRef)
+	case commonmlflow.AuthTypeBasicAuth:
+		if settings.CredentialSecretRef == nil {
+			return commonmlflow.MLflowCredentials{}, util.NewInvalidInputError(
+				"plugins.mlflow.settings.credentialSecretRef is required for authType %q",
+				commonmlflow.AuthTypeBasicAuth,
+			)
+		}
+		return resolveBasicAuthSecretCredentials(ctx, clientSet, namespace, settings.CredentialSecretRef)
+	case commonmlflow.AuthTypeNone:
+		return commonmlflow.MLflowCredentials{AuthType: commonmlflow.AuthTypeNone}, nil
+	default:
+		return commonmlflow.MLflowCredentials{}, util.NewInvalidInputError(
+			"unsupported plugins.mlflow.settings.authType %q",
+			settings.AuthType,
+		)
+	}
+}
+
+func resolveBearerSecretCredentials(
+	ctx context.Context,
+	clientSet kubernetes.Interface,
+	namespace string,
+	ref *commonmlflow.CredentialSecretRef,
+) (commonmlflow.MLflowCredentials, error) {
+	if ref == nil {
+		return commonmlflow.MLflowCredentials{}, util.NewInvalidInputError("MLflow bearer auth requires credentialSecretRef")
+	}
+	if ref.TokenKey == "" {
+		return commonmlflow.MLflowCredentials{}, util.NewInvalidInputError(
+			"plugins.mlflow.settings.credentialSecretRef.tokenKey is required for authType %q",
+			commonmlflow.AuthTypeBearer,
+		)
+	}
+	secret, err := getMLflowCredentialSecret(ctx, clientSet, namespace)
+	if err != nil {
+		return commonmlflow.MLflowCredentials{}, err
+	}
+	token, err := readRequiredSecretKey(secret, namespace, ref.TokenKey)
+	if err != nil {
+		return commonmlflow.MLflowCredentials{}, err
+	}
+	return commonmlflow.MLflowCredentials{
+		AuthType:    commonmlflow.AuthTypeBearer,
+		BearerToken: token,
+	}, nil
+}
+
+func resolveBasicAuthSecretCredentials(
+	ctx context.Context,
+	clientSet kubernetes.Interface,
+	namespace string,
+	ref *commonmlflow.CredentialSecretRef,
+) (commonmlflow.MLflowCredentials, error) {
+	if ref == nil {
+		return commonmlflow.MLflowCredentials{}, util.NewInvalidInputError("MLflow basic auth requires credentialSecretRef")
+	}
+	if ref.UsernameKey == "" {
+		return commonmlflow.MLflowCredentials{}, util.NewInvalidInputError(
+			"plugins.mlflow.settings.credentialSecretRef.usernameKey is required for authType %q",
+			commonmlflow.AuthTypeBasicAuth,
+		)
+	}
+	if ref.PasswordKey == "" {
+		return commonmlflow.MLflowCredentials{}, util.NewInvalidInputError(
+			"plugins.mlflow.settings.credentialSecretRef.passwordKey is required for authType %q",
+			commonmlflow.AuthTypeBasicAuth,
+		)
+	}
+	secret, err := getMLflowCredentialSecret(ctx, clientSet, namespace)
+	if err != nil {
+		return commonmlflow.MLflowCredentials{}, err
+	}
+	username, err := readRequiredSecretKey(secret, namespace, ref.UsernameKey)
+	if err != nil {
+		return commonmlflow.MLflowCredentials{}, err
+	}
+	password, err := readRequiredSecretKey(secret, namespace, ref.PasswordKey)
+	if err != nil {
+		return commonmlflow.MLflowCredentials{}, err
+	}
+	return commonmlflow.MLflowCredentials{
+		AuthType: commonmlflow.AuthTypeBasicAuth,
+		Username: username,
+		Password: password,
+	}, nil
+}
+
+// getMLflowCredentialSecret reads the fixed MLflow credentials Secret from the
+// given namespace.
+func getMLflowCredentialSecret(ctx context.Context, clientSet kubernetes.Interface, namespace string) (*corev1.Secret, error) {
+	if clientSet == nil {
+		return nil, util.NewInternalServerError(
+			fmt.Errorf("clientSet is nil"),
+			"Kubernetes clientset must be provided when reading MLflow credentials secret",
+		)
+	}
+	secret, err := clientSet.CoreV1().Secrets(namespace).Get(ctx, commonmlflow.CredentialSecretName, v1.GetOptions{})
+	if err != nil {
+		return nil, util.NewInternalServerError(
+			err,
+			"failed to read MLflow credentials secret %q in namespace %q",
+			commonmlflow.CredentialSecretName,
+			namespace,
+		)
+	}
+	return secret, nil
+}
+
+// readRequiredSecretKey returns the trimmed value for key from secret, returning
+// an error if the key is missing or resolves to an empty value.
+func readRequiredSecretKey(secret *corev1.Secret, namespace, key string) (string, error) {
+	valueBytes, ok := secret.Data[key]
+	if !ok {
+		return "", util.NewInvalidInputError(
+			"secret %q in namespace %q does not contain key %q",
+			commonmlflow.CredentialSecretName,
+			namespace,
+			key,
+		)
+	}
+	value := strings.TrimSpace(string(valueBytes))
+	if value == "" {
+		return "", util.NewInvalidInputError(
+			"secret %q in namespace %q has an empty value for key %q",
+			commonmlflow.CredentialSecretName,
+			namespace,
+			key,
+		)
+	}
+	return value, nil
+}
+
 // InjectMLflowRuntimeEnv sets KFP_MLFLOW_CONFIG on driver and launcher
 // containers.
-func InjectMLflowRuntimeEnv(executionSpec util.ExecutionSpec, env map[string]string) error {
-	if len(env) == 0 || executionSpec == nil {
+func InjectMLflowRuntimeEnv(executionSpec util.ExecutionSpec, envVars []corev1.EnvVar) error {
+	if len(envVars) == 0 || executionSpec == nil {
 		return nil
 	}
-	return executionSpec.UpsertRuntimeEnvVars(env,
+	return executionSpec.UpsertRuntimeEnvVars(envVars,
 		util.ExecutionRuntimeRoleDriver,
 		util.ExecutionRuntimeRoleLauncher,
 	)
@@ -356,4 +545,16 @@ func ToMLflowTerminalStatus(stateV2 string) string {
 	default:
 		return "FAILED"
 	}
+}
+
+func resolvedMLflowTimeout(pluginConfig *commonmlflow.PluginConfig) time.Duration {
+	defaultTimeout := 30 * time.Second
+	if pluginConfig == nil || pluginConfig.Timeout == "" {
+		return defaultTimeout
+	}
+	timeout, err := time.ParseDuration(pluginConfig.Timeout)
+	if err != nil || timeout <= 0 {
+		return defaultTimeout
+	}
+	return timeout
 }

--- a/backend/src/apiserver/plugins/mlflow/config_test.go
+++ b/backend/src/apiserver/plugins/mlflow/config_test.go
@@ -77,22 +77,22 @@ func TestResolveMLflowPluginInput(t *testing.T) {
 		{
 			name:  "nil input defaults",
 			input: nil,
-			want:  &MLflowPluginInput{ExperimentName: DefaultExperimentName},
+			want:  &MLflowPluginInput{},
 		},
 		{
 			name:  "empty string defaults",
 			input: strPtr(""),
-			want:  &MLflowPluginInput{ExperimentName: DefaultExperimentName},
+			want:  &MLflowPluginInput{},
 		},
 		{
 			name:  "missing mlflow block defaults",
 			input: strPtr(`{"other":{"x":"y"}}`),
-			want:  &MLflowPluginInput{ExperimentName: DefaultExperimentName},
+			want:  &MLflowPluginInput{},
 		},
 		{
 			name:  "missing experiment_name defaults",
 			input: strPtr(`{"mlflow":{"disabled":false}}`),
-			want:  &MLflowPluginInput{ExperimentName: DefaultExperimentName},
+			want:  &MLflowPluginInput{},
 		},
 		{
 			name:  "valid experiment_name is used",
@@ -281,19 +281,29 @@ func TestMergePluginConfigAndSettingsDefaults(t *testing.T) {
 	assert.Equal(t, "/ns-mlflow", settings.MLflowUIPathPrefix)
 }
 
+func TestApplySettingsDefaults_NonKubernetesAuthDefaults(t *testing.T) {
+	settings := ApplySettingsDefaults(&commonmlflow.MLflowPluginSettings{
+		AuthType: commonmlflow.AuthTypeNone,
+	})
+	require.NotNil(t, settings.WorkspacesEnabled)
+	assert.False(t, *settings.WorkspacesEnabled)
+	assert.Equal(t, commonmlflow.AuthTypeNone, settings.AuthType)
+}
+
 func TestBuildMLflowRequestContextKubernetesAuth(t *testing.T) {
 	setupFakeKubernetesConfig(t, "sa-token-value")
 
 	workspacesEnabled := true
-	requestCfg := &ResolvedConfig{
-		Config: &commonmlflow.PluginConfig{
-			Endpoint: "https://mlflow.example.com",
-			Timeout:  "12s",
-		},
-		Settings: &commonmlflow.MLflowPluginSettings{
+	requestCfg := mustResolvedConfig(t, &commonmlflow.PluginConfig{
+		Endpoint: "https://mlflow.example.com",
+		Timeout:  "12s",
+		Settings: ApplySettingsDefaults(&commonmlflow.MLflowPluginSettings{
 			WorkspacesEnabled: &workspacesEnabled,
-		},
-	}
+		}),
+	}, commonmlflow.MLflowCredentials{
+		AuthType:    commonmlflow.AuthTypeKubernetes,
+		BearerToken: "sa-token-value",
+	})
 
 	mlflowCtx, err := BuildMLflowRunRequestContext(context.Background(), "ns1", requestCfg)
 	require.NoError(t, err)
@@ -554,6 +564,7 @@ func TestResolveMLflowRequestConfig_StandaloneIgnoresNamespaceLayers(t *testing.
 			"endpoint": "https://global-mlflow.example.com",
 			"timeout":  "10s",
 			"settings": map[string]interface{}{
+				"authType":              "none",
 				"defaultExperimentName": "GlobalDefault",
 			},
 			"namespaces": map[string]interface{}{
@@ -595,9 +606,10 @@ func TestResolveMLflowRequestConfig_StandaloneIgnoresNamespaceLayers(t *testing.
 	require.NoError(t, err)
 	require.NotNil(t, resolved)
 	require.NotNil(t, resolved.Config)
+	require.NotNil(t, resolved.Config.Settings)
 	assert.Equal(t, "https://global-mlflow.example.com", resolved.Config.Endpoint)
-	require.NotNil(t, resolved.Settings)
-	assert.Equal(t, "GlobalDefault", resolved.Settings.DefaultExperimentName)
+	assert.Equal(t, "GlobalDefault", resolved.Config.Settings.DefaultExperimentName)
+	assert.Equal(t, commonmlflow.AuthTypeNone, resolved.Credentials.AuthType)
 }
 
 func TestResolveMLflowRequestConfig_MultiUserAppliesServerAndLauncherOverrides(t *testing.T) {
@@ -607,6 +619,7 @@ func TestResolveMLflowRequestConfig_MultiUserAppliesServerAndLauncherOverrides(t
 			"endpoint": "https://global-mlflow.example.com",
 			"timeout":  "10s",
 			"settings": map[string]interface{}{
+				"authType":          "none",
 				"workspacesEnabled": true,
 				"kfpBaseURL":        "https://global-kfp.example.com",
 			},
@@ -639,6 +652,7 @@ func TestResolveMLflowRequestConfig_MultiUserAppliesServerAndLauncherOverrides(t
 			Data: map[string]string{
 				LauncherConfigKey: `{
 					"settings": {
+						"experimentDescription": "LauncherDescription",
 						"defaultExperimentName": "LauncherDefault",
 						"injectUserEnvVars": true
 					}
@@ -652,23 +666,119 @@ func TestResolveMLflowRequestConfig_MultiUserAppliesServerAndLauncherOverrides(t
 	require.NoError(t, err)
 	require.NotNil(t, resolved)
 	require.NotNil(t, resolved.Config)
+	require.NotNil(t, resolved.Config.Settings)
 	assert.Equal(t, "https://server-side-override.example.com", resolved.Config.Endpoint)
 	assert.Equal(t, "25s", resolved.Config.Timeout)
-	require.NotNil(t, resolved.Settings)
-	require.NotNil(t, resolved.Settings.WorkspacesEnabled)
-	assert.False(t, *resolved.Settings.WorkspacesEnabled)
-	assert.Equal(t, "https://server-kfp.example.com", resolved.Settings.KFPBaseURL)
-	assert.Equal(t, "LauncherDefault", resolved.Settings.DefaultExperimentName)
-	require.NotNil(t, resolved.Settings.InjectUserEnvVars)
-	assert.True(t, *resolved.Settings.InjectUserEnvVars)
+	require.NotNil(t, resolved.Config.Settings.WorkspacesEnabled)
+	assert.False(t, *resolved.Config.Settings.WorkspacesEnabled)
+	assert.Equal(t, "https://server-kfp.example.com", resolved.Config.Settings.KFPBaseURL)
+	require.NotNil(t, resolved.Config.Settings.ExperimentDescription)
+	assert.Equal(t, "LauncherDescription", *resolved.Config.Settings.ExperimentDescription)
+	assert.Equal(t, "LauncherDefault", resolved.Config.Settings.DefaultExperimentName)
+	require.NotNil(t, resolved.Config.Settings.InjectUserEnvVars)
+	assert.True(t, *resolved.Config.Settings.InjectUserEnvVars)
+	assert.Equal(t, commonmlflow.AuthTypeNone, resolved.Credentials.AuthType)
 }
 
-func TestResolveMLflowRequestConfig_MultiUserLauncherOnlyOverridesAllowedSettings(t *testing.T) {
+func TestResolveMLflowRequestConfig_GlobalCredentialSecretRefDefaultUsed(t *testing.T) {
 	originalPlugins := viper.Get("plugins")
 	viper.Set("plugins", map[string]interface{}{
 		"mlflow": map[string]interface{}{
 			"endpoint": "https://global-mlflow.example.com",
 			"timeout":  "10s",
+			"settings": map[string]interface{}{
+				"authType": "bearer",
+				"credentialSecretRef": map[string]interface{}{
+					"tokenKey": "global-token",
+				},
+			},
+		},
+	})
+	t.Cleanup(func() {
+		viper.Set("plugins", originalPlugins)
+	})
+
+	clientSet := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      commonmlflow.CredentialSecretName,
+			Namespace: "ns-defaults",
+		},
+		Data: map[string][]byte{
+			"global-token": []byte("global-secret"),
+		},
+	})
+	kubeClients := &fakeKubeClientProvider{clientSet: clientSet}
+
+	resolved, err := ResolveMLflowRequestConfig(context.Background(), kubeClients, "ns-defaults")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.NotNil(t, resolved.Config.Settings)
+	require.NotNil(t, resolved.Config.Settings.CredentialSecretRef)
+	assert.Equal(t, "global-token", resolved.Config.Settings.CredentialSecretRef.TokenKey)
+	assert.Equal(t, commonmlflow.AuthTypeBearer, resolved.Credentials.AuthType)
+	assert.Equal(t, "global-secret", resolved.Credentials.BearerToken)
+}
+
+func TestResolveMLflowRequestConfig_MultiUserRejectsInheritedCredentialSecretRefWithoutLauncherOverride(t *testing.T) {
+	originalPlugins := viper.Get("plugins")
+	viper.Set("plugins", map[string]interface{}{
+		"mlflow": map[string]interface{}{
+			"endpoint": "https://global-mlflow.example.com",
+			"timeout":  "10s",
+			"settings": map[string]interface{}{
+				"authType": "basic-auth",
+			},
+			"namespaces": map[string]interface{}{
+				"ns1": map[string]interface{}{
+					"settings": map[string]interface{}{
+						"credentialSecretRef": map[string]interface{}{
+							"usernameKey": "server-username",
+							"passwordKey": "server-password",
+						},
+					},
+				},
+			},
+		},
+	})
+	t.Cleanup(func() {
+		viper.Set("plugins", originalPlugins)
+	})
+	viper.Set(common.MultiUserMode, true)
+	t.Cleanup(func() {
+		viper.Set(common.MultiUserMode, nil)
+	})
+
+	clientSet := k8sfake.NewClientset()
+	kubeClients := &fakeKubeClientProvider{clientSet: clientSet}
+
+	resolved, err := ResolveMLflowRequestConfig(context.Background(), kubeClients, "ns1")
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.Contains(t, err.Error(), "credentialSecretRef is required")
+	assert.Contains(t, err.Error(), commonmlflow.AuthTypeBasicAuth)
+}
+
+func TestResolveMLflowRequestConfig_MultiUserLauncherCredentialSecretRefWinsOverServerSide(t *testing.T) {
+	originalPlugins := viper.Get("plugins")
+	viper.Set("plugins", map[string]interface{}{
+		"mlflow": map[string]interface{}{
+			"endpoint": "https://global-mlflow.example.com",
+			"timeout":  "10s",
+			"settings": map[string]interface{}{
+				"authType": "bearer",
+				"credentialSecretRef": map[string]interface{}{
+					"tokenKey": "global-token",
+				},
+			},
+			"namespaces": map[string]interface{}{
+				"ns1": map[string]interface{}{
+					"settings": map[string]interface{}{
+						"credentialSecretRef": map[string]interface{}{
+							"tokenKey": "server-token",
+						},
+					},
+				},
+			},
 		},
 	})
 	t.Cleanup(func() {
@@ -688,53 +798,22 @@ func TestResolveMLflowRequestConfig_MultiUserLauncherOnlyOverridesAllowedSetting
 			Data: map[string]string{
 				LauncherConfigKey: `{
 					"settings": {
-						"experimentDescription": "LauncherDescription",
-						"defaultExperimentName": "LauncherDefault"
+						"credentialSecretRef": {
+							"tokenKey": "launcher-token"
+						}
 					}
 				}`,
 			},
 		},
-	)
-	kubeClients := &fakeKubeClientProvider{clientSet: clientSet}
-
-	resolved, err := ResolveMLflowRequestConfig(context.Background(), kubeClients, "ns1")
-	require.NoError(t, err)
-	require.NotNil(t, resolved)
-	require.NotNil(t, resolved.Config)
-	assert.Equal(t, "https://global-mlflow.example.com", resolved.Config.Endpoint)
-	require.NotNil(t, resolved.Settings)
-	require.NotNil(t, resolved.Settings.ExperimentDescription)
-	assert.Equal(t, "LauncherDescription", *resolved.Settings.ExperimentDescription)
-	assert.Equal(t, "LauncherDefault", resolved.Settings.DefaultExperimentName)
-}
-
-func TestResolveMLflowRequestConfig_MultiUserGlobalOnlyAllowsEmptyNamespacePlaceholders(t *testing.T) {
-	originalPlugins := viper.Get("plugins")
-	viper.Set("plugins", map[string]interface{}{
-		"mlflow": map[string]interface{}{
-			"endpoint": "https://global-mlflow.example.com",
-			"timeout":  "10s",
-			"namespaces": map[string]interface{}{
-				"ns1": map[string]interface{}{},
-			},
-		},
-	})
-	t.Cleanup(func() {
-		viper.Set("plugins", originalPlugins)
-	})
-	viper.Set(common.MultiUserMode, true)
-	t.Cleanup(func() {
-		viper.Set(common.MultiUserMode, nil)
-	})
-
-	clientSet := k8sfake.NewClientset(
-		&corev1.ConfigMap{
+		&corev1.Secret{
 			ObjectMeta: v1.ObjectMeta{
-				Name:      LauncherConfigMapName,
+				Name:      commonmlflow.CredentialSecretName,
 				Namespace: "ns1",
 			},
-			Data: map[string]string{
-				LauncherConfigKey: `{}`,
+			Data: map[string][]byte{
+				"global-token":   []byte("global-secret"),
+				"server-token":   []byte("server-secret"),
+				"launcher-token": []byte("launcher-secret"),
 			},
 		},
 	)
@@ -743,8 +822,11 @@ func TestResolveMLflowRequestConfig_MultiUserGlobalOnlyAllowsEmptyNamespacePlace
 	resolved, err := ResolveMLflowRequestConfig(context.Background(), kubeClients, "ns1")
 	require.NoError(t, err)
 	require.NotNil(t, resolved)
-	assert.Equal(t, "https://global-mlflow.example.com", resolved.Config.Endpoint)
-	require.NotNil(t, resolved.Settings)
+	require.NotNil(t, resolved.Config.Settings)
+	require.NotNil(t, resolved.Config.Settings.CredentialSecretRef)
+	assert.Equal(t, "launcher-token", resolved.Config.Settings.CredentialSecretRef.TokenKey)
+	assert.Equal(t, commonmlflow.AuthTypeBearer, resolved.Credentials.AuthType)
+	assert.Equal(t, "launcher-secret", resolved.Credentials.BearerToken)
 }
 
 func TestResolveMLflowRequestConfig_MultiUserRejectsForbiddenLauncherFields(t *testing.T) {
@@ -832,14 +914,64 @@ func TestResolveMLflowCredentials_EmptySAToken(t *testing.T) {
 	assert.Contains(t, err.Error(), "bearer token is empty")
 }
 
-func TestBuildMLflowRequestContext_InvalidEndpoint(t *testing.T) {
-	requestCfg := &ResolvedConfig{
-		Config: &commonmlflow.PluginConfig{
-			Endpoint: "not-a-valid-url",
-			Timeout:  "10s",
+func TestResolveBearerSecretCredentials(t *testing.T) {
+	clientSet := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      commonmlflow.CredentialSecretName,
+			Namespace: "ns1",
 		},
-		Settings: &commonmlflow.MLflowPluginSettings{},
-	}
+		Data: map[string][]byte{
+			"token": []byte("custom-token"),
+		},
+	})
+
+	credentials, err := resolveBearerSecretCredentials(
+		context.Background(),
+		clientSet,
+		"ns1",
+		&commonmlflow.CredentialSecretRef{
+			TokenKey: "token",
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, commonmlflow.AuthTypeBearer, credentials.AuthType)
+	assert.Equal(t, "custom-token", credentials.BearerToken)
+}
+
+func TestResolveBasicAuthSecretCredentials_MissingPasswordKey(t *testing.T) {
+	clientSet := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      commonmlflow.CredentialSecretName,
+			Namespace: "ns1",
+		},
+		Data: map[string][]byte{
+			"username": []byte("user"),
+		},
+	})
+
+	_, err := resolveBasicAuthSecretCredentials(
+		context.Background(),
+		clientSet,
+		"ns1",
+		&commonmlflow.CredentialSecretRef{
+			UsernameKey: "username",
+			PasswordKey: "password",
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `does not contain key "password"`)
+}
+
+func TestBuildMLflowRequestContext_InvalidEndpoint(t *testing.T) {
+	requestCfg := mustResolvedConfig(t, &commonmlflow.PluginConfig{
+		Endpoint: "not-a-valid-url",
+		Timeout:  "10s",
+		Settings: ApplySettingsDefaults(&commonmlflow.MLflowPluginSettings{
+			AuthType: commonmlflow.AuthTypeNone,
+		}),
+	}, commonmlflow.MLflowCredentials{
+		AuthType: commonmlflow.AuthTypeNone,
+	})
 	ctx, err := BuildMLflowRunRequestContext(context.Background(), "ns1", requestCfg)
 	require.Error(t, err)
 	assert.Nil(t, ctx)
@@ -849,13 +981,14 @@ func TestBuildMLflowRequestContext_InvalidEndpoint(t *testing.T) {
 func TestBuildMLflowRequestContext_ZeroTimeout(t *testing.T) {
 	setupFakeKubernetesConfig(t, "valid-token")
 
-	requestCfg := &ResolvedConfig{
-		Config: &commonmlflow.PluginConfig{
-			Endpoint: "https://mlflow.example.com",
-			Timeout:  "0s",
-		},
-		Settings: &commonmlflow.MLflowPluginSettings{},
-	}
+	requestCfg := mustResolvedConfig(t, &commonmlflow.PluginConfig{
+		Endpoint: "https://mlflow.example.com",
+		Timeout:  "0s",
+		Settings: ApplySettingsDefaults(&commonmlflow.MLflowPluginSettings{}),
+	}, commonmlflow.MLflowCredentials{
+		AuthType:    commonmlflow.AuthTypeKubernetes,
+		BearerToken: "valid-token",
+	})
 	ctx, err := BuildMLflowRunRequestContext(context.Background(), "ns1", requestCfg)
 	require.Error(t, err)
 	assert.Nil(t, ctx)
@@ -891,13 +1024,14 @@ func TestInjectMLflowRuntimeEnv(t *testing.T) {
 		},
 	})
 
-	env := map[string]string{
-		commonmlflow.EnvMLflowConfig: `{"endpoint":"https://mlflow.example.com","parentRunId":"abc"}`,
-	}
+	env := []corev1.EnvVar{{
+		Name:  commonmlflow.EnvMLflowConfig,
+		Value: `{"endpoint":"https://mlflow.example.com","parentRunId":"abc"}`,
+	}}
 	err := InjectMLflowRuntimeEnv(workflow, env)
 	require.NoError(t, err)
 
-	expectedEnv := corev1.EnvVar{Name: commonmlflow.EnvMLflowConfig, Value: env[commonmlflow.EnvMLflowConfig]}
+	expectedEnv := env[0]
 
 	// Driver container gets the env var.
 	assert.Contains(t, workflow.Spec.Templates[0].Container.Env, expectedEnv)
@@ -910,13 +1044,13 @@ func TestInjectMLflowRuntimeEnv(t *testing.T) {
 }
 
 func TestInjectMLflowRuntimeEnv_NilSpec(t *testing.T) {
-	err := InjectMLflowRuntimeEnv(nil, map[string]string{"key": "val"})
+	err := InjectMLflowRuntimeEnv(nil, []corev1.EnvVar{{Name: "key", Value: "val"}})
 	require.NoError(t, err, "nil spec should be a no-op")
 }
 
 func TestInjectMLflowRuntimeEnv_EmptyEnv(t *testing.T) {
 	workflow := util.NewWorkflow(&workflowapi.Workflow{})
-	err := InjectMLflowRuntimeEnv(workflow, map[string]string{})
+	err := InjectMLflowRuntimeEnv(workflow, []corev1.EnvVar{})
 	require.NoError(t, err, "empty env should be a no-op")
 }
 
@@ -927,15 +1061,16 @@ func newTestMLflowRequestContext(t *testing.T, serverURL string) *commonmlflow.R
 	setupFakeKubernetesConfig(t, "bearer-secret")
 
 	enabled := true
-	requestCfg := &ResolvedConfig{
-		Config: &commonmlflow.PluginConfig{
-			Endpoint: serverURL,
-			Timeout:  "10s",
-		},
-		Settings: &commonmlflow.MLflowPluginSettings{
+	requestCfg := mustResolvedConfig(t, &commonmlflow.PluginConfig{
+		Endpoint: serverURL,
+		Timeout:  "10s",
+		Settings: ApplySettingsDefaults(&commonmlflow.MLflowPluginSettings{
 			WorkspacesEnabled: &enabled,
-		},
-	}
+		}),
+	}, commonmlflow.MLflowCredentials{
+		AuthType:    commonmlflow.AuthTypeKubernetes,
+		BearerToken: "bearer-secret",
+	})
 	ctx, err := BuildMLflowRunRequestContext(context.Background(), "ns1", requestCfg)
 	require.NoError(t, err)
 	require.NotNil(t, ctx)

--- a/backend/src/apiserver/plugins/mlflow/dispatcher.go
+++ b/backend/src/apiserver/plugins/mlflow/dispatcher.go
@@ -16,7 +16,6 @@ package mlflow
 
 import (
 	"context"
-	"time"
 
 	"github.com/golang/glog"
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
@@ -26,8 +25,6 @@ import (
 )
 
 var _ apiserverPlugins.PluginDispatcher = (*Dispatcher)(nil)
-
-const preRunMLflowTimeout = 3 * time.Second
 
 // Dispatcher implements PluginDispatcher for MLflow.
 type Dispatcher struct {
@@ -78,11 +75,11 @@ func (d *Dispatcher) OnBeforeRunCreation(ctx context.Context, run *apiserverPlug
 	}
 
 	handler := NewHandler(mlflowInput, run.Namespace)
-	// Limit MLflow pre-run calls to a short timeout budget while still
-	// honoring parent request cancellation.
-	mlflowCtx, cancel := context.WithTimeout(ctx, preRunMLflowTimeout)
+	// Keep the pre-run MLflow calls within the configured MLflow timeout while
+	// still honoring parent request cancellation.
+	mlflowCtx, cancel := context.WithTimeout(ctx, resolvedMLflowTimeout(resolvedCfg.Config))
 	defer cancel()
-	pluginOutput, pluginErr := handler.OnBeforeRunCreation(mlflowCtx, run, resolvedCfg.Config)
+	pluginOutput, pluginErr := handler.OnBeforeRunCreation(mlflowCtx, run, resolvedCfg)
 	if pluginErr != nil {
 		glog.Warningf("MLflow OnBeforeRunCreation failed for run %q (run creation will continue): %v", run.RunID, pluginErr)
 	}
@@ -92,10 +89,8 @@ func (d *Dispatcher) OnBeforeRunCreation(ctx context.Context, run *apiserverPlug
 	if err := SetPendingRunPluginOutput(run, PluginName, pluginOutput); err != nil {
 		glog.Warningf("Failed to persist MLflow plugin output for run %q: %v", run.RunID, err)
 	}
-	if len(handler.RunStartEnv) != 0 {
-		if err := InjectMLflowRuntimeEnv(executionSpec, handler.RunStartEnv); err != nil {
-			glog.Warningf("Failed to inject MLflow runtime env for run %q: %v", run.RunID, err)
-		}
+	if err := InjectMLflowRuntimeEnv(executionSpec, handler.RunStartEnvVars); err != nil {
+		glog.Warningf("Failed to inject MLflow runtime env for run %q: %v", run.RunID, err)
 	}
 	return nil
 }
@@ -106,8 +101,8 @@ func (d *Dispatcher) OnRunEnd(ctx context.Context, run *apiserverPlugins.Persist
 	mlflowOutput := run.PluginsOutput[PluginName]
 	hasParentRun := mlflowOutput != nil && GetParentRunID(mlflowOutput) != ""
 
-	syncOK := d.executePostAction(ctx, run, "OnRunEnd", func(h *Handler, r *apiserverPlugins.PersistedRun, cfg *commonmlflow.PluginConfig) {
-		if err := h.OnRunEnd(ctx, r, cfg); err != nil {
+	syncOK := d.executePostAction(ctx, run, "OnRunEnd", func(mlflowCtx context.Context, h *Handler, r *apiserverPlugins.PersistedRun, cfg *ResolvedConfig) {
+		if err := h.OnRunEnd(mlflowCtx, r, cfg); err != nil {
 			glog.Warningf("MLflow OnRunEnd failed for run %q: %v", run.RunID, err)
 		}
 	})
@@ -121,8 +116,8 @@ func (d *Dispatcher) OnRunEnd(ctx context.Context, run *apiserverPlugins.Persist
 
 // OnRunRetry reopens the MLflow parent run and any failed/killed nested runs.
 func (d *Dispatcher) OnRunRetry(ctx context.Context, run *apiserverPlugins.PersistedRun) {
-	d.executePostAction(ctx, run, "HandleRetry", func(h *Handler, r *apiserverPlugins.PersistedRun, cfg *commonmlflow.PluginConfig) {
-		h.HandleRetry(ctx, r, cfg)
+	d.executePostAction(ctx, run, "HandleRetry", func(mlflowCtx context.Context, h *Handler, r *apiserverPlugins.PersistedRun, cfg *ResolvedConfig) {
+		h.HandleRetry(mlflowCtx, r, cfg)
 	})
 }
 
@@ -132,20 +127,22 @@ func (d *Dispatcher) executePostAction(
 	ctx context.Context,
 	run *apiserverPlugins.PersistedRun,
 	hookName string,
-	invoke func(*Handler, *apiserverPlugins.PersistedRun, *commonmlflow.PluginConfig),
+	invoke func(context.Context, *Handler, *apiserverPlugins.PersistedRun, *ResolvedConfig),
 ) bool {
 	resolvedCfg, err := ResolveMLflowRequestConfig(ctx, d.kubeClients, run.Namespace)
 	if err != nil {
 		glog.Warningf("MLflow %s: failed to resolve config for namespace %q: %v", hookName, run.Namespace, err)
 	}
+	timeoutCfg := (*commonmlflow.PluginConfig)(nil)
+	if resolvedCfg != nil {
+		timeoutCfg = resolvedCfg.Config
+	}
+	mlflowCtx, cancel := context.WithTimeout(ctx, resolvedMLflowTimeout(timeoutCfg))
+	defer cancel()
 
 	handler := NewHandler(nil, run.Namespace)
 
-	var config *commonmlflow.PluginConfig
-	if resolvedCfg != nil {
-		config = resolvedCfg.Config
-	}
-	invoke(handler, run, config)
+	invoke(mlflowCtx, handler, run, resolvedCfg)
 
 	mlflowSyncOK := false
 	if po := run.PluginsOutput[PluginName]; po != nil {

--- a/backend/src/apiserver/plugins/mlflow/handler.go
+++ b/backend/src/apiserver/plugins/mlflow/handler.go
@@ -25,6 +25,7 @@ import (
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
 	commonmlflow "github.com/kubeflow/pipelines/backend/src/common/plugins/mlflow"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var _ apiserverPlugins.RunPluginHandler = (*Handler)(nil)
@@ -34,9 +35,9 @@ type Handler struct {
 	input     *MLflowPluginInput
 	namespace string
 
-	// RunStartEnv is populated by OnBeforeRunCreation with the single
-	// KFP_MLFLOW_CONFIG env var for the driver and launcher.
-	RunStartEnv map[string]string
+	// RunStartEnvVars is populated by OnBeforeRunCreation with runtime env vars
+	// for the driver and launcher.
+	RunStartEnvVars []corev1.EnvVar
 }
 
 // NewHandler creates a new MLflow plugin handler.
@@ -53,16 +54,20 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 	if h == nil || run == nil || h.input == nil || h.input.Disabled {
 		return nil, nil
 	}
-	pluginConfig, ok := config.(*commonmlflow.PluginConfig)
-	if !ok || pluginConfig == nil {
+	resolvedCfg := resolveHandlerConfig(config)
+	if resolvedCfg == nil || resolvedCfg.Config == nil {
 		return nil, nil
 	}
+	pluginConfig := resolvedCfg.Config
 
-	settings := ApplySettingsDefaults(pluginConfig.Settings)
+	experimentID, experimentName := SelectMLflowExperiment(h.input, pluginConfig.Settings)
 
-	experimentID, experimentName := SelectMLflowExperiment(h.input, settings)
+	settings := pluginConfig.Settings
+	if settings == nil {
+		err := fmt.Errorf("resolved MLflow settings are missing")
+		return FailedPluginOutput(experimentID, experimentName, "", "", err.Error()), err
+	}
 
-	resolvedCfg := &ResolvedConfig{Config: pluginConfig, Settings: settings}
 	mlflowRequestCtx, err := BuildMLflowRunRequestContext(ctx, h.namespace, resolvedCfg)
 	if err != nil {
 		return FailedPluginOutput(experimentID, experimentName, "", "", fmt.Sprintf("failed to build MLflow request context: %v", err)), err
@@ -99,24 +104,37 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 	// managed outside the plugin config. Only InsecureSkipVerify is carried
 	// over because it is a boolean flag independent of filesystem context.
 	mlflowRuntimeConfig := commonmlflow.MLflowRuntimeConfig{
-		Endpoint:           mlflowRequestCtx.BaseURL.String(),
-		Workspace:          workspace,
-		WorkspacesEnabled:  settings.WorkspacesEnabled != nil && *settings.WorkspacesEnabled,
-		ParentRunID:        parentRunID,
-		ExperimentID:       mlflowExperiment.ID,
-		AuthType:           commonmlflow.AuthTypeKubernetes,
-		Timeout:            pluginConfig.Timeout,
-		InsecureSkipVerify: insecureSkipVerify,
-		InjectUserEnvVars:  settings.InjectUserEnvVars != nil && *settings.InjectUserEnvVars,
+		Endpoint:            mlflowRequestCtx.BaseURL.String(),
+		Workspace:           workspace,
+		WorkspacesEnabled:   settings.WorkspacesEnabled != nil && *settings.WorkspacesEnabled,
+		ParentRunID:         parentRunID,
+		ExperimentID:        mlflowExperiment.ID,
+		AuthType:            settings.AuthType,
+		CredentialSecretRef: runtimeCredentialSecretRef(settings),
+		Timeout:             pluginConfig.Timeout,
+		InsecureSkipVerify:  insecureSkipVerify,
+		InjectUserEnvVars:   settings.InjectUserEnvVars != nil && *settings.InjectUserEnvVars,
 	}
 	mlflowConfigJSON, err := json.Marshal(mlflowRuntimeConfig)
 	if err != nil {
 		return FailedPluginOutput(mlflowExperiment.ID, mlflowExperiment.Name, parentRunID, "", fmt.Sprintf("failed to marshal MLflow runtime config: %v", err)), err
 	}
 
-	h.RunStartEnv = map[string]string{
-		commonmlflow.EnvMLflowConfig: string(mlflowConfigJSON),
+	h.RunStartEnvVars = []corev1.EnvVar{{
+		Name:  commonmlflow.EnvMLflowConfig,
+		Value: string(mlflowConfigJSON),
+	}}
+	credentialEnvVars, err := commonmlflow.BuildCredentialEnvVars(settings.CredentialSecretRef, settings.AuthType)
+	if err != nil {
+		return FailedPluginOutput(
+			mlflowExperiment.ID,
+			mlflowExperiment.Name,
+			parentRunID,
+			"",
+			fmt.Sprintf("failed to build MLflow credential env vars: %v", err),
+		), err
 	}
+	h.RunStartEnvVars = append(h.RunStartEnvVars, credentialEnvVars...)
 
 	runURL := BuildRunURL(mlflowRequestCtx, mlflowExperiment.ID, parentRunID, settings)
 	return SuccessfulPluginOutput(mlflowExperiment.ID, mlflowExperiment.Name, parentRunID, runURL), nil
@@ -128,12 +146,11 @@ func (h *Handler) OnRunEnd(ctx context.Context, run *apiserverPlugins.PersistedR
 	if h == nil || run == nil {
 		return nil
 	}
-	pluginConfig, _ := config.(*commonmlflow.PluginConfig)
-	return h.syncOnRunTerminal(ctx, run, pluginConfig)
+	return h.syncOnRunTerminal(ctx, run, resolveHandlerConfig(config))
 }
 
 // syncOnRunTerminal marks the MLflow parent and nested runs as complete/failed.
-func (h *Handler) syncOnRunTerminal(ctx context.Context, run *apiserverPlugins.PersistedRun, config *commonmlflow.PluginConfig) error {
+func (h *Handler) syncOnRunTerminal(ctx context.Context, run *apiserverPlugins.PersistedRun, config *ResolvedConfig) error {
 	endTimeMs := int64(0)
 	endTimeRef := (*int64)(nil)
 	if run.FinishedAt != nil {
@@ -146,13 +163,13 @@ func (h *Handler) syncOnRunTerminal(ctx context.Context, run *apiserverPlugins.P
 }
 
 // HandleRetry reopens the MLflow parent run and any failed/killed nested runs.
-func (h *Handler) HandleRetry(ctx context.Context, run *apiserverPlugins.PersistedRun, config *commonmlflow.PluginConfig) {
+func (h *Handler) HandleRetry(ctx context.Context, run *apiserverPlugins.PersistedRun, config *ResolvedConfig) {
 	h.syncMLflowRuns(ctx, run, config, RunSyncModeRetry, "", nil, "retry")
 }
 
 // syncMLflowRuns resolves the MLflow request context, syncs the parent and nested runs, and
 // updates the plugin output state.
-func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.PersistedRun, config *commonmlflow.PluginConfig, mode RunSyncMode, terminalStatus string, endTimeRef *int64, label string) {
+func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.PersistedRun, config *ResolvedConfig, mode RunSyncMode, terminalStatus string, endTimeRef *int64, label string) {
 	pluginOutput := run.PluginsOutput[PluginName]
 	if pluginOutput == nil {
 		return
@@ -167,17 +184,21 @@ func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.Pers
 		return
 	}
 
-	if config == nil {
+	localConfig := cloneResolvedConfig(config)
+	if localConfig == nil || localConfig.Config == nil {
 		msg := fmt.Sprintf("MLflow %s sync failed: config unavailable", label)
 		glog.Warning(msg)
 		SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_FAILED, msg)
 		return
 	}
+	if localConfig.Config.Settings == nil {
+		msg := fmt.Sprintf("MLflow %s sync failed: resolved MLflow settings are missing", label)
+		glog.Warning(msg)
+		SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_FAILED, msg)
+		return
+	}
 
-	settings := ApplySettingsDefaults(config.Settings)
-
-	resolvedCfg := &ResolvedConfig{Config: config, Settings: settings}
-	mlflowRequestCtx, err := BuildMLflowRunRequestContext(ctx, h.namespace, resolvedCfg)
+	mlflowRequestCtx, err := BuildMLflowRunRequestContext(ctx, h.namespace, localConfig)
 	if err != nil {
 		msg := fmt.Sprintf("MLflow %s sync failed: %v", label, err)
 		glog.Warning(msg)
@@ -193,4 +214,42 @@ func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.Pers
 	} else {
 		SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_SUCCEEDED, "")
 	}
+}
+
+func resolveHandlerConfig(config interface{}) *ResolvedConfig {
+	typedConfig, _ := config.(*ResolvedConfig)
+	return typedConfig
+}
+
+func runtimeCredentialSecretRef(settings *commonmlflow.MLflowPluginSettings) *commonmlflow.CredentialSecretRef {
+	if settings == nil || settings.CredentialSecretRef == nil {
+		return nil
+	}
+	switch settings.AuthType {
+	case commonmlflow.AuthTypeBearer, commonmlflow.AuthTypeBasicAuth:
+		credentialSecretRef := *settings.CredentialSecretRef
+		return &credentialSecretRef
+	default:
+		return nil
+	}
+}
+
+func cloneResolvedConfig(config *ResolvedConfig) *ResolvedConfig {
+	if config == nil {
+		return nil
+	}
+	cloned := *config
+	if config.Config != nil {
+		configCopy := *config.Config
+		cloned.Config = &configCopy
+	}
+	if config.Config != nil && config.Config.Settings != nil {
+		settingsCopy := *config.Config.Settings
+		if settingsCopy.WorkspacesEnabled != nil {
+			workspacesEnabled := *settingsCopy.WorkspacesEnabled
+			settingsCopy.WorkspacesEnabled = &workspacesEnabled
+		}
+		cloned.Config.Settings = &settingsCopy
+	}
+	return &cloned
 }

--- a/backend/src/apiserver/plugins/mlflow/handler_test.go
+++ b/backend/src/apiserver/plugins/mlflow/handler_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // ---- Helpers ----
@@ -44,13 +45,34 @@ func setupSAToken(t *testing.T) func() {
 	return func() {} // cleanup handled by t.Cleanup in setupFakeKubernetesConfig
 }
 
-func testPluginConfig(endpoint string) *commonmlflow.PluginConfig {
+func testPluginConfig(endpoint string) *ResolvedConfig {
 	enabled := true
-	return &commonmlflow.PluginConfig{
-		Endpoint: endpoint,
-		Timeout:  "10s",
-		Settings: &commonmlflow.MLflowPluginSettings{WorkspacesEnabled: &enabled},
+	return &ResolvedConfig{
+		Config: &commonmlflow.PluginConfig{
+			Endpoint: endpoint,
+			Timeout:  "10s",
+			Settings: &commonmlflow.MLflowPluginSettings{WorkspacesEnabled: &enabled},
+		}}
+}
+
+func testResolvedConfig(endpoint string) *ResolvedConfig {
+	cfg := testPluginConfig(endpoint)
+	cfg.Config.Settings = ApplySettingsDefaults(cfg.Config.Settings)
+	resolvedCfg, err := newResolvedConfig(cfg.Config, commonmlflow.MLflowCredentials{
+		AuthType:    commonmlflow.AuthTypeKubernetes,
+		BearerToken: "test-sa-token",
+	})
+	if err != nil {
+		panic(err)
 	}
+	return resolvedCfg
+}
+
+func mustResolvedConfig(t *testing.T, cfg *commonmlflow.PluginConfig, credentials commonmlflow.MLflowCredentials) *ResolvedConfig {
+	t.Helper()
+	resolvedCfg, err := newResolvedConfig(cfg, credentials)
+	require.NoError(t, err)
+	return resolvedCfg
 }
 
 func testPendingRun(id, displayName string) *apiserverPlugins.PendingRun {
@@ -97,19 +119,19 @@ func TestOnBeforeRunCreation_NilConfig_ReturnsNil(t *testing.T) {
 	output, err := handler.OnBeforeRunCreation(context.Background(), testPendingRun("r1", "run-1"), nil)
 	require.NoError(t, err)
 	assert.Nil(t, output)
-	assert.Empty(t, handler.RunStartEnv)
+	assert.Empty(t, handler.RunStartEnvVars)
 }
 
 func TestOnBeforeRunCreation_Disabled_ReturnsNil(t *testing.T) {
 	handler := NewHandler(&MLflowPluginInput{Disabled: true}, "ns1")
-	output, err := handler.OnBeforeRunCreation(context.Background(), testPendingRun("r1", "run-1"), testPluginConfig("http://localhost"))
+	output, err := handler.OnBeforeRunCreation(context.Background(), testPendingRun("r1", "run-1"), testResolvedConfig("http://localhost"))
 	require.NoError(t, err)
 	assert.Nil(t, output)
 }
 
 func TestOnBeforeRunCreation_NilInput_ReturnsNil(t *testing.T) {
 	handler := NewHandler(nil, "ns1")
-	output, err := handler.OnBeforeRunCreation(context.Background(), testPendingRun("r1", "run-1"), testPluginConfig("http://localhost"))
+	output, err := handler.OnBeforeRunCreation(context.Background(), testPendingRun("r1", "run-1"), testResolvedConfig("http://localhost"))
 	require.NoError(t, err)
 	assert.Nil(t, output)
 }
@@ -119,6 +141,60 @@ func TestOnBeforeRunCreation_Success(t *testing.T) {
 	defer cleanup()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/2.0/mlflow/experiments/get-by-name":
+			assert.Equal(t, "Configured-Default", r.URL.Query().Get("experiment_name"))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"experiment":{"experiment_id":"exp-42","name":"Configured-Default"}}`))
+		case "/api/2.0/mlflow/runs/create":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"run":{"info":{"run_id":"mlflow-run-1"}}}`))
+		case "/api/2.0/mlflow/runs/set-tag":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	viper.Set(common.MultiUserMode, false)
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, nil) })
+
+	handler := NewHandler(&MLflowPluginInput{}, "ns1")
+
+	run := testPendingRun("kfp-run-1", "my-run")
+	cfg := testResolvedConfig(server.URL)
+	cfg.Config.Settings.DefaultExperimentName = "Configured-Default"
+	output, err := handler.OnBeforeRunCreation(context.Background(), run, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	assert.Equal(t, apiv2beta1.PluginState_PLUGIN_SUCCEEDED, output.State)
+	assert.Contains(t, output.Entries, EntryExperimentID)
+	assert.Equal(t, "exp-42", output.Entries[EntryExperimentID].Value.GetStringValue())
+	assert.Contains(t, output.Entries, EntryRootRunID)
+	assert.Equal(t, "mlflow-run-1", output.Entries[EntryRootRunID].Value.GetStringValue())
+
+	// Verify RunStartEnv contains single KFP_MLFLOW_CONFIG JSON env var
+	require.NotEmpty(t, handler.RunStartEnvVars)
+
+	var rtCfg commonmlflow.MLflowRuntimeConfig
+	require.NoError(t, json.Unmarshal([]byte(getEnvVarValue(t, handler.RunStartEnvVars, commonmlflow.EnvMLflowConfig)), &rtCfg))
+	assert.Contains(t, rtCfg.Endpoint, server.URL)
+	assert.Equal(t, "ns1", rtCfg.Workspace)
+	assert.Equal(t, "mlflow-run-1", rtCfg.ParentRunID)
+	assert.Equal(t, "exp-42", rtCfg.ExperimentID)
+	assert.Equal(t, "kubernetes", rtCfg.AuthType)
+	assert.False(t, rtCfg.InjectUserEnvVars, "InjectUserEnvVars should default to false")
+}
+
+func TestOnBeforeRunCreation_BasicAuthInjectsCredentialEnvVars(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username, password, ok := r.BasicAuth()
+		require.True(t, ok)
+		assert.Equal(t, "basic-user", username)
+		assert.Equal(t, "basic-pass", password)
 		switch r.URL.Path {
 		case "/api/2.0/mlflow/experiments/get-by-name":
 			w.WriteHeader(http.StatusOK)
@@ -138,31 +214,106 @@ func TestOnBeforeRunCreation_Success(t *testing.T) {
 	viper.Set(common.MultiUserMode, false)
 	t.Cleanup(func() { viper.Set(common.MultiUserMode, nil) })
 
+	settings := ApplySettingsDefaults(&commonmlflow.MLflowPluginSettings{
+		AuthType: commonmlflow.AuthTypeBasicAuth,
+		CredentialSecretRef: &commonmlflow.CredentialSecretRef{
+			UsernameKey: "username",
+			PasswordKey: "password",
+		},
+	})
 	handler := NewHandler(&MLflowPluginInput{ExperimentName: "Default"}, "ns1")
-
 	run := testPendingRun("kfp-run-1", "my-run")
-	output, err := handler.OnBeforeRunCreation(context.Background(), run, testPluginConfig(server.URL))
+
+	output, err := handler.OnBeforeRunCreation(context.Background(), run, mustResolvedConfig(t, &commonmlflow.PluginConfig{
+		Endpoint: server.URL,
+		Timeout:  "10s",
+		Settings: settings,
+	}, commonmlflow.MLflowCredentials{
+		AuthType: commonmlflow.AuthTypeBasicAuth,
+		Username: "basic-user",
+		Password: "basic-pass",
+	}))
 	require.NoError(t, err)
 	require.NotNil(t, output)
-
-	assert.Equal(t, apiv2beta1.PluginState_PLUGIN_SUCCEEDED, output.State)
-	assert.Contains(t, output.Entries, EntryExperimentID)
-	assert.Equal(t, "exp-42", output.Entries[EntryExperimentID].Value.GetStringValue())
-	assert.Contains(t, output.Entries, EntryRootRunID)
-	assert.Equal(t, "mlflow-run-1", output.Entries[EntryRootRunID].Value.GetStringValue())
-
-	// Verify RunStartEnv contains single KFP_MLFLOW_CONFIG JSON env var
-	require.NotEmpty(t, handler.RunStartEnv)
-	assert.Contains(t, handler.RunStartEnv, commonmlflow.EnvMLflowConfig)
+	assert.Equal(t, commonmlflow.EnvMLflowTrackingUsername, handler.RunStartEnvVars[1].Name)
+	require.NotNil(t, handler.RunStartEnvVars[1].ValueFrom)
+	require.NotNil(t, handler.RunStartEnvVars[1].ValueFrom.SecretKeyRef)
+	assert.Equal(t, commonmlflow.CredentialSecretName, handler.RunStartEnvVars[1].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "username", handler.RunStartEnvVars[1].ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, commonmlflow.EnvMLflowTrackingPassword, handler.RunStartEnvVars[2].Name)
+	require.NotNil(t, handler.RunStartEnvVars[2].ValueFrom)
+	require.NotNil(t, handler.RunStartEnvVars[2].ValueFrom.SecretKeyRef)
+	assert.Equal(t, commonmlflow.CredentialSecretName, handler.RunStartEnvVars[2].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "password", handler.RunStartEnvVars[2].ValueFrom.SecretKeyRef.Key)
 
 	var rtCfg commonmlflow.MLflowRuntimeConfig
-	require.NoError(t, json.Unmarshal([]byte(handler.RunStartEnv[commonmlflow.EnvMLflowConfig]), &rtCfg))
-	assert.Contains(t, rtCfg.Endpoint, server.URL)
-	assert.Equal(t, "ns1", rtCfg.Workspace)
-	assert.Equal(t, "mlflow-run-1", rtCfg.ParentRunID)
-	assert.Equal(t, "exp-42", rtCfg.ExperimentID)
-	assert.Equal(t, "kubernetes", rtCfg.AuthType)
-	assert.False(t, rtCfg.InjectUserEnvVars, "InjectUserEnvVars should default to false")
+	require.NoError(t, json.Unmarshal([]byte(getEnvVarValue(t, handler.RunStartEnvVars, commonmlflow.EnvMLflowConfig)), &rtCfg))
+	assert.Equal(t, commonmlflow.AuthTypeBasicAuth, rtCfg.AuthType)
+	require.NotNil(t, rtCfg.CredentialSecretRef)
+	assert.Equal(t, "username", rtCfg.CredentialSecretRef.UsernameKey)
+	assert.Equal(t, "password", rtCfg.CredentialSecretRef.PasswordKey)
+	assert.Empty(t, rtCfg.Workspace)
+}
+
+func TestOnBeforeRunCreation_BearerInjectsTokenCredentialEnvVar(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer custom-token", r.Header.Get("Authorization"))
+		switch r.URL.Path {
+		case "/api/2.0/mlflow/experiments/get-by-name":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"experiment":{"experiment_id":"exp-42","name":"Default"}}`))
+		case "/api/2.0/mlflow/runs/create":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"run":{"info":{"run_id":"mlflow-run-1"}}}`))
+		case "/api/2.0/mlflow/runs/set-tag":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	settings := ApplySettingsDefaults(&commonmlflow.MLflowPluginSettings{
+		AuthType: commonmlflow.AuthTypeBearer,
+		CredentialSecretRef: &commonmlflow.CredentialSecretRef{
+			TokenKey: "token",
+		},
+	})
+	handler := NewHandler(&MLflowPluginInput{ExperimentName: "Default"}, "ns1")
+
+	output, err := handler.OnBeforeRunCreation(context.Background(), testPendingRun("kfp-run-1", "my-run"), mustResolvedConfig(t, &commonmlflow.PluginConfig{
+		Endpoint: server.URL,
+		Timeout:  "10s",
+		Settings: settings,
+	}, commonmlflow.MLflowCredentials{
+		AuthType:    commonmlflow.AuthTypeBearer,
+		BearerToken: "custom-token",
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, commonmlflow.EnvMLflowTrackingToken, handler.RunStartEnvVars[1].Name)
+	require.NotNil(t, handler.RunStartEnvVars[1].ValueFrom)
+	require.NotNil(t, handler.RunStartEnvVars[1].ValueFrom.SecretKeyRef)
+	assert.Equal(t, commonmlflow.CredentialSecretName, handler.RunStartEnvVars[1].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "token", handler.RunStartEnvVars[1].ValueFrom.SecretKeyRef.Key)
+
+	var rtCfg commonmlflow.MLflowRuntimeConfig
+	require.NoError(t, json.Unmarshal([]byte(getEnvVarValue(t, handler.RunStartEnvVars, commonmlflow.EnvMLflowConfig)), &rtCfg))
+	assert.Equal(t, commonmlflow.AuthTypeBearer, rtCfg.AuthType)
+	require.NotNil(t, rtCfg.CredentialSecretRef)
+	assert.Equal(t, "token", rtCfg.CredentialSecretRef.TokenKey)
+}
+
+func getEnvVarValue(t *testing.T, envVars []corev1.EnvVar, name string) string {
+	t.Helper()
+	for _, envVar := range envVars {
+		if envVar.Name == name {
+			return envVar.Value
+		}
+	}
+	t.Fatalf("env var %q not found", name)
+	return ""
 }
 
 func TestOnBeforeRunCreation_MLflowFailure_ReturnsFailedOutput(t *testing.T) {
@@ -181,7 +332,7 @@ func TestOnBeforeRunCreation_MLflowFailure_ReturnsFailedOutput(t *testing.T) {
 	handler := NewHandler(&MLflowPluginInput{ExperimentName: "Default"}, "ns1")
 
 	run := testPendingRun("kfp-run-2", "run-2")
-	output, err := handler.OnBeforeRunCreation(context.Background(), run, testPluginConfig(server.URL))
+	output, err := handler.OnBeforeRunCreation(context.Background(), run, testResolvedConfig(server.URL))
 	require.Error(t, err)
 	require.NotNil(t, output)
 	assert.Equal(t, apiv2beta1.PluginState_PLUGIN_FAILED, output.State)
@@ -192,14 +343,14 @@ func TestOnBeforeRunCreation_MLflowFailure_ReturnsFailedOutput(t *testing.T) {
 
 func TestOnRunEnd_NilRun_ReturnsNil(t *testing.T) {
 	handler := NewHandler(nil, "ns1")
-	err := handler.OnRunEnd(context.Background(), nil, testPluginConfig("http://localhost"))
+	err := handler.OnRunEnd(context.Background(), nil, testResolvedConfig("http://localhost"))
 	require.NoError(t, err)
 }
 
 func TestOnRunEnd_NoPluginOutput_ReturnsNil(t *testing.T) {
 	handler := NewHandler(nil, "ns1")
 	run := testPersistedRun("r1")
-	err := handler.OnRunEnd(context.Background(), run, testPluginConfig("http://localhost"))
+	err := handler.OnRunEnd(context.Background(), run, testResolvedConfig("http://localhost"))
 	require.NoError(t, err)
 }
 
@@ -210,7 +361,7 @@ func TestOnRunEnd_MissingRootRunID_SetsFailedState(t *testing.T) {
 	pluginOutput := SuccessfulPluginOutput("42", "Default", "", "")
 	run := testPersistedRunWithPluginOutput("r-missing-root", pluginOutput)
 
-	err := handler.OnRunEnd(context.Background(), run, testPluginConfig("http://localhost"))
+	err := handler.OnRunEnd(context.Background(), run, testResolvedConfig("http://localhost"))
 	require.NoError(t, err)
 
 	// Verify the plugin output was updated in place
@@ -262,7 +413,7 @@ func TestOnRunEnd_Success(t *testing.T) {
 	run := testPersistedRunWithPluginOutput("r-end-1", pluginOutput)
 	run.State = "SUCCEEDED"
 
-	err := handler.OnRunEnd(context.Background(), run, testPluginConfig(server.URL))
+	err := handler.OnRunEnd(context.Background(), run, testResolvedConfig(server.URL))
 	require.NoError(t, err)
 
 	// Parent run should have been updated
@@ -282,7 +433,7 @@ func TestHandleRetry_NoPluginOutput_NoOp(t *testing.T) {
 	handler := NewHandler(nil, "ns1")
 	run := testPersistedRun("r-retry-noop")
 
-	handler.HandleRetry(context.Background(), run, testPluginConfig("http://localhost"))
+	handler.HandleRetry(context.Background(), run, testResolvedConfig("http://localhost"))
 	// No plugin output → nothing to do
 	assert.Empty(t, run.PluginsOutput)
 }
@@ -293,7 +444,7 @@ func TestHandleRetry_MissingRootRunID_SetsFailedState(t *testing.T) {
 	pluginOutput := SuccessfulPluginOutput("42", "Default", "", "")
 	run := testPersistedRunWithPluginOutput("r-retry-no-root", pluginOutput)
 
-	handler.HandleRetry(context.Background(), run, testPluginConfig("http://localhost"))
+	handler.HandleRetry(context.Background(), run, testResolvedConfig("http://localhost"))
 
 	result := run.PluginsOutput[PluginName]
 	require.NotNil(t, result)
@@ -342,7 +493,7 @@ func TestHandleRetry_Success(t *testing.T) {
 	pluginOutput := FailedPluginOutput("exp-1", "Default", "parent-1", "", "previous failure")
 	run := testPersistedRunWithPluginOutput("r-retry-ok", pluginOutput)
 
-	handler.HandleRetry(context.Background(), run, testPluginConfig(server.URL))
+	handler.HandleRetry(context.Background(), run, testResolvedConfig(server.URL))
 
 	// Parent reopened + nested-1 reopened = 2 update calls
 	require.Len(t, updatePayloads, 2)
@@ -363,14 +514,14 @@ func TestPostRunSyncUsesResolvedConfigInsteadOfLegacyPluginOutputEndpoint(t *tes
 		pluginOutput     *apiv2beta1.PluginOutput
 		runState         string
 		wantUpdateStatus string
-		invoke           func(*Handler, *apiserverPlugins.PersistedRun, *commonmlflow.PluginConfig) error
+		invoke           func(*Handler, *apiserverPlugins.PersistedRun, *ResolvedConfig) error
 	}{
 		{
 			name:             "terminal sync ignores legacy endpoint entry",
 			pluginOutput:     SuccessfulPluginOutput("exp-1", "Default", "parent-1", ""),
 			runState:         "SUCCEEDED",
 			wantUpdateStatus: "FINISHED",
-			invoke: func(handler *Handler, run *apiserverPlugins.PersistedRun, config *commonmlflow.PluginConfig) error {
+			invoke: func(handler *Handler, run *apiserverPlugins.PersistedRun, config *ResolvedConfig) error {
 				return handler.OnRunEnd(context.Background(), run, config)
 			},
 		},
@@ -378,7 +529,7 @@ func TestPostRunSyncUsesResolvedConfigInsteadOfLegacyPluginOutputEndpoint(t *tes
 			name:             "retry sync ignores legacy endpoint entry",
 			pluginOutput:     FailedPluginOutput("exp-1", "Default", "parent-1", "", "previous failure"),
 			wantUpdateStatus: "RUNNING",
-			invoke: func(handler *Handler, run *apiserverPlugins.PersistedRun, config *commonmlflow.PluginConfig) error {
+			invoke: func(handler *Handler, run *apiserverPlugins.PersistedRun, config *ResolvedConfig) error {
 				handler.HandleRetry(context.Background(), run, config)
 				return nil
 			},
@@ -719,10 +870,14 @@ func TestSyncParentAndNestedRuns_Pagination(t *testing.T) {
 	setupFakeKubernetesConfig(t, "sa-token")
 
 	enabled := true
-	requestCfg := &ResolvedConfig{
-		Config:   &commonmlflow.PluginConfig{Endpoint: server.URL, Timeout: "10s"},
-		Settings: &commonmlflow.MLflowPluginSettings{WorkspacesEnabled: &enabled},
-	}
+	requestCfg := mustResolvedConfig(t, &commonmlflow.PluginConfig{
+		Endpoint: server.URL,
+		Timeout:  "10s",
+		Settings: ApplySettingsDefaults(&commonmlflow.MLflowPluginSettings{WorkspacesEnabled: &enabled}),
+	}, commonmlflow.MLflowCredentials{
+		AuthType:    commonmlflow.AuthTypeKubernetes,
+		BearerToken: "bearer-secret",
+	})
 	mlflowCtx, err := BuildMLflowRunRequestContext(context.Background(), "ns1", requestCfg)
 	require.NoError(t, err)
 

--- a/backend/src/common/plugins/mlflow/client.go
+++ b/backend/src/common/plugins/mlflow/client.go
@@ -36,6 +36,9 @@ import (
 // Auth type constants.
 const (
 	AuthTypeKubernetes = "kubernetes"
+	AuthTypeBearer     = "bearer"
+	AuthTypeBasicAuth  = "basic-auth"
+	AuthTypeNone       = "none"
 )
 
 // Retry policy defaults.
@@ -76,6 +79,8 @@ type Config struct {
 	Endpoint          string
 	HTTPClient        *http.Client
 	BearerToken       string
+	Username          string
+	Password          string
 	WorkspacesEnabled bool
 	Workspace         string
 	Retry             RetryPolicy
@@ -126,8 +131,20 @@ type Client struct {
 	endpoint          *url.URL
 	httpClient        *http.Client
 	bearerToken       string
+	username          string
+	password          string
 	workspacesEnabled bool
 	workspace         string
+}
+
+// IsSupportedAuthType reports whether authType is supported by the MLflow integration.
+func IsSupportedAuthType(authType string) bool {
+	switch authType {
+	case AuthTypeKubernetes, AuthTypeBearer, AuthTypeBasicAuth, AuthTypeNone:
+		return true
+	default:
+		return false
+	}
 }
 
 // NewClient creates a new MLflow REST API client.
@@ -158,6 +175,8 @@ func NewClient(cfg Config) (*Client, error) {
 		endpoint:          u,
 		httpClient:        httpClient,
 		bearerToken:       cfg.BearerToken,
+		username:          cfg.Username,
+		password:          cfg.Password,
 		workspacesEnabled: cfg.WorkspacesEnabled,
 		workspace:         cfg.Workspace,
 	}, nil
@@ -359,7 +378,9 @@ func (c *Client) buildURL(path string) *url.URL {
 func (c *Client) applyHeaders(req *http.Request) {
 	req.Header.Set("Content-Type", "application/json")
 
-	if c.bearerToken != "" {
+	if c.username != "" && c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	} else if c.bearerToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.bearerToken)
 	}
 

--- a/backend/src/common/plugins/mlflow/client_test.go
+++ b/backend/src/common/plugins/mlflow/client_test.go
@@ -87,6 +87,38 @@ func TestApplyHeaders_NoBearerToken(t *testing.T) {
 	assert.Empty(t, req.Header.Get("Authorization"))
 }
 
+func TestApplyHeaders_BasicAuth(t *testing.T) {
+	c, _ := NewClient(Config{
+		Endpoint: "http://mlflow.example.com",
+		Username: "mlflow-user",
+		Password: "mlflow-pass",
+	})
+	req, _ := http.NewRequest("GET", "http://mlflow.example.com", nil)
+	c.applyHeaders(req)
+
+	username, password, ok := req.BasicAuth()
+	require.True(t, ok)
+	assert.Equal(t, "mlflow-user", username)
+	assert.Equal(t, "mlflow-pass", password)
+}
+
+func TestApplyHeaders_BasicAuthTakesPrecedenceOverBearer(t *testing.T) {
+	c, _ := NewClient(Config{
+		Endpoint:    "http://mlflow.example.com",
+		BearerToken: "sa-token",
+		Username:    "mlflow-user",
+		Password:    "mlflow-pass",
+	})
+	req, _ := http.NewRequest("GET", "http://mlflow.example.com", nil)
+	c.applyHeaders(req)
+
+	username, password, ok := req.BasicAuth()
+	require.True(t, ok)
+	assert.Equal(t, "mlflow-user", username)
+	assert.Equal(t, "mlflow-pass", password)
+	assert.NotEqual(t, "Bearer sa-token", req.Header.Get("Authorization"))
+}
+
 func TestApplyHeaders_WorkspaceHeader(t *testing.T) {
 	c, _ := NewClient(Config{
 		Endpoint:          "http://mlflow.example.com",
@@ -107,6 +139,33 @@ func TestApplyHeaders_WorkspaceHeader_DisabledWhenFalse(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://mlflow.example.com", nil)
 	c.applyHeaders(req)
 	assert.Empty(t, req.Header.Get(workspaceHeader))
+}
+
+func TestResolveRuntimeMLflowCredentials_Bearer(t *testing.T) {
+	t.Setenv(EnvMLflowTrackingToken, "custom-token")
+	credentials, err := ResolveRuntimeMLflowCredentials(AuthTypeBearer)
+	require.NoError(t, err)
+	assert.Equal(t, AuthTypeBearer, credentials.AuthType)
+	assert.Equal(t, "custom-token", credentials.BearerToken)
+}
+
+func TestResolveRuntimeMLflowCredentials_BasicAuth(t *testing.T) {
+	t.Setenv(EnvMLflowTrackingUsername, "mlflow-user")
+	t.Setenv(EnvMLflowTrackingPassword, "mlflow-pass")
+	credentials, err := ResolveRuntimeMLflowCredentials(AuthTypeBasicAuth)
+	require.NoError(t, err)
+	assert.Equal(t, AuthTypeBasicAuth, credentials.AuthType)
+	assert.Equal(t, "mlflow-user", credentials.Username)
+	assert.Equal(t, "mlflow-pass", credentials.Password)
+}
+
+func TestResolveRuntimeMLflowCredentials_None(t *testing.T) {
+	credentials, err := ResolveRuntimeMLflowCredentials(AuthTypeNone)
+	require.NoError(t, err)
+	assert.Equal(t, AuthTypeNone, credentials.AuthType)
+	assert.Empty(t, credentials.BearerToken)
+	assert.Empty(t, credentials.Username)
+	assert.Empty(t, credentials.Password)
 }
 
 func TestGetExperimentByName_Success(t *testing.T) {

--- a/backend/src/common/plugins/mlflow/config.go
+++ b/backend/src/common/plugins/mlflow/config.go
@@ -17,6 +17,7 @@ package mlflow
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -25,27 +26,39 @@ import (
 	"time"
 
 	"github.com/kubeflow/pipelines/backend/src/common/util"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // EnvMLflowConfig is the single environment variable injected into Argo
 // Workflow templates by the API server.
 const EnvMLflowConfig = "KFP_MLFLOW_CONFIG"
 
+const (
+	EnvMLflowTrackingAuth     = "MLFLOW_TRACKING_AUTH"
+	EnvMLflowTrackingToken    = "MLFLOW_TRACKING_TOKEN"
+	EnvMLflowTrackingUsername = "MLFLOW_TRACKING_USERNAME"
+	EnvMLflowTrackingPassword = "MLFLOW_TRACKING_PASSWORD"
+)
+
+// CredentialSecretName is the fixed Kubernetes Secret name for secret-based MLflow auth.
+const CredentialSecretName = "kfp-mlflow-credentials"
+
 // TagNestedRunParentRunID is the MLflow tag used for nested run parent linkage.
 const TagNestedRunParentRunID = "mlflow.parentRunId"
 
 // MLflowRuntimeConfig is the JSON payload marshaled into KFP_MLFLOW_CONFIG.
 type MLflowRuntimeConfig struct {
-	Endpoint           string     `json:"endpoint"`
-	WorkspacesEnabled  bool       `json:"workspacesEnabled,omitempty"`
-	Workspace          string     `json:"workspace,omitempty"`
-	ParentRunID        string     `json:"parentRunId"`
-	ExperimentID       string     `json:"experimentId"`
-	AuthType           string     `json:"authType"`
-	Timeout            string     `json:"timeout,omitempty"`
-	InsecureSkipVerify bool       `json:"insecureSkipVerify,omitempty"`
-	InjectUserEnvVars  bool       `json:"injectUserEnvVars,omitempty"`
-	TLS                *TLSConfig `json:"tls,omitempty" mapstructure:"tls"`
+	Endpoint            string               `json:"endpoint"`
+	WorkspacesEnabled   bool                 `json:"workspacesEnabled,omitempty"`
+	Workspace           string               `json:"workspace,omitempty"`
+	ParentRunID         string               `json:"parentRunId"`
+	ExperimentID        string               `json:"experimentId"`
+	AuthType            string               `json:"authType"`
+	CredentialSecretRef *CredentialSecretRef `json:"credentialSecretRef,omitempty"`
+	Timeout             string               `json:"timeout,omitempty"`
+	InsecureSkipVerify  bool                 `json:"insecureSkipVerify,omitempty"`
+	InjectUserEnvVars   bool                 `json:"injectUserEnvVars,omitempty"`
+	TLS                 *TLSConfig           `json:"tls,omitempty" mapstructure:"tls"`
 }
 
 // TLSConfig holds TLS settings for the MLflow endpoint.
@@ -62,10 +75,80 @@ type PluginConfig struct {
 	Settings *MLflowPluginSettings `json:"settings,omitempty" mapstructure:"settings"`
 }
 
+// CredentialSecretRef identifies the Secret keys used for MLflow auth.
+type CredentialSecretRef struct {
+	TokenKey    string `json:"tokenKey,omitempty"`
+	UsernameKey string `json:"usernameKey,omitempty"`
+	PasswordKey string `json:"passwordKey,omitempty"`
+}
+
+func buildSecretEnvVar(name, secretKey string) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: name,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: CredentialSecretName},
+				Key:                  secretKey,
+			},
+		},
+	}
+}
+
+// BuildCredentialEnvVars converts secret-based MLflow auth configuration into
+// Kubernetes env vars backed by SecretKeyRef entries.
+func BuildCredentialEnvVars(ref *CredentialSecretRef, authType string) ([]corev1.EnvVar, error) {
+	if ref == nil {
+		switch authType {
+		case AuthTypeBearer, AuthTypeBasicAuth:
+			return nil, fmt.Errorf("credentialSecretRef is required for auth type %q", authType)
+		default:
+			return nil, nil
+		}
+	}
+	switch authType {
+	case AuthTypeBearer:
+		if ref.TokenKey == "" {
+			return nil, fmt.Errorf("credentialSecretRef.tokenKey is required for auth type %q", authType)
+		}
+		return []corev1.EnvVar{buildSecretEnvVar(EnvMLflowTrackingToken, ref.TokenKey)}, nil
+	case AuthTypeBasicAuth:
+		if ref.UsernameKey == "" {
+			return nil, fmt.Errorf("credentialSecretRef.usernameKey is required for auth type %q", authType)
+		}
+		if ref.PasswordKey == "" {
+			return nil, fmt.Errorf("credentialSecretRef.passwordKey is required for auth type %q", authType)
+		}
+		return []corev1.EnvVar{
+			buildSecretEnvVar(EnvMLflowTrackingUsername, ref.UsernameKey),
+			buildSecretEnvVar(EnvMLflowTrackingPassword, ref.PasswordKey),
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (r *CredentialSecretRef) UnmarshalJSON(data []byte) error {
+	type credentialSecretRef CredentialSecretRef
+	var raw struct {
+		credentialSecretRef
+		Name string `json:"name,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw.Name != "" {
+		return fmt.Errorf("credentialSecretRef.name is not supported; Secret name is fixed to %q", CredentialSecretName)
+	}
+	*r = CredentialSecretRef(raw.credentialSecretRef)
+	return nil
+}
+
 // MLflowCredentials holds the resolved authentication credentials for an MLflow endpoint.
 type MLflowCredentials struct {
 	AuthType    string
 	BearerToken string
+	Username    string
+	Password    string
 }
 
 // RequestContext holds a fully resolved MLflow connection: the parsed
@@ -80,14 +163,16 @@ type RequestContext struct {
 // MLflowPluginSettings contains MLflow-specific settings parsed from
 // PluginConfig.Settings.
 type MLflowPluginSettings struct {
-	WorkspacesEnabled     *bool   `json:"workspacesEnabled,omitempty"`
-	ExperimentDescription *string `json:"experimentDescription,omitempty"`
-	DefaultExperimentName string  `json:"defaultExperimentName,omitempty"`
-	KFPBaseURL            string  `json:"kfpBaseURL,omitempty"`
-	KFPRunURLPathTemplate string  `json:"kfpRunURLPathTemplate,omitempty"`
-	MLflowBaseURL         string  `json:"mlflowBaseURL,omitempty"`
-	MLflowUIPathPrefix    string  `json:"mlflowUIPathPrefix,omitempty"`
-	InjectUserEnvVars     *bool   `json:"injectUserEnvVars,omitempty"`
+	WorkspacesEnabled     *bool                `json:"workspacesEnabled,omitempty"`
+	AuthType              string               `json:"authType,omitempty"`
+	CredentialSecretRef   *CredentialSecretRef `json:"credentialSecretRef,omitempty"`
+	ExperimentDescription *string              `json:"experimentDescription,omitempty"`
+	DefaultExperimentName string               `json:"defaultExperimentName,omitempty"`
+	KFPBaseURL            string               `json:"kfpBaseURL,omitempty"`
+	KFPRunURLPathTemplate string               `json:"kfpRunURLPathTemplate,omitempty"`
+	MLflowBaseURL         string               `json:"mlflowBaseURL,omitempty"`
+	MLflowUIPathPrefix    string               `json:"mlflowUIPathPrefix,omitempty"`
+	InjectUserEnvVars     *bool                `json:"injectUserEnvVars,omitempty"`
 }
 
 // MergePluginConfig merges namespace-level overrides into the global config.
@@ -122,6 +207,12 @@ func mergeSettings(global, namespace *MLflowPluginSettings) *MLflowPluginSetting
 	merged := *global // shallow copy
 	if namespace.WorkspacesEnabled != nil {
 		merged.WorkspacesEnabled = namespace.WorkspacesEnabled
+	}
+	if namespace.AuthType != "" {
+		merged.AuthType = namespace.AuthType
+	}
+	if namespace.CredentialSecretRef != nil {
+		merged.CredentialSecretRef = namespace.CredentialSecretRef
 	}
 	if namespace.ExperimentDescription != nil {
 		merged.ExperimentDescription = namespace.ExperimentDescription
@@ -200,11 +291,52 @@ func ResolveMLflowCredentials() (MLflowCredentials, error) {
 	}, nil
 }
 
+// ResolveRuntimeMLflowCredentials resolves the runtime credentials available to
+// the driver and launcher based on the configured auth type.
+func ResolveRuntimeMLflowCredentials(authType string) (MLflowCredentials, error) {
+	switch authType {
+	case AuthTypeKubernetes:
+		return ResolveMLflowCredentials()
+	case AuthTypeBearer:
+		token := strings.TrimSpace(os.Getenv(EnvMLflowTrackingToken))
+		if token == "" {
+			return MLflowCredentials{}, util.NewInvalidInputError("%s is empty for MLflow bearer auth", EnvMLflowTrackingToken)
+		}
+		return MLflowCredentials{
+			AuthType:    AuthTypeBearer,
+			BearerToken: token,
+		}, nil
+	case AuthTypeBasicAuth:
+		username := strings.TrimSpace(os.Getenv(EnvMLflowTrackingUsername))
+		password := strings.TrimSpace(os.Getenv(EnvMLflowTrackingPassword))
+		if username == "" {
+			return MLflowCredentials{}, util.NewInvalidInputError("%s is empty for MLflow basic auth", EnvMLflowTrackingUsername)
+		}
+		if password == "" {
+			return MLflowCredentials{}, util.NewInvalidInputError("%s is empty for MLflow basic auth", EnvMLflowTrackingPassword)
+		}
+		return MLflowCredentials{
+			AuthType: AuthTypeBasicAuth,
+			Username: username,
+			Password: password,
+		}, nil
+	case AuthTypeNone:
+		return MLflowCredentials{AuthType: AuthTypeNone}, nil
+	default:
+		return MLflowCredentials{}, util.NewInvalidInputError("unsupported MLflow auth type %q", authType)
+	}
+}
+
 // BuildMLflowRequestContext is the shared core that validates the PluginConfig,
 // resolves credentials, builds the HTTP client and MLflow client, and returns
 // a ready-to-use RequestContext. The workspace and workspacesEnabled values
 // are caller-specific and passed in directly.
-func BuildMLflowRequestContext(pluginCfg PluginConfig, workspace string, workspacesEnabled bool) (*RequestContext, error) {
+func BuildMLflowRequestContext(
+	pluginCfg PluginConfig,
+	authMaterial MLflowCredentials,
+	workspace string,
+	workspacesEnabled bool,
+) (*RequestContext, error) {
 	baseURL, err := url.Parse(pluginCfg.Endpoint)
 	if err != nil || baseURL.Scheme == "" || baseURL.Host == "" {
 		return nil, util.NewInvalidInputError("invalid plugins.mlflow endpoint %q", pluginCfg.Endpoint)
@@ -215,10 +347,6 @@ func BuildMLflowRequestContext(pluginCfg PluginConfig, workspace string, workspa
 	}
 	if timeout <= 0 {
 		return nil, util.NewInvalidInputError("plugins.mlflow timeout must be > 0")
-	}
-	authMaterial, err := ResolveMLflowCredentials()
-	if err != nil {
-		return nil, err
 	}
 	httpClient, err := BuildHTTPClient(timeout, pluginCfg.TLS)
 	if err != nil {
@@ -234,6 +362,8 @@ func BuildMLflowRequestContext(pluginCfg PluginConfig, workspace string, workspa
 		Endpoint:          pluginCfg.Endpoint,
 		HTTPClient:        httpClient,
 		BearerToken:       authMaterial.BearerToken,
+		Username:          authMaterial.Username,
+		Password:          authMaterial.Password,
 		WorkspacesEnabled: workspacesEnabled,
 		Workspace:         workspace,
 		Retry:             retrySettings,

--- a/backend/src/common/util/execution_spec.go
+++ b/backend/src/common/util/execution_spec.go
@@ -20,6 +20,7 @@ import (
 
 	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -37,7 +38,6 @@ type ExecutionRuntimeRole string
 const (
 	ExecutionRuntimeRoleDriver   ExecutionRuntimeRole = "driver"
 	ExecutionRuntimeRoleLauncher ExecutionRuntimeRole = "launcher"
-	ExecutionRuntimeRoleExecutor ExecutionRuntimeRole = "executor"
 )
 
 var (
@@ -182,7 +182,7 @@ type ExecutionSpec interface {
 
 	// UpsertRuntimeEnvVars adds or replaces env vars on containers that
 	// implement the given runtime roles for this execution engine.
-	UpsertRuntimeEnvVars(envVars map[string]string, roles ...ExecutionRuntimeRole) error
+	UpsertRuntimeEnvVars(envVars []corev1.EnvVar, roles ...ExecutionRuntimeRole) error
 }
 
 // Convert YAML in bytes into ExecutionSpec instance

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -679,19 +679,15 @@ func (w *Workflow) SetLabelsToAllTemplates(key string, value string) {
 
 // UpsertRuntimeEnvVars adds or replaces env vars on workflow containers
 // matching the specified runtime roles using the AnnotationKeyRuntimeRole
-// annotation stamped by the compiler.  Templates without the annotation are
+// annotation stamped by the compiler. Templates without the annotation are
 // skipped.
-func (w *Workflow) UpsertRuntimeEnvVars(envVars map[string]string, roles ...ExecutionRuntimeRole) error {
+func (w *Workflow) UpsertRuntimeEnvVars(envVars []corev1.EnvVar, roles ...ExecutionRuntimeRole) error {
 	if len(envVars) == 0 || len(w.Spec.Templates) == 0 {
 		return nil
 	}
 	roleSet := make(map[ExecutionRuntimeRole]bool, len(roles))
 	for _, r := range roles {
 		roleSet[r] = true
-	}
-	envList := make([]corev1.EnvVar, 0, len(envVars))
-	for k, v := range envVars {
-		envList = append(envList, corev1.EnvVar{Name: k, Value: v})
 	}
 	for i := range w.Spec.Templates {
 		tmpl := &w.Spec.Templates[i]
@@ -701,7 +697,7 @@ func (w *Workflow) UpsertRuntimeEnvVars(envVars map[string]string, roles ...Exec
 
 		role := tmpl.Metadata.Annotations[AnnotationKeyRuntimeRole]
 		if role != "" && roleSet[ExecutionRuntimeRole(role)] {
-			tmpl.Container.Env = upsertEnvVars(tmpl.Container.Env, envList)
+			tmpl.Container.Env = upsertEnvVars(tmpl.Container.Env, envVars)
 		}
 	}
 	return nil

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/agent/persistence/client/artifactclient"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -2743,25 +2744,24 @@ func TestUpsertRuntimeEnvVars_EmptyInputs(t *testing.T) {
 		annotatedTemplate("driver", ExecutionRuntimeRoleDriver),
 	)
 
-	// Empty env map — should be a no-op.
-	assert.NoError(t, w.UpsertRuntimeEnvVars(map[string]string{}, ExecutionRuntimeRoleDriver))
+	// Empty env slice — should be a no-op.
+	assert.NoError(t, w.UpsertRuntimeEnvVars([]corev1.EnvVar{}, ExecutionRuntimeRoleDriver))
 	assert.Empty(t, w.Spec.Templates[0].Container.Env)
 
-	// Nil env map — should be a no-op.
+	// Nil env slice — should be a no-op.
 	assert.NoError(t, w.UpsertRuntimeEnvVars(nil, ExecutionRuntimeRoleDriver))
 
 	// No templates.
 	empty := NewWorkflow(&workflowapi.Workflow{})
-	assert.NoError(t, empty.UpsertRuntimeEnvVars(map[string]string{"K": "V"}, ExecutionRuntimeRoleDriver))
+	assert.NoError(t, empty.UpsertRuntimeEnvVars([]corev1.EnvVar{{Name: "K", Value: "V"}}, ExecutionRuntimeRoleDriver))
 }
 
 func TestUpsertRuntimeEnvVars_DAGTemplateSkipped(t *testing.T) {
 	w := workflowWithTemplates(dagTemplate("dag"))
 	err := w.UpsertRuntimeEnvVars(
-		map[string]string{"K": "V"},
+		[]corev1.EnvVar{{Name: "K", Value: "V"}},
 		ExecutionRuntimeRoleDriver,
 		ExecutionRuntimeRoleLauncher,
-		ExecutionRuntimeRoleExecutor,
 	)
 	assert.NoError(t, err)
 	// DAG template has no container — nothing to modify.
@@ -2792,7 +2792,7 @@ func TestUpsertRuntimeEnvVars_Annotation_DriverRole(t *testing.T) {
 		annotatedTemplate("launcher", ExecutionRuntimeRoleLauncher),
 	)
 	err := w.UpsertRuntimeEnvVars(
-		map[string]string{"KEY": "val"},
+		[]corev1.EnvVar{{Name: "KEY", Value: "val"}},
 		ExecutionRuntimeRoleDriver,
 	)
 	assert.NoError(t, err)
@@ -2809,7 +2809,7 @@ func TestUpsertRuntimeEnvVars_Annotation_LauncherRole(t *testing.T) {
 		annotatedTemplate("launcher", ExecutionRuntimeRoleLauncher),
 	)
 	err := w.UpsertRuntimeEnvVars(
-		map[string]string{"KEY": "val"},
+		[]corev1.EnvVar{{Name: "KEY", Value: "val"}},
 		ExecutionRuntimeRoleLauncher,
 	)
 	assert.NoError(t, err)
@@ -2826,7 +2826,7 @@ func TestUpsertRuntimeEnvVars_Annotation_MultipleRoles(t *testing.T) {
 		dagTemplate("dag"),
 	)
 	err := w.UpsertRuntimeEnvVars(
-		map[string]string{"KEY": "val"},
+		[]corev1.EnvVar{{Name: "KEY", Value: "val"}},
 		ExecutionRuntimeRoleDriver,
 		ExecutionRuntimeRoleLauncher,
 	)
@@ -2844,7 +2844,10 @@ func TestUpsertRuntimeEnvVars_Annotation_UpsertReplacesExisting(t *testing.T) {
 			corev1.EnvVar{Name: "OLD", Value: "before"}),
 	)
 	err := w.UpsertRuntimeEnvVars(
-		map[string]string{"OLD": "after", "NEW": "fresh"},
+		[]corev1.EnvVar{
+			{Name: "OLD", Value: "after"},
+			{Name: "NEW", Value: "fresh"},
+		},
 		ExecutionRuntimeRoleDriver,
 	)
 	assert.NoError(t, err)
@@ -2855,16 +2858,43 @@ func TestUpsertRuntimeEnvVars_Annotation_UpsertReplacesExisting(t *testing.T) {
 	assert.Equal(t, corev1.EnvVar{Name: "NEW", Value: "fresh"}, env[1])
 }
 
+func TestUpsertRuntimeEnvVars_Annotation_UpsertsSecretKeyRef(t *testing.T) {
+	w := workflowWithTemplates(
+		annotatedTemplate("driver", ExecutionRuntimeRoleDriver),
+	)
+
+	err := w.UpsertRuntimeEnvVars(
+		[]corev1.EnvVar{{
+			Name: "MLFLOW_TRACKING_TOKEN",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "mlflow-secret"},
+					Key:                  "token",
+				},
+			},
+		}},
+		ExecutionRuntimeRoleDriver,
+	)
+	assert.NoError(t, err)
+
+	env := w.Spec.Templates[0].Container.Env
+	assert.Len(t, env, 1)
+	require.NotNil(t, env[0].ValueFrom)
+	require.NotNil(t, env[0].ValueFrom.SecretKeyRef)
+	assert.Equal(t, "MLFLOW_TRACKING_TOKEN", env[0].Name)
+	assert.Equal(t, "mlflow-secret", env[0].ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "token", env[0].ValueFrom.SecretKeyRef.Key)
+}
+
 func TestUpsertRuntimeEnvVars_Annotation_UnknownRoleIgnored(t *testing.T) {
 	// A template with an unknown annotation value should not match any role.
 	w := workflowWithTemplates(
 		annotatedTemplate("unknown", "some-other-role"),
 	)
 	err := w.UpsertRuntimeEnvVars(
-		map[string]string{"KEY": "val"},
+		[]corev1.EnvVar{{Name: "KEY", Value: "val"}},
 		ExecutionRuntimeRoleDriver,
 		ExecutionRuntimeRoleLauncher,
-		ExecutionRuntimeRoleExecutor,
 	)
 	assert.NoError(t, err)
 	assert.Empty(t, w.Spec.Templates[0].Container.Env)

--- a/backend/src/v2/common/plugins/dispatcher.go
+++ b/backend/src/v2/common/plugins/dispatcher.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // TaskPluginDispatcher orchestrates plugin lifecycle hooks
@@ -22,7 +23,7 @@ type TaskPluginDispatcher interface {
 	OnTaskEnd(ctx context.Context, taskInfo *TaskInfo) error
 
 	// RetrieveUserContainerEnvVars returns the user-specified environment variables to be set in the task user container.
-	RetrieveUserContainerEnvVars(taskInfo *TaskInfo) (envVars map[string]string, err error)
+	RetrieveUserContainerEnvVars(taskInfo *TaskInfo) (envVars []corev1.EnvVar, err error)
 
 	// ApplyCustomProperties updates the custom properties for all registered task-level plugins.
 	ApplyCustomProperties(properties map[string]string)
@@ -37,7 +38,7 @@ func (NoOpDispatcher) OnTaskStart(ctx context.Context, taskInfo *TaskInfo) (*Tas
 func (NoOpDispatcher) OnTaskEnd(ctx context.Context, taskInfo *TaskInfo) error {
 	return nil
 }
-func (NoOpDispatcher) RetrieveUserContainerEnvVars(taskInfo *TaskInfo) (envVars map[string]string, err error) {
+func (NoOpDispatcher) RetrieveUserContainerEnvVars(taskInfo *TaskInfo) (envVars []corev1.EnvVar, err error) {
 	return nil, nil
 }
 func (NoOpDispatcher) ApplyCustomProperties(properties map[string]string) {
@@ -117,23 +118,24 @@ func (t *TaskPluginDispatcherImpl) OnTaskEnd(ctx context.Context, taskInfo *Task
 	return nil
 }
 
-func (t *TaskPluginDispatcherImpl) RetrieveUserContainerEnvVars(taskInfo *TaskInfo) (injectVars map[string]string, err error) {
+func (t *TaskPluginDispatcherImpl) RetrieveUserContainerEnvVars(taskInfo *TaskInfo) (injectVars []corev1.EnvVar, err error) {
 	if t == nil {
 		return nil, fmt.Errorf("dispatcher must be non-nil")
 	}
 
-	injectVars = make(map[string]string)
+	injectVarNameSet := map[string]bool{}
 	for _, handler := range t.handlers {
 		vars, err := handler.RetrieveUserContainerEnvVars()
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve user container env vars for handler %s: %v", handler.Name(), err)
 		}
 
-		for k, v := range vars {
-			if _, ok := injectVars[k]; !ok {
-				injectVars[k] = v
+		for _, envVar := range vars {
+			if !injectVarNameSet[envVar.Name] {
+				injectVars = append(injectVars, envVar)
+				injectVarNameSet[envVar.Name] = true
 			} else {
-				glog.Errorf("Key %s already present in container env vars. Key-value pair %s:%s will not be added.", k, k, v)
+				glog.Errorf("Key %s already present in container env vars. Duplicate env var will not be added.", envVar.Name)
 			}
 		}
 	}

--- a/backend/src/v2/common/plugins/dispatcher_test.go
+++ b/backend/src/v2/common/plugins/dispatcher_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var _ TaskPluginHandler = (*fakeHandler)(nil)
@@ -20,7 +21,7 @@ type fakeHandler struct {
 	startResult TaskHandlerStartResult
 	startErr    error
 	endErr      error
-	envVars     map[string]string
+	envVars     []corev1.EnvVar
 	envErr      error
 	customProps map[string]string
 }
@@ -32,7 +33,7 @@ func (f *fakeHandler) OnTaskStart(_ context.Context, _ *TaskInfo) (TaskHandlerSt
 func (f *fakeHandler) OnTaskEnd(_ context.Context, _ *TaskInfo) error {
 	return f.endErr
 }
-func (f *fakeHandler) RetrieveUserContainerEnvVars() (map[string]string, error) {
+func (f *fakeHandler) RetrieveUserContainerEnvVars() ([]corev1.EnvVar, error) {
 	return f.envVars, f.envErr
 }
 func (f *fakeHandler) GenerateCustomProperties(_ TaskHandlerStartResult) map[string]string {
@@ -264,9 +265,7 @@ func TestRetrieveUserContainerEnvVars_NilDispatcher_Failure(t *testing.T) {
 }
 
 func TestRetrieveUserContainerEnvVars_Success(t *testing.T) {
-	expectedVars := map[string]string{
-		"PLUGIN_RUN_ID": "fake-run-1",
-	}
+	expectedVars := []corev1.EnvVar{{Name: "PLUGIN_RUN_ID", Value: "fake-run-1"}}
 	handler := &fakeHandler{
 		name:    "FakePlugin",
 		envVars: expectedVars,

--- a/backend/src/v2/common/plugins/handler.go
+++ b/backend/src/v2/common/plugins/handler.go
@@ -3,6 +3,8 @@ package plugins
 
 import (
 	"context"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // TaskStartResult stores the handler-specific start results keyed by handler name.
@@ -29,7 +31,7 @@ type TaskPluginHandler interface {
 	OnTaskEnd(ctx context.Context, taskInfo *TaskInfo) error
 	// RetrieveUserContainerEnvVars returns the user-specified environment variables to be set in the task user container.
 	// Handlers recover per-task state from internal fields set during OnTaskStart or ApplyCustomProperties.
-	RetrieveUserContainerEnvVars() (injectVars map[string]string, err error)
+	RetrieveUserContainerEnvVars() (injectVars []corev1.EnvVar, err error)
 	// GenerateCustomProperties returns key-value pairs to persist as MLMD
 	// execution custom properties. The driver relays these generically without
 	// knowing which plugin produced them.

--- a/backend/src/v2/common/plugins/mlflow/config.go
+++ b/backend/src/v2/common/plugins/mlflow/config.go
@@ -55,7 +55,7 @@ func ParseKfpMLflowRuntimeConfig() (*commonmlflow.MLflowRuntimeConfig, error) {
 	if len(missingFields) > 0 {
 		return nil, fmt.Errorf("missing one or more of the following required fields in KFP_MLFLOW_CONFIG: %s", strings.Join(missingFields, ", "))
 	}
-	if cfg.AuthType != "kubernetes" {
+	if !commonmlflow.IsSupportedAuthType(cfg.AuthType) {
 		return nil, fmt.Errorf("unsupported auth type: %s", cfg.AuthType)
 	}
 	// Only InsecureSkipVerify is propagated from the API server. Driver/launcher CA trust is configured
@@ -75,19 +75,21 @@ func IsEnabled() bool {
 // BuildMLflowTaskRequestContext constructs a fully initialized RequestContext
 // by delegating to the common BuildRequestContext with task-specific parameters.
 func BuildMLflowTaskRequestContext(runtimeCfg commonmlflow.MLflowRuntimeConfig) (*commonmlflow.RequestContext, error) {
-	mlflowPluginSettings := &commonmlflow.MLflowPluginSettings{
-		WorkspacesEnabled: &runtimeCfg.WorkspacesEnabled,
-		KFPBaseURL:        runtimeCfg.Endpoint,
-		InjectUserEnvVars: &runtimeCfg.InjectUserEnvVars,
+	credentials, err := commonmlflow.ResolveRuntimeMLflowCredentials(runtimeCfg.AuthType)
+	if err != nil {
+		return nil, err
 	}
-
 	pluginCfg := commonmlflow.PluginConfig{
 		Endpoint: runtimeCfg.Endpoint,
 		Timeout:  runtimeCfg.Timeout,
 		TLS:      runtimeCfg.TLS,
-		Settings: mlflowPluginSettings,
 	}
-	return commonmlflow.BuildMLflowRequestContext(pluginCfg, runtimeCfg.Workspace, runtimeCfg.WorkspacesEnabled)
+	return commonmlflow.BuildMLflowRequestContext(
+		pluginCfg,
+		credentials,
+		runtimeCfg.Workspace,
+		runtimeCfg.WorkspacesEnabled,
+	)
 }
 
 // ExecutionStateToMLflowTerminalStatus converts a string representing an MLMD Execution_State to an MLflow

--- a/backend/src/v2/common/plugins/mlflow/handler.go
+++ b/backend/src/v2/common/plugins/mlflow/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/glog"
 	commonmlflow "github.com/kubeflow/pipelines/backend/src/common/plugins/mlflow"
 	"github.com/kubeflow/pipelines/backend/src/v2/common/plugins"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var _ plugins.TaskPluginHandler = (*MLflowHandler)(nil)
@@ -36,7 +37,7 @@ func NewMLflowTaskHandler(cfg *commonmlflow.MLflowRuntimeConfig) (*MLflowHandler
 	if cfg == nil {
 		return nil, fmt.Errorf("cfg is nil")
 	}
-	if cfg.AuthType != commonmlflow.AuthTypeKubernetes {
+	if !commonmlflow.IsSupportedAuthType(cfg.AuthType) {
 		return nil, fmt.Errorf("failed to parse MLflow runtime config: unsupported auth type: %s", cfg.AuthType)
 	}
 	return &MLflowHandler{
@@ -115,7 +116,8 @@ func (h *MLflowHandler) OnTaskEnd(ctx context.Context, info *plugins.TaskInfo) e
 	}
 
 	resolvedStatus := ExecutionStateToMLflowTerminalStatus(info.RunStatus)
-	err = requestCtx.Client.UpdateRun(ctx, resolvedRunID, resolvedStatus, new(info.RunEndTime))
+	runEndTime := info.RunEndTime
+	err = requestCtx.Client.UpdateRun(ctx, resolvedRunID, resolvedStatus, &runEndTime)
 	if err != nil {
 		return fmt.Errorf("failed to update MLflow run: %v", err)
 	}
@@ -125,35 +127,44 @@ func (h *MLflowHandler) OnTaskEnd(ctx context.Context, info *plugins.TaskInfo) e
 
 // RetrieveUserContainerEnvVars retrieves environment variables to inject into user containers based on the MLflow runtime config.
 // The run ID is resolved from h.nestedRunID, set during OnTaskStart.
-func (h *MLflowHandler) RetrieveUserContainerEnvVars() (injectVars map[string]string, err error) {
+func (h *MLflowHandler) RetrieveUserContainerEnvVars() (injectVars []corev1.EnvVar, err error) {
 	if h == nil || h.runtimeCfg == nil {
 		return nil, fmt.Errorf("MLflow plugin handler and runtime config must be non-nil")
 	}
-	injectVars = make(map[string]string)
+	if !h.runtimeCfg.InjectUserEnvVars {
+		return nil, nil
+	}
+	if h.nestedRunID == "" {
+		return nil, fmt.Errorf("MLflow run ID is empty. Cannot inject MLFLOW_RUN_ID env var")
+	}
 
-	if h.runtimeCfg.InjectUserEnvVars {
-		if h.nestedRunID != "" {
-			injectVars["MLFLOW_RUN_ID"] = h.nestedRunID
-		} else {
-			return nil, fmt.Errorf("MLflow run ID is empty. Cannot inject MLFLOW_RUN_ID env var")
-		}
-
-		injectVars["MLFLOW_TRACKING_URI"] = h.runtimeCfg.Endpoint
-		injectVars["MLFLOW_EXPERIMENT_ID"] = h.runtimeCfg.ExperimentID
-
+	injectVars = []corev1.EnvVar{
+		{Name: "MLFLOW_RUN_ID", Value: h.nestedRunID},
+		{Name: "MLFLOW_TRACKING_URI", Value: h.runtimeCfg.Endpoint},
+		{Name: "MLFLOW_EXPERIMENT_ID", Value: h.runtimeCfg.ExperimentID},
+	}
+	if h.runtimeCfg.WorkspacesEnabled {
+		injectVars = append(injectVars, corev1.EnvVar{Name: "MLFLOW_WORKSPACE", Value: h.runtimeCfg.Workspace})
+	}
+	switch h.runtimeCfg.AuthType {
+	case commonmlflow.AuthTypeKubernetes:
+		auth := "kubernetes"
 		if h.runtimeCfg.WorkspacesEnabled {
-			injectVars["MLFLOW_WORKSPACE"] = h.runtimeCfg.Workspace
+			auth = "kubernetes-namespaced"
 		}
-		var auth string
-		if h.runtimeCfg.AuthType == "kubernetes" {
-			auth = "kubernetes"
-			if h.runtimeCfg.WorkspacesEnabled {
-				auth = "kubernetes-namespaced"
-			}
-			injectVars["MLFLOW_TRACKING_AUTH"] = auth
-		} else {
-			return nil, fmt.Errorf("MLflow auth type %s is not supported", h.runtimeCfg.AuthType)
+		injectVars = append(injectVars, corev1.EnvVar{Name: commonmlflow.EnvMLflowTrackingAuth, Value: auth})
+	case commonmlflow.AuthTypeBearer:
+		credentialEnvVars, err := commonmlflow.BuildCredentialEnvVars(h.runtimeCfg.CredentialSecretRef, commonmlflow.AuthTypeBearer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build MLflow credential env vars: %v", err)
 		}
+		injectVars = append(injectVars, credentialEnvVars...)
+	case commonmlflow.AuthTypeBasicAuth:
+		credentialEnvVars, err := commonmlflow.BuildCredentialEnvVars(h.runtimeCfg.CredentialSecretRef, commonmlflow.AuthTypeBasicAuth)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build MLflow credential env vars: %v", err)
+		}
+		injectVars = append(injectVars, credentialEnvVars...)
 	}
 	return injectVars, nil
 }

--- a/backend/src/v2/common/plugins/mlflow/handler_test.go
+++ b/backend/src/v2/common/plugins/mlflow/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/v2/common/plugins"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var taskInfoStart = &plugins.TaskInfo{
@@ -467,12 +468,12 @@ func TestRetrieveUserContainerEnvVars_WorkspacesEnabled_InjectVars_Success(t *te
 		InjectUserEnvVars: true,
 	}
 
-	expectedEnvVars := map[string]string{
-		"MLFLOW_RUN_ID":        "test-run-id",
-		"MLFLOW_TRACKING_URI":  "http://localhost",
-		"MLFLOW_EXPERIMENT_ID": "test-exp",
-		"MLFLOW_WORKSPACE":     "test-workspace",
-		"MLFLOW_TRACKING_AUTH": "kubernetes-namespaced",
+	expectedEnvVars := []corev1.EnvVar{
+		{Name: "MLFLOW_RUN_ID", Value: "test-run-id"},
+		{Name: "MLFLOW_TRACKING_URI", Value: "http://localhost"},
+		{Name: "MLFLOW_EXPERIMENT_ID", Value: "test-exp"},
+		{Name: "MLFLOW_WORKSPACE", Value: "test-workspace"},
+		{Name: "MLFLOW_TRACKING_AUTH", Value: "kubernetes-namespaced"},
 	}
 
 	handler, _ := NewMLflowTaskHandler(runtimeCfg)
@@ -495,11 +496,99 @@ func TestRetrieveUserContainerEnvVars_WorkspacesDisabled_InjectVars_Success(t *t
 		InjectUserEnvVars:  true,
 	}
 
-	expectedEnvVars := map[string]string{
-		"MLFLOW_RUN_ID":        "test-run-id",
-		"MLFLOW_TRACKING_URI":  "http://localhost",
-		"MLFLOW_EXPERIMENT_ID": "test-exp",
-		"MLFLOW_TRACKING_AUTH": "kubernetes",
+	expectedEnvVars := []corev1.EnvVar{
+		{Name: "MLFLOW_RUN_ID", Value: "test-run-id"},
+		{Name: "MLFLOW_TRACKING_URI", Value: "http://localhost"},
+		{Name: "MLFLOW_EXPERIMENT_ID", Value: "test-exp"},
+		{Name: "MLFLOW_TRACKING_AUTH", Value: "kubernetes"},
+	}
+
+	handler, _ := NewMLflowTaskHandler(runtimeCfg)
+	handler.nestedRunID = "test-run-id"
+	envVars, err := handler.RetrieveUserContainerEnvVars()
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedEnvVars, envVars)
+}
+
+func TestRetrieveUserContainerEnvVars_BasicAuth_InjectsCredentialSecretRefs(t *testing.T) {
+	runtimeCfg := &commonmlflow.MLflowRuntimeConfig{
+		Endpoint:          "http://localhost",
+		Workspace:         "test-workspace",
+		WorkspacesEnabled: true,
+		ParentRunID:       "test-parent-run-id",
+		ExperimentID:      "test-exp",
+		AuthType:          commonmlflow.AuthTypeBasicAuth,
+		CredentialSecretRef: &commonmlflow.CredentialSecretRef{
+			UsernameKey: "username",
+			PasswordKey: "password",
+		},
+		Timeout:           "10s",
+		InjectUserEnvVars: true,
+	}
+
+	expectedEnvVars := []corev1.EnvVar{
+		{Name: "MLFLOW_RUN_ID", Value: "test-run-id"},
+		{Name: "MLFLOW_TRACKING_URI", Value: "http://localhost"},
+		{Name: "MLFLOW_EXPERIMENT_ID", Value: "test-exp"},
+		{Name: "MLFLOW_WORKSPACE", Value: "test-workspace"},
+		{
+			Name: commonmlflow.EnvMLflowTrackingUsername,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: commonmlflow.CredentialSecretName},
+					Key:                  "username",
+				},
+			},
+		},
+		{
+			Name: commonmlflow.EnvMLflowTrackingPassword,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: commonmlflow.CredentialSecretName},
+					Key:                  "password",
+				},
+			},
+		},
+	}
+
+	handler, _ := NewMLflowTaskHandler(runtimeCfg)
+	handler.nestedRunID = "test-run-id"
+	envVars, err := handler.RetrieveUserContainerEnvVars()
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedEnvVars, envVars)
+	for _, envVar := range envVars {
+		assert.NotEqual(t, commonmlflow.EnvMLflowTrackingAuth, envVar.Name)
+	}
+}
+
+func TestRetrieveUserContainerEnvVars_BearerAuth_InjectsCredentialSecretRef(t *testing.T) {
+	runtimeCfg := &commonmlflow.MLflowRuntimeConfig{
+		Endpoint:     "http://localhost",
+		ParentRunID:  "test-parent-run-id",
+		ExperimentID: "test-exp",
+		AuthType:     commonmlflow.AuthTypeBearer,
+		CredentialSecretRef: &commonmlflow.CredentialSecretRef{
+			TokenKey: "token",
+		},
+		Timeout:           "10s",
+		InjectUserEnvVars: true,
+	}
+
+	expectedEnvVars := []corev1.EnvVar{
+		{Name: "MLFLOW_RUN_ID", Value: "test-run-id"},
+		{Name: "MLFLOW_TRACKING_URI", Value: "http://localhost"},
+		{Name: "MLFLOW_EXPERIMENT_ID", Value: "test-exp"},
+		{
+			Name: commonmlflow.EnvMLflowTrackingToken,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: commonmlflow.CredentialSecretName},
+					Key:                  "token",
+				},
+			},
+		},
 	}
 
 	handler, _ := NewMLflowTaskHandler(runtimeCfg)

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -262,8 +262,21 @@ func initPodSpecPatch(
 	mlPipelineServerPort string,
 	mlmdServerAddress string,
 	mlmdServerPort string,
-	pluginEnvVars map[string]string,
+	pluginEnvVars any,
 ) (*k8score.PodSpec, error) {
+	pluginEnvVarSlice := make([]k8score.EnvVar, 0)
+	switch typedEnvVars := pluginEnvVars.(type) {
+	case nil:
+	case map[string]string:
+		pluginEnvVarSlice = make([]k8score.EnvVar, 0, len(typedEnvVars))
+		for envVar, val := range typedEnvVars {
+			pluginEnvVarSlice = append(pluginEnvVarSlice, k8score.EnvVar{Name: envVar, Value: val})
+		}
+	case []k8score.EnvVar:
+		pluginEnvVarSlice = append(pluginEnvVarSlice, typedEnvVars...)
+	default:
+		return nil, fmt.Errorf("unexpected plugin env var type %T", pluginEnvVars)
+	}
 	executorInputJSON, err := protojson.Marshal(executorInput)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
@@ -280,9 +293,7 @@ func initPodSpecPatch(
 	}
 
 	// Append necessary env variables for task-level plugin(s).
-	for envVar, val := range pluginEnvVars {
-		userEnvVar = append(userEnvVar, k8score.EnvVar{Name: envVar, Value: val})
-	}
+	userEnvVar = append(userEnvVar, pluginEnvVarSlice...)
 
 	userEnvVar = append(userEnvVar, proxy.GetConfig().GetEnvVars()...)
 
@@ -465,7 +476,18 @@ func initPodSpecPatch(
 		podSpec.Containers[0].Resources = res
 	}
 
-	addModelcarsToPodSpec(executorInput.GetInputs().GetArtifacts(), podSpec.Containers[0].Env, podSpec)
+	modelcarEnvVar := slices.Clone(podSpec.Containers[0].Env)
+	if len(pluginEnvVarSlice) > 0 {
+		pluginEnvVarNames := make(map[string]struct{}, len(pluginEnvVarSlice))
+		for _, envVar := range pluginEnvVarSlice {
+			pluginEnvVarNames[envVar.Name] = struct{}{}
+		}
+		modelcarEnvVar = slices.DeleteFunc(modelcarEnvVar, func(envVar k8score.EnvVar) bool {
+			_, ok := pluginEnvVarNames[envVar.Name]
+			return ok
+		})
+	}
+	addModelcarsToPodSpec(executorInput.GetInputs().GetArtifacts(), modelcarEnvVar, podSpec)
 
 	if needsWorkspaceMount(executorInput) {
 		// Validate that no user volume mounts conflict with the workspace

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	commonmlflow "github.com/kubeflow/pipelines/backend/src/common/plugins/mlflow"
 	"github.com/stretchr/testify/require"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
@@ -557,6 +558,89 @@ func Test_initPodSpecPatch_modelcar_input_artifact(t *testing.T) {
 
 	assert.Empty(t, taskConfig.Resources.Limits)
 	assert.Empty(t, taskConfig.Resources.Requests)
+}
+
+func Test_initPodSpecPatch_modelcarDoesNotInheritMLflowCredentialEnvVars(t *testing.T) {
+	containerSpec := &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{
+		Image:   "python:3.11",
+		Args:    []string{"--function_to_execute", "add"},
+		Command: []string{"sh", "-ec", "python3 -m kfp.components.executor_main"},
+		Env: []*pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec_EnvVar{{
+			Name:  "KEEP_ME",
+			Value: "yes",
+		}},
+	}
+	componentSpec := &pipelinespec.ComponentSpec{}
+	executorInput := &pipelinespec.ExecutorInput{
+		Inputs: &pipelinespec.ExecutorInput_Inputs{
+			Artifacts: map[string]*pipelinespec.ArtifactList{
+				"my-model": {
+					Artifacts: []*pipelinespec.RuntimeArtifact{{
+						Uri: "oci://registry.domain.local/my-model:latest",
+					}},
+				},
+			},
+		},
+	}
+	taskConfig := &TaskConfig{}
+
+	pluginEnvVars := []k8score.EnvVar{
+		{Name: commonmlflow.EnvMLflowTrackingToken, Value: "token"},
+		{Name: commonmlflow.EnvMLflowTrackingUsername, Value: "username"},
+		{Name: commonmlflow.EnvMLflowTrackingPassword, Value: "password"},
+	}
+
+	podSpec, err := initPodSpecPatch(
+		containerSpec,
+		componentSpec,
+		executorInput,
+		27,
+		"test",
+		"0254beba-0be4-4065-8d97-7dc5e3adf300",
+		"my-run-name",
+		"1",
+		"false",
+		"false",
+		taskConfig,
+		false,
+		false,
+		"",
+		"ml-pipeline.kubeflow",
+		"8887",
+		"metadata-grpc-service.kubeflow.svc.local",
+		"8080",
+		pluginEnvVars,
+	)
+	require.NoError(t, err)
+	require.Len(t, podSpec.InitContainers, 1)
+	require.Len(t, podSpec.Containers, 2)
+
+	mainEnvNames := make([]string, 0, len(podSpec.Containers[0].Env))
+	for _, envVar := range podSpec.Containers[0].Env {
+		mainEnvNames = append(mainEnvNames, envVar.Name)
+	}
+	assert.Contains(t, mainEnvNames, commonmlflow.EnvMLflowTrackingToken)
+	assert.Contains(t, mainEnvNames, commonmlflow.EnvMLflowTrackingUsername)
+	assert.Contains(t, mainEnvNames, commonmlflow.EnvMLflowTrackingPassword)
+	assert.Contains(t, mainEnvNames, "KEEP_ME")
+
+	modelcarEnvNames := make([]string, 0, len(podSpec.InitContainers[0].Env))
+	for _, envVar := range podSpec.InitContainers[0].Env {
+		modelcarEnvNames = append(modelcarEnvNames, envVar.Name)
+	}
+	assert.NotContains(t, modelcarEnvNames, commonmlflow.EnvMLflowTrackingToken)
+	assert.NotContains(t, modelcarEnvNames, commonmlflow.EnvMLflowTrackingUsername)
+	assert.NotContains(t, modelcarEnvNames, commonmlflow.EnvMLflowTrackingPassword)
+	assert.Contains(t, modelcarEnvNames, "KEEP_ME")
+
+	sidecarEnvNames := make([]string, 0, len(podSpec.Containers[1].Env))
+	for _, envVar := range podSpec.Containers[1].Env {
+		sidecarEnvNames = append(sidecarEnvNames, envVar.Name)
+	}
+	assert.NotContains(t, sidecarEnvNames, commonmlflow.EnvMLflowTrackingToken)
+	assert.NotContains(t, sidecarEnvNames, commonmlflow.EnvMLflowTrackingUsername)
+	assert.NotContains(t, sidecarEnvNames, commonmlflow.EnvMLflowTrackingPassword)
+	assert.Contains(t, sidecarEnvNames, "KEEP_ME")
 }
 
 // Validate that setting publishLogs to true propagates to the driver container

--- a/backend/test/end2end/utils/mlflow_utils.go
+++ b/backend/test/end2end/utils/mlflow_utils.go
@@ -40,6 +40,8 @@ const (
 	mlflowEndpointEnv    = "MLFLOW_TRACKING_URI"
 	mlflowInsecureTLSEnv = "MLFLOW_TRACKING_INSECURE_TLS"
 	mlflowBearerTokenEnv = "MLFLOW_BEARER_TOKEN"
+	mlflowUsernameEnv    = "MLFLOW_TRACKING_USERNAME"
+	mlflowPasswordEnv    = "MLFLOW_TRACKING_PASSWORD"
 	mlflowWorkspaceEnv   = "MLFLOW_WORKSPACE"
 	mlflowPluginKey      = "mlflow"
 )
@@ -48,6 +50,8 @@ func getMLflowClient(endpoint string) (*mlflowclient.Client, error) {
 	insecure := strings.EqualFold(os.Getenv(mlflowInsecureTLSEnv), "true")
 	workspace := os.Getenv(mlflowWorkspaceEnv)
 	bearerToken := os.Getenv(mlflowBearerTokenEnv)
+	username := os.Getenv(mlflowUsernameEnv)
+	password := os.Getenv(mlflowPasswordEnv)
 	httpClient := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
@@ -60,6 +64,8 @@ func getMLflowClient(endpoint string) (*mlflowclient.Client, error) {
 		Endpoint:          endpoint,
 		HTTPClient:        httpClient,
 		BearerToken:       bearerToken,
+		Username:          username,
+		Password:          password,
 		WorkspacesEnabled: workspace != "",
 		Workspace:         workspace,
 	})
@@ -68,6 +74,9 @@ func getMLflowClient(endpoint string) (*mlflowclient.Client, error) {
 	}
 	if bearerToken != "" {
 		logger.Log("MLflow client initialized with bearer token auth")
+	}
+	if username != "" || password != "" {
+		logger.Log("MLflow client initialized with basic auth")
 	}
 	if workspace != "" {
 		logger.Log("MLflow client initialized with workspace header: %s", workspace)

--- a/manifests/kustomize/base/installs/multi-user/api-service/cluster-role.yaml
+++ b/manifests/kustomize/base/installs/multi-user/api-service/cluster-role.yaml
@@ -69,3 +69,11 @@ rules:
   - kfp-launcher
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - kfp-mlflow-credentials
+  verbs:
+  - get

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-role.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-role.yaml
@@ -80,3 +80,11 @@ rules:
   - kfp-launcher
   verbs:
   - get
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - kfp-mlflow-credentials
+  verbs:
+  - get

--- a/proposals/12862-mlflow-integration/README.md
+++ b/proposals/12862-mlflow-integration/README.md
@@ -296,10 +296,10 @@ When a run is created and MLflow is enabled for the namespace:
    `experiment_id` takes precedence if both are set. If neither is provided or `plugins_input.mlflow` is not set at all,
    default to the `"Default"` experiment.
 1. Resolve MLflow credentials for outbound API calls. The API server uses its own SA token when `authType: "kubernetes"`.
-   For `"bearer"` and `"basic-auth"`, the API server reads the credential Secret from `credentialSecretRef`. In
-   multi-user mode, this `credentialSecretRef` must come from the namespace's `kfp-launcher` ConfigMap (see
-   [MLflow Configuration](#mlflow-configuration)). When secret-based auth is enabled, the Argo compiler mounts the
-   credential Secret on the driver, launcher, and user container templates via `env` entries with
+   For `"bearer"` and `"basic-auth"`, the API server reads the fixed `kfp-mlflow-credentials` Secret using the keys from
+   `credentialSecretRef`. In multi-user mode, this `credentialSecretRef` must come from the namespace's `kfp-launcher`
+   ConfigMap (see [MLflow Configuration](#mlflow-configuration)). When secret-based auth is enabled, the Argo compiler
+   mounts the credential Secret on the driver, launcher, and user container templates via `env` entries with
    `valueFrom.secretKeyRef`, mapping Secret keys to the standard MLflow env vars (`MLFLOW_TRACKING_TOKEN`, or
    `MLFLOW_TRACKING_USERNAME` / `MLFLOW_TRACKING_PASSWORD`). This ensures the driver and launcher can authenticate their
    own MLflow REST calls without reading the Secret at runtime, and no secret values appear in the Argo Workflow spec
@@ -573,13 +573,14 @@ unmarshal `KFP_MLFLOW_CONFIG` into the following Go type:
 
 ```go
 type MLflowRuntimeConfig struct {
-	Endpoint            string `json:"endpoint"`
-	Workspace           string `json:"workspace,omitempty"`           // Only set when workspacesEnabled is true
-	ParentRunID         string `json:"parentRunId"`
-	ExperimentID        string `json:"experimentId"`
-	AuthType            string `json:"authType"`                      // "kubernetes", "bearer", or "basic-auth"
-	Timeout             string `json:"timeout,omitempty"`             // e.g. "30s"; defaults to "30s"
-	InsecureSkipVerify  bool   `json:"insecureSkipVerify,omitempty"`  // Skip TLS certificate verification
+    Endpoint            string `json:"endpoint"`
+    Workspace           string `json:"workspace,omitempty"`           // Only set when workspacesEnabled is true
+    ParentRunID         string `json:"parentRunId"`
+    ExperimentID        string `json:"experimentId"`
+    AuthType            string `json:"authType"`                      // "kubernetes", "bearer", or "basic-auth"
+    CredentialSecretRef *CredentialSecretRef `json:"credentialSecretRef,omitempty"` // Secret key names for user-container credential injection
+    Timeout             string `json:"timeout,omitempty"`             // e.g. "30s"; defaults to "30s"
+    InsecureSkipVerify  bool   `json:"insecureSkipVerify,omitempty"`  // Skip TLS certificate verification
 }
 ```
 
@@ -621,6 +622,7 @@ Credential env vars (`MLFLOW_TRACKING_TOKEN`, `MLFLOW_TRACKING_USERNAME`, `MLFLO
 pod startup. The driver, launcher, and user container all receive the same credential env vars, enabling each to
 authenticate its own MLflow REST calls. When `workspace` is present in `KFP_MLFLOW_CONFIG`, the driver and launcher
 include the `X-MLflow-Workspace` header on outbound requests; when it is absent, the header is omitted.
+`credentialSecretRef` inside `KFP_MLFLOW_CONFIG` carries only Secret key names, never the secret values themselves.
 
 `KFP_MLFLOW_CONFIG` is an internal implementation detail and should not be exposed to user code. The launcher currently
 executes the user command via `exec.Command` without setting `command.Env`, so the subprocess inherits the full process
@@ -666,10 +668,12 @@ Configuration is provided at two levels:
   using `"bearer"` or `"basic-auth"` must provide `credentialSecretRef` in this ConfigMap;
   `credentialSecretRef` is never inherited from the API server's global config. If they do not provide it, MLflow
   integration is disabled for runs in that namespace. If the namespace overrides the `endpoint`, it must also provide
-  its own credentials -- the API server's global credentials are never used with a namespace-provided endpoint. A
-  namespace may override only credentials while inheriting the global endpoint, for example to use a namespace-scoped
-  Secret instead of the API server's service account token. If neither the API server nor the namespace ConfigMap
-  provides MLflow configuration, MLflow integration is disabled for that namespace.
+  its own credentials -- the API server's global credentials are never used with a namespace-provided endpoint.
+  `workspacesEnabled` may only be overridden alongside an endpoint override so that workspace-routing changes stay tied
+  to the namespace-owned MLflow endpoint configuration. A namespace may override only credentials while inheriting the
+  global endpoint, for example to use a namespace-scoped Secret instead of the API server's service account token. If
+  neither the API server nor the namespace ConfigMap provides MLflow configuration, MLflow integration is disabled for
+  that namespace.
 
 The Go types for the configuration use a generic `PluginConfig` wrapper with plugin-specific settings in a
 `json.RawMessage` field. This structure aligns with [KEP #12700](https://github.com/kubeflow/pipelines/pull/12700)'s
@@ -693,7 +697,6 @@ The MLflow module parses `Settings` into:
 
 ```go
 type CredentialSecretRef struct {
-	Name        string `json:"name"`                  // Required. K8s Secret name in the run's namespace.
 	TokenKey    string `json:"tokenKey,omitempty"`     // Key for MLFLOW_TRACKING_TOKEN (when authType is "bearer")
 	UsernameKey string `json:"usernameKey,omitempty"`  // Key for MLFLOW_TRACKING_USERNAME (when authType is "basic-auth")
 	PasswordKey string `json:"passwordKey,omitempty"`  // Key for MLFLOW_TRACKING_PASSWORD (when authType is "basic-auth")
@@ -706,6 +709,10 @@ type MLflowPluginSettings struct {
 	ExperimentDescription *string              `json:"experimentDescription,omitempty"` // nil = "Created by Kubeflow Pipelines"; "" = none
 }
 ```
+
+For secret-based auth, `credentialSecretRef` configures only the Secret keys. The Secret name is fixed to
+`kfp-mlflow-credentials` in the run namespace so the API server RBAC can remain scoped to a single Secret
+(`resourceNames: ["kfp-mlflow-credentials"]`).
 
 Standalone API server config example (Kubernetes-native mode):
 
@@ -739,12 +746,24 @@ data:
         "workspacesEnabled": false,
         "authType": "basic-auth",
         "credentialSecretRef": {
-          "name": "kfp-mlflow-credentials",
           "usernameKey": "username",
           "passwordKey": "password"
         }
       }
     }
+```
+
+The matching Secret must be named `kfp-mlflow-credentials`:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kfp-mlflow-credentials
+  namespace: kubeflow-user-example-com
+stringData:
+  username: "<mlflow username>"
+  password: "<mlflow password>"
 ```
 
 The ConfigMap key convention `plugins.<plugin name>` and the API server config nesting `plugins.<plugin name>` are


### PR DESCRIPTION
## Summary

- add MLflow `basic-auth`, `bearer`, and explicit `none` auth support across the API server, driver, launcher, and runtime env injection path
- prevent namespace overrides from falling back to API server credentials, and fail post-run sync closed if auth or workspace provenance drifts from run start
- expand the MLflow E2E workflow setup to exercise `basic-auth` and `none`, and update the direct MLflow test helper to handle each auth mode

## Test plan
- [x] `go test ./backend/src/common/plugins/mlflow ./backend/src/apiserver/plugins/mlflow ./backend/src/v2/common/plugins/mlflow ./backend/src/common/util ./backend/src/apiserver/resource ./backend/test/end2end/utils`
- [x] `bash -n .github/resources/scripts/configure-mlflow.sh`
- [ ] GitHub Actions MLflow matrix