### PR TITLE
fix(test): reduce MLflow E2E terminal-state flakiness

### DIFF
--- a/backend/test/end2end/mlflow_e2e_test.go
+++ b/backend/test/end2end/mlflow_e2e_test.go
@@ -153,8 +153,8 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mlflowExp.ID).To(Equal(mlflowExperimentID))
 
-			// Verify parent run status
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
+			// MLflow terminal sync happens after the KFP run reaches a terminal state.
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED", &timeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify KFP tags on parent run
@@ -193,10 +193,10 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(len(nestedRuns)).To(Equal(1),
 				"Should have exactly 1 nested MLflow run for a single-task pipeline")
 
-			// Verify the nested run is FINISHED
+			// MLflow terminal sync happens after the KFP run reaches a terminal state.
 			nestedRun := nestedRuns[0]
-			Expect(nestedRun.Info.Status).To(Equal("FINISHED"),
-				"Nested MLflow run should be FINISHED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, nestedRun.Info.RunID, mlflowExperimentID, "FINISHED", &timeout)
+			Expect(err).NotTo(HaveOccurred(), "Nested MLflow run should be FINISHED")
 
 			// Verify parent linkage tag is present on the nested run.
 			// Task-level run naming/tagging may vary by launcher/runtime path.
@@ -250,7 +250,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(err).NotTo(HaveOccurred())
 			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
 			Expect(err).NotTo(HaveOccurred())
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED", &timeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify there is one nested run per task
@@ -259,11 +259,12 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(nestedCount).To(Equal(expectedTaskCount),
 				fmt.Sprintf("Should have exactly %d nested MLflow runs (one per task)", expectedTaskCount))
 
-			// Verify all nested runs are FINISHED
+			// MLflow terminal sync happens after the KFP run reaches a terminal state.
 			allRuns, err := e2e_utils.QueryMLflowRuns(mlflowEndpoint, mlflowExperimentID)
 			Expect(err).NotTo(HaveOccurred())
 			for _, run := range allRuns {
-				Expect(run.Info.Status).To(Equal("FINISHED"),
+				err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, run.Info.RunID, mlflowExperimentID, "FINISHED", &timeout)
+				Expect(err).NotTo(HaveOccurred(),
 					fmt.Sprintf("MLflow run %s should be FINISHED", run.Info.RunID))
 			}
 		})
@@ -302,7 +303,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED", &timeout)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -374,7 +375,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(err).NotTo(HaveOccurred())
 			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
 			Expect(err).NotTo(HaveOccurred())
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED", &timeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Direct children of root: 1 loop run + 2 dependent tasks = 3
@@ -407,9 +408,10 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(loopRunID).NotTo(BeEmpty(),
 				"Should find a loop nested run with iteration children")
 
-			// Verify all MLflow runs in the experiment are FINISHED
+			// MLflow terminal sync happens after the KFP run reaches a terminal state.
 			for _, run := range allRuns {
-				Expect(run.Info.Status).To(Equal("FINISHED"),
+				err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, run.Info.RunID, mlflowExperimentID, "FINISHED", &timeout)
+				Expect(err).NotTo(HaveOccurred(),
 					fmt.Sprintf("MLflow run %s should be FINISHED", run.Info.RunID))
 			}
 
@@ -454,19 +456,21 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(rootRunID).NotTo(BeEmpty(), "root_run_id should not be empty")
 			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
 			Expect(err).NotTo(HaveOccurred())
-			// The parent MLflow run should be FAILED because the KFP run failed
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FAILED")
+
+			// The parent MLflow run should be FAILED because the KFP run failed.
+			err = e2e_utils.WaitForMLflowRunStatus(
+				mlflowEndpoint, rootRunID, mlflowExperimentID, "FAILED", &timeout,
+			)
 			Expect(err).NotTo(HaveOccurred())
 
-			// Verify any nested runs are also in a terminal state (FAILED)
+			// MLflow terminal sync happens after the KFP run reaches a terminal
+			// state.
 			allRuns, err := e2e_utils.QueryMLflowRuns(mlflowEndpoint, mlflowExperimentID)
 			Expect(err).NotTo(HaveOccurred())
 			for _, run := range allRuns {
-				if run.Info.RunID != rootRunID {
-					// Nested runs for failed tasks should be FAILED
-					Expect(run.Info.Status).To(Equal("FAILED"),
-						fmt.Sprintf("Nested MLflow run %s should be FAILED", run.Info.RunID))
-				}
+				err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, run.Info.RunID, mlflowExperimentID, "FAILED", &timeout)
+				Expect(err).NotTo(HaveOccurred(),
+					fmt.Sprintf("MLflow run %s should be FAILED", run.Info.RunID))
 			}
 		})
 	})

