### PR TITLE
chore(deps): aggregate open Dependabot bumps

### DIFF
--- a/backend/metadata_writer/requirements.txt
+++ b/backend/metadata_writer/requirements.txt
@@ -22,7 +22,7 @@ google-auth==2.40.3
     # via kubernetes
 grpcio==1.74.0
     # via ml-metadata
-idna==3.10
+idna==3.15
     # via requests
 kubernetes==31.0.0
     # via -r metadata_writer/requirements.in

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -45,7 +45,7 @@ google-resumable-media==2.7.2
     # via google-cloud-storage
 googleapis-common-protos==1.70.0
     # via google-api-core
-idna==3.10
+idna==3.15
     # via requests
 kfp==2.16.0
     # via -r requirements.in
@@ -68,7 +68,7 @@ protobuf==6.33.5
     #   kfp
     #   kfp-pipeline-spec
     #   proto-plus
-pyasn1==0.6.2
+pyasn1==0.6.3
     # via
     #   pyasn1-modules
     #   rsa
@@ -102,7 +102,7 @@ six==1.17.0
     #   python-dateutil
 tabulate==0.9.0
     # via kfp
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   kfp
     #   kfp-server-api

--- a/backend/src/apiserver/visualization/requirements.in
+++ b/backend/src/apiserver/visualization/requirements.in
@@ -1,4 +1,4 @@
-bokeh==1.2.0
+bokeh==3.8.2
 gcsfs==0.2.3
 google-api-python-client==1.7.*
 itables==0.1.0

--- a/backend/src/apiserver/visualization/requirements.in
+++ b/backend/src/apiserver/visualization/requirements.in
@@ -1,4 +1,4 @@
-bokeh==3.8.2
+bokeh==1.2.0
 gcsfs==0.2.3
 google-api-python-client==1.7.*
 itables==0.1.0
@@ -7,7 +7,7 @@ ipython==7.34.0
 Jinja2>=3.1.2,<4
 jupyter-client==8.6.3
 markupsafe>=2.1.1
-nbconvert==7.16.5
+nbconvert==7.17.1
 nbformat==5.10.4
 pyarrow==14.0.1
 scikit-learn==1.5.0

--- a/backend/src/apiserver/visualization/requirements.txt
+++ b/backend/src/apiserver/visualization/requirements.txt
@@ -21,7 +21,7 @@ beautifulsoup4==4.13.5
     # via nbconvert
 bleach[css]==6.2.0
     # via nbconvert
-bokeh==1.2.0
+bokeh==3.8.2
     # via -r requirements.in
 cachetools==5.5.2
     # via google-auth
@@ -31,6 +31,8 @@ charset-normalizer==3.4.3
     # via requests
 comm==0.2.3
     # via ipykernel
+contourpy==1.3.3
+    # via bokeh
 debugpy==1.8.16
     # via ipykernel
 decorator==5.2.1
@@ -134,6 +136,8 @@ mistune==3.1.4
     # via nbconvert
 ml-dtypes==0.3.2
     # via tensorflow
+narwhals==2.15.0
+    # via bokeh
 nbclient==0.10.2
     # via nbconvert
 nbconvert==7.16.5
@@ -148,6 +152,7 @@ nest-asyncio==1.6.0
 numpy==1.26.4
     # via
     #   bokeh
+    #   contourpy
     #   h5py
     #   ml-dtypes
     #   pandas
@@ -168,7 +173,9 @@ packaging==25.0
     #   tensorflow
     #   wheel
 pandas==2.3.2
-    # via itables
+    # via
+    #   bokeh
+    #   itables
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.5
@@ -211,7 +218,6 @@ pyparsing==3.2.3
     # via httplib2
 python-dateutil==2.9.0.post0
     # via
-    #   bokeh
     #   jupyter-client
     #   pandas
 pytz==2025.2
@@ -246,7 +252,6 @@ scipy==1.16.1
 six==1.17.0
     # via
     #   astunparse
-    #   bokeh
     #   google-api-python-client
     #   google-pasta
     #   python-dateutil
@@ -317,6 +322,8 @@ wheel==0.46.2
     # via astunparse
 wrapt==1.14.2
     # via tensorflow
+xyzservices==2025.11.0
+    # via bokeh
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/backend/src/apiserver/visualization/requirements.txt
+++ b/backend/src/apiserver/visualization/requirements.txt
@@ -19,9 +19,9 @@ backcall==0.2.0
     # via ipython
 beautifulsoup4==4.13.5
     # via nbconvert
-bleach[css]==6.2.0
+bleach[css]==6.4.0
     # via nbconvert
-bokeh==3.8.2
+bokeh==1.2.0
     # via -r requirements.in
 cachetools==5.5.2
     # via google-auth
@@ -31,8 +31,6 @@ charset-normalizer==3.4.3
     # via requests
 comm==0.2.3
     # via ipykernel
-contourpy==1.3.3
-    # via bokeh
 debugpy==1.8.16
     # via ipykernel
 decorator==5.2.1
@@ -79,7 +77,7 @@ httplib2==0.30.2
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.10
+idna==3.15
     # via requests
 ipykernel==6.29.5
     # via -r requirements.in
@@ -132,15 +130,13 @@ matplotlib-inline==0.1.7
     # via
     #   ipykernel
     #   ipython
-mistune==3.1.4
+mistune==3.2.1
     # via nbconvert
 ml-dtypes==0.3.2
     # via tensorflow
