### PR TITLE
ci: stop fail-fast from cancelling image builds and their retries

### DIFF
--- a/.github/workflows/image-builds.yml
+++ b/.github/workflows/image-builds.yml
@@ -58,7 +58,11 @@ jobs:
       image_tag: ${{ steps.configure.outputs.image_tag }}
       registry: ${{ steps.configure.outputs.registry }}
     strategy:
-      fail-fast: true
+      # A single failing image build must not cancel the other builds in the
+      # matrix: cancelled jobs skip their rebuild fallback (a cancelled build
+      # step has outcome 'cancelled', not 'failure'), so fail-fast turns one
+      # transient failure into a full workflow failure.
+      fail-fast: false
       matrix:
         include:
           - image: apiserver
@@ -137,6 +141,10 @@ jobs:
             NODE_VERSION=${{ steps.frontend_node.outputs.version }}
           tags: ${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}
           outputs: type=docker,dest=${{ env.ARTIFACTS_PATH }}/${{ env.ARTIFACT_NAME }}.tar
+
+      - name: Wait before rebuilding
+        if: ${{ steps.save-image.outcome == 'failure' }}
+        run: sleep 10
 
       - name: Rebuild Images in case of failure
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary

Rescoped after #13685 merged — that PR fixed the unreachable rebuild fallback this PR originally targeted (and added `no-cache: true`, a better retry than mine). **What remains unfixed is the fail-fast amplification**, and #13685 actually makes it more visible:

- With `fail-fast: true`, one failing image build cancels the other eleven in-flight builds.
- A cancelled build step has outcome `cancelled`, not `failure`, so the cancelled jobs **skip the rebuild fallback #13685 just fixed** — the retry only ever helps the one job that failed first.
- Observed in [run 28797716509](https://github.com/kubeflow/pipelines/actions/runs/28797716509): a single transient `proxy.golang.org` error → 7 failed/cancelled image builds → every dependent E2E/API lane failed.

## Changes

- `fail-fast: false` on the image build matrix, so each image build (and its retry) stands alone.
- A 10-second wait before the rebuild so the retry does not land inside the same transient network window (`no-cache` bypasses stale layers but retries immediately otherwise).

A genuine per-image code failure still fails the workflow — it just no longer takes the other eleven healthy builds down with it.

## Verification

- YAML parse of the modified workflow
- This PR's own `build /` jobs execute the modified workflow