### PR TITLE
fix(backend): retry idempotent MLflow read/update calls on transient timeouts

### DIFF
--- a/backend/src/apiserver/plugins/mlflow/config.go
+++ b/backend/src/apiserver/plugins/mlflow/config.go
@@ -547,21 +547,22 @@ func ToMLflowTerminalStatus(stateV2 string) string {
 	}
 }
 
-// maxSequentialCreatesPerOperation is the number of idempotent create calls the
-// longest MLflow plugin operation performs in sequence. OnBeforeRunCreation
-// creates the experiment and then the parent run; both share one context, so
-// the budget must cover each one retrying independently rather than being
-// consumed by the first.
-const maxSequentialCreatesPerOperation = 2
+// maxSequentialRetriedCallsPerOperation is the number of idempotent, individually
+// retried MLflow calls the longest plugin operation performs in sequence.
+// OnBeforeRunCreation looks up the experiment (get-by-name), then creates the
+// experiment, then creates the parent run; all share one context, so the budget
+// must cover each retrying independently rather than being consumed by an
+// earlier call.
+const maxSequentialRetriedCallsPerOperation = 3
 
 // mlflowOperationBudget is the overall context budget for an MLflow plugin
-// operation. It is sized so every sequential idempotent create in the operation
-// gets its full commonmlflow.CreateMaxAttempts of per-call timeouts, rather than
-// an earlier create exhausting the budget and cutting a later create's retries
+// operation. It is sized so every sequential idempotent call in the operation
+// gets its full commonmlflow.MaxIdempotentAttempts of per-call timeouts, rather
+// than an earlier call exhausting the budget and cutting a later call's retries
 // short. It is only fully consumed under sustained failure; the common path
 // returns as soon as the calls succeed.
 func mlflowOperationBudget(pluginConfig *commonmlflow.PluginConfig) time.Duration {
-	return resolvedMLflowTimeout(pluginConfig) * time.Duration(commonmlflow.CreateMaxAttempts*maxSequentialCreatesPerOperation)
+	return resolvedMLflowTimeout(pluginConfig) * time.Duration(commonmlflow.MaxIdempotentAttempts*maxSequentialRetriedCallsPerOperation)
 }
 
 func resolvedMLflowTimeout(pluginConfig *commonmlflow.PluginConfig) time.Duration {

--- a/backend/src/common/plugins/mlflow/client.go
+++ b/backend/src/common/plugins/mlflow/client.go
@@ -204,13 +204,14 @@ func (c *Client) GetExperiment(ctx context.Context, experimentID string) (*MLflo
 	q.Set("experiment_id", experimentID)
 	reqURL.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create GetExperiment request: %w", err)
-	}
-	c.applyHeaders(req)
-
-	respBody, err := c.do(req)
+	respBody, err := c.callWithIdempotentRetry(ctx, func() ([]byte, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create GetExperiment request: %w", err)
+		}
+		c.applyHeaders(req)
+		return c.do(req)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -230,13 +231,14 @@ func (c *Client) GetExperimentByName(ctx context.Context, name string) (*MLflowE
 	q.Set("experiment_name", name)
 	reqURL.RawQuery = q.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create GetExperimentByName request: %w", err)
-	}
-	c.applyHeaders(req)
-
-	respBody, err := c.do(req)
+	respBody, err := c.callWithIdempotentRetry(ctx, func() ([]byte, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create GetExperimentByName request: %w", err)
+		}
+		c.applyHeaders(req)
+		return c.do(req)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +276,7 @@ func (c *Client) CreateExperiment(ctx context.Context, name string, description 
 			}
 			lastErr = getErr
 		} else {
-			if !isRetryableCreateError(err) {
+			if !isRetryableTransientError(err) {
 				return "", err
 			}
 			lastErr = err
@@ -329,7 +331,7 @@ func (c *Client) CreateRun(ctx context.Context, experimentID, runName string, ta
 		if err == nil {
 			return runID, nil
 		}
-		if !isRetryableCreateError(err) {
+		if !isRetryableTransientError(err) {
 			return "", err
 		}
 		lastErr = err
@@ -394,45 +396,60 @@ func (c *Client) createRunOnce(ctx context.Context, experimentID, runName string
 func (c *Client) findRunByIdempotencyTag(ctx context.Context, experimentID, idempotencyKey string) (runID string, confirmed bool, err error) {
 	// Escape single quotes so a tag value can never alter the filter grammar.
 	filter := fmt.Sprintf("tags.`%s` = '%s'", IdempotencyTagKey, strings.ReplaceAll(idempotencyKey, "'", "''"))
-	var lastErr error
-	for attempt := 0; attempt < CreateMaxAttempts; attempt++ {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return "", false, ctxErr
-		}
-		resp, searchErr := c.SearchRuns(ctx, []string{experimentID}, filter, 1, "")
-		if searchErr != nil {
-			lastErr = searchErr
-			// A definitive (non-transient) error means the search cannot succeed.
-			if !isRetryableCreateError(searchErr) {
-				return "", false, searchErr
-			}
-			if attempt < CreateMaxAttempts-1 {
-				if !sleepWithContext(ctx, createRetryBackoff(attempt)) {
-					return "", false, ctx.Err()
-				}
-			}
-			continue
-		}
-		if len(resp.Runs) == 0 {
-			return "", true, nil // confirmed absent
-		}
-		var run struct {
-			Info struct {
-				RunID string `json:"run_id"`
-			} `json:"info"`
-		}
-		if unmarshalErr := json.Unmarshal(resp.Runs[0], &run); unmarshalErr != nil {
-			return "", false, fmt.Errorf("failed to parse searched run: %w", unmarshalErr)
-		}
-		return run.Info.RunID, true, nil // confirmed present
+	// SearchRuns retries transient failures itself, so a returned error here is
+	// definitive: the search could not confirm the run's state.
+	resp, searchErr := c.SearchRuns(ctx, []string{experimentID}, filter, 1, "")
+	if searchErr != nil {
+		return "", false, searchErr
 	}
-	return "", false, lastErr
+	if len(resp.Runs) == 0 {
+		return "", true, nil // confirmed absent
+	}
+	var run struct {
+		Info struct {
+			RunID string `json:"run_id"`
+		} `json:"info"`
+	}
+	if unmarshalErr := json.Unmarshal(resp.Runs[0], &run); unmarshalErr != nil {
+		return "", false, fmt.Errorf("failed to parse searched run: %w", unmarshalErr)
+	}
+	return run.Info.RunID, true, nil // confirmed present
 }
 
-// isRetryableCreateError reports whether a create failure is transient (client
+// callWithIdempotentRetry runs an idempotent MLflow HTTP call, retrying it on
+// transient failures (client timeout, network error, MLflow 5xx). Each attempt
+// is a fresh request/response, so several fit within the operation context
+// budget even though the per-call HTTP timeout bounds any single attempt. Only
+// use this for idempotent calls (reads and set/last-write-wins writes); the
+// non-idempotent creates are retried separately with duplicate protection, and
+// log-batch is not retried because MLflow params are immutable.
+func (c *Client) callWithIdempotentRetry(ctx context.Context, call func() ([]byte, error)) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt < CreateMaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		body, err := call()
+		if err == nil {
+			return body, nil
+		}
+		if !isRetryableTransientError(err) {
+			return nil, err
+		}
+		lastErr = err
+		if attempt < CreateMaxAttempts-1 {
+			if !sleepWithContext(ctx, createRetryBackoff(attempt)) {
+				return nil, ctx.Err()
+			}
+		}
+	}
+	return nil, lastErr
+}
+
+// isRetryableTransientError reports whether an error is transient (a client
 // timeout, network error, or an MLflow 5xx) and therefore worth retrying an
-// idempotent create.
-func isRetryableCreateError(err error) bool {
+// idempotent request.
+func isRetryableTransientError(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -489,7 +506,9 @@ func (c *Client) UpdateRun(ctx context.Context, runID, status string, endTimeMs 
 	if endTimeMs != nil {
 		body["end_time"] = *endTimeMs
 	}
-	_, err := c.postJSON(ctx, pathRunsUpdate, body)
+	_, err := c.callWithIdempotentRetry(ctx, func() ([]byte, error) {
+		return c.postJSON(ctx, pathRunsUpdate, body)
+	})
 	return err
 }
 
@@ -500,7 +519,9 @@ func (c *Client) SetTag(ctx context.Context, runID, key, value string) error {
 		"key":    key,
 		"value":  value,
 	}
-	_, err := c.postJSON(ctx, pathRunsSetTag, body)
+	_, err := c.callWithIdempotentRetry(ctx, func() ([]byte, error) {
+		return c.postJSON(ctx, pathRunsSetTag, body)
+	})
 	return err
 }
 
@@ -514,7 +535,9 @@ func (c *Client) SearchRuns(ctx context.Context, experimentIDs []string, filter 
 	if pageToken != "" {
 		body["page_token"] = pageToken
 	}
-	respBody, err := c.postJSON(ctx, pathRunsSearch, body)
+	respBody, err := c.callWithIdempotentRetry(ctx, func() ([]byte, error) {
+		return c.postJSON(ctx, pathRunsSearch, body)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/src/common/plugins/mlflow/client.go
+++ b/backend/src/common/plugins/mlflow/client.go
@@ -41,10 +41,11 @@ const (
 	// the experiment for a run already carrying this tag before recreating.
 	IdempotencyTagKey = "mlflow.kfp.idempotencyKey"
 
-	// CreateMaxAttempts bounds the idempotent retries for experiment and run
-	// creation. The MLflow operation context budget is sized to this many
-	// per-call timeouts so the attempts fit within it.
-	CreateMaxAttempts = 3
+	// MaxIdempotentAttempts bounds the retries for any idempotent MLflow call
+	// (reads, set/last-write-wins writes, and the dedup-protected creates). The
+	// MLflow operation context budget is sized to this many per-call timeouts so
+	// the attempts fit within it.
+	MaxIdempotentAttempts = 3
 
 	AuthTypeKubernetes = "kubernetes"
 	AuthTypeBearer     = "bearer"
@@ -59,9 +60,9 @@ const (
 	DefaultRetryElapsed time.Duration = 60 * time.Second
 )
 
-// createRetryInitialBackoff is the base wait before the first create retry.
+// idempotentRetryInitialBackoff is the base wait before the first retry.
 // It is a var so tests can shorten it.
-var createRetryInitialBackoff = 500 * time.Millisecond
+var idempotentRetryInitialBackoff = 500 * time.Millisecond
 
 // MLflow REST API paths.
 const (
@@ -259,7 +260,7 @@ func (c *Client) GetExperimentByName(ctx context.Context, name string) (*MLflowE
 // create-or-get recovery keeps those retries idempotent.
 func (c *Client) CreateExperiment(ctx context.Context, name string, description *string) (string, error) {
 	var lastErr error
-	for attempt := 0; attempt < CreateMaxAttempts; attempt++ {
+	for attempt := 0; attempt < MaxIdempotentAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
@@ -281,13 +282,13 @@ func (c *Client) CreateExperiment(ctx context.Context, name string, description 
 			}
 			lastErr = err
 		}
-		if attempt < CreateMaxAttempts-1 {
-			if !sleepWithContext(ctx, createRetryBackoff(attempt)) {
+		if attempt < MaxIdempotentAttempts-1 {
+			if !sleepWithContext(ctx, idempotentRetryBackoff(attempt)) {
 				return "", ctx.Err()
 			}
 		}
 	}
-	return "", fmt.Errorf("CreateExperiment %q failed after %d attempts: %w", name, CreateMaxAttempts, lastErr)
+	return "", fmt.Errorf("CreateExperiment %q failed after %d attempts: %w", name, MaxIdempotentAttempts, lastErr)
 }
 
 func (c *Client) createExperimentOnce(ctx context.Context, name string, description *string) (string, error) {
@@ -323,7 +324,7 @@ func (c *Client) CreateRun(ctx context.Context, experimentID, runName string, ta
 	}
 
 	var lastErr error
-	for attempt := 0; attempt < CreateMaxAttempts; attempt++ {
+	for attempt := 0; attempt < MaxIdempotentAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
@@ -348,13 +349,13 @@ func (c *Client) CreateRun(ctx context.Context, experimentID, runName string, ta
 			return "", fmt.Errorf("CreateRun in experiment %q failed and its idempotency search could not confirm the run's state (create error: %w; search error: %v)", experimentID, lastErr, searchErr)
 		}
 		// Confirmed absent: the create did not commit, so recreating is safe.
-		if attempt < CreateMaxAttempts-1 {
-			if !sleepWithContext(ctx, createRetryBackoff(attempt)) {
+		if attempt < MaxIdempotentAttempts-1 {
+			if !sleepWithContext(ctx, idempotentRetryBackoff(attempt)) {
 				return "", ctx.Err()
 			}
 		}
 	}
-	return "", fmt.Errorf("CreateRun in experiment %q failed after %d attempts: %w", experimentID, CreateMaxAttempts, lastErr)
+	return "", fmt.Errorf("CreateRun in experiment %q failed after %d attempts: %w", experimentID, MaxIdempotentAttempts, lastErr)
 }
 
 func (c *Client) createRunOnce(ctx context.Context, experimentID, runName string, tags []Tag) (string, error) {
@@ -425,7 +426,7 @@ func (c *Client) findRunByIdempotencyTag(ctx context.Context, experimentID, idem
 // log-batch is not retried because MLflow params are immutable.
 func (c *Client) callWithIdempotentRetry(ctx context.Context, call func() ([]byte, error)) ([]byte, error) {
 	var lastErr error
-	for attempt := 0; attempt < CreateMaxAttempts; attempt++ {
+	for attempt := 0; attempt < MaxIdempotentAttempts; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -437,8 +438,8 @@ func (c *Client) callWithIdempotentRetry(ctx context.Context, call func() ([]byt
 			return nil, err
 		}
 		lastErr = err
-		if attempt < CreateMaxAttempts-1 {
-			if !sleepWithContext(ctx, createRetryBackoff(attempt)) {
+		if attempt < MaxIdempotentAttempts-1 {
+			if !sleepWithContext(ctx, idempotentRetryBackoff(attempt)) {
 				return nil, ctx.Err()
 			}
 		}
@@ -446,9 +447,11 @@ func (c *Client) callWithIdempotentRetry(ctx context.Context, call func() ([]byt
 	return nil, lastErr
 }
 
-// isRetryableTransientError reports whether an error is transient (a client
-// timeout, network error, or an MLflow 5xx) and therefore worth retrying an
-// idempotent request.
+// isRetryableTransientError reports whether an error is transient and therefore
+// worth retrying an idempotent request. Transient means: a context deadline /
+// client per-call timeout, a network error that reports itself as a timeout, an
+// MLflow API 5xx, or any other transport-level failure surfaced as a *url.Error
+// (e.g. connection reset/refused). Definitive API errors (4xx) are not retried.
 func isRetryableTransientError(err error) bool {
 	if err == nil {
 		return false
@@ -469,9 +472,9 @@ func isRetryableTransientError(err error) bool {
 	return errors.As(err, &urlErr)
 }
 
-// createRetryBackoff returns the wait before the next create attempt.
-func createRetryBackoff(attempt int) time.Duration {
-	return createRetryInitialBackoff * time.Duration(1<<attempt)
+// idempotentRetryBackoff returns the wait before the next retry attempt.
+func idempotentRetryBackoff(attempt int) time.Duration {
+	return idempotentRetryInitialBackoff * time.Duration(1<<attempt)
 }
 
 // sleepWithContext waits for d or until ctx is done, returning false if ctx

--- a/backend/src/common/plugins/mlflow/client_test.go
+++ b/backend/src/common/plugins/mlflow/client_test.go
@@ -264,9 +264,9 @@ func TestCreateExperiment_AlreadyExistsRecoversByName(t *testing.T) {
 }
 
 func TestCreateExperiment_RetriesTransientThenSucceeds(t *testing.T) {
-	restore := createRetryInitialBackoff
-	createRetryInitialBackoff = time.Millisecond
-	defer func() { createRetryInitialBackoff = restore }()
+	restore := idempotentRetryInitialBackoff
+	idempotentRetryInitialBackoff = time.Millisecond
+	defer func() { idempotentRetryInitialBackoff = restore }()
 
 	var calls int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -287,9 +287,9 @@ func TestCreateExperiment_RetriesTransientThenSucceeds(t *testing.T) {
 }
 
 func TestCreateRun_IdempotentRecoversAfterTransientFailure(t *testing.T) {
-	restore := createRetryInitialBackoff
-	createRetryInitialBackoff = time.Millisecond
-	defer func() { createRetryInitialBackoff = restore }()
+	restore := idempotentRetryInitialBackoff
+	idempotentRetryInitialBackoff = time.Millisecond
+	defer func() { idempotentRetryInitialBackoff = restore }()
 
 	// The first create times out server-side (503) but the run was committed;
 	// the client finds it by its idempotency tag and reuses it — no duplicate.
@@ -314,9 +314,9 @@ func TestCreateRun_IdempotentRecoversAfterTransientFailure(t *testing.T) {
 }
 
 func TestCreateRun_DoesNotRecreateWhenSearchCannotConfirm(t *testing.T) {
-	restore := createRetryInitialBackoff
-	createRetryInitialBackoff = time.Millisecond
-	defer func() { createRetryInitialBackoff = restore }()
+	restore := idempotentRetryInitialBackoff
+	idempotentRetryInitialBackoff = time.Millisecond
+	defer func() { idempotentRetryInitialBackoff = restore }()
 
 	// The create fails transiently and the idempotency search also fails, so the
 	// client cannot tell whether the run committed. It must NOT recreate (that
@@ -626,9 +626,9 @@ func TestDoWithRetry_SkipsRetryForRunsCreate(t *testing.T) {
 }
 
 func TestCreateExperiment_RetriesExhaustedOnPersistentFailure(t *testing.T) {
-	restore := createRetryInitialBackoff
-	createRetryInitialBackoff = time.Millisecond
-	defer func() { createRetryInitialBackoff = restore }()
+	restore := idempotentRetryInitialBackoff
+	idempotentRetryInitialBackoff = time.Millisecond
+	defer func() { idempotentRetryInitialBackoff = restore }()
 
 	var callCount int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -642,8 +642,8 @@ func TestCreateExperiment_RetriesExhaustedOnPersistentFailure(t *testing.T) {
 	_, err := c.CreateExperiment(context.Background(), "test-exp", nil)
 	require.Error(t, err)
 	// The transport still does not blindly retry the create; the method-level
-	// idempotent retry attempts it CreateMaxAttempts times before giving up.
-	assert.Equal(t, int32(CreateMaxAttempts), atomic.LoadInt32(&callCount))
+	// idempotent retry attempts it MaxIdempotentAttempts times before giving up.
+	assert.Equal(t, int32(MaxIdempotentAttempts), atomic.LoadInt32(&callCount))
 }
 
 func TestDoWithRetry_SkipsRetryForLogBatch(t *testing.T) {
@@ -874,9 +874,9 @@ func testFormattedTags() []interface{} {
 }
 
 func TestGetExperimentByName_RetriesTransientThenSucceeds(t *testing.T) {
-	restore := createRetryInitialBackoff
-	createRetryInitialBackoff = time.Millisecond
-	defer func() { createRetryInitialBackoff = restore }()
+	restore := idempotentRetryInitialBackoff
+	idempotentRetryInitialBackoff = time.Millisecond
+	defer func() { idempotentRetryInitialBackoff = restore }()
 
 	var calls int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -897,9 +897,9 @@ func TestGetExperimentByName_RetriesTransientThenSucceeds(t *testing.T) {
 }
 
 func TestSearchRuns_RetriesTransientThenSucceeds(t *testing.T) {
-	restore := createRetryInitialBackoff
-	createRetryInitialBackoff = time.Millisecond
-	defer func() { createRetryInitialBackoff = restore }()
+	restore := idempotentRetryInitialBackoff
+	idempotentRetryInitialBackoff = time.Millisecond
+	defer func() { idempotentRetryInitialBackoff = restore }()
 
 	var calls int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/src/common/plugins/mlflow/client_test.go
+++ b/backend/src/common/plugins/mlflow/client_test.go
@@ -872,3 +872,64 @@ func testFormattedTags() []interface{} {
 		},
 	}
 }
+
+func TestGetExperimentByName_RetriesTransientThenSucceeds(t *testing.T) {
+	restore := createRetryInitialBackoff
+	createRetryInitialBackoff = time.Millisecond
+	defer func() { createRetryInitialBackoff = restore }()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable) // transient — the pre-create lookup under load
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"experiment":{"experiment_id":"42","name":"exp"}}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	exp, err := c.GetExperimentByName(context.Background(), "exp")
+	require.NoError(t, err)
+	assert.Equal(t, "42", exp.ID)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2), "the read must retry the transient failure")
+}
+
+func TestSearchRuns_RetriesTransientThenSucceeds(t *testing.T) {
+	restore := createRetryInitialBackoff
+	createRetryInitialBackoff = time.Millisecond
+	defer func() { createRetryInitialBackoff = restore }()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusBadGateway) // transient 502 on the POST search
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"r1"}}]}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	resp, err := c.SearchRuns(context.Background(), []string{"exp-1"}, "", 1, "")
+	require.NoError(t, err)
+	require.Len(t, resp.Runs, 1)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2), "the search must retry the transient failure")
+}
+
+func TestGetExperimentByName_DoesNotRetryDefinitiveError(t *testing.T) {
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusNotFound) // 4xx — definitive, not retryable
+		_, _ = w.Write([]byte(`{"error_code":"RESOURCE_DOES_NOT_EXIST","message":"nope"}`))
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	_, err := c.GetExperimentByName(context.Background(), "exp")
+	require.Error(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a definitive 4xx must not be retried")
+}

--- a/backend/src/common/plugins/mlflow/client_test.go
+++ b/backend/src/common/plugins/mlflow/client_test.go
@@ -933,3 +933,38 @@ func TestGetExperimentByName_DoesNotRetryDefinitiveError(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "a definitive 4xx must not be retried")
 }
+
+// TestGetExperimentByName_RetriesClientTimeoutWithFreshRequest exercises the
+// exact path this fix targets: the first request exceeds the per-call HTTP
+// timeout (which the retryRoundTripper treats as permanent and does NOT retry
+// inside a single Do), and callWithIdempotentRetry recovers it by issuing a
+// fresh request. Without the method-level retry this test fails.
+func TestGetExperimentByName_RetriesClientTimeoutWithFreshRequest(t *testing.T) {
+	restore := idempotentRetryInitialBackoff
+	idempotentRetryInitialBackoff = time.Millisecond
+	defer func() { idempotentRetryInitialBackoff = restore }()
+
+	var calls int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			time.Sleep(300 * time.Millisecond) // first request exceeds the client timeout below
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"experiment":{"experiment_id":"77","name":"exp"}}`))
+	}))
+	defer server.Close()
+
+	// Short per-call timeout so the first (slow) request times out; the round
+	// tripper will not retry that timeout, so recovery must come from the
+	// method-level fresh-request retry.
+	c, err := NewClient(Config{
+		Endpoint:   server.URL,
+		HTTPClient: &http.Client{Timeout: 100 * time.Millisecond},
+	})
+	require.NoError(t, err)
+
+	exp, err := c.GetExperimentByName(context.Background(), "exp")
+	require.NoError(t, err)
+	assert.Equal(t, "77", exp.ID)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2), "the per-call timeout must be retried with a fresh request")
+}


### PR DESCRIPTION
## Summary

Follow-up to #13699 (merged). That PR made the MLflow experiment/run **creates** idempotently retryable, but a merge-ref run of the MLflow E2E lanes still failed with `plugins_output.mlflow.entries should have "root_run_id"` — because the failure was **not** on a create:

```
MLflow OnBeforeRunCreation failed ... GET .../experiments/get-by-name failed:
    Client.Timeout exceeded while awaiting headers
```

`GetExperimentByName` (the lookup that runs *before* the create in `EnsureExperimentExists`) timed out, so the flow never reached a create. An audit of the whole client showed this is architectural, not one method:

| Method | idempotent | timeout-resilient before this PR |
|---|---|---|
| GetExperiment / GetExperimentByName / SearchRuns (reads) | yes | ❌ |
| UpdateRun / SetTag (set / last-write-wins) | yes | ❌ |
| CreateExperiment / CreateRun | made idempotent | ✅ (#13699) |
| LogBatch | **no** (params immutable) | ✅ correctly single-shot |

**Root cause:** the `http.Client` per-call timeout bounds an *entire* `Do` including the `retryRoundTripper`'s retries, and the round tripper classifies timeouts as `backoff.Permanent`. So any single call that times out under load fails with **no** retry. #13699 worked around this only for the creates, via *method-level* retry (each attempt a fresh `Do`). Every other idempotent call was still exposed.

## Change

Add `callWithIdempotentRetry` and apply it to the five previously-unprotected idempotent methods (`GetExperiment`, `GetExperimentByName`, `SearchRuns`, `UpdateRun`, `SetTag`). Each attempt is a fresh request, so several fit within the operation-context budget even though the per-call timeout bounds any single attempt.

- `LogBatch` stays single-shot (non-idempotent — MLflow params are immutable).
- The creates keep their duplicate-protected method-level retry from #13699.
- `isRetryableCreateError` → `isRetryableTransientError` (it now classifies read failures too).
- Dropped the now-redundant retry loop inside `findRunByIdempotencyTag`, since `SearchRuns` retries internally.

## Verification

- New tests: `GetExperimentByName` retries a transient failure then succeeds (the actual failing path); `SearchRuns` retries on the POST path; `GetExperimentByName` does not retry a definitive 4xx.
- `go build` / `go vet` / `gofmt` clean; all three MLflow package suites pass.

## Note

This is the completion of #13699 — same root cause (a saturated single-worker MLflow times out individual calls), now covering the read/update calls rather than only the creates. Verified against the *actual* failing call (`get-by-name`) this time.