### PR TITLE
fix(frontend): harden artifact request handling

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -30,6 +30,9 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'backend/**'
+      # Artifact authorization changes must exercise the multi-user artifact
+      # proxy and SeaweedFS namespace-isolation checks below.
+      - 'frontend/server/handlers/artifacts.ts'
       - 'proxy/**'
       - 'manifests/kustomize/**'
       # The artifact-proxy E2E script is exercised only by this workflow, so

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -6,6 +6,7 @@ GitHub Actions workflows are in `.github/workflows/`; reusable composite actions
 - CI covers supported Kubernetes and Argo versions, database and Kubernetes pipeline stores, proxy/cache variants, and GPU scheduling. Preserve the relevant matrix coverage when changing a lane.
 - Use `.github/actions/setup-python-pip-cache` for pip caching. Give each dependency set a distinct `cache-scope` and hash every installed requirements file; do not use `setup-python`'s built-in pip cache.
 - `validate-generated-files.yml` validates backend-generated outputs. `frontend.yml` runs `npm run apis:all` and rejects stale frontend clients.
+- Changes to `frontend/server/handlers/artifacts.ts` trigger `e2e-test.yml` so the multi-user artifact-proxy and SeaweedFS namespace-isolation checks run before artifact authorization changes merge.
 - For workflow-only changes, verify referenced working directories, Docker contexts/files, scripts, and local action paths exist.
 
 ## Common CI failures

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -18,6 +18,7 @@ import {
   findFileOnPodVolume,
   parseJSONString,
   isAllowedResourceName,
+  openFileWithinRoot,
 } from '../utils.js';
 import {
   createMinioClient,
@@ -36,7 +37,6 @@ import { URL } from 'url';
 import { getGCSClient, listGCSObjectNames, downloadGCSObjectStream } from '../gcs-helper.js';
 import type { GCSClient } from '../gcs-helper.js';
 
-import * as fs from 'fs';
 import { isAllowedDomain } from './domain-checker.js';
 import { getK8sSecret } from '../k8s-helper.js';
 import { CredentialBody } from 'google-auth-library';
@@ -343,7 +343,13 @@ export function getArtifactsHandler({
       case 'https': {
         const httpUrl = getHttpUrl(source, http.baseUrl || '', bucket, key);
         if (!httpUrl) {
-          res.status(400).send('HTTP artifact base URL is not configured');
+          res
+            .status(400)
+            .send(
+              http.baseUrl.trim()
+                ? 'Invalid HTTP artifact path'
+                : 'HTTP artifact base URL is not configured',
+            );
           return;
         }
         await getHttpArtifactsHandler(allowedDomain, httpUrl, http.auth, peek)(req, res);
@@ -490,7 +496,14 @@ function getHttpUrl(source: 'http' | 'https', baseUrl: string, bucket: string, k
   }
   try {
     const artifactUrl = new URL(`${source}://${configuredBaseUrl}`);
-    artifactUrl.pathname = [artifactUrl.pathname.replace(/\/+$/, ''), bucket, key]
+    if (
+      key.includes('\\') ||
+      key.split('/').some((segment) => segment === '.' || segment === '..')
+    ) {
+      return undefined;
+    }
+    const escapedKey = key.replace(/%/g, '%25');
+    artifactUrl.pathname = [artifactUrl.pathname.replace(/\/+$/, ''), bucket, escapedKey]
       .filter(Boolean)
       .join('/');
     artifactUrl.search = '';
@@ -527,6 +540,8 @@ function getHttpArtifactsHandler(
     // header.
     const maxRedirects = 5;
     let currentUrl = url;
+    const credentialOrigin = new URL(url).origin;
+    let requestHeaders = headers;
     let response: Awaited<ReturnType<typeof fetch>>;
     for (let hop = 0; ; hop++) {
       const allowedUrl = parseAllowedHttpArtifactUrl(currentUrl, allowedDomain);
@@ -534,7 +549,10 @@ function getHttpArtifactsHandler(
         res.status(500).send(`Domain not allowed.`);
         return;
       }
-      response = await fetch(allowedUrl, { headers, redirect: 'manual' });
+      if (new URL(allowedUrl).origin !== credentialOrigin) {
+        requestHeaders = {};
+      }
+      response = await fetch(allowedUrl, { headers: requestHeaders, redirect: 'manual' });
       const status = response.status ?? 200;
       if (status < 300 || status >= 400) {
         break;
@@ -557,7 +575,7 @@ function getHttpArtifactsHandler(
       // defensively so a bad value turns into a controlled 500 rather than an
       // unhandled exception escaping the handler.
       try {
-        currentUrl = new URL(location, currentUrl).toString();
+        currentUrl = new URL(location, allowedUrl).toString();
       } catch {
         res.status(500).send('Invalid redirect location while retrieving artifact');
         return;
@@ -889,7 +907,7 @@ function getVolumeArtifactsHandler(options: { bucket: string; key: string }, pee
 
       // ml-pipeline-ui server container name also be called 'ml-pipeline-ui-artifact' in KFP multi user mode.
       // https://github.com/kubeflow/manifests/blob/master/pipeline/installs/multi-user/pipelines-profile-controller/sync.py#L212
-      const [filePath, parseError] = findFileOnPodVolume(pod, {
+      const [filePath, parseError, volumeMountPath] = findFileOnPodVolume(pod, {
         containerNames: ['ml-pipeline-ui', 'ml-pipeline-ui-artifact'],
         volumeMountName: bucket,
         filePathInVolume: key,
@@ -900,16 +918,36 @@ function getVolumeArtifactsHandler(options: { bucket: string; key: string }, pee
         return;
       }
 
-      // TODO: support directory and support filePath include wildcards '*'
-      const stat = await fs.promises.stat(filePath);
-      if (stat.isDirectory()) {
-        res
-          .status(400)
-          .send(`Failed to open volume file ${filePath} is directory, does not support now`);
+      if (!volumeMountPath) {
+        res.status(404).send(`Failed to open volume.`);
+        return;
+      }
+      const [fileHandle, containmentError] = await openFileWithinRoot(filePath, volumeMountPath);
+      if (containmentError || !fileHandle) {
+        console.log(`Failed to open volume: ${containmentError?.message || 'unknown error'}`);
+        res.status(containmentError?.pathEscaped ? 404 : 500).send(`Failed to open volume.`);
         return;
       }
 
-      fs.createReadStream(filePath).pipe(new PreviewStream({ peek })).pipe(res);
+      try {
+        // TODO: support directory and support filePath include wildcards '*'
+        const stat = await fileHandle.stat();
+        if (stat.isDirectory()) {
+          await fileHandle.close();
+          res
+            .status(400)
+            .send(`Failed to open volume file ${filePath} is directory, does not support now`);
+          return;
+        }
+
+        fileHandle
+          .createReadStream({ autoClose: true })
+          .pipe(new PreviewStream({ peek }))
+          .pipe(res);
+      } catch (error) {
+        await fileHandle.close().catch(() => undefined);
+        throw error;
+      }
     } catch (err) {
       console.log(`Failed to open volume: ${err}`);
       res.status(500).send(`Failed to open volume.`);

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -340,7 +340,7 @@ export function getArtifactsHandler({
         )(req, res);
         break;
       case 'http':
-      case 'https':
+      case 'https': {
         const httpUrl = getHttpUrl(source, http.baseUrl || '', bucket, key);
         if (!httpUrl) {
           res.status(400).send('HTTP artifact base URL is not configured');
@@ -348,6 +348,7 @@ export function getArtifactsHandler({
         }
         await getHttpArtifactsHandler(allowedDomain, httpUrl, http.auth, peek)(req, res);
         break;
+      }
       case 'volume':
         await getVolumeArtifactsHandler(
           {

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -66,6 +66,10 @@ interface ArtifactsQueryStrings {
   namespace?: string;
 }
 
+type ArtifactSource = ArtifactsQueryStrings['source'];
+
+const ARTIFACT_SOURCES = new Set<ArtifactSource>(['minio', 's3', 'gcs', 'http', 'https', 'volume']);
+
 export interface S3ProviderInfo {
   Provider: string;
   Params: {
@@ -148,12 +152,12 @@ export function getArtifactsAuthMiddleware(
       return;
     }
 
-    const rawNamespace = request.query.namespace;
-    const namespace: string | undefined = Array.isArray(rawNamespace)
-      ? String(rawNamespace[0])
-      : typeof rawNamespace === 'string'
-        ? rawNamespace
-        : undefined;
+    const namespaceParam = getOptionalRequestString(request.query.namespace, 'namespace');
+    if ('error' in namespaceParam) {
+      response.status(namespaceParam.error.status).send(namespaceParam.error.message);
+      return;
+    }
+    const namespace = namespaceParam.value;
 
     if (!namespace) {
       console.warn(
@@ -254,32 +258,14 @@ export function getArtifactsHandler({
 }): Handler {
   const { aws, http, minio, allowedDomain } = artifactsConfigs;
   return async (req, res) => {
-    const source = (useParameter ? req.params.source : req.query.source) as string | undefined;
-    const bucket = (useParameter ? req.params.bucket : req.query.bucket) as string | undefined;
-    const key = (useParameter ? req.params[0] : req.query.key) as string | undefined;
-    const {
-      peek = 0,
-      providerInfo = '',
-      // When auth is enabled, the authorization middleware has already validated
-      // and required the namespace parameter before this handler runs.
-      // When auth is disabled (standalone mode), fallback to serverNamespace
-      // for provider-based credential lookups via getK8sSecret (Issue #9889).
-      namespace = options.server.serverNamespace,
-    } = req.query as Partial<ArtifactsQueryStrings>;
-    if (!source) {
-      res.status(500).send('Storage source is missing from artifact request');
+    const artifactRequest = parseArtifactRequest(req, useParameter, options.server.serverNamespace);
+    if ('error' in artifactRequest) {
+      res.status(artifactRequest.error.status).send(artifactRequest.error.message);
       return;
     }
-    if (!bucket) {
-      res.status(500).send('Storage bucket is missing from artifact request');
-      return;
-    }
+    const { source, bucket, key, peek, providerInfo, namespace } = artifactRequest;
     if (!isAllowedResourceName(bucket)) {
       res.status(500).send('Invalid bucket name');
-      return;
-    }
-    if (!key) {
-      res.status(500).send('Storage key is missing from artifact request');
       return;
     }
     if (key.length > 1024) {
@@ -355,12 +341,12 @@ export function getArtifactsHandler({
         break;
       case 'http':
       case 'https':
-        await getHttpArtifactsHandler(
-          allowedDomain,
-          getHttpUrl(source, http.baseUrl || '', bucket, key),
-          http.auth,
-          peek,
-        )(req, res);
+        const httpUrl = getHttpUrl(source, http.baseUrl || '', bucket, key);
+        if (!httpUrl) {
+          res.status(400).send('HTTP artifact base URL is not configured');
+          return;
+        }
+        await getHttpArtifactsHandler(allowedDomain, httpUrl, http.auth, peek)(req, res);
         break;
       case 'volume':
         await getVolumeArtifactsHandler(
@@ -378,6 +364,117 @@ export function getArtifactsHandler({
   };
 }
 
+type ArtifactRequest =
+  | {
+      source: ArtifactSource;
+      bucket: string;
+      key: string;
+      peek: number;
+      providerInfo: string;
+      namespace: string;
+    }
+  | { error: { status: number; message: string } };
+
+function parseArtifactRequest(
+  req: Request,
+  useParameter: boolean,
+  defaultNamespace: string,
+): ArtifactRequest {
+  const source = getRequiredRequestString(
+    useParameter ? req.params.source : req.query.source,
+    'source',
+    'Storage source is missing from artifact request',
+  );
+  if ('error' in source) {
+    return source;
+  }
+  if (!isArtifactSource(source.value)) {
+    return { error: { status: 500, message: 'Unknown storage source' } };
+  }
+
+  const bucket = getRequiredRequestString(
+    useParameter ? req.params.bucket : req.query.bucket,
+    'bucket',
+    'Storage bucket is missing from artifact request',
+  );
+  if ('error' in bucket) {
+    return bucket;
+  }
+
+  const key = getRequiredRequestString(
+    useParameter ? req.params[0] : req.query.key,
+    'key',
+    'Storage key is missing from artifact request',
+  );
+  if ('error' in key) {
+    return key;
+  }
+
+  const providerInfo = getOptionalRequestString(req.query.providerInfo, 'providerInfo');
+  if ('error' in providerInfo) {
+    return providerInfo;
+  }
+
+  const namespace = getOptionalRequestString(req.query.namespace, 'namespace');
+  if ('error' in namespace) {
+    return namespace;
+  }
+
+  const peek = getOptionalRequestString(req.query.peek, 'peek');
+  if ('error' in peek) {
+    return peek;
+  }
+
+  return {
+    source: source.value,
+    bucket: bucket.value,
+    key: key.value,
+    peek: parsePeekValue(peek.value),
+    providerInfo: providerInfo.value ?? '',
+    namespace: namespace.value ?? defaultNamespace,
+  };
+}
+
+function getRequiredRequestString(
+  value: unknown,
+  name: string,
+  missingMessage: string,
+): { value: string } | { error: { status: number; message: string } } {
+  const optional = getOptionalRequestString(value, name);
+  if ('error' in optional) {
+    return optional;
+  }
+  if (!optional.value) {
+    return { error: { status: 500, message: missingMessage } };
+  }
+  return { value: optional.value };
+}
+
+function getOptionalRequestString(
+  value: unknown,
+  name: string,
+): { value: string | undefined } | { error: { status: number; message: string } } {
+  if (value === undefined) {
+    return { value: undefined };
+  }
+  if (typeof value !== 'string') {
+    return { error: { status: 400, message: `${name} must be a single string value` } };
+  }
+  return { value };
+}
+
+function parsePeekValue(value: string | undefined): number {
+  if (!value) {
+    return 0;
+  }
+  const peek = Number(value);
+  return Number.isFinite(peek) && peek > 0 ? peek : 0;
+}
+
+function isArtifactSource(source: string): source is ArtifactSource {
+  return ARTIFACT_SOURCES.has(source as ArtifactSource);
+}
+
 /**
  * Returns the http/https url to retrieve a kfp artifact (of the form: `${source}://${baseUrl}${bucket}/${key}`)
  * @param source "http" or "https".
@@ -386,9 +483,21 @@ export function getArtifactsHandler({
  * @param key path to the artifact.
  */
 function getHttpUrl(source: 'http' | 'https', baseUrl: string, bucket: string, key: string) {
-  // trim `/` from both ends of the base URL, then append with a single `/` to the end (empty string remains empty)
-  baseUrl = baseUrl.replace(/^\/*(.+?)\/*$/, '$1/');
-  return `${source}://${baseUrl}${bucket}/${key}`;
+  const configuredBaseUrl = baseUrl.trim().replace(/^\/+/, '');
+  if (!configuredBaseUrl) {
+    return undefined;
+  }
+  try {
+    const artifactUrl = new URL(`${source}://${configuredBaseUrl}`);
+    artifactUrl.pathname = [artifactUrl.pathname.replace(/\/+$/, ''), bucket, key]
+      .filter(Boolean)
+      .join('/');
+    artifactUrl.search = '';
+    artifactUrl.hash = '';
+    return artifactUrl.toString();
+  } catch {
+    return undefined;
+  }
 }
 
 function getHttpArtifactsHandler(
@@ -419,11 +528,12 @@ function getHttpArtifactsHandler(
     let currentUrl = url;
     let response: Awaited<ReturnType<typeof fetch>>;
     for (let hop = 0; ; hop++) {
-      if (!isAllowedDomain(currentUrl, allowedDomain)) {
+      const allowedUrl = parseAllowedHttpArtifactUrl(currentUrl, allowedDomain);
+      if (!allowedUrl) {
         res.status(500).send(`Domain not allowed.`);
         return;
       }
-      response = await fetch(currentUrl, { headers, redirect: 'manual' });
+      response = await fetch(allowedUrl, { headers, redirect: 'manual' });
       const status = response.status ?? 200;
       if (status < 300 || status >= 400) {
         break;
@@ -463,6 +573,21 @@ function getHttpArtifactsHandler(
       .pipe(new PreviewStream({ peek }))
       .pipe(res);
   };
+}
+
+function parseAllowedHttpArtifactUrl(url: string, allowedDomain: string): string | undefined {
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return undefined;
+    }
+    if (!isAllowedDomain(parsedUrl.toString(), allowedDomain)) {
+      return undefined;
+    }
+    return parsedUrl.toString();
+  } catch {
+    return undefined;
+  }
 }
 
 function getMinioArtifactHandler(
@@ -875,7 +1000,11 @@ export function getArtifactsProxyHandler({
 function getNamespaceFromUrl(path: string): string | undefined {
   // Gets namespace from query parameter "namespace"
   const params = new URL(path, DUMMY_BASE_PATH).searchParams;
-  return params.get('namespace') || undefined;
+  const namespaces = params.getAll('namespace');
+  if (namespaces.length !== 1) {
+    return undefined;
+  }
+  return namespaces[0] || undefined;
 }
 
 // `new URL('/path')` doesn't work, because URL only accepts full URL with scheme and hostname.

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -69,6 +69,14 @@ interface ArtifactsQueryStrings {
 type ArtifactSource = ArtifactsQueryStrings['source'];
 
 const ARTIFACT_SOURCES = new Set<ArtifactSource>(['minio', 's3', 'gcs', 'http', 'https', 'volume']);
+const ARTIFACT_QUERY_PARAMETER_NAMES = [
+  'source',
+  'bucket',
+  'key',
+  'providerInfo',
+  'namespace',
+  'peek',
+] as const;
 
 export interface S3ProviderInfo {
   Provider: string;
@@ -139,6 +147,12 @@ export function getArtifactsAuthMiddleware(
   envoyAddress?: string,
 ): Handler {
   return async (request: Request, response: Response, next: NextFunction) => {
+    const queryError = validateArtifactQueryParameters(request.query);
+    if (queryError) {
+      response.status(queryError.status).send(queryError.message);
+      return;
+    }
+
     if (!authEnabled) {
       return next();
     }
@@ -468,6 +482,18 @@ function getOptionalRequestString(
     return { error: { status: 400, message: `${name} must be a single string value` } };
   }
   return { value };
+}
+
+function validateArtifactQueryParameters(
+  query: Request['query'],
+): { status: number; message: string } | undefined {
+  for (const name of ARTIFACT_QUERY_PARAMETER_NAMES) {
+    const parameter = getOptionalRequestString(query[name], name);
+    if ('error' in parameter) {
+      return parameter.error;
+    }
+  }
+  return undefined;
 }
 
 function parsePeekValue(value: string | undefined): number {

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -152,12 +152,12 @@ export function getArtifactsAuthMiddleware(
       return;
     }
 
-    const namespaceParam = getOptionalRequestString(request.query.namespace, 'namespace');
-    if ('error' in namespaceParam) {
-      response.status(namespaceParam.error.status).send(namespaceParam.error.message);
+    const namespaceParameter = getOptionalRequestString(request.query.namespace, 'namespace');
+    if ('error' in namespaceParameter) {
+      response.status(namespaceParameter.error.status).send(namespaceParameter.error.message);
       return;
     }
-    const namespace = namespaceParam.value;
+    const namespace = namespaceParameter.value;
 
     if (!namespace) {
       console.warn(

--- a/frontend/server/handlers/domain-checker.test.ts
+++ b/frontend/server/handlers/domain-checker.test.ts
@@ -47,4 +47,8 @@ describe('isAllowedDomain', () => {
   it('accepts the default production allowlist for service URLs', () => {
     expect(isAllowedDomain('http://ml-pipeline.kubeflow:8888/artifacts', '^.*$')).toBe(true);
   });
+
+  it('rejects non-http schemes before applying the allowlist', () => {
+    expect(isAllowedDomain('file:///etc/passwd', '^.*$')).toBe(false);
+  });
 });

--- a/frontend/server/handlers/domain-checker.ts
+++ b/frontend/server/handlers/domain-checker.ts
@@ -15,7 +15,7 @@
 export function isAllowedDomain(urlStr: string, allowedDomain: string): boolean {
   const allowedRegExp = new RegExp(allowedDomain);
   const domain = domain_from_url(urlStr);
-  const allowed = allowedRegExp.test(domain);
+  const allowed = domain.length > 0 && allowedRegExp.test(domain);
   if (!allowed) {
     console.log(`Domain not allowed: ${urlStr}`);
   }
@@ -23,6 +23,13 @@ export function isAllowedDomain(urlStr: string, allowedDomain: string): boolean 
 }
 
 function domain_from_url(url: string): string {
-  const match = url.match(/^(?:https?:\/\/)?(?:[^@/\n]+@)?([^:/?\n]+)/);
-  return match?.[1] ?? '';
+  try {
+    const parsedUrl = new URL(url.includes('://') ? url : `http://${url}`);
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return '';
+    }
+    return parsedUrl.hostname;
+  } catch {
+    return '';
+  }
 }

--- a/frontend/server/integration-tests/artifact-auth.test.ts
+++ b/frontend/server/integration-tests/artifact-auth.test.ts
@@ -179,6 +179,35 @@ describe('/artifacts authorization', () => {
       expect(response.text).toContain('Authentication required');
     });
 
+    it('rejects duplicate namespace parameters before authorization', async () => {
+      const configurations = loadConfigs(argv, {
+        MINIO_ACCESS_KEY: 'minio',
+        MINIO_HOST: 'minio-service',
+        MINIO_NAMESPACE: 'kubeflow',
+        MINIO_PORT: '9000',
+        MINIO_SECRET_KEY: 'minio123',
+        MINIO_SSL: 'false',
+        ML_PIPELINE_SERVICE_HOST: 'localhost',
+        ML_PIPELINE_SERVICE_PORT: '8888',
+        KUBEFLOW_USERID_HEADER: 'kubeflow-userid',
+        KUBEFLOW_USERID_PREFIX: '',
+      });
+
+      configurations.auth.enabled = true;
+
+      app = new UIServer(configurations);
+
+      const request = requests(app.app);
+      const response = await request
+        .get(
+          '/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace&namespace=other-namespace',
+        )
+        .set('kubeflow-userid', 'user@example.com')
+        .expect(400);
+      expect(response.text).toContain('namespace must be a single string value');
+      expect(mockedFetch).not.toHaveBeenCalled();
+    });
+
     it('rejects requests with invalid namespace format', async () => {
       mockedFetch.mockResolvedValue({
         ok: true,

--- a/frontend/server/integration-tests/artifact-auth.test.ts
+++ b/frontend/server/integration-tests/artifact-auth.test.ts
@@ -179,34 +179,45 @@ describe('/artifacts authorization', () => {
       expect(response.text).toContain('Authentication required');
     });
 
-    it('rejects duplicate namespace parameters before authorization', async () => {
-      const configurations = loadConfigs(argv, {
-        MINIO_ACCESS_KEY: 'minio',
-        MINIO_HOST: 'minio-service',
-        MINIO_NAMESPACE: 'kubeflow',
-        MINIO_PORT: '9000',
-        MINIO_SECRET_KEY: 'minio123',
-        MINIO_SSL: 'false',
-        ML_PIPELINE_SERVICE_HOST: 'localhost',
-        ML_PIPELINE_SERVICE_PORT: '8888',
-        KUBEFLOW_USERID_HEADER: 'kubeflow-userid',
-        KUBEFLOW_USERID_PREFIX: '',
-      });
+    it.each(['source', 'bucket', 'key', 'providerInfo', 'namespace', 'peek'])(
+      'rejects duplicate %s parameters before authorization',
+      async (parameterName) => {
+        const configurations = loadConfigs(argv, {
+          MINIO_ACCESS_KEY: 'minio',
+          MINIO_HOST: 'minio-service',
+          MINIO_NAMESPACE: 'kubeflow',
+          MINIO_PORT: '9000',
+          MINIO_SECRET_KEY: 'minio123',
+          MINIO_SSL: 'false',
+          ML_PIPELINE_SERVICE_HOST: 'localhost',
+          ML_PIPELINE_SERVICE_PORT: '8888',
+          KUBEFLOW_USERID_HEADER: 'kubeflow-userid',
+          KUBEFLOW_USERID_PREFIX: '',
+        });
 
-      configurations.auth.enabled = true;
+        configurations.auth.enabled = true;
 
-      app = new UIServer(configurations);
+        app = new UIServer(configurations);
 
-      const request = requests(app.app);
-      const response = await request
-        .get(
-          '/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&namespace=my-namespace&namespace=other-namespace',
-        )
-        .set('kubeflow-userid', 'user@example.com')
-        .expect(400);
-      expect(response.text).toContain('namespace must be a single string value');
-      expect(mockedFetch).not.toHaveBeenCalled();
-    });
+        const request = requests(app.app);
+        const query = new URLSearchParams({
+          source: 'minio',
+          bucket: 'ml-pipeline',
+          key: 'hello/world.txt',
+          providerInfo: '{}',
+          namespace: 'my-namespace',
+          peek: '10',
+        });
+        query.append(parameterName, 'duplicate');
+        const response = await request
+          .get(`/artifacts/get?${query.toString()}`)
+          .set('kubeflow-userid', 'user@example.com')
+          .expect(400);
+        expect(response.text).toContain(`${parameterName} must be a single string value`);
+        expect(mockedFetch).not.toHaveBeenCalled();
+        expect(mockedValidateArtifactNamespace).not.toHaveBeenCalled();
+      },
+    );
 
     it('rejects requests with invalid namespace format', async () => {
       mockedFetch.mockResolvedValue({

--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -102,6 +102,16 @@ describe('/artifacts', () => {
       });
     });
 
+    it('rejects artifact requests with multi-valued query parameters', async () => {
+      const configs = loadConfigs(argv, {});
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      await request
+        .get('/artifacts/get?source=minio&source=s3&bucket=ml-pipeline&key=hello%2Fworld.txt')
+        .expect(400, 'source must be a single string value');
+    });
+
     it('responds with artifact if source is AWS S3, and creds are sourced from Env', async () => {
       const mockedMinioClient: Mock = minio.Client as any;
       const configs = loadConfigs(argv, {});
@@ -577,6 +587,43 @@ describe('/artifacts', () => {
       });
     });
 
+    it('rejects http artifacts with a request-controlled host and default allowlist', async () => {
+      mockedFetch.mockClear();
+      const configs = loadConfigs(argv, {});
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      await request
+        .get('/artifacts/get?source=http&bucket=metadata&key=latest%2Fmeta-data')
+        .expect(400, 'HTTP artifact base URL is not configured');
+      expect(mockedFetch).not.toHaveBeenCalled();
+    });
+
+    it('treats http artifact key metacharacters as path data', async () => {
+      const artifactContent = 'hello world';
+      mockedFetch.mockImplementationOnce((url: string, opts: any) =>
+        url === 'http://foo.bar/ml-pipeline/hello%3Ftoken=secret%23frag'
+          ? Promise.resolve({
+              buffer: () => Promise.resolve(artifactContent),
+              body: toWebStream(artifactContent),
+            })
+          : Promise.reject('Unable to retrieve http artifact.'),
+      );
+      const configs = loadConfigs(argv, {
+        HTTP_BASE_URL: 'foo.bar/',
+      });
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      await request
+        .get('/artifacts/get?source=http&bucket=ml-pipeline&key=hello%3Ftoken%3Dsecret%23frag')
+        .expect(200, artifactContent);
+      expect(mockedFetch).toBeCalledWith('http://foo.bar/ml-pipeline/hello%3Ftoken=secret%23frag', {
+        headers: {},
+        redirect: 'manual',
+      });
+    });
+
     it('responds with partial http artifact if peek=5 flag is set', async () => {
       const artifactContent = 'hello world';
       const mockedFetch: Mock = fetch as any;
@@ -989,6 +1036,45 @@ describe('/artifacts', () => {
       await request
         .get(`/artifacts/get?source=volume&bucket=artifact&key=content&peek=5`)
         .expect(200, artifactContent.slice(0, 5));
+    });
+
+    it('rejects volume artifact paths that leave the mounted volume', async () => {
+      vi.spyOn(serverInfo, 'getHostPod').mockImplementation(() =>
+        Promise.resolve([
+          {
+            spec: {
+              containers: [
+                {
+                  volumeMounts: [
+                    {
+                      name: 'artifact',
+                      mountPath: mkTempDir(),
+                    },
+                  ],
+                  name: 'ml-pipeline-ui',
+                },
+              ],
+              volumes: [
+                {
+                  name: 'artifact',
+                  persistentVolumeClaim: {
+                    claimName: 'artifact_pvc',
+                  },
+                },
+              ],
+            },
+          } as any,
+          undefined,
+        ]),
+      );
+
+      const configs = loadConfigs(argv, {});
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      await request
+        .get('/artifacts/get?source=volume&bucket=artifact&key=..%2Fsecret')
+        .expect(404, 'Failed to open volume.');
     });
 
     it('responds error with a not exist volume', async () => {

--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -624,6 +624,49 @@ describe('/artifacts', () => {
       });
     });
 
+    it.each([
+      ['parent directory segments', '..%2F..%2Fadmin'],
+      ['backslash directory segments', '..%5C..%5Cadmin'],
+    ])('rejects http artifact keys with %s', async (_description, key) => {
+      mockedFetch.mockClear();
+      const configs = loadConfigs(argv, {
+        HTTP_BASE_URL: 'internal.example/artifacts/',
+      });
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      await request
+        .get(`/artifacts/get?source=http&bucket=ml-pipeline&key=${key}`)
+        .expect(400, 'Invalid HTTP artifact path');
+      expect(mockedFetch).not.toHaveBeenCalled();
+    });
+
+    it('keeps double-encoded path navigation inside the artifact root', async () => {
+      const artifactContent = 'encoded path data';
+      const safeUrl =
+        'http://internal.example/artifacts/ml-pipeline/%252e%252e%252f%252e%252e%252fadmin';
+      mockedFetch.mockImplementationOnce((url: string) =>
+        url === safeUrl
+          ? Promise.resolve({ body: toWebStream(artifactContent) })
+          : Promise.reject(`unexpected fetch to ${url}`),
+      );
+      app = new UIServer(
+        loadConfigs(argv, {
+          HTTP_BASE_URL: 'internal.example/artifacts/',
+        }),
+      );
+
+      await requests(app.app)
+        .get(
+          '/artifacts/get?source=http&bucket=ml-pipeline&key=%252e%252e%252f%252e%252e%252fadmin',
+        )
+        .expect(200, artifactContent);
+      expect(mockedFetch).toHaveBeenCalledWith(safeUrl, {
+        headers: {},
+        redirect: 'manual',
+      });
+    });
+
     it('responds with partial http artifact if peek=5 flag is set', async () => {
       const artifactContent = 'hello world';
       const mockedFetch: Mock = fetch as any;
@@ -715,6 +758,8 @@ describe('/artifacts', () => {
       });
       const configs = loadConfigs(argv, {
         ALLOWED_ARTIFACT_DOMAIN_REGEX: '^allowed\\.host$',
+        HTTP_AUTHORIZATION_DEFAULT_VALUE: 'same-origin-token',
+        HTTP_AUTHORIZATION_KEY: 'Authorization',
         HTTP_BASE_URL: 'allowed.host/',
       });
       app = new UIServer(configs);
@@ -724,6 +769,50 @@ describe('/artifacts', () => {
         .get('/artifacts/get?source=http&bucket=ml-pipeline&key=hello%2Fworld.txt')
         .expect(200, artifactContent);
       expect(mockedFetch).toHaveBeenCalledWith(redirectedUrl, {
+        headers: { Authorization: 'same-origin-token' },
+        redirect: 'manual',
+      });
+    });
+
+    it('strips configured authorization when an http redirect changes origin', async () => {
+      mockedFetch.mockClear();
+      const firstUrl = 'https://allowed.host/ml-pipeline/hello/world.txt';
+      const redirectedUrl = 'https://cdn.host/signed/hello/world.txt';
+      const artifactContent = 'redirected body';
+      mockedFetch.mockImplementation((url: string) => {
+        if (url === firstUrl) {
+          return Promise.resolve({
+            status: 302,
+            headers: new Map([['location', redirectedUrl]]),
+            body: toWebStream(''),
+          });
+        }
+        if (url === redirectedUrl) {
+          return Promise.resolve({
+            status: 200,
+            headers: new Map(),
+            body: toWebStream(artifactContent),
+          });
+        }
+        return Promise.reject(`unexpected fetch to ${url}`);
+      });
+      const configs = loadConfigs(argv, {
+        ALLOWED_ARTIFACT_DOMAIN_REGEX: '^(allowed|cdn)\\.host$',
+        HTTP_AUTHORIZATION_DEFAULT_VALUE: 'cross-origin-secret',
+        HTTP_AUTHORIZATION_KEY: 'Authorization',
+        HTTP_BASE_URL: 'allowed.host/',
+      });
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      await request
+        .get('/artifacts/get?source=https&bucket=ml-pipeline&key=hello%2Fworld.txt')
+        .expect(200, artifactContent);
+      expect(mockedFetch).toHaveBeenNthCalledWith(1, firstUrl, {
+        headers: { Authorization: 'cross-origin-secret' },
+        redirect: 'manual',
+      });
+      expect(mockedFetch).toHaveBeenNthCalledWith(2, redirectedUrl, {
         headers: {},
         redirect: 'manual',
       });
@@ -1075,6 +1164,84 @@ describe('/artifacts', () => {
       await request
         .get('/artifacts/get?source=volume&bucket=artifact&key=..%2Fsecret')
         .expect(404, 'Failed to open volume.');
+    });
+
+    it('rejects volume artifacts that are symlinks outside the mounted volume', async () => {
+      const volumePath = mkTempDir();
+      const outsidePath = path.join(mkTempDir(), 'secret');
+      fs.writeFileSync(outsidePath, 'outside secret');
+      fs.symlinkSync(outsidePath, path.join(volumePath, 'leak'));
+      vi.spyOn(serverInfo, 'getHostPod').mockResolvedValue([
+        {
+          spec: {
+            containers: [
+              {
+                volumeMounts: [{ name: 'artifact', mountPath: volumePath }],
+                name: 'ml-pipeline-ui',
+              },
+            ],
+            volumes: [{ name: 'artifact', persistentVolumeClaim: { claimName: 'artifact_pvc' } }],
+          },
+        } as any,
+        undefined,
+      ]);
+
+      app = new UIServer(loadConfigs(argv, {}));
+      await requests(app.app)
+        .get('/artifacts/get?source=volume&bucket=artifact&key=leak')
+        .expect(404, 'Failed to open volume.');
+    });
+
+    it('rejects volume artifacts below a symlinked directory outside the mount', async () => {
+      const volumePath = mkTempDir();
+      const outsideDirectory = mkTempDir();
+      fs.writeFileSync(path.join(outsideDirectory, 'secret'), 'outside secret');
+      fs.symlinkSync(outsideDirectory, path.join(volumePath, 'escape'));
+      vi.spyOn(serverInfo, 'getHostPod').mockResolvedValue([
+        {
+          spec: {
+            containers: [
+              {
+                volumeMounts: [{ name: 'artifact', mountPath: volumePath }],
+                name: 'ml-pipeline-ui',
+              },
+            ],
+            volumes: [{ name: 'artifact', persistentVolumeClaim: { claimName: 'artifact_pvc' } }],
+          },
+        } as any,
+        undefined,
+      ]);
+
+      app = new UIServer(loadConfigs(argv, {}));
+      await requests(app.app)
+        .get('/artifacts/get?source=volume&bucket=artifact&key=escape%2Fsecret')
+        .expect(404, 'Failed to open volume.');
+    });
+
+    it('allows volume artifact symlinks whose targets remain inside the mount', async () => {
+      const volumePath = mkTempDir();
+      const targetPath = path.join(volumePath, 'content');
+      fs.writeFileSync(targetPath, 'inside content');
+      fs.symlinkSync(targetPath, path.join(volumePath, 'link'));
+      vi.spyOn(serverInfo, 'getHostPod').mockResolvedValue([
+        {
+          spec: {
+            containers: [
+              {
+                volumeMounts: [{ name: 'artifact', mountPath: volumePath }],
+                name: 'ml-pipeline-ui',
+              },
+            ],
+            volumes: [{ name: 'artifact', persistentVolumeClaim: { claimName: 'artifact_pvc' } }],
+          },
+        } as any,
+        undefined,
+      ]);
+
+      app = new UIServer(loadConfigs(argv, {}));
+      await requests(app.app)
+        .get('/artifacts/get?source=volume&bucket=artifact&key=link')
+        .expect(200, 'inside content');
     });
 
     it('responds error with a not exist volume', async () => {

--- a/frontend/server/integration-tests/artifact-proxy.test.ts
+++ b/frontend/server/integration-tests/artifact-proxy.test.ts
@@ -191,6 +191,16 @@ describe('/artifacts/get namespaced proxy', () => {
     expect(res.text).not.toContain('stack');
   });
 
+  it('rejects ambiguous namespace query parameters', async () => {
+    const configs = loadConfigs(argv, { ARTIFACTS_SERVICE_PROXY_ENABLED: 'true' });
+    app = new UIServer(configs);
+    await requests(app.app)
+      .get(
+        `/artifacts/get?source=minio&bucket=ml-pipeline&key=hello.txt&namespace=ns-a&namespace=ns-b`,
+      )
+      .expect(400, 'namespace must be a single string value');
+  });
+
   it('proxies a request with basePath too', async () => {
     const { receivedUrls, response } = await setUpNamespacedArtifactService({});
     const configs = loadConfigs(argv, {

--- a/frontend/server/integration-tests/artifact-proxy.test.ts
+++ b/frontend/server/integration-tests/artifact-proxy.test.ts
@@ -191,15 +191,30 @@ describe('/artifacts/get namespaced proxy', () => {
     expect(res.text).not.toContain('stack');
   });
 
-  it('rejects ambiguous namespace query parameters', async () => {
-    const configs = loadConfigs(argv, { ARTIFACTS_SERVICE_PROXY_ENABLED: 'true' });
-    app = new UIServer(configs);
-    await requests(app.app)
-      .get(
-        `/artifacts/get?source=minio&bucket=ml-pipeline&key=hello.txt&namespace=ns-a&namespace=ns-b`,
-      )
-      .expect(400, 'namespace must be a single string value');
-  });
+  it.each(['source', 'bucket', 'key', 'providerInfo', 'namespace', 'peek'])(
+    'rejects ambiguous %s query parameters before proxying',
+    async (parameterName) => {
+      const { receivedUrls } = await setUpNamespacedArtifactService({ namespace: 'ns-a' });
+      const configs = loadConfigs(argv, {
+        ARTIFACTS_SERVICE_PROXY_ENABLED: 'true',
+      });
+      app = new UIServer(configs);
+      const query = new URLSearchParams({
+        source: 'minio',
+        bucket: 'ml-pipeline',
+        key: 'hello.txt',
+        providerInfo: '{}',
+        namespace: 'ns-a',
+        peek: '10',
+      });
+      query.append(parameterName, 'duplicate');
+
+      await requests(app.app)
+        .get(`/artifacts/get?${query.toString()}`)
+        .expect(400, `${parameterName} must be a single string value`);
+      expect(receivedUrls).toEqual([]);
+    },
+  );
 
   it('proxies a request with basePath too', async () => {
     const { receivedUrls, response } = await setUpNamespacedArtifactService({});

--- a/frontend/server/utils.test.ts
+++ b/frontend/server/utils.test.ts
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 import { PassThrough } from 'stream';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import {
   PreviewStream,
   findFileOnPodVolume,
+  openFileWithinRoot,
   parseError,
   resolveFilePathOnVolume,
 } from './utils.js';
@@ -251,6 +255,53 @@ describe('utils', () => {
         '',
         'File ab/c not mounted, expecting the file to be inside volume mount subpath a',
       ]);
+    });
+  });
+
+  describe('openFileWithinRoot', () => {
+    function makeTempDirectory(): string {
+      return fs.mkdtempSync(path.join(os.tmpdir(), 'kfp-volume-test-'));
+    }
+
+    it.each(['final', 'intermediate'])('rejects an outside %s symlink', async (symlinkKind) => {
+      const rootPath = makeTempDirectory();
+      const outsidePath = makeTempDirectory();
+      const outsideFilePath = path.join(outsidePath, 'secret');
+      fs.writeFileSync(outsideFilePath, 'outside secret');
+      const requestedFilePath =
+        symlinkKind === 'final'
+          ? path.join(rootPath, 'leak')
+          : path.join(rootPath, 'escape', 'secret');
+      fs.symlinkSync(
+        symlinkKind === 'final' ? outsideFilePath : outsidePath,
+        symlinkKind === 'final' ? requestedFilePath : path.join(rootPath, 'escape'),
+      );
+
+      try {
+        const [fileHandle, error] = await openFileWithinRoot(requestedFilePath, rootPath);
+        expect(fileHandle).toBeUndefined();
+        expect(error).toMatchObject({ pathEscaped: true });
+      } finally {
+        fs.rmSync(rootPath, { recursive: true, force: true });
+        fs.rmSync(outsidePath, { recursive: true, force: true });
+      }
+    });
+
+    it('opens an in-root symlink through the validated file handle', async () => {
+      const rootPath = makeTempDirectory();
+      const targetPath = path.join(rootPath, 'content');
+      const linkPath = path.join(rootPath, 'link');
+      fs.writeFileSync(targetPath, 'inside content');
+      fs.symlinkSync(targetPath, linkPath);
+
+      try {
+        const [fileHandle, error] = await openFileWithinRoot(linkPath, rootPath);
+        expect(error).toBeUndefined();
+        expect(await fileHandle?.readFile({ encoding: 'utf8' })).toBe('inside content');
+        await fileHandle?.close();
+      } finally {
+        fs.rmSync(rootPath, { recursive: true, force: true });
+      }
     });
   });
 

--- a/frontend/server/utils.test.ts
+++ b/frontend/server/utils.test.ts
@@ -184,6 +184,15 @@ describe('utils', () => {
       expect(path).toEqual(['/data/a/b/c', undefined]);
     });
 
+    it('resolves the volume root without volumeMountSubPath', () => {
+      const path = resolveFilePathOnVolume({
+        filePathInVolume: '',
+        volumeMountPath: '/data',
+        volumeMountSubPath: undefined,
+      });
+      expect(path).toEqual(['/data', undefined]);
+    });
+
     it('with volumeMountSubPath', () => {
       const path = resolveFilePathOnVolume({
         volumeMountPath: '/data',
@@ -211,6 +220,36 @@ describe('utils', () => {
       expect(path).toEqual([
         '',
         'File a/b/c not mounted, expecting the file to be inside volume mount subpath other',
+      ]);
+    });
+
+    it('rejects parent directory traversal', () => {
+      const path = resolveFilePathOnVolume({
+        filePathInVolume: '../secret',
+        volumeMountPath: '/data',
+        volumeMountSubPath: undefined,
+      });
+      expect(path).toEqual(['', 'file path ../secret must not contain parent directory segments']);
+    });
+
+    it('rejects absolute paths', () => {
+      const path = resolveFilePathOnVolume({
+        filePathInVolume: '/etc/passwd',
+        volumeMountPath: '/data',
+        volumeMountSubPath: undefined,
+      });
+      expect(path).toEqual(['', 'file path /etc/passwd must be relative']);
+    });
+
+    it('requires subPath to match a full path segment', () => {
+      const path = resolveFilePathOnVolume({
+        volumeMountPath: '/data',
+        filePathInVolume: 'ab/c',
+        volumeMountSubPath: 'a',
+      });
+      expect(path).toEqual([
+        '',
+        'File ab/c not mounted, expecting the file to be inside volume mount subpath a',
       ]);
     });
   });

--- a/frontend/server/utils.test.ts
+++ b/frontend/server/utils.test.ts
@@ -259,6 +259,10 @@ describe('utils', () => {
   });
 
   describe('openFileWithinRoot', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     function makeTempDirectory(): string {
       return fs.mkdtempSync(path.join(os.tmpdir(), 'kfp-volume-test-'));
     }
@@ -301,6 +305,30 @@ describe('utils', () => {
         await fileHandle?.close();
       } finally {
         fs.rmSync(rootPath, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects an opened descriptor outside the root even when the requested path is inside', async () => {
+      const rootPath = makeTempDirectory();
+      const outsidePath = makeTempDirectory();
+      const requestedFilePath = path.join(rootPath, 'artifact');
+      const outsideFilePath = path.join(outsidePath, 'secret');
+      fs.writeFileSync(requestedFilePath, 'inside content');
+      fs.writeFileSync(outsideFilePath, 'outside secret');
+
+      const outsideFileHandle = await fs.promises.open(outsideFilePath, fs.constants.O_RDONLY);
+      vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+      vi.spyOn(fs.promises, 'open').mockResolvedValueOnce(outsideFileHandle);
+      vi.spyOn(fs.promises, 'readlink').mockResolvedValueOnce(outsideFilePath);
+
+      try {
+        const [fileHandle, error] = await openFileWithinRoot(requestedFilePath, rootPath);
+        expect(fileHandle).toBeUndefined();
+        expect(error).toMatchObject({ pathEscaped: true });
+      } finally {
+        await outsideFileHandle.close().catch(() => undefined);
+        fs.rmSync(rootPath, { recursive: true, force: true });
+        fs.rmSync(outsidePath, { recursive: true, force: true });
       }
     });
   });

--- a/frontend/server/utils.ts
+++ b/frontend/server/utils.ts
@@ -138,7 +138,7 @@ export function findFileOnPodVolume(
     }
     // if volume subPath set, volume subPath must be prefix of key
     if (v?.subPath) {
-      return filePathInVolume.startsWith(v.subPath);
+      return isVolumePathInsideSubPath(filePathInVolume, v.subPath);
     }
     return true;
   });
@@ -158,7 +158,7 @@ export function findFileOnPodVolume(
   });
 
   if (err) {
-    return ['', `${prefixErrorMessage}  err`];
+    return ['', `${prefixErrorMessage} ${err}`];
   }
   return [filePath, undefined];
 }
@@ -169,19 +169,83 @@ export function resolveFilePathOnVolume(volume: {
   volumeMountSubPath: string | undefined;
 }): [string, string | undefined] {
   const { filePathInVolume, volumeMountPath, volumeMountSubPath } = volume;
-  if (!volumeMountSubPath) {
-    return [path.join(volumeMountPath, filePathInVolume), undefined];
+  const [safeFilePathInVolume, filePathErr] = normalizeRelativeVolumePath(
+    filePathInVolume,
+    'file path',
+  );
+  if (filePathErr) {
+    return ['', filePathErr];
   }
-  if (filePathInVolume.startsWith(volumeMountSubPath)) {
-    return [
-      path.join(volumeMountPath, filePathInVolume.substring(volumeMountSubPath.length)),
-      undefined,
-    ];
+  const safeVolumeMountPath = path.normalize(volumeMountPath);
+  if (!path.isAbsolute(safeVolumeMountPath)) {
+    return ['', `Volume mount path ${volumeMountPath} must be absolute`];
+  }
+  if (!volumeMountSubPath) {
+    return [path.join(safeVolumeMountPath, safeFilePathInVolume), undefined];
+  }
+  const [safeVolumeMountSubPath, subPathErr] = normalizeRelativeVolumePath(
+    volumeMountSubPath,
+    'volume mount subpath',
+  );
+  if (subPathErr) {
+    return ['', subPathErr];
+  }
+  if (
+    safeFilePathInVolume === safeVolumeMountSubPath ||
+    safeFilePathInVolume.startsWith(`${safeVolumeMountSubPath}/`)
+  ) {
+    const relativePath =
+      safeFilePathInVolume === safeVolumeMountSubPath
+        ? ''
+        : safeFilePathInVolume.substring(safeVolumeMountSubPath.length + 1);
+    return [path.join(safeVolumeMountPath, relativePath), undefined];
   }
   return [
     '',
     `File ${filePathInVolume} not mounted, expecting the file to be inside volume mount subpath ${volumeMountSubPath}`,
   ];
+}
+
+function normalizeRelativeVolumePath(
+  filePath: string,
+  pathLabel: string,
+): [string, string | undefined] {
+  if (filePath.includes('\0')) {
+    return ['', `Invalid ${pathLabel} ${filePath}`];
+  }
+  if (!filePath) {
+    return ['', undefined];
+  }
+  if (path.isAbsolute(filePath)) {
+    return ['', `${pathLabel} ${filePath} must be relative`];
+  }
+  const segments = filePath.split('/');
+  if (segments.some((segment) => segment === '..')) {
+    return ['', `${pathLabel} ${filePath} must not contain parent directory segments`];
+  }
+  const normalized = path.normalize(filePath);
+  if (normalized === '.' || normalized.startsWith('../') || normalized === '..') {
+    return ['', `Invalid ${pathLabel} ${filePath}`];
+  }
+  return [normalized, undefined];
+}
+
+function isVolumePathInsideSubPath(filePathInVolume: string, volumeMountSubPath: string): boolean {
+  const [safeFilePathInVolume, filePathErr] = normalizeRelativeVolumePath(
+    filePathInVolume,
+    'file path',
+  );
+  const [safeVolumeMountSubPath, subPathErr] = normalizeRelativeVolumePath(
+    volumeMountSubPath,
+    'volume mount subpath',
+  );
+  if (filePathErr || subPathErr) {
+    return false;
+  }
+  return (
+    safeFilePathInVolume === safeVolumeMountSubPath ||
+    safeFilePathInVolume.startsWith(`${safeVolumeMountSubPath}/`)
+  );
 }
 
 export interface PreviewStreamOptions extends TransformOptions {
@@ -351,6 +415,11 @@ function parseK8sError(error: any): ErrorDetails | undefined {
   };
 }
 
-export function isAllowedResourceName(name: string): boolean {
-  return name.length > 0 && name.length <= 63 && /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(name);
+export function isAllowedResourceName(name: unknown): name is string {
+  return (
+    typeof name === 'string' &&
+    name.length > 0 &&
+    name.length <= 63 &&
+    /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(name)
+  );
 }

--- a/frontend/server/utils.ts
+++ b/frontend/server/utils.ts
@@ -11,7 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { readFileSync } from 'fs';
+import { constants as fsConstants, promises as fsPromises, readFileSync } from 'fs';
+import type { FileHandle } from 'fs/promises';
 import { Transform, TransformOptions } from 'stream';
 import { posix as path } from 'path';
 
@@ -85,7 +86,7 @@ export function parseJSONString<T>(str: string) {
  *  - containerNames optional, will match to find container or container[0] in pod will be used
  *  - volumeMountName container volume mount name
  *  - filePathInVolume file path in volume
- * @return [final file path, error message if check failed]
+ * @return [final file path, error message if check failed, normalized volume mount root]
  */
 export function findFileOnPodVolume(
   pod: any,
@@ -94,7 +95,7 @@ export function findFileOnPodVolume(
     volumeMountName: string;
     filePathInVolume: string;
   },
-): [string, string | undefined] {
+): [string, string | undefined, string?] {
   const { containerNames, volumeMountName, filePathInVolume } = options;
 
   const volumes = pod?.spec?.volumes;
@@ -160,7 +161,7 @@ export function findFileOnPodVolume(
   if (err) {
     return ['', `${prefixErrorMessage} ${err}`];
   }
-  return [filePath, undefined];
+  return [filePath, undefined, path.normalize(volumeMount.mountPath)];
 }
 
 export function resolveFilePathOnVolume(volume: {
@@ -204,6 +205,72 @@ export function resolveFilePathOnVolume(volume: {
     '',
     `File ${filePathInVolume} not mounted, expecting the file to be inside volume mount subpath ${volumeMountSubPath}`,
   ];
+}
+
+export interface OpenFileWithinRootError {
+  message: string;
+  pathEscaped: boolean;
+}
+
+export async function openFileWithinRoot(
+  filePath: string,
+  rootPath: string,
+): Promise<[FileHandle | undefined, OpenFileWithinRootError | undefined]> {
+  let fileHandle: FileHandle | undefined;
+  try {
+    const [realFilePath, realRootPath] = await Promise.all([
+      fsPromises.realpath(filePath),
+      fsPromises.realpath(rootPath),
+    ]);
+    if (!isPathWithinRoot(realFilePath, realRootPath)) {
+      return [
+        undefined,
+        {
+          message: `File ${filePath} resolves outside volume mount ${rootPath}`,
+          pathEscaped: true,
+        },
+      ];
+    }
+
+    fileHandle = await fsPromises.open(realFilePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+    const [openedFileStat, currentRealFilePath] = await Promise.all([
+      fileHandle.stat(),
+      fsPromises.realpath(realFilePath),
+    ]);
+    if (!isPathWithinRoot(currentRealFilePath, realRootPath)) {
+      await fileHandle.close();
+      return [
+        undefined,
+        {
+          message: `File ${filePath} changed to resolve outside volume mount ${rootPath}`,
+          pathEscaped: true,
+        },
+      ];
+    }
+    const currentFileStat = await fsPromises.stat(currentRealFilePath);
+    if (openedFileStat.dev !== currentFileStat.dev || openedFileStat.ino !== currentFileStat.ino) {
+      throw new Error(`File ${filePath} changed while it was being opened`);
+    }
+    return [fileHandle, undefined];
+  } catch (error) {
+    await fileHandle?.close().catch(() => undefined);
+    return [
+      undefined,
+      {
+        message: `Failed to open file ${filePath} inside volume mount ${rootPath}: ${error}`,
+        pathEscaped: false,
+      },
+    ];
+  }
+}
+
+function isPathWithinRoot(filePath: string, rootPath: string): boolean {
+  const relativeFilePath = path.relative(rootPath, filePath);
+  return (
+    relativeFilePath !== '..' &&
+    !relativeFilePath.startsWith('../') &&
+    !path.isAbsolute(relativeFilePath)
+  );
 }
 
 function normalizeRelativeVolumePath(

--- a/frontend/server/utils.ts
+++ b/frontend/server/utils.ts
@@ -233,23 +233,16 @@ export async function openFileWithinRoot(
     }
 
     fileHandle = await fsPromises.open(realFilePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
-    const [openedFileStat, currentRealFilePath] = await Promise.all([
-      fileHandle.stat(),
-      fsPromises.realpath(realFilePath),
-    ]);
-    if (!isPathWithinRoot(currentRealFilePath, realRootPath)) {
+    const openedFilePath = await resolveOpenedFilePath(fileHandle, realFilePath, filePath);
+    if (!isPathWithinRoot(openedFilePath, realRootPath)) {
       await fileHandle.close();
       return [
         undefined,
         {
-          message: `File ${filePath} changed to resolve outside volume mount ${rootPath}`,
+          message: `Opened file ${filePath} resolves outside volume mount ${rootPath}`,
           pathEscaped: true,
         },
       ];
-    }
-    const currentFileStat = await fsPromises.stat(currentRealFilePath);
-    if (openedFileStat.dev !== currentFileStat.dev || openedFileStat.ino !== currentFileStat.ino) {
-      throw new Error(`File ${filePath} changed while it was being opened`);
     }
     return [fileHandle, undefined];
   } catch (error) {
@@ -262,6 +255,29 @@ export async function openFileWithinRoot(
       },
     ];
   }
+}
+
+async function resolveOpenedFilePath(
+  fileHandle: FileHandle,
+  realFilePath: string,
+  requestedFilePath: string,
+): Promise<string> {
+  if (process.platform === 'linux') {
+    // Validate the descriptor itself so a mutable path cannot be swapped between
+    // open(), realpath(), and stat(). KFP's frontend server is deployed on Linux.
+    return fsPromises.readlink(`/proc/self/fd/${fileHandle.fd}`);
+  }
+
+  // Keep local development on non-Linux hosts working where /proc is unavailable.
+  const [openedFileStat, currentRealFilePath] = await Promise.all([
+    fileHandle.stat(),
+    fsPromises.realpath(realFilePath),
+  ]);
+  const currentFileStat = await fsPromises.stat(currentRealFilePath);
+  if (openedFileStat.dev !== currentFileStat.dev || openedFileStat.ino !== currentFileStat.ino) {
+    throw new Error(`File ${requestedFilePath} changed while it was being opened`);
+  }
+  return currentRealFilePath;
 }
 
 function isPathWithinRoot(filePath: string, rootPath: string): boolean {


### PR DESCRIPTION
## Summary
- Normalize artifact request inputs and reject multi-valued query parameters before authorization, proxying, or artifact lookup.
- Require configured HTTP artifact base URLs, keep artifact keys inside the configured path, and re-check redirects against the allowlist.
- Strip configured HTTP credentials after a redirect changes origin.
- Harden artifact proxy namespace parsing and open volume artifacts through a canonical, root-contained file handle.

## Verification
- `fnm exec --using ../.nvmrc npx vitest run integration-tests/artifact-get.test.ts integration-tests/artifact-proxy.test.ts integration-tests/artifact-auth.test.ts handlers/domain-checker.test.ts utils.test.ts k8s-helper.test.ts` (146 tests passed)
- `fnm exec --using ../.nvmrc npm run lint`
- `fnm exec --using ../.nvmrc npm run build`
- `fnm exec --using ../.nvmrc npx prettier --check handlers/artifacts.ts integration-tests/artifact-get.test.ts utils.ts utils.test.ts`
- `git diff --check`
