### PR TITLE
fix(backend): narrow MLflow namespace overrides

### DIFF
--- a/backend/src/apiserver/plugins/mlflow/config.go
+++ b/backend/src/apiserver/plugins/mlflow/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
 	commonmlflow "github.com/kubeflow/pipelines/backend/src/common/plugins/mlflow"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -43,6 +44,20 @@ const (
 	LauncherConfigMapName = "kfp-launcher"
 	LauncherConfigKey     = "plugins.mlflow"
 )
+
+// LauncherNamespaceConfig is the restricted MLflow override shape allowed in the
+// namespace-scoped kfp-launcher ConfigMap.
+type LauncherNamespaceConfig struct {
+	Settings *LauncherNamespaceSettings `json:"settings,omitempty"`
+}
+
+// LauncherNamespaceSettings lists the only MLflow settings that a namespace may
+// override through the kfp-launcher ConfigMap.
+type LauncherNamespaceSettings struct {
+	ExperimentDescription *string `json:"experimentDescription,omitempty"`
+	DefaultExperimentName string  `json:"defaultExperimentName,omitempty"`
+	InjectUserEnvVars     *bool   `json:"injectUserEnvVars,omitempty"`
+}
 
 // ApplySettingsDefaults applies default values to a parsed MLflowPluginSettings.
 func ApplySettingsDefaults(settings *commonmlflow.MLflowPluginSettings) *commonmlflow.MLflowPluginSettings {
@@ -104,10 +119,45 @@ func GetGlobalMLflowConfig() (commonmlflow.PluginConfig, bool, error) {
 	return cfg, true, nil
 }
 
-// GetNamespaceMLflowConfig reads the namespace-level MLflow configuration
-// from the kfp-launcher ConfigMap.  Returns nil (no error) when the ConfigMap
-// or key is absent.
-func GetNamespaceMLflowConfig(ctx context.Context, clientSet kubernetes.Interface, namespace string) (*commonmlflow.PluginConfig, error) {
+// GetServerSideNamespaceMLflowConfig reads an optional per-namespace MLflow
+// override from the API server's plugins.mlflow.namespaces config.
+func GetServerSideNamespaceMLflowConfig(namespace string) (*commonmlflow.PluginConfig, error) {
+	if namespace == "" || !viper.IsSet("plugins.mlflow.namespaces") {
+		return nil, nil
+	}
+	raw := viper.Get("plugins.mlflow.namespaces")
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, util.NewInvalidInputError("failed to marshal global plugins.mlflow.namespaces config: %v", err)
+	}
+	var namespaceCfgs map[string]json.RawMessage
+	if err := json.Unmarshal(data, &namespaceCfgs); err != nil {
+		return nil, util.NewInvalidInputError("failed to parse global plugins.mlflow.namespaces config: %v", err)
+	}
+	namespaceRaw, ok := namespaceCfgs[namespace]
+	if !ok {
+		return nil, nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(namespaceRaw))
+	decoder.DisallowUnknownFields()
+	var cfg commonmlflow.PluginConfig
+	if err := decoder.Decode(&cfg); err != nil {
+		return nil, util.NewInvalidInputError("failed to parse global plugins.mlflow.namespaces[%q] config: %v", namespace, err)
+	}
+	var trailing json.RawMessage
+	if trailingErr := decoder.Decode(&trailing); trailingErr != io.EOF {
+		if trailingErr == nil {
+			trailingErr = fmt.Errorf("unexpected trailing JSON content")
+		}
+		return nil, util.NewInvalidInputError("failed to parse global plugins.mlflow.namespaces[%q] config: %v", namespace, trailingErr)
+	}
+	return &cfg, nil
+}
+
+// GetLauncherNamespaceMLflowConfig reads the namespace-level MLflow launcher
+// fragment from the kfp-launcher ConfigMap. Returns nil (no error) when the
+// ConfigMap or key is absent.
+func GetLauncherNamespaceMLflowConfig(ctx context.Context, clientSet kubernetes.Interface, namespace string) (*LauncherNamespaceConfig, error) {
 	if namespace == "" {
 		return nil, util.NewInternalServerError(fmt.Errorf("namespace is empty"), "namespace must be specified when reading MLflow config")
 	}
@@ -125,15 +175,53 @@ func GetNamespaceMLflowConfig(ctx context.Context, clientSet kubernetes.Interfac
 	if !ok || raw == "" {
 		return nil, nil
 	}
-	var cfg commonmlflow.PluginConfig
-	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader([]byte(raw)))
+	decoder.DisallowUnknownFields()
+	var cfg LauncherNamespaceConfig
+	if err := decoder.Decode(&cfg); err != nil {
 		return nil, util.NewInternalServerError(err, "failed to parse MLflow config from key %q in configmap %q/%q", LauncherConfigKey, namespace, LauncherConfigMapName)
+	}
+	var trailing json.RawMessage
+	if trailingErr := decoder.Decode(&trailing); trailingErr != io.EOF {
+		if trailingErr == nil {
+			trailingErr = fmt.Errorf("unexpected trailing JSON content")
+		}
+		return nil, util.NewInternalServerError(trailingErr, "failed to parse MLflow config from key %q in configmap %q/%q", LauncherConfigKey, namespace, LauncherConfigMapName)
 	}
 	return &cfg, nil
 }
 
+func applyLauncherNamespaceOverrides(base commonmlflow.PluginConfig, launcherCfg *LauncherNamespaceConfig) commonmlflow.PluginConfig {
+	if launcherCfg == nil {
+		return base
+	}
+	base.Settings = mergeLauncherNamespaceSettings(base.Settings, launcherCfg.Settings)
+	return base
+}
+
+func mergeLauncherNamespaceSettings(base *commonmlflow.MLflowPluginSettings, overrides *LauncherNamespaceSettings) *commonmlflow.MLflowPluginSettings {
+	if overrides == nil {
+		return base
+	}
+	if base == nil {
+		base = &commonmlflow.MLflowPluginSettings{}
+	}
+	merged := *base
+	if overrides.ExperimentDescription != nil {
+		merged.ExperimentDescription = overrides.ExperimentDescription
+	}
+	if overrides.DefaultExperimentName != "" {
+		merged.DefaultExperimentName = overrides.DefaultExperimentName
+	}
+	if overrides.InjectUserEnvVars != nil {
+		merged.InjectUserEnvVars = overrides.InjectUserEnvVars
+	}
+	return &merged
+}
+
 // ResolveMLflowRequestConfig builds a merged and validated ResolvedConfig for the
-// given namespace, combining global and namespace-level configuration.
+// given namespace, combining global config, optional server-side namespace
+// overrides, and the restricted launcher fragment.
 func ResolveMLflowRequestConfig(ctx context.Context, kubeClients KubeClientProvider, namespace string) (*ResolvedConfig, error) {
 	globalCfg, hasGlobal, err := GetGlobalMLflowConfig()
 	if err != nil {
@@ -143,11 +231,23 @@ func ResolveMLflowRequestConfig(ctx context.Context, kubeClients KubeClientProvi
 		return nil, nil
 	}
 
-	namespaceCfg, err := GetNamespaceMLflowConfig(ctx, kubeClients.GetClientSet(), namespace)
-	if err != nil {
-		return nil, err
+	mergedCfg := globalCfg
+	if common.IsMultiUserMode() {
+		serverSideNamespaceCfg, err := GetServerSideNamespaceMLflowConfig(namespace)
+		if err != nil {
+			return nil, err
+		}
+		mergedCfg = commonmlflow.MergePluginConfig(mergedCfg, serverSideNamespaceCfg)
+
+		if kubeClients == nil {
+			return nil, util.NewInternalServerError(fmt.Errorf("kubeClients is nil"), "Kubernetes clients must be provided when reading MLflow namespace config")
+		}
+		launcherNamespaceCfg, err := GetLauncherNamespaceMLflowConfig(ctx, kubeClients.GetClientSet(), namespace)
+		if err != nil {
+			return nil, err
+		}
+		mergedCfg = applyLauncherNamespaceOverrides(mergedCfg, launcherNamespaceCfg)
 	}
-	mergedCfg := commonmlflow.MergePluginConfig(globalCfg, namespaceCfg)
 	if mergedCfg.Timeout == "" {
 		mergedCfg.Timeout = DefaultTimeout
 	}

--- a/backend/src/apiserver/plugins/mlflow/config_test.go
+++ b/backend/src/apiserver/plugins/mlflow/config_test.go
@@ -27,6 +27,7 @@ import (
 
 	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
 	commonmlflow "github.com/kubeflow/pipelines/backend/src/common/plugins/mlflow"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -438,7 +439,7 @@ func TestCreateRunWithKFPTags(t *testing.T) {
 }
 
 func TestBuildPluginOutput(t *testing.T) {
-	output := SuccessfulPluginOutput("exp-1", "my-exp", "run-1", "https://mlflow.example/runs/run-1", "https://mlflow.example")
+	output := SuccessfulPluginOutput("exp-1", "my-exp", "run-1", "https://mlflow.example/runs/run-1")
 	require.NotNil(t, output)
 	assert.Equal(t, apiv2beta1.PluginState_PLUGIN_SUCCEEDED, output.State)
 	require.Contains(t, output.Entries, "run_url")
@@ -453,7 +454,7 @@ func TestSetPendingRunPluginOutput(t *testing.T) {
 		RunID:         "run-1",
 		PluginsOutput: &existing,
 	}
-	mlflowOutput := SuccessfulPluginOutput("exp-1", "my-exp", "run-1", "https://mlflow.example/runs/run-1", "https://mlflow.example")
+	mlflowOutput := SuccessfulPluginOutput("exp-1", "my-exp", "run-1", "https://mlflow.example/runs/run-1")
 	err := SetPendingRunPluginOutput(run, "mlflow", mlflowOutput)
 	require.NoError(t, err)
 	require.NotNil(t, run.PluginsOutput)
@@ -514,9 +515,10 @@ func TestResolveMLflowRequestConfig_NamespaceOnlyIsDisabled(t *testing.T) {
 			},
 			Data: map[string]string{
 				LauncherConfigKey: `{
-					"endpoint": "https://ns-mlflow.example.com",
-					"timeout": "15s",
-					"settings": {"workspacesEnabled": true}
+					"settings": {
+						"defaultExperimentName": "NamespaceDefault",
+						"injectUserEnvVars": true
+					}
 				}`,
 			},
 		},
@@ -543,6 +545,283 @@ func TestResolveMLflowRequestConfig_NeitherGlobalNorNamespace(t *testing.T) {
 	resolved, err := ResolveMLflowRequestConfig(context.Background(), kubeClients, "empty-ns")
 	require.NoError(t, err)
 	assert.Nil(t, resolved, "MLflow should be disabled when neither global nor namespace config exists")
+}
+
+func TestResolveMLflowRequestConfig_StandaloneIgnoresNamespaceLayers(t *testing.T) {
+	originalPlugins := viper.Get("plugins")
+	viper.Set("plugins", map[string]interface{}{
+		"mlflow": map[string]interface{}{
+			"endpoint": "https://global-mlflow.example.com",
+			"timeout":  "10s",
+			"settings": map[string]interface{}{
+				"defaultExperimentName": "GlobalDefault",
+			},
+			"namespaces": map[string]interface{}{
+				"ns1": map[string]interface{}{
+					"endpoint": "https://server-side-override.example.com",
+					"settings": map[string]interface{}{
+						"defaultExperimentName": "ServerDefault",
+					},
+				},
+			},
+		},
+	})
+	t.Cleanup(func() {
+		viper.Set("plugins", originalPlugins)
+	})
+	viper.Set(common.MultiUserMode, false)
+	t.Cleanup(func() {
+		viper.Set(common.MultiUserMode, nil)
+	})
+
+	clientSet := k8sfake.NewClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      LauncherConfigMapName,
+				Namespace: "ns1",
+			},
+			Data: map[string]string{
+				LauncherConfigKey: `{
+					"settings": {
+						"defaultExperimentName": "StandaloneIgnored"
+					}
+				}`,
+			},
+		},
+	)
+	kubeClients := &fakeKubeClientProvider{clientSet: clientSet}
+
+	resolved, err := ResolveMLflowRequestConfig(context.Background(), kubeClients, "ns1")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.NotNil(t, resolved.Config)
+	assert.Equal(t, "https://global-mlflow.example.com", resolved.Config.Endpoint)
+	require.NotNil(t, resolved.Settings)
+	assert.Equal(t, "GlobalDefault", resolved.Settings.DefaultExperimentName)
+}
+
+func TestResolveMLflowRequestConfig_MultiUserAppliesServerAndLauncherOverrides(t *testing.T) {
+	originalPlugins := viper.Get("plugins")
+	viper.Set("plugins", map[string]interface{}{
+		"mlflow": map[string]interface{}{
+			"endpoint": "https://global-mlflow.example.com",
+			"timeout":  "10s",
+			"settings": map[string]interface{}{
+				"workspacesEnabled": true,
+				"kfpBaseURL":        "https://global-kfp.example.com",
+			},
+			"namespaces": map[string]interface{}{
+				"ns1": map[string]interface{}{
+					"endpoint": "https://server-side-override.example.com",
+					"timeout":  "25s",
+					"settings": map[string]interface{}{
+						"workspacesEnabled": false,
+						"kfpBaseURL":        "https://server-kfp.example.com",
+					},
+				},
+			},
+		},
+	})
+	t.Cleanup(func() {
+		viper.Set("plugins", originalPlugins)
+	})
+	viper.Set(common.MultiUserMode, true)
+	t.Cleanup(func() {
+		viper.Set(common.MultiUserMode, nil)
+	})
+
+	clientSet := k8sfake.NewClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      LauncherConfigMapName,
+				Namespace: "ns1",
+			},
+			Data: map[string]string{
+				LauncherConfigKey: `{
+					"settings": {
+						"defaultExperimentName": "LauncherDefault",
+						"injectUserEnvVars": true
+					}
+				}`,
+			},
+		},
+	)
+	kubeClients := &fakeKubeClientProvider{clientSet: clientSet}
+
+	resolved, err := ResolveMLflowRequestConfig(context.Background(), kubeClients, "ns1")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.NotNil(t, resolved.Config)
+	assert.Equal(t, "https://server-side-override.example.com", resolved.Config.Endpoint)
+	assert.Equal(t, "25s", resolved.Config.Timeout)
+	require.NotNil(t, resolved.Settings)
+	require.NotNil(t, resolved.Settings.WorkspacesEnabled)
+	assert.False(t, *resolved.Settings.WorkspacesEnabled)
+	assert.Equal(t, "https://server-kfp.example.com", resolved.Settings.KFPBaseURL)
+	assert.Equal(t, "LauncherDefault", resolved.Settings.DefaultExperimentName)
+	require.NotNil(t, resolved.Settings.InjectUserEnvVars)
+	assert.True(t, *resolved.Settings.InjectUserEnvVars)
+}
+
+func TestResolveMLflowRequestConfig_MultiUserLauncherOnlyOverridesAllowedSettings(t *testing.T) {
+	originalPlugins := viper.Get("plugins")
+	viper.Set("plugins", map[string]interface{}{
+		"mlflow": map[string]interface{}{
+			"endpoint": "https://global-mlflow.example.com",
+			"timeout":  "10s",
+		},
+	})
+	t.Cleanup(func() {
+		viper.Set("plugins", originalPlugins)
+	})
+	viper.Set(common.MultiUserMode, true)
+	t.Cleanup(func() {
+		viper.Set(common.MultiUserMode, nil)
+	})
+
+	clientSet := k8sfake.NewClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      LauncherConfigMapName,
+				Namespace: "ns1",
+			},
+			Data: map[string]string{
+				LauncherConfigKey: `{
+					"settings": {
+						"experimentDescription": "LauncherDescription",
+						"defaultExperimentName": "LauncherDefault"
+					}
+				}`,
+			},
+		},
+	)
+	kubeClients := &fakeKubeClientProvider{clientSet: clientSet}
+
+	resolved, err := ResolveMLflowRequestConfig(context.Background(), kubeClients, "ns1")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	require.NotNil(t, resolved.Config)
+	assert.Equal(t, "https://global-mlflow.example.com", resolved.Config.Endpoint)
+	require.NotNil(t, resolved.Settings)
+	require.NotNil(t, resolved.Settings.ExperimentDescription)
+	assert.Equal(t, "LauncherDescription", *resolved.Settings.ExperimentDescription)
+	assert.Equal(t, "LauncherDefault", resolved.Settings.DefaultExperimentName)
+}
+
+func TestResolveMLflowRequestConfig_MultiUserGlobalOnlyAllowsEmptyNamespacePlaceholders(t *testing.T) {
+	originalPlugins := viper.Get("plugins")
+	viper.Set("plugins", map[string]interface{}{
+		"mlflow": map[string]interface{}{
+			"endpoint": "https://global-mlflow.example.com",
+			"timeout":  "10s",
+			"namespaces": map[string]interface{}{
+				"ns1": map[string]interface{}{},
+			},
+		},
+	})
+	t.Cleanup(func() {
+		viper.Set("plugins", originalPlugins)
+	})
+	viper.Set(common.MultiUserMode, true)
+	t.Cleanup(func() {
+		viper.Set(common.MultiUserMode, nil)
+	})
+
+	clientSet := k8sfake.NewClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      LauncherConfigMapName,
+				Namespace: "ns1",
+			},
+			Data: map[string]string{
+				LauncherConfigKey: `{}`,
+			},
+		},
+	)
+	kubeClients := &fakeKubeClientProvider{clientSet: clientSet}
+
+	resolved, err := ResolveMLflowRequestConfig(context.Background(), kubeClients, "ns1")
+	require.NoError(t, err)
+	require.NotNil(t, resolved)
+	assert.Equal(t, "https://global-mlflow.example.com", resolved.Config.Endpoint)
+	require.NotNil(t, resolved.Settings)
+}
+
+func TestResolveMLflowRequestConfig_MultiUserRejectsForbiddenLauncherFields(t *testing.T) {
+	originalPlugins := viper.Get("plugins")
+	viper.Set("plugins", map[string]interface{}{
+		"mlflow": map[string]interface{}{
+			"endpoint": "https://global-mlflow.example.com",
+		},
+	})
+	t.Cleanup(func() {
+		viper.Set("plugins", originalPlugins)
+	})
+	viper.Set(common.MultiUserMode, true)
+	t.Cleanup(func() {
+		viper.Set(common.MultiUserMode, nil)
+	})
+
+	clientSet := k8sfake.NewClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      LauncherConfigMapName,
+				Namespace: "ns1",
+			},
+			Data: map[string]string{
+				LauncherConfigKey: `{
+					"endpoint": "https://forbidden-launcher-endpoint.example.com"
+				}`,
+			},
+		},
+	)
+	kubeClients := &fakeKubeClientProvider{clientSet: clientSet}
+
+	resolved, err := ResolveMLflowRequestConfig(context.Background(), kubeClients, "ns1")
+	require.Error(t, err)
+	assert.Nil(t, resolved)
+	assert.Contains(t, err.Error(), `unknown field "endpoint"`)
+}
+
+func TestGetLauncherNamespaceMLflowConfig_RejectsTrailingJSON(t *testing.T) {
+	clientSet := k8sfake.NewClientset(
+		&corev1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      LauncherConfigMapName,
+				Namespace: "ns1",
+			},
+			Data: map[string]string{
+				LauncherConfigKey: `{"settings":{"defaultExperimentName":"LauncherDefault"}} true`,
+			},
+		},
+	)
+
+	cfg, err := GetLauncherNamespaceMLflowConfig(context.Background(), clientSet, "ns1")
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), "failed to parse MLflow config")
+}
+
+func TestGetServerSideNamespaceMLflowConfig_RejectsUnknownFields(t *testing.T) {
+	originalPlugins := viper.Get("plugins")
+	viper.Set("plugins", map[string]interface{}{
+		"mlflow": map[string]interface{}{
+			"endpoint": "https://global-mlflow.example.com",
+			"namespaces": map[string]interface{}{
+				"ns1": map[string]interface{}{
+					"bogusField": true,
+				},
+			},
+		},
+	})
+	t.Cleanup(func() {
+		viper.Set("plugins", originalPlugins)
+	})
+
+	cfg, err := GetServerSideNamespaceMLflowConfig("ns1")
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.Contains(t, err.Error(), `unknown field "bogusfield"`)
 }
 
 func TestResolveMLflowCredentials_EmptySAToken(t *testing.T) {

--- a/backend/src/apiserver/plugins/mlflow/dispatcher.go
+++ b/backend/src/apiserver/plugins/mlflow/dispatcher.go
@@ -67,7 +67,7 @@ func (d *Dispatcher) OnBeforeRunCreation(ctx context.Context, run *apiserverPlug
 	if err != nil {
 		message := "MLflow config resolution failed; run creation will continue: " + err.Error()
 		glog.Warningf("MLflow OnBeforeRunCreation failed for run %q (%s)", run.RunID, message)
-		pluginOutput := FailedPluginOutput(selectedID, selectedName, "", "", "", message)
+		pluginOutput := FailedPluginOutput(selectedID, selectedName, "", "", message)
 		if outputErr := SetPendingRunPluginOutput(run, PluginName, pluginOutput); outputErr != nil {
 			glog.Warningf("Failed to persist MLflow plugin output for run %q: %v", run.RunID, outputErr)
 		}

--- a/backend/src/apiserver/plugins/mlflow/handler.go
+++ b/backend/src/apiserver/plugins/mlflow/handler.go
@@ -58,8 +58,6 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 		return nil, nil
 	}
 
-	endpoint := pluginConfig.Endpoint
-
 	settings := ApplySettingsDefaults(pluginConfig.Settings)
 
 	experimentID, experimentName := SelectMLflowExperiment(h.input, settings)
@@ -67,7 +65,7 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 	resolvedCfg := &ResolvedConfig{Config: pluginConfig, Settings: settings}
 	mlflowRequestCtx, err := BuildMLflowRunRequestContext(ctx, h.namespace, resolvedCfg)
 	if err != nil {
-		return FailedPluginOutput(experimentID, experimentName, "", "", endpoint, fmt.Sprintf("failed to build MLflow request context: %v", err)), err
+		return FailedPluginOutput(experimentID, experimentName, "", "", fmt.Sprintf("failed to build MLflow request context: %v", err)), err
 	}
 
 	mlflowExperiment, err := EnsureExperimentExists(
@@ -78,13 +76,13 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 		settings.ExperimentDescription,
 	)
 	if err != nil {
-		return FailedPluginOutput(experimentID, experimentName, "", "", endpoint, err.Error()), err
+		return FailedPluginOutput(experimentID, experimentName, "", "", err.Error()), err
 	}
 
 	tags := BuildKFPTags(run, settings.KFPBaseURL, settings.KFPRunURLPathTemplate)
 	parentRunID, err := mlflowRequestCtx.Client.CreateRun(ctx, mlflowExperiment.ID, run.DisplayName, tags)
 	if err != nil {
-		return FailedPluginOutput(mlflowExperiment.ID, mlflowExperiment.Name, "", "", endpoint, err.Error()), err
+		return FailedPluginOutput(mlflowExperiment.ID, mlflowExperiment.Name, "", "", err.Error()), err
 	}
 
 	insecureSkipVerify := false
@@ -113,7 +111,7 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 	}
 	mlflowConfigJSON, err := json.Marshal(mlflowRuntimeConfig)
 	if err != nil {
-		return FailedPluginOutput(mlflowExperiment.ID, mlflowExperiment.Name, parentRunID, "", endpoint, fmt.Sprintf("failed to marshal MLflow runtime config: %v", err)), err
+		return FailedPluginOutput(mlflowExperiment.ID, mlflowExperiment.Name, parentRunID, "", fmt.Sprintf("failed to marshal MLflow runtime config: %v", err)), err
 	}
 
 	h.RunStartEnv = map[string]string{
@@ -121,7 +119,7 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 	}
 
 	runURL := BuildRunURL(mlflowRequestCtx, mlflowExperiment.ID, parentRunID, settings)
-	return SuccessfulPluginOutput(mlflowExperiment.ID, mlflowExperiment.Name, parentRunID, runURL, endpoint), nil
+	return SuccessfulPluginOutput(mlflowExperiment.ID, mlflowExperiment.Name, parentRunID, runURL), nil
 }
 
 // OnRunEnd marks the MLflow parent run and any active nested runs as
