### PR TITLE
ci: isolate pip caches by workflow dependency set

### DIFF
--- a/.github/actions/setup-python-pip-cache/action.yml
+++ b/.github/actions/setup-python-pip-cache/action.yml
@@ -1,0 +1,49 @@
+name: Set up Python with isolated pip cache
+description: Set up Python and cache pip downloads without sharing restore keys across workflows
+
+inputs:
+  python-version:
+    description: Python version passed to actions/setup-python
+    required: true
+  cache-scope:
+    description: Stable, unique cache scope for the workflow's dependency set
+    required: true
+  cache-dependency-hash:
+    description: Hash of the files that define the workflow's Python dependencies
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate dependency hash
+      if: ${{ inputs.cache-dependency-hash == '' }}
+      shell: bash
+      run: |
+        echo "::error::No files matched the cache dependency patterns"
+        exit 1
+
+    - name: Set up Python
+      id: setup-python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Resolve pip cache environment
+      id: pip-cache-environment
+      shell: bash
+      run: |
+        platform="${RUNNER_OS}-${RUNNER_ARCH}"
+        if [[ -r /etc/os-release ]]; then
+          source /etc/os-release
+          platform="${platform}-${ID}-${VERSION_ID}"
+        fi
+        echo "directory=$(python -m pip cache dir)" >> "$GITHUB_OUTPUT"
+        echo "platform=${platform}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore pip cache
+      uses: actions/cache@v5
+      with:
+        path: ${{ steps.pip-cache-environment.outputs.directory }}
+        key: setup-python-${{ steps.pip-cache-environment.outputs.platform }}-python-${{ steps.setup-python.outputs.python-version }}-pip-${{ inputs.cache-scope }}-${{ inputs.cache-dependency-hash }}
+        restore-keys: |
+          setup-python-${{ steps.pip-cache-environment.outputs.platform }}-python-${{ steps.setup-python.outputs.python-version }}-pip-${{ inputs.cache-scope }}-

--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -467,7 +467,6 @@ runs:
       if: (!cancelled())
       with:
         python-version: ${{ inputs.report_python_version }}
-        cache: 'pip'
 
     - name: Install Junit2Html plugin
       id: install-junit2html

--- a/.github/workflows/backend-visualization.yml
+++ b/.github/workflows/backend-visualization.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/backend-visualization.yml'
+      - '.github/actions/setup-python-pip-cache/**'
       - 'backend/src/apiserver/visualization/**'
       - 'test/presubmit-backend-visualization.sh'
       - '!**/*.md'
@@ -25,11 +26,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-pip-cache
         with:
           python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: backend/src/apiserver/visualization/requirements*.txt
+          cache-scope: backend-visualization
+          cache-dependency-hash: ${{ hashFiles('backend/src/apiserver/visualization/requirements*.txt') }}
 
       - name: Install dependencies
         run: make install-backend-visualization-deps

--- a/.github/workflows/backend-visualization.yml
+++ b/.github/workflows/backend-visualization.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: backend/src/apiserver/visualization/requirements*.txt
 
       - name: Install dependencies
         run: make install-backend-visualization-deps

--- a/.github/workflows/docs-freshness.yml
+++ b/.github/workflows/docs-freshness.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.10"
-          cache: 'pip'
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/kfp-kubernetes-library-test.yml
+++ b/.github/workflows/kfp-kubernetes-library-test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/kfp-kubernetes-library-test.yml'
+      - '.github/actions/setup-python-pip-cache/**'
       - 'sdk/python/**'
       - 'api/v2alpha1/**'
       - 'kubernetes_platform/**'
@@ -31,13 +32,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-pip-cache
         with:
           python-version: ${{matrix.python.version}}
-          cache: 'pip'
-          cache-dependency-path: |
-            sdk/python/requirements*.txt
-            kubernetes_platform/python/requirements*.txt
+          cache-scope: kfp-kubernetes-library-test
+          cache-dependency-hash: ${{ hashFiles('sdk/python/requirements*.txt', 'kubernetes_platform/python/requirements*.txt') }}
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps

--- a/.github/workflows/kfp-kubernetes-library-test.yml
+++ b/.github/workflows/kfp-kubernetes-library-test.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           python-version: ${{matrix.python.version}}
           cache: 'pip'
