### PR TITLE
chore(deps): update pytest dev requirements

### DIFF
--- a/kubernetes_platform/python/requirements-dev.txt
+++ b/kubernetes_platform/python/requirements-dev.txt
@@ -3,6 +3,8 @@ isort==5.10.1
 mypy==0.941
 pre-commit==2.19.0
 pycln==2.1.1
-pytest==7.1.2
-pytest-xdist==2.5.0
+# pytest 9.0.3 contains the tmpdir handling fix but requires Python 3.10+.
+pytest==8.4.2; python_version < "3.10"
+pytest==9.0.3; python_version >= "3.10"
+pytest-xdist==3.8.0
 yapf==0.32.0

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -8,9 +8,11 @@ pip-tools==6.0.0
 pre-commit==2.19.0
 pycln==2.1.1
 pylint==2.17.7
-pytest==7.1.2
-pytest-cov==3.0.0
-pytest-xdist==2.5.0
+# pytest 9.0.3 contains the tmpdir handling fix but requires Python 3.10+.
+pytest==8.4.2; python_version < "3.10"
+pytest==9.0.3; python_version >= "3.10"
+pytest-cov==7.1.0
+pytest-xdist==3.8.0
 types-protobuf==3.19.15
 types-PyYAML==6.0.5
 types-requests==2.27.14


### PR DESCRIPTION
## Summary
- update SDK and kfp-kubernetes dev pytest pins for the older Dependabot pytest alerts
- use pytest 9.0.3 on Python 3.10+ while keeping Python 3.9 on pytest 8.4.2, the latest compatible pytest line
- bump pytest-cov and pytest-xdist to plugin versions compatible with both pytest lines

## Verification
- `git diff --check`
- `uv run --no-progress --python 3.9 --with-requirements sdk/python/requirements-dev.txt python -m pytest --version`
- `uv run --no-progress --python 3.11 --with-requirements sdk/python/requirements-dev.txt python -m pytest --version`
- `uv run --no-progress --python 3.9 --with-requirements kubernetes_platform/python/requirements-dev.txt python -m pytest --version`
- `uv run --no-progress --python 3.11 --with-requirements kubernetes_platform/python/requirements-dev.txt python -m pytest --version`