### PR TITLE
feat(sdk): support None as a literal for Optional[T] parameters

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -6658,5 +6658,141 @@ class TestPipelineSpecAttributeUniqueError(unittest.TestCase):
         self.assertTrue(my_pipeline.pipeline_spec)
 
 
+class TestNoneLiteralForOptionalParams(unittest.TestCase):
+    """Tests for passing None as an explicit literal argument to optional
+    parameters (Optional[T] / Union[T, None] / T | None).
+    """
+
+    def test_pass_none_to_optional_param_compiles(self):
+        """Pipeline can pass None literal to a component with Optional[T]."""
+
+        @dsl.component
+        def my_comp(x: Optional[int] = None):
+            print(x)
+
+        @dsl.pipeline
+        def my_pipeline():
+            my_comp(x=None)
+
+        # Should compile without raising.
+        spec = my_pipeline.pipeline_spec
+        task_inputs = spec.root.dag.tasks['my-comp'].inputs
+        # The constant should be present as a null_value.
+        runtime_value = task_inputs.parameters['x'].runtime_value.constant
+        self.assertEqual(runtime_value.WhichOneof('kind'), 'null_value')
+
+    def test_pass_none_to_optional_str_param_compiles(self):
+        """Pipeline can pass None literal to a component with Optional[str]."""
+
+        @dsl.component
+        def my_comp(x: Optional[str] = None):
+            return x or 'default'
+
+        @dsl.pipeline
+        def my_pipeline():
+            my_comp(x=None)
+
+        spec = my_pipeline.pipeline_spec
+        task_inputs = spec.root.dag.tasks['my-comp'].inputs
+        runtime_value = task_inputs.parameters['x'].runtime_value.constant
+        self.assertEqual(runtime_value.WhichOneof('kind'), 'null_value')
+
+    def test_pass_none_to_non_optional_param_raises(self):
+        """Passing None to a non-optional parameter should raise ValueError."""
+
+        @dsl.component
+        def my_comp(x: int):
+            print(x)
+
+        with self.assertRaisesRegex(ValueError, 'is not optional'):
+
+            @dsl.pipeline
+            def my_pipeline():
+                my_comp(x=None)
+
+    def test_nested_none_in_dict_compiles(self):
+        """Nested None values inside a dict literal are preserved faithfully
+        via the null_value protobuf encoding."""
+
+        @dsl.component
+        def my_comp(cfg: dict = None):
+            print(cfg)
+
+        @dsl.pipeline
+        def my_pipeline():
+            my_comp(cfg={'key': None, 'other': 42})
+
+        spec = my_pipeline.pipeline_spec
+        task_inputs = spec.root.dag.tasks['my-comp'].inputs
+        runtime_value = task_inputs.parameters['cfg'].runtime_value.constant
+        # The outer value is a struct; its 'key' field should be null.
+        self.assertEqual(runtime_value.WhichOneof('kind'), 'struct_value')
+        key_field = runtime_value.struct_value.fields['key']
+        self.assertEqual(key_field.WhichOneof('kind'), 'null_value')
+
+    def test_nested_none_in_list_compiles(self):
+        """Nested None values inside a list literal are preserved faithfully
+        via the null_value protobuf encoding."""
+
+        @dsl.component
+        def my_comp(items: list = None):
+            print(items)
+
+        @dsl.pipeline
+        def my_pipeline():
+            my_comp(items=[1, None, 'hello'])
+
+        spec = my_pipeline.pipeline_spec
+        task_inputs = spec.root.dag.tasks['my-comp'].inputs
+        runtime_value = task_inputs.parameters['items'].runtime_value.constant
+        self.assertEqual(runtime_value.WhichOneof('kind'), 'list_value')
+        second = runtime_value.list_value.values[1]
+        self.assertEqual(second.WhichOneof('kind'), 'null_value')
+
+    def test_union_with_none_annotation_compiles(self):
+        """Union[T, None] annotation is treated identically to Optional[T]."""
+        import typing
+
+        @dsl.component
+        def my_comp(x: typing.Union[str, None] = None):
+            return x or 'fallback'
+
+        @dsl.pipeline
+        def my_pipeline():
+            my_comp(x=None)
+
+        spec = my_pipeline.pipeline_spec
+        task_inputs = spec.root.dag.tasks['my-comp'].inputs
+        runtime_value = task_inputs.parameters['x'].runtime_value.constant
+        self.assertEqual(runtime_value.WhichOneof('kind'), 'null_value')
+
+    def test_pipeline_level_optional_param_pass_through_none(self):
+        """Pipeline-level Optional[T] param can forward None to a component."""
+
+        @dsl.component
+        def my_comp(x: Optional[int] = None):
+            print(x)
+
+        @dsl.pipeline
+        def my_pipeline(x: Optional[int] = None):
+            my_comp(x=x)
+
+        spec = my_pipeline.pipeline_spec
+        # The pipeline root input 'x' should be optional.
+        root_param = spec.root.input_definitions.parameters['x']
+        self.assertTrue(root_param.is_optional)
+
+    def test_is_optional_preserved_on_optional_param(self):
+        """is_optional flag is set on the component's input spec."""
+
+        @dsl.component
+        def my_comp(x: Optional[int] = None):
+            print(x)
+
+        param_spec = my_comp.pipeline_spec.root.input_definitions.parameters[
+            'x']
+        self.assertTrue(param_spec.is_optional)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -6792,6 +6792,21 @@ class TestNoneLiteralForOptionalParams(unittest.TestCase):
             'x']
         self.assertTrue(param_spec.is_optional)
 
