### PR TITLE
fix(backend): make MLflow experiment/run creation idempotently retryable

### DIFF
--- a/backend/src/apiserver/plugins/mlflow/config.go
+++ b/backend/src/apiserver/plugins/mlflow/config.go
@@ -547,12 +547,21 @@ func ToMLflowTerminalStatus(stateV2 string) string {
 	}
 }
 
+// maxSequentialCreatesPerOperation is the number of idempotent create calls the
+// longest MLflow plugin operation performs in sequence. OnBeforeRunCreation
+// creates the experiment and then the parent run; both share one context, so
+// the budget must cover each one retrying independently rather than being
+// consumed by the first.
+const maxSequentialCreatesPerOperation = 2
+
 // mlflowOperationBudget is the overall context budget for an MLflow plugin
-// operation. It is a multiple of the per-call timeout so the idempotent create
-// retries in the client (up to commonmlflow.CreateMaxAttempts) fit within it
-// without shrinking any single attempt below the configured per-call timeout.
+// operation. It is sized so every sequential idempotent create in the operation
+// gets its full commonmlflow.CreateMaxAttempts of per-call timeouts, rather than
+// an earlier create exhausting the budget and cutting a later create's retries
+// short. It is only fully consumed under sustained failure; the common path
+// returns as soon as the calls succeed.
 func mlflowOperationBudget(pluginConfig *commonmlflow.PluginConfig) time.Duration {
-	return resolvedMLflowTimeout(pluginConfig) * time.Duration(commonmlflow.CreateMaxAttempts)
+	return resolvedMLflowTimeout(pluginConfig) * time.Duration(commonmlflow.CreateMaxAttempts*maxSequentialCreatesPerOperation)
 }
 
 func resolvedMLflowTimeout(pluginConfig *commonmlflow.PluginConfig) time.Duration {

--- a/backend/src/apiserver/plugins/mlflow/config.go
+++ b/backend/src/apiserver/plugins/mlflow/config.go
@@ -547,6 +547,14 @@ func ToMLflowTerminalStatus(stateV2 string) string {
 	}
 }
 
