### PR TITLE
feat(backend): validate executor inputs and emit K8s events

### DIFF
--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -26,6 +26,11 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/api/core/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
@@ -364,6 +369,21 @@ func drive() (err error) {
 	if err != nil {
 		return err
 	}
+
+	var eventRecorder record.EventRecorder
+	restConfig, restErr := util.GetKubernetesConfig()
+	if restErr == nil && restConfig != nil {
+		k8sClient, err := kubernetes.NewForConfig(restConfig)
+		if err == nil {
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: k8sClient.CoreV1().Events(namespace)})
+			eventRecorder = eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "kfp-driver"})
+		} else {
+			glog.Warningf("failed to create kubernetes client for event recorder: %v", err)
+		}
+	} else {
+		glog.Warningf("failed to get kubernetes config for event recorder: %v", restErr)
+	}
 	var tlsCfg *tls.Config
 	if *metadataTLSEnabled {
 		tlsCfg, err = util.GetTLSConfig(*caCertPath)
@@ -430,6 +450,7 @@ func drive() (err error) {
 		MLMDTLSEnabled:             *metadataTLSEnabled,
 		CaCertPath:                 *caCertPath,
 		PluginDispatcher:           pluginDispatcher,
+		EventRecorder:              eventRecorder,
 	}
 	var execution *driver.Execution
 	var driverErr error

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	k8score "k8s.io/api/core/v1"
 	k8sres "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/tools/record"
 )
 
 // Driver options
@@ -57,6 +58,9 @@ type Options struct {
 
 	// optional, allows to specify kubernetes-specific executor config
 	KubernetesExecutorConfig *kubernetesplatform.KubernetesExecutorConfig
+
+	// optional, for emitting Kubernetes events on validation failures or significant state changes
+	EventRecorder record.EventRecorder
 
 	// optional, required only if the {{$.pipeline_job_resource_name}} placeholder is used or the run uses a workspace
 	RunName string

--- a/backend/src/v2/driver/resolve.go
+++ b/backend/src/v2/driver/resolve.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/golang/glog"
@@ -30,6 +31,7 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
+	k8score "k8s.io/api/core/v1"
 )
 
 var ErrResolvedParameterNull = errors.New("the resolved input parameter is null")
@@ -364,8 +366,105 @@ func resolveInputs(
 		}
 		inputs.Artifacts[name] = v
 	}
-	// TODO(Bobgy): validate executor inputs match component inputs definition
+	if err := validateExecutorInputs(inputs, opts.Component); err != nil {
+		taskName := task.GetTaskInfo().GetName()
+		if taskName == "" {
+			taskName = "unknown"
+		}
+
+		if opts.EventRecorder != nil && (opts.RunName != "" || opts.RunID != "") {
+			runName := opts.RunName
+			if runName == "" {
+				runName = opts.RunID
+			}
+			ref := &k8score.ObjectReference{
+				Kind:      "PipelineRun",
+				Name:      runName,
+				Namespace: opts.Namespace,
+			}
+			opts.EventRecorder.Eventf(ref, k8score.EventTypeWarning, "InputValidationFailed", "Task %q: %v", taskName, err)
+		}
+		return nil, fmt.Errorf("task %q: %w", taskName, err)
+	}
 	return inputs, nil
+}
+
+func validateExecutorInputs(inputs *pipelinespec.ExecutorInput_Inputs, component *pipelinespec.ComponentSpec) error {
+	if inputs == nil {
+		return fmt.Errorf("inputs cannot be nil")
+	}
+	if component == nil || component.GetInputDefinitions() == nil {
+		return nil
+	}
+
+	// Validate Parameters
+	for name, paramDef := range component.GetInputDefinitions().GetParameters() {
+		val, ok := inputs.ParameterValues[name]
+		if !ok {
+			if !paramDef.GetIsOptional() && paramDef.GetDefaultValue() == nil {
+				return fmt.Errorf("missing required parameter: %q", name)
+			}
+			continue
+		}
+
+		if val == nil || val.GetKind() == nil {
+			continue
+		}
+		if _, isNull := val.GetKind().(*structpb.Value_NullValue); isNull {
+			continue
+		}
+
+		switch paramDef.GetParameterType() {
+		case pipelinespec.ParameterType_STRING:
+			if _, isString := val.GetKind().(*structpb.Value_StringValue); !isString {
+				return fmt.Errorf("parameter %q expected STRING, got %T", name, val.GetKind())
+			}
+		case pipelinespec.ParameterType_NUMBER_DOUBLE, pipelinespec.ParameterType_NUMBER_INTEGER:
+			numVal, isNum := val.GetKind().(*structpb.Value_NumberValue)
+			if !isNum {
+				return fmt.Errorf("parameter %q expected NUMBER, got %T", name, val.GetKind())
+			}
+			if paramDef.GetParameterType() == pipelinespec.ParameterType_NUMBER_INTEGER {
+				if math.Trunc(numVal.NumberValue) != numVal.NumberValue {
+					return fmt.Errorf("parameter %q expected NUMBER_INTEGER, got %v", name, numVal.NumberValue)
+				}
+			}
+		case pipelinespec.ParameterType_BOOLEAN:
+			if _, isBool := val.GetKind().(*structpb.Value_BoolValue); !isBool {
+				return fmt.Errorf("parameter %q expected BOOLEAN, got %T", name, val.GetKind())
+			}
+		case pipelinespec.ParameterType_LIST:
+			if _, isList := val.GetKind().(*structpb.Value_ListValue); !isList {
+				return fmt.Errorf("parameter %q expected LIST, got %T", name, val.GetKind())
+			}
+		case pipelinespec.ParameterType_STRUCT:
+			if _, isStruct := val.GetKind().(*structpb.Value_StructValue); !isStruct {
+				return fmt.Errorf("parameter %q expected STRUCT, got %T", name, val.GetKind())
+			}
+		default:
+			// Allow unspecified or unknown legacy parameter types to pass for backward compatibility.
+		}
+	}
+
+	// Validate Artifacts
+	for name, artifactDef := range component.GetInputDefinitions().GetArtifacts() {
+		val, ok := inputs.Artifacts[name]
+		if !ok || val == nil {
+			if !artifactDef.GetIsOptional() {
+				return fmt.Errorf("missing required artifact: %q", name)
+			}
+			continue
+		}
+
+		// If the artifact is present but empty, only allow it if it's explicitly an ArtifactList or Optional
+		if len(val.Artifacts) == 0 {
+			if !artifactDef.GetIsArtifactList() && !artifactDef.GetIsOptional() {
+				return fmt.Errorf("missing required artifact: %q", name)
+			}
+		}
+	}
+
+	return nil
 }
 
 // resolveInputParameter resolves an InputParameterSpec

