### PR TITLE
test(frontend): harden log viewer diagnostics and Docker install

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -20,7 +20,8 @@ RUN npm install --global "$(node -p 'require("./package.json").packageManager')"
 
 # Retry with cache clean as a workaround for an intermittent npm EEXIST/ENOENT
 # race condition where parallel download workers collide on the same cache entry.
-RUN npm ci && npm run postinstall || (npm cache clean --force && npm ci && npm run postinstall)
+# npm ci runs the root postinstall script, which installs server and mock-backend deps.
+RUN npm ci || (npm cache clean --force && npm ci)
 RUN npm run build
 
 RUN mkdir -p ./server/dist && \

--- a/test/frontend-integration-test/test-helpers.js
+++ b/test/frontend-integration-test/test-helpers.js
@@ -145,6 +145,15 @@ async function saveDebugScreenshot(name) {
   return screenshotPath;
 }
 
+async function saveDebugScreenshotBestEffort(name) {
+  try {
+    await saveDebugScreenshot(name);
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    console.log(`Unable to save ${name} debug screenshot: ${message}`);
+  }
+}
+
 async function logPipelineSelectorDiagnostics() {
   const rowCount = await browser.execute(() => document.querySelectorAll('[data-testid="table-row"]').length);
   const emptyMessage = await browser.execute(() => {
@@ -290,7 +299,7 @@ async function waitForLogViewerText(
     console.log('LOG_VIEWER_LAST_STATE', lastLogsState);
     console.log('LOG_VIEWER_LAST_TEXT', lastViewerText.slice(0, 500));
     console.log('LOG_VIEWER_URL', await browser.getUrl());
-    await saveDebugScreenshot(screenshotName);
+    await saveDebugScreenshotBestEffort(screenshotName);
     throw error;
   }
 }


### PR DESCRIPTION
**Description of your changes:**

After #13584 merged, this PR no longer carries a separate `helloworld` log-refresh loop. It keeps the remaining small frontend CI cleanups:

- make `waitForLogViewerText` screenshot capture best-effort, so a screenshot failure cannot hide the original log-viewer timeout
- remove a duplicate `npm run postinstall` from the frontend Docker build; `npm ci` already runs the root `postinstall`, which installs the server and mock-backend deps

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).