+          cache-dependency-path: |
+            sdk/python/requirements*.txt
+            kubernetes_platform/python/requirements*.txt
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps

--- a/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
+++ b/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
@@ -39,6 +39,10 @@ jobs:
         with:
           python-version: "3.9"
           cache: 'pip'
+          cache-dependency-path: |
+            sdk/python/requirements*.txt
+            kubernetes_platform/python/requirements*.txt
+            test/kfp-kubernetes-native-migration-tests/requirements.txt
 
       - name: Create KFP cluster
         id: create-kfp-cluster

--- a/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
+++ b/.github/workflows/kfp-kubernetes-native-migration-tests.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/kfp-kubernetes-native-migration-tests.yaml"
+      - ".github/actions/setup-python-pip-cache/**"
       - ".github/workflows/image-builds.yml"
       - ".github/actions/deploy/**"
       - ".github/resources/**"
@@ -35,14 +36,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-pip-cache
         with:
           python-version: "3.9"
-          cache: 'pip'
-          cache-dependency-path: |
-            sdk/python/requirements*.txt
-            kubernetes_platform/python/requirements*.txt
-            test/kfp-kubernetes-native-migration-tests/requirements.txt
+          cache-scope: kfp-kubernetes-native-migration-tests
+          cache-dependency-hash: ${{ hashFiles('sdk/python/requirements*.txt', 'kubernetes_platform/python/requirements*.txt', 'test/kfp-kubernetes-native-migration-tests/requirements.txt') }}
 
       - name: Create KFP cluster
         id: create-kfp-cluster

--- a/.github/workflows/kfp-sdk-client-tests.yml
+++ b/.github/workflows/kfp-sdk-client-tests.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
+          cache-dependency-path: sdk/python/requirements*.txt
 
       - name: Create KFP cluster
         id: create-kfp-cluster

--- a/.github/workflows/kfp-sdk-client-tests.yml
+++ b/.github/workflows/kfp-sdk-client-tests.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/kfp-sdk-client-tests.yml'
+      - '.github/actions/setup-python-pip-cache/**'
       - '.github/workflows/image-builds.yml'
       - '.github/actions/create-cluster/**'
       - '.github/actions/deploy/**'
@@ -42,11 +43,11 @@ jobs:
       # This must occur after "Free up space" step
       # otherwise python version will be overridden
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-pip-cache
         with:
           python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: sdk/python/requirements*.txt
+          cache-scope: kfp-sdk-client-tests
+          cache-dependency-hash: ${{ hashFiles('sdk/python/requirements*.txt') }}
 
       - name: Create KFP cluster
         id: create-kfp-cluster

--- a/.github/workflows/kfp-sdk-tests.yml
+++ b/.github/workflows/kfp-sdk-tests.yml
@@ -34,7 +34,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
-        cache-dependency-path: sdk/python/requirements*.txt
+        cache-dependency-path: |
+          sdk/python/requirements*.txt
+          kubernetes_platform/python/requirements*.txt
 
     - name: Install protobuf dependencies & kfp-pipeline-spec
       id: install-protobuf-deps

--- a/.github/workflows/kfp-sdk-tests.yml
+++ b/.github/workflows/kfp-sdk-tests.yml
@@ -34,6 +34,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+        cache-dependency-path: sdk/python/requirements*.txt
 
     - name: Install protobuf dependencies & kfp-pipeline-spec
       id: install-protobuf-deps

--- a/.github/workflows/kfp-sdk-tests.yml
+++ b/.github/workflows/kfp-sdk-tests.yml
@@ -10,6 +10,7 @@ on:
       - 'test_data/sdk_compiled_pipelines/**'
       - './test/presubmit-tests-sdk.sh'
       - '.github/workflows/kfp-sdk-tests.yml'
+      - '.github/actions/setup-python-pip-cache/**'
       - '!**/*.md'
       - '!**/OWNERS'
 
