### PR TITLE
fix(backend): retry workflow update races in RetryRun

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -52,6 +52,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/util/retry"
 )
 
 // Metric variables. Please prefix the metric names with resource_manager_.
@@ -402,8 +403,6 @@ const MaxTagValueLength = model.MaxTagValueLength
 
 // MaxTagsPerEntity is the maximum number of tags allowed on a single pipeline or pipeline version.
 const MaxTagsPerEntity = model.MaxTagsPerEntity
-
-const maxRetryWorkflowUpdateAttempts = 3
 
 // UpdatePipeline updates mutable fields of a pipeline (display_name, tags).
 // Both fields are updated in a single transaction via UpdatePipelineFields.
@@ -1134,45 +1133,78 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 
 func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, namespace string, runID string, newExecSpec util.ExecutionSpec) (util.ExecutionSpec, error) {
 	workflowClient := r.getWorkflowClient(namespace)
+	var retriedWorkflow util.ExecutionSpec
 	var lastWorkflowError error
+	lastWorkflowAction := "reconciling workflow"
 
-	for attempt := 0; attempt < maxRetryWorkflowUpdateAttempts; attempt++ {
+	err := retry.OnError(retry.DefaultRetry, isRetryableWorkflowReconcileError, func() error {
+		lastWorkflowAction = "getting workflow"
 		latestWorkflow, err := workflowClient.Get(ctx, newExecSpec.ExecutionName(), v1.GetOptions{})
 		if err == nil {
 			newExecSpec.SetVersion(latestWorkflow.Version())
+			lastWorkflowAction = "updating workflow"
 			updatedWorkflow, err := workflowClient.Update(ctx, newExecSpec, v1.UpdateOptions{})
 			if err == nil {
-				return updatedWorkflow, nil
+				retriedWorkflow = updatedWorkflow
+				return nil
 			}
 			lastWorkflowError = err
-			if apierrors.IsConflict(err) {
-				continue
-			}
 			if !apierrors.IsNotFound(err) {
-				return nil, util.NewInternalServerError(err, "Failed to retry run %s due to error updating workflow", runID)
+				return err
 			}
 		} else {
 			lastWorkflowError = err
 			if !apierrors.IsNotFound(err) {
-				return nil, util.NewInternalServerError(err, "Failed to retry run %s due to error getting workflow", runID)
+				return err
 			}
 		}
 
 		newExecSpec.SetVersion("")
+		lastWorkflowAction = "creating workflow"
 		newCreatedWorkflow, createError := workflowClient.Create(ctx, newExecSpec, v1.CreateOptions{})
 		if createError == nil {
-			return newCreatedWorkflow, nil
+			retriedWorkflow = newCreatedWorkflow
+			return nil
 		}
-		if apierrors.IsAlreadyExists(createError) {
-			continue
-		}
-		if createError, ok := createError.(net.Error); ok && createError.Timeout() {
-			return nil, util.NewUnavailableServerError(createError, "Failed to retry run %s due to error creating workflow - try again later. Last workflow error: %s", runID, lastWorkflowError.Error())
-		}
-		return nil, util.NewInternalServerError(createError, "Failed to retry run %s due to error creating workflow. Last workflow error: %s", runID, lastWorkflowError.Error())
+		lastWorkflowError = createError
+		return createError
+	})
+	if err == nil {
+		return retriedWorkflow, nil
 	}
 
-	return nil, util.NewInternalServerError(lastWorkflowError, "Failed to retry run %s due to error reconciling workflow after retries. Last workflow error: %s", runID, lastWorkflowError.Error())
+	lastWorkflowErrorMessage := "none"
+	if lastWorkflowError != nil {
+		lastWorkflowErrorMessage = lastWorkflowError.Error()
+	}
+	if apierrors.IsConflict(err) || apierrors.IsAlreadyExists(err) {
+		return nil, util.NewInternalServerError(err, "Failed to retry run %s due to error reconciling workflow after retries. Last workflow error: %s", runID, lastWorkflowErrorMessage)
+	}
+	if isTransientWorkflowReconcileError(err) {
+		return nil, util.NewUnavailableServerError(err, "Failed to retry run %s due to error %s - try again later. Last workflow error: %s", runID, lastWorkflowAction, lastWorkflowErrorMessage)
+	}
+	return nil, util.NewInternalServerError(err, "Failed to retry run %s due to error %s. Last workflow error: %s", runID, lastWorkflowAction, lastWorkflowErrorMessage)
+}
+
+func isRetryableWorkflowReconcileError(err error) bool {
+	return apierrors.IsConflict(err) ||
+		apierrors.IsAlreadyExists(err) ||
+		isTransientWorkflowReconcileError(err)
+}
+
+func isTransientWorkflowReconcileError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if netError, ok := err.(net.Error); ok && netError.Timeout() {
+		return true
+	}
+	return apierrors.IsServerTimeout(err) ||
+		apierrors.IsTimeout(err) ||
+		apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err) ||
+		apierrors.IsUnexpectedServerError(err)
 }
 
 // Fetches execution logs and writes to the destination.

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1154,7 +1154,7 @@ func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, names
 			}
 		} else {
 			lastWorkflowError = err
-			if !apierrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) && !isTransientWorkflowReconcileError(err) {
 				return err
 			}
 		}
