### PR TITLE
ci: give legacy v2 integration tests an intentional time budget

### DIFF
--- a/.github/workflows/legacy-v2-api-integration-tests.yml
+++ b/.github/workflows/legacy-v2-api-integration-tests.yml
@@ -97,11 +97,42 @@ jobs:
         # by cache tests that execute sequential pipeline runs. Go's default
         # 10-minute test binary timeout leaves under a minute of headroom, so
         # ordinary lane slowness kills the whole binary mid-run with a panic.
-        run: go test -v -timeout 20m ./... -args -runIntegrationTests=true -namespace=kubeflow -tlsEnabled=${{ matrix.pod_to_pod_tls_enabled }} -caCertPath=${{ env.CA_CERT_PATH }} -repoName=${{ github.repository }} -branchName=${{ github.ref_name }}
+        # Output is teed to a file so the step below can turn a budget
+        # overrun into an explicit annotation instead of a buried panic.
+        shell: bash
+        run: go test -v -timeout 20m ./... -args -runIntegrationTests=true -namespace=kubeflow -tlsEnabled=${{ matrix.pod_to_pod_tls_enabled }} -caCertPath=${{ env.CA_CERT_PATH }} -repoName=${{ github.repository }} -branchName=${{ github.ref_name }} 2>&1 | tee "$RUNNER_TEMP/go-test-output.log"
         env:
           PULL_NUMBER: ${{ github.event.pull_request.number }}
           PIPELINE_STORE: ${{ matrix.pipeline_store }}
         continue-on-error: true
