### PR TITLE
ci: verify MLflow is reachable in-cluster before running E2E tests

### DIFF
--- a/.github/resources/scripts/configure-mlflow.sh
+++ b/.github/resources/scripts/configure-mlflow.sh
@@ -239,6 +239,13 @@ PROBE
     kubectl get endpoints -n "$MLFLOW_NAMESPACE" || true
     kubectl describe svc "$MLFLOW_SVC" -n "$MLFLOW_NAMESPACE" || true
     kubectl logs -n "$MLFLOW_NAMESPACE" -l app=mlflow --tail=50 --all-containers=true --prefix=true || true
+    # The MLflow operator ships a NetworkPolicy selecting the mlflow pod, and
+    # newer Kind node images enforce NetworkPolicies (older kindnet ignored
+    # them). Capture the policies and the CNI/enforcement agent logs so a
+    # dropped-by-policy failure is distinguishable from an unresponsive server.
+    kubectl get networkpolicy -A -o yaml || true
+    kubectl logs -n kube-system -l app=kindnet --tail=100 --prefix=true || true
+    kubectl logs -n kube-system -l app=kube-network-policies --tail=100 --prefix=true || true
     exit 1
   fi
 }

--- a/.github/resources/scripts/configure-mlflow.sh
+++ b/.github/resources/scripts/configure-mlflow.sh
@@ -198,6 +198,53 @@ if [ "$STATUS" != "200" ]; then
   exit 1
 fi
 