@@ -30,13 +31,11 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: ./.github/actions/setup-python-pip-cache
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: |
-          sdk/python/requirements*.txt
-          kubernetes_platform/python/requirements*.txt
+        cache-scope: kfp-sdk-tests
+        cache-dependency-hash: ${{ hashFiles('sdk/python/requirements*.txt', 'kubernetes_platform/python/requirements*.txt') }}
 
     - name: Install protobuf dependencies & kfp-pipeline-spec
       id: install-protobuf-deps

--- a/.github/workflows/kfp-sdk-unit-tests.yml
+++ b/.github/workflows/kfp-sdk-unit-tests.yml
@@ -9,6 +9,7 @@ on:
       - 'sdk/**'
       - './test/presubmit-tests-sdk-unit.sh'
       - '.github/workflows/kfp-sdk-unit-tests.yml'
+      - '.github/actions/setup-python-pip-cache/**'
       - '!**/*.md'
       - '!**/OWNERS'
 
@@ -28,13 +29,11 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: ./.github/actions/setup-python-pip-cache
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: |
-          sdk/python/requirements*.txt
-          kubernetes_platform/python/requirements*.txt
+        cache-scope: kfp-sdk-unit-tests
+        cache-dependency-hash: ${{ hashFiles('sdk/python/requirements*.txt', 'kubernetes_platform/python/requirements*.txt') }}
 
     - name: Install protobuf dependencies & kfp-pipeline-spec
       id: install-protobuf-deps

--- a/.github/workflows/kfp-sdk-unit-tests.yml
+++ b/.github/workflows/kfp-sdk-unit-tests.yml
@@ -32,6 +32,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
+        cache-dependency-path: |
+          sdk/python/requirements*.txt
+          kubernetes_platform/python/requirements*.txt
 
     - name: Install protobuf dependencies & kfp-pipeline-spec
       id: install-protobuf-deps

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
 
       - name: Install build dependencies
         run: |
@@ -86,7 +85,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
 
       - name: Install build dependencies
         run: |
@@ -132,7 +130,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
 
       - name: Install build dependencies
         run: |
@@ -178,7 +175,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          cache: 'pip'
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/readthedocs-builds.yml
+++ b/.github/workflows/readthedocs-builds.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: 'pip'
+          cache-dependency-path: docs/sdk/requirements.txt
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps

--- a/.github/workflows/readthedocs-builds.yml
+++ b/.github/workflows/readthedocs-builds.yml
@@ -28,7 +28,10 @@ jobs:
         with:
           python-version: "3.10"
           cache: 'pip'
-          cache-dependency-path: docs/sdk/requirements.txt
+          cache-dependency-path: |
+            docs/sdk/requirements.txt
+            sdk/python/requirements*.txt
+            kubernetes_platform/python/requirements*.txt
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps

--- a/.github/workflows/readthedocs-builds.yml
+++ b/.github/workflows/readthedocs-builds.yml
@@ -9,6 +9,7 @@ on:
       - sdk/**
       - kubernetes_platform/**
       - .github/workflows/readthedocs-builds.yml
+      - .github/actions/setup-python-pip-cache/**
       - .readthedocs.yml
 
 
@@ -24,14 +25,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-pip-cache
         with:
           python-version: "3.10"
-          cache: 'pip'
-          cache-dependency-path: |
-            docs/sdk/requirements.txt
-            sdk/python/requirements*.txt
-            kubernetes_platform/python/requirements*.txt
+          cache-scope: readthedocs-builds
+          cache-dependency-hash: ${{ hashFiles('docs/sdk/requirements.txt', 'sdk/python/requirements*.txt', 'kubernetes_platform/python/requirements*.txt') }}
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps

--- a/.github/workflows/sdk-docformatter.yml
+++ b/.github/workflows/sdk-docformatter.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           python-version: 3.9
           cache: 'pip'
+          cache-dependency-path: sdk/python/requirements-dev.txt
 
       - name: Run docformatter tests
         run: ./test/presubmit-docformatter-sdk.sh

--- a/.github/workflows/sdk-docformatter.yml
+++ b/.github/workflows/sdk-docformatter.yml
@@ -9,6 +9,7 @@ on:
       - 'sdk/python/**'
       - 'test/presubmit-docformatter-sdk.sh'
       - '.github/workflows/sdk-docformatter.yml'
+      - '.github/actions/setup-python-pip-cache/**'
       - '!**/*.md'
       - '!**/OWNERS'
 
