### PR TITLE
fix(compiler): fallback to subvar parameters for LoopArgumentVariable boundary crossing

### DIFF
--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -176,8 +176,22 @@ def build_task_spec_for_task(
             component_input_parameter = (
                 compiler_utils.additional_input_name_for_pipeline_channel(
                     input_value.loop_argument))
-            assert component_input_parameter in parent_component_inputs.parameters, \
-                f'component_input_parameter: {component_input_parameter} not found. All inputs: {parent_component_inputs}'
+
+            # When a LoopArgumentVariable crosses a group boundary (e.g. dsl.If
+            # nested inside dsl.ParallelFor with dict items), the parent group
+            # registers subvar parameters instead of the raw loop argument channel.
+            # Fall back to the subvar-qualified name in that case.
+            if component_input_parameter not in parent_component_inputs.parameters:
+                subvar_input_parameter = (
+                    compiler_utils.additional_input_name_for_pipeline_channel(
+                        input_value))
+                assert subvar_input_parameter in parent_component_inputs.parameters, \
+                    f'component_input_parameter: {component_input_parameter} not found. All inputs: {parent_component_inputs}'
+                component_input_parameter = subvar_input_parameter
+            else:
+                assert component_input_parameter in parent_component_inputs.parameters, \
+                    f'component_input_parameter: {component_input_parameter} not found. All inputs: {parent_component_inputs}'
+
             pipeline_task_spec.inputs.parameters[
                 input_name].component_input_parameter = (
                     component_input_parameter)

--- a/sdk/python/test/compilation/pipeline_compilation_test.py
+++ b/sdk/python/test/compilation/pipeline_compilation_test.py
@@ -216,6 +216,8 @@ from test_data.sdk_compiled_pipelines.valid.pipeline_with_metadata_fields import
     dataset_concatenator as pipeline_with_metadata_fields
 from test_data.sdk_compiled_pipelines.valid.pipeline_with_nested_loops import \
     my_pipeline as nested_loops_pipeline
+from test_data.sdk_compiled_pipelines.valid.pipeline_with_loop_subvars import \
+    my_pipeline as pipeline_with_loop_subvars
 from test_data.sdk_compiled_pipelines.valid.pipeline_with_parallelfor_list_artifacts import \
     my_pipeline as pipeline_with_parallelfor_list_artifacts
 from test_data.sdk_compiled_pipelines.valid.pipeline_with_parallelfor_parallelism import \
@@ -814,6 +816,13 @@ class TestPipelineCompilation:
                 pipeline_func_args=None,
                 compiled_file_name='pipeline_with_loops_and_conditions.yaml',
                 expected_compiled_file_path=f'{_VALID_PIPELINE_FILES}/pipeline_with_loops_and_conditions.yaml'
+            ),
+            TestData(
+                pipeline_name='pipeline-with-loop-subvars',
+                pipeline_func=pipeline_with_loop_subvars,
+                pipeline_func_args=None,
+                compiled_file_name='pipeline_with_loop_subvars.yaml',
+                expected_compiled_file_path=f'{_VALID_PIPELINE_FILES}/pipeline_with_loop_subvars.yaml'
             ),
             TestData(
                 pipeline_name='pipeline-with-various-io-types',

--- a/test_data/sdk_compiled_pipelines/valid/pipeline_with_loop_subvars.py
+++ b/test_data/sdk_compiled_pipelines/valid/pipeline_with_loop_subvars.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import compiler
+from kfp import dsl
+from kfp.dsl import component
+
+
+@component
+def print_op(msg: str):
+    print(msg)
+
+
+@dsl.pipeline(name='pipeline-with-loop-subvars')
+def my_pipeline():
+    with dsl.ParallelFor([{'a': '1', 'b': '2'}]) as item:
+        with dsl.If(item.a == '1'):
+            print_op(msg=item.b)
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=my_pipeline,
+        package_path=__file__.replace('.py', '.yaml'))

--- a/test_data/sdk_compiled_pipelines/valid/pipeline_with_loop_subvars.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/pipeline_with_loop_subvars.yaml
@@ -1,0 +1,99 @@
+# PIPELINE DEFINITION
+# Name: pipeline-with-loop-subvars
+components:
+  comp-condition-3:
+    dag:
+      tasks:
+        print-op:
+          cachingOptions:
+            enableCache: true
+          componentRef:
+            name: comp-print-op
+          inputs:
+            parameters:
+              msg:
+                componentInputParameter: pipelinechannel--loop-item-param-1-subvar-b
+                parameterExpressionSelector: parseJson(string_value)["b"]
+          taskInfo:
+            name: print-op
+    inputDefinitions:
+      parameters:
+        pipelinechannel--loop-item-param-1-subvar-a:
+          parameterType: STRING
+        pipelinechannel--loop-item-param-1-subvar-b:
+          parameterType: STRING
+  comp-for-loop-2:
+    dag:
+      tasks:
+        condition-3:
+          componentRef:
+            name: comp-condition-3
+          inputs:
+            parameters:
+              pipelinechannel--loop-item-param-1-subvar-a:
+                componentInputParameter: pipelinechannel--loop-item-param-1
+                parameterExpressionSelector: parseJson(string_value)["a"]
+              pipelinechannel--loop-item-param-1-subvar-b:
+                componentInputParameter: pipelinechannel--loop-item-param-1
+                parameterExpressionSelector: parseJson(string_value)["b"]
+          taskInfo:
+            name: condition-3
+          triggerPolicy:
+            condition: inputs.parameter_values['pipelinechannel--loop-item-param-1-subvar-a']
+              == '1'
+    inputDefinitions:
+      parameters:
+        pipelinechannel--loop-item-param-1:
+          parameterType: STRUCT
+  comp-print-op:
+    executorLabel: exec-print-op
+    inputDefinitions:
+      parameters:
+        msg:
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-print-op:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_op
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_op(msg: str):\n    print(msg)\n\n"
+        image: python:3.11
+pipelineInfo:
+  name: pipeline-with-loop-subvars
+root:
+  dag:
+    tasks:
+      for-loop-2:
+        componentRef:
+          name: comp-for-loop-2
+        parameterIterator:
+          itemInput: pipelinechannel--loop-item-param-1
+          items:
+            raw: '[{"a": "1", "b": "2"}]'
+        taskInfo:
+          name: for-loop-2
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.15.2


### PR DESCRIPTION
**Description of your changes:**
Fixes #13273

## Problem
When a `LoopArgumentVariable` (e.g. `item.b` from a dict-typed `dsl.ParallelFor`) 
crosses a group boundary into a nested `dsl.If`, the compiler asserts on the raw 
parent channel name (`pipelinechannel--loop-item-param-1`) but the parent group 
only registers subvar-qualified parameters (`-subvar-a`, `-subvar-b`), causing:

    AssertionError: component_input_parameter: pipelinechannel--loop-item-param-1 
    not found.

## Fix
In `build_task_spec_for_task`, when the raw parent channel is not found in 
`parent_component_inputs.parameters`, fall back to checking the subvar-qualified 
name via `additional_input_name_for_pipeline_channel(input_value)` (which includes 
the subvar suffix). If the subvar name is found, use it as `component_input_parameter`.

## Reproducer
```python
@dsl.pipeline
def my_pipeline():
    with dsl.ParallelFor([{'a': '1', 'b': '2'}]) as item:
        with dsl.If(item.a == '1'):
            print_op(msg=item.b)  # previously crashed
```

Before fix: `AssertionError` at `pipeline_spec_builder.py:179`  
After fix: Compiles successfully and generates correct PipelineSpec YAML.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).