+# The port-forward health check above bypasses cluster networking (it goes
+# runner -> kubelet -> pod), but the API server reaches MLflow through the
+# ClusterIP service DNS path. That path has failed while the port-forward
+# path was healthy (run 28974862974: every API-server MLflow call timed out
+# although all pods were Ready and the localhost health check passed), so
+# probe the exact endpoint the API server is configured with from inside
+# the cluster. Any HTTP status proves the endpoint is serving; only a
+# connection failure or timeout fails the probe. python:3.11 is one of the
+# preloaded runtime base images, so this does not pull from a registry.
+verify_mlflow_in_cluster_reachability() {
+  local probe_script
+  probe_script=$(cat <<'PROBE'
+import ssl, sys, time, urllib.error, urllib.request
+
+url = sys.argv[1] + "/health"
+context = ssl.create_default_context()
+context.check_hostname = False
+context.verify_mode = ssl.CERT_NONE
+for attempt in range(1, 13):
+    try:
+        with urllib.request.urlopen(url, timeout=10, context=context) as response:
+            print(f"in-cluster MLflow endpoint responded: HTTP {response.status}")
+            sys.exit(0)
+    except urllib.error.HTTPError as http_error:
+        print(f"in-cluster MLflow endpoint responded: HTTP {http_error.code}")
+        sys.exit(0)
+    except Exception as error:
+        print(f"attempt {attempt}/12: {error}", flush=True)
+        time.sleep(10)
+print(f"ERROR: no HTTP response from {url} inside the cluster")
+sys.exit(1)
+PROBE
+)
+
+  echo "Verifying in-cluster reachability of ${MLFLOW_ENDPOINT} (the endpoint the API server uses)..."
+  if ! kubectl run mlflow-in-cluster-probe -n "$KFP_NAMESPACE" --rm -i --restart=Never       --image=python:3.11 --command -- python3 -c "$probe_script" "$MLFLOW_ENDPOINT"; then
+    echo "ERROR: MLflow endpoint ${MLFLOW_ENDPOINT} is not reachable from inside the cluster;"
+    echo "API-server MLflow calls would time out even though pods are Ready."
+    kubectl get endpoints -n "$MLFLOW_NAMESPACE" || true
+    kubectl describe svc "$MLFLOW_SVC" -n "$MLFLOW_NAMESPACE" || true
+    kubectl logs -n "$MLFLOW_NAMESPACE" -l app=mlflow --tail=50 --all-containers=true --prefix=true || true
+    exit 1
+  fi
+}
+
+verify_mlflow_in_cluster_reachability
+
 verify_mlflow_api_auth() {
   local api_url="${MLFLOW_SCHEME}://localhost:8080${MLFLOW_STATIC_PREFIX}/api/2.0/mlflow/experiments/search"
   local api_status

--- a/.github/resources/scripts/configure-mlflow.sh
+++ b/.github/resources/scripts/configure-mlflow.sh
@@ -236,7 +236,7 @@ PROBE
   if ! kubectl run mlflow-in-cluster-probe -n "$KFP_NAMESPACE" --rm -i --restart=Never       --image=python:3.11 --command -- python3 -c "$probe_script" "$MLFLOW_ENDPOINT"; then
     echo "ERROR: MLflow endpoint ${MLFLOW_ENDPOINT} is not reachable from inside the cluster;"
     echo "API-server MLflow calls would time out even though pods are Ready."
-    kubectl get endpoints -n "$MLFLOW_NAMESPACE" || true
+    kubectl get endpoints "$MLFLOW_SVC" -n "$MLFLOW_NAMESPACE" -o wide || true
     kubectl describe svc "$MLFLOW_SVC" -n "$MLFLOW_NAMESPACE" || true
     kubectl logs -n "$MLFLOW_NAMESPACE" -l app=mlflow --tail=50 --all-containers=true --prefix=true || true
     # The MLflow operator ships a NetworkPolicy selecting the mlflow pod, and


### PR DESCRIPTION
## Summary

Diagnosis of the failing MLflow lane on #13690 ([run 28974862974](https://github.com/kubeflow/pipelines/actions/runs/28974862974), K8s v1.36.1, kubernetes auth): all 8 MLflow E2E tests failed with missing `root_run_id`/`experiment_id` in `plugins_output`, because **every** API-server call to `https://mlflow.opendatahub.svc.cluster.local:8443` timed out awaiting headers from the first test onward.

Yet every readiness gate had passed:
- `Wait for MLflow stack readiness` → `kubectl wait` on pods (pod-level only)
- `configure-mlflow.sh`'s health loop → requires HTTP 200, but through a **port-forward** (`localhost:8080`), which routes runner → kubelet → pod and does not traverse the ClusterIP service path the API server uses

Nothing ever verifies the in-cluster service DNS endpoint that the API server is configured with — so a lane where that endpoint cannot serve produces eight misleading test failures instead of one clear configure-time error.

## Change

After the existing checks, `configure-mlflow.sh` probes the exact configured endpoint (`$MLFLOW_ENDPOINT/health`) from a pod inside the cluster (in the KFP namespace, where the API server runs):

- Any HTTP status counts as "serving" — auth semantics are verified separately; the failure class here is timeouts, not rejections
- 12 attempts over ~2 minutes; on exhaustion the lane fails at configure time with diagnostics: the MLflow service's endpoints, service description, MLflow pod logs, **all NetworkPolicies, and kindnet / kube-network-policies agent logs**
- The probe pod uses `python:3.11`, one of the preloaded runtime base images, so no registry pull is added

## Scope and root-cause status (see comment thread for the full analysis)

Root cause of the intermittent whole-lane failures is **not yet established**; recent history shows v1.36.1 MLflow lanes passing 35 of 39 runs, so this is intermittent, and the failing run's evidence cannot distinguish "in-cluster path dead while port-forward healthy" from "MLflow stopped serving on all paths after the pre-test health check" (the checks were minutes apart). Two candidate mechanisms are documented in the comments: NetworkPolicy enforcement-agent instability (the operator ships a policy selecting the mlflow pod — the diagnostics here capture the evidence) and a single-worker wedge (`workers: 1` chart default — one stuck request stops the server on every path while the pod stays Ready).

This probe is the discriminator between those classes rather than a fix for either: a lane that fails the probe never had a working endpoint (diagnostics attached); a lane that passes the probe but dies during tests points at the progressive-wedge class. It also closes the real gap that the failing run demonstrated — no gate exercised the endpoint the API server actually uses.

## Verification

- `bash -n` on the modified script; embedded probe validated with `py_compile`
- This PR's own MLflow E2E lanes execute the probe in every auth/storage variant