@@ -1178,7 +1178,7 @@ func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, names
 		lastWorkflowErrorMessage = lastWorkflowError.Error()
 	}
 	if apierrors.IsConflict(err) || apierrors.IsAlreadyExists(err) {
-		return nil, util.NewInternalServerError(err, "Failed to retry run %s due to error reconciling workflow after retries. Last workflow error: %s", runID, lastWorkflowErrorMessage)
+		return nil, util.NewUnavailableServerError(err, "Failed to retry run %s due to error reconciling workflow after retries - try again later. Last workflow error: %s", runID, lastWorkflowErrorMessage)
 	}
 	if isTransientWorkflowReconcileError(err) {
 		return nil, util.NewUnavailableServerError(err, "Failed to retry run %s due to error %s - try again later. Last workflow error: %s", runID, lastWorkflowAction, lastWorkflowErrorMessage)

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1132,7 +1132,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	return nil
 }
 
-func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, namespace string, runId string, newExecSpec util.ExecutionSpec) (util.ExecutionSpec, error) {
+func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, namespace string, runID string, newExecSpec util.ExecutionSpec) (util.ExecutionSpec, error) {
 	workflowClient := r.getWorkflowClient(namespace)
 	var updateError error
 
@@ -1145,11 +1145,17 @@ func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, names
 				return updatedWorkflow, nil
 			}
 			updateError = err
-			if isKubernetesConflict(err) {
+			if apierrors.IsConflict(err) {
 				continue
+			}
+			if !apierrors.IsNotFound(err) {
+				return nil, util.NewInternalServerError(err, "Failed to retry run %s due to error updating workflow", runID)
 			}
 		} else {
 			updateError = err
+			if !apierrors.IsNotFound(err) {
+				return nil, util.NewInternalServerError(err, "Failed to retry run %s due to error getting workflow", runID)
+			}
 		}
 
 		newExecSpec.SetVersion("")
@@ -1157,24 +1163,16 @@ func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, names
 		if createError == nil {
 			return newCreatedWorkflow, nil
 		}
-		if isKubernetesAlreadyExists(createError) {
+		if apierrors.IsAlreadyExists(createError) {
 			continue
 		}
 		if createError, ok := createError.(net.Error); ok && createError.Timeout() {
-			return nil, util.NewUnavailableServerError(createError, "Failed to retry run %s due to error creating and updating a workflow - try again later. Update error: %s", runId, updateError.Error())
+			return nil, util.NewUnavailableServerError(createError, "Failed to retry run %s due to error creating and updating a workflow - try again later. Update error: %s", runID, updateError.Error())
 		}
-		return nil, util.NewInternalServerError(createError, "Failed to retry run %s due to error updating and creating a workflow. Update error: %s", runId, updateError.Error())
+		return nil, util.NewInternalServerError(createError, "Failed to retry run %s due to error updating and creating a workflow. Update error: %s", runID, updateError.Error())
 	}
 
