### PR TITLE
ci: retry build dependency downloads

### DIFF
--- a/.github/actions/protobuf/action.yml
+++ b/.github/actions/protobuf/action.yml
@@ -32,7 +32,7 @@ runs:
       shell: bash
       run: |
         PROTOC_ZIP=protoc-${{inputs.protoc_version}}-linux-x86_64.zip
-        curl -sSL --retry 3 --retry-delay 10 --retry-all-errors -O https://github.com/protocolbuffers/protobuf/releases/download/v${{inputs.protoc_version}}/$PROTOC_ZIP
+        curl -sSL --fail --retry 3 --retry-delay 10 --retry-all-errors -O https://github.com/protocolbuffers/protobuf/releases/download/v${{inputs.protoc_version}}/$PROTOC_ZIP
         sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
         sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
         rm $PROTOC_ZIP

--- a/.github/actions/protobuf/action.yml
+++ b/.github/actions/protobuf/action.yml
@@ -32,7 +32,7 @@ runs:
       shell: bash
       run: |
         PROTOC_ZIP=protoc-${{inputs.protoc_version}}-linux-x86_64.zip
-        curl -sSL -O https://github.com/protocolbuffers/protobuf/releases/download/v${{inputs.protoc_version}}/$PROTOC_ZIP
+        curl -sSL --retry 3 --retry-delay 10 --retry-all-errors -O https://github.com/protocolbuffers/protobuf/releases/download/v${{inputs.protoc_version}}/$PROTOC_ZIP
         sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
         sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
         rm $PROTOC_ZIP

--- a/api/Makefile
+++ b/api/Makefile
@@ -105,10 +105,16 @@ fetch-protos: fetch-googleapis fetch-protobuf
 fetch-googleapis:
 	@echo "Downloading google/rpc/status.proto from googleapis@$(GOOGLEAPIS_COMMIT)..."
 	mkdir -p $(PROTO_DST_DIR)/rpc
-	wget -qO $(PROTO_DST_DIR)/rpc/status.proto https://raw.githubusercontent.com/googleapis/googleapis/$(GOOGLEAPIS_COMMIT)/google/rpc/status.proto
+	wget --tries=3 --waitretry=10 --retry-on-http-error=429,500,502,503 -qO $(PROTO_DST_DIR)/rpc/status.proto https://raw.githubusercontent.com/googleapis/googleapis/$(GOOGLEAPIS_COMMIT)/google/rpc/status.proto
 
 fetch-protobuf: clean-protobuf-tmp
-	@git clone --depth 1 --branch $(PROTOBUF_TAG) https://github.com/protocolbuffers/protobuf.git $(TMP_PROTOBUF_DIR)
+	@for attempt in 1 2 3; do \
+		rm -rf $(TMP_PROTOBUF_DIR); \
+		git clone --depth 1 --branch $(PROTOBUF_TAG) https://github.com/protocolbuffers/protobuf.git $(TMP_PROTOBUF_DIR) && break; \
+		echo "git clone of protobuf failed (attempt $$attempt); retrying in 10s..."; \
+		sleep 10; \
+	done
+	@test -d $(TMP_PROTOBUF_DIR)/src/google/protobuf
 	@mkdir -p $(PROTO_DST_DIR)/protobuf
 	@cp $(TMP_PROTOBUF_DIR)/src/google/protobuf/*.proto $(PROTO_DST_DIR)/protobuf/
 

--- a/backend/api/Makefile
+++ b/backend/api/Makefile
@@ -51,7 +51,7 @@ fetch-dependencies: v2beta1/google/rpc/status.proto
 
 v2beta1/google/rpc/status.proto:
 	mkdir -p v2beta1/google/rpc
-	wget -O v2beta1/google/rpc/status.proto https://raw.githubusercontent.com/googleapis/googleapis/047d3a8ac7f75383855df0166144f891d7af08d9/google/rpc/status.proto
+	wget --tries=3 --waitretry=10 --retry-on-http-error=429,500,502,503 -O v2beta1/google/rpc/status.proto https://raw.githubusercontent.com/googleapis/googleapis/047d3a8ac7f75383855df0166144f891d7af08d9/google/rpc/status.proto
 
 # Generate clients starting by building api-generator image locally.
 # Note, this should only be used for local development purposes. Once any change is made to the Dockerfile,


### PR DESCRIPTION
## Summary

Both `KFP Kubernetes Native Migration Tests` lanes on #13690 failed **at the same second** in `Install protobuf dependencies & kfp-pipeline-spec`: the unretried `wget` of `google/rpc/status.proto` from `raw.githubusercontent.com` in `api/Makefile` returned a server error (wget exit 8, [run 28974863350](https://github.com/kubeflow/pipelines/actions/runs/28974863350)). Correlated failure across parallel lanes is the signature of a single upstream blip hitting a single-shot fetch — the same class as the proxy.golang.org incident addressed by #13656.

An audit for the pattern (bare `wget`/`curl`/`git clone` of build dependencies on CI critical paths, no retry) found exactly four sites, all in the protobuf tool chain used by the SDK unit tests, kfp-kubernetes tests, migration tests, sdk-upgrade, and validate-generated-files workflows:

| Site | Fetch | Fix |
|---|---|---|
| `api/Makefile` `fetch-googleapis` | `status.proto` from raw.githubusercontent.com (the #13690 failure) | `wget --tries=3 --waitretry=10 --retry-on-http-error=429,500,502,503` |
| `api/Makefile` `fetch-protobuf` | `git clone` of protocolbuffers/protobuf | 3-attempt loop, clean re-clone per attempt, existence check after |
| `backend/api/Makefile` | same `status.proto` wget | same wget flags |
| `.github/actions/protobuf/action.yml` | protoc release zip | `curl --fail --retry 3 --retry-delay 10 --retry-all-errors` |

Deliberately unchanged: health-check `curl`s that already sit in polling loops (`configure-mlflow.sh`, `test-and-report`) and the release lookup in `upgrade-test.yml`, which already retries in a `for attempt` loop.

## Follow-up

Authentication for the `raw.githubusercontent.com` proto fetches (to raise the anonymous rate-limit ceiling that causes the 429s) is added in a separate PR on top of this retry change.

## Verification

- `make -C api fetch-googleapis` runs successfully with the new wget flags (fetches the pinned `status.proto`)
- `make -n -C api fetch-protobuf` shows correct shell expansion of the retry loop
- YAML parse of the modified composite action
- This PR's own checks exercise the `protobuf` action end-to-end
