### PR TITLE
fix(backend,frontend): wire code_source_url end-to-end through upload endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-19
+- Last updated: 2026-07-20
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -328,6 +328,12 @@ The following files are generated; edit their sources and regenerate:
 - Frontend OpenAPI clients under `frontend/src/apis`, `frontend/src/apisv2beta1`, `frontend/server/src/generated/apis`, and `frontend/server/src/generated/apisv2beta1`, with shared runtime/model support under `frontend/src/generated/openapi` and `frontend/server/src/generated/openapi`
   - Sources: Swagger specs under `backend/api/**/swagger/*.json`
   - Generate: `cd frontend && npm run apis` / `npm run apis:v2beta1` / `npm run apis:all` (uses pinned Docker image `openapitools/openapi-generator-cli:v7.19.0`)
+- Backend Go HTTP client under `backend/api/v2beta1/go_http_client`
+  - Sources: `backend/api/v2beta1/swagger/*.swagger.json` (compiled from `backend/api/v2beta1/*.proto`; `pipeline.upload.swagger.json` is manually maintained)
+  - Generate: `cd backend/api && make generate`
+- Backend Python HTTP client under `backend/api/v2beta1/python_http_client`
+  - Sources: `backend/api/v2beta1/swagger/kfp_api_single_file.swagger.json`
+  - Generate: `cd backend/api && make generate-kfp-server-api-package`
 - Frontend MLMD proto outputs under `frontend/src/third_party/mlmd/generated`
   - Sources: `third_party/ml-metadata/*.proto`
   - Generate: `cd frontend && npm run build:protos`