@@ -174,14 +172,6 @@ func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.Pers
 		glog.Warning(msg)
 		SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_FAILED, msg)
 		return
-	}
-
-	// Use the endpoint stored at run-start time so that in-flight runs
-	// always talk to the MLflow server where their parent run was created,
-	// even if the admin changes the endpoint while the run is in progress.
-	storedEndpoint := GetStringEntry(pluginOutput, EntryEndpoint)
-	if storedEndpoint != "" {
-		config.Endpoint = storedEndpoint
 	}
 
 	settings := ApplySettingsDefaults(config.Settings)

--- a/backend/src/apiserver/plugins/mlflow/handler_test.go
+++ b/backend/src/apiserver/plugins/mlflow/handler_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
@@ -32,6 +33,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
 // ---- Helpers ----
@@ -73,6 +75,19 @@ func testPersistedRunWithPluginOutput(id string, pluginOutput *apiv2beta1.Plugin
 		r.PluginsOutput[PluginName] = pluginOutput
 	}
 	return r
+}
+
+func addLegacyEndpointEntry(pluginOutput *apiv2beta1.PluginOutput, endpoint string) *apiv2beta1.PluginOutput {
+	if pluginOutput == nil {
+		return nil
+	}
+	if pluginOutput.Entries == nil {
+		pluginOutput.Entries = make(map[string]*apiv2beta1.MetadataValue)
+	}
+	pluginOutput.Entries["endpoint"] = &apiv2beta1.MetadataValue{
+		Value: structpb.NewStringValue(endpoint),
+	}
+	return pluginOutput
 }
 
 // ---- OnBeforeRunCreation tests ----
