### PR TITLE
fix(frontend): fix blank screen on npm start

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -51,7 +51,7 @@
     "src/apis",
     "src/generated",
     "webpack",
-    "**/?*test.*",
+    "**/?*test.*"
   ],
   "include": [
     "src",

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -55,6 +55,9 @@ export default defineConfig(({ mode }) => ({
     port: 3000,
     proxy,
   },
+  optimizeDeps: {
+    exclude: ['@mui/material/colors'],
+  },
   build: {
     target: 'es2015',
     outDir: 'build',


### PR DESCRIPTION
**Description of changes:**
Two small, frontend fixes found while getting local dev set up:

1. frontend/tsconfig.json had a trailing comma in its exclude array — invalid strict JSON, though tsc's own lenient parser let it slide.

2. npm start rendered a completely blank screen with `ReferenceError: init_blue is not defined` in the console. Vite's dependency optimizer was splitting @mui/material's colors module into a shared chunk between two entry points and dropping the chunk's init function in the process. Reproduced deterministically, including after a fully forced, cache-cleared re-optimization. Fixed by excluding @mui/material/colors from pre-bundling so it's served as native ESM instead. Only affects the dev server - npm run build (Rollup/Rolldown) was never affected and still builds cleanly.


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
