### PR TITLE
ci: preload runtime base images once per workflow

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -93,6 +93,7 @@ runs:
 
         if [[ -f "${RUNTIME_BASE_IMAGE_ARCHIVE}" ]]; then
           if kind --name "${{ inputs.cluster_name }}" load image-archive "${RUNTIME_BASE_IMAGE_ARCHIVE}"; then
+            rm "${RUNTIME_BASE_IMAGE_ARCHIVE}"
             exit 0
           fi
 

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -87,15 +87,21 @@ runs:
     - name: Load Runtime Base Images Into Kind
       shell: bash
       run: |
-        docker pull docker.io/alpine:3.23
-        docker pull python:3.11
-        docker pull registry.access.redhat.com/ubi9/python-311:latest
-        kind load docker-image docker.io/alpine:3.23 --name ${{ inputs.cluster_name }}
-        kind load docker-image python:3.11 --name ${{ inputs.cluster_name }}
-        kind load docker-image registry.access.redhat.com/ubi9/python-311:latest --name ${{ inputs.cluster_name }}
-        docker image rm docker.io/alpine:3.23
-        docker image rm python:3.11
-        docker image rm registry.access.redhat.com/ubi9/python-311:latest
+        set -euo pipefail
+
+        RUNTIME_BASE_IMAGE_ARCHIVE="${{ inputs.image_path }}/runtime-base-images/runtime-base-images.tar"
+
+        if [[ -f "${RUNTIME_BASE_IMAGE_ARCHIVE}" ]]; then
+          if kind --name "${{ inputs.cluster_name }}" load image-archive "${RUNTIME_BASE_IMAGE_ARCHIVE}"; then
+            exit 0
+          fi
+
+          echo "::warning::Failed to load runtime base image archive at ${RUNTIME_BASE_IMAGE_ARCHIVE}; pulling images directly."
+        else
+          echo "::warning::Runtime base image archive not found at ${RUNTIME_BASE_IMAGE_ARCHIVE}; pulling images directly."
+        fi
+        source .github/resources/scripts/helper-functions.sh
+        load_runtime_base_images_into_kind .github/resources/runtime-base-images.txt "${{ inputs.cluster_name }}"
 
     - name: Deploy Squid
       id: deploy-squid

--- a/.github/resources/runtime-base-images.txt
+++ b/.github/resources/runtime-base-images.txt
@@ -1,0 +1,3 @@
+docker.io/alpine:3.23
+python:3.11
+registry.access.redhat.com/ubi9/python-311:latest

--- a/.github/resources/scripts/helper-functions.sh
+++ b/.github/resources/scripts/helper-functions.sh
@@ -28,6 +28,86 @@ retry() {
   done
 }
 
