### PR TITLE
test(backend): avoid retrying permanent archived log errors

### DIFF
--- a/backend/test/testutil/archived_workflow_logs.go
+++ b/backend/test/testutil/archived_workflow_logs.go
@@ -2,8 +2,10 @@ package testutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"path"
 	"sort"
 	"strings"
@@ -65,13 +67,41 @@ func listLogKeys(ctx context.Context, client *minio.Client, bucket, prefix strin
 	return keys, nil
 }
 
+type logKeyLister func(ctx context.Context, client *minio.Client, bucket, prefix string) ([]string, error)
+
+func isPermanentLogListError(err error) bool {
+	var errorResponse minio.ErrorResponse
+	if !errors.As(err, &errorResponse) {
+		return false
+	}
+
+	switch errorResponse.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return true
+	}
+
+	switch errorResponse.Code {
+	case "AccessDenied", "InvalidAccessKeyId", "InvalidToken", "SignatureDoesNotMatch":
+		return true
+	default:
+		return false
+	}
+}
+
 func pollForLogKeys(ctx context.Context, client *minio.Client, bucket, prefix string) ([]string, time.Duration, error) {
+	return pollForLogKeysWithLister(ctx, client, bucket, prefix, listLogKeys)
+}
+
+func pollForLogKeysWithLister(ctx context.Context, client *minio.Client, bucket, prefix string, lister logKeyLister) ([]string, time.Duration, error) {
 	start := time.Now()
 	deadline := start.Add(pollTimeout)
 	for {
-		keys, err := listLogKeys(ctx, client, bucket, prefix)
+		keys, err := lister(ctx, client, bucket, prefix)
 		if err == nil && len(keys) > 0 {
 			return keys, time.Since(start), nil
+		}
+		if isPermanentLogListError(err) {
+			return nil, time.Since(start), fmt.Errorf("failed listing objects under %q: %w", prefix, err)
 		}
 		if time.Now().After(deadline) {
 			if err != nil {

--- a/backend/test/testutil/archived_workflow_logs_test.go
+++ b/backend/test/testutil/archived_workflow_logs_test.go
@@ -1,0 +1,120 @@
+package testutil
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+)
+
+func TestIsPermanentLogListError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "access denied code",
+			err:  minio.ErrorResponse{Code: "AccessDenied"},
+			want: true,
+		},
+		{
+			name: "forbidden status",
+			err:  minio.ErrorResponse{StatusCode: http.StatusForbidden},
+			want: true,
+		},
+		{
+			name: "unauthorized status",
+			err:  minio.ErrorResponse{StatusCode: http.StatusUnauthorized},
+			want: true,
+		},
+		{
+			name: "wrapped credential error",
+			err:  errors.Join(errors.New("list failed"), minio.ErrorResponse{Code: "InvalidAccessKeyId"}),
+			want: true,
+		},
+		{
+			name: "transient service error",
+			err:  minio.ErrorResponse{Code: "InternalError", StatusCode: http.StatusInternalServerError},
+			want: false,
+		},
+		{
+			name: "ordinary error",
+			err:  errors.New("temporary network failure"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPermanentLogListError(tt.err)
+			if got != tt.want {
+				t.Fatalf("isPermanentLogListError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPollForLogKeysWithListerReturnsImmediatelyOnPermanentError(t *testing.T) {
+	calls := 0
+	_, _, err := pollForLogKeysWithLister(
+		context.Background(),
+		nil,
+		"mlpipeline",
+		"private-artifacts/kubeflow-user-example-com/workflow/",
+		func(ctx context.Context, client *minio.Client, bucket, prefix string) ([]string, error) {
+			calls++
+			if calls > 1 {
+				t.Fatalf("permanent list error was retried %d times", calls)
+			}
+			return nil, minio.ErrorResponse{
+				Code:       "AccessDenied",
+				Message:    "Access Denied",
+				StatusCode: http.StatusForbidden,
+			}
+		},
+	)
+
+	if err == nil {
+		t.Fatal("pollForLogKeysWithLister() error = nil, want permanent list error")
+	}
+	if calls != 1 {
+		t.Fatalf("lister calls = %d, want 1", calls)
+	}
+	if !strings.Contains(err.Error(), "failed listing objects") {
+		t.Fatalf("error = %q, want failed listing objects context", err)
+	}
+	if !strings.Contains(err.Error(), "Access Denied") {
+		t.Fatalf("error = %q, want original Access Denied error", err)
+	}
+}
+
+func TestPollForLogKeysWithListerReturnsKeys(t *testing.T) {
+	wantKeys := []string{"private-artifacts/ns/workflow/main.log"}
+
+	gotKeys, _, err := pollForLogKeysWithLister(
+		context.Background(),
+		nil,
+		"mlpipeline",
+		"private-artifacts/ns/workflow/",
+		func(ctx context.Context, client *minio.Client, bucket, prefix string) ([]string, error) {
+			return wantKeys, nil
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("pollForLogKeysWithLister() error = %v, want nil", err)
+	}
+	if !reflect.DeepEqual(gotKeys, wantKeys) {
+		t.Fatalf("pollForLogKeysWithLister() keys = %v, want %v", gotKeys, wantKeys)
+	}
+}


### PR DESCRIPTION
## Summary
- Treat permanent S3/MinIO auth failures during archived workflow log diagnostics as non-retryable.
- Keep polling for successful, empty, and transient list responses.
- Add focused tests for permanent-error classification and poll behavior.

## Root cause
The archived log collector retried every ListObjects error until the 90s timeout. In the failing multi-user artifact-proxy E2E lane, MinIO returned AccessDenied for private-artifacts paths; retrying a permanent auth error delayed diagnostics and compounded flake time.

## Verification
- go test -count=1 ./backend/test/testutil

Related context: observed while triaging kubeflow/pipelines#13577 CI.