--- a/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service/upload_pipeline_parameters.go
+++ b/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service/upload_pipeline_parameters.go
@@ -61,6 +61,12 @@ UploadPipelineParams contains all the parameters to send to the API endpoint
 */
 type UploadPipelineParams struct {
 
+	/* CodeSourceURL.
+
+	   Optional URL to the pipeline source code.
+	*/
+	CodeSourceURL *string
+
 	// Description.
 	Description *string
 
@@ -138,6 +144,17 @@ func (o *UploadPipelineParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCodeSourceURL adds the codeSourceURL to the upload pipeline params
+func (o *UploadPipelineParams) WithCodeSourceURL(codeSourceURL *string) *UploadPipelineParams {
+	o.SetCodeSourceURL(codeSourceURL)
+	return o
+}
+
+// SetCodeSourceURL adds the codeSourceUrl to the upload pipeline params
+func (o *UploadPipelineParams) SetCodeSourceURL(codeSourceURL *string) {
+	o.CodeSourceURL = codeSourceURL
+}
+
 // WithDescription adds the description to the upload pipeline params
 func (o *UploadPipelineParams) WithDescription(description *string) *UploadPipelineParams {
 	o.SetDescription(description)
@@ -211,6 +228,23 @@ func (o *UploadPipelineParams) WriteToRequest(r runtime.ClientRequest, reg strfm
 		return err
 	}
 	var res []error
+
+	if o.CodeSourceURL != nil {
+
+		// query param code_source_url
+		var qrCodeSourceURL string
+
+		if o.CodeSourceURL != nil {
+			qrCodeSourceURL = *o.CodeSourceURL
+		}
+		qCodeSourceURL := qrCodeSourceURL
+		if qCodeSourceURL != "" {
+
+			if err := r.SetQueryParam("code_source_url", qCodeSourceURL); err != nil {
+				return err
+			}
+		}
+	}
 
 	if o.Description != nil {
 

--- a/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service/upload_pipeline_version_parameters.go
+++ b/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service/upload_pipeline_version_parameters.go
@@ -61,6 +61,12 @@ UploadPipelineVersionParams contains all the parameters to send to the API endpo
 */
 type UploadPipelineVersionParams struct {
 
+	/* CodeSourceURL.
+
+	   Optional URL to the pipeline source code.
+	*/
+	CodeSourceURL *string
+
 	// Description.
 	Description *string
 
@@ -138,6 +144,17 @@ func (o *UploadPipelineVersionParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithCodeSourceURL adds the codeSourceURL to the upload pipeline version params
+func (o *UploadPipelineVersionParams) WithCodeSourceURL(codeSourceURL *string) *UploadPipelineVersionParams {
+	o.SetCodeSourceURL(codeSourceURL)
+	return o
+}
+
+// SetCodeSourceURL adds the codeSourceUrl to the upload pipeline version params
+func (o *UploadPipelineVersionParams) SetCodeSourceURL(codeSourceURL *string) {
+	o.CodeSourceURL = codeSourceURL
+}
+
 // WithDescription adds the description to the upload pipeline version params
 func (o *UploadPipelineVersionParams) WithDescription(description *string) *UploadPipelineVersionParams {
 	o.SetDescription(description)
@@ -211,6 +228,23 @@ func (o *UploadPipelineVersionParams) WriteToRequest(r runtime.ClientRequest, re
 		return err
 	}
 	var res []error
+
+	if o.CodeSourceURL != nil {
+
+		// query param code_source_url
+		var qrCodeSourceURL string
+
+		if o.CodeSourceURL != nil {
+			qrCodeSourceURL = *o.CodeSourceURL
+		}
+		qCodeSourceURL := qrCodeSourceURL
+		if qCodeSourceURL != "" {
+
+			if err := r.SetQueryParam("code_source_url", qCodeSourceURL); err != nil {
+				return err
+			}
+		}
+	}
 
 	if o.Description != nil {
 

--- a/backend/api/v2beta1/python_http_client/docs/PipelineUploadServiceApi.md
+++ b/backend/api/v2beta1/python_http_client/docs/PipelineUploadServiceApi.md
@@ -9,7 +9,7 @@ Method | HTTP request | Description
 
 
 # **upload_pipeline**
-> V2beta1Pipeline upload_pipeline(uploadfile, name=name, display_name=display_name, description=description, namespace=namespace, tags=tags)
+> V2beta1Pipeline upload_pipeline(uploadfile, name=name, display_name=display_name, description=description, namespace=namespace, tags=tags, code_source_url=code_source_url)
 
 
 
@@ -53,9 +53,10 @@ display_name = 'display_name_example' # str |  (optional)
 description = 'description_example' # str |  (optional)
 namespace = 'namespace_example' # str |  (optional)
 tags = 'tags_example' # str | JSON-encoded map of key-value pairs for pipeline tags. (optional)
+code_source_url = 'code_source_url_example' # str | Optional URL to the pipeline source code. (optional)
 
     try:
-        api_response = api_instance.upload_pipeline(uploadfile, name=name, display_name=display_name, description=description, namespace=namespace, tags=tags)
+        api_response = api_instance.upload_pipeline(uploadfile, name=name, display_name=display_name, description=description, namespace=namespace, tags=tags, code_source_url=code_source_url)
         pprint(api_response)
     except ApiException as e:
         print("Exception when calling PipelineUploadServiceApi->upload_pipeline: %s\n" % e)
@@ -71,6 +72,7 @@ Name | Type | Description  | Notes
  **description** | **str**|  | [optional] 
  **namespace** | **str**|  | [optional] 
  **tags** | **str**| JSON-encoded map of key-value pairs for pipeline tags. | [optional] 
+ **code_source_url** | **str**| Optional URL to the pipeline source code. | [optional] 
 
 ### Return type
 
@@ -94,7 +96,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **upload_pipeline_version**
-> V2beta1PipelineVersion upload_pipeline_version(uploadfile, name=name, display_name=display_name, pipelineid=pipelineid, description=description, tags=tags)
+> V2beta1PipelineVersion upload_pipeline_version(uploadfile, name=name, display_name=display_name, pipelineid=pipelineid, description=description, tags=tags, code_source_url=code_source_url)
 
 
 
@@ -138,9 +140,10 @@ display_name = 'display_name_example' # str |  (optional)
 pipelineid = 'pipelineid_example' # str |  (optional)
 description = 'description_example' # str |  (optional)
 tags = 'tags_example' # str | JSON-encoded map of key-value pairs for pipeline version tags. (optional)
+code_source_url = 'code_source_url_example' # str | Optional URL to the pipeline source code. (optional)
 
     try:
-        api_response = api_instance.upload_pipeline_version(uploadfile, name=name, display_name=display_name, pipelineid=pipelineid, description=description, tags=tags)
+        api_response = api_instance.upload_pipeline_version(uploadfile, name=name, display_name=display_name, pipelineid=pipelineid, description=description, tags=tags, code_source_url=code_source_url)
         pprint(api_response)
     except ApiException as e:
         print("Exception when calling PipelineUploadServiceApi->upload_pipeline_version: %s\n" % e)
@@ -156,6 +159,7 @@ Name | Type | Description  | Notes
  **pipelineid** | **str**|  | [optional] 
  **description** | **str**|  | [optional] 
  **tags** | **str**| JSON-encoded map of key-value pairs for pipeline version tags. | [optional] 
+ **code_source_url** | **str**| Optional URL to the pipeline source code. | [optional] 
 
 ### Return type
 

--- a/backend/api/v2beta1/python_http_client/kfp_server_api/api/pipeline_upload_service_api.py
+++ b/backend/api/v2beta1/python_http_client/kfp_server_api/api/pipeline_upload_service_api.py
@@ -57,6 +57,8 @@ class PipelineUploadServiceApi(object):
         :type namespace: str
         :param tags: JSON-encoded map of key-value pairs for pipeline tags.
         :type tags: str
+        :param code_source_url: Optional URL to the pipeline source code.
+        :type code_source_url: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the urllib3.HTTPResponse object will
@@ -95,6 +97,8 @@ class PipelineUploadServiceApi(object):
         :type namespace: str
         :param tags: JSON-encoded map of key-value pairs for pipeline tags.
         :type tags: str
+        :param code_source_url: Optional URL to the pipeline source code.
+        :type code_source_url: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _return_http_data_only: response data without head status code
@@ -122,7 +126,8 @@ class PipelineUploadServiceApi(object):
             'display_name',
             'description',
             'namespace',
-            'tags'
+            'tags',
+            'code_source_url'
         ]
         all_params.extend(
             [
@@ -161,6 +166,8 @@ class PipelineUploadServiceApi(object):
             query_params.append(('namespace', local_var_params['namespace']))  # noqa: E501
         if 'tags' in local_var_params and local_var_params['tags'] is not None:  # noqa: E501
             query_params.append(('tags', local_var_params['tags']))  # noqa: E501
+        if 'code_source_url' in local_var_params and local_var_params['code_source_url'] is not None:  # noqa: E501
+            query_params.append(('code_source_url', local_var_params['code_source_url']))  # noqa: E501
 
         header_params = {}
 
@@ -218,6 +225,8 @@ class PipelineUploadServiceApi(object):
         :type description: str
         :param tags: JSON-encoded map of key-value pairs for pipeline version tags.
         :type tags: str
+        :param code_source_url: Optional URL to the pipeline source code.
+        :type code_source_url: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _preload_content: if False, the urllib3.HTTPResponse object will
@@ -256,6 +265,8 @@ class PipelineUploadServiceApi(object):
         :type description: str
         :param tags: JSON-encoded map of key-value pairs for pipeline version tags.
         :type tags: str
+        :param code_source_url: Optional URL to the pipeline source code.
+        :type code_source_url: str
         :param async_req: Whether to execute the request asynchronously.
         :type async_req: bool, optional
         :param _return_http_data_only: response data without head status code
@@ -283,7 +294,8 @@ class PipelineUploadServiceApi(object):
             'display_name',
             'pipelineid',
             'description',
-            'tags'
+            'tags',
+            'code_source_url'
         ]
         all_params.extend(
             [
@@ -322,6 +334,8 @@ class PipelineUploadServiceApi(object):
             query_params.append(('description', local_var_params['description']))  # noqa: E501
         if 'tags' in local_var_params and local_var_params['tags'] is not None:  # noqa: E501
             query_params.append(('tags', local_var_params['tags']))  # noqa: E501
+        if 'code_source_url' in local_var_params and local_var_params['code_source_url'] is not None:  # noqa: E501
+            query_params.append(('code_source_url', local_var_params['code_source_url']))  # noqa: E501
 
         header_params = {}
 

--- a/backend/api/v2beta1/swagger/kfp_api_single_file.swagger.json
+++ b/backend/api/v2beta1/swagger/kfp_api_single_file.swagger.json
@@ -995,6 +995,13 @@
             "required": false,
             "type": "string",
             "description": "JSON-encoded map of key-value pairs for pipeline tags."
+          },
+          {
+            "name": "code_source_url",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Optional URL to the pipeline source code."
           }
         ],
         "tags": [
@@ -1063,6 +1070,13 @@
             "required": false,
             "type": "string",
             "description": "JSON-encoded map of key-value pairs for pipeline version tags."
+          },
+          {
+            "name": "code_source_url",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Optional URL to the pipeline source code."
           }
         ],
         "tags": [

--- a/backend/api/v2beta1/swagger/pipeline.upload.swagger.json
+++ b/backend/api/v2beta1/swagger/pipeline.upload.swagger.json
@@ -63,6 +63,13 @@
             "required": false,
             "type": "string",
             "description": "JSON-encoded map of key-value pairs for pipeline tags."
+          },
+          {
+            "name": "code_source_url",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Optional URL to the pipeline source code."
           }
         ],
         "tags": ["PipelineUploadService"]
@@ -125,6 +132,13 @@
             "required": false,
             "type": "string",
             "description": "JSON-encoded map of key-value pairs for pipeline version tags."
+          },
+          {
+            "name": "code_source_url",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Optional URL to the pipeline source code."
           }
         ],
         "tags": ["PipelineUploadService"]

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -533,12 +533,13 @@ func toApiPipelineVersion(pv *model.PipelineVersion) *apiv2beta1.PipelineVersion
 		Tags:              pv.Tags,
 	}
 
-	// Infer pipeline url
+	// Set code source url
 	if pv.CodeSourceUrl != "" {
-		apiPipelineVersion.PackageUrl = &apiv2beta1.Url{
-			PipelineUrl: string(pv.PipelineSpecURI),
-		}
-	} else if pv.PipelineSpecURI != "" {
+		apiPipelineVersion.CodeSourceUrl = pv.CodeSourceUrl
+	}
+
+	// Set package url from pipeline spec URI
+	if pv.PipelineSpecURI != "" {
 		apiPipelineVersion.PackageUrl = &apiv2beta1.Url{
 			PipelineUrl: string(pv.PipelineSpecURI),
 		}

--- a/backend/src/apiserver/server/api_converter_test.go
+++ b/backend/src/apiserver/server/api_converter_test.go
@@ -5315,6 +5315,35 @@ func TestToApiPipelineVersionsV1_MultipleVersions(t *testing.T) {
 	assert.Equal(t, "version-2", result[1].Id)
 }
 
+func TestToApiPipelineVersion_OnlyPipelineSpecURI(t *testing.T) {
+	pv := &model.PipelineVersion{
+		UUID:            "version-1",
+		Name:            "v1",
+		DisplayName:     "v1",
+		CreatedAtInSec:  100,
+		PipelineId:      "pipeline-1",
+		PipelineSpecURI: "http://package/v1",
+	}
+	result := toApiPipelineVersion(pv)
+	assert.Empty(t, result.CodeSourceUrl)
+	assert.NotNil(t, result.PackageUrl)
+	assert.Equal(t, "http://package/v1", result.PackageUrl.PipelineUrl)
+}
+
+func TestToApiPipelineVersion_OnlyCodeSourceUrl(t *testing.T) {
+	pv := &model.PipelineVersion{
+		UUID:           "version-1",
+		Name:           "v1",
+		DisplayName:    "v1",
+		CreatedAtInSec: 100,
+		PipelineId:     "pipeline-1",
+		CodeSourceUrl:  "http://repo/v1",
+	}
+	result := toApiPipelineVersion(pv)
+	assert.Equal(t, "http://repo/v1", result.CodeSourceUrl)
+	assert.Nil(t, result.PackageUrl)
+}
+
 func TestToApiPipelineVersions_Empty(t *testing.T) {
 	result := toApiPipelineVersions([]*model.PipelineVersion{})
 	assert.NotNil(t, result)

--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -47,7 +47,8 @@ const (
 	DisplayNameQueryStringKey = "display_name"
 	DescriptionQueryStringKey = "description"
 	NamespaceStringQuery      = "namespace"
-	TagsQueryStringKey        = "tags"
+	TagsQueryStringKey           = "tags"
+	CodeSourceURLQueryStringKey  = "code_source_url"
 	// Pipeline Id in the query string specifies a pipeline when creating versions.
 	PipelineKey = "pipelineid"
 )
@@ -165,10 +166,11 @@ func (s *PipelineUploadServer) uploadPipeline(apiVersion string, w http.Response
 	}
 
 	pipelineVersion := &model.PipelineVersion{
-		Name:         pipeline.Name,
-		DisplayName:  pipeline.DisplayName,
-		Description:  pipeline.Description,
-		PipelineSpec: model.LargeText(pipelineFile),
+		Name:          pipeline.Name,
+		DisplayName:   pipeline.DisplayName,
+		Description:   pipeline.Description,
+		PipelineSpec:  model.LargeText(pipelineFile),
+		CodeSourceUrl: r.URL.Query().Get(CodeSourceURLQueryStringKey),
 	}
 
 	if err := validation.ValidateFieldLength("Pipeline", "Name", pipeline.Name); err != nil {
@@ -326,12 +328,13 @@ func (s *PipelineUploadServer) uploadPipelineVersion(apiVersion string, w http.R
 
 	newPipelineVersion, err := s.resourceManager.CreatePipelineVersion(
 		&model.PipelineVersion{
-			Name:         pipelineVersionName,
-			DisplayName:  displayName,
-			Description:  model.LargeText(r.URL.Query().Get(DescriptionQueryStringKey)),
-			PipelineId:   pipelineID,
-			PipelineSpec: model.LargeText(pipelineFile),
-			Tags:         versionTags,
+			Name:          pipelineVersionName,
+			DisplayName:   displayName,
+			Description:   model.LargeText(r.URL.Query().Get(DescriptionQueryStringKey)),
+			PipelineId:    pipelineID,
+			PipelineSpec:  model.LargeText(pipelineFile),
+			CodeSourceUrl: r.URL.Query().Get(CodeSourceURLQueryStringKey),
+			Tags:          versionTags,
 		},
 	)
 	if err != nil {

--- a/backend/src/apiserver/server/pipeline_upload_server_test.go
+++ b/backend/src/apiserver/server/pipeline_upload_server_test.go
@@ -446,6 +446,49 @@ func TestUploadPipeline_Tarball(t *testing.T) {
 	assert.Equal(t, versionsExpect, versions)
 }
 
+func TestUploadPipeline_CodeSourceUrl(t *testing.T) {
+	clientManager, server := setupClientManagerAndServer()
+	bytesBuffer, writer := setupWriter("")
+	setWriterWithBuffer("uploadfile", "hello-world.yaml", "apiVersion: argoproj.io/v1alpha1\nkind: Workflow", writer)
+	response := uploadPipeline(
+		fmt.Sprintf("/apis/v2beta1/pipelines/upload?name=%s&code_source_url=%s",
+			url.PathEscape("my-pipeline"), url.PathEscape("https://github.com/example/repo")),
+		bytes.NewReader(bytesBuffer.Bytes()), writer, server.UploadPipeline)
+	assert.Equal(t, 200, response.Code)
+
+	// Verify the pipeline version stored in DB has CodeSourceUrl set
+	opts, _ := list.NewOptions(&model.PipelineVersion{}, 2, "", nil)
+	versions, totalSize, _, err := clientManager.PipelineStore().ListPipelineVersions(DefaultFakeUUID, opts, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, totalSize)
+	assert.Equal(t, "https://github.com/example/repo", versions[0].CodeSourceUrl)
+}
+
+func TestUploadPipelineVersion_CodeSourceUrl(t *testing.T) {
+	clientManager, server := setupClientManagerAndServer()
+	// First create a pipeline
+	bytesBuffer, writer := setupWriter("")
+	setWriterWithBuffer("uploadfile", "hello-world.yaml", "apiVersion: argoproj.io/v1alpha1\nkind: Workflow", writer)
+	response := uploadPipeline("/apis/v2beta1/pipelines/upload",
+		bytes.NewReader(bytesBuffer.Bytes()), writer, server.UploadPipeline)
+	assert.Equal(t, 200, response.Code)
+
+	// Upload a version with code_source_url
+	server = updateClientManager(clientManager, util.NewFakeUUIDGeneratorOrFatal(fakeVersionUUID, nil))
+	bytesBuffer, writer = setupWriter("")
+	setWriterWithBuffer("uploadfile", "hello-world.yaml", "apiVersion: argoproj.io/v1alpha1\nkind: Workflow", writer)
+	response = uploadPipeline(
+		fmt.Sprintf("/apis/v2beta1/pipelines/upload_version?name=%s&pipelineid=%s&code_source_url=%s",
+			url.PathEscape(fakeVersionName), DefaultFakeUUID, url.PathEscape("https://github.com/example/repo")),
+		bytes.NewReader(bytesBuffer.Bytes()), writer, server.UploadPipelineVersion)
+	assert.Equal(t, 200, response.Code)
+
+	// Verify the pipeline version stored in DB has CodeSourceUrl set
+	pipelineVersion, err := clientManager.PipelineStore().GetPipelineVersion(fakeVersionUUID)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://github.com/example/repo", pipelineVersion.CodeSourceUrl)
+}
+
 func TestUploadPipeline_GetFormFileError(t *testing.T) {
 	_, server := setupClientManagerAndServer()
 	bytesBuffer, writer := setupWriter("I am invalid file")

--- a/backend/src/common/client/api_server/v2/pipeline_upload_client_kubernetes.go
+++ b/backend/src/common/client/api_server/v2/pipeline_upload_client_kubernetes.go
@@ -151,7 +151,7 @@ func (c *PipelineUploadClientKubernetes) Upload(parameters *params.UploadPipelin
 			"Namespace cannot be set as an upload parameter")
 	}
 
-	piplineSpec, err := io.ReadAll(parameters.Uploadfile)
+	pipelineSpec, err := io.ReadAll(parameters.Uploadfile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read pipeline spec: %w", err)
 	}
@@ -165,7 +165,7 @@ func (c *PipelineUploadClientKubernetes) Upload(parameters *params.UploadPipelin
 			"Failed to upload pipeline")
 	}
 
-	if _, err := template.NewV2SpecTemplate(piplineSpec, template.TemplateOptions{}); err != nil {
+	if _, err := template.NewV2SpecTemplate(pipelineSpec, template.TemplateOptions{}); err != nil {
 		return nil, util.NewUserError(err,
 			fmt.Sprintf("Failed to upload pipeline. Params: '%v'", parameters),
 			"Failed to upload pipeline")
@@ -214,7 +214,7 @@ func (c *PipelineUploadClientKubernetes) Upload(parameters *params.UploadPipelin
 		Name:         name,
 		DisplayName:  displayName,
 		Description:  apimodel.LargeText(description),
-		PipelineSpec: apimodel.LargeText(piplineSpec),
+		PipelineSpec: apimodel.LargeText(pipelineSpec),
 	}
 	if parameters.CodeSourceURL != nil {
 		pipelineVersionModel.CodeSourceUrl = *parameters.CodeSourceURL

--- a/backend/src/common/client/api_server/v2/pipeline_upload_client_kubernetes.go
+++ b/backend/src/common/client/api_server/v2/pipeline_upload_client_kubernetes.go
@@ -216,6 +216,9 @@ func (c *PipelineUploadClientKubernetes) Upload(parameters *params.UploadPipelin
 		Description:  apimodel.LargeText(description),
 		PipelineSpec: apimodel.LargeText(piplineSpec),
 	}
+	if parameters.CodeSourceURL != nil {
+		pipelineVersionModel.CodeSourceUrl = *parameters.CodeSourceURL
+	}
 
 	pipelineVersion, err := k8sapi.FromPipelineVersionModel(*createdPipelineModel, pipelineVersionModel)
 	if err != nil {
@@ -311,6 +314,9 @@ func (c *PipelineUploadClientKubernetes) UploadPipelineVersion(filePath string, 
 		Description:  apimodel.LargeText(description),
 		PipelineId:   modelPipeline.UUID,
 		Tags:         tags,
+	}
+	if parameters.CodeSourceURL != nil {
+		modelPipelineVersion.CodeSourceUrl = *parameters.CodeSourceURL
 	}
 
 	pipelineVersion, err := k8sapi.FromPipelineVersionModel(*modelPipeline, modelPipelineVersion)

--- a/backend/src/common/client/api_server/v2/pipeline_upload_client_kubernetes_test.go
+++ b/backend/src/common/client/api_server/v2/pipeline_upload_client_kubernetes_test.go
@@ -1,0 +1,488 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api_server_v2 //nolint:staticcheck // ST1003: package name matches existing convention in this directory
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	params "github.com/kubeflow/pipelines/backend/api/v2beta1/go_http_client/pipeline_upload_client/pipeline_upload_service"
+	k8sapi "github.com/kubeflow/pipelines/backend/src/crd/kubernetes/v2beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const testNamespace = "test-ns"
+
+func basicPipelineSpecYAML() string {
+	return `pipelineInfo:
+  name: test-pipeline
+  displayName: Test Pipeline
+root:
+  dag:
+    tasks: {}
+schemaVersion: "2.1.0"
+sdkVersion: kfp-2.13.0`
+}
+
+func newFakeClient(objects ...ctrlclient.Object) ctrlclient.Client {
+	testScheme := k8sruntime.NewScheme()
+	if err := k8sapi.AddToScheme(testScheme); err != nil {
+		panic(err)
+	}
+
+	builder := fake.NewClientBuilder().WithScheme(testScheme)
+	if len(objects) > 0 {
+		builder = builder.WithObjects(objects...)
+	}
+
+	return builder.Build()
+}
+
+func newUploadClient(client ctrlclient.Client) *PipelineUploadClientKubernetes {
+	return &PipelineUploadClientKubernetes{
+		ctrlClient: client,
+		namespace:  testNamespace,
+	}
+}
+
+func pipelineSpecReader(name string) runtime.NamedReadCloser {
+	return runtime.NamedReader(name, io.NopCloser(bytes.NewReader([]byte(basicPipelineSpecYAML()))))
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+// newExistingPipeline returns a Pipeline CRD pre-populated for UploadPipelineVersion tests.
+func newExistingPipeline() *k8sapi.Pipeline {
+	return &k8sapi.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "pipeline-uid-123",
+			Name:      "existing-pipeline",
+			Namespace: testNamespace,
+		},
+		Spec: k8sapi.PipelineSpec{
+			DisplayName: "Existing Pipeline",
+			Description: "An existing pipeline for testing",
+		},
+	}
+}
+
+// writeSpecFile writes the basic pipeline spec YAML to a temp file and returns its path.
+func writeSpecFile(t *testing.T) string {
+	t.Helper()
+	specPath := t.TempDir() + "/pipeline.yaml"
+	require.NoError(t, os.WriteFile(specPath, []byte(basicPipelineSpecYAML()), 0644))
+	return specPath
+}
+
+// --- Upload (pipeline + initial version) tests ---
+
+func TestUpload_HappyPath(t *testing.T) {
+	fakeClient := newFakeClient()
+	uploadClient := newUploadClient(fakeClient)
+
+	uploadParams := params.NewUploadPipelineParams()
+	uploadParams.Name = stringPtr("my-pipeline")
+	uploadParams.DisplayName = stringPtr("My Pipeline")
+	uploadParams.Description = stringPtr("A test pipeline")
+	uploadParams.Uploadfile = pipelineSpecReader("my-pipeline.yaml")
+
+	result, err := uploadClient.Upload(uploadParams)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "my-pipeline", result.Name)
+	assert.Equal(t, "My Pipeline", result.DisplayName)
+	assert.Equal(t, "A test pipeline", result.Description)
+	assert.Equal(t, testNamespace, result.Namespace)
+
+	// Verify both CRDs were created.
+	pipelineList := &k8sapi.PipelineList{}
+	require.NoError(t, fakeClient.List(t.Context(), pipelineList, &ctrlclient.ListOptions{Namespace: testNamespace}))
+	require.Len(t, pipelineList.Items, 1)
+	assert.Equal(t, "My Pipeline", pipelineList.Items[0].Spec.DisplayName)
+
+	versionList := &k8sapi.PipelineVersionList{}
+	require.NoError(t, fakeClient.List(t.Context(), versionList, &ctrlclient.ListOptions{Namespace: testNamespace}))
+	require.Len(t, versionList.Items, 1)
+	assert.Equal(t, "My Pipeline", versionList.Items[0].Spec.DisplayName)
+	assert.Equal(t, "A test pipeline", versionList.Items[0].Spec.Description)
+}
+
+func TestUpload_NameDefaultsToFileName(t *testing.T) {
+	fakeClient := newFakeClient()
+	uploadClient := newUploadClient(fakeClient)
+
+	uploadParams := params.NewUploadPipelineParams()
+	// Name, DisplayName, and Description are all nil — name should default to the file name.
+	uploadParams.Uploadfile = pipelineSpecReader("hello-world.yaml")
+
+	result, err := uploadClient.Upload(uploadParams)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "hello-world.yaml", result.Name)
+	assert.Equal(t, "hello-world.yaml", result.DisplayName)
+}
+
+func TestUpload_NamespaceMismatchReturnsError(t *testing.T) {
+	fakeClient := newFakeClient()
+	uploadClient := newUploadClient(fakeClient)
+
+	uploadParams := params.NewUploadPipelineParams()
+	uploadParams.Name = stringPtr("my-pipeline")
+	uploadParams.Namespace = stringPtr("wrong-namespace")
+	uploadParams.Uploadfile = pipelineSpecReader("my-pipeline.yaml")
+
+	result, err := uploadClient.Upload(uploadParams)
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Namespace cannot be set")
+}
+
+func TestUpload_InvalidTagsReturnsError(t *testing.T) {
+	fakeClient := newFakeClient()
+	uploadClient := newUploadClient(fakeClient)
+
+	uploadParams := params.NewUploadPipelineParams()
+	uploadParams.Name = stringPtr("my-pipeline")
+	uploadParams.Tags = stringPtr("not valid json")
+	uploadParams.Uploadfile = pipelineSpecReader("my-pipeline.yaml")
+
+	result, err := uploadClient.Upload(uploadParams)
+	assert.Nil(t, result)
+	require.Error(t, err)
+}
+
+func TestUpload_TagsPersisted(t *testing.T) {
+	fakeClient := newFakeClient()
+	uploadClient := newUploadClient(fakeClient)
+
+	uploadParams := params.NewUploadPipelineParams()
+	uploadParams.Name = stringPtr("tagged-pipeline")
+	uploadParams.Tags = stringPtr(`{"env": "staging", "team": "ml"}`)
+	uploadParams.Uploadfile = pipelineSpecReader("tagged-pipeline.yaml")
+
+	result, err := uploadClient.Upload(uploadParams)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, map[string]string{"env": "staging", "team": "ml"}, result.Tags)
+}
+
+func TestUpload_CodeSourceURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		codeSourceURL *string
+		wantStoredURL string
+	}{
+		{
+			name:          "CodeSourceURL is set",
+			codeSourceURL: stringPtr("https://github.com/example/repo"),
+			wantStoredURL: "https://github.com/example/repo",
+		},
+		{
+			name:          "CodeSourceURL is nil",
+			codeSourceURL: nil,
+			wantStoredURL: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := newFakeClient()
+			uploadClient := newUploadClient(fakeClient)
+
+			uploadParams := params.NewUploadPipelineParams()
+			uploadParams.Name = stringPtr("test-pipeline")
+			uploadParams.Uploadfile = pipelineSpecReader("test-pipeline.yaml")
+			uploadParams.CodeSourceURL = tt.codeSourceURL
+
+			result, err := uploadClient.Upload(uploadParams)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			versionList := &k8sapi.PipelineVersionList{}
+			err = fakeClient.List(t.Context(), versionList, &ctrlclient.ListOptions{
+				Namespace: testNamespace,
+			})
+			require.NoError(t, err)
+			require.Len(t, versionList.Items, 1)
+
+			assert.Equal(t, tt.wantStoredURL, versionList.Items[0].Spec.CodeSourceURL)
+		})
+	}
+}
+
+// --- UploadPipelineVersion tests ---
+
+func TestUploadPipelineVersion_HappyPath(t *testing.T) {
+	fakeClient := newFakeClient(newExistingPipeline())
+	uploadClient := newUploadClient(fakeClient)
+	specPath := writeSpecFile(t)
+
+	versionParams := params.NewUploadPipelineVersionParams()
+	versionParams.Pipelineid = stringPtr("pipeline-uid-123")
+	versionParams.Name = stringPtr("version-one")
+	versionParams.DisplayName = stringPtr("Version One")
+	versionParams.Description = stringPtr("First version")
+
+	result, err := uploadClient.UploadPipelineVersion(specPath, versionParams)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "version-one", result.Name)
+	assert.Equal(t, "Version One", result.DisplayName)
+	assert.Equal(t, "First version", result.Description)
+	assert.Equal(t, "pipeline-uid-123", result.PipelineID)
+	assert.NotNil(t, result.PipelineSpec, "PipelineSpec should be populated in the response")
+
+	// Verify the CRD was created with an owner reference to the parent pipeline.
+	versionList := &k8sapi.PipelineVersionList{}
+	require.NoError(t, fakeClient.List(t.Context(), versionList, &ctrlclient.ListOptions{Namespace: testNamespace}))
+	require.Len(t, versionList.Items, 1)
+
+	ownerRefs := versionList.Items[0].OwnerReferences
+	require.Len(t, ownerRefs, 1, "PipelineVersion should have an owner reference to its Pipeline")
+	assert.Equal(t, "existing-pipeline", ownerRefs[0].Name)
+}
+
+func TestUploadPipelineVersion_MissingPipelineIDReturnsError(t *testing.T) {
+	fakeClient := newFakeClient()
+	uploadClient := newUploadClient(fakeClient)
+	specPath := writeSpecFile(t)
+
+	versionParams := params.NewUploadPipelineVersionParams()
+	// Pipelineid is nil.
+	versionParams.Name = stringPtr("version-one")
+
+	result, err := uploadClient.UploadPipelineVersion(specPath, versionParams)
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pipelineid is required")
+}
+
+func TestUploadPipelineVersion_PipelineNotFoundReturnsError(t *testing.T) {
+	fakeClient := newFakeClient() // No pre-existing pipeline.
+	uploadClient := newUploadClient(fakeClient)
+	specPath := writeSpecFile(t)
+
+	versionParams := params.NewUploadPipelineVersionParams()
+	versionParams.Pipelineid = stringPtr("nonexistent-uid")
+	versionParams.Name = stringPtr("version-one")
+
+	result, err := uploadClient.UploadPipelineVersion(specPath, versionParams)
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "pipeline not found")
+}
+
+func TestUploadPipelineVersion_InvalidTagsReturnsError(t *testing.T) {
+	fakeClient := newFakeClient(newExistingPipeline())
+	uploadClient := newUploadClient(fakeClient)
+	specPath := writeSpecFile(t)
+
+	versionParams := params.NewUploadPipelineVersionParams()
+	versionParams.Pipelineid = stringPtr("pipeline-uid-123")
+	versionParams.Name = stringPtr("version-one")
+	versionParams.Tags = stringPtr("{bad json")
+
+	result, err := uploadClient.UploadPipelineVersion(specPath, versionParams)
+	assert.Nil(t, result)
+	require.Error(t, err)
+}
+
+func TestUploadPipelineVersion_TagsPersisted(t *testing.T) {
+	fakeClient := newFakeClient(newExistingPipeline())
+	uploadClient := newUploadClient(fakeClient)
+	specPath := writeSpecFile(t)
+
+	versionParams := params.NewUploadPipelineVersionParams()
+	versionParams.Pipelineid = stringPtr("pipeline-uid-123")
+	versionParams.Name = stringPtr("tagged-version")
+	versionParams.Tags = stringPtr(`{"release": "canary"}`)
+
+	result, err := uploadClient.UploadPipelineVersion(specPath, versionParams)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, map[string]string{"release": "canary"}, result.Tags)
+}
+
+func TestUploadPipelineVersion_FileNotFoundReturnsError(t *testing.T) {
+	fakeClient := newFakeClient(newExistingPipeline())
+	uploadClient := newUploadClient(fakeClient)
+
+	versionParams := params.NewUploadPipelineVersionParams()
+	versionParams.Pipelineid = stringPtr("pipeline-uid-123")
+	versionParams.Name = stringPtr("version-one")
+
+	result, err := uploadClient.UploadPipelineVersion("/nonexistent/path.yaml", versionParams)
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to open file")
+}
+
+func TestUploadPipelineVersion_CodeSourceURL(t *testing.T) {
+	tests := []struct {
+		name            string
+		codeSourceURL   *string
+		wantStoredURL   string
+		wantReturnedURL string
+	}{
+		{
+			name:            "CodeSourceURL is set",
+			codeSourceURL:   stringPtr("https://github.com/example/repo/v2"),
+			wantStoredURL:   "https://github.com/example/repo/v2",
+			wantReturnedURL: "https://github.com/example/repo/v2",
+		},
+		{
+			name:            "CodeSourceURL is nil",
+			codeSourceURL:   nil,
+			wantStoredURL:   "",
+			wantReturnedURL: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := newFakeClient(newExistingPipeline())
+			uploadClient := newUploadClient(fakeClient)
+			specPath := writeSpecFile(t)
+
+			versionParams := params.NewUploadPipelineVersionParams()
+			versionParams.Pipelineid = stringPtr("pipeline-uid-123")
+			versionParams.Name = stringPtr("version-one")
+			versionParams.CodeSourceURL = tt.codeSourceURL
+
+			result, err := uploadClient.UploadPipelineVersion(specPath, versionParams)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			assert.Equal(t, tt.wantReturnedURL, result.CodeSourceURL,
+				"CodeSourceURL in the returned pipeline version model should match")
+
+			versionList := &k8sapi.PipelineVersionList{}
+			err = fakeClient.List(t.Context(), versionList, &ctrlclient.ListOptions{
+				Namespace: testNamespace,
+			})
+			require.NoError(t, err)
+			require.Len(t, versionList.Items, 1)
+
+			assert.Equal(t, tt.wantStoredURL, versionList.Items[0].Spec.CodeSourceURL,
+				"CodeSourceURL on the created PipelineVersion CRD should match the upload parameter")
+		})
+	}
+}
+
+// --- UploadFile tests ---
+
+func TestUploadFile_HappyPath(t *testing.T) {
+	fakeClient := newFakeClient()
+	uploadClient := newUploadClient(fakeClient)
+	specPath := writeSpecFile(t)
+
+	uploadParams := params.NewUploadPipelineParams()
+	uploadParams.Name = stringPtr("file-upload-pipeline")
+
+	result, err := uploadClient.UploadFile(specPath, uploadParams)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "file-upload-pipeline", result.Name)
+	assert.Equal(t, testNamespace, result.Namespace)
+}
+
+func TestUploadFile_FileNotFoundReturnsError(t *testing.T) {
+	fakeClient := newFakeClient()
+	uploadClient := newUploadClient(fakeClient)
+
+	uploadParams := params.NewUploadPipelineParams()
+	uploadParams.Name = stringPtr("my-pipeline")
+
+	result, err := uploadClient.UploadFile("/nonexistent/path.yaml", uploadParams)
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to open file")
+}
+
+// --- Helper function tests ---
+
+func TestDeriveNameDisplayAndDescription(t *testing.T) {
+	tests := []struct {
+		testName            string
+		providedName        *string
+		providedDisplayName *string
+		providedDescription *string
+		defaultName         string
+		wantName            string
+		wantDisplayName     string
+		wantDescription     string
+	}{
+		{
+			testName:        "all nil uses default",
+			defaultName:     "default.yaml",
+			wantName:        "default.yaml",
+			wantDisplayName: "default.yaml",
+			wantDescription: "",
+		},
+		{
+			testName:        "name provided",
+			providedName:    stringPtr("custom-name"),
+			defaultName:     "default.yaml",
+			wantName:        "custom-name",
+			wantDisplayName: "custom-name",
+			wantDescription: "",
+		},
+		{
+			testName:            "display name provided without name",
+			providedDisplayName: stringPtr("Custom Display"),
+			defaultName:         "default.yaml",
+			wantName:            "Custom Display",
+			wantDisplayName:     "Custom Display",
+			wantDescription:     "",
+		},
+		{
+			testName:            "all fields provided",
+			providedName:        stringPtr("my-name"),
+			providedDisplayName: stringPtr("My Display Name"),
+			providedDescription: stringPtr("My description"),
+			defaultName:         "default.yaml",
+			wantName:            "my-name",
+			wantDisplayName:     "My Display Name",
+			wantDescription:     "My description",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			name, displayName, description := deriveNameDisplayAndDescription(
+				tt.providedName, tt.providedDisplayName, tt.providedDescription, tt.defaultName,
+			)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantDisplayName, displayName)
+			assert.Equal(t, tt.wantDescription, description)
+		})
+	}
+}