--- a/backend/src/v2/driver/resolve_test.go
+++ b/backend/src/v2/driver/resolve_test.go
@@ -456,3 +456,172 @@ func TestGetProducerTask_ArtifactOutputKeyMissingReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "pipelinechannel--condition-branches-1-oneof-1")
 	assert.Contains(t, err.Error(), "condition-branches-1")
 }
+
+func TestValidateExecutorInputs(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputs    *pipelinespec.ExecutorInput_Inputs
+		component *pipelinespec.ComponentSpec
+		wantErr   bool
+		errStr    string
+	}{
+		{
+			name: "Valid STRING parameter",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"param1": structpb.NewStringValue("hello"),
+				},
+			},
+			component: &pipelinespec.ComponentSpec{
+				InputDefinitions: &pipelinespec.ComponentInputsSpec{
+					Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+						"param1": {
+							ParameterType: pipelinespec.ParameterType_STRING,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid STRING parameter type mismatch",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"param1": structpb.NewNumberValue(123),
+				},
+			},
+			component: &pipelinespec.ComponentSpec{
+				InputDefinitions: &pipelinespec.ComponentInputsSpec{
+					Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+						"param1": {
+							ParameterType: pipelinespec.ParameterType_STRING,
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errStr:  "expected STRING, got *structpb.Value_NumberValue",
+		},
+		{
+			name: "Missing required parameter",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{},
+			},
+			component: &pipelinespec.ComponentSpec{
+				InputDefinitions: &pipelinespec.ComponentInputsSpec{
+					Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+						"param1": {
+							ParameterType: pipelinespec.ParameterType_STRING,
+							IsOptional:    false,
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errStr:  "missing required parameter: \"param1\"",
+		},
+		{
+			name: "Missing optional parameter",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{},
+			},
+			component: &pipelinespec.ComponentSpec{
+				InputDefinitions: &pipelinespec.ComponentInputsSpec{
+					Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+						"param1": {
+							ParameterType: pipelinespec.ParameterType_STRING,
+							IsOptional:    true,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Missing required parameter but has DefaultValue",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{},
+			},
+			component: &pipelinespec.ComponentSpec{
+				InputDefinitions: &pipelinespec.ComponentInputsSpec{
+					Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+						"param1": {
+							ParameterType: pipelinespec.ParameterType_STRING,
+							IsOptional:    false,
+							DefaultValue:  structpb.NewStringValue("default"),
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Optional parameter provided as NullValue",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"param1": structpb.NewNullValue(),
+				},
+			},
+			component: &pipelinespec.ComponentSpec{
+				InputDefinitions: &pipelinespec.ComponentInputsSpec{
+					Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+						"param1": {
+							ParameterType: pipelinespec.ParameterType_STRING,
+							IsOptional:    true,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "NUMBER_INTEGER with float value",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"param1": structpb.NewNumberValue(123.45),
+				},
+			},
+			component: &pipelinespec.ComponentSpec{
+				InputDefinitions: &pipelinespec.ComponentInputsSpec{
+					Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+						"param1": {
+							ParameterType: pipelinespec.ParameterType_NUMBER_INTEGER,
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errStr:  "expected NUMBER_INTEGER",
+		},
+		{
+			name: "NUMBER_INTEGER with integer value",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"param1": structpb.NewNumberValue(123.0),
+				},
+			},
+			component: &pipelinespec.ComponentSpec{
+				InputDefinitions: &pipelinespec.ComponentInputsSpec{
+					Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+						"param1": {
+							ParameterType: pipelinespec.ParameterType_NUMBER_INTEGER,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateExecutorInputs(tc.inputs, tc.component)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errStr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR addresses tech-debt by strictly validating resolved inputs against the ComponentSpec schema before task execution. It also introduces Kubernetes Event emission on validation failures to improve pipeline observability.