### PR TITLE
fix(backend): deduplicate paramTask serialization to prevent etcd limits

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -754,10 +754,18 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 	// TODO(gkcalat): consider to avoid updating runtime manifest at create time and let
 	// persistence agent update the runtime data.
 	if tmpl.GetTemplateType() == template.V1 && run.RunDetails.WorkflowRuntimeManifest == "" {
-		run.WorkflowRuntimeManifest = model.LargeText(newExecSpec.ToStringForStore())
+		compressedManifest, err := util.GzipCompressBase64(newExecSpec.ToStringForStore())
+		if err != nil {
+			return nil, util.NewInternalServerError(err, "Failed to compress the workflow runtime manifest")
+		}
+		run.WorkflowRuntimeManifest = model.LargeText(compressedManifest)
 		run.WorkflowSpecManifest = model.LargeText(manifest)
 	} else if tmpl.GetTemplateType() == template.V2 {
-		run.PipelineRuntimeManifest = model.LargeText(newExecSpec.ToStringForStore())
+		compressedManifest, err := util.GzipCompressBase64(newExecSpec.ToStringForStore())
+		if err != nil {
+			return nil, util.NewInternalServerError(err, "Failed to compress the pipeline runtime manifest")
+		}
+		run.PipelineRuntimeManifest = model.LargeText(compressedManifest)
 		run.PipelineSpecManifest = model.LargeText(manifest)
 	} else {
 		run.PipelineSpecManifest = model.LargeText(manifest)
@@ -1080,7 +1088,11 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	if run.RunDetails.WorkflowRuntimeManifest == "" {
 		return util.NewBadRequestError(util.NewInvalidInputError("Workflow manifest cannot be empty"), "Failed to retry run %s due to error fetching workflow manifest", runId)
 	}
-	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.RunDetails.WorkflowRuntimeManifest))
+	decompressedManifest, err := util.GzipDecompressBase64(string(run.RunDetails.WorkflowRuntimeManifest))
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to retry run %s due to error decompressing the workflow manifest", runId)
+	}
+	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(decompressedManifest))
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to retry run %s due to error parsing the workflow manifest", runId)
 	}
@@ -1135,7 +1147,11 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	condition := string(newExecSpec.ExecutionStatus().Condition())
 	run.Conditions = condition
 	run.FinishedAtInSec = 0
-	run.WorkflowRuntimeManifest = model.LargeText(newExecSpec.ToStringForStore())
+	compressedManifest, err := util.GzipCompressBase64(newExecSpec.ToStringForStore())
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to retry run %s due to error compressing the workflow manifest", runId)
+	}
+	run.WorkflowRuntimeManifest = model.LargeText(compressedManifest)
 	run.State = model.RuntimeState(condition).ToV2()
 	// OnRunRetry persists plugin output independently; leave PluginsOutput unchanged here.
 	run.PluginsOutputString = nil
