### PR TITLE
fix(backend): avoid logging secret references

### DIFF
--- a/backend/src/apiserver/plugins/mlflow/config.go
+++ b/backend/src/apiserver/plugins/mlflow/config.go
@@ -430,7 +430,7 @@ func resolveBearerSecretCredentials(
 	if err != nil {
 		return commonmlflow.MLflowCredentials{}, err
 	}
-	token, err := readRequiredSecretKey(secret, namespace, ref.TokenKey)
+	token, err := readRequiredSecretKey(secret, namespace, ref.TokenKey, "bearer token")
 	if err != nil {
 		return commonmlflow.MLflowCredentials{}, err
 	}
@@ -465,11 +465,11 @@ func resolveBasicAuthSecretCredentials(
 	if err != nil {
 		return commonmlflow.MLflowCredentials{}, err
 	}
-	username, err := readRequiredSecretKey(secret, namespace, ref.UsernameKey)
+	username, err := readRequiredSecretKey(secret, namespace, ref.UsernameKey, "username")
 	if err != nil {
 		return commonmlflow.MLflowCredentials{}, err
 	}
-	password, err := readRequiredSecretKey(secret, namespace, ref.PasswordKey)
+	password, err := readRequiredSecretKey(secret, namespace, ref.PasswordKey, "password")
 	if err != nil {
 		return commonmlflow.MLflowCredentials{}, err
 	}
@@ -502,22 +502,24 @@ func getMLflowCredentialSecret(ctx context.Context, clientSet kubernetes.Interfa
 }
 
 // readRequiredSecretKey returns the trimmed value for key from secret, returning
-// an error if the key is missing or resolves to an empty value.
-func readRequiredSecretKey(secret *corev1.Secret, namespace, key string) (string, error) {
+// an error that identifies the credential role if the key is missing or empty.
+func readRequiredSecretKey(secret *corev1.Secret, namespace, key, credentialRole string) (string, error) {
 	valueBytes, ok := secret.Data[key]
 	if !ok {
 		return "", util.NewInvalidInputError(
-			"secret %q in namespace %q does not contain a required key",
+			"secret %q in namespace %q does not contain a value for the required MLflow %s credential",
 			commonmlflow.CredentialSecretName,
 			namespace,
+			credentialRole,
 		)
 	}
 	value := strings.TrimSpace(string(valueBytes))
 	if value == "" {
 		return "", util.NewInvalidInputError(
-			"secret %q in namespace %q has an empty value for a required key",
+			"secret %q in namespace %q has an empty value for the required MLflow %s credential",
 			commonmlflow.CredentialSecretName,
 			namespace,
+			credentialRole,
 		)
 	}
 	return value, nil

--- a/backend/src/apiserver/plugins/mlflow/config.go
+++ b/backend/src/apiserver/plugins/mlflow/config.go
@@ -507,19 +507,17 @@ func readRequiredSecretKey(secret *corev1.Secret, namespace, key string) (string
 	valueBytes, ok := secret.Data[key]
 	if !ok {
 		return "", util.NewInvalidInputError(
-			"secret %q in namespace %q does not contain key %q",
+			"secret %q in namespace %q does not contain a required key",
 			commonmlflow.CredentialSecretName,
 			namespace,
-			key,
 		)
 	}
 	value := strings.TrimSpace(string(valueBytes))
 	if value == "" {
 		return "", util.NewInvalidInputError(
-			"secret %q in namespace %q has an empty value for key %q",
+			"secret %q in namespace %q has an empty value for a required key",
 			commonmlflow.CredentialSecretName,
 			namespace,
-			key,
 		)
 	}
 	return value, nil

--- a/backend/src/apiserver/plugins/mlflow/config_test.go
+++ b/backend/src/apiserver/plugins/mlflow/config_test.go
@@ -847,7 +847,34 @@ func TestResolveBasicAuthSecretCredentials_MissingPasswordKey(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `does not contain key "password"`)
+	assert.Contains(t, err.Error(), "does not contain a required key")
+	assert.NotContains(t, err.Error(), "password")
+}
+
+func TestResolveBasicAuthSecretCredentials_EmptyPasswordKeyValue(t *testing.T) {
+	clientSet := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      commonmlflow.CredentialSecretName,
+			Namespace: "ns1",
+		},
+		Data: map[string][]byte{
+			"username": []byte("user"),
+			"password": []byte(" "),
+		},
+	})
+
+	_, err := resolveBasicAuthSecretCredentials(
+		context.Background(),
+		clientSet,
+		"ns1",
+		&commonmlflow.CredentialSecretRef{
+			UsernameKey: "username",
+			PasswordKey: "password",
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has an empty value for a required key")
+	assert.NotContains(t, err.Error(), "password")
 }
 
 func TestBuildMLflowRequestContext_InvalidEndpoint(t *testing.T) {

--- a/backend/src/apiserver/plugins/mlflow/config_test.go
+++ b/backend/src/apiserver/plugins/mlflow/config_test.go
@@ -826,14 +826,33 @@ func TestResolveBearerSecretCredentials(t *testing.T) {
 	assert.Equal(t, "custom-token", credentials.BearerToken)
 }
 
-func TestResolveBasicAuthSecretCredentials_MissingPasswordKey(t *testing.T) {
+func TestResolveBearerSecretCredentials_MissingTokenValue(t *testing.T) {
+	clientSet := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      commonmlflow.CredentialSecretName,
+			Namespace: "ns1",
+		},
+	})
+
+	_, err := resolveBearerSecretCredentials(
+		context.Background(),
+		clientSet,
+		"ns1",
+		&commonplugins.CredentialSecretRef{TokenKey: "custom-token-field"},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required MLflow bearer token credential")
+	assert.NotContains(t, err.Error(), "custom-token-field")
+}
+
+func TestResolveBasicAuthSecretCredentials_MissingUsernameValue(t *testing.T) {
 	clientSet := k8sfake.NewClientset(&corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      commonmlflow.CredentialSecretName,
 			Namespace: "ns1",
 		},
 		Data: map[string][]byte{
-			"username": []byte("user"),
+			"custom-password-field": []byte("password"),
 		},
 	})
 
@@ -842,13 +861,38 @@ func TestResolveBasicAuthSecretCredentials_MissingPasswordKey(t *testing.T) {
 		clientSet,
 		"ns1",
 		&commonplugins.CredentialSecretRef{
-			UsernameKey: "username",
-			PasswordKey: "password",
+			UsernameKey: "custom-username-field",
+			PasswordKey: "custom-password-field",
 		},
 	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not contain a required key")
-	assert.NotContains(t, err.Error(), "password")
+	assert.Contains(t, err.Error(), "required MLflow username credential")
+	assert.NotContains(t, err.Error(), "custom-username-field")
+}
+
+func TestResolveBasicAuthSecretCredentials_MissingPasswordValue(t *testing.T) {
+	clientSet := k8sfake.NewClientset(&corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      commonmlflow.CredentialSecretName,
+			Namespace: "ns1",
+		},
+		Data: map[string][]byte{
+			"custom-username-field": []byte("user"),
+		},
+	})
+
+	_, err := resolveBasicAuthSecretCredentials(
+		context.Background(),
+		clientSet,
+		"ns1",
+		&commonplugins.CredentialSecretRef{
+			UsernameKey: "custom-username-field",
+			PasswordKey: "custom-password-field",
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required MLflow password credential")
+	assert.NotContains(t, err.Error(), "custom-password-field")
 }
 
 func TestResolveBasicAuthSecretCredentials_EmptyPasswordKeyValue(t *testing.T) {
@@ -858,8 +902,8 @@ func TestResolveBasicAuthSecretCredentials_EmptyPasswordKeyValue(t *testing.T) {
 			Namespace: "ns1",
 		},
 		Data: map[string][]byte{
-			"username": []byte("user"),
-			"password": []byte(" "),
+			"custom-username-field": []byte("user"),
+			"custom-password-field": []byte(" "),
 		},
 	})
 
@@ -867,14 +911,14 @@ func TestResolveBasicAuthSecretCredentials_EmptyPasswordKeyValue(t *testing.T) {
 		context.Background(),
 		clientSet,
 		"ns1",
-		&commonmlflow.CredentialSecretRef{
-			UsernameKey: "username",
-			PasswordKey: "password",
+		&commonplugins.CredentialSecretRef{
+			UsernameKey: "custom-username-field",
+			PasswordKey: "custom-password-field",
 		},
 	)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "has an empty value for a required key")
-	assert.NotContains(t, err.Error(), "password")
+	assert.Contains(t, err.Error(), "empty value for the required MLflow password credential")
+	assert.NotContains(t, err.Error(), "custom-password-field")
 }
 
 func TestBuildMLflowRequestContext_InvalidEndpoint(t *testing.T) {
@@ -1524,9 +1568,10 @@ func TestReadRequiredSecretKey_MissingKey(t *testing.T) {
 			"other-key": []byte("value"),
 		},
 	}
