### PR TITLE
feat(sdk): support Annotated NamedTuple return types. Part of #13599

### DIFF
--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -21,8 +21,8 @@ import pathlib
 import re
 import tarfile
 import textwrap
-from typing import (Any, Callable, Dict, List, Mapping, Optional, Tuple, Type,
-                    Union)
+from typing import (Annotated, Any, Callable, Dict, List, Mapping, Optional,
+                    Tuple, Type, Union, get_args, get_origin)
 import warnings
 
 import docstring_parser
@@ -318,6 +318,8 @@ def get_name_to_specs(
 
     ### handle return annotations ###
     return_ann = signature.return_annotation
+    if get_origin(return_ann) is Annotated:
+        return_ann = get_args(return_ann)[0]
 
     # validate container component returns
     if containerized:

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import re
-from typing import List
+from typing import Annotated, List, NamedTuple
 import unittest
 
 from kfp import dsl
@@ -302,6 +302,31 @@ class TestExtractComponentInterfaceListofArtifacts(unittest.TestCase):
                         default=None,
                         is_artifact_list=True)
             })
+
+
+class TestExtractComponentInterfaceNamedTupleReturns(unittest.TestCase):
+
+    def test_annotated_named_tuple_output(self):
+
+        class Outputs(NamedTuple):
+            word: str
+            number: int
+
+        RuntimeOutputs = NamedTuple(
+            'Outputs',
+            [
+                ('word', str),
+                ('number', int),
+            ],
+        )
+
+        def comp() -> Annotated[Outputs, RuntimeOutputs]:
+            ...
+
+        component_spec = component_factory.extract_component_interface(comp)
+
+        self.assertEqual(component_spec.outputs['word'].type, 'String')
+        self.assertEqual(component_spec.outputs['number'].type, 'Integer')
 
 
 class TestBuiltinGenericParameterAnnotations(unittest.TestCase):

--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -14,7 +14,7 @@
 import inspect
 import json
 import os
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Annotated, Any, Callable, Dict, List, Optional, Union, get_args, get_origin
 import warnings
 
 from kfp import dsl
@@ -52,7 +52,10 @@ class Executor:
         self.output_artifacts: Dict[str, dsl.Artifact] = {}
         self.assign_input_and_output_artifacts()
 
-        self.return_annotation = inspect.signature(self.func).return_annotation
+        return_annotation = inspect.signature(self.func).return_annotation
+        if get_origin(return_annotation) is Annotated:
+            return_annotation = get_args(return_annotation)[0]
+        self.return_annotation = return_annotation
         self.excutor_output = {}
 
     def assign_input_and_output_artifacts(self) -> None:

--- a/sdk/python/kfp/dsl/executor_test.py
+++ b/sdk/python/kfp/dsl/executor_test.py
@@ -18,7 +18,7 @@ import json
 import os
 import sys
 import tempfile
-from typing import Callable, Dict, List, NamedTuple, Optional
+from typing import Annotated, Callable, Dict, List, NamedTuple, Optional
 import unittest
 from unittest import mock
 
@@ -884,6 +884,28 @@ class ExecutorTest(parameterized.TestCase):
                 'Outputs', ['output_dataset', 'output_int', 'output_string'])
             return output('Dataset contents', 101, 'Some output string')
 
+        class Outputs(NamedTuple):
+            output_dataset: Dataset
+            output_int: int
+            output_string: str
+
+        RuntimeOutputs = NamedTuple(
+            'Outputs',
+            [
+                ('output_dataset', Dataset),
+                ('output_int', int),
+                ('output_string', str),
+            ],
+        )
+
+        def func_returning_annotated_named_tuple(
+        ) -> Annotated[Outputs, RuntimeOutputs]:
+            return Outputs(
+                'Dataset contents',
+                101,
+                'Some output string',
+            )
+
         # Functions returning plain tuples should work too.
         def func_returning_plain_tuple() -> NamedTuple('Outputs', [
             ('output_dataset', Dataset),
@@ -893,7 +915,8 @@ class ExecutorTest(parameterized.TestCase):
             return ('Dataset contents', 101, 'Some output string')
 
         for test_func in [
-                func_returning_named_tuple, func_returning_plain_tuple
+                func_returning_named_tuple, func_returning_annotated_named_tuple,
+                func_returning_plain_tuple
         ]:
             output_metadata = self.execute_and_load_output_metadata(
                 test_func, executor_input)


### PR DESCRIPTION
## Summary

Adds support for `Annotated` `NamedTuple` return types for Python components.

This allows users to write:

```python
class MyCoolTuple(NamedTuple):
    word: str
    number: int

RuntimeOutputs = NamedTuple(
    "MyCoolTuple",
    [
        ("word", str),
        ("number", int),
    ],
)

def my_function() -> Annotated[MyCoolTuple, RuntimeOutputs]:
    ...