@@ -25,11 +26,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-pip-cache
         with:
           python-version: 3.9
-          cache: 'pip'
-          cache-dependency-path: sdk/python/requirements-dev.txt
+          cache-scope: sdk-docformatter
+          cache-dependency-hash: ${{ hashFiles('sdk/python/requirements-dev.txt') }}
 
       - name: Run docformatter tests
         run: ./test/presubmit-docformatter-sdk.sh

--- a/.github/workflows/sdk-isort.yml
+++ b/.github/workflows/sdk-isort.yml
@@ -10,6 +10,7 @@ on:
       - 'sdk/python/**'
       - 'test/presubmit-isort-sdk.sh'
       - '.github/workflows/sdk-isort.yml'
+      - '.github/actions/setup-python-pip-cache/**'
       - '!**/*.md'
       - '!**/OWNERS'
 
@@ -26,11 +27,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-pip-cache
         with:
           python-version: 3.9
-          cache: 'pip'
-          cache-dependency-path: sdk/python/requirements-dev.txt
+          cache-scope: sdk-isort
+          cache-dependency-hash: ${{ hashFiles('sdk/python/requirements-dev.txt') }}
 
       - name: Run isort tests
         run: ./test/presubmit-isort-sdk.sh

--- a/.github/workflows/sdk-isort.yml
+++ b/.github/workflows/sdk-isort.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           python-version: 3.9
           cache: 'pip'
+          cache-dependency-path: sdk/python/requirements-dev.txt
 
       - name: Run isort tests
         run: ./test/presubmit-isort-sdk.sh

--- a/.github/workflows/sdk-upgrade.yml
+++ b/.github/workflows/sdk-upgrade.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           python-version: 3.9
           cache: 'pip'
+          cache-dependency-path: sdk/python/requirements*.txt
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps

--- a/.github/workflows/sdk-upgrade.yml
+++ b/.github/workflows/sdk-upgrade.yml
@@ -9,6 +9,7 @@ on:
       - 'sdk/python/**'
       - 'test/presubmit-test-sdk-upgrade.sh'
       - '.github/workflows/sdk-upgrade.yml'
+      - '.github/actions/setup-python-pip-cache/**'
       - '!**/*.md'
       - '!**/OWNERS'
 
@@ -25,11 +26,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-pip-cache
         with:
           python-version: 3.9
-          cache: 'pip'
-          cache-dependency-path: sdk/python/requirements*.txt
+          cache-scope: sdk-upgrade
+          cache-dependency-hash: ${{ hashFiles('sdk/python/requirements*.txt') }}
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps

--- a/.github/workflows/sdk-yapf.yml
+++ b/.github/workflows/sdk-yapf.yml
@@ -31,6 +31,7 @@ jobs:
       with:
         python-version: '3.9'
         cache: 'pip'
+        cache-dependency-path: sdk/python/requirements-dev.txt
 
     - name: Install dependencies
       run: pip install yapf

--- a/.github/workflows/sdk-yapf.yml
+++ b/.github/workflows/sdk-yapf.yml
@@ -10,6 +10,7 @@ on:
       - 'sdk/python/**'
       - 'test/presubmit-yapf-sdk.sh'
       - '.github/workflows/sdk-yapf.yml'
+      - '.github/actions/setup-python-pip-cache/**'
       - '!**/*.md'
       - '!**/OWNERS'
 
@@ -27,11 +28,11 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: ./.github/actions/setup-python-pip-cache
       with:
         python-version: '3.9'
-        cache: 'pip'
-        cache-dependency-path: sdk/python/requirements-dev.txt
+        cache-scope: sdk-yapf
+        cache-dependency-hash: ${{ hashFiles('sdk/python/requirements-dev.txt') }}
 
     - name: Install dependencies
       run: pip install yapf

--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/validate-generated-files.yml'
+      - '.github/actions/setup-python-pip-cache/**'
       - 'backend/api/**/*.proto'
       - 'backend/api/**/go_http_client/**'
       - 'backend/api/**/go_client/**'
@@ -40,13 +41,11 @@ jobs:
         uses: ./.github/actions/setup-go
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-pip-cache
         with:
           python-version: 3.9
