### PR TITLE
test(frontend): harden node log viewer e2e wait

### DIFF
--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -23,6 +23,7 @@ const {
   waitForCondition,
   waitForGraphNodeCount,
   waitForHashPrefix,
+  waitForLogViewerText,
   waitForRunPageReady,
 } = require('./test-helpers');
 
@@ -37,6 +38,7 @@ const runWithoutExperimentDescription =
 const uiTimeout = 5000;
 const runStartTimeout = 30000;
 const runCompletionTimeout = 60000;
+const logsLoadTimeout = 60000;
 const outputParameterValue = 'Hello world in test';
 
 async function waitForRunParameterField(selector) {
@@ -209,17 +211,11 @@ describe('deploy helloworld sample run', () => {
 
   it('shows logs from node', async () => {
     await $('button=Logs').click();
-    await $('#logViewer').waitForDisplayed({ timeout: uiTimeout });
-    await waitForCondition(
-      async () => {
-        const logs = await $('#logViewer').getText();
-        return logs.indexOf(outputParameterValue + ' from node: ') > -1;
-      },
-      {
-        timeout: uiTimeout,
-        timeoutMsg: `expected log viewer to contain ${outputParameterValue}`,
-      },
-    );
+    await waitForLogViewerText(outputParameterValue + ' from node: ', {
+      timeout: logsLoadTimeout,
+      interval: 5000,
+      screenshotName: 'node-logs',
+    });
   });
 
   it('navigates to the runs page', async () => {

--- a/test/frontend-integration-test/test-helpers.js
+++ b/test/frontend-integration-test/test-helpers.js
@@ -221,6 +221,80 @@ async function waitForTableRows(
   return await $$(selector);
 }
 
+async function waitForLogViewerText(
+  expectedText,
+  { timeout = defaultTimeout, interval = 1000, screenshotName = 'log-viewer' } = {},
+) {
+  let lastLogsState = 'not-started';
+  let lastViewerText = '';
+  let lastRefreshTimestamp = 0;
+  let isRefreshingLogs = false;
+
+  try {
+    await waitForCondition(
+      async () => {
+        if (await isSelectorDisplayed('#logViewer')) {
+          const viewerText = await $('#logViewer').getText();
+          lastViewerText = viewerText;
+          if (!expectedText || viewerText.includes(expectedText)) {
+            lastLogsState = 'viewer-ready';
+            return true;
+          }
+          lastLogsState = viewerText.trim() ? 'viewer-missing-expected-text' : 'viewer-empty';
+        }
+
+        const logsPanelBusy = await isSelectorDisplayed('[role="progressbar"]');
+        if (isRefreshingLogs) {
+          if (logsPanelBusy) {
+            lastLogsState = 'waiting-for-log-refresh-to-settle';
+            return false;
+          }
+          isRefreshingLogs = false;
+        }
+
+        const logsFetchFailed = await pageContainsText('Failed to retrieve pod logs.');
+        if (
+          logsFetchFailed &&
+          !isRefreshingLogs &&
+          Date.now() - lastRefreshTimestamp >= interval
+        ) {
+          const refreshButton = await $('button=Refresh');
+          if (
+            (await refreshButton.isExisting()) &&
+            (await refreshButton.isDisplayed()) &&
+            (await refreshButton.isEnabled())
+          ) {
+            lastLogsState = 'refreshing-log-fetch';
+            lastRefreshTimestamp = Date.now();
+            isRefreshingLogs = true;
+            await refreshButton.click();
+            return false;
+          }
+        }
+
+        if (logsPanelBusy) {
+          lastLogsState = 'loading-log-viewer';
+        }
+
+        return false;
+      },
+      {
+        timeout,
+        interval,
+        timeoutMsg: expectedText
+          ? `expected log viewer to contain ${expectedText}`
+          : 'expected log viewer to become ready',
+      },
+    );
+  } catch (error) {
+    console.log('LOG_VIEWER_LAST_STATE', lastLogsState);
+    console.log('LOG_VIEWER_LAST_TEXT', lastViewerText.slice(0, 500));
+    console.log('LOG_VIEWER_URL', await browser.getUrl());
+    await saveDebugScreenshot(screenshotName);
+    throw error;
+  }
+}
+
 function annotatePhaseError(phaseName, error) {
   if (error instanceof Error) {
     error.message = `[${phaseName}] ${error.message}`;
@@ -260,6 +334,7 @@ module.exports = {
   waitForCondition,
   waitForGraphNodeCount,
   waitForHashPrefix,
+  waitForLogViewerText,
   waitForRunPageReady,
   waitForTableRows,
 };


### PR DESCRIPTION
## Summary
- wait for the helloworld logs pane to finish loading before asserting log output
- retry transient pod-log fetch failures through the logs banner refresh path
- capture better diagnostics when the log viewer still does not settle

## Test plan
- [x] `node --check test/frontend-integration-test/test-helpers.js`
- [x] `node --check test/frontend-integration-test/helloworld.spec.js`
- [ ] Full frontend integration tests not run locally