### PR TITLE
chore(deps): update requests constraints

### DIFF
--- a/kubernetes_platform/python/requirements.in
+++ b/kubernetes_platform/python/requirements.in
@@ -6,6 +6,9 @@
 # api/v2alpha1/python/requirements.txt
 protobuf>=6.33.5,<7.0
 kfp>=2.14.5,<3
-requests==2.33.0
+# requests 2.33.0 drops Python 3.9 support. Keep Python 3.9 on the
+# compatible line and use the patched line where supported.
+requests==2.32.5; python_version < "3.10"
+requests==2.33.0; python_version >= "3.10"
 # Keep Python 3.9 installs working until KFP drops Python 3.9 support.
 urllib3<2.7.0

--- a/kubernetes_platform/python/requirements.in
+++ b/kubernetes_platform/python/requirements.in
@@ -6,5 +6,6 @@
 # api/v2alpha1/python/requirements.txt
 protobuf>=6.33.5,<7.0
 kfp>=2.14.5,<3
+requests==2.33.0
 # Keep Python 3.9 installs working until KFP drops Python 3.9 support.
 urllib3<2.7.0

--- a/kubernetes_platform/python/requirements.txt
+++ b/kubernetes_platform/python/requirements.txt
@@ -77,8 +77,9 @@ pyyaml==6.0.3
     # via
     #   kfp
     #   kubernetes
-requests==2.32.5
+requests==2.33.0
     # via
+    #   -r requirements.in
     #   google-api-core
     #   google-cloud-storage
     #   kubernetes
@@ -99,6 +100,7 @@ tabulate==0.9.0
     # via kfp
 urllib3==2.6.3
     # via
+    #   -r requirements.in
     #   kfp
     #   kfp-server-api
     #   kubernetes

--- a/kubernetes_platform/python/requirements.txt
+++ b/kubernetes_platform/python/requirements.txt
@@ -77,6 +77,14 @@ pyyaml==6.0.3
     # via
     #   kfp
     #   kubernetes
+requests==2.32.5 ; python_version < "3.10"
+    # via
+    #   -r requirements.in
+    #   google-api-core
+    #   google-cloud-storage
+    #   kubernetes
+    #   requests-oauthlib
+    #   requests-toolbelt
 requests==2.33.0 ; python_version >= "3.10"
     # via
     #   -r requirements.in

--- a/kubernetes_platform/python/requirements.txt
+++ b/kubernetes_platform/python/requirements.txt
@@ -77,7 +77,7 @@ pyyaml==6.0.3
     # via
     #   kfp
     #   kubernetes
-requests==2.33.0
+requests==2.33.0 ; python_version >= "3.10"
     # via
     #   -r requirements.in
     #   google-api-core

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -26,7 +26,10 @@ kubernetes>=8.0.0,<31
 # api/v2alpha1/python/requirements.txt
 protobuf>=6.31.1,<7.0
 PyYAML>=5.3,<7
-requests==2.33.0
+# requests 2.33.0 drops Python 3.9 support. Keep Python 3.9 on the
+# compatible line and use the patched line where supported.
+requests==2.32.5; python_version < "3.10"
+requests==2.33.0; python_version >= "3.10"
 requests-toolbelt>=0.8.0,<2
 tabulate>=0.8.6,<1
 # Keep Python 3.9 installs working until KFP drops Python 3.9 support.

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -26,6 +26,7 @@ kubernetes>=8.0.0,<31
 # api/v2alpha1/python/requirements.txt
 protobuf>=6.31.1,<7.0
 PyYAML>=5.3,<7
+requests==2.33.0
 requests-toolbelt>=0.8.0,<2
 tabulate>=0.8.6,<1
 # Keep Python 3.9 installs working until KFP drops Python 3.9 support.

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -74,8 +74,9 @@ pyyaml==6.0.3
     # via
     #   -r requirements.in
     #   kubernetes
-requests==2.32.5
+requests==2.33.0
     # via
+    #   -r requirements.in
     #   google-api-core
     #   google-cloud-storage
     #   kubernetes

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -74,7 +74,7 @@ pyyaml==6.0.3
     # via
     #   -r requirements.in
     #   kubernetes
-requests==2.33.0
+requests==2.33.0 ; python_version >= "3.10"
     # via
     #   -r requirements.in
     #   google-api-core

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -74,6 +74,14 @@ pyyaml==6.0.3
     # via
     #   -r requirements.in
     #   kubernetes
+requests==2.32.5 ; python_version < "3.10"
+    # via
+    #   -r requirements.in
+    #   google-api-core
+    #   google-cloud-storage
+    #   kubernetes
+    #   requests-oauthlib
+    #   requests-toolbelt
 requests==2.33.0 ; python_version >= "3.10"
     # via
     #   -r requirements.in


### PR DESCRIPTION
## Summary

- add explicit Python-versioned `requests` source constraints for the SDK and Kubernetes platform packages
- keep Python 3.9 on `requests==2.32.5`, the newest compatible line
- use `requests==2.33.0` on Python 3.10+
- regenerate both generated requirements files from their `.in` sources

This is scoped to the requests advisory batch. #13660 handles the urllib3 source constraints separately.

## Notes

`requests==2.33.0` requires Python >=3.10, while KFP still supports Python 3.9. The `.in` files now encode that compatibility boundary directly so package installs remain valid on Python 3.9.

## Verification

- `cd sdk/python && pip-compile --no-header --no-emit-index-url --resolver=backtracking --output-file requirements.txt requirements.in`
- `cd kubernetes_platform/python && pip-compile --no-header --no-emit-index-url --resolver=backtracking --output-file requirements.txt requirements.in`
- `git diff --check`
- parsed the updated requirement markers for Python 3.9 and Python 3.10 behavior
- `python -m pip install --dry-run --ignore-installed -r sdk/python/requirements.txt`
- `python -m pip install --dry-run --ignore-installed -r kubernetes_platform/python/requirements.txt`