-	_, err := readRequiredSecretKey(secret, "ns1", "missing-key")
+	_, err := readRequiredSecretKey(secret, "ns1", "missing-key", "test")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `does not contain key "missing-key"`)
+	assert.Contains(t, err.Error(), "required MLflow test credential")
+	assert.NotContains(t, err.Error(), "missing-key")
 }
 
 func TestReadRequiredSecretKey_EmptyValue(t *testing.T) {
@@ -1535,9 +1580,10 @@ func TestReadRequiredSecretKey_EmptyValue(t *testing.T) {
 			"empty-key": []byte(""),
 		},
 	}
-	_, err := readRequiredSecretKey(secret, "ns1", "empty-key")
+	_, err := readRequiredSecretKey(secret, "ns1", "empty-key", "test")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "has an empty value")
+	assert.Contains(t, err.Error(), "empty value for the required MLflow test credential")
+	assert.NotContains(t, err.Error(), "empty-key")
 }
 
 func TestReadRequiredSecretKey_WhitespaceValue(t *testing.T) {
@@ -1546,9 +1592,10 @@ func TestReadRequiredSecretKey_WhitespaceValue(t *testing.T) {
 			"whitespace-key": []byte("   \n\t   "),
 		},
 	}
-	_, err := readRequiredSecretKey(secret, "ns1", "whitespace-key")
+	_, err := readRequiredSecretKey(secret, "ns1", "whitespace-key", "test")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "has an empty value")
+	assert.Contains(t, err.Error(), "empty value for the required MLflow test credential")
+	assert.NotContains(t, err.Error(), "whitespace-key")
 }
 
 func TestReadRequiredSecretKey_Success(t *testing.T) {
@@ -1557,7 +1604,7 @@ func TestReadRequiredSecretKey_Success(t *testing.T) {
 			"valid-key": []byte("  valid-value  \n"),
 		},
 	}