@@ -192,7 +207,7 @@ func TestOnRunEnd_MissingRootRunID_SetsFailedState(t *testing.T) {
 	handler := NewHandler(nil, "ns1")
 
 	// Build a run with plugin output that has no root_run_id
-	pluginOutput := SuccessfulPluginOutput("42", "Default", "", "", "")
+	pluginOutput := SuccessfulPluginOutput("42", "Default", "", "")
 	run := testPersistedRunWithPluginOutput("r-missing-root", pluginOutput)
 
 	err := handler.OnRunEnd(context.Background(), run, testPluginConfig("http://localhost"))
@@ -208,7 +223,7 @@ func TestOnRunEnd_MissingRootRunID_SetsFailedState(t *testing.T) {
 func TestOnRunEnd_NilConfig_SetsFailedState(t *testing.T) {
 	handler := NewHandler(nil, "ns1")
 
-	pluginOutput := SuccessfulPluginOutput("42", "Default", "parent-1", "", "")
+	pluginOutput := SuccessfulPluginOutput("42", "Default", "parent-1", "")
 	run := testPersistedRunWithPluginOutput("r-nil-config", pluginOutput)
 
 	err := handler.OnRunEnd(context.Background(), run, nil)
@@ -243,7 +258,7 @@ func TestOnRunEnd_Success(t *testing.T) {
 
 	handler := NewHandler(nil, "ns1")
 
-	pluginOutput := SuccessfulPluginOutput("exp-1", "Default", "mlflow-parent-1", "", server.URL)
+	pluginOutput := SuccessfulPluginOutput("exp-1", "Default", "mlflow-parent-1", "")
 	run := testPersistedRunWithPluginOutput("r-end-1", pluginOutput)
 	run.State = "SUCCEEDED"
 
@@ -275,7 +290,7 @@ func TestHandleRetry_NoPluginOutput_NoOp(t *testing.T) {
 func TestHandleRetry_MissingRootRunID_SetsFailedState(t *testing.T) {
 	handler := NewHandler(nil, "ns1")
 
-	pluginOutput := SuccessfulPluginOutput("42", "Default", "", "", "")
+	pluginOutput := SuccessfulPluginOutput("42", "Default", "", "")
 	run := testPersistedRunWithPluginOutput("r-retry-no-root", pluginOutput)
 
 	handler.HandleRetry(context.Background(), run, testPluginConfig("http://localhost"))
@@ -289,7 +304,7 @@ func TestHandleRetry_MissingRootRunID_SetsFailedState(t *testing.T) {
 func TestHandleRetry_NilConfig_SetsFailedState(t *testing.T) {
 	handler := NewHandler(nil, "ns1")
 
-	pluginOutput := SuccessfulPluginOutput("42", "Default", "parent-1", "", "")
+	pluginOutput := SuccessfulPluginOutput("42", "Default", "parent-1", "")
 	run := testPersistedRunWithPluginOutput("r-retry-nil-config", pluginOutput)
 
 	handler.HandleRetry(context.Background(), run, nil)
@@ -324,7 +339,7 @@ func TestHandleRetry_Success(t *testing.T) {
 
 	handler := NewHandler(nil, "ns1")
 
-	pluginOutput := FailedPluginOutput("exp-1", "Default", "parent-1", "", server.URL, "previous failure")
+	pluginOutput := FailedPluginOutput("exp-1", "Default", "parent-1", "", "previous failure")
 	run := testPersistedRunWithPluginOutput("r-retry-ok", pluginOutput)
 
 	handler.HandleRetry(context.Background(), run, testPluginConfig(server.URL))
@@ -340,6 +355,96 @@ func TestHandleRetry_Success(t *testing.T) {
 	result := run.PluginsOutput[PluginName]
 	require.NotNil(t, result)
 	assert.Equal(t, apiv2beta1.PluginState_PLUGIN_SUCCEEDED, result.State)
+}
+
+func TestPostRunSyncUsesResolvedConfigInsteadOfLegacyPluginOutputEndpoint(t *testing.T) {
+	tests := []struct {
+		name             string
+		pluginOutput     *apiv2beta1.PluginOutput
+		runState         string
+		wantUpdateStatus string
+		invoke           func(*Handler, *apiserverPlugins.PersistedRun, *commonmlflow.PluginConfig) error
+	}{
+		{
+			name:             "terminal sync ignores legacy endpoint entry",
+			pluginOutput:     SuccessfulPluginOutput("exp-1", "Default", "parent-1", ""),
+			runState:         "SUCCEEDED",
+			wantUpdateStatus: "FINISHED",
+			invoke: func(handler *Handler, run *apiserverPlugins.PersistedRun, config *commonmlflow.PluginConfig) error {
+				return handler.OnRunEnd(context.Background(), run, config)
+			},
+		},
+		{
+			name:             "retry sync ignores legacy endpoint entry",
+			pluginOutput:     FailedPluginOutput("exp-1", "Default", "parent-1", "", "previous failure"),
+			wantUpdateStatus: "RUNNING",
+			invoke: func(handler *Handler, run *apiserverPlugins.PersistedRun, config *commonmlflow.PluginConfig) error {
+				handler.HandleRetry(context.Background(), run, config)
+				return nil
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cleanup := setupSAToken(t)
+			defer cleanup()
+
+			var mu sync.Mutex
+			var staleCalls int
+			staleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				staleCalls++
+				mu.Unlock()
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error_code":"INTERNAL_ERROR","message":"stale endpoint should not be used"}`))
+			}))
+			defer staleServer.Close()
+
+			searchCalls := 0
+			updatePayloads := []string{}
+			freshServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/2.0/mlflow/runs/update":
+					body, _ := io.ReadAll(r.Body)
+					mu.Lock()
+					updatePayloads = append(updatePayloads, string(body))
+					mu.Unlock()
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{}`))
+				case "/api/2.0/mlflow/runs/search":
+					mu.Lock()
+					searchCalls++
+					mu.Unlock()
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"runs":[]}`))
+				default:
+					t.Fatalf("unexpected path: %s", r.URL.Path)
+				}
+			}))
+			defer freshServer.Close()
+
+			handler := NewHandler(nil, "ns1")
+			pluginOutput := addLegacyEndpointEntry(testCase.pluginOutput, staleServer.URL)
+			run := testPersistedRunWithPluginOutput("r-sync-fresh-config", pluginOutput)
+			run.State = testCase.runState
+
+			err := testCase.invoke(handler, run, testPluginConfig(freshServer.URL))
+			require.NoError(t, err)
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.Zero(t, staleCalls, "legacy plugins_output endpoint should be ignored")
+			require.Len(t, updatePayloads, 1)
+			assert.Equal(t, 1, searchCalls)
+			assert.Contains(t, updatePayloads[0], "parent-1")
+			assert.Contains(t, updatePayloads[0], testCase.wantUpdateStatus)
+
+			result := run.PluginsOutput[PluginName]
+			require.NotNil(t, result)
+			assert.Equal(t, apiv2beta1.PluginState_PLUGIN_SUCCEEDED, result.State)
+		})
+	}
 }
 
 // ---- BuildKFPRunURL tests ----
