### PR TITLE
ci: authenticate googleapis proto fetches to avoid 429 rate limits

### DIFF
--- a/.github/actions/protobuf/action.yml
+++ b/.github/actions/protobuf/action.yml
@@ -53,6 +53,10 @@ runs:
     - name: Generate API proto files
       working-directory: ./api
       shell: bash
+      env:
+        # Authenticates the googleapis proto fetch in the Makefile to avoid
+        # anonymous per-IP 429 rate limits on raw.githubusercontent.com.
+        GITHUB_TOKEN: ${{ github.token }}
       run: make clean python
     - name: Install kfp-pipeline-spec from source
       shell: bash

--- a/api/Makefile
+++ b/api/Makefile
@@ -104,8 +104,26 @@ fetch-protos: fetch-googleapis fetch-protobuf
 
 fetch-googleapis:
 	@echo "Downloading google/rpc/status.proto from googleapis@$(GOOGLEAPIS_COMMIT)..."
-	mkdir -p $(PROTO_DST_DIR)/rpc
-	wget --tries=3 --waitretry=10 --retry-on-http-error=429,500,502,503 -qO $(PROTO_DST_DIR)/rpc/status.proto https://raw.githubusercontent.com/googleapis/googleapis/$(GOOGLEAPIS_COMMIT)/google/rpc/status.proto
+	@mkdir -p $(PROTO_DST_DIR)/rpc
+	@# Authenticate with GITHUB_TOKEN when set to avoid anonymous per-IP 429
+	@# rate limits on raw.githubusercontent.com. The bearer header is passed
+	@# through a temporary WGETRC file, never on the command line, so it
+	@# cannot leak into an echoed recipe or CI log. The whole recipe is
+	@# @-suppressed for the same reason. If the authenticated fetch fails
+	@# (e.g. token scoping), it falls back to an anonymous fetch, so behavior
+	@# is never worse than without a token; both paths keep the retries.
+	@wget_cmd="wget --tries=3 --waitretry=10 --retry-on-http-error=429,500,502,503 -qO $(PROTO_DST_DIR)/rpc/status.proto https://raw.githubusercontent.com/googleapis/googleapis/$(GOOGLEAPIS_COMMIT)/google/rpc/status.proto"; \
+	if [ -n "$$GITHUB_TOKEN" ]; then \
+		wgetrc=$$(mktemp); \
+		printf 'header = Authorization: Bearer %s\n' "$$GITHUB_TOKEN" > "$$wgetrc"; \
+		WGETRC=$$wgetrc $$wget_cmd || $$wget_cmd; \
+		status=$$?; \
+		rm -f "$$wgetrc"; \
+	else \
+		$$wget_cmd; \
+		status=$$?; \
+	fi; \
+	exit $$status
 
 fetch-protobuf: clean-protobuf-tmp
 	@for attempt in 1 2 3; do \

--- a/api/Makefile
+++ b/api/Makefile
@@ -114,7 +114,7 @@ fetch-googleapis:
 	@# is never worse than without a token; both paths keep the retries.
 	@wget_cmd="wget --tries=3 --waitretry=10 --retry-on-http-error=429,500,502,503 -qO $(PROTO_DST_DIR)/rpc/status.proto https://raw.githubusercontent.com/googleapis/googleapis/$(GOOGLEAPIS_COMMIT)/google/rpc/status.proto"; \
 	if [ -n "$$GITHUB_TOKEN" ]; then \
-		wgetrc=$$(mktemp); \
+		wgetrc=$$(mktemp "$${TMPDIR:-/tmp}/kfp-proto-wgetrc.XXXXXX"); \
 		printf 'header = Authorization: Bearer %s\n' "$$GITHUB_TOKEN" > "$$wgetrc"; \
 		WGETRC=$$wgetrc $$wget_cmd || $$wget_cmd; \
 		status=$$?; \

--- a/backend/api/Makefile
+++ b/backend/api/Makefile
@@ -50,8 +50,24 @@ generate-kfp-server-api-package:
 fetch-dependencies: v2beta1/google/rpc/status.proto
 
 v2beta1/google/rpc/status.proto:
