### PR TITLE
fix(backend): avoid stale final-state labels on retry

### DIFF
--- a/backend/src/agent/persistence/worker/workflow_saver_test.go
+++ b/backend/src/agent/persistence/worker/workflow_saver_test.go
@@ -21,6 +21,7 @@ import (
 
 	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/backend/src/agent/persistence/client"
+	"github.com/kubeflow/pipelines/backend/src/agent/persistence/client/artifactclient"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -127,6 +128,56 @@ func TestWorkflow_Save_TransientFailureWhileReporting(t *testing.T) {
 	assert.Equal(t, true, util.HasCustomCode(err, util.CUSTOM_CODE_TRANSIENT))
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "transient failure")
+}
+
+func TestWorkflow_Save_RetryableReportSkipsMetrics(t *testing.T) {
+	workflowFake := client.NewWorkflowClientFake()
+	pipelineFake := client.NewPipelineClientFake()
+	pipelineFake.SetError(util.NewCustomError(fmt.Errorf("stale terminal report"), util.CUSTOM_CODE_TRANSIENT,
+		"My Transient Error"))
+
+	workflow := util.NewWorkflow(&workflowapi.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "MY_NAMESPACE",
+			Name:      "MY_NAME",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "MY_UUID"},
+		},
+		Status: workflowapi.WorkflowStatus{
+			Nodes: map[string]workflowapi.NodeStatus{
+				"node-1": {
+					ID:           "node-1",
+					TemplateName: "template-1",
+					Phase:        workflowapi.NodeSucceeded,
+					Outputs: &workflowapi.Outputs{
+						Artifacts: []workflowapi.Artifact{{Name: "mlpipeline-metrics"}},
+					},
+				},
+			},
+		},
+	})
+	metricsJSON := `{"metrics": [{"name": "accuracy", "numberValue": 0.77}]}`
+	artifactData, err := util.ArchiveTgz(map[string]string{"file": metricsJSON})
+	assert.Nil(t, err)
+	pipelineFake.StubArtifact(
+		&artifactclient.ReadArtifactRequest{
+			RunID:        "MY_UUID",
+			NodeID:       "node-1",
+			ArtifactName: "mlpipeline-metrics",
+		},
+		&artifactclient.ReadArtifactResponse{
+			Data: []byte(artifactData),
+		})
+
+	workflowFake.Put("MY_NAMESPACE", "MY_NAME", workflow)
+
+	saver := NewWorkflowSaver(workflowFake, pipelineFake, 100)
+
+	err = saver.Save("MY_KEY", "MY_NAMESPACE", "MY_NAME", 20)
+
+	assert.Equal(t, true, util.HasCustomCode(err, util.CUSTOM_CODE_TRANSIENT))
+	assert.NotNil(t, err)
+	assert.Nil(t, pipelineFake.GetReadArtifactRequest())
+	assert.Nil(t, pipelineFake.GetReportedMetricsRequest())
 }
 
 func TestWorkflow_Save_SkippedDueToFinalStatue(t *testing.T) {

--- a/backend/src/apiserver/client/workflow_fake.go
+++ b/backend/src/apiserver/client/workflow_fake.go
@@ -83,6 +83,7 @@ func (c *FakeWorkflowClient) Update(ctx context.Context, execSpec util.Execution
 	name := workflow.GetObjectMeta().GetName()
 	_, ok = c.workflows[name]
 	if ok {
+		c.workflows[name] = workflow.Workflow
 		return workflow, nil
 	}
 	return nil, k8errors.NewNotFound(k8schema.ParseGroupResource("workflows.argoproj.io"), name)

--- a/backend/src/apiserver/client/workflow_fake.go
+++ b/backend/src/apiserver/client/workflow_fake.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/golang/glog"
@@ -34,6 +35,12 @@ import (
 type FakeWorkflowClient struct {
 	workflows       map[string]*v1alpha1.Workflow
 	lastGeneratedId int
+}
+
+type jsonPatchOperation struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
 }
 
 func NewWorkflowClientFake() *FakeWorkflowClient {
@@ -107,9 +114,13 @@ func (c *FakeWorkflowClient) DeleteCollection(ctx context.Context, options v1.De
 func (c *FakeWorkflowClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions,
 	subresources ...string,
 ) (util.ExecutionSpec, error) {
-	_, ok := c.workflows[name]
+	workflow, ok := c.workflows[name]
 	if !ok {
 		return nil, k8errors.NewNotFound(k8schema.ParseGroupResource("workflows.argoproj.io"), name)
+	}
+
+	if pt == types.JSONPatchType {
+		return applyJSONPatchToFakeWorkflow(workflow, name, data)
 	}
 
 	var dat map[string]interface{}
@@ -143,6 +154,51 @@ func (c *FakeWorkflowClient) Patch(ctx context.Context, name string, pt types.Pa
 		}
 	}
 	return nil, errors.New("Failed to patch workflow")
+}
+
+func applyJSONPatchToFakeWorkflow(workflow *v1alpha1.Workflow, name string, data []byte) (util.ExecutionSpec, error) {
+	var patchOperations []jsonPatchOperation
+	if err := json.Unmarshal(data, &patchOperations); err != nil {
+		return nil, err
+	}
+
+	for _, patchOperation := range patchOperations {
+		switch patchOperation.Op {
+		case "test":
+			actualValue, ok := fakeWorkflowJSONPatchValue(workflow, patchOperation.Path)
+			if !ok || actualValue != fmt.Sprint(patchOperation.Value) {
+				return nil, k8errors.NewConflict(k8schema.ParseGroupResource("workflows.argoproj.io"), name, fmt.Errorf("json patch test failed for %s", patchOperation.Path))
+			}
+		case "add":
+			if !strings.HasPrefix(patchOperation.Path, "/metadata/labels/") {
+				return nil, fmt.Errorf("unsupported fake JSON patch add path %q", patchOperation.Path)
+			}
+			labelKey := unescapeJSONPointerPathPart(strings.TrimPrefix(patchOperation.Path, "/metadata/labels/"))
+			if workflow.Labels == nil {
+				workflow.Labels = map[string]string{}
+			}
+			workflow.Labels[labelKey] = fmt.Sprint(patchOperation.Value)
+		default:
+			return nil, fmt.Errorf("unsupported fake JSON patch operation %q", patchOperation.Op)
+		}
+	}
+
+	return util.NewWorkflow(workflow), nil
+}
+
+func fakeWorkflowJSONPatchValue(workflow *v1alpha1.Workflow, path string) (string, bool) {
+	switch path {
+	case "/metadata/resourceVersion":
+		return workflow.ResourceVersion, true
+	case "/status/phase":
+		return string(workflow.Status.Phase), true
+	default:
+		return "", false
+	}
+}
+
+func unescapeJSONPointerPathPart(pathPart string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(pathPart, "~1", "/"), "~0", "~")
 }
 
 type FakeBadWorkflowClient struct {

--- a/backend/src/apiserver/client/workflow_fake_test.go
+++ b/backend/src/apiserver/client/workflow_fake_test.go
@@ -135,8 +135,9 @@ func TestFakeWorkflowClient_Update(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update() unexpected error: %v", err)
 	}
-	workflow.SetLabels("updated-label", "true")
-	_, err = client.Update(ctx, workflow, v1.UpdateOptions{})
+	workflowWithUpdatedLabels := util.NewWorkflow(workflow.Workflow.DeepCopy())
+	workflowWithUpdatedLabels.SetLabels("updated-label", "true")
+	_, err = client.Update(ctx, workflowWithUpdatedLabels, v1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Update() unexpected error: %v", err)
 	}

--- a/backend/src/apiserver/client/workflow_fake_test.go
+++ b/backend/src/apiserver/client/workflow_fake_test.go
@@ -135,7 +135,7 @@ func TestFakeWorkflowClient_Update(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update() unexpected error: %v", err)
 	}
-	workflowWithUpdatedLabels := util.NewWorkflow(workflow.Workflow.DeepCopy())
+	workflowWithUpdatedLabels := util.NewWorkflow(workflow.DeepCopy())
 	workflowWithUpdatedLabels.SetLabels("updated-label", "true")
 	_, err = client.Update(ctx, workflowWithUpdatedLabels, v1.UpdateOptions{})
 	if err != nil {

--- a/backend/src/apiserver/client/workflow_fake_test.go
+++ b/backend/src/apiserver/client/workflow_fake_test.go
@@ -135,6 +135,18 @@ func TestFakeWorkflowClient_Update(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update() unexpected error: %v", err)
 	}
+	workflow.SetLabels("updated-label", "true")
+	_, err = client.Update(ctx, workflow, v1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Update() unexpected error: %v", err)
+	}
+	updated, err := client.Get(ctx, "update-me", v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get() unexpected error after Update(): %v", err)
+	}
+	if updated.ExecutionObjectMeta().Labels["updated-label"] != "true" {
+		t.Errorf("Update() did not persist workflow changes, got labels: %v", updated.ExecutionObjectMeta().Labels)
+	}
 }
 
 func TestFakeWorkflowClient_UpdateNotFound(t *testing.T) {

--- a/backend/src/apiserver/plugins/handler.go
+++ b/backend/src/apiserver/plugins/handler.go
@@ -52,5 +52,9 @@ type PersistedRun struct {
 // RunPluginHandler defines the generic run-level plugin lifecycle hooks
 type RunPluginHandler interface {
 	OnBeforeRunCreation(ctx context.Context, run *PendingRun, config interface{}) (*apiv2beta1.PluginOutput, error)
-	OnRunEnd(ctx context.Context, run *PersistedRun, config interface{}) error
+	// OnRunEnd is called when a run reaches a terminal state. The returned
+	// bool reports whether a failed sync is transient and worth retrying;
+	// permanent failures (for example missing or invalid plugin config)
+	// must return false so they cannot block run finalization forever.
+	OnRunEnd(ctx context.Context, run *PersistedRun, config interface{}) (bool, error)
 }

--- a/backend/src/apiserver/plugins/mlflow/dispatcher.go
+++ b/backend/src/apiserver/plugins/mlflow/dispatcher.go
@@ -97,18 +97,28 @@ func (d *Dispatcher) OnBeforeRunCreation(ctx context.Context, run *apiserverPlug
 
 // OnRunEnd syncs the MLflow parent and nested runs at terminal state.
 // Returns true if the sync succeeded or there is nothing to retry.
+// Permanent failures (for example missing or invalid MLflow config) are
+// recorded in the plugin output and reported as "nothing to retry" so a
+// broken configuration cannot strand completed runs in terminal-report
+// retry; only transient sync failures request a retry.
 func (d *Dispatcher) OnRunEnd(ctx context.Context, run *apiserverPlugins.PersistedRun) bool {
 	mlflowOutput := run.PluginsOutput[PluginName]
 	hasParentRun := mlflowOutput != nil && GetParentRunID(mlflowOutput) != ""
 
-	syncOK := d.executePostAction(ctx, run, "OnRunEnd", func(mlflowCtx context.Context, h *Handler, r *apiserverPlugins.PersistedRun, cfg *ResolvedConfig) {
-		if err := h.OnRunEnd(mlflowCtx, r, cfg); err != nil {
+	syncOK, retryRequested, persisted := d.executePostAction(ctx, run, "OnRunEnd", func(mlflowCtx context.Context, h *Handler, r *apiserverPlugins.PersistedRun, cfg *ResolvedConfig) bool {
+		retryable, err := h.OnRunEnd(mlflowCtx, r, cfg)
+		if err != nil {
 			glog.Warningf("MLflow OnRunEnd failed for run %q: %v", run.RunID, err)
 		}
+		return retryable
 	})
 
-	// Only signal retry-needed when there's a parent run that failed to close.
-	if hasParentRun && !syncOK {
+	// The plugin outcome could not be recorded; retry so it is not lost.
+	if !persisted {
+		return false
+	}
+	// Only signal retry-needed when a transient failure left a parent run open.
+	if hasParentRun && !syncOK && retryRequested {
 		return false
 	}
 	return true
@@ -116,19 +126,21 @@ func (d *Dispatcher) OnRunEnd(ctx context.Context, run *apiserverPlugins.Persist
 
 // OnRunRetry reopens the MLflow parent run and any failed/killed nested runs.
 func (d *Dispatcher) OnRunRetry(ctx context.Context, run *apiserverPlugins.PersistedRun) {
-	d.executePostAction(ctx, run, "HandleRetry", func(mlflowCtx context.Context, h *Handler, r *apiserverPlugins.PersistedRun, cfg *ResolvedConfig) {
+	d.executePostAction(ctx, run, "HandleRetry", func(mlflowCtx context.Context, h *Handler, r *apiserverPlugins.PersistedRun, cfg *ResolvedConfig) bool {
 		h.HandleRetry(mlflowCtx, r, cfg)
+		return false
 	})
 }
 
 // executePostAction handles the common setup for OnRunEnd and HandleRetry.
-// Returns true if the MLflow sync succeeded.
+// It reports whether the MLflow sync succeeded, whether the hook requested a
+// retry for a transient failure, and whether the plugin output was persisted.
 func (d *Dispatcher) executePostAction(
 	ctx context.Context,
 	run *apiserverPlugins.PersistedRun,
 	hookName string,
-	invoke func(context.Context, *Handler, *apiserverPlugins.PersistedRun, *ResolvedConfig),
-) bool {
+	invoke func(context.Context, *Handler, *apiserverPlugins.PersistedRun, *ResolvedConfig) bool,
+) (syncOK, retryRequested, persisted bool) {
 	resolvedCfg, err := ResolveMLflowRequestConfig(ctx, d.kubeClients, run.Namespace)
 	if err != nil {
 		glog.Warningf("MLflow %s: failed to resolve config for namespace %q: %v", hookName, run.Namespace, err)
@@ -142,16 +154,16 @@ func (d *Dispatcher) executePostAction(
 
 	handler := NewHandler(nil, run.Namespace)
 
-	invoke(mlflowCtx, handler, run, resolvedCfg)
+	retryRequested = invoke(mlflowCtx, handler, run, resolvedCfg)
 
-	mlflowSyncOK := false
+	syncOK = false
 	if po := run.PluginsOutput[PluginName]; po != nil {
-		mlflowSyncOK = po.State == apiv2beta1.PluginState_PLUGIN_SUCCEEDED
+		syncOK = po.State == apiv2beta1.PluginState_PLUGIN_SUCCEEDED
 	}
 
 	if err := PersistPluginsOutput(run, d.runOutputStore); err != nil {
 		glog.Warningf("MLflow %s: failed to persist plugin output for run %q: %v", hookName, run.RunID, err)
-		return false
+		return syncOK, retryRequested, false
 	}
-	return mlflowSyncOK
+	return syncOK, retryRequested, true
 }

--- a/backend/src/apiserver/plugins/mlflow/dispatcher_test.go
+++ b/backend/src/apiserver/plugins/mlflow/dispatcher_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mlflow
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apiv2beta1 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+type fakeRunPluginOutputStore struct {
+	updatedRunIDs []string
+}
+
+func (f *fakeRunPluginOutputStore) UpdateRunPluginsOutput(runID string, pluginsOutput *model.LargeText) error {
+	f.updatedRunIDs = append(f.updatedRunIDs, runID)
+	return nil
+}
+
+// TestDispatcherOnRunEnd_PermanentConfigFailureDoesNotRequestRetry covers the
+// stranded-run scenario: when the MLflow config is permanently unavailable,
+// OnRunEnd must record the failure in the plugin output and report "nothing to
+// retry" so the run can still be finalized and its workflow garbage collected.
+func TestDispatcherOnRunEnd_PermanentConfigFailureDoesNotRequestRetry(t *testing.T) {
+	originalPlugins := viper.Get("plugins")
+	viper.Set("plugins", nil)
+	t.Cleanup(func() {
+		viper.Set("plugins", originalPlugins)
+	})
+
+	outputStore := &fakeRunPluginOutputStore{}
+	dispatcher := NewRunPluginDispatcher(&fakeKubeClientProvider{clientSet: k8sfake.NewClientset()}, outputStore)
+
+	pluginOutput := SuccessfulPluginOutput("exp-1", "Default", "parent-1", "")
+	run := testPersistedRunWithPluginOutput("r-permanent-config", pluginOutput)
+	run.State = "FAILED"
+
+	assert.True(t, dispatcher.OnRunEnd(context.Background(), run),
+		"a permanent config failure must not request a retry")
+
+	result := run.PluginsOutput[PluginName]
+	require.NotNil(t, result)
+	assert.Equal(t, apiv2beta1.PluginState_PLUGIN_FAILED, result.State)
+	assert.Contains(t, result.StateMessage, "config unavailable")
+	assert.Equal(t, []string{"r-permanent-config"}, outputStore.updatedRunIDs,
+		"the failed plugin output should still be persisted")
+}
+
+// TestDispatcherOnRunEnd_TransientSyncFailureRequestsRetry verifies that a
+// failing MLflow server (as opposed to missing config) still requests a retry
+// when a parent run is left open.
+func TestDispatcherOnRunEnd_TransientSyncFailureRequestsRetry(t *testing.T) {
+	cleanup := setupSAToken(t)
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error_code":"INTERNAL_ERROR"}`))
+	}))
+	defer server.Close()
+
+	originalPlugins := viper.Get("plugins")
+	viper.Set("plugins", map[string]interface{}{
+		"mlflow": map[string]interface{}{
+			"endpoint": server.URL,
+			"timeout":  "10s",
+			"settings": map[string]interface{}{
+				"workspacesEnabled": false,
+			},
+		},
+	})
+	t.Cleanup(func() {
+		viper.Set("plugins", originalPlugins)
+	})
+
+	outputStore := &fakeRunPluginOutputStore{}
+	dispatcher := NewRunPluginDispatcher(&fakeKubeClientProvider{clientSet: k8sfake.NewClientset()}, outputStore)
+
+	pluginOutput := SuccessfulPluginOutput("exp-1", "Default", "parent-1", "")
+	run := testPersistedRunWithPluginOutput("r-transient-sync", pluginOutput)
+	run.State = "FAILED"
+
+	assert.False(t, dispatcher.OnRunEnd(context.Background(), run),
+		"a transient MLflow sync failure should request a retry")
+
+	result := run.PluginsOutput[PluginName]
+	require.NotNil(t, result)
+	assert.Equal(t, apiv2beta1.PluginState_PLUGIN_FAILED, result.State)
+	assert.Equal(t, []string{"r-transient-sync"}, outputStore.updatedRunIDs)
+}

--- a/backend/src/apiserver/plugins/mlflow/handler.go
+++ b/backend/src/apiserver/plugins/mlflow/handler.go
@@ -141,16 +141,21 @@ func (h *Handler) OnBeforeRunCreation(ctx context.Context, run *apiserverPlugins
 }
 
 // OnRunEnd marks the MLflow parent run and any active nested runs as
-// complete/failed when the KFP run reaches a terminal state.
-func (h *Handler) OnRunEnd(ctx context.Context, run *apiserverPlugins.PersistedRun, config interface{}) error {
+// complete/failed when the KFP run reaches a terminal state. The returned
+// bool reports whether a failed sync is worth retrying: transient MLflow
+// call failures request a retry, while permanent problems (missing parent
+// run id, unavailable or invalid config) are recorded in the plugin output
+// and must not block run finalization.
+func (h *Handler) OnRunEnd(ctx context.Context, run *apiserverPlugins.PersistedRun, config interface{}) (bool, error) {
 	if h == nil || run == nil {
-		return nil
+		return false, nil
 	}
-	return h.syncOnRunTerminal(ctx, run, resolveHandlerConfig(config))
+	return h.syncOnRunTerminal(ctx, run, resolveHandlerConfig(config)), nil
 }
 
 // syncOnRunTerminal marks the MLflow parent and nested runs as complete/failed.
-func (h *Handler) syncOnRunTerminal(ctx context.Context, run *apiserverPlugins.PersistedRun, config *ResolvedConfig) error {
+// It returns true when the sync failed transiently and should be retried.
+func (h *Handler) syncOnRunTerminal(ctx context.Context, run *apiserverPlugins.PersistedRun, config *ResolvedConfig) bool {
 	endTimeMs := int64(0)
 	endTimeRef := (*int64)(nil)
 	if run.FinishedAt != nil {
@@ -158,8 +163,7 @@ func (h *Handler) syncOnRunTerminal(ctx context.Context, run *apiserverPlugins.P
 		endTimeRef = &endTimeMs
 	}
 	terminalStatus := ToMLflowTerminalStatus(run.State)
-	h.syncMLflowRuns(ctx, run, config, RunSyncModeTerminal, terminalStatus, endTimeRef, "terminal")
-	return nil
+	return h.syncMLflowRuns(ctx, run, config, RunSyncModeTerminal, terminalStatus, endTimeRef, "terminal")
 }
 
 // HandleRetry reopens the MLflow parent run and any failed/killed nested runs.
@@ -168,11 +172,14 @@ func (h *Handler) HandleRetry(ctx context.Context, run *apiserverPlugins.Persist
 }
 
 // syncMLflowRuns resolves the MLflow request context, syncs the parent and nested runs, and
-// updates the plugin output state.
-func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.PersistedRun, config *ResolvedConfig, mode RunSyncMode, terminalStatus string, endTimeRef *int64, label string) {
+// updates the plugin output state. The returned bool reports whether the failure is
+// transient and worth retrying; permanent failures (missing parent run id, unavailable
+// or invalid config, unresolvable credentials) return false so callers do not retry
+// a sync that cannot succeed until an operator fixes the configuration.
+func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.PersistedRun, config *ResolvedConfig, mode RunSyncMode, terminalStatus string, endTimeRef *int64, label string) bool {
 	pluginOutput := run.PluginsOutput[PluginName]
 	if pluginOutput == nil {
-		return
+		return false
 	}
 
 	parentRunID := GetParentRunID(pluginOutput)
@@ -181,7 +188,7 @@ func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.Pers
 		msg := fmt.Sprintf("MLflow %s sync skipped: missing parent root_run_id in plugins_output.mlflow", label)
 		glog.Warning(msg)
 		SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_FAILED, msg)
-		return
+		return false
 	}
 
 	localConfig := cloneResolvedConfig(config)
@@ -189,13 +196,13 @@ func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.Pers
 		msg := fmt.Sprintf("MLflow %s sync failed: config unavailable", label)
 		glog.Warning(msg)
 		SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_FAILED, msg)
-		return
+		return false
 	}
 	if localConfig.Config.Settings == nil {
 		msg := fmt.Sprintf("MLflow %s sync failed: resolved MLflow settings are missing", label)
 		glog.Warning(msg)
 		SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_FAILED, msg)
-		return
+		return false
 	}
 
 	mlflowRequestCtx, err := BuildMLflowRunRequestContext(ctx, h.namespace, localConfig)
@@ -203,7 +210,7 @@ func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.Pers
 		msg := fmt.Sprintf("MLflow %s sync failed: %v", label, err)
 		glog.Warning(msg)
 		SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_FAILED, msg)
-		return
+		return false
 	}
 
 	syncErrors := SyncParentAndNestedRuns(ctx, mlflowRequestCtx, parentRunID, experimentID, mode, terminalStatus, endTimeRef)
@@ -211,9 +218,12 @@ func (h *Handler) syncMLflowRuns(ctx context.Context, run *apiserverPlugins.Pers
 		msg := strings.Join(syncErrors, "; ")
 		glog.Warningf("MLflow %s sync encountered errors for run %s: %s", label, run.RunID, msg)
 		SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_FAILED, msg)
-	} else {
-		SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_SUCCEEDED, "")
+		// The MLflow calls themselves failed (network, availability, or
+		// server-side errors); a later retry can succeed.
+		return true
 	}
+	SetPluginOutputState(pluginOutput, apiv2beta1.PluginState_PLUGIN_SUCCEEDED, "")
+	return false
 }
 
 func resolveHandlerConfig(config interface{}) *ResolvedConfig {

--- a/backend/src/apiserver/plugins/mlflow/handler_test.go
+++ b/backend/src/apiserver/plugins/mlflow/handler_test.go
@@ -343,15 +343,17 @@ func TestOnBeforeRunCreation_MLflowFailure_ReturnsFailedOutput(t *testing.T) {
 
 func TestOnRunEnd_NilRun_ReturnsNil(t *testing.T) {
 	handler := NewHandler(nil, "ns1")
-	err := handler.OnRunEnd(context.Background(), nil, testResolvedConfig("http://localhost"))
+	retryable, err := handler.OnRunEnd(context.Background(), nil, testResolvedConfig("http://localhost"))
 	require.NoError(t, err)
+	assert.False(t, retryable)
 }
 
 func TestOnRunEnd_NoPluginOutput_ReturnsNil(t *testing.T) {
 	handler := NewHandler(nil, "ns1")
 	run := testPersistedRun("r1")
-	err := handler.OnRunEnd(context.Background(), run, testResolvedConfig("http://localhost"))
+	retryable, err := handler.OnRunEnd(context.Background(), run, testResolvedConfig("http://localhost"))
 	require.NoError(t, err)
+	assert.False(t, retryable)
 }
 
 func TestOnRunEnd_MissingRootRunID_SetsFailedState(t *testing.T) {
@@ -361,8 +363,9 @@ func TestOnRunEnd_MissingRootRunID_SetsFailedState(t *testing.T) {
 	pluginOutput := SuccessfulPluginOutput("42", "Default", "", "")
 	run := testPersistedRunWithPluginOutput("r-missing-root", pluginOutput)
 
-	err := handler.OnRunEnd(context.Background(), run, testResolvedConfig("http://localhost"))
+	retryable, err := handler.OnRunEnd(context.Background(), run, testResolvedConfig("http://localhost"))
 	require.NoError(t, err)
+	assert.False(t, retryable, "missing parent run id is permanent and must not request a retry")
 
 	// Verify the plugin output was updated in place
 	result := run.PluginsOutput[PluginName]
@@ -377,8 +380,9 @@ func TestOnRunEnd_NilConfig_SetsFailedState(t *testing.T) {
 	pluginOutput := SuccessfulPluginOutput("42", "Default", "parent-1", "")
 	run := testPersistedRunWithPluginOutput("r-nil-config", pluginOutput)
 
-	err := handler.OnRunEnd(context.Background(), run, nil)
+	retryable, err := handler.OnRunEnd(context.Background(), run, nil)
 	require.NoError(t, err)
+	assert.False(t, retryable, "unavailable config is permanent and must not request a retry")
 
 	result := run.PluginsOutput[PluginName]
 	require.NotNil(t, result)
@@ -413,8 +417,9 @@ func TestOnRunEnd_Success(t *testing.T) {
 	run := testPersistedRunWithPluginOutput("r-end-1", pluginOutput)
 	run.State = "SUCCEEDED"
 
-	err := handler.OnRunEnd(context.Background(), run, testResolvedConfig(server.URL))
+	retryable, err := handler.OnRunEnd(context.Background(), run, testResolvedConfig(server.URL))
 	require.NoError(t, err)
+	assert.False(t, retryable)
 
 	// Parent run should have been updated
 	require.NotEmpty(t, updateCalls)
@@ -522,7 +527,8 @@ func TestPostRunSyncUsesResolvedConfigInsteadOfLegacyPluginOutputEndpoint(t *tes
 			runState:         "SUCCEEDED",
 			wantUpdateStatus: "FINISHED",
 			invoke: func(handler *Handler, run *apiserverPlugins.PersistedRun, config *ResolvedConfig) error {
-				return handler.OnRunEnd(context.Background(), run, config)
+				_, err := handler.OnRunEnd(context.Background(), run, config)
+				return err
 			},
 		},
 		{

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1538,6 +1538,19 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 	if execSpec.IsTerminating() {
 		state = model.RuntimeState(string(exec.ExecutionPhase(model.RunTerminatingConditionsV1))).ToV2()
 	}
+	if execStatus.IsInFinalState() {
+		workflowStillMatchesReport, err := r.workflowStillMatchesReportedVersion(ctx, execSpec)
+		if err != nil {
+			return nil, err
+		}
+		if !workflowStillMatchesReport {
+			return nil, terminalWorkflowReportDeferredError(
+				runId,
+				execSpec,
+				"workflow resource version changed before terminal report was persisted",
+			)
+		}
+	}
 	// If run already exists, simply update it
 	run, updateError := r.GetRun(runId)
 	if updateError == nil {
@@ -1679,65 +1692,114 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 		}
 	}
 	if execStatus.IsInFinalState() {
-		// Notify plugins of terminal state. If a plugin sync fails and
-		// needs retry, defer the persistedFinalState label so the
-		// persistence agent re-reports the workflow on its next cycle.
-		shouldPersistFinalState := true
+		// Notify plugins of terminal state. If terminal handling cannot be
+		// completed, return a retryable signal before callers report tasks or
+		// workflow metrics from a stale terminal report.
 		if run != nil && run.PluginsOutputString != nil && *run.PluginsOutputString != "" {
 			pr, prErr := apiservermlflow.ModelToPersistedRun(run, execSpec.ExecutionNamespace())
 			if prErr != nil {
 				glog.Warningf("Failed to build PersistedRun for plugin sync on run %q: %v", run.UUID, prErr)
 			} else if !r.pluginDispatcher.OnRunEnd(ctx, pr) {
 				glog.Warningf("Plugin sync failed for run %q; deferring persistedFinalState label so persistence agent retries", run.UUID)
-				shouldPersistFinalState = false
+				return nil, terminalWorkflowReportDeferredError(
+					runId,
+					execSpec,
+					"plugin terminal sync requested retry",
+				)
 			}
 		}
 
-		if shouldPersistFinalState {
-			stillMatchesReportedFinalState, err := r.runStillMatchesReportedFinalState(runId, state, execStatus.FinishedAt())
-			if err != nil {
-				return nil, err
-			}
-			shouldPersistFinalState = stillMatchesReportedFinalState
+		stillMatchesReportedFinalState, err := r.runStillMatchesReportedFinalState(runId, state, execStatus.FinishedAt())
+		if err != nil {
+			return nil, err
 		}
-
-		if shouldPersistFinalState {
-			labelAdded, err := addWorkflowLabelIfWorkflowUnchanged(
-				ctx,
-				r.getWorkflowClient(execSpec.ExecutionNamespace()),
-				execSpec.ExecutionName(),
-				execSpec.Version(),
-				util.LabelKeyWorkflowPersistedFinalState,
-				"true",
+		if !stillMatchesReportedFinalState {
+			return nil, terminalWorkflowReportDeferredError(
+				runId,
+				execSpec,
+				"run state changed while reporting terminal workflow state",
 			)
-			if err != nil {
-				message := fmt.Sprintf("Failed to add PersistedFinalState label to workflow %s", execSpec.ExecutionName())
-				// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
-				// report workflows that no longer exist. It's important to return a not found error, so that persistence
-				// agent won't retry again.
-				if util.IsNotFound(err) {
-					return nil, util.NewNotFoundError(err, "%s", message)
-				} else {
-					return nil, util.Wrapf(err, "%s", message)
-				}
+		}
+
+		labelAdded, err := addWorkflowLabelIfWorkflowUnchanged(
+			ctx,
+			r.getWorkflowClient(execSpec.ExecutionNamespace()),
+			execSpec.ExecutionName(),
+			execSpec.Version(),
+			util.LabelKeyWorkflowPersistedFinalState,
+			"true",
+		)
+		if err != nil {
+			message := fmt.Sprintf("Failed to add PersistedFinalState label to workflow %s", execSpec.ExecutionName())
+			// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
+			// report workflows that no longer exist. It's important to return a not found error, so that persistence
+			// agent won't retry again.
+			if util.IsNotFound(err) {
+				return nil, util.NewNotFoundError(err, "%s", message)
+			} else {
+				return nil, util.Wrapf(err, "%s", message)
 			}
-			if labelAdded && r.options.CollectMetrics {
-				execNamespace := execSpec.ExecutionNamespace()
-				execName := execSpec.ExecutionName()
+		}
+		if !labelAdded {
+			return nil, terminalWorkflowReportDeferredError(
+				runId,
+				execSpec,
+				"workflow resource version changed before persistedFinalState label could be added",
+			)
+		}
+		if r.options.CollectMetrics {
+			execNamespace := execSpec.ExecutionNamespace()
+			execName := execSpec.ExecutionName()
 
-				if execStatus.Condition() == exec.ExecutionSucceeded {
-					workflowSuccessCounter.WithLabelValues(execNamespace, execName).Inc()
-				} else {
-					glog.Errorf("pipeline '%s' finished with an error", execName)
+			if execStatus.Condition() == exec.ExecutionSucceeded {
+				workflowSuccessCounter.WithLabelValues(execNamespace, execName).Inc()
+			} else {
+				glog.Errorf("pipeline '%s' finished with an error", execName)
 
-					// also collects counts regarding retries
-					workflowFailedCounter.WithLabelValues(execNamespace, execName).Inc()
-				}
+				// also collects counts regarding retries
+				workflowFailedCounter.WithLabelValues(execNamespace, execName).Inc()
 			}
 		}
 	}
 	execSpec.SetLabels(util.LabelKeyWorkflowRunId, runId)
 	return execSpec, nil
+}
+
+func terminalWorkflowReportDeferredError(runID string, execSpec util.ExecutionSpec, reason string) error {
+	return util.NewUnavailableServerError(
+		errors.New(reason),
+		"Skipping terminal workflow report for run %s workflow %s: %s",
+		runID,
+		execSpec.ExecutionName(),
+		reason,
+	)
+}
+
+func (r *ResourceManager) workflowStillMatchesReportedVersion(ctx context.Context, execSpec util.ExecutionSpec) (bool, error) {
+	reportedVersion := execSpec.Version()
+	if reportedVersion == "" {
+		return true, nil
+	}
+
+	currentWorkflow, err := r.getWorkflowClient(execSpec.ExecutionNamespace()).Get(ctx, execSpec.ExecutionName(), v1.GetOptions{})
+	if err != nil {
+		message := fmt.Sprintf("Failed to verify current workflow version while reporting completed workflow %s", execSpec.ExecutionName())
+		if util.IsNotFound(err) {
+			return false, util.NewNotFoundError(err, "%s", message)
+		}
+		return false, util.Wrapf(err, "%s", message)
+	}
+	if currentWorkflow.Version() == reportedVersion {
+		return true, nil
+	}
+
+	glog.Warningf(
+		"Skip reporting terminal workflow state for workflow %q because the workflow changed before terminal reporting: reported resourceVersion=%q, current resourceVersion=%q",
+		execSpec.ExecutionName(),
+		reportedVersion,
+		currentWorkflow.Version(),
+	)
+	return false, nil
 }
 
 func (r *ResourceManager) runStillMatchesReportedFinalState(runID string, state model.RuntimeState, finishedAtInSec int64) (bool, error) {

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1682,59 +1682,62 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 		// Notify plugins of terminal state. If a plugin sync fails and
 		// needs retry, defer the persistedFinalState label so the
 		// persistence agent re-reports the workflow on its next cycle.
+		shouldPersistFinalState := true
 		if run != nil && run.PluginsOutputString != nil && *run.PluginsOutputString != "" {
 			pr, prErr := apiservermlflow.ModelToPersistedRun(run, execSpec.ExecutionNamespace())
 			if prErr != nil {
 				glog.Warningf("Failed to build PersistedRun for plugin sync on run %q: %v", run.UUID, prErr)
 			} else if !r.pluginDispatcher.OnRunEnd(ctx, pr) {
 				glog.Warningf("Plugin sync failed for run %q; deferring persistedFinalState label so persistence agent retries", run.UUID)
-				return nil, nil
+				shouldPersistFinalState = false
 			}
 		}
 
-		shouldPersistFinalState, err := r.runStillMatchesReportedFinalState(runId, state, execStatus.FinishedAt())
-		if err != nil {
-			return nil, err
-		}
-		if !shouldPersistFinalState {
-			return nil, nil
-		}
-
-		err = addWorkflowLabel(ctx, r.getWorkflowClient(execSpec.ExecutionNamespace()), execSpec.ExecutionName(), util.LabelKeyWorkflowPersistedFinalState, "true")
-		if err != nil {
-			message := fmt.Sprintf("Failed to add PersistedFinalState label to workflow %s", execSpec.ExecutionName())
-			// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
-			// report workflows that no longer exist. It's important to return a not found error, so that persistence
-			// agent won't retry again.
-			if util.IsNotFound(err) {
-				return nil, util.NewNotFoundError(err, "%s", message)
-			} else {
-				return nil, util.Wrapf(err, "%s", message)
+		if shouldPersistFinalState {
+			stillMatchesReportedFinalState, err := r.runStillMatchesReportedFinalState(runId, state, execStatus.FinishedAt())
+			if err != nil {
+				return nil, err
 			}
+			shouldPersistFinalState = stillMatchesReportedFinalState
 		}
 
-		if r.options.CollectMetrics {
-			execNamespace := execSpec.ExecutionNamespace()
-			execName := execSpec.ExecutionName()
+		if shouldPersistFinalState {
+			err := addWorkflowLabel(ctx, r.getWorkflowClient(execSpec.ExecutionNamespace()), execSpec.ExecutionName(), util.LabelKeyWorkflowPersistedFinalState, "true")
+			if err != nil {
+				message := fmt.Sprintf("Failed to add PersistedFinalState label to workflow %s", execSpec.ExecutionName())
+				// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
+				// report workflows that no longer exist. It's important to return a not found error, so that persistence
+				// agent won't retry again.
+				if util.IsNotFound(err) {
+					return nil, util.NewNotFoundError(err, "%s", message)
+				} else {
+					return nil, util.Wrapf(err, "%s", message)
+				}
+			}
 
-			if execStatus.Condition() == exec.ExecutionSucceeded {
-				workflowSuccessCounter.WithLabelValues(execNamespace, execName).Inc()
-			} else {
-				glog.Errorf("pipeline '%s' finished with an error", execName)
+			if r.options.CollectMetrics {
+				execNamespace := execSpec.ExecutionNamespace()
+				execName := execSpec.ExecutionName()
 
-				// also collects counts regarding retries
-				workflowFailedCounter.WithLabelValues(execNamespace, execName).Inc()
+				if execStatus.Condition() == exec.ExecutionSucceeded {
+					workflowSuccessCounter.WithLabelValues(execNamespace, execName).Inc()
+				} else {
+					glog.Errorf("pipeline '%s' finished with an error", execName)
+
+					// also collects counts regarding retries
+					workflowFailedCounter.WithLabelValues(execNamespace, execName).Inc()
+				}
 			}
 		}
 	}
-	execSpec.SetLabels("pipeline/runid", runId)
+	execSpec.SetLabels(util.LabelKeyWorkflowRunId, runId)
 	return execSpec, nil
 }
 
-func (r *ResourceManager) runStillMatchesReportedFinalState(runId string, state model.RuntimeState, finishedAtInSec int64) (bool, error) {
-	currentRun, err := r.GetRun(runId)
+func (r *ResourceManager) runStillMatchesReportedFinalState(runID string, state model.RuntimeState, finishedAtInSec int64) (bool, error) {
+	currentRun, err := r.GetRun(runID)
 	if err != nil {
-		return false, util.Wrapf(err, "Failed to verify current state for completed workflow report on run %s", runId)
+		return false, util.Wrapf(err, "Failed to verify current state for completed workflow report on run %s", runID)
 	}
 	if currentRun.State == state && currentRun.FinishedAtInSec == finishedAtInSec {
 		return true, nil
@@ -1742,7 +1745,7 @@ func (r *ResourceManager) runStillMatchesReportedFinalState(runId string, state 
 
 	glog.Warningf(
 		"Skip adding persistedFinalState label for run %q because the run changed while reporting the terminal workflow state: reported state=%q finishedAt=%d, current state=%q finishedAt=%d",
-		runId,
+		runID,
 		state,
 		finishedAtInSec,
 		currentRun.State,

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1793,7 +1793,7 @@ func addWorkflowLabelIfWorkflowUnchanged(
 
 	patch, err := json.Marshal(patchObj)
 	if err != nil {
-		return false, util.NewInternalServerError(err, "Unexpected error while marshalling a patch object")
+		return false, util.NewInternalServerError(err, "Unexpected error while marshaling a patch object")
 	}
 
 	operation := func() error {

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1692,7 +1692,15 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 			}
 		}
 
-		err := addWorkflowLabel(ctx, r.getWorkflowClient(execSpec.ExecutionNamespace()), execSpec.ExecutionName(), util.LabelKeyWorkflowPersistedFinalState, "true")
+		shouldPersistFinalState, err := r.runStillMatchesReportedFinalState(runId, state, execStatus.FinishedAt())
+		if err != nil {
+			return nil, err
+		}
+		if !shouldPersistFinalState {
+			return nil, nil
+		}
+
+		err = addWorkflowLabel(ctx, r.getWorkflowClient(execSpec.ExecutionNamespace()), execSpec.ExecutionName(), util.LabelKeyWorkflowPersistedFinalState, "true")
 		if err != nil {
 			message := fmt.Sprintf("Failed to add PersistedFinalState label to workflow %s", execSpec.ExecutionName())
 			// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
@@ -1721,6 +1729,26 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 	}
 	execSpec.SetLabels("pipeline/runid", runId)
 	return execSpec, nil
+}
+
+func (r *ResourceManager) runStillMatchesReportedFinalState(runId string, state model.RuntimeState, finishedAtInSec int64) (bool, error) {
+	currentRun, err := r.GetRun(runId)
+	if err != nil {
+		return false, util.Wrapf(err, "Failed to verify current state for completed workflow report on run %s", runId)
+	}
+	if currentRun.State == state && currentRun.FinishedAtInSec == finishedAtInSec {
+		return true, nil
+	}
+
+	glog.Warningf(
+		"Skip adding persistedFinalState label for run %q because the run changed while reporting the terminal workflow state: reported state=%q finishedAt=%d, current state=%q finishedAt=%d",
+		runId,
+		state,
+		finishedAtInSec,
+		currentRun.State,
+		currentRun.FinishedAtInSec,
+	)
+	return false, nil
 }
 
 // Adds a label for a workflow.

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1783,11 +1783,19 @@ func (r *ResourceManager) workflowStillMatchesReportedVersion(ctx context.Contex
 
 	currentWorkflow, err := r.getWorkflowClient(execSpec.ExecutionNamespace()).Get(ctx, execSpec.ExecutionName(), v1.GetOptions{})
 	if err != nil {
-		message := fmt.Sprintf("Failed to verify current workflow version while reporting completed workflow %s", execSpec.ExecutionName())
 		if util.IsNotFound(err) {
-			return false, util.NewNotFoundError(err, "%s", message)
+			// The workflow CR is already gone, e.g. deleted between the
+			// persistence agent's read and this report. Proceed with the
+			// reported terminal state so the run row is still finalized;
+			// the persistedFinalState label step then surfaces the NotFound
+			// signal to the caller after the database write.
+			glog.Warningf(
+				"Workflow %q was not found while verifying the reported version; proceeding with the reported terminal state",
+				execSpec.ExecutionName(),
+			)
+			return true, nil
 		}
-		return false, util.Wrapf(err, "%s", message)
+		return false, util.Wrapf(err, "Failed to verify current workflow version while reporting completed workflow %s", execSpec.ExecutionName())
 	}
 	if currentWorkflow.Version() == reportedVersion {
 		return true, nil

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1702,7 +1702,14 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 		}
 
 		if shouldPersistFinalState {
-			err := addWorkflowLabel(ctx, r.getWorkflowClient(execSpec.ExecutionNamespace()), execSpec.ExecutionName(), util.LabelKeyWorkflowPersistedFinalState, "true")
+			labelAdded, err := addWorkflowLabelIfWorkflowUnchanged(
+				ctx,
+				r.getWorkflowClient(execSpec.ExecutionNamespace()),
+				execSpec.ExecutionName(),
+				execSpec.Version(),
+				util.LabelKeyWorkflowPersistedFinalState,
+				"true",
+			)
 			if err != nil {
 				message := fmt.Sprintf("Failed to add PersistedFinalState label to workflow %s", execSpec.ExecutionName())
 				// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
@@ -1714,8 +1721,7 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 					return nil, util.Wrapf(err, "%s", message)
 				}
 			}
-
-			if r.options.CollectMetrics {
+			if labelAdded && r.options.CollectMetrics {
 				execNamespace := execSpec.ExecutionNamespace()
 				execName := execSpec.ExecutionName()
 
@@ -1754,27 +1760,65 @@ func (r *ResourceManager) runStillMatchesReportedFinalState(runID string, state 
 	return false, nil
 }
 
-// Adds a label for a workflow.
-func addWorkflowLabel(ctx context.Context, wfClient util.ExecutionInterface, name string, labelKey string, labelValue string) error {
-	patchObj := map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels": map[string]interface{}{
-				labelKey: labelValue,
-			},
-		},
+type jsonPatchOperation struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value,omitempty"`
+}
+
+// Adds a label only if the workflow still matches the object that reported the
+// terminal state. This prevents a stale terminal report from labeling a retried
+// workflow after RetryRun has updated the same workflow name back to Running.
+func addWorkflowLabelIfWorkflowUnchanged(
+	ctx context.Context,
+	wfClient util.ExecutionInterface,
+	name string,
+	expectedResourceVersion string,
+	labelKey string,
+	labelValue string,
+) (bool, error) {
+	patchObj := []jsonPatchOperation{}
+	if expectedResourceVersion != "" {
+		patchObj = append(patchObj, jsonPatchOperation{
+			Op:    "test",
+			Path:  "/metadata/resourceVersion",
+			Value: expectedResourceVersion,
+		})
 	}
+	patchObj = append(patchObj, jsonPatchOperation{
+		Op:    "add",
+		Path:  "/metadata/labels/" + escapeJSONPointerPathPart(labelKey),
+		Value: labelValue,
+	})
 
 	patch, err := json.Marshal(patchObj)
 	if err != nil {
-		return util.NewInternalServerError(err, "Unexpected error while marshalling a patch object")
+		return false, util.NewInternalServerError(err, "Unexpected error while marshalling a patch object")
 	}
 
 	operation := func() error {
-		_, err = wfClient.Patch(ctx, name, types.MergePatchType, patch, v1.PatchOptions{})
+		_, err = wfClient.Patch(ctx, name, types.JSONPatchType, patch, v1.PatchOptions{})
+		if apierrors.IsConflict(err) {
+			return backoff.Permanent(err)
+		}
 		return err
 	}
 	err = backoff.Retry(operation, newStandardBackoffPolicy())
-	return err
+	if permanentErr, ok := err.(*backoff.PermanentError); ok {
+		err = permanentErr.Err
+	}
+	if apierrors.IsConflict(err) {
+		glog.Warningf("Skip adding workflow label %q to workflow %q because the workflow changed while reporting the terminal state", labelKey, name)
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func escapeJSONPointerPathPart(pathPart string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(pathPart, "~", "~0"), "/", "~1")
 }
 
 // Updates a recurring run with a scheduled workflow CR.

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -247,6 +247,22 @@ func (d *retryDuringTerminalReportDispatcher) OnRunEnd(ctx context.Context, _ *a
 func (d *retryDuringTerminalReportDispatcher) OnRunRetry(context.Context, *apiserverPlugins.PersistedRun) {
 }
 
+type countingTerminalReportDispatcher struct {
+	onRunEndCalls int
+}
+
+func (d *countingTerminalReportDispatcher) OnBeforeRunCreation(context.Context, *apiserverPlugins.PendingRun, util.ExecutionSpec) error {
+	return nil
+}
+
+func (d *countingTerminalReportDispatcher) OnRunEnd(context.Context, *apiserverPlugins.PersistedRun) bool {
+	d.onRunEndCalls++
+	return true
+}
+
+func (d *countingTerminalReportDispatcher) OnRunRetry(context.Context, *apiserverPlugins.PersistedRun) {
+}
+
 func TestReadRunLogFromArchiveStreamsObjectStoreFile(t *testing.T) {
 	logArchive := archive.NewLogArchive("/logs", "main.log")
 	execSpec, err := util.NewExecutionSpecJSON(util.CurrentExecutionType(), []byte(testWorkflow.ToStringForStore()))
@@ -3884,6 +3900,58 @@ func TestAddWorkflowLabelIfWorkflowUnchanged_SkipsWhenWorkflowWasRetried(t *test
 	assert.False(t, hasFinalStateLabel)
 }
 
+func TestReportWorkflowResource_SkipsTerminalPluginSyncWhenReportedWorkflowIsStale(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	namespace := "ns1"
+	ctx := context.Background()
+	defer store.Close()
+
+	runWithPluginOutput, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	mlflowOutput := apiservermlflow.SuccessfulPluginOutput("exp-1", "exp-1", "parent-run-1", "https://mlflow.example/runs/parent-run-1")
+	pluginsOutput, err := apiservermlflow.SerializePluginsOutput(map[string]*apiv2beta1.PluginOutput{apiservermlflow.PluginName: mlflowOutput})
+	require.NoError(t, err)
+	runWithPluginOutput.State = model.RuntimeStateRunning
+	runWithPluginOutput.Conditions = string(model.RuntimeStateRunning.ToV1())
+	runWithPluginOutput.FinishedAtInSec = 0
+	runWithPluginOutput.PluginsOutputString = pluginsOutput
+	require.NoError(t, manager.runStore.UpdateRun(runWithPluginOutput))
+
+	dispatcher := &countingTerminalReportDispatcher{}
+	manager.pluginDispatcher = dispatcher
+
+	currentWorkflow, err := store.ExecClientFake.Execution(namespace).Get(ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	currentWorkflow.SetVersion("retry-version")
+	_, err = store.ExecClientFake.Execution(namespace).Update(ctx, currentWorkflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	staleTerminalWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:            run.K8SName,
+			Namespace:       namespace,
+			UID:             types.UID(run.UUID),
+			ResourceVersion: "terminal-version",
+			Labels:          map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{
+			Phase:      v1alpha1.WorkflowFailed,
+			FinishedAt: v1.NewTime(time.Unix(123, 0)),
+		},
+	})
+
+	reportedWorkflow, err := manager.ReportWorkflowResource(ctx, staleTerminalWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable))
+	assert.Nil(t, reportedWorkflow)
+	assert.Equal(t, 0, dispatcher.onRunEndCalls)
+
+	currentRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateRunning, currentRun.State)
+	assert.Equal(t, int64(0), currentRun.FinishedAtInSec)
+}
+
 func TestReportWorkflowResource_SkipsPersistedFinalStateLabelWhenRunRetriedDuringPluginSync(t *testing.T) {
 	store, manager, run := initWithOneTimeRun(t)
 	namespace := "ns1"
@@ -3917,10 +3985,10 @@ func TestReportWorkflowResource_SkipsPersistedFinalStateLabelWhenRunRetriedDurin
 	})
 
 	reportedWorkflow, err := manager.ReportWorkflowResource(context.Background(), workflow)
-	require.NoError(t, err)
-	require.NotNil(t, reportedWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable))
+	assert.Nil(t, reportedWorkflow)
 	require.NoError(t, dispatcher.retryErr)
-	assert.Equal(t, run.UUID, reportedWorkflow.ExecutionObjectMeta().Labels[util.LabelKeyWorkflowRunId])
 
 	retriedRun, err := manager.GetRun(run.UUID)
 	require.NoError(t, err)
@@ -3987,7 +4055,8 @@ func TestReportWorkflow_WithMLflowOnRunEnd(t *testing.T) {
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
 	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable))
 
 	// After terminal report, the plugin dispatcher's OnRunEnd should have fired.
 	// Without MLflow config in Viper, the handler sets PLUGIN_FAILED.

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3851,6 +3851,39 @@ func TestReportWorkflowResource_WorkflowCompleted(t *testing.T) {
 	assert.Equal(t, wf.ExecutionObjectMeta().Labels[util.LabelKeyWorkflowPersistedFinalState], "true")
 }
 
+func TestAddWorkflowLabelIfWorkflowUnchanged_SkipsWhenWorkflowWasRetried(t *testing.T) {
+	wfClient := client.NewWorkflowClientFake()
+	ctx := context.Background()
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:            "workflow-name",
+			Namespace:       "ns1",
+			ResourceVersion: "retry-version",
+			Labels:          map[string]string{util.LabelKeyWorkflowRunId: "run-id"},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+	_, err := wfClient.Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	labelAdded, err := addWorkflowLabelIfWorkflowUnchanged(
+		ctx,
+		wfClient,
+		"workflow-name",
+		"terminal-version",
+		util.LabelKeyWorkflowPersistedFinalState,
+		"true",
+	)
+	require.NoError(t, err)
+	assert.False(t, labelAdded)
+
+	updatedWorkflow, err := wfClient.Get(ctx, "workflow-name", v1.GetOptions{})
+	require.NoError(t, err)
+	_, hasFinalStateLabel := updatedWorkflow.ExecutionObjectMeta().Labels[util.LabelKeyWorkflowPersistedFinalState]
+	assert.False(t, hasFinalStateLabel)
+}
+
 func TestReportWorkflowResource_SkipsPersistedFinalStateLabelWhenRunRetriedDuringPluginSync(t *testing.T) {
 	store, manager, run := initWithOneTimeRun(t)
 	namespace := "ns1"

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -4091,16 +4091,18 @@ func TestReportWorkflow_WithMLflowOnRunEnd(t *testing.T) {
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
 	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
-	require.Error(t, err)
-	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable))
+	require.NoError(t, err,
+		"an unavailable MLflow config is a permanent plugin failure and must not block run finalization")
 
 	// After terminal report, the plugin dispatcher's OnRunEnd should have fired.
-	// Without MLflow config in Viper, the handler sets PLUGIN_FAILED.
+	// Without MLflow config in Viper, the handler sets PLUGIN_FAILED, and the
+	// run still reaches its terminal state.
 	updatedRun, err := manager.GetRun(run.UUID)
 	require.NoError(t, err)
 	require.NotNil(t, updatedRun.PluginsOutputString, "PluginsOutputString should be updated after terminal report")
 	assert.Contains(t, string(*updatedRun.PluginsOutputString), "PLUGIN_FAILED")
 	assert.Contains(t, string(*updatedRun.PluginsOutputString), "config unavailable")
+	assert.Equal(t, model.RuntimeStateFailed, updatedRun.State)
 }
 
 func TestReportWorkflowResource_WorkflowCompleted_WorkflowNotFound(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3952,6 +3952,42 @@ func TestReportWorkflowResource_SkipsTerminalPluginSyncWhenReportedWorkflowIsSta
 	assert.Equal(t, int64(0), currentRun.FinishedAtInSec)
 }
 
+func TestReportWorkflowResource_FinalizesRunWhenWorkflowDeletedBeforeTerminalReport(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	namespace := "ns1"
+	ctx := context.Background()
+	defer store.Close()
+
+	// Report a terminal workflow whose CR no longer exists, simulating a
+	// deletion between the persistence agent's read and this report. The run
+	// row must still be finalized before the caller receives the NotFound
+	// signal that stops further retries.
+	deletedWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:            run.K8SName + "-deleted",
+			Namespace:       namespace,
+			UID:             types.UID(run.UUID),
+			ResourceVersion: "terminal-version",
+			Labels:          map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{
+			Phase:      v1alpha1.WorkflowFailed,
+			FinishedAt: v1.NewTime(time.Unix(123, 0)),
+		},
+	})
+
+	reportedWorkflow, err := manager.ReportWorkflowResource(ctx, deletedWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound),
+		"caller should receive the NotFound signal so the persistence agent stops retrying")
+	assert.Nil(t, reportedWorkflow)
+
+	currentRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateFailed, currentRun.State)
+	assert.Equal(t, int64(123), currentRun.FinishedAtInSec)
+}
+
 func TestReportWorkflowResource_SkipsPersistedFinalStateLabelWhenRunRetriedDuringPluginSync(t *testing.T) {
 	store, manager, run := initWithOneTimeRun(t)
 	namespace := "ns1"

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3883,9 +3883,11 @@ func TestReportWorkflowResource_SkipsPersistedFinalStateLabelWhenRunRetriedDurin
 		},
 	})
 
-	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
+	reportedWorkflow, err := manager.ReportWorkflowResource(context.Background(), workflow)
 	require.NoError(t, err)
+	require.NotNil(t, reportedWorkflow)
 	require.NoError(t, dispatcher.retryErr)
+	assert.Equal(t, run.UUID, reportedWorkflow.ExecutionObjectMeta().Labels[util.LabelKeyWorkflowRunId])
 
 	retriedRun, err := manager.GetRun(run.UUID)
 	require.NoError(t, err)

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/list"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
+	apiserverPlugins "github.com/kubeflow/pipelines/backend/src/apiserver/plugins"
 	apiservermlflow "github.com/kubeflow/pipelines/backend/src/apiserver/plugins/mlflow"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/storage"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/template"
@@ -227,6 +228,24 @@ var testWorkflow = util.NewWorkflow(&v1alpha1.Workflow{
 	},
 	Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
 })
+
+type retryDuringTerminalReportDispatcher struct {
+	manager  *ResourceManager
+	runID    string
+	retryErr error
+}
+
+func (d *retryDuringTerminalReportDispatcher) OnBeforeRunCreation(context.Context, *apiserverPlugins.PendingRun, util.ExecutionSpec) error {
+	return nil
+}
+
+func (d *retryDuringTerminalReportDispatcher) OnRunEnd(ctx context.Context, _ *apiserverPlugins.PersistedRun) bool {
+	d.retryErr = d.manager.RetryRun(ctx, d.runID)
+	return true
+}
+
+func (d *retryDuringTerminalReportDispatcher) OnRunRetry(context.Context, *apiserverPlugins.PersistedRun) {
+}
 
 func TestReadRunLogFromArchiveStreamsObjectStoreFile(t *testing.T) {
 	logArchive := archive.NewLogArchive("/logs", "main.log")
@@ -3830,6 +3849,54 @@ func TestReportWorkflowResource_WorkflowCompleted(t *testing.T) {
 	wf, err := store.ExecClientFake.Execution(namespace).Get(context.Background(), run.K8SName, v1.GetOptions{})
 	assert.Nil(t, err)
 	assert.Equal(t, wf.ExecutionObjectMeta().Labels[util.LabelKeyWorkflowPersistedFinalState], "true")
+}
+
+func TestReportWorkflowResource_SkipsPersistedFinalStateLabelWhenRunRetriedDuringPluginSync(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	namespace := "ns1"
+	defer store.Close()
+
+	runWithPluginOutput, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	mlflowOutput := apiservermlflow.SuccessfulPluginOutput("exp-1", "exp-1", "parent-run-1", "https://mlflow.example/runs/parent-run-1")
+	pluginsOutput, err := apiservermlflow.SerializePluginsOutput(map[string]*apiv2beta1.PluginOutput{apiservermlflow.PluginName: mlflowOutput})
+	require.NoError(t, err)
+	runWithPluginOutput.PluginsOutputString = pluginsOutput
+	require.NoError(t, manager.runStore.UpdateRun(runWithPluginOutput))
+
+	dispatcher := &retryDuringTerminalReportDispatcher{
+		manager: manager,
+		runID:   run.UUID,
+	}
+	manager.pluginDispatcher = dispatcher
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: namespace,
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{
+			Phase:      v1alpha1.WorkflowFailed,
+			FinishedAt: v1.NewTime(time.Unix(123, 0)),
+		},
+	})
+
+	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
+	require.NoError(t, err)
+	require.NoError(t, dispatcher.retryErr)
+
+	retriedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateRunning, retriedRun.State)
+	assert.Equal(t, int64(0), retriedRun.FinishedAtInSec)
+
+	retriedWorkflow, err := store.ExecClientFake.Execution(namespace).Get(context.Background(), run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, string(v1alpha1.WorkflowRunning), string(retriedWorkflow.ExecutionStatus().Condition()))
+	_, hasFinalStateLabel := retriedWorkflow.ExecutionObjectMeta().Labels[util.LabelKeyWorkflowPersistedFinalState]
+	assert.False(t, hasFinalStateLabel)
 }
 
 // TestReportWorkflow_WithMLflowOnRunEnd verifies that when a run has PluginsOutputString


### PR DESCRIPTION
## Summary

Follow-up to #13555 for the MLflow E2E RetryRun flake where a retried intentionally failing run could remain RUNNING until timeout.

ReportWorkflowResource writes terminal run state before plugin terminal sync and before adding pipeline/persistedFinalState. If RetryRun happens before or during terminal reporting, a stale terminal report can either terminalize plugin state again or fall through to task/metric reporting for an already-retried workflow.

This updates terminal reporting to:

- Check the reported workflow resourceVersion against the live workflow before terminal DB/plugin handling when a resourceVersion is available.
- Return a retryable Unavailable signal when terminal handling is stale or deferred, so reportWorkflow and the persistence worker skip downstream task/metric reporting and retry with the current workflow state.
- Keep the resourceVersion-guarded persistedFinalState label patch so a workflow updated by RetryRun is not labeled as persisted.
- Fix FakeWorkflowClient.Update so unit tests assert live workflow updates.

## Tests

- go test -count=1 ./backend/src/apiserver/resource
- go test -count=1 ./backend/src/apiserver/server
- go test -count=1 ./backend/src/agent/persistence/worker
- git diff --check