-	return nil, util.NewInternalServerError(updateError, "Failed to retry run %s due to error updating and creating a workflow after retries. Update error: %s", runId, updateError.Error())
-}
-
-func isKubernetesConflict(err error) bool {
-	return apierrors.IsConflict(err) || apierrors.IsConflict(errors.Cause(err)) || apierrors.IsConflict(errors.Unwrap(err))
-}
-
-func isKubernetesAlreadyExists(err error) bool {
-	return apierrors.IsAlreadyExists(err) || apierrors.IsAlreadyExists(errors.Cause(err)) || apierrors.IsAlreadyExists(errors.Unwrap(err))
+	return nil, util.NewInternalServerError(updateError, "Failed to retry run %s due to error updating and creating a workflow after retries. Update error: %s", runID, updateError.Error())
 }
 
 // Fetches execution logs and writes to the destination.

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -403,6 +403,8 @@ const MaxTagValueLength = model.MaxTagValueLength
 // MaxTagsPerEntity is the maximum number of tags allowed on a single pipeline or pipeline version.
 const MaxTagsPerEntity = model.MaxTagsPerEntity
 
+const maxRetryWorkflowUpdateAttempts = 3
+
 // UpdatePipeline updates mutable fields of a pipeline (display_name, tags).
 // Both fields are updated in a single transaction via UpdatePipelineFields.
 func (r *ResourceManager) UpdatePipeline(pipelineID string, displayName string, tags map[string]string) (*model.Pipeline, error) {
@@ -1105,25 +1107,9 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		return util.NewInternalServerError(err, "Failed to retry run %s due to error cleaning up the failed pods from the previous attempt", runId)
 	}
 
