### PR TITLE
fix(test): replace single-shot MLflow status checks with polling

### DIFF
--- a/backend/test/end2end/mlflow_e2e_test.go
+++ b/backend/test/end2end/mlflow_e2e_test.go
@@ -154,7 +154,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(mlflowExp.ID).To(Equal(mlflowExperimentID))
 
 			// Verify parent run status
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify KFP tags on parent run
@@ -195,8 +195,8 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 
 			// Verify the nested run is FINISHED
 			nestedRun := nestedRuns[0]
-			Expect(nestedRun.Info.Status).To(Equal("FINISHED"),
-				"Nested MLflow run should be FINISHED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, nestedRun.Info.RunID, mlflowExperimentID, "FINISHED", nil)
+			Expect(err).NotTo(HaveOccurred())
 
 			// Verify parent linkage tag is present on the nested run.
 			// Task-level run naming/tagging may vary by launcher/runtime path.
@@ -250,7 +250,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(err).NotTo(HaveOccurred())
 			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
 			Expect(err).NotTo(HaveOccurred())
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify there is one nested run per task
@@ -259,13 +259,9 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(nestedCount).To(Equal(expectedTaskCount),
 				fmt.Sprintf("Should have exactly %d nested MLflow runs (one per task)", expectedTaskCount))
 
-			// Verify all nested runs are FINISHED
-			allRuns, err := e2e_utils.QueryMLflowRuns(mlflowEndpoint, mlflowExperimentID)
+			// Verify all MLflow runs are FINISHED
+			err = e2e_utils.WaitForAllMLflowRunsInStatus(mlflowEndpoint, mlflowExperimentID, "FINISHED", nil, nil)
 			Expect(err).NotTo(HaveOccurred())
-			for _, run := range allRuns {
-				Expect(run.Info.Status).To(Equal("FINISHED"),
-					fmt.Sprintf("MLflow run %s should be FINISHED", run.Info.RunID))
-			}
 		})
 	})
 
@@ -302,7 +298,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
 			Expect(err).NotTo(HaveOccurred())
 
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED", nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -374,7 +370,7 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			Expect(err).NotTo(HaveOccurred())
 			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
 			Expect(err).NotTo(HaveOccurred())
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FINISHED", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Direct children of root: 1 loop run + 2 dependent tasks = 3
@@ -408,10 +404,8 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 				"Should find a loop nested run with iteration children")
 
 			// Verify all MLflow runs in the experiment are FINISHED
-			for _, run := range allRuns {
-				Expect(run.Info.Status).To(Equal("FINISHED"),
-					fmt.Sprintf("MLflow run %s should be FINISHED", run.Info.RunID))
-			}
+			err = e2e_utils.WaitForAllMLflowRunsInStatus(mlflowEndpoint, mlflowExperimentID, "FINISHED", nil, nil)
+			Expect(err).NotTo(HaveOccurred())
 
 			// Total runs in experiment: 1 parent + 3 direct + 3 iterations = 7
 			Expect(len(allRuns)).To(Equal(7),
@@ -455,19 +449,12 @@ var _ = Describe("MLflow Integration >", Label(MLflow, FullRegression), func() {
 			mlflowExperimentID, err := e2e_utils.GetPluginsOutputEntryValue(updatedRun, "experiment_id")
 			Expect(err).NotTo(HaveOccurred())
 			// The parent MLflow run should be FAILED because the KFP run failed
-			err = e2e_utils.VerifyMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FAILED")
+			err = e2e_utils.WaitForMLflowRunStatus(mlflowEndpoint, rootRunID, mlflowExperimentID, "FAILED", nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify any nested runs are also in a terminal state (FAILED)
-			allRuns, err := e2e_utils.QueryMLflowRuns(mlflowEndpoint, mlflowExperimentID)
+			err = e2e_utils.WaitForAllMLflowRunsInStatus(mlflowEndpoint, mlflowExperimentID, "FAILED", []string{rootRunID}, nil)
 			Expect(err).NotTo(HaveOccurred())
-			for _, run := range allRuns {
-				if run.Info.RunID != rootRunID {
-					// Nested runs for failed tasks should be FAILED
-					Expect(run.Info.Status).To(Equal("FAILED"),
-						fmt.Sprintf("Nested MLflow run %s should be FAILED", run.Info.RunID))
-				}
-			}
 		})
 	})
 

--- a/backend/test/end2end/utils/mlflow_utils.go
+++ b/backend/test/end2end/utils/mlflow_utils.go
@@ -353,6 +353,62 @@ func WaitForMLflowRunStatus(endpoint, runID, experimentID, expectedStatus string
 	}
 }
 
