### PR TITLE
fix(backend): authorize ReadRunLogV1 before streaming run logs

### DIFF
--- a/backend/src/apiserver/client/kubernetes_core_fake.go
+++ b/backend/src/apiserver/client/kubernetes_core_fake.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/kubeflow/pipelines/backend/src/common/util"
+	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/client-go/kubernetes"
@@ -42,6 +43,22 @@ func (c *FakeKuberneteCoreClient) GetClientSet() kubernetes.Interface {
 
 func NewFakeKuberneteCoresClient() *FakeKuberneteCoreClient {
 	return &FakeKuberneteCoreClient{&FakePodClient{}}
+}
+
+type FakeKubernetesCoreClientWithPod struct {
+	podClientFake *FakePodClientWithPod
+}
+
+func NewFakeKubernetesCoreClientWithPod(pod *corev1.Pod) *FakeKubernetesCoreClientWithPod {
+	return &FakeKubernetesCoreClientWithPod{&FakePodClientWithPod{Pod: pod}}
+}
+
+func (c *FakeKubernetesCoreClientWithPod) PodClient(namespace string) v1.PodInterface {
+	return c.podClientFake
+}
+
+func (c *FakeKubernetesCoreClientWithPod) GetClientSet() kubernetes.Interface {
+	return k8sfake.NewClientset()
 }
 
 type FakeKubernetesCoreClientWithBadPodClient struct {

--- a/backend/src/apiserver/client/pod_fake.go
+++ b/backend/src/apiserver/client/pod_fake.go
@@ -104,6 +104,17 @@ type FakeBadPodClient struct {
 	FakePodClient
 }
 
+// FakePodClientWithPod serves a fixed pod from Get, so tests can exercise
+// checks against pod metadata such as the run id label.
+type FakePodClientWithPod struct {
+	FakePodClient
+	Pod *corev1.Pod
+}
+
+func (c FakePodClientWithPod) Get(ctx context.Context, name string, options v1.GetOptions) (*corev1.Pod, error) {
+	return c.Pod, nil
+}
+
 func (FakeBadPodClient) Delete(ctx context.Context, name string, options v1.DeleteOptions) error {
 	return errors.New("failed to delete pod")
 }

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -41,6 +41,7 @@ const (
 	RbacResourceVerbUnarchive     = "unarchive"
 	RbacResourceVerbReportMetrics = "reportMetrics"
 	RbacResourceVerbReadArtifact  = "readArtifact"
+	RbacResourceVerbReadLog       = "readLog"
 	RbacResourceVerbReport        = "report"
 )
 

--- a/backend/src/apiserver/resource/client_manager_fake.go
+++ b/backend/src/apiserver/resource/client_manager_fake.go
@@ -37,7 +37,7 @@ type FakeClientManager struct {
 	objectStore                   storage.ObjectStore
 	ExecClientFake                *client.FakeExecClient
 	swfClientFake                 *client.FakeSwfClient
-	k8sCoreClientFake             *client.FakeKuberneteCoreClient
+	KubernetesCoreClientFake      client.KubernetesCoreInterface
 	SubjectAccessReviewClientFake client.SubjectAccessReviewInterface
 	tokenReviewClientFake         client.TokenReviewInterface
 	logArchive                    archive.LogArchiveInterface
@@ -77,7 +77,7 @@ func NewFakeClientManager(time util.TimeInterface, uuid util.UUIDGeneratorInterf
 		defaultExperimentStore:        storage.NewDefaultExperimentStore(db),
 		objectStore:                   newFakeObjectStore(),
 		swfClientFake:                 client.NewFakeSwfClient(),
-		k8sCoreClientFake:             client.NewFakeKuberneteCoresClient(),
+		KubernetesCoreClientFake:      client.NewFakeKuberneteCoresClient(),
 		SubjectAccessReviewClientFake: client.NewFakeSubjectAccessReviewClient(),
 		tokenReviewClientFake:         client.NewFakeTokenReviewClient(),
 		logArchive:                    archive.NewLogArchive("/logs", "main.log"),
@@ -171,7 +171,7 @@ func (f *FakeClientManager) SwfClient() client.SwfClientInterface {
 }
 
 func (f *FakeClientManager) KubernetesCoreClient() client.KubernetesCoreInterface {
-	return f.k8sCoreClientFake
+	return f.KubernetesCoreClientFake
 }
 
 func (f *FakeClientManager) SubjectAccessReviewClient() client.SubjectAccessReviewInterface {

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1159,7 +1159,7 @@ func (r *ResourceManager) ReadLog(ctx context.Context, runId string, nodeId stri
 	if err != nil {
 		return util.NewBadRequestError(err, "Failed to read logs for run %v due to namespace fetching error", runId)
 	}
-	err = r.readRunLogFromPod(ctx, namespace, nodeId, follow, dst)
+	err = r.readRunLogFromPod(ctx, runId, namespace, nodeId, follow, dst)
 	if err != nil && r.logArchive != nil {
 		err = r.readRunLogFromArchive(string(run.WorkflowRuntimeManifest), nodeId, dst)
 		if err != nil {
@@ -1173,7 +1173,21 @@ func (r *ResourceManager) ReadLog(ctx context.Context, runId string, nodeId stri
 }
 
 // Fetches execution logs from a pod.
-func (r *ResourceManager) readRunLogFromPod(ctx context.Context, namespace string, nodeId string, follow bool, dst io.Writer) error {
+func (r *ResourceManager) readRunLogFromPod(ctx context.Context, runId string, namespace string, nodeId string, follow bool, dst io.Writer) error {
+	// The caller controls nodeId, so confirm the pod was created by this run
+	// before streaming, otherwise the run only selects a namespace and any pod
+	// in it could be read with the API server's credentials.
+	pod, err := r.k8sCoreClient.PodClient(namespace).Get(ctx, nodeId, v1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			glog.Errorf("Failed to get pod %v: %v", nodeId, err)
+		}
+		return util.NewInternalServerError(err, "Failed to read logs from pod %v due to error fetching the pod", nodeId)
+	}
+	if pod == nil || pod.Labels[util.LabelKeyWorkflowRunId] != runId {
+		return util.NewInvalidInputError("Pod %v does not belong to run %v", nodeId, runId)
+	}
+
 	logOptions := corev1.PodLogOptions{
 		Container:  "main",
 		Timestamps: false,

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1173,19 +1173,19 @@ func (r *ResourceManager) ReadLog(ctx context.Context, runId string, nodeId stri
 }
 
 // Fetches execution logs from a pod.
-func (r *ResourceManager) readRunLogFromPod(ctx context.Context, runID string, namespace string, nodeId string, follow bool, dst io.Writer) error {
-	// The caller controls nodeId, so confirm the pod was created by this run
+func (r *ResourceManager) readRunLogFromPod(ctx context.Context, runID string, namespace string, nodeID string, follow bool, dst io.Writer) error {
+	// The caller controls nodeID, so confirm the pod was created by this run
 	// before streaming, otherwise the run only selects a namespace and any pod
 	// in it could be read with the API server's credentials.
-	pod, err := r.k8sCoreClient.PodClient(namespace).Get(ctx, nodeId, v1.GetOptions{})
+	pod, err := r.k8sCoreClient.PodClient(namespace).Get(ctx, nodeID, v1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			glog.Errorf("Failed to get pod %v: %v", nodeId, err)
+			glog.Errorf("Failed to get pod %v: %v", nodeID, err)
 		}
-		return util.NewInternalServerError(err, "Failed to read logs from pod %v due to error fetching the pod", nodeId)
+		return util.NewInternalServerError(err, "Failed to read logs from pod %v due to error fetching the pod", nodeID)
 	}
 	if pod == nil || pod.Labels[util.LabelKeyWorkflowRunId] != runID {
-		return util.NewInvalidInputError("Pod %v does not belong to run %v", nodeId, runID)
+		return util.NewInvalidInputError("Pod %v does not belong to run %v", nodeID, runID)
 	}
 
 	logOptions := corev1.PodLogOptions{
@@ -1194,19 +1194,19 @@ func (r *ResourceManager) readRunLogFromPod(ctx context.Context, runID string, n
 		Follow:     follow,
 	}
 
-	req := r.k8sCoreClient.PodClient(namespace).GetLogs(nodeId, &logOptions)
+	req := r.k8sCoreClient.PodClient(namespace).GetLogs(nodeID, &logOptions)
 	podLogs, err := req.Stream(ctx)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			glog.Errorf("Failed to read logs from pod %v: %v", nodeId, err)
+			glog.Errorf("Failed to read logs from pod %v: %v", nodeID, err)
 		}
-		return util.NewInternalServerError(err, "Failed to read logs from pod %v due to error opening log stream", nodeId)
+		return util.NewInternalServerError(err, "Failed to read logs from pod %v due to error opening log stream", nodeID)
 	}
 	defer podLogs.Close()
 
 	_, err = io.Copy(dst, podLogs)
 	if err != nil && !errors.Is(err, io.EOF) {
-		return util.NewInternalServerError(err, "Failed to read logs from pod %v due to error in streaming the log", nodeId)
+		return util.NewInternalServerError(err, "Failed to read logs from pod %v due to error in streaming the log", nodeID)
 	}
 	return nil
 }

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1173,7 +1173,7 @@ func (r *ResourceManager) ReadLog(ctx context.Context, runId string, nodeId stri
 }
 
 // Fetches execution logs from a pod.
-func (r *ResourceManager) readRunLogFromPod(ctx context.Context, runId string, namespace string, nodeId string, follow bool, dst io.Writer) error {
+func (r *ResourceManager) readRunLogFromPod(ctx context.Context, runID string, namespace string, nodeId string, follow bool, dst io.Writer) error {
 	// The caller controls nodeId, so confirm the pod was created by this run
 	// before streaming, otherwise the run only selects a namespace and any pod
 	// in it could be read with the API server's credentials.
@@ -1184,8 +1184,8 @@ func (r *ResourceManager) readRunLogFromPod(ctx context.Context, runId string, n
 		}
 		return util.NewInternalServerError(err, "Failed to read logs from pod %v due to error fetching the pod", nodeId)
 	}
-	if pod == nil || pod.Labels[util.LabelKeyWorkflowRunId] != runId {
-		return util.NewInvalidInputError("Pod %v does not belong to run %v", nodeId, runId)
+	if pod == nil || pod.Labels[util.LabelKeyWorkflowRunId] != runID {
+		return util.NewInvalidInputError("Pod %v does not belong to run %v", nodeId, runID)
 	}
 
 	logOptions := corev1.PodLogOptions{

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3023,6 +3023,30 @@ func TestRetryRun_UpdateAndCreateFailed(t *testing.T) {
 	assert.Contains(t, err.Error(), "error updating and creating a workflow")
 }
 
+// The node id in a log request is caller controlled, so a run must not act as
+// a namespace selector for arbitrary pods: a pod whose run id label does not
+// match the requested run is rejected before any logs are streamed.
+func TestReadRunLogFromPod_PodNotFromRun(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	defer store.Close()
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+
+	foreignPod := &corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "victim-pod",
+			Namespace: "ns1",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "some-other-run"},
+		},
+	}
+	manager.k8sCoreClient = client.NewFakeKubernetesCoreClientWithPod(foreignPod)
+
+	var buf bytes.Buffer
+	err := manager.readRunLogFromPod(context.Background(), "run-1", "ns1", "victim-pod", false, &buf)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "does not belong to run")
+	assert.Empty(t, buf.String())
+}
+
 func TestUnarchiveRun_OK(t *testing.T) {
 	store, manager, runDetail := initWithOneTimeRun(t)
 	defer store.Close()

--- a/backend/src/apiserver/server/run_log_server.go
+++ b/backend/src/apiserver/server/run_log_server.go
@@ -23,7 +23,10 @@ import (
 	"github.com/golang/glog"
 	"github.com/gorilla/mux"
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
 const (
@@ -33,8 +36,8 @@ const (
 )
 
 type RunLogServer struct {
-	resourceManager *resource.ResourceManager
-	httpClient      *http.Client
+	*BaseRunServer
+	httpClient *http.Client
 }
 
 // Log streaming endpoint
@@ -58,6 +61,11 @@ func (s *RunLogServer) ReadRunLogV1(w http.ResponseWriter, r *http.Request) {
 
 	follow := vars[Follow] == "true" // defaults to false
 
+	if err := s.canAccessRun(r.Context(), runId, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbGet}); err != nil {
+		s.writeErrorToResponse(w, http.StatusForbidden, util.Wrap(err, "Failed to authorize the request"))
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "text/plain")
 	w.Header().Set("Cache-Control", "no-cache, private")
@@ -80,5 +88,11 @@ func (s *RunLogServer) writeErrorToResponse(w http.ResponseWriter, code int, err
 }
 
 func NewRunLogServer(resourceManager *resource.ResourceManager) *RunLogServer {
-	return &RunLogServer{resourceManager: resourceManager, httpClient: http.DefaultClient}
+	return &RunLogServer{
+		BaseRunServer: &BaseRunServer{
+			resourceManager: resourceManager,
+			options:         &RunServerOptions{CollectMetrics: false},
+		},
+		httpClient: http.DefaultClient,
+	}
 }

--- a/backend/src/apiserver/server/run_log_server.go
+++ b/backend/src/apiserver/server/run_log_server.go
@@ -81,13 +81,15 @@ func (s *RunLogServer) ReadRunLogV1(w http.ResponseWriter, r *http.Request) {
 // so the caller identity arrives in the request headers, not in gRPC metadata.
 // Copy the headers into metadata so the authenticators can read them, as
 // canUploadVersionedPipeline does.
+// The dedicated readLog verb keeps log access behind a SubjectAccessReview even
+// in shared read mode, which auto-approves the shared get/list verbs.
 func (s *RunLogServer) authorize(r *http.Request, runID string) error {
 	md := metadata.MD{}
 	for key, values := range r.Header {
 		md.Set(key, values...)
 	}
 	ctx := metadata.NewIncomingContext(r.Context(), md)
-	return s.canAccessRun(ctx, runID, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbGet})
+	return s.canAccessRun(ctx, runID, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbReadLog})
 }
 
 func (s *RunLogServer) writeErrorToResponse(w http.ResponseWriter, code int, err error) {

--- a/backend/src/apiserver/server/run_log_server.go
+++ b/backend/src/apiserver/server/run_log_server.go
@@ -67,7 +67,9 @@ func (s *RunLogServer) ReadRunLogV1(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	// Set the success headers without committing a status code: the first
+	// streamed log write sends 200 implicitly, while a validation failure
+	// inside ReadLog can still produce a non-2xx JSON response.
 	w.Header().Set("Content-Type", "text/plain")
 	w.Header().Set("Cache-Control", "no-cache, private")
 

--- a/backend/src/apiserver/server/run_log_server.go
+++ b/backend/src/apiserver/server/run_log_server.go
@@ -78,6 +78,7 @@ func (s *RunLogServer) ReadRunLogV1(w http.ResponseWriter, r *http.Request) {
 
 func (s *RunLogServer) writeErrorToResponse(w http.ResponseWriter, code int, err error) {
 	glog.Errorf("Failed to read run log. Error: %+v", err)
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	errorResponse := &api.Error{ErrorMessage: err.Error(), ErrorDetails: fmt.Sprintf("%+v", err)}
 	errBytes, err := json.Marshal(errorResponse)

--- a/backend/src/apiserver/server/run_log_server.go
+++ b/backend/src/apiserver/server/run_log_server.go
@@ -81,13 +81,13 @@ func (s *RunLogServer) ReadRunLogV1(w http.ResponseWriter, r *http.Request) {
 // so the caller identity arrives in the request headers, not in gRPC metadata.
 // Copy the headers into metadata so the authenticators can read them, as
 // canUploadVersionedPipeline does.
-func (s *RunLogServer) authorize(r *http.Request, runId string) error {
+func (s *RunLogServer) authorize(r *http.Request, runID string) error {
 	md := metadata.MD{}
 	for key, values := range r.Header {
 		md.Set(key, values...)
 	}
 	ctx := metadata.NewIncomingContext(r.Context(), md)
-	return s.canAccessRun(ctx, runId, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbGet})
+	return s.canAccessRun(ctx, runID, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbGet})
 }
 
 func (s *RunLogServer) writeErrorToResponse(w http.ResponseWriter, code int, err error) {

--- a/backend/src/apiserver/server/run_log_server.go
+++ b/backend/src/apiserver/server/run_log_server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
+	"google.golang.org/grpc/metadata"
 	authorizationv1 "k8s.io/api/authorization/v1"
 )
 
@@ -61,7 +62,7 @@ func (s *RunLogServer) ReadRunLogV1(w http.ResponseWriter, r *http.Request) {
 
 	follow := vars[Follow] == "true" // defaults to false
 
-	if err := s.canAccessRun(r.Context(), runId, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbGet}); err != nil {
+	if err := s.authorize(r, runId); err != nil {
 		s.writeErrorToResponse(w, http.StatusForbidden, util.Wrap(err, "Failed to authorize the request"))
 		return
 	}
@@ -74,6 +75,19 @@ func (s *RunLogServer) ReadRunLogV1(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.writeErrorToResponse(w, http.StatusInternalServerError, err)
 	}
+}
+
+// This route is registered directly on the mux rather than through grpc-gateway,
+// so the caller identity arrives in the request headers, not in gRPC metadata.
+// Copy the headers into metadata so the authenticators can read them, as
+// canUploadVersionedPipeline does.
+func (s *RunLogServer) authorize(r *http.Request, runId string) error {
+	md := metadata.MD{}
+	for key, values := range r.Header {
+		md.Set(key, values...)
+	}
+	ctx := metadata.NewIncomingContext(r.Context(), md)
+	return s.canAccessRun(ctx, runId, &authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbGet})
 }
 
 func (s *RunLogServer) writeErrorToResponse(w http.ResponseWriter, code int, err error) {

--- a/backend/src/apiserver/server/run_log_server_test.go
+++ b/backend/src/apiserver/server/run_log_server_test.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -22,7 +23,12 @@ import (
 
 	"github.com/gorilla/mux"
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestNewRunLogServer(t *testing.T) {
@@ -82,4 +88,32 @@ func TestReadRunLogV1_MissingNodeId(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.Contains(t, recorder.Body.String(), NodeKey)
+}
+
+func TestReadRunLogV1_Unauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	clients, _, run := initWithOneTimeRun(t)
+	defer clients.Close()
+
+	// Deny access for the log read while keeping the seeded run intact, so the
+	// request reaches the authorization check rather than failing earlier.
+	clients.SubjectAccessReviewClientFake = client.NewFakeSubjectAccessReviewClientUnauthorized()
+	manager := resource.NewResourceManager(clients, &resource.ResourceManagerOptions{CollectMetrics: false})
+	server := NewRunLogServer(manager)
+
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	req := httptest.NewRequest("GET", "/test", nil).WithContext(ctx)
+	req = mux.SetURLVars(req, map[string]string{
+		RunKey:  run.UUID,
+		NodeKey: "node-1",
+	})
+
+	recorder := httptest.NewRecorder()
+	server.ReadRunLogV1(recorder, req)
+
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Failed to authorize")
 }

--- a/backend/src/apiserver/server/run_log_server_test.go
+++ b/backend/src/apiserver/server/run_log_server_test.go
@@ -25,8 +25,11 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewRunLogServer(t *testing.T) {
@@ -144,6 +147,39 @@ func TestReadRunLogV1_SharedReadModeStillDenied(t *testing.T) {
 
 	assert.Equal(t, http.StatusForbidden, recorder.Code)
 	assert.Contains(t, recorder.Body.String(), "Check if you have access to namespace")
+}
+
+// A pod whose run id label does not match the requested run is rejected inside
+// ReadLog, after the handler has already started its response. This pins that
+// the handler does not commit a 200 before that validation: the failure must
+// still surface to the client as a non-2xx JSON response.
+func TestReadRunLogV1_PodNotFromRun(t *testing.T) {
+	clients, _, run := initWithOneTimeRun(t)
+	defer clients.Close()
+
+	foreignPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "victim-pod",
+			Namespace: "ns1",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "some-other-run"},
+		},
+	}
+	clients.KubernetesCoreClientFake = client.NewFakeKubernetesCoreClientWithPod(foreignPod)
+	manager := resource.NewResourceManager(clients, &resource.ResourceManagerOptions{CollectMetrics: false})
+	server := NewRunLogServer(manager)
+
+	req := httptest.NewRequest("GET", "/apis/v1alpha1/runs/"+run.UUID+"/nodes/victim-pod/log", nil)
+	req = mux.SetURLVars(req, map[string]string{
+		RunKey:  run.UUID,
+		NodeKey: "victim-pod",
+	})
+
+	recorder := httptest.NewRecorder()
+	server.ReadRunLogV1(recorder, req)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.Equal(t, "application/json", recorder.Result().Header.Get("Content-Type"))
+	assert.Contains(t, recorder.Body.String(), "Failed to read logs for run "+run.UUID)
 }
 
 func TestReadRunLogV1_AuthorizedOverPlainHTTP(t *testing.T) {

--- a/backend/src/apiserver/server/run_log_server_test.go
+++ b/backend/src/apiserver/server/run_log_server_test.go
@@ -15,7 +15,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -28,7 +27,6 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc/metadata"
 )
 
 func TestNewRunLogServer(t *testing.T) {
@@ -103,9 +101,8 @@ func TestReadRunLogV1_Unauthorized(t *testing.T) {
 	manager := resource.NewResourceManager(clients, &resource.ResourceManagerOptions{CollectMetrics: false})
 	server := NewRunLogServer(manager)
 
-	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
-	ctx := metadata.NewIncomingContext(context.Background(), md)
-	req := httptest.NewRequest("GET", "/test", nil).WithContext(ctx)
+	req := httptest.NewRequest("GET", "/apis/v1alpha1/runs/"+run.UUID+"/nodes/node-1/log", nil)
+	req.Header.Set(common.GoogleIAPUserIdentityHeader, common.GoogleIAPUserIdentityPrefix+"user@google.com")
 	req = mux.SetURLVars(req, map[string]string{
 		RunKey:  run.UUID,
 		NodeKey: "node-1",
@@ -115,6 +112,20 @@ func TestReadRunLogV1_Unauthorized(t *testing.T) {
 	server.ReadRunLogV1(recorder, req)
 
 	assert.Equal(t, http.StatusForbidden, recorder.Code)
-	assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
-	assert.Contains(t, recorder.Body.String(), "Failed to authorize")
+	assert.Equal(t, "application/json", recorder.Result().Header.Get("Content-Type"))
+	assert.Contains(t, recorder.Body.String(), "Check if you have access to namespace")
+}
+
+func TestReadRunLogV1_AuthorizedOverPlainHTTP(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	clients, manager, run := initWithOneTimeRun(t) // default SAR fake authorizes
+	defer clients.Close()
+	server := NewRunLogServer(manager)
+
+	req := httptest.NewRequest("GET", "/apis/v1alpha1/runs/"+run.UUID+"/nodes/node-1/log", nil)
+	req.Header.Set(common.GoogleIAPUserIdentityHeader, common.GoogleIAPUserIdentityPrefix+"user@google.com")
+
+	assert.NoError(t, server.authorize(req, run.UUID))
 }

--- a/backend/src/apiserver/server/run_log_server_test.go
+++ b/backend/src/apiserver/server/run_log_server_test.go
@@ -116,6 +116,36 @@ func TestReadRunLogV1_Unauthorized(t *testing.T) {
 	assert.Contains(t, recorder.Body.String(), "Check if you have access to namespace")
 }
 
+// Shared read mode auto-approves the get and list verbs, so log reads use the
+// dedicated readLog verb to stay behind a SubjectAccessReview. This pins that:
+// an unauthorized caller must still get a 403 with shared read enabled.
+func TestReadRunLogV1_SharedReadModeStillDenied(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.MultiUserModeSharedReadAccess, "true")
+	defer viper.Set(common.MultiUserModeSharedReadAccess, "false")
+
+	clients, _, run := initWithOneTimeRun(t)
+	defer clients.Close()
+
+	clients.SubjectAccessReviewClientFake = client.NewFakeSubjectAccessReviewClientUnauthorized()
+	manager := resource.NewResourceManager(clients, &resource.ResourceManagerOptions{CollectMetrics: false})
+	server := NewRunLogServer(manager)
+
+	req := httptest.NewRequest("GET", "/apis/v1alpha1/runs/"+run.UUID+"/nodes/node-1/log", nil)
+	req.Header.Set(common.GoogleIAPUserIdentityHeader, common.GoogleIAPUserIdentityPrefix+"user@google.com")
+	req = mux.SetURLVars(req, map[string]string{
+		RunKey:  run.UUID,
+		NodeKey: "node-1",
+	})
+
+	recorder := httptest.NewRecorder()
+	server.ReadRunLogV1(recorder, req)
+
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Check if you have access to namespace")
+}
+
 func TestReadRunLogV1_AuthorizedOverPlainHTTP(t *testing.T) {
 	viper.Set(common.MultiUserMode, "true")
 	defer viper.Set(common.MultiUserMode, "false")

--- a/backend/src/apiserver/server/run_log_server_test.go
+++ b/backend/src/apiserver/server/run_log_server_test.go
@@ -115,5 +115,6 @@ func TestReadRunLogV1_Unauthorized(t *testing.T) {
 	server.ReadRunLogV1(recorder, req)
 
 	assert.Equal(t, http.StatusForbidden, recorder.Code)
+	assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
 	assert.Contains(t, recorder.Body.String(), "Failed to authorize")
 }

--- a/manifests/kustomize/base/installs/multi-user/view-edit-cluster-roles.yaml
+++ b/manifests/kustomize/base/installs/multi-user/view-edit-cluster-roles.yaml
@@ -71,6 +71,7 @@ rules:
   - unarchive
   - reportMetrics
   - readArtifact
+  - readLog
 - apiGroups:
   - pipelines.kubeflow.org
   resources:
@@ -126,6 +127,7 @@ rules:
   - get
   - list
   - readArtifact
+  - readLog
 - apiGroups:
   - kubeflow.org
   resources:


### PR DESCRIPTION
**Description of your changes:**

The run log endpoint `/apis/v1alpha1/runs/{run_id}/nodes/{node_id}/log` streams pod logs through `ReadRunLogV1`, but unlike the sibling artifact endpoints (`ReadArtifact` / `ReadArtifactV1`) it never calls `canAccessRun`. In multi-user mode any authenticated user can read the logs of a run in a namespace they have no access to by supplying that run id, since the handler goes straight to `resourceManager.ReadLog`.

Add the same `canAccessRun` gate the artifact reader already uses, with the `get` verb, before any response is written. Keeping the check in the handler mirrors `ReadArtifact` and the gRPC run methods, so authorization sits next to the resource it guards rather than being pushed into `ReadLog`, which other read paths share. The added test drives the handler in multi-user mode with an unauthorized caller and asserts a 403.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
