### PR TITLE
test: authenticate and retry raw.githubusercontent.com URL verification

### DIFF
--- a/.github/workflows/integration-tests-v1.yml
+++ b/.github/workflows/integration-tests-v1.yml
@@ -85,6 +85,9 @@ jobs:
         run: go test -v ./... -args -runIntegrationTests=true -namespace=kubeflow -repoName=${{ github.repository }} -branchName=${{ github.ref_name }}
         env:
           PULL_NUMBER: ${{ github.event.pull_request.number }}
+          # Authenticates the raw.githubusercontent.com HEAD in
+          # GetRepoBranchURLRAW to avoid anonymous per-IP 429 rate limits.
+          GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true
 
       - name: Collect failed logs

--- a/.github/workflows/legacy-v2-api-integration-tests.yml
+++ b/.github/workflows/legacy-v2-api-integration-tests.yml
@@ -104,6 +104,9 @@ jobs:
         env:
           PULL_NUMBER: ${{ github.event.pull_request.number }}
           PIPELINE_STORE: ${{ matrix.pipeline_store }}
+          # Authenticates the raw.githubusercontent.com HEAD in
+          # GetRepoBranchURLRAW to avoid anonymous per-IP 429 rate limits.
+          GITHUB_TOKEN: ${{ github.token }}
         continue-on-error: true
 
       - name: Explain suite time budget overrun