-	// First try to update workflow
-	// If fail to get the workflow, return error.
-	latestWorkflow, updateError := r.getWorkflowClient(namespace).Get(ctx, newExecSpec.ExecutionName(), v1.GetOptions{})
-	if updateError == nil {
-		// Update the workflow's resource version to latest.
-		newExecSpec.SetVersion(latestWorkflow.Version())
-		_, updateError = r.getWorkflowClient(namespace).Update(ctx, newExecSpec, v1.UpdateOptions{})
-	}
-	if updateError != nil {
-		// Remove resource version
-		newExecSpec.SetVersion("")
-		newCreatedWorkflow, createError := r.getWorkflowClient(namespace).Create(ctx, newExecSpec, v1.CreateOptions{})
-		if createError != nil {
-			if createError, ok := createError.(net.Error); ok && createError.Timeout() {
-				return util.NewUnavailableServerError(createError, "Failed to retry run %s due to error creating and updating a workflow - try again later. Update error: %s", runId, updateError.Error())
-			}
-			return util.NewInternalServerError(createError, "Failed to retry run %s due to error updating and creating a workflow. Update error: %s", runId, updateError.Error())
-		}
-		newExecSpec = newCreatedWorkflow
+	newExecSpec, err = r.updateOrCreateRetryWorkflow(ctx, namespace, runId, newExecSpec)
+	if err != nil {
+		return err
 	}
 	// Notify plugins of retry
 	if run.PluginsOutputString != nil && *run.PluginsOutputString != "" {
@@ -1144,6 +1130,51 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		return util.NewInternalServerError(err, "Failed to retry run %s due to error updating entry", runId)
 	}
 	return nil
+}
+
+func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, namespace string, runId string, newExecSpec util.ExecutionSpec) (util.ExecutionSpec, error) {
+	workflowClient := r.getWorkflowClient(namespace)
+	var updateError error
+
+	for attempt := 0; attempt < maxRetryWorkflowUpdateAttempts; attempt++ {
+		latestWorkflow, err := workflowClient.Get(ctx, newExecSpec.ExecutionName(), v1.GetOptions{})
+		if err == nil {
+			newExecSpec.SetVersion(latestWorkflow.Version())
+			updatedWorkflow, err := workflowClient.Update(ctx, newExecSpec, v1.UpdateOptions{})
+			if err == nil {
+				return updatedWorkflow, nil
+			}
+			updateError = err
+			if isKubernetesConflict(err) {
+				continue
+			}
+		} else {
+			updateError = err
+		}
+
+		newExecSpec.SetVersion("")
+		newCreatedWorkflow, createError := workflowClient.Create(ctx, newExecSpec, v1.CreateOptions{})
+		if createError == nil {
+			return newCreatedWorkflow, nil
+		}
+		if isKubernetesAlreadyExists(createError) {
+			continue
+		}
+		if createError, ok := createError.(net.Error); ok && createError.Timeout() {
+			return nil, util.NewUnavailableServerError(createError, "Failed to retry run %s due to error creating and updating a workflow - try again later. Update error: %s", runId, updateError.Error())
+		}
+		return nil, util.NewInternalServerError(createError, "Failed to retry run %s due to error updating and creating a workflow. Update error: %s", runId, updateError.Error())
+	}
+
+	return nil, util.NewInternalServerError(updateError, "Failed to retry run %s due to error updating and creating a workflow after retries. Update error: %s", runId, updateError.Error())
+}
+
+func isKubernetesConflict(err error) bool {
+	return apierrors.IsConflict(err) || apierrors.IsConflict(errors.Cause(err)) || apierrors.IsConflict(errors.Unwrap(err))
+}
+
+func isKubernetesAlreadyExists(err error) bool {
+	return apierrors.IsAlreadyExists(err) || apierrors.IsAlreadyExists(errors.Cause(err)) || apierrors.IsAlreadyExists(errors.Unwrap(err))
 }
 
 // Fetches execution logs and writes to the destination.

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1134,7 +1134,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 
 func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, namespace string, runID string, newExecSpec util.ExecutionSpec) (util.ExecutionSpec, error) {
 	workflowClient := r.getWorkflowClient(namespace)
-	var updateError error
+	var lastWorkflowError error
 
 	for attempt := 0; attempt < maxRetryWorkflowUpdateAttempts; attempt++ {
 		latestWorkflow, err := workflowClient.Get(ctx, newExecSpec.ExecutionName(), v1.GetOptions{})
@@ -1144,7 +1144,7 @@ func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, names
 			if err == nil {
 				return updatedWorkflow, nil
 			}
-			updateError = err
+			lastWorkflowError = err
 			if apierrors.IsConflict(err) {
 				continue
 			}
@@ -1152,7 +1152,7 @@ func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, names
 				return nil, util.NewInternalServerError(err, "Failed to retry run %s due to error updating workflow", runID)
 			}
 		} else {
-			updateError = err
+			lastWorkflowError = err
 			if !apierrors.IsNotFound(err) {
 				return nil, util.NewInternalServerError(err, "Failed to retry run %s due to error getting workflow", runID)
 			}
@@ -1167,12 +1167,12 @@ func (r *ResourceManager) updateOrCreateRetryWorkflow(ctx context.Context, names
 			continue
 		}
 		if createError, ok := createError.(net.Error); ok && createError.Timeout() {
-			return nil, util.NewUnavailableServerError(createError, "Failed to retry run %s due to error creating and updating a workflow - try again later. Update error: %s", runID, updateError.Error())
+			return nil, util.NewUnavailableServerError(createError, "Failed to retry run %s due to error creating workflow - try again later. Last workflow error: %s", runID, lastWorkflowError.Error())
 		}
-		return nil, util.NewInternalServerError(createError, "Failed to retry run %s due to error updating and creating a workflow. Update error: %s", runID, updateError.Error())
+		return nil, util.NewInternalServerError(createError, "Failed to retry run %s due to error creating workflow. Last workflow error: %s", runID, lastWorkflowError.Error())
 	}
 
-	return nil, util.NewInternalServerError(updateError, "Failed to retry run %s due to error updating and creating a workflow after retries. Update error: %s", runID, updateError.Error())
+	return nil, util.NewInternalServerError(lastWorkflowError, "Failed to retry run %s due to error reconciling workflow after retries. Last workflow error: %s", runID, lastWorkflowError.Error())
 }
 
 // Fetches execution logs and writes to the destination.

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -599,6 +599,25 @@ func (c *createAlreadyExistsWorkflowClient) Create(ctx context.Context, execSpec
 	return c.FakeWorkflowClient.Create(ctx, execSpec, opts)
 }
 
