### PR TITLE
chore(deps): bump fast-xml-builder from 1.1.9 to 1.2.0 in /test/frontend-integration-test

### DIFF
--- a/test/frontend-integration-test/package-lock.json
+++ b/test/frontend-integration-test/package-lock.json
@@ -2876,9 +2876,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
-      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -2887,7 +2887,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -6157,6 +6158,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder": {


### PR DESCRIPTION
Replaces #13375, which has conflicts after `master` moved forward.

Note: #13620 is an aggregate dependency bump that also includes this lockfile update. This PR keeps the `fast-xml-builder` update isolated in case maintainers prefer a standalone replacement for #13375.

## Summary
- Regenerated `test/frontend-integration-test/package-lock.json` from current `master`.
- Bumped the transitive `fast-xml-builder` lockfile entry from `1.1.9` to `1.2.0`.
- Added the new `xml-naming@0.1.0` transitive dependency required by `fast-xml-builder@1.2.0`.

## Verification
- `npm update fast-xml-builder --package-lock-only --ignore-scripts --no-audit --no-fund`
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm ls fast-xml-builder path-expression-matcher xml-naming`
- `git diff --check`
