### PR TITLE
fix(cache): harden cache deployer kubectl download

### DIFF
--- a/.github/workflows/presubmit-backend.yml
+++ b/.github/workflows/presubmit-backend.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     paths:
       - 'backend/**'
+      - 'test/cache-deployer/**'
+      - 'test/presubmit-backend-test.sh'
 
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-22
+- Last updated: 2026-07-23
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,7 @@ Notes:
 
 - API Server tests under `backend/test/v2/api` are integration tests run with Ginkgo; they require a running cluster and are not part of unit tests.
 - Compiler tests live under `backend/test/compiler` and E2E tests under `backend/test/end2end`; both are Ginkgo-based and excluded from unit presubmits.
+- Backend presubmit also runs `test/cache-deployer/deploy-cache-service_test.sh` for cache deployer shell behavior.
 - See `test/README.md` for integration/E2E test infrastructure details (Kind clusters, GitHub Actions setup).
 
 ### Backend Ginkgo test suites

--- a/backend/src/cache/deployer/deploy-cache-service.sh
+++ b/backend/src/cache/deployer/deploy-cache-service.sh
@@ -34,10 +34,18 @@ mkdir -p "$HOME/bin"
 export PATH="$HOME/bin:$PATH"
 {
     server_version_major_minor=$(kubectl version --output json | jq --raw-output '(.serverVersion.major + "." + .serverVersion.minor)' | tr -d '"+')
-    stable_build_version=$(curl -fsSL "https://dl.k8s.io/release/stable-${server_version_major_minor}.txt")
-    kubectl_url="https://dl.k8s.io/release/${stable_build_version}/bin/linux/amd64/kubectl"
-    curl -L -o "$HOME/bin/kubectl" "$kubectl_url"
-    chmod +x "$HOME/bin/kubectl"
+    if stable_build_version=$(curl -fsSL "https://dl.k8s.io/release/stable-${server_version_major_minor}.txt"); then
+        kubectl_url="https://dl.k8s.io/release/${stable_build_version}/bin/linux/amd64/kubectl"
+        kubectl_tmp=$(mktemp "$HOME/bin/kubectl.XXXXXX")
+        if curl -fsSL -o "$kubectl_tmp" "$kubectl_url" && chmod +x "$kubectl_tmp" && mv "$kubectl_tmp" "$HOME/bin/kubectl"; then
+            :
+        else
+            rm -f "$kubectl_tmp"
+            echo "Warning: failed to download kubectl ${stable_build_version}; using kubectl from PATH."
+        fi
+    else
+        echo "Warning: failed to resolve stable kubectl version for Kubernetes ${server_version_major_minor}; using kubectl from PATH."
+    fi
 } || true
 
 # This should fail if there are connectivity problems

--- a/backend/src/cache/deployer/deploy-cache-service.sh
+++ b/backend/src/cache/deployer/deploy-cache-service.sh
@@ -18,6 +18,50 @@
 # Prerequisite: config kubectl to talk to your cluster. See ref below:
 # https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl
 
+detect_kubectl_arch() {
+    case "$(uname -m)" in
+        x86_64 | amd64)
+            echo "amd64"
+            ;;
+        aarch64 | arm64)
+            echo "arm64"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+install_version_matched_kubectl() {
+    # Getting correct kubectl. Kubernetes only supports kubectl versions within +/-1 minor version.
+    # kubectl has some resource version information hardcoded, so using too old kubectl can lead to errors
+    mkdir -p "$HOME/bin"
+    export PATH="$HOME/bin:$PATH"
+    {
+        server_version_major_minor=$(kubectl version --output json | jq --raw-output '(.serverVersion.major + "." + .serverVersion.minor)' | tr -d '"+')
+        if stable_build_version=$(curl -fsSL "https://dl.k8s.io/release/stable-${server_version_major_minor}.txt"); then
+            if kubectl_arch=$(detect_kubectl_arch); then
+                kubectl_url="https://dl.k8s.io/release/${stable_build_version}/bin/linux/${kubectl_arch}/kubectl"
+                kubectl_tmp=$(mktemp "$HOME/bin/kubectl.XXXXXX")
+                if curl -fsSL -o "$kubectl_tmp" "$kubectl_url" && chmod +x "$kubectl_tmp" && "$kubectl_tmp" version --client=true >/dev/null 2>&1 && mv "$kubectl_tmp" "$HOME/bin/kubectl"; then
+                    :
+                else
+                    rm -f "$kubectl_tmp"
+                    echo "Warning: failed to download a runnable kubectl ${stable_build_version} for ${kubectl_arch}; using kubectl from PATH."
+                fi
+            else
+                echo "Warning: unsupported architecture $(uname -m); using kubectl from PATH."
+            fi
+        else
+            echo "Warning: failed to resolve stable kubectl version for Kubernetes ${server_version_major_minor}; using kubectl from PATH."
+        fi
+    } || true
+}
+
+if [ "${DEPLOY_CACHE_SERVICE_LIBRARY_MODE:-false}" = "true" ]; then
+    return 0 2>/dev/null || exit 0
+fi
+
 set -ex
 
 # Warning: grep in this image does not support long option names like --word-regexp