-          cache: 'pip'
-          cache-dependency-path: |
-            sdk/python/requirements*.txt
-            kubernetes_platform/python/requirements*.txt
+          cache-scope: validate-generated-files
+          cache-dependency-hash: ${{ hashFiles('sdk/python/requirements*.txt', 'kubernetes_platform/python/requirements*.txt') }}
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps

--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -43,6 +43,10 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.9
+          cache: 'pip'
+          cache-dependency-path: |
+            sdk/python/requirements*.txt
+            kubernetes_platform/python/requirements*.txt
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps

--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: 3.9
-          cache: 'pip'
 
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -547,6 +547,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 - The `protobuf` composite action prepares `protoc` and related dependencies when compiling Python protobufs.
 - The `create-cluster` action caches Kind node images by Kubernetes version to reduce Docker Hub pulls.
 - Python workflows use `actions/cache@v5` for pip cache to reduce repeated dependency installs.
+- Workflows using `setup-python` with `cache: 'pip'` must set `cache-dependency-path` to the requirement files the job actually installs; without it the cache key hashes every requirements file in the monorepo, so any dependency bump anywhere invalidates every workflow's pip cache.
 
 ### Code style and formatting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-13
+- Last updated: 2026-07-14
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -547,7 +547,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 - The `protobuf` composite action prepares `protoc` and related dependencies when compiling Python protobufs.
 - The `create-cluster` action caches Kind node images by Kubernetes version to reduce Docker Hub pulls.
 - Python workflows use `actions/cache@v5` for pip cache to reduce repeated dependency installs.
-- Workflows using `setup-python` with `cache: 'pip'` must set `cache-dependency-path` to the requirement files the job actually installs; without it the cache key hashes every requirements file in the monorepo, so any dependency bump anywhere invalidates every workflow's pip cache.
+- Workflows that cache pip downloads must use `.github/actions/setup-python-pip-cache` with a unique `cache-scope` for each dependency set and a `cache-dependency-hash` covering the requirement files the job installs. Do not use `setup-python`'s built-in `cache: 'pip'`: its generic restore prefix can propagate one workflow's global pip cache into another workflow's cache entry.
 
 ### Code style and formatting
 


### PR DESCRIPTION
## Summary

Isolate pip download caches by workflow dependency set so unrelated Python jobs no longer share immutable keys or restore one another's global pip cache.

The repository's built-in `setup-python` pip caches previously consumed a large share of the Actions cache budget. The default dependency discovery hashed every requirements file in the monorepo, while `setup-python`'s generic restore prefix allowed a cache miss in one workflow to restore and re-save another workflow's accumulated pip cache.

## Changes

- Add `.github/actions/setup-python-pip-cache`:
  - uses `actions/setup-python@v6` only for interpreter installation;
  - uses `actions/cache@v5` for pip downloads;
  - includes runner platform, resolved Python version, a stable dependency-set scope, and the dependency-file hash in the primary key;
  - limits fallback restores to the same platform, Python version, and scope.
- Migrate all 12 requirement-driven pip cache consumers to the shared action with unique scopes.
- Add the shared action path to each consumer workflow's pull-request path filters.
- Keep caching disabled for jobs that only install one or two small inline tools (`docs-freshness`, package publishing, and test reporting).
- Document the cache-isolation contract in `AGENTS.md`.

## Expected effect

- Dependency changes invalidate only the workflows whose declared requirement files changed.
- Workflows with different inline install sets cannot contend for the same immutable primary key.
- A scoped cache miss cannot import and re-save another workflow's global pip cache.
- Pip caches should stop crowding out higher-value Kind node and runtime image caches as old entries age out.

## Verification

- Rebased onto current `origin/master` and resolved the `AGENTS.md` conflict.
- `git diff --check origin/master...HEAD`
- Ruby YAML parse of the new composite action and all changed workflows
- Repo-pinned `actionlint v1.7.9` on all 12 consumer workflows
- Audit confirming:
  - exactly 12 consumers;
  - every scope is unique;
  - every consumer triggers when the shared action changes;
  - every dependency glob matches files;
  - no built-in `setup-python cache: pip` usage remains
- Independent post-change review found no actionable issues