+for_each_runtime_base_image() {
+  local images_file=$1
+  local image_callback=$2
+  local image_count=0
+  local image
+
+  while IFS= read -r image; do
+    if [[ -z "$image" || "$image" == \#* ]]; then
+      continue
+    fi
+
+    "$image_callback" "$image" || return 1
+    image_count=$((image_count+1))
+  done < "$images_file"
+
+  if [[ "$image_count" -eq 0 ]]; then
+    echo "No runtime base images configured in $images_file." >&2
+    return 1
+  fi
+}
+
+pull_image_with_backoff() {
+  local image=$1
+  local max_attempts=5
+  local attempt=1
+
+  while [[ "$attempt" -le "$max_attempts" ]]; do
+    if docker pull "$image"; then
+      return 0
+    fi
+
+    if [[ "$attempt" -eq "$max_attempts" ]]; then
+      return 1
+    fi
+
+    local sleep_seconds=$((attempt * 20))
+    echo "Retrying $image in ${sleep_seconds}s..."
+    sleep "$sleep_seconds"
+    attempt=$((attempt+1))
+  done
+}
+
+pull_and_save_runtime_base_images() {
+  local images_file=$1
+  local archive_path=$2
+  local runtime_base_images=()
+  local image
+
+  while IFS= read -r image; do
+    if [[ -z "$image" || "$image" == \#* ]]; then
+      continue
+    fi
+
+    pull_image_with_backoff "$image"
+    runtime_base_images+=("$image")
+  done < "$images_file"
+
+  if [[ "${#runtime_base_images[@]}" -eq 0 ]]; then
+    echo "No runtime base images configured in $images_file." >&2
+    return 1
+  fi
+
+  docker save "${runtime_base_images[@]}" -o "$archive_path"
+}
+
+load_runtime_base_images_into_kind() {
+  local images_file=$1
+  local cluster_name=$2
+
+  load_runtime_base_image() {
+    local image=$1
+
+    pull_image_with_backoff "$image"
+    kind --name "$cluster_name" load docker-image "$image"
+    docker image rm "$image"
+  }
+
+  for_each_runtime_base_image "$images_file" load_runtime_base_image
+}
+
 wait_for_namespace () {
     if [[ $# -ne 3 ]]
     then

--- a/.github/resources/scripts/helper-functions.sh
+++ b/.github/resources/scripts/helper-functions.sh
@@ -81,7 +81,7 @@ pull_and_save_runtime_base_images() {
       continue
     fi
 
-    pull_image_with_backoff "$image"
+    pull_image_with_backoff "$image" || return 1
     runtime_base_images+=("$image")
   done < "$images_file"
 
@@ -100,8 +100,8 @@ load_runtime_base_images_into_kind() {
   load_runtime_base_image() {
     local image=$1
 
-    pull_image_with_backoff "$image"
-    kind --name "$cluster_name" load docker-image "$image"
+    pull_image_with_backoff "$image" || return 1
+    kind --name "$cluster_name" load docker-image "$image" || return 1
     docker image rm "$image"
   }
 

--- a/.github/resources/scripts/helper-functions.sh
+++ b/.github/resources/scripts/helper-functions.sh
@@ -74,21 +74,15 @@ pull_and_save_runtime_base_images() {
   local images_file=$1
   local archive_path=$2
   local runtime_base_images=()
-  local image
 
-  while IFS= read -r image; do
-    if [[ -z "$image" || "$image" == \#* ]]; then
-      continue
-    fi
+  pull_runtime_base_image() {
+    local image=$1
 
     pull_image_with_backoff "$image" || return 1
     runtime_base_images+=("$image")
-  done < "$images_file"
+  }
 
-  if [[ "${#runtime_base_images[@]}" -eq 0 ]]; then
-    echo "No runtime base images configured in $images_file." >&2
-    return 1
-  fi
+  for_each_runtime_base_image "$images_file" pull_runtime_base_image || return 1
 
   docker save "${runtime_base_images[@]}" -o "$archive_path"
 }
@@ -102,7 +96,7 @@ load_runtime_base_images_into_kind() {
 
     pull_image_with_backoff "$image" || return 1
     kind --name "$cluster_name" load docker-image "$image" || return 1
-    docker image rm "$image"
+    docker image rm "$image" || true
   }
 
   for_each_runtime_base_image "$images_file" load_runtime_base_image

--- a/.github/workflows/image-builds.yml
+++ b/.github/workflows/image-builds.yml
@@ -19,6 +19,37 @@ env:
   GITHUB_SHA: ${{ github.sha }}
 
 jobs:
+  runtime-base-images:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+    env:
+      ARTIFACT_NAME: "runtime-base-images"
+      ARTIFACTS_PATH: "images_${{ github.run_id }}"
+      RUNTIME_BASE_IMAGE_ARCHIVE: "runtime-base-images.tar"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Create Artifacts Path Directory
+        run: mkdir -p ${{ env.ARTIFACTS_PATH }}
+
+      - name: Pull and save runtime base images
+        shell: bash
+        run: |
+          set -euo pipefail
+          source .github/resources/scripts/helper-functions.sh
+          pull_and_save_runtime_base_images \
+            .github/resources/runtime-base-images.txt \
+            "${ARTIFACTS_PATH}/${RUNTIME_BASE_IMAGE_ARCHIVE}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.ARTIFACTS_PATH }}/${{ env.RUNTIME_BASE_IMAGE_ARCHIVE }}
+          retention-days: 1
+
   image-build:
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- add a runtime base-image artifact to the reusable image build workflow
- load runtime base images from that archive in deploy jobs when available
- keep retry/backoff direct-pull fallback when the archive is missing or fails to load
- keep fallback image cleanup best-effort after images are loaded into Kind

## Verification
- `bash -n .github/resources/scripts/helper-functions.sh`
- YAML parsed with Ruby for `.github/workflows/image-builds.yml` and `.github/actions/deploy/action.yml`
- `git diff --check`
- helper simulation with fake `docker` and `kind` functions covering archive creation and non-fatal fallback cleanup

Cross-run caching is intentionally not included in this PR; that remains a follow-up discussion.