+type retryableUpdateFailureWorkflowClient struct {
+	*client.FakeWorkflowClient
+	updateFailuresRemaining int
+	createCalls             int
+}
+
+func (c *retryableUpdateFailureWorkflowClient) Update(ctx context.Context, execSpec util.ExecutionSpec, opts v1.UpdateOptions) (util.ExecutionSpec, error) {
+	if c.updateFailuresRemaining > 0 {
+		c.updateFailuresRemaining--
+		return nil, apierrors.NewServiceUnavailable("apiserver temporarily unavailable")
+	}
+	return c.FakeWorkflowClient.Update(ctx, execSpec, opts)
+}
+
+func (c *retryableUpdateFailureWorkflowClient) Create(ctx context.Context, execSpec util.ExecutionSpec, opts v1.CreateOptions) (util.ExecutionSpec, error) {
+	c.createCalls++
+	return c.FakeWorkflowClient.Create(ctx, execSpec, opts)
+}
+
 type genericUpdateFailureWorkflowClient struct {
 	*client.FakeWorkflowClient
 	createCalls int
@@ -2991,6 +3010,25 @@ func TestRetryRun_RetriesWorkflowUpdateAfterCreateAlreadyExists(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, alreadyExistsWorkflowClient.updateNotFoundRemaining)
 	assert.Equal(t, 0, alreadyExistsWorkflowClient.createAlreadyExistsRemaining)
+}
+
+func TestRetryRun_RetriesRetryableWorkflowUpdateFailure(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	workflowClient := client.NewWorkflowClientFake()
+	seedRetryWorkflow(t, manager, runDetail.UUID, workflowClient)
+	retryableFailureWorkflowClient := &retryableUpdateFailureWorkflowClient{
+		FakeWorkflowClient:      workflowClient,
+		updateFailuresRemaining: 1,
+	}
+	manager.execClient = &retryWorkflowExecClient{workflowClient: retryableFailureWorkflowClient}
+
+	err := manager.RetryRun(context.Background(), runDetail.UUID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, retryableFailureWorkflowClient.updateFailuresRemaining)
+	assert.Equal(t, 0, retryableFailureWorkflowClient.createCalls)
 }
 
 func TestRetryRun_GenericWorkflowUpdateFailureDoesNotCreate(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -51,7 +51,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -542,6 +544,72 @@ func initWithOneTimeFailedRunOffloaded(t *testing.T) (*FakeClientManager, *Resou
 	_, err = manager.ReportWorkflowResource(ctx, updatedWorkflow)
 	assert.Nil(t, err)
 	return store, manager, runDetail
+}
+
+type retryWorkflowExecClient struct {
+	workflowClient util.ExecutionInterface
+}
+
+func (c *retryWorkflowExecClient) Execution(namespace string) util.ExecutionInterface {
+	return c.workflowClient
+}
+
+func (c *retryWorkflowExecClient) Compare(old, new interface{}) bool {
+	return false
+}
+
+type updateConflictWorkflowClient struct {
+	*client.FakeWorkflowClient
+	updateConflictsRemaining int
+	createCalls              int
+}
+
+func (c *updateConflictWorkflowClient) Update(ctx context.Context, execSpec util.ExecutionSpec, opts v1.UpdateOptions) (util.ExecutionSpec, error) {
+	if c.updateConflictsRemaining > 0 {
+		c.updateConflictsRemaining--
+		return nil, apierrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "workflows"}, execSpec.ExecutionName(), errors.New("stale workflow"))
+	}
+	return c.FakeWorkflowClient.Update(ctx, execSpec, opts)
+}
+
+func (c *updateConflictWorkflowClient) Create(ctx context.Context, execSpec util.ExecutionSpec, opts v1.CreateOptions) (util.ExecutionSpec, error) {
+	c.createCalls++
+	return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "argoproj.io", Resource: "workflows"}, execSpec.ExecutionName())
+}
+
+type createAlreadyExistsWorkflowClient struct {
+	*client.FakeWorkflowClient
+	updateErrorsRemaining        int
+	createAlreadyExistsRemaining int
+}
+
+func (c *createAlreadyExistsWorkflowClient) Update(ctx context.Context, execSpec util.ExecutionSpec, opts v1.UpdateOptions) (util.ExecutionSpec, error) {
+	if c.updateErrorsRemaining > 0 {
+		c.updateErrorsRemaining--
+		return nil, errors.New("transient update failure")
+	}
+	return c.FakeWorkflowClient.Update(ctx, execSpec, opts)
+}
+
+func (c *createAlreadyExistsWorkflowClient) Create(ctx context.Context, execSpec util.ExecutionSpec, opts v1.CreateOptions) (util.ExecutionSpec, error) {
+	if c.createAlreadyExistsRemaining > 0 {
+		c.createAlreadyExistsRemaining--
+		return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "argoproj.io", Resource: "workflows"}, execSpec.ExecutionName())
+	}
+	return c.FakeWorkflowClient.Create(ctx, execSpec, opts)
+}
+
+func seedRetryWorkflow(t *testing.T, manager *ResourceManager, runID string, workflowClient util.ExecutionInterface) {
+	t.Helper()
+	run, err := manager.GetRun(runID)
+	require.NoError(t, err)
+	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.RunDetails.WorkflowRuntimeManifest))
+	require.NoError(t, err)
+	require.NoError(t, execSpec.Decompress())
+	retryExecSpec, _, err := execSpec.GenerateRetryExecution()
+	require.NoError(t, err)
+	_, err = workflowClient.Create(context.Background(), retryExecSpec, v1.CreateOptions{})
+	require.NoError(t, err)
 }
 
 // Tests CreatePipeline and CreatePipelineVersion
