### PR TITLE
fix(backend): stream bounded object store reads

### DIFF
--- a/backend/src/apiserver/archive/log.go
+++ b/backend/src/apiserver/archive/log.go
@@ -320,6 +320,7 @@ func decompressLogArchiveReader(logReader io.Reader) (io.Reader, func() error, e
 		}
 		return nil, nil, err
 	}
+	// Every gzip-compressed stream starts with the two bytes 0x1f 0x8b.
 	if header[0] != 0x1f || header[1] != 0x8b {
 		return bufferedLogReader, nil, nil
 	}

--- a/backend/src/apiserver/archive/log.go
+++ b/backend/src/apiserver/archive/log.go
@@ -45,6 +45,7 @@ type ExtractLogOptions struct {
 type LogArchiveInterface interface {
 	GetLogObjectKey(workflow util.ExecutionSpec, nodeId string) (string, error)
 	CopyLogFromArchive(logContent []byte, dst io.Writer, opts ExtractLogOptions) error
+	CopyLogFromArchiveReader(logReader io.Reader, dst io.Writer, opts ExtractLogOptions) error
 }
 
 // Log Archive.
@@ -259,9 +260,17 @@ func (a *LogArchive) GetLogObjectKey(workflow util.ExecutionSpec, nodeID string)
 
 // CopyLogFromArchive copies a task run archived log into expected format.
 func (a *LogArchive) CopyLogFromArchive(logContent []byte, dst io.Writer, opts ExtractLogOptions) error {
-	reader, err := decompressLogArchive(logContent)
+	return a.CopyLogFromArchiveReader(bytes.NewReader(logContent), dst, opts)
+}
+
+// CopyLogFromArchiveReader copies a task run archived log stream into expected format.
+func (a *LogArchive) CopyLogFromArchiveReader(logReader io.Reader, dst io.Writer, opts ExtractLogOptions) error {
+	reader, closeReader, err := decompressLogArchiveReader(logReader)
 	if err != nil {
 		return err
+	}
+	if closeReader != nil {
+		defer closeReader()
 	}
 
 	scanner := bufio.NewScanner(reader)
@@ -292,30 +301,53 @@ func (a *LogArchive) CopyLogFromArchive(logContent []byte, dst io.Writer, opts E
 			return util.NewInternalServerError(err, "error in parsing the log lines")
 		}
 	}
+	if err := scanner.Err(); err != nil {
+		return util.NewInternalServerError(err, "error in scanning the log lines")
+	}
 
 	return nil
 }
 