@@ -1161,7 +1177,11 @@ func (r *ResourceManager) ReadLog(ctx context.Context, runId string, nodeId stri
 	}
 	err = r.readRunLogFromPod(ctx, namespace, nodeId, follow, dst)
 	if err != nil && r.logArchive != nil {
-		err = r.readRunLogFromArchive(string(run.WorkflowRuntimeManifest), nodeId, dst)
+		decompressedManifest, decompressErr := util.GzipDecompressBase64(string(run.WorkflowRuntimeManifest))
+		if decompressErr != nil {
+			return util.NewBadRequestError(decompressErr, "Failed to read logs for run %v due to error decompressing workflow manifest", runId)
+		}
+		err = r.readRunLogFromArchive(decompressedManifest, nodeId, dst)
 		if err != nil {
 			return util.NewBadRequestError(err, "Failed to read logs for run %v", runId)
 		}
@@ -1557,7 +1577,11 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 		run.State = state
 		run.Conditions = string(state.ToV1())
 		run.FinishedAtInSec = execStatus.FinishedAt()
-		run.WorkflowRuntimeManifest = model.LargeText(execSpec.ToStringForStore())
+		compressedManifest, compressErr := util.GzipCompressBase64(execSpec.ToStringForStore())
+		if compressErr != nil {
+			return nil, util.Wrapf(compressErr, "Failed to report a workflow for existing run %s during compressing the workflow manifest", runId)
+		}
+		run.WorkflowRuntimeManifest = model.LargeText(compressedManifest)
 		if updateError = r.runStore.UpdateRun(run); updateError != nil {
 			return nil, util.Wrapf(updateError, "Failed to report a workflow for existing run %s during updating the run. Check if the run entry is corrupted", runId)
 		}
@@ -1658,6 +1682,10 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 		if scheduledTimeInSec == 0 {
 			scheduledTimeInSec = objMeta.CreationTimestamp.Unix()
 		}
+		compressedManifest, err := util.GzipCompressBase64(execSpec.ToStringForStore())
+		if err != nil {
+			return nil, util.Wrapf(err, "Failed to report a workflow for run %s due to error compressing the workflow manifest", runId)
+		}
 		run = &model.Run{
 			UUID:           runId,
 			ExperimentId:   experimentId,
@@ -1668,7 +1696,7 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 			Namespace:      namespace,
 			PipelineSpec:   pipelineSpec,
 			RunDetails: model.RunDetails{
-				WorkflowRuntimeManifest: model.LargeText(execSpec.ToStringForStore()),
+				WorkflowRuntimeManifest: model.LargeText(compressedManifest),
 				CreatedAtInSec:          objMeta.CreationTimestamp.Unix(),
 				ScheduledAtInSec:        scheduledTimeInSec,
 				FinishedAtInSec:         execStatus.FinishedAt(),
@@ -2064,10 +2092,14 @@ func (r *ResourceManager) ResolveArtifactPath(runID string, nodeID string, artif
 	if run.WorkflowRuntimeManifest == "" {
 		return "", util.NewInvalidInputError("read artifact from run with v2 IR spec is not supported")
 	}
-	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.WorkflowRuntimeManifest))
+	decompressedManifest, err := util.GzipDecompressBase64(string(run.WorkflowRuntimeManifest))
+	if err != nil {
+		return "", util.NewInternalServerError(err, "failed to decompress workflow manifest")
+	}
+	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(decompressedManifest))
 	if err != nil {
 		return "", util.NewInternalServerError(
-			err, "failed to unmarshal workflow '%s'", run.WorkflowRuntimeManifest)
+			err, "failed to unmarshal workflow '%s'", decompressedManifest)
 	}
 	artifactPath := execSpec.ExecutionStatus().FindObjectStoreArtifactKeyOrEmpty(nodeID, artifactName)
 	if artifactPath == "" {

--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -1697,18 +1697,22 @@ func toApiRunDetailV1(r *model.Run) *apiv1beta1.RunDetail {
 	apiRunDetails := &apiv1beta1.RunDetail{
 		Run: apiRunV1,
 	}
+	// GzipDecompressBase64 returns its input unchanged if it isn't compressed,
+	// so this is safe for manifests written before compression was introduced.
+	pipelineManifest, _ := util.GzipDecompressBase64(string(r.PipelineRuntimeManifest))
+	workflowManifest, _ := util.GzipDecompressBase64(string(r.WorkflowRuntimeManifest))
 	if r.RunDetails.WorkflowRuntimeManifest == "" {
 		apiRunDetails.PipelineRuntime = &apiv1beta1.PipelineRuntime{
-			PipelineManifest: string(r.PipelineRuntimeManifest),
+			PipelineManifest: pipelineManifest,
 		}
 	} else if r.RunDetails.PipelineRuntimeManifest == "" {
 		apiRunDetails.PipelineRuntime = &apiv1beta1.PipelineRuntime{
-			WorkflowManifest: string(r.WorkflowRuntimeManifest),
+			WorkflowManifest: workflowManifest,
 		}
 	} else {
 		apiRunDetails.PipelineRuntime = &apiv1beta1.PipelineRuntime{
-			PipelineManifest: string(r.PipelineRuntimeManifest),
-			WorkflowManifest: string(r.WorkflowRuntimeManifest),
+			PipelineManifest: pipelineManifest,
+			WorkflowManifest: workflowManifest,
 		}
 	}
 	return apiRunDetails

--- a/backend/src/common/util/compress.go
+++ b/backend/src/common/util/compress.go
@@ -1,0 +1,61 @@
+// Copyright 2025 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"io"
+)
+
+// GzipCompressBase64 gzip-compresses s and returns it as a base64-encoded
+// string, suitable for embedding in places that only accept plain strings
+// (e.g. Argo Workflow parameters, database text columns).
+func GzipCompressBase64(s string) (string, error) {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write([]byte(s)); err != nil {
+		return "", err
+	}
+	if err := w.Close(); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+// GzipDecompressBase64 reverses GzipCompressBase64. If s is empty, or is not
+// valid base64/gzip data, it is returned unchanged. This keeps the function
+// safe to call on data that may have been written before compression was
+// introduced, or during a rolling upgrade.
+func GzipDecompressBase64(s string) (string, error) {
+	if s == "" {
+		return s, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return s, nil
+	}
+	r, err := gzip.NewReader(bytes.NewReader(decoded))
+	if err != nil {
+		return s, nil
+	}
+	defer r.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		return s, nil
+	}
+	return string(out), nil
+}

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -337,10 +337,14 @@ func drive() (err error) {
 	}
 	var taskSpec *pipelinespec.PipelineTaskSpec
 	if *taskSpecJSON != "" {
-		glog.Infof("input TaskSpec:%s\n", prettyPrint(*taskSpecJSON))
+		decompressedTaskSpecJSON, err := util.GzipDecompressBase64(*taskSpecJSON)
+		if err != nil {
+			return fmt.Errorf("failed to decompress task spec, error: %w", err)
+		}
+		glog.Infof("input TaskSpec:%s\n", prettyPrint(decompressedTaskSpecJSON))
 		taskSpec = &pipelinespec.PipelineTaskSpec{}
-		if err := util.UnmarshalString(*taskSpecJSON, taskSpec); err != nil {
-			return fmt.Errorf("failed to unmarshal task spec, error: %w\ntask: %v", err, prettyPrint(*taskSpecJSON))
+		if err := util.UnmarshalString(decompressedTaskSpecJSON, taskSpec); err != nil {
+			return fmt.Errorf("failed to unmarshal task spec, error: %w\ntask: %v", err, prettyPrint(decompressedTaskSpecJSON))
 		}
 	}
 	glog.Infof("input ContainerSpec:%s\n", prettyPrint(*containerSpecJson))
@@ -350,10 +354,14 @@ func drive() (err error) {
 	}
 	var runtimeConfig *pipelinespec.PipelineJob_RuntimeConfig
 	if *runtimeConfigJSON != "" {
-		glog.Infof("input RuntimeConfig:%s\n", prettyPrint(*runtimeConfigJSON))
+		decompressedRuntimeConfigJSON, err := util.GzipDecompressBase64(*runtimeConfigJSON)
+		if err != nil {
+			return fmt.Errorf("failed to decompress runtime config, error: %w", err)
+		}
+		glog.Infof("input RuntimeConfig:%s\n", prettyPrint(decompressedRuntimeConfigJSON))
 		runtimeConfig = &pipelinespec.PipelineJob_RuntimeConfig{}
-		if err := util.UnmarshalString(*runtimeConfigJSON, runtimeConfig); err != nil {
-			return fmt.Errorf("failed to unmarshal runtime config, error: %w\nruntimeConfig: %v", err, runtimeConfigJSON)
+		if err := util.UnmarshalString(decompressedRuntimeConfigJSON, runtimeConfig); err != nil {
+			return fmt.Errorf("failed to unmarshal runtime config, error: %w\nruntimeConfig: %v", err, decompressedRuntimeConfigJSON)
 		}
 	}
 	k8sExecCfg, err := parseExecConfigJson(k8sExecConfigJson)

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -150,13 +150,19 @@ func GetPipelineRunAsUser() *int64 {
 }
 
 func (c *workflowCompiler) containerDriverTask(name string, inputs containerDriverInputs) (*wfapi.DAGTask, *containerDriverOutputs) {
+	taskCompressed, err := util.GzipCompressBase64(inputs.task)
+	if err != nil {
+		// Gzip-compressing an in-memory string cannot practically fail; fall back to the
+		// uncompressed value rather than surfacing a signature change across all callers.
+		taskCompressed = inputs.task
+	}
 	dagTask := &wfapi.DAGTask{
 		Name:     name,
 		Template: c.addContainerDriverTemplate(),
 		Arguments: wfapi.Arguments{
 			Parameters: []wfapi.Parameter{
 				{Name: paramComponent, Value: wfapi.AnyStringPtr(inputs.component)},
-				{Name: paramTask, Value: wfapi.AnyStringPtr(inputs.task)},
+				{Name: paramTask, Value: wfapi.AnyStringPtr(taskCompressed)},
 				{Name: paramContainer, Value: wfapi.AnyStringPtr(inputs.container)},
 				{Name: paramTaskName, Value: wfapi.AnyStringPtr(inputs.taskName)},
 				{Name: paramParentDagID, Value: wfapi.AnyStringPtr(inputs.parentDagID)},

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -527,18 +527,26 @@ func (c *workflowCompiler) dagDriverTask(name string, inputs dagDriverInputs) (*
 		if err != nil {
 			return nil, nil, fmt.Errorf("dagDriverTask: marshaling runtime config to proto JSON failed: %w", err)
 		}
+		runtimeConfigCompressed, err := util.GzipCompressBase64(runtimeConfigJson)
+		if err != nil {
+			return nil, nil, fmt.Errorf("dagDriverTask: compressing runtime config failed: %w", err)
+		}
 		params = append(params, wfapi.Parameter{
 			Name:  paramRuntimeConfig,
-			Value: wfapi.AnyStringPtr(runtimeConfigJson),
+			Value: wfapi.AnyStringPtr(runtimeConfigCompressed),
 		}, wfapi.Parameter{
 			Name:  paramDriverType,
 			Value: wfapi.AnyStringPtr("ROOT_DAG"),
 		})
 	}
 	if inputs.task != "" {
+		taskCompressed, err := util.GzipCompressBase64(inputs.task)
+		if err != nil {
+			return nil, nil, fmt.Errorf("dagDriverTask: compressing task spec failed: %w", err)
+		}
 		params = append(params, wfapi.Parameter{
 			Name:  paramTask,
-			Value: wfapi.AnyStringPtr(inputs.task),
+			Value: wfapi.AnyStringPtr(taskCompressed),
 		})
 	}
 

--- a/backend/src/v2/compiler/argocompiler/importer.go
+++ b/backend/src/v2/compiler/argocompiler/importer.go
@@ -44,12 +44,16 @@ func (c *workflowCompiler) importerTask(name string, task *pipelinespec.Pipeline
 	if err != nil {
 		return nil, err
 	}
+	taskJSONCompressed, err := util.GzipCompressBase64(taskJSON)
+	if err != nil {
+		return nil, err
+	}
 	return &wfapi.DAGTask{
 		Name:     name,
 		Template: c.addImporterTemplate(downloadToWorkspace),
 		Arguments: wfapi.Arguments{Parameters: []wfapi.Parameter{{
 			Name:  paramTask,
-			Value: wfapi.AnyStringPtr(taskJSON),
+			Value: wfapi.AnyStringPtr(taskJSONCompressed),
 		}, {
 			Name:  paramComponent,
 			Value: wfapi.AnyStringPtr(componentPlaceholder),

--- a/backend/src/v2/component/importer_launcher.go
+++ b/backend/src/v2/component/importer_launcher.go
@@ -74,8 +74,12 @@ func NewImporterLauncher(ctx context.Context, componentSpecJSON, importerSpecJSO
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal importer spec: %w", err)
 	}
+	decompressedTaskSpecJSON, err := util.GzipDecompressBase64(taskSpecJSON)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decompress task spec: %w", err)
+	}
 	task := &pipelinespec.PipelineTaskSpec{}
-	err = protojson.Unmarshal([]byte(taskSpecJSON), task)
+	err = protojson.Unmarshal([]byte(decompressedTaskSpecJSON), task)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal task spec: %w", err)
 	}


### PR DESCRIPTION
### Description
Addresses #13422. Large pipelines with highly repeated tasks trigger the 3MB etcd `request-entity-too-large` limits because `paramTask` and `PipelineRuntimeManifest` configurations serialize raw duplicate JSON blocks.

### Solution
Implemented standard library `compress/gzip` + `base64` compression helper utilities inside a decoupled `backend/src/common/util/compress.go` module.
- Applied transparent compression before embedding literal parameters on the compiler-side (`dag.go`, `container.go`, `importer.go`).
- Added automated decompressed flag decoding on the driver-side interfaces.
- Handled storage layer filters inside `resource_manager.go` to safely process raw fallback strings, ensuring rolling cluster updates remain backward-compatible.