### PR TITLE
chore(sdk): run YAPF workflow through make Fixes #11703

### DIFF
--- a/.github/workflows/sdk-yapf.yml
+++ b/.github/workflows/sdk-yapf.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'api/**'
       - 'sdk/python/**'
+      - 'sdk/Makefile'
       - 'test/presubmit-yapf-sdk.sh'
       - '.github/workflows/sdk-yapf.yml'
       - '!**/*.md'
@@ -32,8 +33,8 @@ jobs:
         python-version: '3.9'
         cache: 'pip'
 
-    - name: Install dependencies
-      run: pip install yapf
+    - name: Install YAPF SDK test dependencies
+      run: make -C sdk install-test-yapf-deps
 
     - name: Run YAPF SDK Tests
-      run: ./test/presubmit-yapf-sdk.sh
+      run: make -C sdk test-yapf

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -30,3 +30,12 @@ clean-python:
 	rm -rf python/build
 	rm -rf python/dist
 	rm -rf python/kfp.egg-info
+
+.PHONY: install-test-yapf-deps
+install-test-yapf-deps:
+	cd .. && python3 -m pip install --upgrade pip
+	cd .. && python3 -m pip install $$(grep 'yapf==' sdk/python/requirements-dev.txt) pre_commit_hooks
+
+.PHONY: test-yapf
+test-yapf:
+	cd .. && ./test/presubmit-yapf-sdk.sh

--- a/test/presubmit-yapf-sdk.sh
+++ b/test/presubmit-yapf-sdk.sh
@@ -15,5 +15,5 @@
 
 source_root=$(pwd)
 
-python3 -m pre_commit_hooks.string_fixer $(find sdk/python/kfp/**/*.py -type f)
+find sdk/python/kfp -name '*.py' -type f -print0 | xargs -0 python3 -m pre_commit_hooks.string_fixer
 yapf --recursive --diff "${source_root}/sdk/python/"

--- a/test/presubmit-yapf-sdk.sh
+++ b/test/presubmit-yapf-sdk.sh
@@ -15,8 +15,5 @@
 
 source_root=$(pwd)
 
-python3 -m pip install --upgrade pip
-python3 -m pip install $(grep 'yapf==' sdk/python/requirements-dev.txt)
-python3 -m pip install pre_commit_hooks
 python3 -m pre_commit_hooks.string_fixer $(find sdk/python/kfp/**/*.py -type f)
 yapf --recursive --diff "${source_root}/sdk/python/"


### PR DESCRIPTION
## Summary

Updates the KFP SDK YAPF workflow to call make targets instead of invoking the presubmit script directly.

## Why this helps

This makes the SDK YAPF check easier to reproduce locally and moves the workflow toward the make-based test entrypoints requested in #11703.

## Changes made

- Added `make -C sdk install-test-yapf-deps` for installing the YAPF check dependencies.
- Added `make -C sdk test-yapf` for running the existing SDK YAPF presubmit script.
- Updated `.github/workflows/sdk-yapf.yml` to use the new make targets.
- Moved dependency installation out of `test/presubmit-yapf-sdk.sh` so the test target only runs the check.

## Testing

- `make -C sdk install-test-yapf-deps`
- `make -C sdk test-yapf`
- `git diff --check`

Fixes #11703