-func decompressLogArchive(logContent []byte) (io.Reader, error) {
-	// Decompress tar archive
-	compressedReader := bytes.NewReader(logContent)
-	decompressedLogs, gzipErr := gzip.NewReader(compressedReader)
-	if gzipErr != nil {
-		// err = util.NewInternalServerError(gzipErr, "Failed to decompress the archived log file")
-		// It's not compressed - use original content
-		return bytes.NewReader(logContent), nil
+func decompressLogArchiveReader(logReader io.Reader) (io.Reader, func() error, error) {
+	bufferedLogReader := bufio.NewReader(logReader)
+	header, err := bufferedLogReader.Peek(2)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return bufferedLogReader, nil, nil
+		}
+		return nil, nil, err
+	}
+	if header[0] != 0x1f || header[1] != 0x8b {
+		return bufferedLogReader, nil, nil
 	}
 
-	archiveReader := tar.NewReader(decompressedLogs)
-	header, tarErr := archiveReader.Next()
-	if tarErr != nil || header.Typeflag != tar.TypeReg {
-		// It's not a tar archive - use decompressed content
-		compressedReader.Reset(logContent)
-		err := decompressedLogs.Reset(compressedReader)
-		return decompressedLogs, err
-	} else {
-		return archiveReader, nil
+	decompressedLogs, err := gzip.NewReader(bufferedLogReader)
+	if err != nil {
+		return nil, nil, err
 	}
+
+	bufferedDecompressedLogs := bufio.NewReader(decompressedLogs)
+	tarHeader, err := bufferedDecompressedLogs.Peek(512)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return bufferedDecompressedLogs, decompressedLogs.Close, nil
+		}
+		decompressedLogs.Close()
+		return nil, nil, err
+	}
+
+	headerReader := tar.NewReader(bytes.NewReader(tarHeader))
+	headerInfo, err := headerReader.Next()
+	if err != nil || headerInfo.Typeflag != tar.TypeReg {
+		return bufferedDecompressedLogs, decompressedLogs.Close, nil
+	}
+
+	archiveReader := tar.NewReader(bufferedDecompressedLogs)
+	if _, err := archiveReader.Next(); err != nil {
+		decompressedLogs.Close()
+		return nil, nil, err
+	}
+	return archiveReader, decompressedLogs.Close, nil
 }
 
 func writeLogLn(dst io.Writer, log []byte, timestamp []byte, opts ExtractLogOptions) error {

--- a/backend/src/apiserver/archive/log.go
+++ b/backend/src/apiserver/archive/log.go
@@ -35,6 +35,8 @@ type LogFormat string
 const (
 	LogFormatJSON = LogFormat("json-lines")
 	LogFormatText = LogFormat("text")
+
+	maxArchivedLogLineBytes = 1 << 20 // 1 MiB
 )
 
 type ExtractLogOptions struct {
@@ -274,6 +276,7 @@ func (a *LogArchive) CopyLogFromArchiveReader(logReader io.Reader, dst io.Writer
 	}
 
 	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxArchivedLogLineBytes)
 	for scanner.Scan() {
 		// line := strings.Trim(scanner.LogFormatText(), "\n\r\t ")
 		bytes := scanner.Bytes()

--- a/backend/src/apiserver/archive/log_test.go
+++ b/backend/src/apiserver/archive/log_test.go
@@ -21,6 +21,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,6 +66,9 @@ type oneByteReader struct {
 }
 
 func (r *oneByteReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
 	if r.offset >= len(r.content) {
 		return 0, io.EOF
 	}
@@ -163,6 +167,18 @@ func TestCopyLogFromArchive_FromJsonToText(t *testing.T) {
 	assert.Equal(t, "[ERROR] Unable to connect", line)
 }
 
+func TestCopyLogFromArchiveReader_AllowsLargeLogLine(t *testing.T) {
+	logArchive := initLogArchive()
+	opts := ExtractLogOptions{LogFormat: LogFormatText, Timestamps: false}
+	dst := bytes.Buffer{}
+	largeLogLine := strings.Repeat("x", bufio.MaxScanTokenSize*2)
+	src := compressInput(t, largeLogLine+"\n")
+
+	err := logArchive.CopyLogFromArchiveReader(bytes.NewReader(src), &dst, opts)
+	assert.Nil(t, err)
+	assert.Equal(t, largeLogLine+"\n", dst.String())
+}
+
 func TestCopyLogFromArchiveReader_FromTarGzipStream(t *testing.T) {
 	logArchive := initLogArchive()
 	opts := ExtractLogOptions{LogFormat: LogFormatText, Timestamps: false}
@@ -180,6 +196,17 @@ func TestCopyLogFromArchiveReader_FromTarGzipStream(t *testing.T) {
 	assert.True(t, scanner.Scan())
 	line = scanner.Text()
 	assert.Equal(t, "[ERROR] Unable to connect", line)
+}
+
+func TestOneByteReaderAllowsZeroLengthRead(t *testing.T) {
+	reader := &oneByteReader{content: []byte("x")}
+	buffer := make([]byte, 0)
+
+	n, err := reader.Read(buffer)
+
+	assert.Equal(t, 0, n)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, reader.offset)
 }
 
 func TestCopyLogFromArchive_FromJsonToTextWithTimestamp(t *testing.T) {

--- a/backend/src/apiserver/archive/log_test.go
+++ b/backend/src/apiserver/archive/log_test.go
@@ -28,6 +28,7 @@ import (
 	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -52,9 +53,9 @@ func compressTarInput(t *testing.T, name string, content string) []byte {
 		Size:     int64(len(contents)),
 		Typeflag: tar.TypeReg,
 	})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	_, err = tw.Write(contents)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Nil(t, tw.Close())
 	assert.Nil(t, gw.Close())
 	return src.Bytes()
@@ -175,7 +176,7 @@ func TestCopyLogFromArchiveReader_AllowsLargeLogLine(t *testing.T) {
 	src := compressInput(t, largeLogLine+"\n")
 
 	err := logArchive.CopyLogFromArchiveReader(bytes.NewReader(src), &dst, opts)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, largeLogLine+"\n", dst.String())
 }
 
@@ -186,14 +187,14 @@ func TestCopyLogFromArchiveReader_FromTarGzipStream(t *testing.T) {
 	src := compressTarInput(t, "main.log", logJsonLines)
 
 	err := logArchive.CopyLogFromArchiveReader(&oneByteReader{content: src}, &dst, opts)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	scanner := bufio.NewScanner(&dst)
-	assert.True(t, scanner.Scan())
+	require.True(t, scanner.Scan())
 	line := scanner.Text()
 	assert.Equal(t, "[INFO] OK", line)
 
-	assert.True(t, scanner.Scan())
+	require.True(t, scanner.Scan())
 	line = scanner.Text()
 	assert.Equal(t, "[ERROR] Unable to connect", line)
 }
@@ -205,7 +206,7 @@ func TestOneByteReaderAllowsZeroLengthRead(t *testing.T) {
 	n, err := reader.Read(buffer)
 
 	assert.Equal(t, 0, n)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	assert.Equal(t, 0, reader.offset)
 }
 

--- a/backend/src/apiserver/archive/log_test.go
+++ b/backend/src/apiserver/archive/log_test.go
@@ -15,10 +15,12 @@
 package archive
 
 import (
+	"archive/tar"
 	"bufio"
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"io"
 	"testing"
 	"time"
 
@@ -33,9 +35,42 @@ func compressInput(t *testing.T, content string) []byte {
 	gw := gzip.NewWriter(&src)
 	_, err := gw.Write([]byte(content))
 	assert.Nil(t, err)
-	err = gw.Flush()
+	err = gw.Close()
 	assert.Nil(t, err)
 	return src.Bytes()
+}
+
+func compressTarInput(t *testing.T, name string, content string) []byte {
+	src := bytes.Buffer{}
+	gw := gzip.NewWriter(&src)
+	tw := tar.NewWriter(gw)
+	contents := []byte(content)
+	err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     0600,
+		Size:     int64(len(contents)),
+		Typeflag: tar.TypeReg,
+	})
+	assert.Nil(t, err)
+	_, err = tw.Write(contents)
+	assert.Nil(t, err)
+	assert.Nil(t, tw.Close())
+	assert.Nil(t, gw.Close())
+	return src.Bytes()
+}
+
+type oneByteReader struct {
+	content []byte
+	offset  int
+}
+
+func (r *oneByteReader) Read(p []byte) (int, error) {
+	if r.offset >= len(r.content) {
+		return 0, io.EOF
+	}
+	p[0] = r.content[r.offset]
+	r.offset++
+	return 1, nil
 }
 
 var logJsonLines = `
@@ -116,6 +151,25 @@ func TestCopyLogFromArchive_FromJsonToText(t *testing.T) {
 	src := compressInput(t, logJsonLines)
 
 	err := logArchive.CopyLogFromArchive(src, &dst, opts)
+	assert.Nil(t, err)
+
+	scanner := bufio.NewScanner(&dst)
+	assert.True(t, scanner.Scan())
+	line := scanner.Text()
+	assert.Equal(t, "[INFO] OK", line)
+
+	assert.True(t, scanner.Scan())
+	line = scanner.Text()
+	assert.Equal(t, "[ERROR] Unable to connect", line)
+}
+
+func TestCopyLogFromArchiveReader_FromTarGzipStream(t *testing.T) {
+	logArchive := initLogArchive()
+	opts := ExtractLogOptions{LogFormat: LogFormatText, Timestamps: false}
+	dst := bytes.Buffer{}
+	src := compressTarInput(t, "main.log", logJsonLines)
+
+	err := logArchive.CopyLogFromArchiveReader(&oneByteReader{content: src}, &dst, opts)
 	assert.Nil(t, err)
 
 	scanner := bufio.NewScanner(&dst)

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1233,12 +1233,13 @@ func (r *ResourceManager) readRunLogFromArchive(workflowManifest string, nodeId 
 		return util.NewInternalServerError(err, "Failed to read logs from archive %v", nodeId)
 	}
 
-	logContent, err := r.objectStore.GetFile(context.TODO(), logPath)
+	logReader, err := r.objectStore.GetFileReader(context.TODO(), logPath)
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to read logs from archive %v due to error fetching the log file", nodeId)
 	}
+	defer logReader.Close()
 
-	err = r.logArchive.CopyLogFromArchive(logContent, dst, archive.ExtractLogOptions{LogFormat: archive.LogFormatText, Timestamps: false})
+	err = r.logArchive.CopyLogFromArchiveReader(logReader, dst, archive.ExtractLogOptions{LogFormat: archive.LogFormatText, Timestamps: false})
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to read logs from archive %v due to error copying the log file", nodeId)
 	}
@@ -1812,13 +1813,13 @@ func (r *ResourceManager) fetchTemplateFromPipelineVersion(pipelineVersion *mode
 		return bytes, string(pipelineVersion.PipelineSpecURI), nil
 	} else {
 		// Try reading object store from pipeline_spec_uri
-		template, errURI := r.objectStore.GetFile(context.TODO(), string(pipelineVersion.PipelineSpecURI))
+		template, errURI := r.readPipelineSpecFromObjectStore(context.TODO(), string(pipelineVersion.PipelineSpecURI))
 		if errURI != nil {
 			// Try reading object store from pipeline_version_id
-			template, errUUID := r.objectStore.GetFile(context.TODO(), r.objectStore.GetPipelineKey(fmt.Sprint(pipelineVersion.UUID)))
+			template, errUUID := r.readPipelineSpecFromObjectStore(context.TODO(), r.objectStore.GetPipelineKey(fmt.Sprint(pipelineVersion.UUID)))
 			if errUUID != nil {
 				// Try reading object store from pipeline_id
-				template, errPipelineID := r.objectStore.GetFile(context.TODO(), r.objectStore.GetPipelineKey(fmt.Sprint(pipelineVersion.PipelineId)))
+				template, errPipelineID := r.readPipelineSpecFromObjectStore(context.TODO(), r.objectStore.GetPipelineKey(fmt.Sprint(pipelineVersion.PipelineId)))
 				if errPipelineID != nil {
 					return nil, "", util.Wrap(
 						util.Wrap(
@@ -1834,6 +1835,27 @@ func (r *ResourceManager) fetchTemplateFromPipelineVersion(pipelineVersion *mode
 		}
 		return template, "", nil
 	}
+}
+
+func (r *ResourceManager) readPipelineSpecFromObjectStore(ctx context.Context, filePath string) ([]byte, error) {
+	reader, err := r.objectStore.GetFileReader(ctx, filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	limitedReader := io.LimitReader(reader, int64(common.MaxFileLength)+1)
+	pipelineSpec, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to read pipeline spec from %v", filePath)
+	}
+	if len(pipelineSpec) > common.MaxFileLength {
+		return nil, util.NewInvalidInputError(
+			"Pipeline spec file size too large (%v bytes). Maximum supported size: %v.",
+			len(pipelineSpec), common.MaxFileLength,
+		)
+	}
+	return pipelineSpec, nil
 }
 
 // Creates the default experiment entry.

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -15,6 +15,7 @@
 package resource
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -31,6 +32,7 @@ import (
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/argoproj/argo-workflows/v4/util/file"
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/archive"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
@@ -116,10 +118,6 @@ func (m *FakeBadObjectStore) DeleteFile(ctx context.Context, filePath string) er
 	return errors.New("Not implemented")
 }
 
-func (m *FakeBadObjectStore) GetFile(ctx context.Context, filePath string) ([]byte, error) {
-	return []byte(""), nil
-}
-
 func (m *FakeBadObjectStore) AddAsYamlFile(ctx context.Context, o interface{}, filePath string) error {
 	return util.NewInternalServerError(errors.New("Error"), "bad object store")
 }
@@ -130,6 +128,45 @@ func (m *FakeBadObjectStore) GetFromYamlFile(ctx context.Context, o interface{},
 
 func (m *FakeBadObjectStore) GetFileReader(context.Context, string) (io.ReadCloser, error) {
 	return nil, util.NewInternalServerError(errors.New("Error"), "bad object store")
+}
+
+type readerOnlyObjectStore struct {
+	files              map[string][]byte
+	getFileReaderPaths []string
+}
+
+func (m *readerOnlyObjectStore) GetPipelineKey(pipelineID string) string {
+	return "pipelines/" + pipelineID
+}
+
+func (m *readerOnlyObjectStore) AddFile(ctx context.Context, template []byte, filePath string) error {
+	if m.files == nil {
+		m.files = map[string][]byte{}
+	}
+	m.files[filePath] = template
+	return nil
+}
+
+func (m *readerOnlyObjectStore) DeleteFile(ctx context.Context, filePath string) error {
+	delete(m.files, filePath)
+	return nil
+}
+
+func (m *readerOnlyObjectStore) AddAsYamlFile(ctx context.Context, o interface{}, filePath string) error {
+	return nil
+}
+
+func (m *readerOnlyObjectStore) GetFromYamlFile(ctx context.Context, o interface{}, filePath string) error {
+	return nil
+}
+
+func (m *readerOnlyObjectStore) GetFileReader(ctx context.Context, filePath string) (io.ReadCloser, error) {
+	m.getFileReaderPaths = append(m.getFileReaderPaths, filePath)
+	content, ok := m.files[filePath]
+	if !ok {
+		return nil, util.NewInternalServerError(errors.New("not found"), "file not found")
+	}
+	return io.NopCloser(bytes.NewReader(content)), nil
 }
 
 func createPipelineV1(name string) *model.Pipeline {
@@ -190,6 +227,61 @@ var testWorkflow = util.NewWorkflow(&v1alpha1.Workflow{
 	},
 	Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
 })
+
+func TestReadRunLogFromArchiveStreamsObjectStoreFile(t *testing.T) {
+	logArchive := archive.NewLogArchive("/logs", "main.log")
+	execSpec, err := util.NewExecutionSpecJSON(util.CurrentExecutionType(), []byte(testWorkflow.ToStringForStore()))
+	require.NoError(t, err)
+	logPath, err := logArchive.GetLogObjectKey(execSpec, "node-id")
+	require.NoError(t, err)
+
+	objectStore := &readerOnlyObjectStore{
+		files: map[string][]byte{
+			logPath: []byte("archived log line\n"),
+		},
+	}
+	manager := &ResourceManager{
+		objectStore: objectStore,
+		logArchive:  logArchive,
+	}
+
+	var dst bytes.Buffer
+	err = manager.readRunLogFromArchive(testWorkflow.ToStringForStore(), "node-id", &dst)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{logPath}, objectStore.getFileReaderPaths)
+	assert.Equal(t, "archived log line\n", dst.String())
+}
+
+func TestReadPipelineSpecFromObjectStoreUsesReaderAndLimit(t *testing.T) {
+	objectStore := &readerOnlyObjectStore{
+		files: map[string][]byte{
+			"pipeline-spec.yaml": []byte("apiVersion: argoproj.io/v1alpha1\nkind: Workflow\n"),
+		},
+	}
+	manager := &ResourceManager{objectStore: objectStore}
+
+	pipelineSpec, err := manager.readPipelineSpecFromObjectStore(context.Background(), "pipeline-spec.yaml")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"pipeline-spec.yaml"}, objectStore.getFileReaderPaths)
+	assert.Equal(t, "apiVersion: argoproj.io/v1alpha1\nkind: Workflow\n", string(pipelineSpec))
+}
+
+func TestReadPipelineSpecFromObjectStoreRejectsOversizedFile(t *testing.T) {
+	objectStore := &readerOnlyObjectStore{
+		files: map[string][]byte{
+			"pipeline-spec.yaml": bytes.Repeat([]byte("x"), common.MaxFileLength+1),
+		},
+	}
+	manager := &ResourceManager{objectStore: objectStore}
+
+	_, err := manager.readPipelineSpecFromObjectStore(context.Background(), "pipeline-spec.yaml")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Pipeline spec file size too large")
+	assert.Equal(t, []string{"pipeline-spec.yaml"}, objectStore.getFileReaderPaths)
+}
 
 // Util function to create an initial state with pipeline uploaded
 func initWithPipeline(t *testing.T) (*FakeClientManager, *ResourceManager, *model.Pipeline, *model.PipelineVersion) {

--- a/backend/src/apiserver/storage/blob_object_store.go
+++ b/backend/src/apiserver/storage/blob_object_store.go
@@ -16,11 +16,11 @@
 package storage
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"path"
 
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"gocloud.dev/blob"
 	"sigs.k8s.io/yaml"
@@ -64,22 +64,6 @@ func (b *BlobObjectStore) DeleteFile(ctx context.Context, filePath string) error
 	return nil
 }
 
-func (b *BlobObjectStore) GetFile(ctx context.Context, filePath string) ([]byte, error) {
-	reader, err := b.bucket.NewReader(ctx, filePath, nil)
-	if err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to get file %v", filePath)
-	}
-	defer reader.Close()
-
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(reader)
-	if err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to read file %v", filePath)
-	}
-
-	return buf.Bytes(), nil
-}
-
 // GetFileReader returns a streaming reader for safe access to large files.
 // This method streams directly from blob storage without buffering.
 func (b *BlobObjectStore) GetFileReader(ctx context.Context, filePath string) (io.ReadCloser, error) {
@@ -95,6 +79,32 @@ func (b *BlobObjectStore) GetFileReader(ctx context.Context, filePath string) (i
 	return reader, nil
 }
 
+// ReadFileLimited reads an object into memory only after applying an explicit
+// caller-provided size contract.
+func (b *BlobObjectStore) ReadFileLimited(ctx context.Context, filePath string, maxBytes int64) ([]byte, error) {
+	if maxBytes < 0 {
+		return nil, util.NewInvalidInputError("maximum file size must be non-negative")
+	}
+
+	reader, err := b.GetFileReader(ctx, filePath)
+	if err != nil {
+		return nil, util.Wrap(err, "Failed to get file reader")
+	}
+	defer reader.Close()
+
+	fileBytes, err := io.ReadAll(io.LimitReader(reader, maxBytes+1))
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "Failed to read file %v", filePath)
+	}
+	if int64(len(fileBytes)) > maxBytes {
+		return nil, util.NewInvalidInputError(
+			"File %v size too large (%v bytes). Maximum supported size: %v.",
+			filePath, len(fileBytes), maxBytes,
+		)
+	}
+	return fileBytes, nil
+}
+
 func (b *BlobObjectStore) AddAsYamlFile(ctx context.Context, o interface{}, filePath string) error {
 	yamlBytes, err := yaml.Marshal(o)
 	if err != nil {
@@ -108,7 +118,7 @@ func (b *BlobObjectStore) AddAsYamlFile(ctx context.Context, o interface{}, file
 }
 
 func (b *BlobObjectStore) GetFromYamlFile(ctx context.Context, o interface{}, filePath string) error {
-	yamlBytes, err := b.GetFile(ctx, filePath)
+	yamlBytes, err := b.ReadFileLimited(ctx, filePath, int64(common.MaxFileLength))
 	if err != nil {
 		return util.Wrap(err, "Failed to read from a yaml file")
 	}

--- a/backend/src/apiserver/storage/blob_object_store_test.go
+++ b/backend/src/apiserver/storage/blob_object_store_test.go
@@ -18,12 +18,18 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"gocloud.dev/blob/memblob"
 )
+
+func TestBlobObjectStoreDoesNotExposeUnboundedGetFile(t *testing.T) {
+	_, ok := reflect.TypeOf((*BlobObjectStore)(nil)).MethodByName("GetFile")
+	require.False(t, ok)
+}
 
 func TestBlobObjectStore_AddFile(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
@@ -36,7 +42,7 @@ func TestBlobObjectStore_AddFile(t *testing.T) {
 	err := store.AddFile(ctx, content, "test/file.txt")
 	require.Nil(t, err)
 
-	readContent, err := store.GetFile(ctx, "test/file.txt")
+	readContent, err := store.ReadFileLimited(ctx, "test/file.txt", int64(len(content)))
 	require.Nil(t, err)
 	require.Equal(t, content, readContent)
 }
@@ -78,7 +84,7 @@ func TestBlobObjectStore_DeleteFile(t *testing.T) {
 	err = store.DeleteFile(ctx, "test/delete.txt")
 	require.Nil(t, err)
 
-	_, err = store.GetFile(ctx, "test/delete.txt")
+	_, err = store.GetFileReader(ctx, "test/delete.txt")
 	require.NotNil(t, err)
 }
 
@@ -122,32 +128,47 @@ func TestBlobObjectStore_GetPipelineKey(t *testing.T) {
 	require.Equal(t, expectedKey, actualKey)
 }
 
-func TestBlobObjectStore_GetFile(t *testing.T) {
+func TestBlobObjectStore_ReadFileLimited(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	defer bucket.Close()
 
 	store := NewBlobObjectStore(bucket, "pipelines")
 	ctx := context.Background()
 
-	content := []byte("test content for GetFile")
+	content := []byte("test content for ReadFileLimited")
 	err := store.AddFile(ctx, content, "test/getfile.txt")
 	require.Nil(t, err)
 
-	readContent, err := store.GetFile(ctx, "test/getfile.txt")
+	readContent, err := store.ReadFileLimited(ctx, "test/getfile.txt", int64(len(content)))
 	require.Nil(t, err)
 	require.Equal(t, content, readContent)
 }
 
-func TestBlobObjectStore_GetFile_NotFound(t *testing.T) {
+func TestBlobObjectStore_ReadFileLimited_Oversized(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	defer bucket.Close()
 
 	store := NewBlobObjectStore(bucket, "pipelines")
 	ctx := context.Background()
 
-	_, err := store.GetFile(ctx, "non-existent.txt")
+	err := store.AddFile(ctx, []byte("oversized"), "test/oversized.txt")
+	require.NoError(t, err)
+
+	_, err = store.ReadFileLimited(ctx, "test/oversized.txt", 4)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Failed to get file")
+	require.Contains(t, err.Error(), "size too large")
+}
+
+func TestBlobObjectStore_ReadFileLimited_NotFound(t *testing.T) {
+	bucket := memblob.OpenBucket(nil)
+	defer bucket.Close()
+
+	store := NewBlobObjectStore(bucket, "pipelines")
+	ctx := context.Background()
+
+	_, err := store.ReadFileLimited(ctx, "non-existent.txt", 1024)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Failed to get file reader")
 }
 
 func TestBlobObjectStore_GetFileReader_NotFound(t *testing.T) {

--- a/backend/src/apiserver/storage/object_store.go
+++ b/backend/src/apiserver/storage/object_store.go
@@ -23,9 +23,7 @@ import (
 type ObjectStore interface {
 	AddFile(ctx context.Context, template []byte, filePath string) error
 	DeleteFile(ctx context.Context, filePath string) error
-	GetFile(ctx context.Context, filePath string) ([]byte, error)
 	// GetFileReader returns a streaming reader for the file content.
-	// Use this method instead of GetFile for streaming access to large files.
 	GetFileReader(ctx context.Context, filePath string) (io.ReadCloser, error)
 	AddAsYamlFile(ctx context.Context, o interface{}, filePath string) error
 	GetFromYamlFile(ctx context.Context, o interface{}, filePath string) error


### PR DESCRIPTION
## Summary
- stream archived log reads from object storage through the log archive parser
- bound stored pipeline spec reads with the existing common.MaxFileLength contract
- remove the unbounded GetFile API and add an explicit ReadFileLimited helper
- add regression coverage to prevent re-exposing BlobObjectStore.GetFile

## Why
This closes the remaining ADA-KUBEFL-04 object-store buffering gap after artifact downloads were moved to streaming in #12394. Artifact downloads already use GetFileReader; this change moves the remaining production object-store reads to streaming or explicit bounded reads.

## Verification
- GOCACHE=/tmp/kfp-go-cache go test -count=1 ./backend/src/apiserver/storage ./backend/src/apiserver/resource ./backend/src/apiserver/archive
- GOCACHE=/tmp/kfp-go-cache go test -run '^$' ./backend/src/apiserver/...
- rg -n "\.GetFile\(|GetFile\(" backend/src/apiserver backend/src/common backend/test
- git diff --check