### PR TITLE
fix(ci): prevent ci-passed label when workflows await approval

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -16,6 +16,7 @@ jobs:
   check_ci_status:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       checks: read
     steps:
       - name: Determine whether CI polling is needed
@@ -42,10 +43,50 @@ jobs:
           echo "reason=${reason}" >> "$GITHUB_OUTPUT"
           echo "${reason}"
 
+      - name: Wait for action_required workflow runs to be approved
+        id: approval_gate
+        if: steps.eligibility.outputs.should_poll == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const headSha = context.payload.pull_request.head.sha;
+            const maxAttempts = 31;
+            const intervalMs = 10_000;
+
+            const listRequest = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              status: "action_required",
+              head_sha: headSha,
+            };
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              core.info(`[Attempt ${attempt}/${maxAttempts}] Checking for action_required runs for ${headSha}`);
+              const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, listRequest);
+
+              if (runs.length === 0) {
+                core.info("No action_required workflow runs found. All runs have been approved.");
+                return;
+              }
+
+              core.info(`Found ${runs.length} action_required run(s): ${runs.map(r => r.name).join(', ')}`);
+
+              if (attempt < maxAttempts) {
+                core.info(`Waiting ${intervalMs / 1000}s for approval...`);
+                await new Promise(r => setTimeout(r, intervalMs));
+              }
+            }
+
+            core.setFailed(
+              `${headSha} still has action_required workflow runs after ${(maxAttempts - 1) * intervalMs / 1000}s. ` +
+              `CI cannot pass while workflows are awaiting approval.`
+            );
+
       - name: Check if all CI checks passed
         id: poll
-        if: steps.eligibility.outputs.should_poll == 'true'
-        uses: wechuli/allcheckspassed@0b68b3b7d92e595bcbdea0c860d05605720cf479
+        if: steps.eligibility.outputs.should_poll == 'true' && steps.approval_gate.outcome == 'success'
+        uses: wechuli/allcheckspassed@204ff63e89eabdc8086f0c50b91f675bcf37c8f6
         with:
           delay: '5'
           retries: '10'

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -48,10 +48,13 @@ jobs:
         if: steps.eligibility.outputs.should_poll == 'true'
         uses: actions/github-script@v8
         with:
+          retries: 3
           script: |
             const headSha = context.payload.pull_request.head.sha;
+            // Timing: approve window (60s) < this gate (300s) < allcheckspassed delay (5min)
             const maxAttempts = 31;
             const intervalMs = 10_000;
+            const initialDelayMs = 15_000;
 
             const listRequest = {
               owner: context.repo.owner,
@@ -60,6 +63,10 @@ jobs:
               status: "action_required",
               head_sha: headSha,
             };
+
+            // Wait for GitHub to finish registering workflow runs before the first check
+            core.info(`Waiting ${initialDelayMs / 1000}s for workflow runs to be registered...`);
+            await new Promise(r => setTimeout(r, initialDelayMs));
 
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {
               core.info(`[Attempt ${attempt}/${maxAttempts}] Checking for action_required runs for ${headSha}`);

--- a/.github/workflows/gh-workflow-approve.yml
+++ b/.github/workflows/gh-workflow-approve.yml
@@ -9,6 +9,7 @@ on:
     types:
       - labeled
       - synchronize
+      - reopened
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
@@ -47,26 +48,47 @@ jobs:
         if: steps.membership-check.outputs.is_member == 'true' || contains(github.event.pull_request.labels.*.name, 'ok-to-test')
         uses: actions/github-script@v8
         with:
-          retries: 3
+          retries: 3 # github-script level: retries the entire script on transient API errors
           script: |
-            const request = {
+            // Poll for runs that may not exist yet due to race with workflow creation
+            const maxAttempts = 7;
+            const intervalMs = 10_000;
+            const headSha = context.payload.pull_request.head.sha;
+
+            const listRequest = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               event: "pull_request",
               status: "action_required",
-              head_sha: context.payload.pull_request.head.sha,
+              head_sha: headSha,
+            };
+
+            let runs = [];
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              core.info(`[Attempt ${attempt}/${maxAttempts}] Querying action_required runs for ${headSha}`);
+              runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, listRequest);
+
+              if (runs.length > 0) {
+                core.info(`Found ${runs.length} workflow run(s) to approve.`);
+                break;
+              }
+
+              if (attempt < maxAttempts) {
+                core.info(`No runs found yet. Waiting ${intervalMs / 1000}s before retry...`);
+                await new Promise(r => setTimeout(r, intervalMs));
+              }
             }
 
-            core.info(`Getting workflow runs that need approval for commit ${request.head_sha}`)
-            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, request)
-
-            core.info(`Found ${runs.length} workflow runs that need approval`)
-            for (const run of runs) {
-              core.info(`Approving workflow run ${run.id}`)
-              const request = {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                run_id: run.id,
+            if (runs.length === 0) {
+              core.warning(`No action_required workflow runs found for ${headSha} after ${maxAttempts} attempts.`);
+            } else {
+              for (const run of runs) {
+                core.info(`Approving workflow run ${run.id} (${run.name})`);
+                await github.rest.actions.approveWorkflowRun({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                });
               }
-              await github.rest.actions.approveWorkflowRun(request)
+              core.info(`Approved ${runs.length} workflow run(s).`);
             }


### PR DESCRIPTION
## Summary

- Add `reopened` trigger to the approve workflow so it fires when a PR is closed and reopened
- Add a retry loop (60s) to the approve workflow to wait for `pull_request` runs to be created before approving, fixing the race condition where the approve script ran before GitHub finished creating the workflow runs
- Add an approval gate step in CI Check that blocks `allcheckspassed` polling until all `action_required` workflow runs are approved (5-min timeout), preventing `ci-passed` from being added while workflows are invisible to the Check Runs API
- Bump `wechuli/allcheckspassed` to v2.4.0 (`204ff63e89eabdc8086f0c50b91f675bcf37c8f6`)

## Root cause

Workflows awaiting approval (`action_required`) do not create GitHub Check Runs. The `allcheckspassed` action polls Check Runs, so unapproved workflows are invisible to it. This caused `ci-passed` to be added while 11 workflows were still stuck awaiting approval (observed on #13609).

## Test plan

- [ ] Verify on an external-contributor PR: add `ok-to-test` → approve workflow fires with retry, CI Check gate waits for approval to clear before polling
- [ ] Close and reopen a PR → verify approve workflow fires on `reopened` event
- [ ] Verify org member PRs are unaffected (0 `action_required` runs → gate passes immediately)
- [ ] Confirm `ci-passed` is only added after all workflows actually complete