### PR TITLE
fix(frontend): contain volume artifact path to its mount root

### DIFF
--- a/frontend/server/utils.test.ts
+++ b/frontend/server/utils.test.ts
@@ -213,6 +213,30 @@ describe('utils', () => {
         'File a/b/c not mounted, expecting the file to be inside volume mount subpath other',
       ]);
     });
+
+    it('rejects a filePathInVolume that escapes the volume mount path', () => {
+      const path = resolveFilePathOnVolume({
+        volumeMountPath: '/data',
+        filePathInVolume: '../../../../etc/passwd',
+        volumeMountSubPath: undefined,
+      });
+      expect(path).toEqual([
+        '',
+        'File ../../../../etc/passwd resolves outside of volume mount path /data',
+      ]);
+    });
+
+    it('rejects an escape that hides behind the volumeMountSubPath prefix', () => {
+      const path = resolveFilePathOnVolume({
+        volumeMountPath: '/data',
+        filePathInVolume: 'a/../../../etc/passwd',
+        volumeMountSubPath: 'a',
+      });
+      expect(path).toEqual([
+        '',
+        'File a/../../../etc/passwd resolves outside of volume mount path /data',
+      ]);
+    });
   });
 
   describe('parseError', () => {

--- a/frontend/server/utils.test.ts
+++ b/frontend/server/utils.test.ts
@@ -237,6 +237,15 @@ describe('utils', () => {
         'File a/../../../etc/passwd resolves outside of volume mount path /data',
       ]);
     });
+
+    it('allows a file name starting with .. that stays inside the mount path', () => {
+      const path = resolveFilePathOnVolume({
+        volumeMountPath: '/data',
+        filePathInVolume: '..foo/bar',
+        volumeMountSubPath: undefined,
+      });
+      expect(path).toEqual(['/data/..foo/bar', undefined]);
+    });
   });
 
   describe('parseError', () => {

--- a/frontend/server/utils.ts
+++ b/frontend/server/utils.ts
@@ -169,19 +169,29 @@ export function resolveFilePathOnVolume(volume: {
   volumeMountSubPath: string | undefined;
 }): [string, string | undefined] {
   const { filePathInVolume, volumeMountPath, volumeMountSubPath } = volume;
+  let relativePath: string;
   if (!volumeMountSubPath) {
-    return [path.join(volumeMountPath, filePathInVolume), undefined];
-  }
-  if (filePathInVolume.startsWith(volumeMountSubPath)) {
+    relativePath = filePathInVolume;
+  } else if (filePathInVolume.startsWith(volumeMountSubPath)) {
+    relativePath = filePathInVolume.substring(volumeMountSubPath.length);
+  } else {
     return [
-      path.join(volumeMountPath, filePathInVolume.substring(volumeMountSubPath.length)),
-      undefined,
+      '',
+      `File ${filePathInVolume} not mounted, expecting the file to be inside volume mount subpath ${volumeMountSubPath}`,
     ];
   }
-  return [
-    '',
-    `File ${filePathInVolume} not mounted, expecting the file to be inside volume mount subpath ${volumeMountSubPath}`,
-  ];
+
+  const resolvedPath = path.join(volumeMountPath, relativePath);
+  // path.join normalizes away `..` segments, so a key like `../../etc/passwd`
+  // can land outside the mount. Keep the result contained to the mount root.
+  const relativeToMount = path.relative(volumeMountPath, resolvedPath);
+  if (relativeToMount.startsWith('..') || path.isAbsolute(relativeToMount)) {
+    return [
+      '',
+      `File ${filePathInVolume} resolves outside of volume mount path ${volumeMountPath}`,
+    ];
+  }
+  return [resolvedPath, undefined];
 }
 
 export interface PreviewStreamOptions extends TransformOptions {

--- a/frontend/server/utils.ts
+++ b/frontend/server/utils.ts
@@ -185,7 +185,11 @@ export function resolveFilePathOnVolume(volume: {
   // path.join normalizes away `..` segments, so a key like `../../etc/passwd`
   // can land outside the mount. Keep the result contained to the mount root.
   const relativeToMount = path.relative(volumeMountPath, resolvedPath);
-  if (relativeToMount.startsWith('..') || path.isAbsolute(relativeToMount)) {
+  if (
+    relativeToMount === '..' ||
+    relativeToMount.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativeToMount)
+  ) {
     return [
       '',
       `File ${filePathInVolume} resolves outside of volume mount path ${volumeMountPath}`,


### PR DESCRIPTION
**Description of your changes:**

Repro: request a `volume://` artifact (or a TensorBoard `volume://` logdir) with key `../../../../etc/passwd`; the ml-pipeline-ui server resolves it to `/etc/passwd` and streams the file back.
Cause: `resolveFilePathOnVolume` builds the path with `path.join(volumeMountPath, key)`, and `key` reaches it straight from the request (only length-capped), so `..` segments normalize outside the mount before `fs.createReadStream` reads it.
Fix: reject a resolved path that lands outside the mount root. Both `getVolumeArtifactsHandler` and the tensorboard logdir parser resolve through this helper, so the single check covers both request entry points.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 