+    def test_pass_none_to_optional_artifact_raises(self):
+        """Passing None to an optional artifact input should raise ValueError."""
+
+        @dsl.component
+        def my_comp(x: Optional[Input[Artifact]] = None):
+            print(x)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"is an artifact input and cannot be set to None\. Omit the argument to leave it unset\."):
+
+            @dsl.pipeline
+            def my_pipeline():
+                my_comp(x=None)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -6766,9 +6766,8 @@ class TestNoneLiteralForOptionalParams(unittest.TestCase):
         runtime_value = task_inputs.parameters['x'].runtime_value.constant
         self.assertEqual(runtime_value.WhichOneof('kind'), 'null_value')
 
-    def test_pipeline_level_optional_param_pass_through_none(self):
-        """Pipeline-level Optional[T] param can forward None to a component."""
-
+    def test_pipeline_level_optional_param_is_marked_optional(self):
+        """Pipeline-level Optional[T] input is marked optional in the pipeline spec."""
         @dsl.component
         def my_comp(x: Optional[int] = None):
             print(x)

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -50,7 +50,9 @@ group_type_to_dsl_class = {
 }
 
 
-def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
+def to_protobuf_value(
+    value: Optional[type_utils.PARAMETER_TYPES]
+) -> struct_pb2.Value:
     """Creates a google.protobuf.struct_pb2.Value message out of a provide
     value.
 
@@ -64,7 +66,7 @@ def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
         ValueError if the given value is not one of the parameter types.
     """
     if value is None:
-        return struct_pb2.Value(null_value=0)
+        return struct_pb2.Value(null_value=struct_pb2.NullValue.NULL_VALUE)
     # bool check must be above (int, float) check because bool is a subclass of int so isinstance(True, int) == True
     elif isinstance(value, bool):
         return struct_pb2.Value(bool_value=value)
@@ -258,6 +260,11 @@ def build_task_spec_for_task(
                         component_input_parameter)
 
         elif input_value is None:
+            input_spec = task.component_spec.inputs[input_name]
+            if not type_utils.is_parameter_type(input_spec.type):
+                raise ValueError(
+                    f'Input {input_name!r} of component {task.component_spec.name!r} is an artifact input and cannot be set to None. Omit the argument to leave it unset.'
+                )
             # None is a valid constant for optional parameters (Optional[T] / Union[T, None]).
             # Encode it as a protobuf null_value so it round-trips faithfully.
             pipeline_task_spec.inputs.parameters[

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -63,8 +63,10 @@ def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
     Raises:
         ValueError if the given value is not one of the parameter types.
     """
+    if value is None:
+        return struct_pb2.Value(null_value=0)
     # bool check must be above (int, float) check because bool is a subclass of int so isinstance(True, int) == True
-    if isinstance(value, bool):
+    elif isinstance(value, bool):
         return struct_pb2.Value(bool_value=value)
     elif isinstance(value, str):
         return struct_pb2.Value(string_value=value)
@@ -81,7 +83,7 @@ def to_protobuf_value(value: type_utils.PARAMETER_TYPES) -> struct_pb2.Value:
                 values=[to_protobuf_value(v) for v in value]))
     else:
         raise ValueError('Value must be one of the following types: '
-                         'str, int, float, bool, dict, and list. Got: '
+                         'str, int, float, bool, dict, list, and None. Got: '
                          f'"{value}" of type "{type(value)}".')
 
 
@@ -255,6 +257,13 @@ def build_task_spec_for_task(
                     input_name].component_input_parameter = (
                         component_input_parameter)
 
+        elif input_value is None:
+            # None is a valid constant for optional parameters (Optional[T] / Union[T, None]).
+            # Encode it as a protobuf null_value so it round-trips faithfully.
+            pipeline_task_spec.inputs.parameters[
+                input_name].runtime_value.constant.CopyFrom(
+                    to_protobuf_value(None))
+
         elif isinstance(input_value, (str, int, float, bool, dict, list)):
             pipeline_channels = (
                 pipeline_channel.extract_pipeline_channels_from_any(input_value)
@@ -326,7 +335,7 @@ def build_task_spec_for_task(
         else:
             raise ValueError(
                 'Input argument supports only the following types: '
-                'str, int, float, bool, dict, and list.'
+                'str, int, float, bool, dict, list, and None.'
                 f'Got {input_value} of type {type(input_value)}.')
 
     return pipeline_task_spec

--- a/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
@@ -985,5 +985,57 @@ def pipeline_spec_from_file(filepath: str) -> str:
     return json_format.ParseDict(dictionary, pipeline_spec_pb2.PipelineSpec())
 
 
+class TestToProtobufValue(unittest.TestCase):
+    """Tests for pipeline_spec_builder.to_protobuf_value.
+
+    Ensures that None and nested-None values inside dicts/lists are encoded as
+    protobuf null_value (Part 1 of issue #12838).
+    """
+
+    def test_none_encodes_as_null_value(self):
+        result = pipeline_spec_builder.to_protobuf_value(None)
+        self.assertEqual(result.WhichOneof('kind'), 'null_value')
+
+    def test_string_encodes_correctly(self):
+        result = pipeline_spec_builder.to_protobuf_value('hello')
+        self.assertEqual(result.string_value, 'hello')
+
+    def test_int_encodes_correctly(self):
+        result = pipeline_spec_builder.to_protobuf_value(42)
+        self.assertEqual(result.number_value, 42.0)
+
+    def test_bool_encodes_correctly(self):
+        result = pipeline_spec_builder.to_protobuf_value(True)
+        self.assertTrue(result.bool_value)
+
+    def test_dict_with_nested_none_encodes_null_field(self):
+        result = pipeline_spec_builder.to_protobuf_value({'key': None, 'val': 1})
+        self.assertEqual(result.WhichOneof('kind'), 'struct_value')
+        self.assertEqual(
+            result.struct_value.fields['key'].WhichOneof('kind'), 'null_value')
+        self.assertEqual(result.struct_value.fields['val'].number_value, 1.0)
+
+    def test_list_with_nested_none_encodes_null_element(self):
+        result = pipeline_spec_builder.to_protobuf_value([1, None, 'hello'])
+        self.assertEqual(result.WhichOneof('kind'), 'list_value')
+        self.assertEqual(result.list_value.values[0].number_value, 1.0)
+        self.assertEqual(
+            result.list_value.values[1].WhichOneof('kind'), 'null_value')
+        self.assertEqual(result.list_value.values[2].string_value, 'hello')
+
+    def test_deeply_nested_none_in_dict_list(self):
+        result = pipeline_spec_builder.to_protobuf_value(
+            {'items': [None, {'inner': None}]})
+        items = result.struct_value.fields['items'].list_value.values
+        self.assertEqual(items[0].WhichOneof('kind'), 'null_value')
+        self.assertEqual(
+            items[1].struct_value.fields['inner'].WhichOneof('kind'),
+            'null_value')
+
+    def test_invalid_type_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            pipeline_spec_builder.to_protobuf_value(object())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -408,15 +408,10 @@ class Executor:
                 func_kwargs[k] = self.get_input_artifact(k)
 
             elif is_parameter(v):
-                value = self.get_input_parameter_value(k)
-                if value is not None:
-                    func_kwargs[k] = value
-                elif k in (self.executor_input.get('inputs', {}).get(
-                        'parameterValues', {})):
-                    # The parameter was explicitly set to null/None in the
-                    # pipeline spec.  Pass it through so the function receives
-                    # the expected None value for Optional[T] parameters.
-                    func_kwargs[k] = None
+                parameter_values = self.executor_input.get('inputs', {}).get(
+                    'parameterValues')
+                if parameter_values is not None and k in parameter_values:
+                    func_kwargs[k] = parameter_values[k]
 
             elif type_annotations.is_Input_Output_artifact_annotation(v):
                 if type_annotations.is_artifact_wrapped_in_Input(v):

--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -411,6 +411,12 @@ class Executor:
                 value = self.get_input_parameter_value(k)
                 if value is not None:
                     func_kwargs[k] = value
+                elif k in (self.executor_input.get('inputs', {}).get(
+                        'parameterValues', {})):
+                    # The parameter was explicitly set to null/None in the
+                    # pipeline spec.  Pass it through so the function receives
+                    # the expected None value for Optional[T] parameters.
+                    func_kwargs[k] = None
 
             elif type_annotations.is_Input_Output_artifact_annotation(v):
                 if type_annotations.is_artifact_wrapped_in_Input(v):

--- a/sdk/python/kfp/dsl/executor_test.py
+++ b/sdk/python/kfp/dsl/executor_test.py
@@ -982,6 +982,47 @@ class ExecutorTest(parameterized.TestCase):
                 },
             })
 
+    def test_function_with_explicit_none_inputs(self):
+        executor_input = """\
+        {
+          "inputs": {
+            "parameterValues": {
+              "first_message": "Hello",
+              "second_message": null
+            }
+          },
+          "outputs": {
+            "parameters": {
+              "Output": {
+                "outputFile": "gs://some-bucket/output"
+              }
+            },
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func(
+            first_message: str = 'default value',
+            second_message: Optional[str] = 'default second',
+            third_message: Optional[str] = 'default third',
+        ) -> str:
+            return (f'{first_message} ({type(first_message)}), '
+                    f'{second_message} ({type(second_message)}), '
+                    f'{third_message} ({type(third_message)}).')
+
+        output_metadata = self.execute_and_load_output_metadata(
+            test_func, executor_input)
+
+        self.assertDictEqual(
+            output_metadata, {
+                'parameterValues': {
+                    'Output': "Hello (<class 'str'>), "
+                              "None (<class 'NoneType'>), "
+                              "default third (<class 'str'>)."
+                },
+            })
+
     def test_function_with_optional_input_artifact(self):
         executor_input = """\
         {

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -152,10 +152,20 @@ class PipelineTask:
 
             input_spec = component_spec.inputs[input_name]
 
-            # None is a valid literal for optional parameters (e.g. Optional[T],
-            # Union[T, None], or T | None). Skip the type compatibility check so
-            # that passing None to an optional input does not raise an error.
-            if argument_value is not None:
+            # `None` is a valid literal only for optional *parameter* inputs (e.g.
+            # Optional[T], Union[T, None], or T | None).
+            if argument_value is None:
+                if not input_spec.optional:
+                    raise ValueError(
+                        f'Input {input_name!r} of component {component_spec.name!r}'
+                        f' is not optional and cannot be set to None.'
+                    )
+                if not type_utils.is_parameter_type(input_spec.type):
+                    raise ValueError(
+                        f'Input {input_name!r} of component {component_spec.name!r}'
+                        f' is an artifact input and cannot be set to None. Omit the argument to leave it unset.'
+                    )
+            else:
                 type_utils.verify_type_compatibility(
                     given_value=argument_value,
                     expected_spec=input_spec,
@@ -163,11 +173,6 @@ class PipelineTask:
                         f'Incompatible argument passed to the input '
                         f'{input_name!r} of component {component_spec.name!r}: '
                     ),
-                )
-            elif not input_spec.optional:
-                raise ValueError(
-                    f'Input {input_name!r} of component {component_spec.name!r}'
-                    f' is not optional and cannot be set to None.'
                 )
 
         self.component_spec = component_spec

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -152,13 +152,23 @@ class PipelineTask:
 
             input_spec = component_spec.inputs[input_name]
 
-            type_utils.verify_type_compatibility(
-                given_value=argument_value,
-                expected_spec=input_spec,
-                error_message_prefix=(
-                    f'Incompatible argument passed to the input '
-                    f'{input_name!r} of component {component_spec.name!r}: '),
-            )
+            # None is a valid literal for optional parameters (e.g. Optional[T],
+            # Union[T, None], or T | None). Skip the type compatibility check so
+            # that passing None to an optional input does not raise an error.
+            if argument_value is not None:
+                type_utils.verify_type_compatibility(
+                    given_value=argument_value,
+                    expected_spec=input_spec,
+                    error_message_prefix=(
+                        f'Incompatible argument passed to the input '
+                        f'{input_name!r} of component {component_spec.name!r}: '
+                    ),
+                )
+            elif not input_spec.optional:
+                raise ValueError(
+                    f'Input {input_name!r} of component {component_spec.name!r}'
+                    f' is not optional and cannot be set to None.'
+                )
 
         self.component_spec = component_spec
 


### PR DESCRIPTION
## Summary

This PR restores support for passing `None` to optional pipeline parameters (`Optional[T]`, `Union[T, None]`, and `T | None`) and adds proper protobuf encoding for `None` values, including nested occurrences inside dictionaries and lists.

Previously, KFP v2 rejected explicit `None` values during pipeline compilation and execution, despite protobuf providing native `null_value` support.

## What Changed

### Compiler
- Encode Python `None` as protobuf `null_value`.
- Allow `None` constants when building task specifications.
- Support nested `None` values inside dictionaries and lists.

### DSL
- Allow `None` to be passed to optional component inputs.
- Preserve validation for required inputs by raising a clear error when `None` is supplied to non-optional parameters.

### Executor
- Distinguish between:
  - parameter not provided
  - parameter explicitly provided as `None`
- Pass explicit `None` through to component functions during execution.

## Tests

Added tests covering:

- Passing `None` to `Optional[int]`
- Passing `None` to `Optional[str]`
- Rejecting `None` for required parameters
- Nested `None` inside dictionaries
- Nested `None` inside lists
- `Union[T, None]` annotations
- Pipeline-level optional parameters
- `to_protobuf_value(None)` encoding
- Regression tests for existing parameter types

## Example

Before:

```python
@dsl.component
def comp(x: Optional[int] = None):
    ...

comp(x=None)   # ❌ Error
```
After:
```python
@dsl.component
def comp(x: Optional[int] = None):
    ...

comp(x=None)   # ✅ Supported
```
Nested values are also supported:
```python
comp(cfg={"key": None})
comp(items=[1, None, "hello"])

```
## Related Issues
Fixes #12838