### PR TITLE
fix(backend): initialize driver executions as PENDING

### DIFF
--- a/backend/src/v2/driver/container.go
+++ b/backend/src/v2/driver/container.go
@@ -186,7 +186,7 @@ func Container(ctx context.Context, opts Options, mlmd *metadata.Client, cacheCl
 		ecfg.PluginCustomProperties = pluginStartResult.CustomProperties
 	}
 
-	// TODO(Bobgy): change execution state to pending, because this is driver, execution hasn't started.
+	ecfg.State = pb.Execution_NEW.Enum()
 	createdExecution, err := mlmd.CreateExecution(ctx, pipeline, ecfg)
 	if err != nil {
 		if isAlreadyExistsErr(err) {

--- a/backend/src/v2/driver/dag.go
+++ b/backend/src/v2/driver/dag.go
@@ -207,7 +207,7 @@ func DAG(ctx context.Context, opts Options, mlmd *metadata.Client) (execution *E
 	glog.V(4).Info("ecfg: ", string(b))
 	glog.V(4).Infof("dag: %v", dag)
 
-	// TODO(Bobgy): change execution state to pending, because this is driver, execution hasn't started.
+	ecfg.State = pb.Execution_NEW.Enum()
 	createdExecution, err = mlmd.CreateExecution(ctx, pipeline, ecfg)
 	if err != nil {
 		return execution, err

--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -912,7 +912,7 @@ func createPVC(
 	}
 
 	// Create execution in MLMD
-	// TODO(Bobgy): change execution state to pending, because this is driver, execution hasn't started.
+	ecfg.State = pb.Execution_NEW.Enum()
 	createdExecution, err = mlmd.CreateExecution(ctx, pipeline, ecfg)
 	if err != nil {
 		return "", createdExecution, pb.Execution_FAILED, fmt.Errorf("error creating MLMD execution for createpvc: %w", err)
@@ -1051,7 +1051,7 @@ func deletePVC(
 	}
 
 	// Create execution in MLMD
-	// TODO(Bobgy): change execution state to pending, because this is driver, execution hasn't started.
+	ecfg.State = pb.Execution_NEW.Enum()
 	createdExecution, err = mlmd.CreateExecution(ctx, pipeline, ecfg)
 	if err != nil {
 		return createdExecution, pb.Execution_FAILED, fmt.Errorf("error creating MLMD execution for createpvc: %w", err)

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -200,6 +200,7 @@ type ExecutionConfig struct {
 	DisplayName      string // optional, MLMD execution display name.
 	Name             string // optional, MLMD execution name. When provided, this needs to be unique among all MLMD executions.
 	ExecutionType    ExecutionType
+	State            *pb.Execution_State // optional, overrides the default RUNNING state.
 	NotTriggered     bool  // optional, not triggered executions will have CANCELED state.
 	ParentDagID      int64 // parent DAG execution ID. Only the root DAG does not have a parent DAG.
 	InputParameters  map[string]*structpb.Value
@@ -657,6 +658,9 @@ func (c *Client) CreateExecution(ctx context.Context, pipeline *Pipeline, config
 		e.Name = &config.Name
 	}
 	e.LastKnownState = pb.Execution_RUNNING.Enum()
+	if config.State != nil {
+		e.LastKnownState = config.State
+	}
 	if config.NotTriggered {
 		// Note, in MLMD, CANCELED state means exactly as what we call
 		// not triggered.


### PR DESCRIPTION
This PR resolves multiple TODOs in the V2 driver where execution state was incorrectly initialized as RUNNING before Kubernetes resources were created. By extending ExecutionConfig to accept an explicit State override, we now correctly initialize these MLMD executions as NEW (Pending).