--- a/frontend/src/lib/Apis.test.ts
+++ b/frontend/src/lib/Apis.test.ts
@@ -340,6 +340,66 @@ describe('Apis', () => {
     );
   });
 
+  it('uploadPipelineV2 with codeSourceUrl', async () => {
+    const spy = fetchSpy(JSON.stringify({ pipeline_id: 'new-pipeline-id' }));
+    await Apis.uploadPipelineV2(
+      'test pipeline name',
+      'test display name',
+      'test description',
+      new File([], 'test name'),
+      'test-ns',
+      'https://github.com/example/repo',
+    );
+    expect(spy).toHaveBeenCalledWith(
+      'apis/v2beta1/pipelines/upload?name=' +
+        encodeURIComponent('test pipeline name') +
+        '&display_name=' +
+        encodeURIComponent('test display name') +
+        '&description=' +
+        encodeURIComponent('test description') +
+        '&namespace=' +
+        encodeURIComponent('test-ns') +
+        '&code_source_url=' +
+        encodeURIComponent('https://github.com/example/repo'),
+      {
+        body: expect.anything(),
+        cache: 'no-cache',
+        credentials: 'same-origin',
+        method: 'POST',
+      },
+    );
+  });
+
+  it('uploadPipelineVersionV2 with codeSourceUrl', async () => {
+    const spy = fetchSpy(JSON.stringify({ pipeline_version_id: 'new-version-id' }));
+    await Apis.uploadPipelineVersionV2(
+      'test version name',
+      'test display name',
+      'test-pipeline-id',
+      new File([], 'test name'),
+      'test description',
+      'https://github.com/example/repo',
+    );
+    expect(spy).toHaveBeenCalledWith(
+      'apis/v2beta1/pipelines/upload_version?name=' +
+        encodeURIComponent('test version name') +
+        '&pipelineid=' +
+        encodeURIComponent('test-pipeline-id') +
+        '&display_name=' +
+        encodeURIComponent('test display name') +
+        '&description=' +
+        encodeURIComponent('test description') +
+        '&code_source_url=' +
+        encodeURIComponent('https://github.com/example/repo'),
+      {
+        body: expect.anything(),
+        cache: 'no-cache',
+        credentials: 'same-origin',
+        method: 'POST',
+      },
+    );
+  });
+
   it('checks if Tensorboard pod is ready', async () => {
     const spy = fetchSpy('');
     const ready = await Apis.isTensorboardPodReady('apps/tensorboard/proxy/test-token/');

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -489,6 +489,7 @@ export class Apis {
     pipelineDescription: string,
     pipelineData: File,
     namespace?: string,
+    codeSourceUrl?: string,
   ): Promise<V2beta1Pipeline> {
     const fd = new FormData();
     fd.append('uploadfile', pipelineData, pipelineData.name);
@@ -498,6 +499,9 @@ export class Apis {
 
     if (namespace) {
       query = `${query}&namespace=${encodeURIComponent(namespace)}`;
+    }
+    if (codeSourceUrl) {
+      query = `${query}&code_source_url=${encodeURIComponent(codeSourceUrl)}`;
     }
 
     return await this._fetchAndParse<V2beta1Pipeline>('/pipelines/upload', v2beta1Prefix, query, {
@@ -513,6 +517,7 @@ export class Apis {
     pipelineId: string,
     versionData: File,
     description?: string,
+    codeSourceUrl?: string,
   ): Promise<V2beta1PipelineVersion> {
     const fd = new FormData();
     fd.append('uploadfile', versionData, versionData.name);
@@ -521,7 +526,8 @@ export class Apis {
       v2beta1Prefix,
       `name=${encodeURIComponent(versionName)}&pipelineid=${encodeURIComponent(pipelineId)}` +
         `&display_name=${encodeURIComponent(versionDisplayName)}` +
-        (description ? `&description=${encodeURIComponent(description)}` : ''),
+        (description ? `&description=${encodeURIComponent(description)}` : '') +
+        (codeSourceUrl ? `&code_source_url=${encodeURIComponent(codeSourceUrl)}` : ''),
       {
         body: fd,
         cache: 'no-cache',

--- a/frontend/src/pages/NewPipelineVersion.test.tsx
+++ b/frontend/src/pages/NewPipelineVersion.test.tsx
@@ -292,6 +292,64 @@ describe('NewPipelineVersion', () => {
         },
       });
     });
+
+    it('sends code_source_url when creating a version from file upload', async () => {
+      const uploadVersionSpy = vi
+        .spyOn(Apis, 'uploadPipelineVersionV2')
+        .mockResolvedValue(MOCK_PIPELINE_VERSION as any);
+
+      await renderExistingPipeline({ withRef: true });
+
+      const versionNameInput = screen.getByLabelText(/Pipeline Version Name/);
+      fireEvent.change(versionNameInput, { target: { value: 'test version name' } });
+
+      await userEvent.click(screen.getByLabelText(/Upload a file/i));
+
+      const file = new File(['file contents'], 'pipeline.yaml', { type: 'text/plain' });
+      await simulateFileDrop([file]);
+
+      const codeSourceInput = screen.getByLabelText(/Code Source/);
+      fireEvent.change(codeSourceInput, { target: { value: 'https://github.com/example/repo' } });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+      await waitFor(() => expect(uploadVersionSpy).toHaveBeenCalledTimes(1));
+
+      expect(uploadVersionSpy).toHaveBeenLastCalledWith(
+        'test version name',
+        '',
+        'original-run-pipeline-id',
+        file,
+        '',
+        'https://github.com/example/repo',
+      );
+    });
+
+    it('sends code_source_url when creating a version from URL with code source filled', async () => {
+      await renderExistingPipeline();
+
+      const versionNameInput = screen.getByLabelText(/Pipeline Version Name/);
+      fireEvent.change(versionNameInput, { target: { value: 'test version name' } });
+
+      const urlInput = screen.getByLabelText(/Package Url/);
+      fireEvent.change(urlInput, { target: { value: 'https://dummy_package_url' } });
+
+      const codeSourceInput = screen.getByLabelText(/Code Source/);
+      fireEvent.change(codeSourceInput, { target: { value: 'https://github.com/example/repo' } });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+      await waitFor(() => expect(createPipelineVersionSpy).toHaveBeenCalledTimes(1));
+
+      expect(createPipelineVersionSpy).toHaveBeenLastCalledWith('original-run-pipeline-id', {
+        pipeline_id: 'original-run-pipeline-id',
+        name: 'test version name',
+        display_name: '',
+        description: '',
+        package_url: {
+          pipeline_url: 'https://dummy_package_url',
+        },
+        code_source_url: 'https://github.com/example/repo',
+      });
+    });
   });
 
   describe('creating new pipeline', () => {
@@ -433,6 +491,7 @@ describe('NewPipelineVersion', () => {
         'test pipeline description',
         file,
         undefined,
+        undefined,
       );
     });
 
@@ -469,6 +528,7 @@ describe('NewPipelineVersion', () => {
         'test pipeline description',
         file,
         'ns',
+        undefined,
       );
     });
 
@@ -509,6 +569,42 @@ describe('NewPipelineVersion', () => {
         'test pipeline description',
         file,
         undefined,
+        undefined,
+      );
+    });
+
+    it('creates pipeline from local file with code source url', async () => {
+      await renderNewPipelineVersion(
+        '',
+        { buildInfo: { apiServerMultiUser: false } },
+        { withRef: true },
+      );
+
+      await userEvent.click(screen.getByLabelText(/Upload a file/i));
+      fireEvent.change(screen.getByLabelText(/Pipeline Name/), {
+        target: { value: 'test pipeline name' },
+      });
+      fireEvent.change(screen.getByLabelText(/Pipeline Description/), {
+        target: { value: 'test pipeline description' },
+      });
+
+      const file = new File(['file contents'], 'file_name', { type: 'text/plain' });
+      await simulateFileDrop([file]);
+
+      fireEvent.change(screen.getByLabelText(/Code Source/), {
+        target: { value: 'https://github.com/example/repo' },
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+      await waitFor(() => expect(uploadPipelineSpy).toHaveBeenCalled());
+
+      expect(uploadPipelineSpy).toHaveBeenLastCalledWith(
+        'test pipeline name',
+        '',
+        'test pipeline description',
+        file,
+        undefined,
+        'https://github.com/example/repo',
       );
     });
 

--- a/frontend/src/pages/NewPipelineVersion.tsx
+++ b/frontend/src/pages/NewPipelineVersion.tsx
@@ -608,6 +608,7 @@ export class NewPipelineVersion extends Page<NewPipelineVersionProps, NewPipelin
             this.state.pipelineDescription,
             this.state.file!,
             namespace,
+            this.state.codeSourceUrl || undefined,
           );
           const listVersionsResponse = await Apis.pipelineServiceApiV2.listPipelineVersions(
             pipelineResponse.pipeline_id!,
@@ -670,6 +671,7 @@ export class NewPipelineVersion extends Page<NewPipelineVersionProps, NewPipelin
         this.state.pipelineId!,
         this.state.file,
         this.state.pipelineVersionDescription,
+        this.state.codeSourceUrl || undefined,
       );
     } else {
       // this.state.importMethod === ImportMethod.URL
@@ -679,6 +681,7 @@ export class NewPipelineVersion extends Page<NewPipelineVersionProps, NewPipelin
         name: this.state.pipelineVersionName,
         description: this.state.pipelineVersionDescription,
         package_url: { pipeline_url: this.state.packageUrl },
+        code_source_url: this.state.codeSourceUrl || undefined,
       };
       return Apis.pipelineServiceApiV2.createPipelineVersion(this.state.pipelineId!, newPipeline);
     }


### PR DESCRIPTION
## Summary

- **Backend (converter):** `toApiPipelineVersion` now sets `code_source_url` and `package_url` independently, so existing DB values are returned in API responses even when only one is populated.
- **Backend (upload handlers):** `uploadPipeline` and `uploadPipelineVersion` read the new `code_source_url` query parameter and persist it on the `PipelineVersion` model.
- **Frontend (Apis):** `uploadPipelineV2` and `uploadPipelineVersionV2` accept an optional `codeSourceUrl` and append it to the upload query string.
- **Frontend (NewPipelineVersion):** The `codeSourceUrl` form field value is now passed through all three creation paths (new pipeline from file, new version from file, new version from URL).

## Test plan

- [x] Backend unit tests pass (`go test ./backend/src/apiserver/server/...`)
- [x] New tests: `TestUploadPipeline_CodeSourceUrl`, `TestUploadPipelineVersion_CodeSourceUrl`
- [x] New frontend test: `uploadPipelineVersionV2 with codeSourceUrl` (Apis.test.ts)
- [x] New frontend test: `sends code_source_url when creating a version from URL` (NewPipelineVersion.test.tsx)
- [x] Manual: create pipeline with Code Source URL filled → verify DB `CodeSourceUrl` column is populated

## Test Evidence

Before:

<img width="947" height="695" alt="Screenshot 2026-07-12 at 10 29 55 PM" src="https://github.com/user-attachments/assets/da661b5c-3bcd-4492-b708-0a3089a65671" />

After:

<img width="963" height="712" alt="Screenshot 2026-07-12 at 11 26 37 PM" src="https://github.com/user-attachments/assets/bb433e97-bfc7-44b8-8982-4749904c1d24" />