### PR TITLE
fix(ci): make image rebuild step actually run after build failure

### DIFF
--- a/.github/workflows/image-builds.yml
+++ b/.github/workflows/image-builds.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Rebuild Images in case of failure
         uses: docker/build-push-action@v6
-        if: ${{ steps.save-image.outcome != 'success' && steps.setup-buildx.outcome == 'success' }}
+        if: ${{ failure() && steps.save-image.outcome == 'failure' && steps.setup-buildx.outcome == 'success' }}
         id: rebuild
         env:
           # Disable the job summary report in the GitHub Actions UI
@@ -149,6 +149,7 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: false
+          no-cache: true
           build-args: |
             NODE_VERSION=${{ steps.frontend_node.outputs.version }}
           tags: ${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.IMAGE_TAG }}
@@ -156,7 +157,7 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
-        if: ${{ steps.save-image.outcome == 'success' || steps.rebuild.outcome == 'success' }}
+        if: ${{ always() && (steps.save-image.outcome == 'success' || steps.rebuild.outcome == 'success') }}
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.ARTIFACTS_PATH }}/${{ env.ARTIFACT_NAME }}.tar

--- a/.github/workflows/image-builds.yml
+++ b/.github/workflows/image-builds.yml
@@ -126,6 +126,7 @@ jobs:
         uses: docker/build-push-action@v6
         if: ${{ steps.setup-buildx.outcome == 'success' }}
         id: save-image
+        continue-on-error: true
         env:
           # Disable the job summary report in the GitHub Actions UI
           DOCKER_BUILD_SUMMARY: false
@@ -140,7 +141,7 @@ jobs:
 
       - name: Rebuild Images in case of failure
         uses: docker/build-push-action@v6
-        if: ${{ failure() && steps.save-image.outcome == 'failure' && steps.setup-buildx.outcome == 'success' }}
+        if: ${{ steps.save-image.outcome == 'failure' && steps.setup-buildx.outcome == 'success' }}
         id: rebuild
         env:
           # Disable the job summary report in the GitHub Actions UI
@@ -157,7 +158,7 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
-        if: ${{ always() && (steps.save-image.outcome == 'success' || steps.rebuild.outcome == 'success') }}
+        if: ${{ steps.save-image.outcome == 'success' || steps.rebuild.outcome == 'success' }}
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ${{ env.ARTIFACTS_PATH }}/${{ env.ARTIFACT_NAME }}.tar

--- a/.github/workflows/image-builds.yml
+++ b/.github/workflows/image-builds.yml
@@ -124,7 +124,6 @@ jobs:
 
       - name: Build and save Docker image
         uses: docker/build-push-action@v6
-        if: ${{ steps.setup-buildx.outcome == 'success' }}
         id: save-image
         continue-on-error: true
         env:
@@ -141,7 +140,7 @@ jobs:
 
       - name: Rebuild Images in case of failure
         uses: docker/build-push-action@v6
-        if: ${{ steps.save-image.outcome == 'failure' && steps.setup-buildx.outcome == 'success' }}
+        if: ${{ steps.save-image.outcome == 'failure' }}
         id: rebuild
         env:
           # Disable the job summary report in the GitHub Actions UI


### PR DESCRIPTION
## Summary

The rebuild step in `image-builds.yml` was silently skipped on every build failure because its `if` condition lacked a status check function — GitHub Actions implicitly ANDed it with `success()`, which is `false` after the first build fails.

Additionally, even if the rebuild step had run, the job would still end as `failure` (blocking downstream jobs and triggering `fail-fast` cancellation of sibling matrix jobs) because the initial build step hard-fails the job.

### Changes

- Added `continue-on-error: true` to the initial build step so the job stays in `success` state, giving the rebuild a chance to recover without triggering `fail-fast` or blocking downstream jobs.
- Tightened the rebuild condition to `steps.save-image.outcome == 'failure'` (positive match instead of `!= 'success'`) so it only fires on actual failure, not on `skipped` or `cancelled`.
- Added `no-cache: true` to the rebuild step to bypass corrupt BuildKit cache layers that caused the original failure.
- The upload step condition is unchanged — with `continue-on-error: true` on the initial build, the implicit `success()` AND works correctly for all cases.

## Test plan

- [ ] Verify the rebuild step runs when the initial build fails (e.g., transient cache corruption)
- [ ] Verify the rebuild step does NOT run when the job is cancelled (fail-fast from another matrix job)
- [ ] Verify the upload step runs after a successful rebuild
- [ ] Verify normal builds (no failure) are unaffected
- [ ] Verify downstream jobs (`needs: build`) proceed when the rebuild succeeds