### PR TITLE
ci: dump pod state when multi-user readiness waits time out

### DIFF
--- a/.github/resources/scripts/deploy-kfp.sh
+++ b/.github/resources/scripts/deploy-kfp.sh
@@ -140,9 +140,19 @@ wait_for_pods_ready() {
   echo "----- describe (container readiness / events) -----"
   kubectl "${scope_args[@]}" describe pods || true
   echo "----- recent namespace events -----"
-  kubectl -n "$namespace" get events --sort-by=.lastTimestamp 2>/dev/null | tail -40 || true
+  # Sort by creationTimestamp: lastTimestamp is deprecated/absent for
+  # events.k8s.io/v1 objects, which leaves the output unsorted on new clusters.
+  kubectl -n "$namespace" get events --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -40 || true
   echo "----- logs (all containers, incl. istio-proxy sidecar) -----"
-  kubectl "${scope_args[@]}" logs --all-containers=true --tail=100 --prefix=true || true
+  if [ -n "$selector" ]; then
+    kubectl -n "$namespace" logs -l "$selector" --all-containers=true --tail=100 --prefix=true || true
+  else
+    # kubectl logs needs a resource or selector; with no selector (e.g. the
+    # Istio wait covers the whole namespace) dump each pod individually.
+    for pod in $(kubectl -n "$namespace" get pods -o name 2>/dev/null | head -20); do
+      kubectl -n "$namespace" logs "$pod" --all-containers=true --tail=100 --prefix=true || true
+    done
+  fi
   return 1
 }
 

--- a/.github/resources/scripts/deploy-kfp.sh
+++ b/.github/resources/scripts/deploy-kfp.sh
@@ -113,13 +113,46 @@ fi
 
 
 # Deploy multi-user prerequisites if multi-user mode is enabled
+# wait_for_pods_ready waits for pods to reach condition=Ready and, on timeout,
+# dumps pod status, per-container readiness (including any istio-proxy sidecar),
+# recent namespace events, and container logs before failing. These multi-user
+# prerequisites intermittently miss the readiness deadline; without this a
+# timeout under `set -e` exits with only a bare "timed out" line and no state,
+# leaving the cause (sidecar not ready, image pull, slow init) undiagnosable.
+wait_for_pods_ready() {
+  local namespace="$1" selector="$2" timeout="$3" label="$4"
+  local wait_args=(-n "$namespace" wait --for=condition=Ready pods --timeout "$timeout")
+  local scope_args=(-n "$namespace")
+  if [ -n "$selector" ]; then
+    wait_args+=(-l "$selector")
+    scope_args+=(-l "$selector")
+  else
+    wait_args+=(--all)
+  fi
+
+  if kubectl "${wait_args[@]}"; then
+    return 0
+  fi
+
+  echo "ERROR: ${label} did not become Ready within ${timeout}; collecting diagnostics:"
+  echo "----- pods -----"
+  kubectl "${scope_args[@]}" get pods -o wide || true
+  echo "----- describe (container readiness / events) -----"
+  kubectl "${scope_args[@]}" describe pods || true
+  echo "----- recent namespace events -----"
+  kubectl -n "$namespace" get events --sort-by=.lastTimestamp 2>/dev/null | tail -40 || true
+  echo "----- logs (all containers, incl. istio-proxy sidecar) -----"
+  kubectl "${scope_args[@]}" logs --all-containers=true --tail=100 --prefix=true || true
+  return 1
+}
+
 if [ "${MULTI_USER}" == "true" ]; then
   echo "Installing Istio..."
   kubectl apply -k https://github.com/kubeflow/manifests/common/istio/istio-crds/base?ref=master
   kubectl apply -k https://github.com/kubeflow/manifests/common/istio/istio-namespace/base?ref=master
   kubectl apply -k https://github.com/kubeflow/manifests/common/istio/istio-install/base?ref=master
   echo "Waiting for all Istio Pods to become ready..."
-  kubectl wait --for=condition=Ready pods --all -n istio-system --timeout=300s
+  wait_for_pods_ready istio-system "" 300s "Istio pods"
 
   echo "Deploying Metacontroller CRD..."
   kubectl apply -f manifests/kustomize/third-party/metacontroller/base/crd.yaml
@@ -127,7 +160,7 @@ if [ "${MULTI_USER}" == "true" ]; then
 
   echo "Installing Profile Controller Resources..."
   kubectl apply -k https://github.com/kubeflow/manifests/applications/dashboard/upstream/profile-controller/overlays/kubeflow?ref=master
-  kubectl -n kubeflow wait --for=condition=Ready pods -l app.kubernetes.io/name=profile-controller --timeout 180s
+  wait_for_pods_ready kubeflow "app.kubernetes.io/name=profile-controller" 180s "profile-controller pod"
 fi
 
 # Manifests will be deployed according to the flag provided


### PR DESCRIPTION
## Problem

The multi-user E2E lane intermittently fails in `Deploy KFP` with:

```
error: timed out waiting for the condition on pods/profiles-deployment-...
```

The profile-controller pod does not reach `condition=Ready` within the 180s wait in `deploy-kfp.sh`. It is **intermittent** (multi-user lanes pass ~80% of completed runs), so it is not a systemic break of the `kubeflow/manifests` `ref=master` sources it is deployed from — it is a readiness-lag flake on the loaded v1.36.1 lane. The pod is Istio-sidecar-injected, so "not Ready" is often the `istio-proxy` sidecar, but **we cannot tell**: the wait is a bare `kubectl wait` under `set -e`, so a timeout exits with that single line and **no pod state** — every occurrence is undiagnosable.

## Change

Add `wait_for_pods_ready`, which waits for `condition=Ready` and, on timeout, dumps before failing:
- pod list (`-o wide`, restart counts / READY column),
- `describe` (per-container readiness and pod events — surfaces sidecar-not-ready and image-pull),
- recent namespace events,
- all-container logs including the `istio-proxy` sidecar.

Applied to the two readiness waits in the multi-user block (Istio pods and the profile-controller pod). The success path is unchanged.

This does not attempt to *fix* the flake — deliberately. Bumping the timeout or pinning manifests without knowing whether the slow component is the sidecar, an image pull, or controller init would be guessing. This makes the next occurrence produce the evidence to fix it precisely.

## Verification

- `bash -n` clean
- Functionally exercised both paths against a live cluster: the ready path returns 0 for existing pods; the timeout path prints all diagnostic sections and then fails under `set -e`