@@ -28,25 +72,7 @@ NAMESPACE=${NAMESPACE_TO_WATCH:-kubeflow}
 MUTATING_WEBHOOK_CONFIGURATION_NAME="cache-webhook-${NAMESPACE}"
 WEBHOOK_SECRET_NAME=webhook-server-tls
 
-# Getting correct kubectl. Kubernetes only supports kubectl versions within +/-1 minor version.
-# kubectl has some resource version information hardcoded, so using too old kubectl can lead to errors
-mkdir -p "$HOME/bin"
-export PATH="$HOME/bin:$PATH"
-{
-    server_version_major_minor=$(kubectl version --output json | jq --raw-output '(.serverVersion.major + "." + .serverVersion.minor)' | tr -d '"+')
-    if stable_build_version=$(curl -fsSL "https://dl.k8s.io/release/stable-${server_version_major_minor}.txt"); then
-        kubectl_url="https://dl.k8s.io/release/${stable_build_version}/bin/linux/amd64/kubectl"
-        kubectl_tmp=$(mktemp "$HOME/bin/kubectl.XXXXXX")
-        if curl -fsSL -o "$kubectl_tmp" "$kubectl_url" && chmod +x "$kubectl_tmp" && mv "$kubectl_tmp" "$HOME/bin/kubectl"; then
-            :
-        else
-            rm -f "$kubectl_tmp"
-            echo "Warning: failed to download kubectl ${stable_build_version}; using kubectl from PATH."
-        fi
-    else
-        echo "Warning: failed to resolve stable kubectl version for Kubernetes ${server_version_major_minor}; using kubectl from PATH."
-    fi
-} || true
+install_version_matched_kubectl
 
 # This should fail if there are connectivity problems
 # Gotcha: Listing all objects requires list permission,

