### PR TITLE
fix(manifests): raise SeaweedFS CPU request and add failure diagnostics

### DIFF
--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -363,6 +363,12 @@ runs:
         if [ "${{ inputs.proxy }}" = "true" ]; then
           ./.github/resources/scripts/collect-logs.sh --ns tinyproxy --output /tmp/tmp_pod_log.txt
         fi
+        # Targeted SeaweedFS diagnostics: E2E lanes intermittently fail with
+        # dial-timeout errors to the SeaweedFS ClusterIP. This captures the
+        # restart/contention/dataplane evidence needed to tell whether a CPU
+        # request bump (which this workflow's manifests carry) is the right
+        # lever or the failure is elsewhere.
+        ./.github/resources/scripts/collect-seaweedfs-diagnostics.sh --ns "$NAMESPACE" --output /tmp/tmp_pod_log.txt
       continue-on-error: true
 
     - name: Set up Python for reporting

--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -368,7 +368,7 @@ runs:
         # restart/contention/dataplane evidence needed to tell whether a CPU
         # request bump (which this workflow's manifests carry) is the right
         # lever or the failure is elsewhere.
-        ./.github/resources/scripts/collect-seaweedfs-diagnostics.sh --ns "$NAMESPACE" --output /tmp/tmp_pod_log.txt
+        ./.github/resources/scripts/collect-seaweedfs-diagnostics.sh --namespace "$NAMESPACE" --output /tmp/tmp_pod_log.txt
       continue-on-error: true
 
     - name: Set up Python for reporting

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -32,9 +32,9 @@ OUTPUT_FILE=""
 
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
-        --ns) NS="$2"; shift ;;
-        --selector) SELECTOR="$2"; shift ;;
-        --output) OUTPUT_FILE="$2"; shift ;;
+        --ns) NS="${2:?--ns requires a value}"; shift ;;
+        --selector) SELECTOR="${2:?--selector requires a value}"; shift ;;
+        --output) OUTPUT_FILE="${2:?--output requires a value}"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -52,7 +52,10 @@ emit() {
 {
     echo "================ SeaweedFS failure diagnostics ================"
 
-    POD=$(kubectl get pod -n "$NS" -l "$SELECTOR" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    # Newest matching pod: with strategy Recreate there is normally one, but a
+    # rollout can briefly leave a Terminating pod alongside the new one, and the
+    # new pod is the one whose state matters.
+    POD=$(kubectl get pod -n "$NS" -l "$SELECTOR" --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}' 2>/dev/null || true)
     if [[ -z "$POD" ]]; then
         echo "No SeaweedFS pod (selector '$SELECTOR') found in namespace '$NS'; skipping."
         echo "=============================================================="
@@ -87,8 +90,10 @@ emit() {
     # If SeaweedFS is Running with no restarts and the node is healthy but the
     # ClusterIP still times out, the failure is in the service dataplane.
     kubectl get pod -n kube-system -l k8s-app=kube-proxy -o wide 2>/dev/null || true
-    kubectl get endpoints -n "$NS" -l "$SELECTOR" -o wide 2>/dev/null \
-        || kubectl get endpoints seaweedfs -n "$NS" -o wide 2>/dev/null || true
+    # Query Endpoints by service name: the SeaweedFS Service has no labels, so a
+    # label selector matches nothing (and would still exit 0, masking the miss).
+    # Empty ENDPOINTS here means the Service has no ready backends.
+    kubectl get endpoints seaweedfs -n "$NS" -o wide 2>/dev/null || true
 
     echo
     echo "----- full describe (events, resource config) -----"

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -11,7 +11,7 @@
 #
 #   1. SeaweedFS crashed/restarted   -> pod restart count and last terminated
 #                                        state (OOMKilled, etc.)
-#   2. Node CPU/mem contention       -> node allocated requests vs allocatable
+#   2. Node CPU/memory contention    -> node allocated requests vs allocatable
 #                                        and node pressure conditions. The
 #                                        SeaweedFS deployment sets a CPU request
 #                                        (no limit), so scheduling shares only
@@ -26,13 +26,13 @@
 
 set -u
 
-NS="kubeflow"
+NAMESPACE="kubeflow"
 SELECTOR="app=seaweedfs"
 OUTPUT_FILE=""
 
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
-        --ns) NS="${2:?--ns requires a value}"; shift ;;
+        --namespace) NAMESPACE="${2:?--namespace requires a value}"; shift ;;
         --selector) SELECTOR="${2:?--selector requires a value}"; shift ;;
         --output) OUTPUT_FILE="${2:?--output requires a value}"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