@@ -2870,6 +2938,45 @@ func TestRetryRun(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, string(actualRunDetail.WorkflowRuntimeManifest), "Running")
 	assert.Equal(t, actualRunDetail.RunDetails.State, model.RuntimeStateRunning)
+}
+
+func TestRetryRun_RetriesWorkflowUpdateConflict(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	workflowClient := client.NewWorkflowClientFake()
+	seedRetryWorkflow(t, manager, runDetail.UUID, workflowClient)
+	conflictWorkflowClient := &updateConflictWorkflowClient{
+		FakeWorkflowClient:       workflowClient,
+		updateConflictsRemaining: 1,
+	}
+	manager.execClient = &retryWorkflowExecClient{workflowClient: conflictWorkflowClient}
+
+	err := manager.RetryRun(context.Background(), runDetail.UUID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, conflictWorkflowClient.updateConflictsRemaining)
+	assert.Equal(t, 0, conflictWorkflowClient.createCalls)
+}
+
+func TestRetryRun_RetriesWorkflowUpdateAfterCreateAlreadyExists(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	workflowClient := client.NewWorkflowClientFake()
+	seedRetryWorkflow(t, manager, runDetail.UUID, workflowClient)
+	alreadyExistsWorkflowClient := &createAlreadyExistsWorkflowClient{
+		FakeWorkflowClient:           workflowClient,
+		updateErrorsRemaining:        1,
+		createAlreadyExistsRemaining: 1,
+	}
+	manager.execClient = &retryWorkflowExecClient{workflowClient: alreadyExistsWorkflowClient}
+
+	err := manager.RetryRun(context.Background(), runDetail.UUID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, alreadyExistsWorkflowClient.updateErrorsRemaining)
+	assert.Equal(t, 0, alreadyExistsWorkflowClient.createAlreadyExistsRemaining)
 }
 
 func TestRetryRun_PreservesRunFields(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -577,6 +577,22 @@ func (c *updateConflictWorkflowClient) Create(ctx context.Context, execSpec util
 	return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "argoproj.io", Resource: "workflows"}, execSpec.ExecutionName())
 }
 
+type persistentConflictWorkflowClient struct {
+	*client.FakeWorkflowClient
+	updateCalls int
+	createCalls int
+}
+
+func (c *persistentConflictWorkflowClient) Update(ctx context.Context, execSpec util.ExecutionSpec, opts v1.UpdateOptions) (util.ExecutionSpec, error) {
+	c.updateCalls++
+	return nil, apierrors.NewConflict(schema.GroupResource{Group: "argoproj.io", Resource: "workflows"}, execSpec.ExecutionName(), errors.New("stale workflow"))
+}
+
+func (c *persistentConflictWorkflowClient) Create(ctx context.Context, execSpec util.ExecutionSpec, opts v1.CreateOptions) (util.ExecutionSpec, error) {
+	c.createCalls++
+	return c.FakeWorkflowClient.Create(ctx, execSpec, opts)
+}
+
 type createAlreadyExistsWorkflowClient struct {
 	*client.FakeWorkflowClient
 	updateNotFoundRemaining      int
@@ -596,6 +612,25 @@ func (c *createAlreadyExistsWorkflowClient) Create(ctx context.Context, execSpec
 		c.createAlreadyExistsRemaining--
 		return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "argoproj.io", Resource: "workflows"}, execSpec.ExecutionName())
 	}
