### PR TITLE
fix(test): poll ListPipelineVersions when verifying uploaded tags

### DIFF
--- a/backend/test/v2/api/pipeline_upload_api_test.go
+++ b/backend/test/v2/api/pipeline_upload_api_test.go
@@ -228,19 +228,20 @@ var _ = Describe("Verify Pipeline Upload Version with Tags >", Label(constants.P
 
 			uploadPipelineVersionAndVerify(helloWorldPipelineSpecFilePath, parameters, expectedPipelineVersion)
 
-			// Verify tags via ListPipelineVersions
-			versions := testutil.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil)
-			Expect(len(versions)).To(BeNumerically(">=", 2))
-
-			var foundTaggedVersion bool
-			for _, v := range versions {
-				if v.DisplayName == versionName {
-					Expect(v.Tags).To(Equal(tags), "Tagged version should include tags in list response")
-					foundTaggedVersion = true
-					break
+			// Verify tags via ListPipelineVersions. The Kubernetes-native
+			// pipeline store lists versions from an informer cache that can
+			// lag the upload, so poll until the tagged version appears.
+			var taggedVersionTags map[string]string
+			Eventually(func() bool {
+				for _, v := range testutil.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil) {
+					if v.DisplayName == versionName {
+						taggedVersionTags = v.Tags
+						return true
+					}
 				}
-			}
-			Expect(foundTaggedVersion).To(BeTrue(), "Should find the tagged version in the list")
+				return false
+			}, "30s", "1s").Should(BeTrue(), "Should find the tagged version in the list")
+			Expect(taggedVersionTags).To(Equal(tags), "Tagged version should include tags in list response")
 		})
 
 		It("Upload a pipeline version without tags and verify no tags are returned", func() {

--- a/backend/test/v2/api/pipeline_upload_api_test.go
+++ b/backend/test/v2/api/pipeline_upload_api_test.go
@@ -230,18 +230,21 @@ var _ = Describe("Verify Pipeline Upload Version with Tags >", Label(constants.P
 
 			// Verify tags via ListPipelineVersions. The Kubernetes-native
 			// pipeline store lists versions from an informer cache that can
-			// lag the upload, so poll until the tagged version appears.
-			var taggedVersionTags map[string]string
-			Eventually(func() bool {
-				for _, v := range testutil.GetSortedPipelineVersionsByCreatedAt(pipelineClient, createdPipeline.PipelineID, nil) {
-					if v.DisplayName == versionName {
-						taggedVersionTags = v.Tags
-						return true
-					}
+			// lag the upload, so poll until both versions are listed.
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: createdPipeline.PipelineID,
+			})
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(BeNumerically(">=", 2), "Expected at least 2 pipeline versions after uploading a tagged version")
+
+			var foundTaggedVersion bool
+			for _, v := range result.Versions {
+				if v.DisplayName == versionName {
+					Expect(v.Tags).To(Equal(tags), "Tagged version should include tags in list response")
+					foundTaggedVersion = true
+					break
 				}
-				return false
-			}, "30s", "1s").Should(BeTrue(), "Should find the tagged version in the list")
-			Expect(taggedVersionTags).To(Equal(tags), "Tagged version should include tags in list response")
+			}
+			Expect(foundTaggedVersion).To(BeTrue(), "Should find the tagged version in the list")
 		})
 
 		It("Upload a pipeline version without tags and verify no tags are returned", func() {


### PR DESCRIPTION
## Summary

`Upload a pipeline version with tags and verify tags via ListPipelineVersions` performs a single-shot `ListPipelineVersions` immediately after uploading the second version. With the Kubernetes-native pipeline store the list is served from an informer cache that can lag the upload, so the list intermittently returns only one version and the `len(versions) >= 2` assertion fails.

Observed on master push run [28647353732](https://github.com/kubeflow/pipelines/actions/runs/28647353732) in the `K8s Native API - K8sVersion=v1.35.0 cacheEnabled=true argoVersion=v4.0.5 uploadPipelinesWithKubernetesClient=true` lane:

```
[FAIL] Verify Pipeline Upload Version with Tags > Upload a pipeline version with tags and verify tags are stored >
[It] Upload a pipeline version with tags and verify tags via ListPipelineVersions
pipeline_upload_api_test.go:233: Expected <int>: 1 to be >= <int>: 2
```

## Fix

Poll with `Eventually` (30s timeout, 1s interval) until the tagged version appears in the list response, then assert its tags — the same polling pattern already used for eventual consistency elsewhere in the API tests (e.g. #13622, #13593). The sibling `GetPipelineVersion` tag test is unaffected since it reads the version directly.

## Test plan

- [x] `go vet ./backend/test/v2/api/` and `gofmt` clean
- [ ] API Server Tests lanes on this PR (the modified test runs in every lane; the race is only reachable with `uploadPipelinesWithKubernetesClient=true`)