@@ -551,7 +656,7 @@ func TestModelToPersistedRun_BasicFields(t *testing.T) {
 
 func TestSerializeDeserializePluginsOutput_RoundTrip(t *testing.T) {
 	original := map[string]*apiv2beta1.PluginOutput{
-		"mlflow":       SuccessfulPluginOutput("exp-1", "Default", "parent-1", "", ""),
+		"mlflow":       SuccessfulPluginOutput("exp-1", "Default", "parent-1", ""),
 		"other_plugin": {State: apiv2beta1.PluginState_PLUGIN_SUCCEEDED},
 	}
 	lt, err := SerializePluginsOutput(original)

--- a/backend/src/apiserver/plugins/mlflow/run_start.go
+++ b/backend/src/apiserver/plugins/mlflow/run_start.go
@@ -97,7 +97,6 @@ const (
 	EntryExperimentID            = "experiment_id"
 	EntryRootRunID               = "root_run_id"
 	EntryRunURL                  = "run_url"
-	EntryEndpoint                = "endpoint"
 )
 
 type Experiment struct {
@@ -256,12 +255,12 @@ func BuildRunURL(requestCtx *commonmlflow.RequestContext, experimentID, runID st
 	return trackingUIBase + uiPathPrefix + "/#" + trackingMlflowRunPath
 }
 
-func SuccessfulPluginOutput(experimentID, experimentName, runID, runURL, endpoint string) *apiv2beta1.PluginOutput {
-	return buildPluginOutput(experimentID, experimentName, runID, runURL, endpoint, apiv2beta1.PluginState_PLUGIN_SUCCEEDED, "")
+func SuccessfulPluginOutput(experimentID, experimentName, runID, runURL string) *apiv2beta1.PluginOutput {
+	return buildPluginOutput(experimentID, experimentName, runID, runURL, apiv2beta1.PluginState_PLUGIN_SUCCEEDED, "")
 }
 
-func FailedPluginOutput(experimentID, experimentName, runID, runURL, endpoint, stateMessage string) *apiv2beta1.PluginOutput {
-	return buildPluginOutput(experimentID, experimentName, runID, runURL, endpoint, apiv2beta1.PluginState_PLUGIN_FAILED, stateMessage)
+func FailedPluginOutput(experimentID, experimentName, runID, runURL, stateMessage string) *apiv2beta1.PluginOutput {
+	return buildPluginOutput(experimentID, experimentName, runID, runURL, apiv2beta1.PluginState_PLUGIN_FAILED, stateMessage)
 }
 
 // upsertPluginOutput merges a single plugin's output into an existing
@@ -476,7 +475,7 @@ func syncNestedRuns(ctx context.Context, requestCtx *commonmlflow.RequestContext
 	return syncErrors
 }
 
-func buildPluginOutput(experimentID, experimentName, runID, runURL, endpoint string, state apiv2beta1.PluginState, stateMessage string) *apiv2beta1.PluginOutput {
+func buildPluginOutput(experimentID, experimentName, runID, runURL string, state apiv2beta1.PluginState, stateMessage string) *apiv2beta1.PluginOutput {
 	entries := map[string]*apiv2beta1.MetadataValue{}
 	if experimentName != "" {
 		entries[EntryExperimentName] = &apiv2beta1.MetadataValue{Value: structpb.NewStringValue(experimentName)}
@@ -492,9 +491,6 @@ func buildPluginOutput(experimentID, experimentName, runID, runURL, endpoint str
 			Value:      structpb.NewStringValue(runURL),
 			RenderType: apiv2beta1.MetadataValue_URL.Enum(),
 		}
-	}
-	if endpoint != "" {
-		entries[EntryEndpoint] = &apiv2beta1.MetadataValue{Value: structpb.NewStringValue(endpoint)}
 	}
 	return &apiv2beta1.PluginOutput{
 		Entries:      entries,

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -2823,7 +2823,7 @@ func TestRetryRun_ReopensMLflowParentAndFailedNestedRuns(t *testing.T) {
 
 	runWithPluginOutput, err := manager.GetRun(runDetail.UUID)
 	require.NoError(t, err)
-	mlflowOutput := apiservermlflow.SuccessfulPluginOutput("exp-1", "exp-1", "parent-run-1", server.URL+"/runs/parent-run-1", server.URL)
+	mlflowOutput := apiservermlflow.SuccessfulPluginOutput("exp-1", "exp-1", "parent-run-1", server.URL+"/runs/parent-run-1")
 	lt, err := apiservermlflow.SerializePluginsOutput(map[string]*apiv2beta1.PluginOutput{apiservermlflow.PluginName: mlflowOutput})
 	require.NoError(t, err)
 	runWithPluginOutput.PluginsOutputString = lt


### PR DESCRIPTION
**Description of your changes:**

Fixes #13582 by keeping the MLflow endpoint server-owned and limiting namespace kfp-launcher overrides to non-routing settings. This prevents a namespace ConfigMap from steering API-server MLflow requests while still allowing explicit multi-user override layering.

Use the currently resolved MLflow endpoint for terminal sync and retries instead of reusing the value stored in plugin output. This is less surprising because the configured endpoint remains the source of truth, even if DNS names or service endpoints change while the logical MLflow server stays the same.


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