--- a/test/cache-deployer/deploy-cache-service_test.sh
+++ b/test/cache-deployer/deploy-cache-service_test.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+#
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "${TEST_ROOT}"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+write_mock_commands() {
+    local mock_bin=$1
+    mkdir -p "${mock_bin}"
+
+    cat >"${mock_bin}/uname" <<'EOF'
+#!/bin/sh
+if [ "$1" = "-m" ]; then
+    echo "${TEST_UNAME_MACHINE}"
+    exit 0
+fi
+exec /usr/bin/uname "$@"
+EOF
+
+    cat >"${mock_bin}/jq" <<'EOF'
+#!/bin/sh
+cat >/dev/null
+echo "1.36"
+EOF
+
+    cat >"${mock_bin}/kubectl" <<'EOF'
+#!/bin/sh
+if [ "$1" = "version" ] && [ "$2" = "--output" ]; then
+    echo '{"serverVersion":{"major":"1","minor":"36"}}'
+    exit 0
+fi
+echo "$@" >>"${TEST_FALLBACK_KUBECTL_LOG}"
+EOF
+
+    cat >"${mock_bin}/curl" <<'EOF'
+#!/bin/sh
+if [ "$1" = "-fsSL" ] && [ "$#" -eq 2 ]; then
+    echo "v1.36.2"
+    exit 0
+fi
+
+if [ "$1" = "-fsSL" ] && [ "$2" = "-o" ]; then
+    output_path=$3
+    kubectl_url=$4
+    echo "${kubectl_url}" >>"${TEST_CURL_URL_LOG}"
+    cat >"${output_path}" <<'DOWNLOADED_KUBECTL'
+#!/bin/sh
+echo "$@" >>"${TEST_DOWNLOADED_KUBECTL_LOG}"
+exit "${TEST_DOWNLOADED_KUBECTL_EXIT_CODE}"
+DOWNLOADED_KUBECTL
+    exit 0
+fi
+
+echo "unexpected curl args: $*" >&2
+exit 1
+EOF
+
+    chmod +x "${mock_bin}/uname" "${mock_bin}/jq" "${mock_bin}/kubectl" "${mock_bin}/curl"
+}
+
+run_install_test() {
+    local uname_machine=$1
+    local downloaded_exit_code=$2
+    local expected_arch=$3
+    local expect_installed=$4
+    local test_dir="${TEST_ROOT}/${uname_machine}-${downloaded_exit_code}"
+    local home_dir="${test_dir}/home"
+    local mock_bin="${test_dir}/mock-bin"
+
+    mkdir -p "${home_dir}"
+    write_mock_commands "${mock_bin}"
+
+    export DEPLOY_CACHE_SERVICE_LIBRARY_MODE=true
+    export HOME="${home_dir}"
+    export PATH="${mock_bin}:/usr/bin:/bin"
+    export TEST_UNAME_MACHINE="${uname_machine}"
+    export TEST_DOWNLOADED_KUBECTL_EXIT_CODE="${downloaded_exit_code}"
+    export TEST_CURL_URL_LOG="${test_dir}/curl-url.log"
+    export TEST_DOWNLOADED_KUBECTL_LOG="${test_dir}/downloaded-kubectl.log"
+    export TEST_FALLBACK_KUBECTL_LOG="${test_dir}/fallback-kubectl.log"
+
+    # shellcheck source=/dev/null
+    source "${REPO_ROOT}/backend/src/cache/deployer/deploy-cache-service.sh"
+    install_version_matched_kubectl
+
+    grep -q "/linux/${expected_arch}/kubectl" "${TEST_CURL_URL_LOG}" ||
+        fail "expected kubectl URL to use linux/${expected_arch}"
+    grep -q "version --client=true" "${TEST_DOWNLOADED_KUBECTL_LOG}" ||
+        fail "expected downloaded kubectl to be validated before install"
+
+    if [ "${expect_installed}" = "true" ]; then
+        [ -x "${home_dir}/bin/kubectl" ] || fail "expected kubectl to be installed"
+    else
+        [ ! -e "${home_dir}/bin/kubectl" ] ||
+            fail "expected invalid downloaded kubectl to be removed instead of installed"
+    fi
+}
+
+run_install_test "aarch64" "0" "arm64" "true"
+run_install_test "aarch64" "126" "arm64" "false"
+run_install_test "x86_64" "0" "amd64" "true"
+
+echo "deploy-cache-service kubectl install tests passed"

--- a/test/presubmit-backend-test.sh
+++ b/test/presubmit-backend-test.sh
@@ -20,6 +20,9 @@ set -ex
 # Add installed go binaries to PATH.
 export PATH="${PATH}:$(go env GOPATH)/bin"
 
+# Check cache deployer shell helpers that are not covered by Go tests.
+./test/cache-deployer/deploy-cache-service_test.sh
+
 # 1. Check go modules are tidy
 # Reference: https://github.com/golang/go/issues/27005#issuecomment-564892876
 go mod download


### PR DESCRIPTION
**Description of your changes:**

`deploy-cache-service.sh` installs a Kubernetes-version-matched `kubectl` before it creates the cache webhook. Current `master` already uses `dl.k8s.io` for that download; this PR keeps that endpoint and hardens the install path.

The old flow downloaded directly into `$HOME/bin/kubectl`. If the download failed or returned a bad file, it could leave a broken `kubectl` at the front of `PATH` and block the intended fallback. It also always used the `linux/amd64` binary, which is wrong on arm64 runners or developer machines.

This PR:

- detects the local architecture (`amd64` or `arm64`)
- downloads to a temporary file first
- validates the downloaded binary with `kubectl version --client=true`
- moves it into `$HOME/bin/kubectl` only after validation succeeds
- keeps the existing best-effort fallback to the `kubectl` already on `PATH`
- adds a focused shell regression test and wires it into backend presubmit

This is cache-deployer robustness only. It does not change cache webhook behavior.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).