### PR TITLE
feat: add TLS MinVersion and cipher suite CLI flags to apiserver

### DIFF
--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -191,7 +191,7 @@ func initCerts() (*tls.Config, error) {
 	}
 	tlsCfg.ServerName = common.GetMLPipelineServiceName() + "." + common.GetPodNamespace() + ".svc." + common.GetClusterDomain()
 	tlsCfg.Certificates = []tls.Certificate{serverCert}
-	glog.Infof("TLS cert key/pair loaded (MinVersion: %d)", tlsCfg.MinVersion)
+	glog.Infof("TLS cert key/pair loaded (MinVersion: %s)", *tlsMinVersion)
 	return tlsCfg, nil
 }
 

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -80,6 +80,8 @@ var (
 	sampleConfigPath              = flag.String("sampleconfig", "", "Path to samples")
 	tlsCertPath                   = flag.String("tlsCertPath", "", "Path to the public TLS cert.")
 	tlsCertKeyPath                = flag.String("tlsCertKeyPath", "", "Path to the private TLS key cert.")
+	tlsMinVersion                 = flag.String("tlsMinVersion", "VersionTLS12", "Minimum TLS version (VersionTLS12 or VersionTLS13)")
+	tlsCipherSuites               = flag.String("tlsCipherSuites", "", "Comma-separated list of TLS cipher suites (Go names from crypto/tls.CipherSuites and InsecureCipherSuites). Only applies to TLS 1.0-1.2; TLS 1.3 cipher suites are not configurable in Go. If empty, Go defaults are used.")
 	collectMetricsFlag            = flag.Bool("collectMetricsFlag", true, "Whether to collect Prometheus metrics in API server.")
 	usePipelinesKubernetesStorage = flag.Bool("pipelinesStoreKubernetes", false, "Store and run pipeline versions in Kubernetes")
 	disableWebhook                = flag.Bool("disableWebhook", false, "Set this if pipelinesStoreKubernetes is on but using a global webhook in a separate pod")
@@ -102,6 +104,63 @@ type HTTPRouterDeps struct {
 	ReadArtifact            http.HandlerFunc
 }
 
+func parseTLSVersion(version string) uint16 {
+	switch strings.TrimSpace(version) {
+	case "", "VersionTLS12":
+		return tls.VersionTLS12
+	case "VersionTLS13":
+		return tls.VersionTLS13
+	default:
+		glog.Warningf("Unrecognized TLS version %q, defaulting to VersionTLS12", version)
+		return tls.VersionTLS12
+	}
+}
+
+func parseTLSCipherSuites(commaSeparated string) []uint16 {
+	if commaSeparated == "" {
+		return nil
+	}
+	allCiphers := make(map[string]uint16)
+	for _, cs := range tls.CipherSuites() {
+		allCiphers[cs.Name] = cs.ID
+	}
+	for _, cs := range tls.InsecureCipherSuites() {
+		allCiphers[cs.Name] = cs.ID
+	}
+	var ids []uint16
+	for _, name := range strings.Split(commaSeparated, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if id, ok := allCiphers[name]; ok {
+			ids = append(ids, id)
+		} else {
+			glog.Warningf("Unknown TLS cipher suite %q, skipping", name)
+		}
+	}
+	return ids
+}
+
+func buildTLSConfig() *tls.Config {
+	cfg := &tls.Config{
+		MinVersion: parseTLSVersion(*tlsMinVersion),
+		NextProtos: []string{"h2", "http/1.1"},
+	}
+	if trimmed := strings.TrimSpace(*tlsCipherSuites); trimmed != "" {
+		if cfg.MinVersion >= tls.VersionTLS13 {
+			glog.Warningf("--tlsCipherSuites is ignored for TLS 1.3 (cipher suites are not configurable in Go for TLS 1.3)")
+		} else {
+			suites := parseTLSCipherSuites(trimmed)
+			if len(suites) == 0 {
+				glog.Fatalf("--tlsCipherSuites was set but no valid cipher suites were recognized. Use Go cipher suite names from crypto/tls.CipherSuites() or InsecureCipherSuites(). Note: TLS 1.3 cipher suites are not configurable in Go.")
+			}
+			cfg.CipherSuites = suites
+		}
+	}
+	return cfg
+}
+
 func initCerts() (*tls.Config, error) {
 	switch {
 	case *tlsCertPath == "" && *tlsCertKeyPath == "":
@@ -117,11 +176,10 @@ func initCerts() (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	tlsCfg := &tls.Config{
-		ServerName:   common.GetMLPipelineServiceName() + "." + common.GetPodNamespace() + ".svc." + common.GetClusterDomain(),
-		Certificates: []tls.Certificate{serverCert},
-	}
-	glog.Info("TLS cert key/pair loaded.")
+	tlsCfg := buildTLSConfig()
+	tlsCfg.ServerName = common.GetMLPipelineServiceName() + "." + common.GetPodNamespace() + ".svc." + common.GetClusterDomain()
+	tlsCfg.Certificates = []tls.Certificate{serverCert}
+	glog.Infof("TLS cert key/pair loaded (MinVersion: %d)", tlsCfg.MinVersion)
 	return tlsCfg, err
 }
 
@@ -544,8 +602,9 @@ func startWebhook(client ctrlclient.Client, clientNoCahe ctrlclient.Client, wg *
 	topMux.Handle("/webhooks/mutate-pipelineversion", pvMutateWebhook)
 
 	webhookServer := &http.Server{
-		Addr:    *webhookPortFlag,
-		Handler: topMux,
+		Addr:      *webhookPortFlag,
+		Handler:   topMux,
+		TLSConfig: buildTLSConfig(),
 	}
 
 	go func() {

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -116,6 +116,7 @@ func parseTLSVersion(version string) (uint16, error) {
 }
 
 func parseTLSCipherSuites(commaSeparated string) ([]uint16, error) {
+	commaSeparated = strings.TrimSpace(commaSeparated)
 	if commaSeparated == "" {
 		return nil, nil
 	}

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -104,21 +104,20 @@ type HTTPRouterDeps struct {
 	ReadArtifact            http.HandlerFunc
 }
 
-func parseTLSVersion(version string) uint16 {
+func parseTLSVersion(version string) (uint16, error) {
 	switch strings.TrimSpace(version) {
 	case "", "VersionTLS12":
-		return tls.VersionTLS12
+		return tls.VersionTLS12, nil
 	case "VersionTLS13":
-		return tls.VersionTLS13
+		return tls.VersionTLS13, nil
 	default:
-		glog.Warningf("Unrecognized TLS version %q, defaulting to VersionTLS12", version)
-		return tls.VersionTLS12
+		return 0, fmt.Errorf("unrecognized TLS version %q, valid values are VersionTLS12 and VersionTLS13", version)
 	}
 }
 
-func parseTLSCipherSuites(commaSeparated string) []uint16 {
+func parseTLSCipherSuites(commaSeparated string) ([]uint16, error) {
 	if commaSeparated == "" {
-		return nil
+		return nil, nil
 	}
 	allCiphers := make(map[string]uint16)
 	for _, cs := range tls.CipherSuites() {
@@ -128,6 +127,7 @@ func parseTLSCipherSuites(commaSeparated string) []uint16 {
 		allCiphers[cs.Name] = cs.ID
 	}
 	var ids []uint16
+	var unknown []string
 	for _, name := range strings.Split(commaSeparated, ",") {
 		name = strings.TrimSpace(name)
 		if name == "" {
@@ -136,29 +136,38 @@ func parseTLSCipherSuites(commaSeparated string) []uint16 {
 		if id, ok := allCiphers[name]; ok {
 			ids = append(ids, id)
 		} else {
-			glog.Warningf("Unknown TLS cipher suite %q, skipping", name)
+			unknown = append(unknown, name)
 		}
 	}
-	return ids
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf("unknown TLS cipher suite(s): %s. Use Go cipher suite names from crypto/tls.CipherSuites() or InsecureCipherSuites()", strings.Join(unknown, ", "))
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("--tlsCipherSuites was set but no cipher suites were specified")
+	}
+	return ids, nil
 }
 
-func buildTLSConfig() *tls.Config {
+func buildTLSConfig() (*tls.Config, error) {
+	minVersion, err := parseTLSVersion(*tlsMinVersion)
+	if err != nil {
+		return nil, fmt.Errorf("invalid --tlsMinVersion: %w", err)
+	}
 	cfg := &tls.Config{
-		MinVersion: parseTLSVersion(*tlsMinVersion),
+		MinVersion: minVersion,
 		NextProtos: []string{"h2", "http/1.1"},
 	}
 	if trimmed := strings.TrimSpace(*tlsCipherSuites); trimmed != "" {
 		if cfg.MinVersion >= tls.VersionTLS13 {
-			glog.Warningf("--tlsCipherSuites is ignored for TLS 1.3 (cipher suites are not configurable in Go for TLS 1.3)")
-		} else {
-			suites := parseTLSCipherSuites(trimmed)
-			if len(suites) == 0 {
-				glog.Fatalf("--tlsCipherSuites was set but no valid cipher suites were recognized. Use Go cipher suite names from crypto/tls.CipherSuites() or InsecureCipherSuites(). Note: TLS 1.3 cipher suites are not configurable in Go.")
-			}
-			cfg.CipherSuites = suites
+			return nil, fmt.Errorf("--tlsCipherSuites cannot be used with TLS 1.3 (cipher suites are not configurable in Go for TLS 1.3)")
 		}
+		suites, err := parseTLSCipherSuites(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --tlsCipherSuites: %w", err)
+		}
+		cfg.CipherSuites = suites
 	}
-	return cfg
+	return cfg, nil
 }
 
 func initCerts() (*tls.Config, error) {
@@ -176,11 +185,14 @@ func initCerts() (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	tlsCfg := buildTLSConfig()
+	tlsCfg, err := buildTLSConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %v", err)
+	}
 	tlsCfg.ServerName = common.GetMLPipelineServiceName() + "." + common.GetPodNamespace() + ".svc." + common.GetClusterDomain()
 	tlsCfg.Certificates = []tls.Certificate{serverCert}
 	glog.Infof("TLS cert key/pair loaded (MinVersion: %d)", tlsCfg.MinVersion)
-	return tlsCfg, err
+	return tlsCfg, nil
 }
 
 func main() {
@@ -601,10 +613,15 @@ func startWebhook(client ctrlclient.Client, clientNoCahe ctrlclient.Client, wg *
 	topMux.Handle("/webhooks/validate-pipelineversion", pvValidateWebhook)
 	topMux.Handle("/webhooks/mutate-pipelineversion", pvMutateWebhook)
 
+	tlsConfig, err := buildTLSConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %v", err)
+	}
+
 	webhookServer := &http.Server{
 		Addr:      *webhookPortFlag,
 		Handler:   topMux,
-		TLSConfig: buildTLSConfig(),
+		TLSConfig: tlsConfig,
 	}
 
 	go func() {

--- a/backend/src/apiserver/tls_config_test.go
+++ b/backend/src/apiserver/tls_config_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"crypto/tls"
+	"strings"
 	"testing"
 )
 
@@ -24,15 +25,29 @@ func TestParseTLSVersion(t *testing.T) {
 		name     string
 		input    string
 		expected uint16
+		wantErr  bool
 	}{
-		{"TLS 1.2", "VersionTLS12", tls.VersionTLS12},
-		{"TLS 1.3", "VersionTLS13", tls.VersionTLS13},
-		{"empty defaults to TLS 1.2", "", tls.VersionTLS12},
-		{"unrecognized defaults to TLS 1.2", "SomeBogusVersion", tls.VersionTLS12},
+		{"empty defaults to TLS 1.2", "", tls.VersionTLS12, false},
+		{"TLS 1.2", "VersionTLS12", tls.VersionTLS12, false},
+		{"TLS 1.3", "VersionTLS13", tls.VersionTLS13, false},
+		{"whitespace trimmed TLS 1.2", " VersionTLS12 ", tls.VersionTLS12, false},
+		{"whitespace trimmed TLS 1.3", " VersionTLS13 ", tls.VersionTLS13, false},
+		{"bogus version is error", "bogus", 0, true},
+		{"VersionTLS11 is error", "VersionTLS11", 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseTLSVersion(tt.input)
+			got, err := parseTLSVersion(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseTLSVersion(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseTLSVersion(%q) unexpected error: %v", tt.input, err)
+				return
+			}
 			if got != tt.expected {
 				t.Errorf("parseTLSVersion(%q) = %d, want %d", tt.input, got, tt.expected)
 			}
@@ -45,17 +60,31 @@ func TestParseTLSCipherSuites(t *testing.T) {
 		name      string
 		input     string
 		wantCount int
+		wantErr   bool
 	}{
-		{"empty returns nil", "", 0},
-		{"single valid cipher", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", 1},
-		{"multiple valid ciphers", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", 2},
-		{"unknown cipher skipped", "BOGUS_CIPHER", 0},
-		{"mixed valid and invalid", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,BOGUS", 1},
-		{"whitespace trimmed", " TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 , TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ", 2},
+		{"empty returns nil", "", 0, false},
+		{"single valid cipher", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", 1, false},
+		{"multiple valid ciphers", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", 2, false},
+		{"whitespace trimmed", " TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 , TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ", 2, false},
+		{"insecure cipher accepted", "TLS_RSA_WITH_RC4_128_SHA", 1, false},
+		{"unknown cipher is error", "BOGUS_CIPHER", 0, true},
+		{"mixed valid and invalid is error", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,BOGUS", 0, true},
+		{"only commas is error", ",,", 0, true},
+		{"whitespace only returns nil", "", 0, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseTLSCipherSuites(tt.input)
+			got, err := parseTLSCipherSuites(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseTLSCipherSuites(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseTLSCipherSuites(%q) unexpected error: %v", tt.input, err)
+				return
+			}
 			if len(got) != tt.wantCount {
 				t.Errorf("parseTLSCipherSuites(%q) returned %d ciphers, want %d", tt.input, len(got), tt.wantCount)
 			}
@@ -64,26 +93,178 @@ func TestParseTLSCipherSuites(t *testing.T) {
 }
 
 func TestBuildTLSConfig(t *testing.T) {
-	origMin := tlsMinVersion
-	origCiphers := tlsCipherSuites
-	t.Cleanup(func() {
-		tlsMinVersion = origMin
-		tlsCipherSuites = origCiphers
-	})
-	defaultMin := "VersionTLS12"
-	defaultCiphers := ""
-	tlsMinVersion = &defaultMin
-	tlsCipherSuites = &defaultCiphers
-
-	cfg := buildTLSConfig()
-
-	if cfg.MinVersion != tls.VersionTLS12 {
-		t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tls.VersionTLS12)
+	tests := []struct {
+		name           string
+		minVersion     string
+		cipherSuites   string
+		wantErr        bool
+		errContains    string
+		wantMinVersion uint16
+		wantCiphers    int
+	}{
+		{
+			name:           "defaults: TLS 1.2, no ciphers",
+			minVersion:     "",
+			cipherSuites:   "",
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    0,
+		},
+		{
+			name:           "explicit TLS 1.2, no ciphers",
+			minVersion:     "VersionTLS12",
+			cipherSuites:   "",
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    0,
+		},
+		{
+			name:           "TLS 1.2 with one cipher",
+			minVersion:     "VersionTLS12",
+			cipherSuites:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    1,
+		},
+		{
+			name:           "TLS 1.2 with two ciphers",
+			minVersion:     "VersionTLS12",
+			cipherSuites:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    2,
+		},
+		{
+			name:           "TLS 1.2 with insecure cipher accepted",
+			minVersion:     "VersionTLS12",
+			cipherSuites:   "TLS_RSA_WITH_RC4_128_SHA",
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    1,
+		},
+		{
+			name:           "TLS 1.3, no ciphers",
+			minVersion:     "VersionTLS13",
+			cipherSuites:   "",
+			wantMinVersion: tls.VersionTLS13,
+			wantCiphers:    0,
+		},
+		{
+			name:           "unset version with one cipher",
+			minVersion:     "",
+			cipherSuites:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    1,
+		},
+		{
+			name:           "whitespace-only ciphers treated as empty",
+			minVersion:     "VersionTLS12",
+			cipherSuites:   "   ",
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    0,
+		},
+		{
+			name:           "whitespace version trimmed",
+			minVersion:     " VersionTLS12 ",
+			cipherSuites:   "",
+			wantMinVersion: tls.VersionTLS12,
+			wantCiphers:    0,
+		},
+		// Error cases
+		{
+			name:         "bogus version is error",
+			minVersion:   "bogus",
+			cipherSuites: "",
+			wantErr:      true,
+			errContains:  "invalid --tlsMinVersion",
+		},
+		{
+			name:         "bogus version with valid ciphers is error",
+			minVersion:   "bogus",
+			cipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			wantErr:      true,
+			errContains:  "invalid --tlsMinVersion",
+		},
+		{
+			name:         "all bogus ciphers is error",
+			minVersion:   "VersionTLS12",
+			cipherSuites: "BOGUS_CIPHER",
+			wantErr:      true,
+			errContains:  "unknown TLS cipher suite",
+		},
+		{
+			name:         "mixed valid and invalid ciphers is error",
+			minVersion:   "VersionTLS12",
+			cipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,BOGUS",
+			wantErr:      true,
+			errContains:  "unknown TLS cipher suite",
+		},
+		{
+			name:         "unset version with bogus cipher is error",
+			minVersion:   "",
+			cipherSuites: "BOGUS_CIPHER",
+			wantErr:      true,
+			errContains:  "unknown TLS cipher suite",
+		},
+		{
+			name:         "only commas is error",
+			minVersion:   "VersionTLS12",
+			cipherSuites: ",,",
+			wantErr:      true,
+			errContains:  "no cipher suites were specified",
+		},
+		{
+			name:         "TLS 1.3 with ciphers is error",
+			minVersion:   "VersionTLS13",
+			cipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			wantErr:      true,
+			errContains:  "cannot be used with TLS 1.3",
+		},
+		{
+			name:         "TLS 1.3 with bogus cipher is error",
+			minVersion:   "VersionTLS13",
+			cipherSuites: "BOGUS_CIPHER",
+			wantErr:      true,
+			errContains:  "cannot be used with TLS 1.3",
+		},
+		{
+			name:         "TLS 1.3 with insecure cipher is error",
+			minVersion:   "VersionTLS13",
+			cipherSuites: "TLS_RSA_WITH_RC4_128_SHA",
+			wantErr:      true,
+			errContains:  "cannot be used with TLS 1.3",
+		},
 	}
-	if len(cfg.NextProtos) != 2 || cfg.NextProtos[0] != "h2" || cfg.NextProtos[1] != "http/1.1" {
-		t.Errorf("NextProtos = %v, want [h2 http/1.1]", cfg.NextProtos)
-	}
-	if cfg.CipherSuites != nil {
-		t.Errorf("CipherSuites should be nil when flag is empty, got %v", cfg.CipherSuites)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origMin := tlsMinVersion
+			origCiphers := tlsCipherSuites
+			t.Cleanup(func() {
+				tlsMinVersion = origMin
+				tlsCipherSuites = origCiphers
+			})
+			minVer := tt.minVersion
+			ciphers := tt.cipherSuites
+			tlsMinVersion = &minVer
+			tlsCipherSuites = &ciphers
+
+			cfg, err := buildTLSConfig()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("buildTLSConfig() expected error containing %q, got nil", tt.errContains)
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("buildTLSConfig() error = %q, want it to contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildTLSConfig() unexpected error: %v", err)
+			}
+			if cfg.MinVersion != tt.wantMinVersion {
+				t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tt.wantMinVersion)
+			}
+			if len(cfg.CipherSuites) != tt.wantCiphers {
+				t.Errorf("CipherSuites count = %d, want %d", len(cfg.CipherSuites), tt.wantCiphers)
+			}
+			if len(cfg.NextProtos) != 2 || cfg.NextProtos[0] != "h2" || cfg.NextProtos[1] != "http/1.1" {
+				t.Errorf("NextProtos = %v, want [h2 http/1.1]", cfg.NextProtos)
+			}
+		})
 	}
 }

--- a/backend/src/apiserver/tls_config_test.go
+++ b/backend/src/apiserver/tls_config_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestParseTLSVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected uint16
+	}{
+		{"TLS 1.2", "VersionTLS12", tls.VersionTLS12},
+		{"TLS 1.3", "VersionTLS13", tls.VersionTLS13},
+		{"empty defaults to TLS 1.2", "", tls.VersionTLS12},
+		{"unrecognized defaults to TLS 1.2", "SomeBogusVersion", tls.VersionTLS12},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTLSVersion(tt.input)
+			if got != tt.expected {
+				t.Errorf("parseTLSVersion(%q) = %d, want %d", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseTLSCipherSuites(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantCount int
+	}{
+		{"empty returns nil", "", 0},
+		{"single valid cipher", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", 1},
+		{"multiple valid ciphers", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", 2},
+		{"unknown cipher skipped", "BOGUS_CIPHER", 0},
+		{"mixed valid and invalid", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,BOGUS", 1},
+		{"whitespace trimmed", " TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 , TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 ", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTLSCipherSuites(tt.input)
+			if len(got) != tt.wantCount {
+				t.Errorf("parseTLSCipherSuites(%q) returned %d ciphers, want %d", tt.input, len(got), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestBuildTLSConfig(t *testing.T) {
+	origMin := tlsMinVersion
+	origCiphers := tlsCipherSuites
+	t.Cleanup(func() {
+		tlsMinVersion = origMin
+		tlsCipherSuites = origCiphers
+	})
+	defaultMin := "VersionTLS12"
+	defaultCiphers := ""
+	tlsMinVersion = &defaultMin
+	tlsCipherSuites = &defaultCiphers
+
+	cfg := buildTLSConfig()
+
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion = %d, want %d", cfg.MinVersion, tls.VersionTLS12)
+	}
+	if len(cfg.NextProtos) != 2 || cfg.NextProtos[0] != "h2" || cfg.NextProtos[1] != "http/1.1" {
+		t.Errorf("NextProtos = %v, want [h2 http/1.1]", cfg.NextProtos)
+	}
+	if cfg.CipherSuites != nil {
+		t.Errorf("CipherSuites should be nil when flag is empty, got %v", cfg.CipherSuites)
+	}
+}

--- a/backend/src/apiserver/tls_config_test.go
+++ b/backend/src/apiserver/tls_config_test.go
@@ -70,7 +70,7 @@ func TestParseTLSCipherSuites(t *testing.T) {
 		{"unknown cipher is error", "BOGUS_CIPHER", 0, true},
 		{"mixed valid and invalid is error", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,BOGUS", 0, true},
 		{"only commas is error", ",,", 0, true},
-		{"whitespace only returns nil", "", 0, false},
+		{"whitespace only returns nil", "    ", 0, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Add `--tlsMinVersion` and `--tlsCipherSuites` CLI flags to the apiserver binary so TLS configuration can be controlled externally by the deploying operator or platform.

## Changes

- `backend/src/apiserver/main.go`: Add `--tlsMinVersion` flag (default `VersionTLS12`), `--tlsCipherSuites` flag (comma-separated Go cipher names), and `buildTLSConfig()` helper
- All 3 TLS surfaces (gRPC :8887, HTTP :8888, webhook :8443) now honor the configured MinVersion, CipherSuites, and NextProtos (ALPN `["h2", "http/1.1"]`)

## Context

Platform operators (e.g., OpenShift, Kubernetes distributions with TLS policy enforcement) need to pass cluster-wide TLS security settings to operands. This change enables that without adding platform-specific dependencies to the apiserver itself. The operator reads the cluster TLS policy and passes the values via these flags in the deployment template.

## Test plan

- [x] Build passes
- [x] Integration tests pass
- [x] Backward compatible: flags have sensible defaults (TLS 1.2, Go default ciphers)