### PR TITLE
fix(frontend): hide read-only graph handles

### DIFF
--- a/frontend/src/components/graph/ArtifactNode.test.tsx
+++ b/frontend/src/components/graph/ArtifactNode.test.tsx
@@ -77,7 +77,12 @@ describe('ArtifactNode', () => {
 
     expect(handles).toHaveLength(2);
     handles.forEach((handle) => {
-      expect(handle).toHaveStyle({ opacity: '0' });
+      expect(handle).toHaveStyle({
+        height: '1px',
+        opacity: '0',
+        pointerEvents: 'none',
+        width: '1px',
+      });
       expect(handle).not.toHaveClass('connectable');
       expect(handle).not.toHaveClass('connectablestart');
       expect(handle).not.toHaveClass('connectableend');

--- a/frontend/src/components/graph/ArtifactNode.test.tsx
+++ b/frontend/src/components/graph/ArtifactNode.test.tsx
@@ -68,4 +68,20 @@ describe('ArtifactNode', () => {
     );
     expect(screen.getByTestId('artifact-42')).toBeInTheDocument();
   });
+
+  it('renders hidden, non-connectable edge anchors', () => {
+    const { container } = renderWithProvider(
+      <ArtifactNode id='artifact-1' data={{ label: 'anchored-artifact', state: undefined }} />,
+    );
+    const handles = container.querySelectorAll('.react-flow__handle');
+
+    expect(handles).toHaveLength(2);
+    handles.forEach((handle) => {
+      expect(handle).toHaveStyle({ opacity: '0' });
+      expect(handle).not.toHaveClass('connectable');
+      expect(handle).not.toHaveClass('connectablestart');
+      expect(handle).not.toHaveClass('connectableend');
+      expect(handle).not.toHaveClass('connectionindicator');
+    });
+  });
 });

--- a/frontend/src/components/graph/ArtifactNode.test.tsx
+++ b/frontend/src/components/graph/ArtifactNode.test.tsx
@@ -79,6 +79,8 @@ describe('ArtifactNode', () => {
     handles.forEach((handle) => {
       expect(handle).toHaveStyle({
         height: '1px',
+        minHeight: '1px',
+        minWidth: '1px',
         opacity: '0',
         pointerEvents: 'none',
         width: '1px',

--- a/frontend/src/components/graph/ArtifactNode.tsx
+++ b/frontend/src/components/graph/ArtifactNode.tsx
@@ -16,9 +16,9 @@
 
 import FolderIcon from '@mui/icons-material/Folder';
 import React from 'react';
-import { Handle, Position } from '@xyflow/react';
 import { Artifact } from 'src/third_party/mlmd';
 import { ArtifactFlowElementData } from './Constants';
+import { ReadOnlyNodeHandles } from './ReadOnlyNodeHandles';
 
 interface ArtifactNodeProps {
   id: string;
@@ -45,18 +45,7 @@ function ArtifactNode({ id, data }: ArtifactNodeProps) {
           </div>
         </div>
       </button>
-      <Handle
-        type='target'
-        position={Position.Top}
-        isValidConnection={() => false}
-        style={{ background: '#000', height: '1px', width: '1px', border: 0 }}
-      />
-      <Handle
-        type='source'
-        position={Position.Bottom}
-        isValidConnection={() => false}
-        style={{ background: '#000', height: '1px', width: '1px', border: 0 }}
-      />
+      <ReadOnlyNodeHandles />
     </>
   );
 }

--- a/frontend/src/components/graph/ExecutionNode.test.tsx
+++ b/frontend/src/components/graph/ExecutionNode.test.tsx
@@ -77,7 +77,12 @@ describe('ExecutionNode', () => {
 
     expect(handles).toHaveLength(2);
     handles.forEach((handle) => {
-      expect(handle).toHaveStyle({ opacity: '0' });
+      expect(handle).toHaveStyle({
+        height: '1px',
+        opacity: '0',
+        pointerEvents: 'none',
+        width: '1px',
+      });
       expect(handle).not.toHaveClass('connectable');
       expect(handle).not.toHaveClass('connectablestart');
       expect(handle).not.toHaveClass('connectableend');

--- a/frontend/src/components/graph/ExecutionNode.test.tsx
+++ b/frontend/src/components/graph/ExecutionNode.test.tsx
@@ -68,6 +68,22 @@ describe('ExecutionNode', () => {
     );
     expect(screen.getByTitle('titled-step')).toBeInTheDocument();
   });
+
+  it('renders hidden, non-connectable edge anchors', () => {
+    const { container } = renderWithProvider(
+      <ExecutionNode id='exec-1' data={{ label: 'anchored-step', state: undefined }} />,
+    );
+    const handles = container.querySelectorAll('.react-flow__handle');
+
+    expect(handles).toHaveLength(2);
+    handles.forEach((handle) => {
+      expect(handle).toHaveStyle({ opacity: '0' });
+      expect(handle).not.toHaveClass('connectable');
+      expect(handle).not.toHaveClass('connectablestart');
+      expect(handle).not.toHaveClass('connectableend');
+      expect(handle).not.toHaveClass('connectionindicator');
+    });
+  });
 });
 
 describe('getIcon', () => {

--- a/frontend/src/components/graph/ExecutionNode.test.tsx
+++ b/frontend/src/components/graph/ExecutionNode.test.tsx
@@ -79,6 +79,8 @@ describe('ExecutionNode', () => {
     handles.forEach((handle) => {
       expect(handle).toHaveStyle({
         height: '1px',
+        minHeight: '1px',
+        minWidth: '1px',
         opacity: '0',
         pointerEvents: 'none',
         width: '1px',

--- a/frontend/src/components/graph/ExecutionNode.tsx
+++ b/frontend/src/components/graph/ExecutionNode.tsx
@@ -21,12 +21,12 @@ import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import RemoveCircleOutlineIcon from '@mui/icons-material/RemoveCircleOutline';
 import { ReactElement } from 'react';
-import { Handle, Position } from '@xyflow/react';
 import StopCircle from 'src/icons/StopCircle';
 import { Execution } from 'src/third_party/mlmd';
 import { classes } from 'typestyle';
 import { ExecutionFlowElementData } from './Constants';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
+import { ReadOnlyNodeHandles } from './ReadOnlyNodeHandles';
 
 export interface ExecutionNodeProps {
   id: string;
@@ -63,18 +63,7 @@ function ExecutionNode({ id, data }: ExecutionNodeProps) {
           </div>
         </button>
       </div>
-      <Handle
-        type='target'
-        position={Position.Top}
-        isValidConnection={() => false}
-        style={{ background: '#000', height: '1px', width: '1px', border: 0 }}
-      />
-      <Handle
-        type='source'
-        position={Position.Bottom}
-        isValidConnection={() => false}
-        style={{ background: '#000', height: '1px', width: '1px', border: 0 }}
-      />
+      <ReadOnlyNodeHandles />
     </>
   );
 }

--- a/frontend/src/components/graph/ReadOnlyNodeHandles.tsx
+++ b/frontend/src/components/graph/ReadOnlyNodeHandles.tsx
@@ -20,6 +20,8 @@ import { Handle, Position } from '@xyflow/react';
 const hiddenHandleStyle: CSSProperties = {
   border: 0,
   height: '1px',
+  minHeight: '1px',
+  minWidth: '1px',
   opacity: 0,
   pointerEvents: 'none',
   width: '1px',

--- a/frontend/src/components/graph/ReadOnlyNodeHandles.tsx
+++ b/frontend/src/components/graph/ReadOnlyNodeHandles.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CSSProperties } from 'react';
+import { Handle, Position } from '@xyflow/react';
+
+const hiddenHandleStyle: CSSProperties = {
+  opacity: 0,
+};
+
+function ReadOnlyNodeHandle({ type, position }: { type: 'source' | 'target'; position: Position }) {
+  return (
+    <Handle
+      type={type}
+      position={position}
+      isConnectable={false}
+      isConnectableStart={false}
+      isConnectableEnd={false}
+      style={hiddenHandleStyle}
+    />
+  );
+}
+
+export function ReadOnlyNodeHandles() {
+  return (
+    <>
+      <ReadOnlyNodeHandle type='target' position={Position.Top} />
+      <ReadOnlyNodeHandle type='source' position={Position.Bottom} />
+    </>
+  );
+}

--- a/frontend/src/components/graph/ReadOnlyNodeHandles.tsx
+++ b/frontend/src/components/graph/ReadOnlyNodeHandles.tsx
@@ -18,7 +18,11 @@ import type { CSSProperties } from 'react';
 import { Handle, Position } from '@xyflow/react';
 
 const hiddenHandleStyle: CSSProperties = {
+  border: 0,
+  height: '1px',
   opacity: 0,
+  pointerEvents: 'none',
+  width: '1px',
 };
 
 function ReadOnlyNodeHandle({ type, position }: { type: 'source' | 'target'; position: Position }) {

--- a/frontend/src/components/graph/SubDagNode.test.tsx
+++ b/frontend/src/components/graph/SubDagNode.test.tsx
@@ -72,4 +72,18 @@ describe('SubDagNode', () => {
     renderWithProvider(<SubDagNode id='subdag-42' data={defaultData} />);
     expect(screen.getByTestId('subdag-42')).toBeInTheDocument();
   });
+
+  it('renders hidden, non-connectable edge anchors', () => {
+    const { container } = renderWithProvider(<SubDagNode id='subdag-1' data={defaultData} />);
+    const handles = container.querySelectorAll('.react-flow__handle');
+
+    expect(handles).toHaveLength(2);
+    handles.forEach((handle) => {
+      expect(handle).toHaveStyle({ opacity: '0' });
+      expect(handle).not.toHaveClass('connectable');
+      expect(handle).not.toHaveClass('connectablestart');
+      expect(handle).not.toHaveClass('connectableend');
+      expect(handle).not.toHaveClass('connectionindicator');
+    });
+  });
 });

--- a/frontend/src/components/graph/SubDagNode.test.tsx
+++ b/frontend/src/components/graph/SubDagNode.test.tsx
@@ -79,7 +79,12 @@ describe('SubDagNode', () => {
 
     expect(handles).toHaveLength(2);
     handles.forEach((handle) => {
-      expect(handle).toHaveStyle({ opacity: '0' });
+      expect(handle).toHaveStyle({
+        height: '1px',
+        opacity: '0',
+        pointerEvents: 'none',
+        width: '1px',
+      });
       expect(handle).not.toHaveClass('connectable');
       expect(handle).not.toHaveClass('connectablestart');
       expect(handle).not.toHaveClass('connectableend');

--- a/frontend/src/components/graph/SubDagNode.test.tsx
+++ b/frontend/src/components/graph/SubDagNode.test.tsx
@@ -81,6 +81,8 @@ describe('SubDagNode', () => {
     handles.forEach((handle) => {
       expect(handle).toHaveStyle({
         height: '1px',
+        minHeight: '1px',
+        minWidth: '1px',
         opacity: '0',
         pointerEvents: 'none',
         width: '1px',

--- a/frontend/src/components/graph/SubDagNode.tsx
+++ b/frontend/src/components/graph/SubDagNode.tsx
@@ -16,9 +16,9 @@
 
 import CropFreeIcon from '@mui/icons-material/CropFree';
 import React from 'react';
-import { Handle, Position } from '@xyflow/react';
 import { SubDagFlowElementData } from './Constants';
 import { getExecutionIcon, getIcon } from './ExecutionNode';
+import { ReadOnlyNodeHandles } from './ReadOnlyNodeHandles';
 // import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 // import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
@@ -77,20 +77,7 @@ function SubDagNode({ id, data }: SubDagNodeProps) {
           </div>
         </div>
       </button>
-      <Handle
-        type='target'
-        position={Position.Top}
-        isValidConnection={(connection) => connection.source === 'some-id'}
-        onConnect={(params) => console.log('handle onConnect', params)}
-        style={{ background: '#000', height: '1px', width: '1px', border: 0 }}
-      />
-      <Handle
-        type='source'
-        position={Position.Bottom}
-        isValidConnection={(connection) => connection.source === 'some-id'}
-        onConnect={(params) => console.log('handle onConnect', params)}
-        style={{ background: '#000', height: '1px', width: '1px', border: 0 }}
-      />
+      <ReadOnlyNodeHandles />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- replace visible/connectable React Flow handles in graph nodes with shared read-only anchors
- keep top/bottom anchors so existing static edges continue to render
- add regression coverage for execution, artifact, and sub-DAG nodes

## Regression source
The visible 1px handles were originally added in #6613, but the user-visible regression that lets users drag a temporary dead edge was introduced by #12945 when graph nodes migrated from `react-flow-renderer` to `@xyflow/react`. In `@xyflow/react`, connection drag starts from `isConnectableStart`; the existing `isValidConnection={() => false}` guard only rejected the final connection.

## Screenshots
Before, with visible graph handles:

![Before: visible graph handles](https://github.com/jeffspahr/jeffspahr-pipelines/releases/download/codex-graph-handle-screenshots-20260701/kfp-graph-handles-before.png)

After, same run and same graph framing:

![After: handles hidden with same graph framing](https://github.com/jeffspahr/jeffspahr-pipelines/releases/download/codex-graph-handle-screenshots-20260701/kfp-graph-handles-after-same-framing.png)

## Verification
- `fnm exec --using .nvmrc -- npm run test:ui -- src/components/graph/ArtifactNode.test.tsx src/components/graph/ExecutionNode.test.tsx src/components/graph/SubDagNode.test.tsx`
- `fnm exec --using .nvmrc -- npx prettier --check src/components/graph/ReadOnlyNodeHandles.tsx src/components/graph/ArtifactNode.test.tsx src/components/graph/ExecutionNode.test.tsx src/components/graph/SubDagNode.test.tsx`
- `fnm exec --using .nvmrc -- npm run build`
- Built frontend served via `npm run start:proxy-and-server` against local KFP sample run `ef1a2e62-88b4-4460-8428-696ae646e900`: graph rendered 5 nodes, 6 static edges, and 10 hidden handles
- Browser DOM validation on rebuilt asset `index-DMcCDCtC.js`: all handles computed as `width: 1px`, `height: 1px`, `min-width: 1px`, `min-height: 1px`, `opacity: 0`, `pointer-events: none`, and no connectable classes
- Browser drag probe from a handle coordinate produced no temporary React Flow connection line (`beforeConnections=0`, `afterConnections=0`)