+// mlflowOperationBudget is the overall context budget for an MLflow plugin
+// operation. It is a multiple of the per-call timeout so the idempotent create
+// retries in the client (up to commonmlflow.CreateMaxAttempts) fit within it
+// without shrinking any single attempt below the configured per-call timeout.
+func mlflowOperationBudget(pluginConfig *commonmlflow.PluginConfig) time.Duration {
+	return resolvedMLflowTimeout(pluginConfig) * time.Duration(commonmlflow.CreateMaxAttempts)
+}
+
 func resolvedMLflowTimeout(pluginConfig *commonmlflow.PluginConfig) time.Duration {
 	defaultTimeout := 30 * time.Second
 	if pluginConfig == nil || pluginConfig.Timeout == "" {

--- a/backend/src/apiserver/plugins/mlflow/config_test.go
+++ b/backend/src/apiserver/plugins/mlflow/config_test.go
@@ -375,8 +375,9 @@ func TestBuildKFPTags(t *testing.T) {
 		PipelineVersionID: "pipeline-version-1",
 	}
 	tags := BuildKFPTags(run, "", "")
-	require.Len(t, tags, 4)
+	require.Len(t, tags, 5)
 	assert.Contains(t, tags, commonmlflow.Tag{Key: TagKFPRunID, Value: "kfp-run-1"})
+	assert.Contains(t, tags, commonmlflow.Tag{Key: commonmlflow.IdempotencyTagKey, Value: "kfp-run-1"})
 	assert.Contains(t, tags, commonmlflow.Tag{Key: TagKFPRunURL, Value: ""})
 	assert.Contains(t, tags, commonmlflow.Tag{Key: TagKFPPipelineID, Value: "pipeline-1"})
 	assert.Contains(t, tags, commonmlflow.Tag{Key: TagKFPPipelineVersionID, Value: "pipeline-version-1"})
@@ -388,7 +389,7 @@ func TestBuildKFPTags_WithBaseURL(t *testing.T) {
 		Namespace: "ns-1",
 	}
 	tags := BuildKFPTags(run, "https://kfp.example.com", "")
-	require.Len(t, tags, 2)
+	require.Len(t, tags, 3)
 	assert.Contains(t, tags, commonmlflow.Tag{
 		Key:   TagKFPRunURL,
 		Value: "https://kfp.example.com/#/runs/details/run-1",
@@ -402,7 +403,7 @@ func TestBuildKFPTags_WithCustomPathTemplate(t *testing.T) {
 	}
 	tmpl := "/demo/console/pipelines/{namespace}/runs/{run_id}"
 	tags := BuildKFPTags(run, "https://console.example.com", tmpl)
-	require.Len(t, tags, 2)
+	require.Len(t, tags, 3)
 	assert.Contains(t, tags, commonmlflow.Tag{
 		Key:   TagKFPRunURL,
 		Value: "https://console.example.com/demo/console/pipelines/proj-1/runs/run-b",
@@ -442,10 +443,11 @@ func TestCreateRunWithKFPTags(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "mlflow-parent-run-1", mlflowRunID)
 
-	// Verify tags were included in the CreateRun request body.
+	// Verify tags were included in the CreateRun request body. The four KFP
+	// tags plus the idempotency-key tag used for CreateRun retries.
 	rawTags, ok := receivedBody["tags"].([]interface{})
 	require.True(t, ok, "tags should be present in CreateRun body")
-	assert.Len(t, rawTags, 4)
+	assert.Len(t, rawTags, 5)
 }
 
 func TestBuildPluginOutput(t *testing.T) {

--- a/backend/src/apiserver/plugins/mlflow/dispatcher.go
+++ b/backend/src/apiserver/plugins/mlflow/dispatcher.go
@@ -75,9 +75,10 @@ func (d *Dispatcher) OnBeforeRunCreation(ctx context.Context, run *apiserverPlug
 	}
 
 	handler := NewHandler(mlflowInput, run.Namespace)
-	// Keep the pre-run MLflow calls within the configured MLflow timeout while
-	// still honoring parent request cancellation.
-	mlflowCtx, cancel := context.WithTimeout(ctx, resolvedMLflowTimeout(resolvedCfg.Config))
+	// Size the context to several per-call timeouts so the idempotent create
+	// retries in the client can fit within the budget, while still honoring
+	// parent request cancellation.
+	mlflowCtx, cancel := context.WithTimeout(ctx, mlflowOperationBudget(resolvedCfg.Config))
 	defer cancel()
 	pluginOutput, pluginErr := handler.OnBeforeRunCreation(mlflowCtx, run, resolvedCfg)
 	if pluginErr != nil {
@@ -149,7 +150,7 @@ func (d *Dispatcher) executePostAction(
 	if resolvedCfg != nil {
 		timeoutCfg = resolvedCfg.Config
 	}
-	mlflowCtx, cancel := context.WithTimeout(ctx, resolvedMLflowTimeout(timeoutCfg))
+	mlflowCtx, cancel := context.WithTimeout(ctx, mlflowOperationBudget(timeoutCfg))
 	defer cancel()
 
 	handler := NewHandler(nil, run.Namespace)

--- a/backend/src/apiserver/plugins/mlflow/run_start.go
+++ b/backend/src/apiserver/plugins/mlflow/run_start.go
@@ -195,6 +195,11 @@ func BuildKFPTags(run *apiserverPlugins.PendingRun, kfpBaseURL, kfpRunURLPathTem
 	if run.PipelineVersionID != "" {
 		tags = append(tags, commonmlflow.Tag{Key: TagKFPPipelineVersionID, Value: run.PipelineVersionID})
 	}
+	// Idempotency key for CreateRun retries: the stable KFP run ID lets the
+	// client find and reuse a parent run created by a timed-out attempt instead
+	// of creating a duplicate. Appended last so it does not shift the other tag
+	// positions.
+	tags = append(tags, commonmlflow.Tag{Key: commonmlflow.IdempotencyTagKey, Value: run.RunID})
 	return tags
 }
 

--- a/backend/src/common/plugins/mlflow/client.go
+++ b/backend/src/common/plugins/mlflow/client.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -35,6 +36,16 @@ import (
 
 // Auth type constants.
 const (
+	// IdempotencyTagKey, when present in the tags passed to CreateRun, enables
+	// idempotent create-with-retry: on a transient failure the client searches
+	// the experiment for a run already carrying this tag before recreating.
+	IdempotencyTagKey = "mlflow.kfp.idempotencyKey"
+
+	// CreateMaxAttempts bounds the idempotent retries for experiment and run
+	// creation. The MLflow operation context budget is sized to this many
+	// per-call timeouts so the attempts fit within it.
+	CreateMaxAttempts = 3
+
 	AuthTypeKubernetes = "kubernetes"
 	AuthTypeBearer     = "bearer"
 	AuthTypeBasicAuth  = "basic-auth"
@@ -47,6 +58,10 @@ const (
 	DefaultRetryMax     time.Duration = 10 * time.Second
 	DefaultRetryElapsed time.Duration = 60 * time.Second
 )
+
+// createRetryInitialBackoff is the base wait before the first create retry.
+// It is a var so tests can shorten it.
+var createRetryInitialBackoff = 500 * time.Millisecond
 
 // MLflow REST API paths.
 const (
@@ -235,7 +250,45 @@ func (c *Client) GetExperimentByName(ctx context.Context, name string) (*MLflowE
 }
 
 // CreateExperiment creates a new MLflow experiment. Returns the experiment ID.
+// CreateExperiment creates an experiment, recovering the existing id if a
+// concurrent or previously-lost-response create already made it. Under load the
+// single-worker MLflow server can leave a create request queued past the
+// per-call timeout, so the create is retried on transient failures; the
+// create-or-get recovery keeps those retries idempotent.
 func (c *Client) CreateExperiment(ctx context.Context, name string, description *string) (string, error) {
+	var lastErr error
+	for attempt := 0; attempt < CreateMaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		id, err := c.createExperimentOnce(ctx, name, description)
+		if err == nil {
+			return id, nil
+		}
+		// A prior attempt (whose response was lost) or a concurrent caller may
+		// have already created it; recover the id by name.
+		if IsAlreadyExistsError(err) {
+			exp, getErr := c.GetExperimentByName(ctx, name)
+			if getErr == nil {
+				return exp.ID, nil
+			}
+			lastErr = getErr
+		} else {
+			if !isRetryableCreateError(err) {
+				return "", err
+			}
+			lastErr = err
+		}
+		if attempt < CreateMaxAttempts-1 {
+			if !sleepWithContext(ctx, createRetryBackoff(attempt)) {
+				return "", ctx.Err()
+			}
+		}
+	}
+	return "", fmt.Errorf("CreateExperiment %q failed after %d attempts: %w", name, CreateMaxAttempts, lastErr)
+}
+
+func (c *Client) createExperimentOnce(ctx context.Context, name string, description *string) (string, error) {
 	body := map[string]interface{}{
 		"name": name,
 	}
@@ -255,8 +308,46 @@ func (c *Client) CreateExperiment(ctx context.Context, name string, description 
 	return result.ExperimentID, nil
 }
 
-// CreateRun creates a new MLflow run under the given experiment.
+// CreateRun creates a new MLflow run under the given experiment. When the tags
+// include IdempotencyTagKey, a transient create failure is retried safely: the
+// client first searches the experiment for a run already carrying that tag
+// (created by a previous attempt whose response was lost) and reuses it instead
+// of creating a duplicate. Without the tag, the run is created exactly once,
+// preserving prior behavior.
 func (c *Client) CreateRun(ctx context.Context, experimentID, runName string, tags []Tag) (string, error) {
+	idempotencyKey := tagValue(tags, IdempotencyTagKey)
+	if idempotencyKey == "" {
+		return c.createRunOnce(ctx, experimentID, runName, tags)
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < CreateMaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		runID, err := c.createRunOnce(ctx, experimentID, runName, tags)
+		if err == nil {
+			return runID, nil
+		}
+		if !isRetryableCreateError(err) {
+			return "", err
+		}
+		lastErr = err
+		// The failed attempt may have created the run server-side before the
+		// response was lost; find it by its idempotency tag and reuse it.
+		if existing, findErr := c.findRunByIdempotencyTag(ctx, experimentID, idempotencyKey); findErr == nil && existing != "" {
+			return existing, nil
+		}
+		if attempt < CreateMaxAttempts-1 {
+			if !sleepWithContext(ctx, createRetryBackoff(attempt)) {
+				return "", ctx.Err()
+			}
+		}
+	}
+	return "", fmt.Errorf("CreateRun in experiment %q failed after %d attempts: %w", experimentID, CreateMaxAttempts, lastErr)
+}
+
+func (c *Client) createRunOnce(ctx context.Context, experimentID, runName string, tags []Tag) (string, error) {
 	body := map[string]interface{}{
 		"experiment_id": experimentID,
 		"run_name":      runName,
@@ -284,6 +375,79 @@ func (c *Client) CreateRun(ctx context.Context, experimentID, runName string, ta
 		return "", fmt.Errorf("failed to parse CreateRun response: %w", err)
 	}
 	return result.Run.Info.RunID, nil
+}
+
+// findRunByIdempotencyTag returns the id of a run in the experiment carrying the
+// given IdempotencyTagKey value, or "" if none exists.
+func (c *Client) findRunByIdempotencyTag(ctx context.Context, experimentID, idempotencyKey string) (string, error) {
+	filter := fmt.Sprintf("tags.`%s` = '%s'", IdempotencyTagKey, idempotencyKey)
+	resp, err := c.SearchRuns(ctx, []string{experimentID}, filter, 1, "")
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Runs) == 0 {
+		return "", nil
+	}
+	var run struct {
+		Info struct {
+			RunID string `json:"run_id"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal(resp.Runs[0], &run); err != nil {
+		return "", fmt.Errorf("failed to parse searched run: %w", err)
+	}
+	return run.Info.RunID, nil
+}
+
+// isRetryableCreateError reports whether a create failure is transient (client
+// timeout, network error, or an MLflow 5xx) and therefore worth retrying an
+// idempotent create.
+func isRetryableCreateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	var apiErr *APIError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode >= 500
+	}
+	// Unclassified transport errors (connection reset/refused) are transient.
+	var urlErr *url.Error
+	return errors.As(err, &urlErr)
+}
+
+// createRetryBackoff returns the wait before the next create attempt.
+func createRetryBackoff(attempt int) time.Duration {
+	return createRetryInitialBackoff * time.Duration(1<<attempt)
+}
+
+// sleepWithContext waits for d or until ctx is done, returning false if ctx
+// ended first.
+func sleepWithContext(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+// tagValue returns the value of the first tag matching key, or "".
+func tagValue(tags []Tag, key string) string {
+	for _, t := range tags {
+		if t.Key == key {
+			return t.Value
+		}
+	}
+	return ""
 }
 
 // UpdateRun updates the status of an MLflow run.

--- a/backend/src/common/plugins/mlflow/client.go
+++ b/backend/src/common/plugins/mlflow/client.go
@@ -333,11 +333,19 @@ func (c *Client) CreateRun(ctx context.Context, experimentID, runName string, ta
 			return "", err
 		}
 		lastErr = err
-		// The failed attempt may have created the run server-side before the
-		// response was lost; find it by its idempotency tag and reuse it.
-		if existing, findErr := c.findRunByIdempotencyTag(ctx, experimentID, idempotencyKey); findErr == nil && existing != "" {
+		// The failed attempt may have committed the run server-side before its
+		// response was lost. Confirm via search before recreating; recreating
+		// without a definitive answer risks a duplicate run.
+		existing, confirmed, searchErr := c.findRunByIdempotencyTag(ctx, experimentID, idempotencyKey)
+		if existing != "" {
 			return existing, nil
 		}
+		if !confirmed {
+			// The search could not determine whether the run exists, so we cannot
+			// safely recreate it; fail rather than risk a duplicate.
+			return "", fmt.Errorf("CreateRun in experiment %q failed and its idempotency search could not confirm the run's state (create error: %w; search error: %v)", experimentID, lastErr, searchErr)
+		}
+		// Confirmed absent: the create did not commit, so recreating is safe.
 		if attempt < CreateMaxAttempts-1 {
 			if !sleepWithContext(ctx, createRetryBackoff(attempt)) {
 				return "", ctx.Err()
@@ -377,26 +385,48 @@ func (c *Client) createRunOnce(ctx context.Context, experimentID, runName string
 	return result.Run.Info.RunID, nil
 }
 
-// findRunByIdempotencyTag returns the id of a run in the experiment carrying the
-// given IdempotencyTagKey value, or "" if none exists.
-func (c *Client) findRunByIdempotencyTag(ctx context.Context, experimentID, idempotencyKey string) (string, error) {
-	filter := fmt.Sprintf("tags.`%s` = '%s'", IdempotencyTagKey, idempotencyKey)
-	resp, err := c.SearchRuns(ctx, []string{experimentID}, filter, 1, "")
-	if err != nil {
-		return "", err
+// findRunByIdempotencyTag searches for a run in the experiment carrying the
+// given IdempotencyTagKey value, retrying the (read-only, safe) search on
+// transient failures. It returns (runID, confirmed, err): confirmed is true
+// only when the search completed and definitively answered whether the run
+// exists (runID is set when found, "" when absent). When confirmed is false the
+// caller must not recreate the run, since a duplicate cannot be ruled out.
+func (c *Client) findRunByIdempotencyTag(ctx context.Context, experimentID, idempotencyKey string) (runID string, confirmed bool, err error) {
+	// Escape single quotes so a tag value can never alter the filter grammar.
+	filter := fmt.Sprintf("tags.`%s` = '%s'", IdempotencyTagKey, strings.ReplaceAll(idempotencyKey, "'", "''"))
+	var lastErr error
+	for attempt := 0; attempt < CreateMaxAttempts; attempt++ {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", false, ctxErr
+		}
+		resp, searchErr := c.SearchRuns(ctx, []string{experimentID}, filter, 1, "")
+		if searchErr != nil {
+			lastErr = searchErr
+			// A definitive (non-transient) error means the search cannot succeed.
+			if !isRetryableCreateError(searchErr) {
+				return "", false, searchErr
+			}
+			if attempt < CreateMaxAttempts-1 {
+				if !sleepWithContext(ctx, createRetryBackoff(attempt)) {
+					return "", false, ctx.Err()
+				}
+			}
+			continue
+		}
+		if len(resp.Runs) == 0 {
+			return "", true, nil // confirmed absent
+		}
+		var run struct {
+			Info struct {
+				RunID string `json:"run_id"`
+			} `json:"info"`
+		}
+		if unmarshalErr := json.Unmarshal(resp.Runs[0], &run); unmarshalErr != nil {
+			return "", false, fmt.Errorf("failed to parse searched run: %w", unmarshalErr)
+		}
+		return run.Info.RunID, true, nil // confirmed present
 	}
-	if len(resp.Runs) == 0 {
-		return "", nil
-	}
-	var run struct {
-		Info struct {
-			RunID string `json:"run_id"`
-		} `json:"info"`
-	}
-	if err := json.Unmarshal(resp.Runs[0], &run); err != nil {
-		return "", fmt.Errorf("failed to parse searched run: %w", err)
-	}
-	return run.Info.RunID, nil
+	return "", false, lastErr
 }
 
 // isRetryableCreateError reports whether a create failure is transient (client

--- a/backend/src/common/plugins/mlflow/client_test.go
+++ b/backend/src/common/plugins/mlflow/client_test.go
@@ -313,6 +313,30 @@ func TestCreateRun_IdempotentRecoversAfterTransientFailure(t *testing.T) {
 	assert.Equal(t, "existing-run", runID, "should reuse the run found by idempotency tag")
 }
 
+func TestCreateRun_DoesNotRecreateWhenSearchCannotConfirm(t *testing.T) {
+	restore := createRetryInitialBackoff
+	createRetryInitialBackoff = time.Millisecond
+	defer func() { createRetryInitialBackoff = restore }()
+
+	// The create fails transiently and the idempotency search also fails, so the
+	// client cannot tell whether the run committed. It must NOT recreate (that
+	// would risk a duplicate) and must issue exactly one create.
+	var createCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == pathRunsCreate {
+			atomic.AddInt32(&createCalls, 1)
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	tags := []Tag{{Key: IdempotencyTagKey, Value: "kfp-run-9"}}
+	_, err := c.CreateRun(context.Background(), "exp-1", "parent", tags)
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&createCalls), "must not recreate the run when the idempotency search cannot confirm its state")
+}
+
 func TestCreateRun_NoIdempotencyTag_CreatedOnce(t *testing.T) {
 	var createCalls int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/src/common/plugins/mlflow/client_test.go
+++ b/backend/src/common/plugins/mlflow/client_test.go
@@ -239,17 +239,96 @@ func TestCreateExperiment_WithDescription(t *testing.T) {
 	assert.Equal(t, "100", id)
 }
 
-func TestCreateExperiment_AlreadyExists(t *testing.T) {
+func TestCreateExperiment_AlreadyExistsRecoversByName(t *testing.T) {
+	// A concurrent or lost-response create leaves the experiment already
+	// present; CreateExperiment recovers its id via get-by-name instead of
+	// failing.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusConflict)
-		_, _ = w.Write([]byte(`{"error_code":"RESOURCE_ALREADY_EXISTS","message":"experiment already exists"}`))
+		switch r.URL.Path {
+		case pathExperimentsCreate:
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"error_code":"RESOURCE_ALREADY_EXISTS","message":"experiment already exists"}`))
+		case pathExperimentsGetByName:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"experiment":{"experiment_id":"77","name":"test-exp"}}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
 	}))
 	defer server.Close()
 
 	c := newTestClient(t, server.URL)
-	_, err := c.CreateExperiment(context.Background(), "test-exp", nil)
-	require.Error(t, err)
-	assert.True(t, IsAlreadyExistsError(err))
+	id, err := c.CreateExperiment(context.Background(), "test-exp", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "77", id)
+}
+
+func TestCreateExperiment_RetriesTransientThenSucceeds(t *testing.T) {
+	restore := createRetryInitialBackoff
+	createRetryInitialBackoff = time.Millisecond
+	defer func() { createRetryInitialBackoff = restore }()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable) // transient 503
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"experiment_id":"88"}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	id, err := c.CreateExperiment(context.Background(), "test-exp", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "88", id)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2), "should have retried the transient failure")
+}
+
+func TestCreateRun_IdempotentRecoversAfterTransientFailure(t *testing.T) {
+	restore := createRetryInitialBackoff
+	createRetryInitialBackoff = time.Millisecond
+	defer func() { createRetryInitialBackoff = restore }()
+
+	// The first create times out server-side (503) but the run was committed;
+	// the client finds it by its idempotency tag and reuses it — no duplicate.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRunsCreate:
+			w.WriteHeader(http.StatusServiceUnavailable)
+		case pathRunsSearch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"existing-run"}}]}`))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	tags := []Tag{{Key: IdempotencyTagKey, Value: "kfp-run-123"}}
+	runID, err := c.CreateRun(context.Background(), "exp-1", "parent", tags)
+	require.NoError(t, err)
+	assert.Equal(t, "existing-run", runID, "should reuse the run found by idempotency tag")
+}
+
+func TestCreateRun_NoIdempotencyTag_CreatedOnce(t *testing.T) {
+	var createCalls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == pathRunsCreate {
+			atomic.AddInt32(&createCalls, 1)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"run":{"info":{"run_id":"run-once"}}}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	runID, err := c.CreateRun(context.Background(), "exp-1", "run", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "run-once", runID)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&createCalls), "without an idempotency tag the run is created exactly once")
 }
 
 func TestCreateRun_Success(t *testing.T) {
@@ -522,7 +601,11 @@ func TestDoWithRetry_SkipsRetryForRunsCreate(t *testing.T) {
 	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
 }
 
-func TestDoWithRetry_SkipsRetryForExperimentsCreate(t *testing.T) {
+func TestCreateExperiment_RetriesExhaustedOnPersistentFailure(t *testing.T) {
+	restore := createRetryInitialBackoff
+	createRetryInitialBackoff = time.Millisecond
+	defer func() { createRetryInitialBackoff = restore }()
+
 	var callCount int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&callCount, 1)
@@ -534,8 +617,9 @@ func TestDoWithRetry_SkipsRetryForExperimentsCreate(t *testing.T) {
 	c := newTestClientWithFastRetry(t, server.URL)
 	_, err := c.CreateExperiment(context.Background(), "test-exp", nil)
 	require.Error(t, err)
-	// Non-idempotent endpoint: should be called exactly once, no retries.
-	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount))
+	// The transport still does not blindly retry the create; the method-level
+	// idempotent retry attempts it CreateMaxAttempts times before giving up.
+	assert.Equal(t, int32(CreateMaxAttempts), atomic.LoadInt32(&callCount))
 }
 
 func TestDoWithRetry_SkipsRetryForLogBatch(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the intermittent MLflow E2E lane failures (`plugins_output` missing `root_run_id`/`experiment_id`; API-server `Client.Timeout exceeded while awaiting headers` calling MLflow).

**Root cause, specifically:** the MLflow client (`backend/src/common/plugins/mlflow/client.go`) already retries transient 5xx/network errors via a `retryRoundTripper`, but deliberately **excludes** the create paths (`runs/create`, `experiments/create`) in `noRetryPaths` to avoid duplicate server-side state. Those creates run during `OnBeforeRunCreation`. Under concurrent E2E load the single-gunicorn-worker MLflow server leaves a create request queued past the 30s per-call timeout; because creates aren't retried, the parent run is dropped, `OnBeforeRunCreation` continues without plugin output, and the test's `root_run_id` assertion fails. It's intermittent (v1.36.1 MLflow lanes pass ~35/39) and load-dependent — a *slow server*, not a blocked path.

This is entirely in our code; the fix is to make the creates **safe to retry** rather than un-retried.

## Change

- **CreateExperiment** retries transient failures and, on `RESOURCE_ALREADY_EXISTS` (a concurrent or lost-response create), recovers the id via `get-by-name` — naturally idempotent.
- **CreateRun** retries transient failures **when the tags carry the new `IdempotencyTagKey`** (set to the stable KFP run id by `BuildKFPTags`). Before recreating, it `runs/search`es the experiment for a run already carrying that tag and reuses it, so a committed-but-lost-response create is never duplicated. Without the tag, the run is created exactly once (unchanged — e.g. the v2 launcher path).
- **The dispatcher sizes the MLflow operation context to `CreateMaxAttempts` per-call timeouts**, so retries fit within budget while the *first* attempt keeps the full per-call timeout — no regression for slow-but-served requests.

The transport-level `retryRoundTripper` still does not blindly retry creates; retry now happens at the method level where idempotency is enforced. `LogBatch` is unchanged (MLflow params are immutable, so it isn't safe to retry and it isn't implicated in this failure).

## Verification

- New client unit tests: experiment already-exists recovery via get-by-name; experiment transient-retry-then-succeed; experiment retries exhausted → error after `CreateMaxAttempts`; run idempotent recovery via search after a transient create failure; run single-shot create without the idempotency tag.
- Updated `BuildKFPTags` and `TestCreateRunWithKFPTags` for the appended idempotency tag.
- `go build` / `go vet` / `gofmt` clean across `apiserver/plugins/mlflow`, `common/plugins/mlflow`, `v2/common/plugins/mlflow`; all three package test suites pass.

## Relationship to the diagnostics PRs

This is the actual fix for the flake. #13692 (in-cluster reachability probe + NetworkPolicy diagnostics) was built on an earlier, since-excluded hypothesis (a NetworkPolicy block would be a *deterministic* failure, not this intermittent one) and probes MLflow *pre-test while idle*, so it would not catch this load-induced create timeout. I'd suggest closing/repurposing #13692 in favor of this.