### PR TITLE
fix(backend): prevent API server crash when MLflow sync defers a run's final state

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1687,8 +1687,15 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 			if prErr != nil {
 				glog.Warningf("Failed to build PersistedRun for plugin sync on run %q: %v", run.UUID, prErr)
 			} else if !r.pluginDispatcher.OnRunEnd(ctx, pr) {
+				// Return a retryable error (Unavailable) rather than success:
+				// the persistence agent treats it as transient and re-reports
+				// the workflow with backoff, and the caller never receives a
+				// nil ExecutionSpec with a nil error.
 				glog.Warningf("Plugin sync failed for run %q; deferring persistedFinalState label so persistence agent retries", run.UUID)
-				return nil, nil
+				return nil, util.NewUnavailableServerError(
+					fmt.Errorf("plugin sync failed for run %s", run.UUID),
+					"Deferring persistedFinalState label for workflow %s - will retry",
+					execSpec.ExecutionName())
 			}
 		}
 

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3834,7 +3834,10 @@ func TestReportWorkflowResource_WorkflowCompleted(t *testing.T) {
 
 // TestReportWorkflow_WithMLflowOnRunEnd verifies that when a run has PluginsOutputString
 // set, reporting a terminal workflow triggers the plugin dispatcher's
-// OnRunEnd, which updates the plugin output state.
+// OnRunEnd, which updates the plugin output state. When OnRunEnd cannot close
+// the MLflow parent run, the report must return a retryable (Unavailable)
+// error — never a nil ExecutionSpec with a nil error — and must defer the
+// persistedFinalState label so the persistence agent re-reports the workflow.
 func TestReportWorkflow_WithMLflowOnRunEnd(t *testing.T) {
 	// Set a dummy MLflow config so the manager creates a real MLflow dispatcher,
 	// then clear it before the run lifecycle to simulate config being unavailable
@@ -3874,7 +3877,8 @@ func TestReportWorkflow_WithMLflowOnRunEnd(t *testing.T) {
 	require.NotNil(t, createdRun.PluginsOutputString)
 	assert.Contains(t, string(*createdRun.PluginsOutputString), "parent-run-1")
 
-	// Report a terminal (failed) workflow.
+	// Report a terminal (failed) workflow. Create it in the fake cluster first
+	// so the persistedFinalState label can be verified afterwards.
 	workflow := util.NewWorkflow(&v1alpha1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      run.K8SName,
@@ -3884,8 +3888,26 @@ func TestReportWorkflow_WithMLflowOnRunEnd(t *testing.T) {
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
-	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
+	_, err = store.ExecClientFake.Execution("ns1").Create(context.Background(), workflow, v1.CreateOptions{})
 	require.NoError(t, err)
+	execSpec, err := manager.ReportWorkflowResource(context.Background(), workflow)
+
+	// OnRunEnd fails to close the MLflow parent run (config unavailable), so
+	// the report must surface a retryable Unavailable error instead of
+	// returning a nil ExecutionSpec with a nil error (which would panic the
+	// ReportWorkflow gRPC handler). The persistence agent treats Unavailable
+	// as transient and re-reports the workflow with backoff.
+	require.Error(t, err)
+	assert.Nil(t, execSpec)
+	assert.Truef(t, util.IsUserErrorCodeMatch(err, codes.Unavailable),
+		"Expected retryable Unavailable error when plugin sync is deferred, got: %v", err)
+	assert.Contains(t, err.Error(), "Deferring persistedFinalState label")
+
+	// The persistedFinalState label must NOT be set, so the persistence agent
+	// retries the report once MLflow recovers.
+	wf, getErr := store.ExecClientFake.Execution("ns1").Get(context.Background(), run.K8SName, v1.GetOptions{})
+	require.NoError(t, getErr)
+	assert.NotEqual(t, "true", wf.ExecutionObjectMeta().Labels[util.LabelKeyWorkflowPersistedFinalState])
 
 	// After terminal report, the plugin dispatcher's OnRunEnd should have fired.
 	// Without MLflow config in Viper, the handler sets PLUGIN_FAILED.


### PR DESCRIPTION
## **Description of your changes:**

I found a bug where the API server could crash. When a run finishes and MLflow sync hasn't completed yet, the code was returning (nil, nil) instead of an error, and the gRPC handler wasn't expecting that so it crashed on the nil value.

Fixed it by returning an Unavailable error instead, so the persistence agent just retries later with backoff. Same pattern we already use for the GC grace period case, so nothing new, just consistent.

### **Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