+	return c.FakeWorkflowClient.Create(ctx, execSpec, opts)
+}
+
+type retryableGetFailureWorkflowClient struct {
+	*client.FakeWorkflowClient
+	getFailuresRemaining int
+	createCalls          int
+}
+
+func (c *retryableGetFailureWorkflowClient) Get(ctx context.Context, name string, options v1.GetOptions) (util.ExecutionSpec, error) {
+	if c.getFailuresRemaining > 0 {
+		c.getFailuresRemaining--
+		return nil, apierrors.NewServiceUnavailable("apiserver temporarily unavailable")
+	}
+	return c.FakeWorkflowClient.Get(ctx, name, options)
+}
+
+func (c *retryableGetFailureWorkflowClient) Create(ctx context.Context, execSpec util.ExecutionSpec, opts v1.CreateOptions) (util.ExecutionSpec, error) {
+	c.createCalls++
 	return c.FakeWorkflowClient.Create(ctx, execSpec, opts)
 }
 
@@ -2992,6 +3027,25 @@ func TestRetryRun_RetriesWorkflowUpdateConflict(t *testing.T) {
 	assert.Equal(t, 0, conflictWorkflowClient.createCalls)
 }
 
+func TestRetryRun_ReturnsUnavailableWhenWorkflowUpdateConflictPersists(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	workflowClient := client.NewWorkflowClientFake()
+	seedRetryWorkflow(t, manager, runDetail.UUID, workflowClient)
+	conflictWorkflowClient := &persistentConflictWorkflowClient{
+		FakeWorkflowClient: workflowClient,
+	}
+	manager.execClient = &retryWorkflowExecClient{workflowClient: conflictWorkflowClient}
+
+	err := manager.RetryRun(context.Background(), runDetail.UUID)
+
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable), "expected retryable error after persistent workflow update conflict, got: %v", err)
+	assert.Greater(t, conflictWorkflowClient.updateCalls, 1)
+	assert.Equal(t, 0, conflictWorkflowClient.createCalls)
+}
+
 func TestRetryRun_RetriesWorkflowUpdateAfterCreateAlreadyExists(t *testing.T) {
 	store, manager, runDetail := initWithOneTimeFailedRun(t)
 	defer store.Close()
@@ -3010,6 +3064,23 @@ func TestRetryRun_RetriesWorkflowUpdateAfterCreateAlreadyExists(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, alreadyExistsWorkflowClient.updateNotFoundRemaining)
 	assert.Equal(t, 0, alreadyExistsWorkflowClient.createAlreadyExistsRemaining)
+}
+
+func TestRetryRun_CreatesWorkflowAfterRetryableGetFailure(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	workflowClient := &retryableGetFailureWorkflowClient{
+		FakeWorkflowClient:   client.NewWorkflowClientFake(),
+		getFailuresRemaining: 10,
+	}
+	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+
+	err := manager.RetryRun(context.Background(), runDetail.UUID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 9, workflowClient.getFailuresRemaining)
+	assert.Equal(t, 1, workflowClient.createCalls)
 }
 
 func TestRetryRun_RetriesRetryableWorkflowUpdateFailure(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -579,14 +579,14 @@ func (c *updateConflictWorkflowClient) Create(ctx context.Context, execSpec util
 
 type createAlreadyExistsWorkflowClient struct {
 	*client.FakeWorkflowClient
-	updateErrorsRemaining        int
+	updateNotFoundRemaining      int
 	createAlreadyExistsRemaining int
 }
 
 func (c *createAlreadyExistsWorkflowClient) Update(ctx context.Context, execSpec util.ExecutionSpec, opts v1.UpdateOptions) (util.ExecutionSpec, error) {
-	if c.updateErrorsRemaining > 0 {
-		c.updateErrorsRemaining--
-		return nil, errors.New("transient update failure")
+	if c.updateNotFoundRemaining > 0 {
+		c.updateNotFoundRemaining--
+		return nil, apierrors.NewNotFound(schema.GroupResource{Group: "argoproj.io", Resource: "workflows"}, execSpec.ExecutionName())
 	}
 	return c.FakeWorkflowClient.Update(ctx, execSpec, opts)
 }
@@ -599,11 +599,25 @@ func (c *createAlreadyExistsWorkflowClient) Create(ctx context.Context, execSpec
 	return c.FakeWorkflowClient.Create(ctx, execSpec, opts)
 }
 
+type genericUpdateFailureWorkflowClient struct {
+	*client.FakeWorkflowClient
+	createCalls int
+}
+
+func (c *genericUpdateFailureWorkflowClient) Update(ctx context.Context, execSpec util.ExecutionSpec, opts v1.UpdateOptions) (util.ExecutionSpec, error) {
+	return nil, errors.New("transient update failure")
+}
+
+func (c *genericUpdateFailureWorkflowClient) Create(ctx context.Context, execSpec util.ExecutionSpec, opts v1.CreateOptions) (util.ExecutionSpec, error) {
+	c.createCalls++
+	return nil, apierrors.NewAlreadyExists(schema.GroupResource{Group: "argoproj.io", Resource: "workflows"}, execSpec.ExecutionName())
+}
+
 func seedRetryWorkflow(t *testing.T, manager *ResourceManager, runID string, workflowClient util.ExecutionInterface) {
 	t.Helper()
 	run, err := manager.GetRun(runID)
 	require.NoError(t, err)
-	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.RunDetails.WorkflowRuntimeManifest))
+	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.WorkflowRuntimeManifest))
 	require.NoError(t, err)
 	require.NoError(t, execSpec.Decompress())
 	retryExecSpec, _, err := execSpec.GenerateRetryExecution()