@@ -55,9 +55,9 @@ emit() {
     # Newest matching pod: with strategy Recreate there is normally one, but a
     # rollout can briefly leave a Terminating pod alongside the new one, and the
     # new pod is the one whose state matters.
-    POD=$(kubectl get pod -n "$NS" -l "$SELECTOR" --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}' 2>/dev/null || true)
+    POD=$(kubectl get pod -n "$NAMESPACE" -l "$SELECTOR" --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}' 2>/dev/null || true)
     if [[ -z "$POD" ]]; then
-        echo "No SeaweedFS pod (selector '$SELECTOR') found in namespace '$NS'; skipping."
+        echo "No SeaweedFS pod (selector '$SELECTOR') found in namespace '$NAMESPACE'; skipping."
         echo "=============================================================="
         exit 0
     fi
@@ -67,10 +67,10 @@ emit() {
     echo "----- (1) restarts / last terminated state -----"
     # A non-zero restart count or an OOMKilled/Error last state means the dial
     # timeouts are the pod being down, and the CPU request is not the lever.
-    kubectl get pod "$POD" -n "$NS" -o wide 2>/dev/null || true
-    kubectl get pod "$POD" -n "$NS" -o jsonpath='restartCount={.status.containerStatuses[0].restartCount}{"\n"}lastState={.status.containerStatuses[0].lastState}{"\n"}qosClass={.status.qosClass}{"\n"}' 2>/dev/null || true
+    kubectl get pod "$POD" -n "$NAMESPACE" -o wide 2>/dev/null || true
+    kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='restartCount={.status.containerStatuses[0].restartCount}{"\n"}lastState={.status.containerStatuses[0].lastState}{"\n"}qosClass={.status.qosClass}{"\n"}' 2>/dev/null || true
 
-    NODE=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)
+    NODE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)
 
     echo
     echo "----- (2) node contention on $NODE -----"
