### PR TITLE
fix(test): update frontend integration npm deps

### DIFF
--- a/test/frontend-integration-test/package-lock.json
+++ b/test/frontend-integration-test/package-lock.json
@@ -3360,9 +3360,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4900,15 +4900,6 @@
       "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -5296,12 +5287,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {

--- a/test/frontend-integration-test/package-lock.json
+++ b/test/frontend-integration-test/package-lock.json
@@ -16,6 +16,9 @@
         "mocha": "^10.8.2",
         "wait-port": "^1.0.4",
         "webdriverio": "^9.24.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/test/frontend-integration-test/package.json
+++ b/test/frontend-integration-test/package.json
@@ -16,7 +16,12 @@
     "docker": "docker build -t gcr.io/ml-pipeline/e2e-tests .",
     "test": "wdio wdio.conf.js"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "overrides": {
-    "serialize-javascript": "7.0.5"
+    "mocha": {
+      "serialize-javascript": "7.0.5"
+    }
   }
 }

--- a/test/frontend-integration-test/package.json
+++ b/test/frontend-integration-test/package.json
@@ -15,5 +15,8 @@
   "scripts": {
     "docker": "docker build -t gcr.io/ml-pipeline/e2e-tests .",
     "test": "wdio wdio.conf.js"
+  },
+  "overrides": {
+    "serialize-javascript": "7.0.5"
   }
 }


### PR DESCRIPTION
## Summary

Remediates the remaining open npm Dependabot alerts in `test/frontend-integration-test`.

- updates transitive `ip-address` from `10.1.0` to `10.2.0`
- scopes a Mocha-only `serialize-javascript@7.0.5` override for Mocha's transitive range
- declares `node >=20.0.0` for this package to match `serialize-javascript@7`
- regenerates `test/frontend-integration-test/package-lock.json`

## Verification

- `fnm exec --using ../../frontend/.nvmrc -- npm audit --package-lock-only --omit=optional --json`
- `fnm exec --using ../../frontend/.nvmrc -- npm ci --ignore-scripts --no-audit --no-fund`
- `fnm exec --using ../../frontend/.nvmrc -- npm ls --all serialize-javascript ip-address`
- `git diff --check`