-	value, err := readRequiredSecretKey(secret, "ns1", "valid-key")
+	value, err := readRequiredSecretKey(secret, "ns1", "valid-key", "test")
 	require.NoError(t, err)
 	assert.Equal(t, "valid-value", value)
 }

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"time"
@@ -555,7 +556,8 @@ func parseExecConfigJson(k8sExecConfigJson *string) (*kubernetesplatform.Kuberne
 		glog.Info(kubernetesConfigLogMessage(*k8sExecConfigJson))
 		k8sExecCfg = &kubernetesplatform.KubernetesExecutorConfig{}
 		if err := util.UnmarshalString(*k8sExecConfigJson, k8sExecCfg); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal Kubernetes config: %w", err)
+			// protojson errors can quote raw input tokens, including secret refs.
+			return nil, errors.New("failed to unmarshal Kubernetes config")
 		}
 	}
 	return k8sExecCfg, nil

--- a/backend/src/v2/cmd/driver/main.go
+++ b/backend/src/v2/cmd/driver/main.go
@@ -552,10 +552,10 @@ func drive() (err error) {
 func parseExecConfigJson(k8sExecConfigJson *string) (*kubernetesplatform.KubernetesExecutorConfig, error) {
 	var k8sExecCfg *kubernetesplatform.KubernetesExecutorConfig
 	if *k8sExecConfigJson != "" {
-		glog.Infof("input kubernetesConfig:%s\n", prettyPrint(*k8sExecConfigJson))
+		glog.Info(kubernetesConfigLogMessage(*k8sExecConfigJson))
 		k8sExecCfg = &kubernetesplatform.KubernetesExecutorConfig{}
 		if err := util.UnmarshalString(*k8sExecConfigJson, k8sExecCfg); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal Kubernetes config, error: %w\nKubernetesConfig: %v", err, k8sExecConfigJson)
+			return nil, fmt.Errorf("failed to unmarshal Kubernetes config: %w", err)
 		}
 	}
 	return k8sExecCfg, nil
@@ -599,7 +599,7 @@ func handleExecution(execution *driver.Execution, driverType string, executionPa
 		}
 	}
 	if execution.PodSpecPatch != "" {
-		glog.Infof("output podSpecPatch=\n%s\n", execution.PodSpecPatch)
+		glog.Info(podSpecPatchLogMessage(execution.PodSpecPatch))
 		if executionPaths.PodSpecPatch == "" {
 			return fmt.Errorf("--pod_spec_patch_path is required for container executor drivers")
 		}
@@ -616,6 +616,16 @@ func handleExecution(execution *driver.Execution, driverType string, executionPa
 		glog.Infof("output ExecutorInput:%s\n", prettyPrint(executorInputJSON))
 	}
 	return nil
+}
+
+func podSpecPatchLogMessage(podSpecPatch string) string {
+	// Pod spec patches can include secretKeyRef fields. Log only metadata.
+	return fmt.Sprintf("output podSpecPatch: %d bytes", len(podSpecPatch))
+}
+
+func kubernetesConfigLogMessage(kubernetesConfig string) string {
+	// Kubernetes executor config can include secret refs. Log only metadata.
+	return fmt.Sprintf("input kubernetesConfig: %d bytes", len(kubernetesConfig))
 }
 
 func prettyPrint(jsonStr string) string {

--- a/backend/src/v2/cmd/driver/main_test.go
+++ b/backend/src/v2/cmd/driver/main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/v2/driver"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,6 +68,42 @@ func TestSpecParsing(t *testing.T) {
 		assert.Equal(t, tc.wantErr, err != nil)
 		assert.True(t, proto.Equal(tc.expected, cfg))
 	}