@@ -93,11 +93,11 @@ emit() {
     # Query Endpoints by service name: the SeaweedFS Service has no labels, so a
     # label selector matches nothing (and would still exit 0, masking the miss).
     # Empty ENDPOINTS here means the Service has no ready backends.
-    kubectl get endpoints seaweedfs -n "$NS" -o wide 2>/dev/null || true
+    kubectl get endpoints seaweedfs -n "$NAMESPACE" -o wide 2>/dev/null || true
 
     echo
     echo "----- full describe (events, resource config) -----"
-    kubectl describe pod "$POD" -n "$NS" 2>/dev/null || true
+    kubectl describe pod "$POD" -n "$NAMESPACE" 2>/dev/null || true
 
     echo "=============================================================="
 } | emit

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# Collects targeted SeaweedFS diagnostics after an E2E test failure.
+#
+# E2E lanes intermittently fail with many
+#   dial tcp <seaweedfs-clusterip>:9000: i/o timeout
+# errors while pipelines upload artifacts and logs. That signature (the TCP
+# connection is never established) has three candidate causes, and this script
+# captures the evidence that distinguishes them without needing metrics-server
+# (which these Kind clusters do not run):
+#
+#   1. SeaweedFS crashed/restarted   -> pod restart count and last terminated
+#                                        state (OOMKilled, etc.)
+#   2. Node CPU/mem contention       -> node allocated requests vs allocatable
+#                                        and node pressure conditions. The
+#                                        SeaweedFS deployment sets a CPU request
+#                                        (no limit), so scheduling shares only
+#                                        matter when the node is contended.
+#   3. Cluster dataplane failure     -> SeaweedFS is Running with no restarts
+#                                        and the node is healthy, yet the
+#                                        ClusterIP path times out (kube-proxy /
+#                                        CNI). Captured by ruling out 1 and 2
+#                                        plus kube-proxy pod state.
+#
+# All commands are best-effort; a missing object never fails the caller.
+
+set -u
+
+NS="kubeflow"
+SELECTOR="app=seaweedfs"
+OUTPUT_FILE=""
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --ns) NS="$2"; shift ;;
+        --selector) SELECTOR="$2"; shift ;;
+        --output) OUTPUT_FILE="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+emit() {
+    if [[ -n "$OUTPUT_FILE" ]]; then
+        mkdir -p "$(dirname "$OUTPUT_FILE")"
+        tee -a "$OUTPUT_FILE"
+    else
+        cat
+    fi
+}
+
+{
+    echo "================ SeaweedFS failure diagnostics ================"
+
+    POD=$(kubectl get pod -n "$NS" -l "$SELECTOR" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+    if [[ -z "$POD" ]]; then
+        echo "No SeaweedFS pod (selector '$SELECTOR') found in namespace '$NS'; skipping."
+        echo "=============================================================="
+        exit 0
+    fi
+    echo "SeaweedFS pod: $POD"
+
+    echo
+    echo "----- (1) restarts / last terminated state -----"
+    # A non-zero restart count or an OOMKilled/Error last state means the dial
+    # timeouts are the pod being down, and the CPU request is not the lever.
+    kubectl get pod "$POD" -n "$NS" -o wide 2>/dev/null || true
+    kubectl get pod "$POD" -n "$NS" -o jsonpath='restartCount={.status.containerStatuses[0].restartCount}{"\n"}lastState={.status.containerStatuses[0].lastState}{"\n"}qosClass={.status.qosClass}{"\n"}' 2>/dev/null || true
+
+    NODE=$(kubectl get pod "$POD" -n "$NS" -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)
+
+    echo
+    echo "----- (2) node contention on $NODE -----"
+    # 'Allocated resources' shows summed CPU requests vs allocatable. If CPU
+    # requests approach allocatable, SeaweedFS competes for shares under load
+    # and a larger request helps; if the node is idle, contention is not the
+    # cause and a request bump will not help.
+    if [[ -n "$NODE" ]]; then
+        kubectl describe node "$NODE" 2>/dev/null \
+            | sed -n '/Conditions:/,/Addresses:/p;/Allocated resources:/,/Events:/p' || true
+    else
+        echo "Could not resolve SeaweedFS node."
+    fi
+
+    echo
+    echo "----- (3) dataplane: kube-proxy / CNI -----"
+    # If SeaweedFS is Running with no restarts and the node is healthy but the
+    # ClusterIP still times out, the failure is in the service dataplane.
+    kubectl get pod -n kube-system -l k8s-app=kube-proxy -o wide 2>/dev/null || true
+    kubectl get endpoints -n "$NS" -l "$SELECTOR" -o wide 2>/dev/null \
+        || kubectl get endpoints seaweedfs -n "$NS" -o wide 2>/dev/null || true
+
+    echo
+    echo "----- full describe (events, resource config) -----"
+    kubectl describe pod "$POD" -n "$NS" 2>/dev/null || true
+
+    echo "=============================================================="
+} | emit

--- a/manifests/kustomize/third-party/seaweedfs/base/seaweedfs/seaweedfs-deployment.yaml
+++ b/manifests/kustomize/third-party/seaweedfs/base/seaweedfs/seaweedfs-deployment.yaml
@@ -142,7 +142,7 @@ spec:
           name: data
         resources:
           requests:
-            cpu: 500m
+            cpu: 128m
             memory: 256Mi
       volumes:
       - name: data

--- a/manifests/kustomize/third-party/seaweedfs/base/seaweedfs/seaweedfs-deployment.yaml
+++ b/manifests/kustomize/third-party/seaweedfs/base/seaweedfs/seaweedfs-deployment.yaml
@@ -142,7 +142,7 @@ spec:
           name: data
         resources:
           requests:
-            cpu: 64m
+            cpu: 500m
             memory: 256Mi
       volumes:
       - name: data


### PR DESCRIPTION
## Summary

- Raise the product SeaweedFS CPU request from `64m` to `128m`.
- Keep memory unchanged at `256Mi`.
- Make the change in the product manifest so CI standalone manifests and product manifests stay aligned.

## Context

This came from investigating an E2E flake seen while reviewing #13588. The failed lane passed on rerun, but the original failure had cluster/storage symptoms rather than a PR-specific code regression:

- The failing `E2EEssential` job ran with 10 Ginkgo nodes.
- It accumulated multiple flakes before `iris_pipeline_compiled.yaml` timed out.
- Failed Argo wait-container logs showed S3 artifact/log upload failures to `seaweedfs.kubeflow.svc:9000`, including TCP I/O timeouts.
- The PR under review changed `RetryRun`, while the stuck path was an ordinary `CreateRun` pipeline execution.

The standalone CI overlays include the product `platform-agnostic` manifests, so product manifest changes also apply to the CI lane that showed the flake.

## Why 128m

CPU requests are not CPU limits: SeaweedFS can burst above the request when node CPU is available. That means the flake data does not prove SeaweedFS is intrinsically CPU-bound, and a large product request such as `500m` would be too strong for the evidence.

This PR uses `128m` as a conservative request bump that gives SeaweedFS a little more reserved share under node contention while keeping product resource expectations close to the existing `64m` request. We should continue to monitor whether storage/DNS timeout flakes recur in CI before making any larger resource change.

## Local pressure test notes

I ran exploratory local Kind tests with the same 10-node `E2EEssential` Ginkgo shape at several SeaweedFS CPU request values:

| SeaweedFS CPU request | Local result |
| --- | --- |
| `200m` | Passed eventually, but had flakes and SeaweedFS S3 timeout output. |
| `250m` | Passed eventually, but had flakes and slow completion. |
| `300m` | One clean run. |
| `350m` | One clean run. |
| `400m` | Passed eventually, but had a flake and SeaweedFS S3 timeout output. |
| `450m` | Passed eventually, but had a flake with SeaweedFS S3 timeout and metadata DNS timeout output. |
| `500m` | Best local result: two runs, with the second run passing 20/20 with 0 flakes and no SeaweedFS timeout matches. |

These local results are useful for stress context, but they are not conclusive root-cause evidence. The explicit DNS timeout output in the local runs suggests broader Kind node/CoreDNS/network pressure may have contributed.

## Verification

- `git diff --check`
- Local 10-node `E2EEssential` exploratory runs during the flake investigation
- PR CI after opening this PR passed the relevant `E2EEssential` lanes with the original `500m` version; this reduced `128m` version still needs normal PR CI signal


## Diagnostics: validate the lever on the next occurrence

The CPU-request bump is a conservative, evidence-thin mitigation (as the table above shows, local stress could not conclusively attribute the flake to SeaweedFS CPU). To stop guessing, this PR also adds `collect-seaweedfs-diagnostics.sh`, invoked from the existing failure log-collection step in `test-and-report`, which captures on every E2E test failure the exact evidence that discriminates the three candidate causes of the `dial tcp <seaweedfs>:9000: i/o timeout` signature:

1. **SeaweedFS crashed/restarted** — pod restart count and last terminated state (OOMKilled, etc.). If non-zero, dial timeouts are the pod being down and CPU request is not the lever.
2. **Node CPU/memory contention** — the node's allocated-requests-vs-allocatable and pressure conditions. The deployment sets a CPU *request* with no limit, so scheduling shares only matter when the node is contended; if the node is idle at failure time, a request bump will not help. This is the evidence that directly validates or refutes this PR's change.
3. **Cluster dataplane failure** — SeaweedFS Running with no restarts and a healthy node, yet the ClusterIP path times out (kube-proxy / CNI). Ruled in by eliminating 1 and 2.

`metrics-server` is not deployed in these Kind clusters, so runtime CPU utilization is unavailable; node allocated-requests stand in for scheduling contention. The script is best-effort (a missing object never fails the job) and its output goes to both the step log and the uploaded pod-log artifact.

So the two halves of this PR are complementary: the request bump is a low-risk attempt at mitigation, and the diagnostics make the *next* dial-timeout failure produce the data to confirm whether it worked or point at the real cause.