+
+      - name: Explain suite time budget overrun
+        if: ${{ steps.tests.outcome != 'success' }}
+        shell: bash
+        run: |
+          LOG="$RUNNER_TEMP/go-test-output.log"
+          if [ ! -f "$LOG" ] || ! grep -q 'panic: test timed out after' "$LOG"; then
+            echo "Tests failed for a reason other than the suite time budget; see the test step output."
+            exit 0
+          fi
+          BUDGET=$(grep -m1 -oE 'test timed out after [0-9a-z]+' "$LOG" | awk '{print $NF}')
+          {
+            echo "## :alarm_clock: Test suite exceeded its ${BUDGET} time budget"
+            echo
+            echo "The whole \`go test\` binary was killed by its \`-timeout\`, discarding all results."
+            echo "This is almost always **cumulative lane slowness**, not a hung test: the suite's"
+            echo "normal runtime is ~9.5 minutes, and the interrupted test below usually shows a"
+            echo "near-zero elapsed time, meaning the budget was consumed by everything before it."
+            echo
+            echo '```'
+            grep -A 8 'panic: test timed out after' "$LOG" | head -10
+            echo '```'
+            echo
+            echo "**If this recurs on otherwise healthy PRs:** the suite has outgrown its budget —"
+            echo "raise \`-timeout\` in this workflow or speed up the suite (see the TestCache notes"
+            echo "in the PR that introduced this message) rather than rerunning repeatedly."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error title=Legacy V2 suite exceeded its ${BUDGET} test budget::The go test binary was killed by -timeout (${BUDGET}), discarding all results. This is cumulative lane slowness, not a hung test - the interrupted test typically shows ~0s elapsed. Normal suite runtime is ~9.5m. See the job summary for details."
 
       - name: Collect failed logs
         if: ${{ steps.deploy.outcome != 'success' || steps.forward-mlmd-port.outcome != 'success' || steps.tests.outcome != 'success' }}

--- a/.github/workflows/legacy-v2-api-integration-tests.yml
+++ b/.github/workflows/legacy-v2-api-integration-tests.yml
@@ -30,6 +30,9 @@ jobs:
 
   api-integration-tests-v2:
     runs-on: ubuntu-latest
+    # Real ceiling for a hung suite. Without this the job inherits GitHub's
+    # 6-hour default, and the go test -timeout below is the only hang-stop.
+    timeout-minutes: 40
     needs: build
     strategy:
       matrix:
@@ -90,7 +93,11 @@ jobs:
         id: tests
         if: ${{ steps.forward-mlmd-port.outcome == 'success' }}
         working-directory: ./backend/test/v2/integration
-        run: go test -v ./... -args -runIntegrationTests=true -namespace=kubeflow -tlsEnabled=${{ matrix.pod_to_pod_tls_enabled }} -caCertPath=${{ env.CA_CERT_PATH }} -repoName=${{ github.repository }} -branchName=${{ github.ref_name }}
+        # -timeout 20m: the suite's normal runtime is ~9.5 minutes, dominated
+        # by cache tests that execute sequential pipeline runs. Go's default
+        # 10-minute test binary timeout leaves under a minute of headroom, so
+        # ordinary lane slowness kills the whole binary mid-run with a panic.
+        run: go test -v -timeout 20m ./... -args -runIntegrationTests=true -namespace=kubeflow -tlsEnabled=${{ matrix.pod_to_pod_tls_enabled }} -caCertPath=${{ env.CA_CERT_PATH }} -repoName=${{ github.repository }} -branchName=${{ github.ref_name }}
         env:
           PULL_NUMBER: ${{ github.event.pull_request.number }}
           PIPELINE_STORE: ${{ matrix.pipeline_store }}


### PR DESCRIPTION
## The failure

Ten lane failures across the last two days of PR CI share one signature in the `KFP API Integration V2 (Legacy)` workflow:

```
panic: test timed out after 10m0s
    running tests:
        TestPipelineVersionAPI (0s)
```

The `go test` invocation passes no `-timeout`, so the binary runs under Go's default **10-minute** test timeout. When it fires, Go does not fail the current test — it kills the entire binary with a panic and a goroutine dump, discarding every already-passed result and every test not yet run.

## Why the suite trips it

Measured on green runs, the test step takes **10.5–12.5 minutes**, of which ~1.5 min is compilation (the timeout clock starts when the compiled binary starts) — so the binary's normal runtime is **~9–9.5 minutes against a 10-minute fuse: under a minute of headroom**.

The runtime is legitimate, not waste. `TestCache` alone is ~7 of those minutes (74% of the suite), and its three subtests each execute **sequential full pipeline runs by definition** — a cache test must complete a run, then run the same pipeline again to observe the cache hit:

| Test | Time |
|---|---|
| `TestCache/TestCacheSingleRunWithPVC_SameName_Caches` | 191s |
| `TestCache/TestCacheRecurringRun` | 151s |
| `TestCache/TestCacheSingleRun` | 81s |

With <5% headroom, ordinary lane slowness — a busy runner, slower cluster operations — tips the cumulative runtime past 10:00. The panic evidence confirms cumulative slowness rather than a hang: the interrupted test shows **`(0s)`** — it had just started when the alarm fired; the budget was consumed a few seconds at a time by everything before it. This also explains why the failure looks random: which test gets caught depends only on where the clock runs out. Historical note: this suite ran at the same ~11-minute step time on K8s v1.35.0 before the recent version bump, so this is a chronic budget problem, not a regression.

## The changes

1. **`-timeout 20m`** on the `go test` invocation — roughly 2× normal runtime. This matches the headroom ratio this suite's own past flake fixes settled on (#11916 and #12916 both resolved cache-test flakiness by raising wait ceilings to ~2× nominal). A genuinely hung test still dies, with a budget that matches what the suite actually is.
2. **`timeout-minutes: 40`** on the job — it previously inherited GitHub's **6-hour** default, meaning the go-test timeout was the only effective hang-stop. A green job takes ~20–23 minutes end to end; 40 gives the enlarged test budget plus setup and log collection real room while capping a true hang at a sane cost.

## Making future overruns self-explanatory

When a `-timeout` still fires, the raw signal is a panic and goroutine dump buried mid-log, which reads like a crash. The test step now tees its output, and a follow-up step (which runs only when the failure is a budget overrun — ordinary test failures are untouched) converts it into:

- a **GitHub error annotation** on the job and PR checks UI stating the budget that was exceeded and that a near-zero elapsed time on the interrupted test means cumulative slowness, not a hang
- a **job summary** with the interrupted-test block from the panic and explicit guidance: if this recurs on otherwise healthy PRs, the suite has outgrown its budget — raise `-timeout` or speed up the suite instead of rerunning repeatedly

Both paths are functionally tested against a captured panic block (budget string is extracted dynamically, so the message stays correct if the budget changes).

## What this deliberately does not do

Alternatives considered and set aside, with reasons:

- **Shrinking `TestCacheRecurringRun`'s 60-second schedule interval**: the interval is load-bearing, not arbitrary. The test's wait predicate requires *every* run in the namespace to be `SUCCEEDED` before asserting; the hello-world run takes ~35s, so any interval below run duration (10s, even 30s) spawns overlapping runs faster than they finish and the predicate can never hold — a deterministic failure, not a speedup.
- **Parallelizing the three cache subtests** (~4 min potential): blocked by the same predicate — `ListAll` sees sibling tests' runs and indexes `allRuns[1]` from the shared namespace list. Parallelizing safely requires scoping the run listing to each test's own experiment first. Worth doing as a follow-up test refactor; not a workflow budget fix.

## Verification

- YAML parse of the modified workflow
- This PR's own `KFP API Integration V2 (Legacy)` lanes run the suite under the new budget