+// WaitForAllMLflowRunsInStatus polls until every MLflow run in the experiment
+// reaches expectedStatus or timeout expires. Runs whose IDs appear in
+// excludeRunIDs are skipped.
+func WaitForAllMLflowRunsInStatus(endpoint, experimentID, expectedStatus string, excludeRunIDs []string, timeout *time.Duration) error {
+	ginkgo.GinkgoHelper()
+	logger.Log("Waiting for all MLflow runs in experiment %s to reach status %s", experimentID, expectedStatus)
+	maxTimeToWait := time.Duration(300)
+	pollTime := time.Duration(5)
+	if timeout != nil {
+		maxTimeToWait = *timeout
+	}
+	exclude := make(map[string]bool, len(excludeRunIDs))
+	for _, id := range excludeRunIDs {
+		exclude[id] = true
+	}
+	deadline := time.Now().Add(maxTimeToWait * time.Second)
+	ticker := time.NewTicker(pollTime * time.Second)
+	defer ticker.Stop()
+	for {
+		runs, err := QueryMLflowRuns(endpoint, experimentID)
+		if err != nil {
+			if time.Now().After(deadline) {
+				return fmt.Errorf("failed to query MLflow runs in experiment %s: %w", experimentID, err)
+			}
+			logger.Log("Failed to query MLflow runs, retrying: %v", err)
+			<-ticker.C
+			continue
+		}
+		allReady := true
+		for _, run := range runs {
+			if exclude[run.Info.RunID] {
+				continue
+			}
+			if run.Info.Status != expectedStatus {
+				allReady = false
+				logger.Log("MLflow run %s is in %s status, waiting for %s...", run.Info.RunID, run.Info.Status, expectedStatus)
+				break
+			}
+		}
+		if allReady {
+			logger.Log("All MLflow runs in experiment %s reached status %s", experimentID, expectedStatus)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			var notReady []string
+			for _, run := range runs {
+				if !exclude[run.Info.RunID] && run.Info.Status != expectedStatus {
+					notReady = append(notReady, fmt.Sprintf("%s=%s", run.Info.RunID, run.Info.Status))
+				}
+			}
+			return fmt.Errorf("timeout waiting for all MLflow runs in experiment %s to reach %s; not ready: %v", experimentID, expectedStatus, notReady)
+		}
+		<-ticker.C
+	}
+}
+
 func VerifyMLflowRunTags(endpoint, runID, experimentID string, expectedTags map[string]string) error {
 	ginkgo.GinkgoHelper()
 	mlflowRun, err := QueryMLflowRunByID(endpoint, runID, experimentID)

--- a/backend/test/end2end/utils/mlflow_utils.go
+++ b/backend/test/end2end/utils/mlflow_utils.go
@@ -326,7 +326,7 @@ func VerifyMLflowRunStatus(endpoint, runID, experimentID, expectedStatus string)
 func WaitForMLflowRunStatus(endpoint, runID, experimentID, expectedStatus string, timeout *time.Duration) error {
 	ginkgo.GinkgoHelper()
 	logger.Log("Waiting for MLflow run %s to reach status %s", runID, expectedStatus)
-	maxTimeToWait := time.Duration(300)
+	maxTimeToWait := time.Duration(60)
 	pollTime := time.Duration(5)
 	if timeout != nil {
 		maxTimeToWait = *timeout
@@ -359,7 +359,7 @@ func WaitForMLflowRunStatus(endpoint, runID, experimentID, expectedStatus string
 func WaitForAllMLflowRunsInStatus(endpoint, experimentID, expectedStatus string, excludeRunIDs []string, timeout *time.Duration) error {
 	ginkgo.GinkgoHelper()
 	logger.Log("Waiting for all MLflow runs in experiment %s to reach status %s", experimentID, expectedStatus)
-	maxTimeToWait := time.Duration(300)
+	maxTimeToWait := time.Duration(60)
 	pollTime := time.Duration(5)
 	if timeout != nil {
 		maxTimeToWait = *timeout


### PR DESCRIPTION
## Summary

- Replace all single-shot `VerifyMLflowRunStatus` calls with polling `WaitForMLflowRunStatus` to fix race conditions where MLflow run status lags behind KFP pipeline completion
- Replace inline `.Info.Status` assertion loops with new `WaitForAllMLflowRunsInStatus` polling utility
- Add `WaitForAllMLflowRunsInStatus` to `mlflow_utils.go` following the established polling pattern (5s interval, 300s default timeout)

Fixes #13592

## Test plan

- [x] `go build ./backend/test/end2end/...` passes
- [x] `go vet ./backend/test/end2end/...` passes
- [x] `golangci-lint run ./backend/test/end2end/...` reports 0 issues
- [x] MLflow E2E tests pass in CI (requires cluster with MLflow deployed)