+}
+
+func TestPodSpecPatchLogMessageDoesNotIncludePatchContent(t *testing.T) {
+	podSpecPatch := `{"containers":[{"env":[{"valueFrom":{"secretKeyRef":{"name":"mlflow-secret","key":"password"}}}]}]}`
+
+	message := podSpecPatchLogMessage(podSpecPatch)
+
+	assert.Contains(t, message, "output podSpecPatch")
+	assert.Contains(t, message, "bytes")
+	assert.NotContains(t, message, "secretKeyRef")
+	assert.NotContains(t, message, "mlflow-secret")
+	assert.NotContains(t, message, "password")
+}
+
+func TestKubernetesConfigLogMessageDoesNotIncludeConfigContent(t *testing.T) {
+	kubernetesConfig := `{"secretAsEnv":[{"secretName":"mlflow-secret","keyToEnv":[{"secretKey":"password","envVar":"PASSWORD"}]}]}`
+
+	message := kubernetesConfigLogMessage(kubernetesConfig)
+
+	assert.Contains(t, message, "input kubernetesConfig")
+	assert.Contains(t, message, "bytes")
+	assert.NotContains(t, message, "secretAsEnv")
+	assert.NotContains(t, message, "mlflow-secret")
+	assert.NotContains(t, message, "password")
+}
+
+func TestParseExecConfigJsonErrorDoesNotIncludeConfigContent(t *testing.T) {
+	kubernetesConfig := `{"secretAsEnv":[{"secretName":"mlflow-secret","keyToEnv":[{"secretKey":"password","envVar":"PASSWORD"}]}`
+
+	_, err := parseExecConfigJson(&kubernetesConfig)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to unmarshal Kubernetes config")
+	assert.NotContains(t, err.Error(), "secretAsEnv")
+	assert.NotContains(t, err.Error(), "mlflow-secret")
+	assert.NotContains(t, err.Error(), "password")
 }
 
 func TestGetPipelineJobTimePlaceholderUsage(t *testing.T) {

--- a/backend/src/v2/cmd/driver/main_test.go
+++ b/backend/src/v2/cmd/driver/main_test.go
@@ -95,15 +95,13 @@ func TestKubernetesConfigLogMessageDoesNotIncludeConfigContent(t *testing.T) {
 }
 
 func TestParseExecConfigJsonErrorDoesNotIncludeConfigContent(t *testing.T) {
-	kubernetesConfig := `{"secretAsEnv":[{"secretName":"mlflow-secret","keyToEnv":[{"secretKey":"password","envVar":"PASSWORD"}]}`
+	kubernetesConfig := `"mlflow-secret"`
 
 	_, err := parseExecConfigJson(&kubernetesConfig)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to unmarshal Kubernetes config")
-	assert.NotContains(t, err.Error(), "secretAsEnv")
+	assert.Equal(t, "failed to unmarshal Kubernetes config", err.Error())
 	assert.NotContains(t, err.Error(), "mlflow-secret")
-	assert.NotContains(t, err.Error(), "password")
 }
 
 func TestGetPipelineJobTimePlaceholderUsage(t *testing.T) {

--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -403,5 +403,14 @@ func getS3BucketCredential(
 		s3Creds := credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")
 		return &s3Creds, err
 	}
-	return nil, fmt.Errorf("could not find required bucket credential values; both access key and secret key must be present")
+	// Name which credential role is missing without echoing the configured
+	// secret data key names.
+	missingValues := make([]string, 0, 2)
+	if accessKey == "" {
+		missingValues = append(missingValues, "access key")
+	}
+	if secretKey == "" {
+		missingValues = append(missingValues, "secret key")
+	}
+	return nil, fmt.Errorf("bucket credential secret has no value for: %s", strings.Join(missingValues, ", "))
 }

--- a/backend/src/v2/objectstore/object_store.go
+++ b/backend/src/v2/objectstore/object_store.go
@@ -403,5 +403,5 @@ func getS3BucketCredential(
 		s3Creds := credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")
 		return &s3Creds, err
 	}
-	return nil, fmt.Errorf("could not find specified keys '%s' or '%s'", bucketAccessKeyKey, bucketSecretKeyKey)
+	return nil, fmt.Errorf("could not find required bucket credential values; both access key and secret key must be present")
 }

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -501,6 +501,7 @@ func Test_createS3BucketSession(t *testing.T) {
 		expectedPathStyle bool
 		wantErr           bool
 		errorMsg          string
+		forbiddenErrorMsg []string
 	}{
 		{
 			msg: "Bucket with session",
@@ -591,7 +592,11 @@ func Test_createS3BucketSession(t *testing.T) {
 			},
 			expectValidClient: false,
 			wantErr:           true,
-			errorMsg:          "could not find specified keys",
+			errorMsg:          "both access key and secret key must be present",
+			forbiddenErrorMsg: []string{
+				"does_not_exist_secret_key",
+				"does_not_exist_access_key",
+			},
 		},
 	}
 	for _, test := range tt {
@@ -612,6 +617,9 @@ func Test_createS3BucketSession(t *testing.T) {
 				assert.Error(t, err)
 				if test.errorMsg != "" {
 					assert.Contains(t, err.Error(), test.errorMsg)
+				}
+				for _, forbidden := range test.forbiddenErrorMsg {
+					assert.NotContains(t, err.Error(), forbidden)
 				}
 			} else {
 				assert.Nil(t, err)

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -660,7 +660,7 @@ func TestGetS3BucketCredentialReportsMissingRoleWithoutConfiguredKeyNames(t *tes
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			clientSet := fake.NewSimpleClientset(&corev1.Secret{
+			clientSet := fake.NewClientset(&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "s3-provider-secret", Namespace: "testnamespace"},
 				Data:       test.secretData,
 			})

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -592,7 +592,7 @@ func Test_createS3BucketSession(t *testing.T) {
 			},
 			expectValidClient: false,
 			wantErr:           true,
-			errorMsg:          "both access key and secret key must be present",
+			errorMsg:          "bucket credential secret has no value for: access key, secret key",
 			forbiddenErrorMsg: []string{
 				"does_not_exist_secret_key",
 				"does_not_exist_access_key",

--- a/backend/src/v2/objectstore/object_store_test.go
+++ b/backend/src/v2/objectstore/object_store_test.go
@@ -636,6 +636,52 @@ func Test_createS3BucketSession(t *testing.T) {
 	}
 }
 
+func TestGetS3BucketCredentialReportsMissingRoleWithoutConfiguredKeyNames(t *testing.T) {
+	tests := []struct {
+		name            string
+		secretData      map[string][]byte
+		expectedMissing string
+	}{
+		{
+			name: "access key missing",
+			secretData: map[string][]byte{
+				"custom-secret-key-field": []byte("secret-key-value"),
+			},
+			expectedMissing: "access key",
+		},
+		{
+			name: "secret key missing",
+			secretData: map[string][]byte{
+				"custom-access-key-field": []byte("access-key-value"),
+			},
+			expectedMissing: "secret key",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientSet := fake.NewSimpleClientset(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "s3-provider-secret", Namespace: "testnamespace"},
+				Data:       test.secretData,
+			})
+
+			_, err := getS3BucketCredential(
+				context.Background(),
+				clientSet,
+				"testnamespace",
+				"s3-provider-secret",
+				"custom-secret-key-field",
+				"custom-access-key-field",
+			)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "has no value for: "+test.expectedMissing)
+			assert.NotContains(t, err.Error(), "custom-access-key-field")
+			assert.NotContains(t, err.Error(), "custom-secret-key-field")
+		})
+	}
+}
+
 func TestOpenBucketUsesExplicitS3ClientForEnvCredentials(t *testing.T) {
 	t.Setenv("AWS_REGION", "us-east-1")
 


### PR DESCRIPTION
## Summary

- Stop logging raw driver pod spec patches and Kubernetes executor configs; log byte counts instead.
- Stop returning configured S3 bucket and MLflow credential secret key names in errors that are logged by callers.
- Add focused regression tests for the sensitive log-message and error-string contracts.

## Why

CodeQL flagged `go/clear-text-logging` flows where Kubernetes secret reference fields could reach backend logs through driver, objectstore/launcher, and MLflow plugin paths.

This is expected to address code scanning alerts #759, #758, #757, #666, #665, #664, #663, #198, and #56.

## Tests

- `go test ./backend/src/v2/cmd/driver ./backend/src/v2/objectstore ./backend/src/apiserver/plugins/mlflow`
- `git diff --check`
