### PR TITLE
fix(backend): fall back to direct module fetch on Go proxy errors

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,6 +21,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# Fall back to fetching modules directly from source on any module proxy
+# error (the default comma separator only falls back on 404/410), so a
+# transient proxy.golang.org failure cannot fail the build.
+ENV GOPROXY=https://proxy.golang.org|direct
 RUN GO111MODULE=on go mod download
 
 COPY . .

--- a/backend/Dockerfile.cacheserver
+++ b/backend/Dockerfile.cacheserver
@@ -25,6 +25,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# Fall back to fetching modules directly from source on any module proxy
+# error (the default comma separator only falls back on 404/410), so a
+# transient proxy.golang.org failure cannot fail the build.
+ENV GOPROXY=https://proxy.golang.org|direct
 RUN GO111MODULE=on go mod download
 
 COPY . .

--- a/backend/Dockerfile.conformance
+++ b/backend/Dockerfile.conformance
@@ -23,6 +23,10 @@ WORKDIR /go/src/github.com/kubeflow/pipelines
 COPY ./go.mod ./
 COPY ./go.sum ./
 
+# Fall back to fetching modules directly from source on any module proxy
+# error (the default comma separator only falls back on 404/410), so a
+# transient proxy.golang.org failure cannot fail the build.
+ENV GOPROXY=https://proxy.golang.org|direct
 RUN GO111MODULE=on go mod download
 
 COPY . .

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -23,6 +23,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# git is required by the GOPROXY direct fallback below to fetch modules
+# from source when the module proxy errors.
+RUN apk add --no-cache git
+
 # Fall back to fetching modules directly from source on any module proxy
 # error (the default comma separator only falls back on 404/410), so a
 # transient proxy.golang.org failure cannot fail the build.

--- a/backend/Dockerfile.driver
+++ b/backend/Dockerfile.driver
@@ -23,6 +23,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# Fall back to fetching modules directly from source on any module proxy
+# error (the default comma separator only falls back on 404/410), so a
+# transient proxy.golang.org failure cannot fail the build.
+ENV GOPROXY=https://proxy.golang.org|direct
 RUN GO111MODULE=on go mod download
 
 COPY . .

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -21,6 +21,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# git is required by the GOPROXY direct fallback below to fetch modules
+# from source when the module proxy errors.
+RUN apk add --no-cache git
+
 # Fall back to fetching modules directly from source on any module proxy
 # error (the default comma separator only falls back on 404/410), so a
 # transient proxy.golang.org failure cannot fail the build.

--- a/backend/Dockerfile.launcher
+++ b/backend/Dockerfile.launcher
@@ -21,6 +21,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# Fall back to fetching modules directly from source on any module proxy
+# error (the default comma separator only falls back on 404/410), so a
+# transient proxy.golang.org failure cannot fail the build.
+ENV GOPROXY=https://proxy.golang.org|direct
 RUN GO111MODULE=on go mod download
 
 COPY . .

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -21,6 +21,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# git is required by the GOPROXY direct fallback below to fetch modules
+# from source when the module proxy errors.
+RUN apk add --no-cache git
+
 # Fall back to fetching modules directly from source on any module proxy
 # error (the default comma separator only falls back on 404/410), so a
 # transient proxy.golang.org failure cannot fail the build.

--- a/backend/Dockerfile.persistenceagent
+++ b/backend/Dockerfile.persistenceagent
@@ -21,6 +21,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# Fall back to fetching modules directly from source on any module proxy
+# error (the default comma separator only falls back on 404/410), so a
+# transient proxy.golang.org failure cannot fail the build.
+ENV GOPROXY=https://proxy.golang.org|direct
 RUN GO111MODULE=on go mod download
 
 COPY . .

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -21,6 +21,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# git is required by the GOPROXY direct fallback below to fetch modules
+# from source when the module proxy errors.
+RUN apk add --no-cache git
+
 # Fall back to fetching modules directly from source on any module proxy
 # error (the default comma separator only falls back on 404/410), so a
 # transient proxy.golang.org failure cannot fail the build.

--- a/backend/Dockerfile.scheduledworkflow
+++ b/backend/Dockerfile.scheduledworkflow
@@ -21,6 +21,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# Fall back to fetching modules directly from source on any module proxy
+# error (the default comma separator only falls back on 404/410), so a
+# transient proxy.golang.org failure cannot fail the build.
+ENV GOPROXY=https://proxy.golang.org|direct
 RUN GO111MODULE=on go mod download
 
 COPY . .

--- a/backend/Dockerfile.viewercontroller
+++ b/backend/Dockerfile.viewercontroller
@@ -24,6 +24,10 @@ COPY ./go.sum ./
 COPY ./kubernetes_platform/go.mod ./kubernetes_platform/go.mod
 COPY ./api/go.mod ./api/go.mod
 
+# Fall back to fetching modules directly from source on any module proxy
+# error (the default comma separator only falls back on 404/410), so a
+# transient proxy.golang.org failure cannot fail the build.
+ENV GOPROXY=https://proxy.golang.org|direct
 RUN GO111MODULE=on go mod download
 
 COPY . .


### PR DESCRIPTION
## Summary

CI image builds run `go mod download` inside Docker with Go's default `GOPROXY=https://proxy.golang.org,direct`. The **comma** separator only falls back to `direct` on 404/410 responses — any other proxy failure is terminal. In [run 28797716509](https://github.com/kubeflow/pipelines/actions/runs/28797716509) a transient stream error from proxy.golang.org (`INTERNAL_ERROR; received from peer`) failed the `cache-server` build and, through fail-fast cancellation, all twelve image builds and every dependent E2E/API lane.

## Change

Set `GOPROXY=https://proxy.golang.org|direct` in each Go builder stage (8 backend Dockerfiles). With the **pipe** separator, Go falls back to fetching modules directly from source on *any* proxy error, so this failure class self-heals mid-build instead of failing it.

- The `ENV` is declared in the builder stage of the multi-stage builds only; runtime images are unchanged.
- Complements #13655, which makes the image-build workflow's rebuild fallback reachable and stops fail-fast amplification — that PR handles arbitrary transients at the workflow level, this one removes the most common in-build network failure entirely.

## Verification

- This PR's own `build /` jobs build all 8 modified Dockerfiles end-to-end
- Proxy-fallback behavior is Go-documented semantics ([Module proxies, GOPROXY protocol](https://go.dev/ref/mod#goproxy-protocol)): pipe = fall back on any error, comma = fall back only on 404/410