-	mkdir -p v2beta1/google/rpc
-	wget --tries=3 --waitretry=10 --retry-on-http-error=429,500,502,503 -O v2beta1/google/rpc/status.proto https://raw.githubusercontent.com/googleapis/googleapis/047d3a8ac7f75383855df0166144f891d7af08d9/google/rpc/status.proto
+	@mkdir -p v2beta1/google/rpc
+	@# Authenticate with GITHUB_TOKEN when set to avoid anonymous per-IP 429
+	@# rate limits on raw.githubusercontent.com. The bearer header is passed
+	@# through a temporary WGETRC file, never on the command line. If the
+	@# authenticated fetch fails it falls back to an anonymous fetch, so
+	@# behavior is never worse than without a token.
+	@wget_cmd="wget --tries=3 --waitretry=10 --retry-on-http-error=429,500,502,503 -O v2beta1/google/rpc/status.proto https://raw.githubusercontent.com/googleapis/googleapis/047d3a8ac7f75383855df0166144f891d7af08d9/google/rpc/status.proto"; \
+	if [ -n "$$GITHUB_TOKEN" ]; then \
+		wgetrc=$$(mktemp); \
+		printf 'header = Authorization: Bearer %s\n' "$$GITHUB_TOKEN" > "$$wgetrc"; \
+		WGETRC=$$wgetrc $$wget_cmd || $$wget_cmd; \
+		status=$$?; \
+		rm -f "$$wgetrc"; \
+	else \
+		$$wget_cmd; \
+		status=$$?; \
+	fi; \
+	exit $$status
 
 # Generate clients starting by building api-generator image locally.
 # Note, this should only be used for local development purposes. Once any change is made to the Dockerfile,

--- a/backend/api/Makefile
+++ b/backend/api/Makefile
@@ -58,7 +58,7 @@ v2beta1/google/rpc/status.proto:
 	@# behavior is never worse than without a token.
 	@wget_cmd="wget --tries=3 --waitretry=10 --retry-on-http-error=429,500,502,503 -O v2beta1/google/rpc/status.proto https://raw.githubusercontent.com/googleapis/googleapis/047d3a8ac7f75383855df0166144f891d7af08d9/google/rpc/status.proto"; \
 	if [ -n "$$GITHUB_TOKEN" ]; then \
-		wgetrc=$$(mktemp); \
+		wgetrc=$$(mktemp "$${TMPDIR:-/tmp}/kfp-proto-wgetrc.XXXXXX"); \
 		printf 'header = Authorization: Bearer %s\n' "$$GITHUB_TOKEN" > "$$wgetrc"; \
 		WGETRC=$$wgetrc $$wget_cmd || $$wget_cmd; \
 		status=$$?; \


### PR DESCRIPTION
## Summary

Follow-up to #13691, which added **retries** to the build-dependency proto fetches. Retry treats the symptom; the underlying cause of the `raw.githubusercontent.com` failures is **anonymous per-IP rate limiting** on shared CI egress IPs (the same root cause as the test-side 429s fixed in #13695). This PR adds **authentication** on top of that retry so the fetches use the far larger per-token rate limit.

## Change

The `googleapis` `status.proto` fetches in `api/Makefile` and `backend/api/Makefile` now send a bearer token from `GITHUB_TOKEN` when set, with `github.token` plumbed once into the `protobuf` composite action's proto-generation step — the CI chokepoint every affected workflow (SDK unit tests, kfp-kubernetes tests, migration tests, sdk-upgrade, validate-generated-files) routes through.

Safety properties:
- **No token on the command line.** The header is passed via a temporary `WGETRC` file and the recipe is `@`-suppressed, so the token cannot leak into an echoed recipe or CI log (verified: 0 token appearances in recipe output). `WGETRC` is used rather than `--netrc-file` (a curl-only flag) because it makes wget send the `Authorization` header **proactively** — raw.githubusercontent returns 429, not a 401 challenge, so netrc-style deferred auth would not fire.
- **Never worse than anonymous.** If the authenticated fetch fails (e.g. cross-org token scoping), it falls back to the anonymous fetch; both paths keep the #13691 retries.
- **Local runs unchanged.** Without `GITHUB_TOKEN` set, the fetch stays anonymous exactly as before.

The `protoc` release-zip and `git clone` fetches from #13691 stay retry-only: the protoc zip is on the release CDN (`objects.githubusercontent.com`) with far higher anonymous limits, and `git clone` is not a rate-limit hotspot here.

## Verification

- Anonymous path unchanged: `env -u GITHUB_TOKEN make -C api fetch-googleapis` fetches the pinned `status.proto`
- Auth path fetches successfully; `wget -d` confirms the `Authorization: Bearer` header is sent proactively (`raw.githubusercontent.com` responds `Vary: Authorization`)
- Token does not appear in recipe output (grep count 0) with the token set
- Auth-failure fallback verified: an invalid token still yields a successful fetch via the anonymous fallback
- YAML parse of the modified composite action; this PR's checks exercise the `protobuf` action end-to-end