-narwhals==2.15.0
-    # via bokeh
 nbclient==0.10.2
     # via nbconvert
-nbconvert==7.16.5
+nbconvert==7.17.1
     # via -r requirements.in
 nbformat==5.10.4
     # via
@@ -152,7 +148,6 @@ nest-asyncio==1.6.0
 numpy==1.26.4
     # via
     #   bokeh
-    #   contourpy
     #   h5py
     #   ml-dtypes
     #   pandas
@@ -173,9 +168,7 @@ packaging==25.0
     #   tensorflow
     #   wheel
 pandas==2.3.2
-    # via
-    #   bokeh
-    #   itables
+    # via itables
 pandocfilters==1.5.1
     # via nbconvert
 parso==0.8.5
@@ -184,7 +177,7 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==11.3.0
+pillow==12.2.0
     # via bokeh
 platformdirs==4.4.0
     # via jupyter-core
@@ -204,13 +197,13 @@ ptyprocess==0.7.0
     # via pexpect
 pyarrow==14.0.1
     # via -r requirements.in
-pyasn1==0.6.2
+pyasn1==0.6.3
     # via
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via google-auth
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   ipython
     #   nbconvert
@@ -218,6 +211,7 @@ pyparsing==3.2.3
     # via httplib2
 python-dateutil==2.9.0.post0
     # via
+    #   bokeh
     #   jupyter-client
     #   pandas
 pytz==2025.2
@@ -232,7 +226,7 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.5
+requests==2.33.0
     # via
     #   gcsfs
     #   requests-oauthlib
@@ -252,6 +246,7 @@ scipy==1.16.1
 six==1.17.0
     # via
     #   astunparse
+    #   bokeh
     #   google-api-python-client
     #   google-pasta
     #   python-dateutil
@@ -281,7 +276,7 @@ threadpoolctl==3.6.0
     # via scikit-learn
 tinycss2==1.4.0
     # via bleach
-tornado==6.5.2
+tornado==6.5.7
     # via
     #   -r requirements.in
     #   bokeh
@@ -306,7 +301,7 @@ tzdata==2025.2
     # via pandas
 uritemplate==3.0.1
     # via google-api-python-client
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests
 wcwidth==0.2.13
     # via prompt-toolkit
@@ -322,8 +317,6 @@ wheel==0.46.2
     # via astunparse
 wrapt==1.14.2
     # via tensorflow
-xyzservices==2025.11.0
-    # via bokeh
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/frontend/server/package-lock.json
+++ b/frontend/server/package-lock.json
@@ -14,7 +14,7 @@
         "google-auth-library": "^7.14.1",
         "google-protobuf": "^3.17.3",
         "gunzip-maybe": "^1.4.1",
-        "http-proxy-middleware": "^2.0.7",
+        "http-proxy-middleware": "^2.0.10",
         "js-yaml": "^4.2.0",
         "lodash": ">=4.18.1",
         "minio": "~8.0.7",
@@ -3594,9 +3594,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",

--- a/frontend/server/package.json
+++ b/frontend/server/package.json
@@ -12,7 +12,7 @@
     "google-auth-library": "^7.14.1",
     "google-protobuf": "^3.17.3",
     "gunzip-maybe": "^1.4.1",
-    "http-proxy-middleware": "^2.0.7",
+    "http-proxy-middleware": "^2.0.10",
     "js-yaml": "^4.2.0",
     "lodash": ">=4.18.1",
     "minio": "~8.0.7",

--- a/kubernetes_platform/python/requirements.txt
+++ b/kubernetes_platform/python/requirements.txt
@@ -39,7 +39,7 @@ google-resumable-media==2.8.0
     # via google-cloud-storage
 googleapis-common-protos==1.72.0
     # via google-api-core
-idna==3.11
+idna==3.15
     # via requests
 kfp==2.15.0
     # via -r requirements.in
@@ -63,7 +63,7 @@ protobuf==6.33.5
     #   kfp
     #   kfp-pipeline-spec
     #   proto-plus
-pyasn1==0.6.2
+pyasn1==0.6.3
     # via
     #   pyasn1-modules
     #   rsa

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -39,7 +39,7 @@ google-resumable-media==2.8.0
     # via google-cloud-storage
 googleapis-common-protos==1.72.0
     # via google-api-core
-idna==3.11
+idna==3.15
     # via requests
 kfp-pipeline-spec==2.15.0
     # via -r requirements.in
@@ -60,7 +60,7 @@ protobuf==6.33.5
     #   googleapis-common-protos
     #   kfp-pipeline-spec
     #   proto-plus
-pyasn1==0.6.2
+pyasn1==0.6.3
     # via
     #   pyasn1-modules
     #   rsa

--- a/test/frontend-integration-test/package-lock.json
+++ b/test/frontend-integration-test/package-lock.json
@@ -2876,9 +2876,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
-      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -2887,7 +2887,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -6157,6 +6158,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {


### PR DESCRIPTION
## Summary
- aggregate the still-relevant open Dependabot updates on top of current `master`
- bump the shared Python requirements files plus the frontend lockfiles to the latest open dependency versions
- exclude stale Dependabot PRs that already landed on `master`, were superseded by newer bumps, or target files removed from `master`

## Test plan
- [x] `git diff --check`
- [x] Parsed the edited `package.json` and lockfiles as JSON
- [ ] Let GitHub Actions run full CI