@@ -2967,7 +2981,7 @@ func TestRetryRun_RetriesWorkflowUpdateAfterCreateAlreadyExists(t *testing.T) {
 	seedRetryWorkflow(t, manager, runDetail.UUID, workflowClient)
 	alreadyExistsWorkflowClient := &createAlreadyExistsWorkflowClient{
 		FakeWorkflowClient:           workflowClient,
-		updateErrorsRemaining:        1,
+		updateNotFoundRemaining:      1,
 		createAlreadyExistsRemaining: 1,
 	}
 	manager.execClient = &retryWorkflowExecClient{workflowClient: alreadyExistsWorkflowClient}
@@ -2975,8 +2989,26 @@ func TestRetryRun_RetriesWorkflowUpdateAfterCreateAlreadyExists(t *testing.T) {
 	err := manager.RetryRun(context.Background(), runDetail.UUID)
 
 	require.NoError(t, err)
-	assert.Equal(t, 0, alreadyExistsWorkflowClient.updateErrorsRemaining)
+	assert.Equal(t, 0, alreadyExistsWorkflowClient.updateNotFoundRemaining)
 	assert.Equal(t, 0, alreadyExistsWorkflowClient.createAlreadyExistsRemaining)
+}
+
+func TestRetryRun_GenericWorkflowUpdateFailureDoesNotCreate(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	workflowClient := client.NewWorkflowClientFake()
+	seedRetryWorkflow(t, manager, runDetail.UUID, workflowClient)
+	genericFailureWorkflowClient := &genericUpdateFailureWorkflowClient{
+		FakeWorkflowClient: workflowClient,
+	}
+	manager.execClient = &retryWorkflowExecClient{workflowClient: genericFailureWorkflowClient}
+
+	err := manager.RetryRun(context.Background(), runDetail.UUID)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error updating workflow")
+	assert.Equal(t, 0, genericFailureWorkflowClient.createCalls)
 }
 
 func TestRetryRun_PreservesRunFields(t *testing.T) {
@@ -3127,7 +3159,7 @@ func TestRetryRun_UpdateAndCreateFailed(t *testing.T) {
 	manager.execClient = client.NewFakeExecClientWithBadWorkflow()
 	err := manager.RetryRun(context.Background(), runDetail.UUID)
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "error updating and creating a workflow")
+	assert.Contains(t, err.Error(), "error getting workflow")
 }
 
 func TestUnarchiveRun_OK(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**

Makes `RetryRun` tolerate transient Kubernetes workflow races during retry.

- retries workflow update after a Kubernetes conflict
- retries update when create fallback finds the workflow already exists
- keeps non-race update/create errors returning as failures

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
