### PR TITLE
fix(backend): avoid noisy traceback on benign metadata-writer watch timeout

### DIFF
--- a/backend/metadata_writer/src/metadata_writer.py
+++ b/backend/metadata_writer/src/metadata_writer.py
@@ -18,6 +18,7 @@ import os
 import re
 import collections
 import kubernetes
+import urllib3
 import yaml
 from time import sleep
 import lru
@@ -402,6 +403,11 @@ while True:
         # If the for loop ended, a server-side timeout occurred. Continue watching.
         pass
 
+    except urllib3.exceptions.ReadTimeoutError:
+        # The watch read timed out (e.g. on an idle cluster). This is an expected,
+        # benign event - re-establish the watch without printing a full traceback.
+        print("Watch connection timed out. Re-establishing the watch.")
+        continue
     except Exception as e:
         # Handle any errors, print stack trace, and continue watching.
         import traceback


### PR DESCRIPTION
> A note on scope: this is a small, cosmetic, logging-only change on the v1 (Argo) `metadata-writer` path - no change to control flow or recovery behavior. I realize this component is less central under v2, where the driver/launcher write metadata inline, so I kept the change as minimal and low-risk as possible. I opened it as a ready-to-review PR rather than filing an issue first just to keep the overhead low - but I'm very happy to convert it to a tracking issue, adjust the approach or wording, or drop it entirely if you'd prefer not to carry changes here. No worries either way, and thanks for taking a look!

The `metadata-writer` pod watch currently logs a full Python traceback whenever the client-side watch read times out, even though the watch loop already recovers by reconnecting.

The watch is configured with a client-side read timeout (`K8S_WATCH_CLIENT_SIDE_TIMEOUT`, default `60s`) that is shorter than the server-side watch timeout (`K8S_WATCH_SERVER_SIDE_TIMEOUT`, default `1800s`). On an idle cluster, no pod events are received, so the client-side timeout naturally expires first, raising `urllib3.exceptions.ReadTimeoutError`.

The existing `try/except` already handles this correctly by re-establishing the watch, so there is no crash, restart loop, or metadata loss. However, because the exception is handled by the generic exception path, a full traceback is logged for what is effectively a successful reconnect.

While this does not affect functionality, it can generate unnecessary log noise on idle clusters and make expected reconnects look similar to genuine watch failures when reviewing logs.

This change catches `urllib3.exceptions.ReadTimeoutError` before the generic exception handler and logs a single concise message instead. The reconnect behavior is otherwise unchanged.

Specifically:

* the existing client-side timeout remains unchanged and continues to detect genuinely stalled watches
* all other exceptions continue to be logged with a full traceback
* no new dependency is introduced (`urllib3` is already available via the Kubernetes client)

**Before**

```text
Traceback (most recent call last):
  File "/kfp/metadata_writer/metadata_writer.py", line 167, in <module>
    for event in pod_stream:
  ...
urllib3.exceptions.ReadTimeoutError: HTTPSConnectionPool(host='10.43.0.1', port=443): Read timed out.

Start watching Kubernetes Pods created by Argo
```

**After**

```text
Watch read timed out; re-establishing the watch.
Start watching Kubernetes Pods created by Argo
```

**Checklist:**

* [x] You have signed off your commits.
* [x] The PR title follows the project's title convention.
