### PR TITLE
chore(deps): update urllib3 constraints

### DIFF
--- a/.github/resources/scripts/kfp-readiness/requirements.txt
+++ b/.github/resources/scripts/kfp-readiness/requirements.txt
@@ -1,2 +1,3 @@
 kubernetes==30.1.0
-urllib3==2.6.3
+urllib3==2.6.3; python_version < "3.10"
+urllib3==2.7.0; python_version >= "3.10"

--- a/kubernetes_platform/python/requirements.in
+++ b/kubernetes_platform/python/requirements.in
@@ -6,5 +6,7 @@
 # api/v2alpha1/python/requirements.txt
 protobuf>=6.33.5,<7.0
 kfp>=2.14.5,<3
-# Keep Python 3.9 installs working until KFP drops Python 3.9 support.
-urllib3<2.7.0
+# urllib3 2.7.0 drops Python 3.9 support. Keep Python 3.9 on the
+# compatible line and use the patched line where supported.
+urllib3==2.6.3; python_version < "3.10"
+urllib3==2.7.0; python_version >= "3.10"

--- a/kubernetes_platform/python/requirements.txt
+++ b/kubernetes_platform/python/requirements.txt
@@ -97,8 +97,9 @@ six==1.17.0
     #   python-dateutil
 tabulate==0.9.0
     # via kfp
-urllib3==2.6.3
+urllib3==2.7.0 ; python_version >= "3.10"
     # via
+    #   -r requirements.in
     #   kfp
     #   kfp-server-api
     #   kubernetes

--- a/kubernetes_platform/python/requirements.txt
+++ b/kubernetes_platform/python/requirements.txt
@@ -97,6 +97,13 @@ six==1.17.0
     #   python-dateutil
 tabulate==0.9.0
     # via kfp
+urllib3==2.6.3 ; python_version < "3.10"
+    # via
+    #   -r requirements.in
+    #   kfp
+    #   kfp-server-api
+    #   kubernetes
+    #   requests
 urllib3==2.7.0 ; python_version >= "3.10"
     # via
     #   -r requirements.in

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -28,8 +28,10 @@ protobuf>=6.31.1,<7.0
 PyYAML>=5.3,<7
 requests-toolbelt>=0.8.0,<2
 tabulate>=0.8.6,<1
-# Keep Python 3.9 installs working until KFP drops Python 3.9 support.
-urllib3<2.7.0
+# urllib3 2.7.0 drops Python 3.9 support. Keep Python 3.9 on the
+# compatible line and use the patched line where supported.
+urllib3==2.6.3; python_version < "3.10"
+urllib3==2.7.0; python_version >= "3.10"
 
 ## standard library backports ##
 typing-extensions>=3.7.4,<5; python_version<"3.9"

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -94,6 +94,12 @@ six==1.17.0
     #   python-dateutil
 tabulate==0.9.0
     # via -r requirements.in
+urllib3==2.6.3 ; python_version < "3.10"
+    # via
+    #   -r requirements.in
+    #   kfp-server-api
+    #   kubernetes
+    #   requests
 urllib3==2.7.0 ; python_version >= "3.10"
     # via
     #   -r requirements.in

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -94,7 +94,7 @@ six==1.17.0
     #   python-dateutil
 tabulate==0.9.0
     # via -r requirements.in
-urllib3==2.6.3
+urllib3==2.7.0 ; python_version >= "3.10"
     # via
     #   -r requirements.in
     #   kfp-server-api


### PR DESCRIPTION
## Summary

- replace the broad `urllib3<2.7.0` source constraints with explicit Python-versioned pins
- use `urllib3==2.7.0` on Python 3.10+ while keeping Python 3.9 on the compatible `2.6.3` line
- include the same split pin in `.github/resources/scripts/kfp-readiness/requirements.txt`
- regenerate the SDK and Kubernetes platform requirements outputs from their `.in` sources

Supersedes #13631 and #13639 with one source-of-truth urllib3 update.

## Notes

`urllib3==2.7.0` does not support Python 3.9, while KFP still supports Python 3.9. The `.in` files now encode that compatibility boundary directly so future regenerations do not lose the constraint.

## Verification

- `cd sdk/python && pip-compile --no-header --no-emit-index-url --resolver=backtracking --output-file requirements.txt requirements.in`
- `cd kubernetes_platform/python && pip-compile --no-header --no-emit-index-url --resolver=backtracking --output-file requirements.txt requirements.in`
- `git diff --check`
- parsed the updated requirement markers for Python 3.9 and Python 3.10 behavior
- `python -m pip install --dry-run --ignore-installed -r .github/resources/scripts/kfp-readiness/requirements.txt`