--- a/backend/test/testutil/github_url_verify_test.go
+++ b/backend/test/testutil/github_url_verify_test.go
@@ -27,8 +27,8 @@ import (
 func TestHeadWithGitHubAuthAndRetry_RetriesThenSucceeds(t *testing.T) {
 	var calls int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// First two attempts are rate limited, the third succeeds.
-		if atomic.AddInt32(&calls, 1) < 3 {
+		// First attempt is rate limited, the second succeeds.
+		if atomic.AddInt32(&calls, 1) < 2 {
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
@@ -41,14 +41,14 @@ func TestHeadWithGitHubAuthAndRetry_RetriesThenSucceeds(t *testing.T) {
 	require.NotNil(t, resp)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, int32(3), atomic.LoadInt32(&calls), "should have retried the 429s")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "should have retried the 429")
 }
 
 func TestHeadWithGitHubAuthAndRetry_SetsBearerTokenWhenPresent(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "test-token-123")
-	var gotAuth string
+	var gotAuth atomic.Value
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotAuth = r.Header.Get("Authorization")
+		gotAuth.Store(r.Header.Get("Authorization"))
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -56,15 +56,15 @@ func TestHeadWithGitHubAuthAndRetry_SetsBearerTokenWhenPresent(t *testing.T) {
 	resp, err := headWithGitHubAuthAndRetry(server.URL)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.Equal(t, "Bearer test-token-123", gotAuth)
+	assert.Equal(t, "Bearer test-token-123", gotAuth.Load())
 }
 
 func TestHeadWithGitHubAuthAndRetry_NoTokenNoHeader(t *testing.T) {
 	t.Setenv("GITHUB_TOKEN", "")
-	sawAuth := false
+	var sawAuth atomic.Bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "" {
-			sawAuth = true
+			sawAuth.Store(true)
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -73,7 +73,7 @@ func TestHeadWithGitHubAuthAndRetry_NoTokenNoHeader(t *testing.T) {
 	resp, err := headWithGitHubAuthAndRetry(server.URL)
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	assert.False(t, sawAuth, "no Authorization header should be sent without GITHUB_TOKEN")
+	assert.False(t, sawAuth.Load(), "no Authorization header should be sent without GITHUB_TOKEN")
 }
 
 func TestHeadWithGitHubAuthAndRetry_DoesNotRetryNotFound(t *testing.T) {

--- a/backend/test/testutil/github_url_verify_test.go
+++ b/backend/test/testutil/github_url_verify_test.go
@@ -19,12 +19,17 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestHeadWithGitHubAuthAndRetry_RetriesThenSucceeds(t *testing.T) {
+	restore := headRetryBackoffUnit
+	headRetryBackoffUnit = time.Millisecond
+	defer func() { headRetryBackoffUnit = restore }()
+
 	var calls int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// First attempt is rate limited, the second succeeds.
@@ -89,4 +94,45 @@ func TestHeadWithGitHubAuthAndRetry_DoesNotRetryNotFound(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a genuine 404 must not be retried")
+}
+
+func TestHeadWithGitHubAuthAndRetry_Retries5xx(t *testing.T) {
+	restore := headRetryBackoffUnit
+	headRetryBackoffUnit = time.Millisecond
+	defer func() { headRetryBackoffUnit = restore }()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) < 2 {
+			w.WriteHeader(http.StatusBadGateway) // transient 5xx
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	resp, err := headWithGitHubAuthAndRetry(server.URL)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "should have retried the 502")
+}
+
+func TestHeadWithGitHubAuthAndRetry_ExhaustsRetries(t *testing.T) {
+	restore := headRetryBackoffUnit
+	headRetryBackoffUnit = time.Millisecond
+	defer func() { headRetryBackoffUnit = restore }()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusTooManyRequests) // rate limited on every attempt
+	}))
+	defer server.Close()
+
+	resp, err := headWithGitHubAuthAndRetry(server.URL)
+	require.Error(t, err, "exhausted retries should return the last error")
+	assert.Nil(t, resp)
+	assert.Equal(t, int32(headRetryMaxAttempts), atomic.LoadInt32(&calls), "should have attempted headRetryMaxAttempts times")
 }

--- a/backend/test/testutil/github_url_verify_test.go
+++ b/backend/test/testutil/github_url_verify_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadWithGitHubAuthAndRetry_RetriesThenSucceeds(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// First two attempts are rate limited, the third succeeds.
+		if atomic.AddInt32(&calls, 1) < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	resp, err := headWithGitHubAuthAndRetry(server.URL)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls), "should have retried the 429s")
+}
+
+func TestHeadWithGitHubAuthAndRetry_SetsBearerTokenWhenPresent(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "test-token-123")
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	resp, err := headWithGitHubAuthAndRetry(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, "Bearer test-token-123", gotAuth)
+}
+
+func TestHeadWithGitHubAuthAndRetry_NoTokenNoHeader(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	sawAuth := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			sawAuth = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	resp, err := headWithGitHubAuthAndRetry(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.False(t, sawAuth, "no Authorization header should be sent without GITHUB_TOKEN")
+}
+
+func TestHeadWithGitHubAuthAndRetry_DoesNotRetryNotFound(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	resp, err := headWithGitHubAuthAndRetry(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a genuine 404 must not be retried")
+}

--- a/backend/test/testutil/test_utils.go
+++ b/backend/test/testutil/test_utils.go
@@ -273,7 +273,8 @@ func headWithGitHubAuthAndRetry(url string) (*http.Response, error) {
 		}
 
 		resp, err := http.DefaultClient.Do(request)
-		if err != nil {
+		switch {
+		case err != nil:
 			lastErr = err
 			// Do can return a non-nil response alongside an error (e.g. a
 			// redirect-policy error); close it so connections are not leaked
@@ -283,12 +284,12 @@ func headWithGitHubAuthAndRetry(url string) (*http.Response, error) {
 					logger.Log("Warning: failed to close response body: %v", closeErr)
 				}
 			}
-		} else if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
 			lastErr = fmt.Errorf("transient status %d from %s", resp.StatusCode, url)
 			if closeErr := resp.Body.Close(); closeErr != nil {
 				logger.Log("Warning: failed to close response body: %v", closeErr)
 			}
-		} else {
+		default:
 			return resp, nil
 		}
 

--- a/backend/test/testutil/test_utils.go
+++ b/backend/test/testutil/test_utils.go
@@ -258,10 +258,16 @@ func GetRepoBranchURLRAW(repoName, branch, path string) (string, error) {
 // from GITHUB_TOKEN when set, and retries rate-limit (429) and server (5xx)
 // responses with a bounded backoff. A definitive response (2xx/4xx other than
 // 429) is returned immediately so a genuinely missing file is not retried.
+// headRetryMaxAttempts bounds the URL-verification retries; headRetryBackoffUnit
+// is the base backoff unit (a var so tests can shorten it).
+const headRetryMaxAttempts = 4
+
+var headRetryBackoffUnit = time.Second
+
 func headWithGitHubAuthAndRetry(url string) (*http.Response, error) {
 	token := os.Getenv("GITHUB_TOKEN")
 
-	const maxAttempts = 4
+	maxAttempts := headRetryMaxAttempts
 	var lastErr error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		request, err := http.NewRequest(http.MethodHead, url, nil)
@@ -294,7 +300,7 @@ func headWithGitHubAuthAndRetry(url string) (*http.Response, error) {
 		}
 
 		if attempt < maxAttempts {
-			backoff := time.Duration(1<<attempt) * time.Second
+			backoff := time.Duration(1<<attempt) * headRetryBackoffUnit
 			logger.Log("URL HEAD %s failed (attempt %d/%d): %v; retrying in %s",
 				url, attempt, maxAttempts, lastErr, backoff)
 			time.Sleep(backoff)

--- a/backend/test/testutil/test_utils.go
+++ b/backend/test/testutil/test_utils.go
@@ -225,8 +225,12 @@ func GetRepoBranchURLRAW(repoName, branch, path string) (string, error) {
 		url = fmt.Sprintf("https://raw.githubusercontent.com/%s/pull/%s/head/%s", repoName, pullNumber, path)
 	}
 
-	// Verify the URL exists
-	resp, err := http.Head(url)
+	// Verify the URL exists. Anonymous requests to raw.githubusercontent.com
+	// are rate limited per source IP, and CI runners share heavily-used egress
+	// IPs, so this HEAD intermittently returns 429. Authenticate with
+	// GITHUB_TOKEN when available (raising the limit to the per-token bucket)
+	// and retry transient rate-limit / server errors.
+	resp, err := headWithGitHubAuthAndRetry(url)
 	if err != nil {
 		return url, fmt.Errorf("failed to verify URL exists: %s\n"+
 			"Error: %v\n"+
@@ -248,6 +252,46 @@ func GetRepoBranchURLRAW(repoName, branch, path string) (string, error) {
 	}
 
 	return url, nil
+}
+
+// headWithGitHubAuthAndRetry issues a HEAD request, attaching a bearer token
+// from GITHUB_TOKEN when set, and retries rate-limit (429) and server (5xx)
+// responses with a bounded backoff. A definitive response (2xx/4xx other than
+// 429) is returned immediately so a genuinely missing file is not retried.
+func headWithGitHubAuthAndRetry(url string) (*http.Response, error) {
+	token := os.Getenv("GITHUB_TOKEN")
+
+	const maxAttempts = 4
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		request, err := http.NewRequest(http.MethodHead, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		if token != "" {
+			request.Header.Set("Authorization", "Bearer "+token)
+		}
+
+		resp, err := http.DefaultClient.Do(request)
+		if err != nil {
+			lastErr = err
+		} else if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			lastErr = fmt.Errorf("transient status %d from %s", resp.StatusCode, url)
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				logger.Log("Warning: failed to close response body: %v", closeErr)
+			}
+		} else {
+			return resp, nil
+		}
+
+		if attempt < maxAttempts {
+			backoff := time.Duration(1<<attempt) * time.Second
+			logger.Log("URL HEAD %s failed (attempt %d/%d): %v; retrying in %s",
+				url, attempt, maxAttempts, lastErr, backoff)
+			time.Sleep(backoff)
+		}
+	}
+	return nil, lastErr
 }
 
 // getBranchOrPR returns a human-readable string indicating whether we're using a branch or PR

--- a/backend/test/testutil/test_utils.go
+++ b/backend/test/testutil/test_utils.go
@@ -275,6 +275,14 @@ func headWithGitHubAuthAndRetry(url string) (*http.Response, error) {
 		resp, err := http.DefaultClient.Do(request)
 		if err != nil {
 			lastErr = err
+			// Do can return a non-nil response alongside an error (e.g. a
+			// redirect-policy error); close it so connections are not leaked
+			// across retries.
+			if resp != nil {
+				if closeErr := resp.Body.Close(); closeErr != nil {
+					logger.Log("Warning: failed to close response body: %v", closeErr)
+				}
+			}
 		} else if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
 			lastErr = fmt.Errorf("transient status %d from %s", resp.StatusCode, url)
 			if closeErr := resp.Body.Close(); closeErr != nil {


### PR DESCRIPTION
## Summary

Integration tests verify pipeline resource URLs by issuing an **anonymous** `HEAD` to `raw.githubusercontent.com` (`GetRepoBranchURLRAW`, `backend/test/testutil/test_utils.go`). Anonymous requests to that host are rate limited per source IP, and CI runners share heavily-used egress IPs, so the HEAD intermittently returns **HTTP 429** and fails the suite. Observed on PRs #13692, #13674, and #13693 as:

```
URL verification failed with status 429:
https://raw.githubusercontent.com/kubeflow/pipelines/pull/<N>/head/backend/test/v2/resources/sequential-v2.yaml
```

Same upstream host as the proto fetches hardened in #13691, but a different, previously-uncovered code path — and `GetRepoBranchURLRAW` is the single chokepoint every URL-upload integration test funnels through (`backend/test/integration`, `backend/test/v2/integration`).

## Change

- `GetRepoBranchURLRAW` now attaches `Authorization: Bearer $GITHUB_TOKEN` when the env var is set — moving from the anonymous per-IP bucket to the far larger per-token bucket — and retries 429/5xx with bounded backoff. A definitive 2xx/4xx other than 429 returns immediately, so a genuinely missing file is **not** retried.
- `GITHUB_TOKEN: ${{ github.token }}` is plumbed into the two workflow test steps whose suites call the function (`integration-tests-v1`, `legacy-v2-api-integration-tests`).
- Local runs without a token stay anonymous and behave exactly as before.

## Scope of the broader audit

I swept CI for other anonymous fetches of rate-limited GitHub hosts. Findings for follow-up (not in this PR, to keep it focused on the confirmed failure):

- **Build-side proto fetches** (`api/Makefile`, `backend/api/Makefile`, `third_party/ml-metadata/Makefile`, `frontend/scripts/pipelinespec.sh`) pull `status.proto`/MLMD protos from `raw.githubusercontent.com` anonymously. #13691 added retry to two of these but none are authenticated.
- **The apiserver's own fetch** of a pipeline URL on import is anonymous by design (a production server has no user token); in CI it shares the runner egress IP. Reducing test reliance on `raw.githubusercontent.com` from the cluster is the deeper mitigation.
- Already correct: `upgrade-test.yml`'s `api.github.com` call authenticates with `github.token` and retries — the model this PR follows.

## Verification

- `go build` / `go vet` / `gofmt` clean
- New unit tests cover: bearer token attached when `GITHUB_TOKEN` set, no header when unset, 429 retried-then-succeeds, and 404 not retried