--- a/backend/test/end2end/utils/mlflow_utils.go
+++ b/backend/test/end2end/utils/mlflow_utils.go
@@ -26,6 +26,7 @@ import (
 
 	runparams "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_client/run_service"
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_model"
+	common_api_server "github.com/kubeflow/pipelines/backend/src/common/client/api_server"
 	apiserver "github.com/kubeflow/pipelines/backend/src/common/client/api_server/v2"
 	mlflowclient "github.com/kubeflow/pipelines/backend/src/common/plugins/mlflow"
 	"github.com/kubeflow/pipelines/backend/test/config"
@@ -42,6 +43,9 @@ const (
 	mlflowBearerTokenEnv = "MLFLOW_BEARER_TOKEN"
 	mlflowWorkspaceEnv   = "MLFLOW_WORKSPACE"
 	mlflowPluginKey      = "mlflow"
+	runRetryTimeout      = 2*common_api_server.APIServerDefaultTimeout +
+		runRetryInterval
+	runRetryInterval = 1 * time.Second
 )
 
 func getMLflowClient(endpoint string) (*mlflowclient.Client, error) {
@@ -81,11 +85,18 @@ func getMLflowClient(endpoint string) (*mlflowclient.Client, error) {
 // RetryPipelineRun retries a failed/terminated KFP pipeline run.
 func RetryPipelineRun(runClient *apiserver.RunClient, runID string) {
 	ginkgo.GinkgoHelper()
-	retryParams := runparams.NewRunServiceRetryRunParams()
-	retryParams.RunID = runID
-	err := runClient.Retry(retryParams)
-	gomega.Expect(err).NotTo(gomega.HaveOccurred(),
-		fmt.Sprintf("Failed to retry run %s", runID))
+	gomega.Eventually(func() error {
+		retryParams := runparams.NewRunServiceRetryRunParams()
+		retryParams.RunID = runID
+		err := runClient.Retry(retryParams)
+		if err != nil {
+			logger.Log("Retrying RetryRun for %s after transient error: %v", runID, err)
+		}
+		return err
+	}, runRetryTimeout, runRetryInterval).Should(
+		gomega.Succeed(),
+		fmt.Sprintf("Failed to retry run %s", runID),
+	)
 	logger.Log("Retried Pipeline Run, runId=%s", runID)
 }
 

--- a/backend/test/testutil/pipeline_run_utils.go
+++ b/backend/test/testutil/pipeline_run_utils.go
@@ -24,11 +24,18 @@ import (
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	run_params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_client/run_service"
 	"github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/run_model"
+	common_api_server "github.com/kubeflow/pipelines/backend/src/common/client/api_server"
 	api_server "github.com/kubeflow/pipelines/backend/src/common/client/api_server/v2"
 	"github.com/kubeflow/pipelines/backend/test/logger"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+)
+
+const (
+	runClientRetryTimeout = 2*common_api_server.APIServerDefaultTimeout +
+		runClientRetryInterval
+	runClientRetryInterval = 1 * time.Second
 )
 
 func DeletePipelineRun(client *api_server.RunClient, runID string) {
@@ -78,10 +85,20 @@ func TerminatePipelineRun(client *api_server.RunClient, runID string) {
 
 func GetPipelineRun(runClient *api_server.RunClient, pipelineRunID *string) *run_model.V2beta1Run {
 	logger.Log("Get a pipeline run with id=%s", *pipelineRunID)
-	pipelineRun, runError := runClient.Get(&run_params.RunServiceGetRunParams{
-		RunID: *pipelineRunID,
-	})
-	gomega.Expect(runError).NotTo(gomega.HaveOccurred(), "Failed to get run with id="+*pipelineRunID)
+	var pipelineRun *run_model.V2beta1Run
+	gomega.Eventually(func() error {
+		var runError error
+		pipelineRun, runError = runClient.Get(&run_params.RunServiceGetRunParams{
+			RunID: *pipelineRunID,
+		})
+		if runError != nil {
+			logger.Log("Retrying get run %s after transient error: %v", *pipelineRunID, runError)
+		}
+		return runError
+	}, runClientRetryTimeout, runClientRetryInterval).Should(
+		gomega.Succeed(),
+		"Failed to get run with id="+*pipelineRunID,
+	)
 	return pipelineRun
 }
 


### PR DESCRIPTION
## Summary
- wait for MLflow E2E assertions to poll for terminal run states
  instead of checking immediately after KFP run completion
- retry transient RunService get/retry errors that happen while
  the API server and Argo reconcile failed-run updates

## Test plan
- [x] `go test ./backend/test/testutil ./backend/test/end2end/utils \
  ./backend/test/end2end -run TestDoesNotExist`