### PR TITLE
ci: run SDK unit tests in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/kfp-sdk-tests.yml
+++ b/.github/workflows/kfp-sdk-tests.yml
@@ -8,7 +8,7 @@ on:
       - 'api/**'
       - 'sdk/**'
       - 'test_data/sdk_compiled_pipelines/**'
-      - './test/presubmit-tests-sdk.sh'
+      - 'test/presubmit-tests-sdk.sh'
       - '.github/workflows/kfp-sdk-tests.yml'
       - '!**/*.md'
       - '!**/OWNERS'

--- a/.github/workflows/kfp-sdk-unit-tests.yml
+++ b/.github/workflows/kfp-sdk-unit-tests.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - 'api/**'
       - 'sdk/**'
-      - './test/presubmit-tests-sdk-unit.sh'
+      - 'test/presubmit-tests-sdk-unit.sh'
       - '.github/workflows/kfp-sdk-unit-tests.yml'
       - '!**/*.md'
       - '!**/OWNERS'

--- a/test/presubmit-tests-sdk-unit.sh
+++ b/test/presubmit-tests-sdk-unit.sh
@@ -16,6 +16,8 @@
 source_root=$(pwd)
 SETUP_ENV="${SETUP_ENV:-true}"
 JUNIT_XML="${JUNIT_XML:-sdk-unit.xml}"
+# Number of pytest-xdist workers; set to 0 to disable xdist (e.g. for bisecting).
+PYTEST_PARALLEL_WORKERS="${PYTEST_PARALLEL_WORKERS:-auto}"
 
 if [ "${SETUP_ENV}" = "true" ]; then
   # Create a virtual environment and activate it
@@ -48,7 +50,7 @@ fi
 # Run tests in parallel with pytest-xdist. --dist loadfile keeps all tests in
 # a file on the same worker so file-scoped fixtures and local-execution state
 # stay isolated. -s is dropped because xdist workers do not forward live output.
-pytest -v -n auto --dist loadfile sdk/python/kfp --cov=kfp --junitxml="${JUNIT_XML}"
+python -m pytest -v -n "${PYTEST_PARALLEL_WORKERS}" --dist loadfile sdk/python/kfp --cov=kfp --junitxml="${JUNIT_XML}"
 
 if [ "${SETUP_ENV}" = "true" ]; then
   # Deactivate the virtual environment

--- a/test/presubmit-tests-sdk-unit.sh
+++ b/test/presubmit-tests-sdk-unit.sh
@@ -45,7 +45,10 @@ else
   export KFP_PACKAGE_PATH="git+https://github.com/${REPO_NAME}@refs/pull/${PULL_NUMBER}/merge#egg=kfp&subdirectory=sdk/python"
 fi
 
-pytest -v -s sdk/python/kfp --cov=kfp --junitxml="${JUNIT_XML}"
+# Run tests in parallel with pytest-xdist. --dist loadfile keeps all tests in
+# a file on the same worker so file-scoped fixtures and local-execution state
+# stay isolated. -s is dropped because xdist workers do not forward live output.
+pytest -v -n auto --dist loadfile sdk/python/kfp --cov=kfp --junitxml="${JUNIT_XML}"
 
 if [ "${SETUP_ENV}" = "true" ]; then
   # Deactivate the virtual environment


### PR DESCRIPTION
## Summary

> **⏱ Time savings (measured on this PR's latest checks): SDK unit tests drop from 28–32 min to ~16–19 min per Python version** (`sdk-unit-tests (3.13)` 16m57s, `(3.9)` 18m30s) — roughly a 40% cut, ~12 min off the SDK-PR critical path.

The SDK unit test job (`kfp-sdk-unit-tests.yml`) runs a single-process `pytest --cov` and takes **28–32 minutes per Python version**, making it one of the longest wall-clock gates on SDK PRs. `pytest-xdist==3.8.0` is already pinned in `sdk/python/requirements-dev.txt` but unused.

This adds `-n auto --dist loadfile` to `test/presubmit-tests-sdk-unit.sh`:

- `--dist loadfile` keeps all tests in a file on the same worker, so file-scoped fixtures and sequential in-file assumptions hold. Cross-file state is per-worker-process (each worker gets its own `local.init` global state), and the local-runner tests already isolate per test via `tempfile.TemporaryDirectory` in `LocalRunnerEnvironmentTestCase`.
- `-s` is dropped: xdist workers do not forward live output, so it was inert; the junit XML and coverage report are unchanged (pytest-cov combines worker coverage automatically).

## Verification

- Ran the full suite locally with the new flags (Python 3.13, same pytest/xdist/cov pins as CI): all tests that run on this platform pass under parallel execution, with no ordering- or isolation-related failures. The only failures were in `kfp/local` venv-creation tests that fail identically **without** xdist on this platform (macOS-specific, they pass on Linux), so they are not parallelization regressions.
- This PR's own `KFP SDK Unit Tests` checks (3.9 and 3.13 on Ubuntu) run the modified script end-to-end and passed under parallel execution.

## Update (review follow-up)

- pytest is now invoked as `python -m pytest -n "${PYTEST_PARALLEL_WORKERS}"` with `PYTEST_PARALLEL_WORKERS=auto` overridable (0 disables xdist), matching `test/presubmit-tests-sdk.sh`.
- This PR also fixes the `pull_request` path filters in `kfp-sdk-unit-tests.yml` and `kfp-sdk-tests.yml`: the `'./test/...'` entries never match because GitHub path filters do not resolve a leading `./`, which is why the SDK unit tests check did not run on the initial script-only revision of this PR. With the filter corrected, the workflow now runs here and exercises the modified script.

