### PR TITLE
ci(e2e): capture ClusterIP dataplane and accept-queue diagnostics

### DIFF
--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -363,12 +363,15 @@ runs:
         if [ "${{ inputs.proxy }}" = "true" ]; then
           ./.github/resources/scripts/collect-logs.sh --ns tinyproxy --output /tmp/tmp_pod_log.txt
         fi
-        # Targeted SeaweedFS diagnostics: E2E lanes intermittently fail with
-        # dial-timeout errors to the SeaweedFS ClusterIP. This captures the
-        # restart/contention/dataplane evidence needed to tell whether a CPU
-        # request bump (which this workflow's manifests carry) is the right
-        # lever or the failure is elsewhere.
-        ./.github/resources/scripts/collect-seaweedfs-diagnostics.sh --namespace "$NAMESPACE" --output /tmp/tmp_pod_log.txt
+        # Dataplane diagnostics: E2E lanes intermittently fail with dial-timeout
+        # errors to in-cluster ClusterIPs (SeaweedFS :9000, the MLflow service
+        # VIP, ...). This captures SeaweedFS restart/contention evidence plus,
+        # per Kind node, the conntrack table state and the iptables/ipvs program
+        # for every ClusterIP the just-collected pod logs recorded a dial
+        # timeout against -- distinguishing conntrack exhaustion from a
+        # missing/stale service program. --dial-timeout-log points at the pod
+        # logs gathered above so the probe self-targets whichever VIP failed.
+        ./.github/resources/scripts/collect-seaweedfs-diagnostics.sh --namespace "$NAMESPACE" --dial-timeout-log /tmp/tmp_pod_log.txt --output /tmp/tmp_pod_log.txt
       continue-on-error: true
 
     - name: Set up Python for reporting

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -19,8 +19,20 @@
 #   3. Cluster dataplane failure     -> SeaweedFS is Running with no restarts
 #                                        and the node is healthy, yet the
 #                                        ClusterIP path times out (kube-proxy /
-#                                        CNI). Captured by ruling out 1 and 2
-#                                        plus kube-proxy pod state.
+#                                        CNI). Ruled in by 1 and 2 being clean
+#                                        plus kube-proxy pod state, and probed
+#                                        directly in section (4).
+#
+# Section (4) inspects the Kind node's netfilter state for the failing
+# SeaweedFS ClusterIP. The leading dataplane candidate is conntrack-table
+# saturation: the nested-parallel lanes open a burst of simultaneous
+# connections, and once the node conntrack table fills, new SYNs are dropped
+# and every dial reports 'i/o timeout' while the pod's own liveness probe
+# (kubelet -> pod IP) keeps passing, so the pod is never restarted. The
+# durable evidence is the cumulative insert_failed/drop counters in
+# /proc/net/stat/nf_conntrack and any 'nf_conntrack: table full' dmesg line;
+# the presence or absence of iptables/ipvs rules for the ClusterIP separates
+# conntrack exhaustion from a missing/stale service program.
 #
 # All commands are best-effort; a missing object never fails the caller.
 
@@ -94,6 +106,43 @@ emit() {
     # label selector matches nothing (and would still exit 0, masking the miss).
     # Empty ENDPOINTS here means the Service has no ready backends.
     kubectl get endpoints seaweedfs -n "$NAMESPACE" -o wide 2>/dev/null || true
+
+    # The ClusterIP is the address the failing dials target; section (4) probes
+    # the node's netfilter state for exactly this VIP.
+    CLUSTER_IP=$(kubectl get svc seaweedfs -n "$NAMESPACE" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
+    echo "SeaweedFS ClusterIP: ${CLUSTER_IP:-<unresolved>}"
+
+    echo
+    echo "----- (4) node netfilter state for ClusterIP ${CLUSTER_IP:-<unresolved>} -----"
+    # Kind runs each node as a Docker container named after the Kubernetes node,
+    # so 'docker exec <node>' reaches the node's network namespace where
+    # kube-proxy programs the ClusterIP and the kernel tracks connections. This
+    # is best-effort: multi-node clusters, non-Docker runtimes, or a locked-down
+    # runner simply skip it.
+    if [[ -z "$NODE" ]]; then
+        echo "Could not resolve SeaweedFS node; skipping node-level dataplane probe."
+    elif ! command -v docker >/dev/null 2>&1 || ! docker inspect "$NODE" >/dev/null 2>&1; then
+        echo "Kind node '$NODE' not inspectable via docker from this runner; skipping node-level dataplane probe."
+    else
+        echo "conntrack in-use / max:"
+        # Point-in-time gauge; may have drained by the time diagnostics run.
+        docker exec "$NODE" sh -c 'cat /proc/sys/net/netfilter/nf_conntrack_count /proc/sys/net/netfilter/nf_conntrack_max 2>/dev/null | paste -sd/ -' 2>/dev/null || echo "(unavailable)"
+        echo "conntrack stat header + totals (durable; nonzero insert_failed/drop == table pressure):"
+        # /proc/net/stat/nf_conntrack has one row per CPU; the insert_failed and
+        # drop columns are cumulative since boot and survive the burst draining.
+        docker exec "$NODE" sh -c 'cat /proc/net/stat/nf_conntrack 2>/dev/null' 2>/dev/null || echo "(unavailable)"
+        echo "kernel 'nf_conntrack: table full' events:"
+        docker exec "$NODE" sh -c "dmesg 2>/dev/null | grep -i 'nf_conntrack: table full' | tail -5" 2>/dev/null || true
+        echo "(if the two lines above are blank, no table-full event was logged)"
+        echo "service program for $CLUSTER_IP (iptables, then ipvs fallback):"
+        if [[ -n "$CLUSTER_IP" ]]; then
+            # Rules present + conntrack pressure == exhaustion; rules absent ==
+            # kube-proxy never (re)programmed the VIP (missing/stale service).
+            docker exec "$NODE" sh -c "iptables-save 2>/dev/null | grep -F '$CLUSTER_IP' || ipvsadm -Ln 2>/dev/null | grep -A4 '$CLUSTER_IP' || echo '(no iptables/ipvs rule references $CLUSTER_IP)'" 2>/dev/null || echo "(unavailable)"
+        else
+            echo "ClusterIP unresolved; cannot query service program."
+        fi
+    fi
 
     echo
     echo "----- full describe (events, resource config) -----"

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -23,19 +23,28 @@
 #                                        plus kube-proxy pod state, and probed
 #                                        directly in section (4).
 #
-# Section (4) inspects every Kind node's netfilter state for the failing
-# SeaweedFS ClusterIP (a ClusterIP dial is DNAT'd and conntrack-tracked on the
-# client pod's node, which need not be the SeaweedFS node). The leading
-# dataplane candidate is conntrack-table saturation: the nested-parallel lanes
-# open a burst of simultaneous connections, and once a node conntrack table
-# fills, new SYNs are dropped and every dial reports 'i/o timeout' while the
-# pod's own liveness probe (kubelet -> pod IP) keeps passing, so the pod is
-# never restarted. The durable evidence is the cumulative insert_failed/drop
-# counters in /proc/net/stat/nf_conntrack and any 'nf_conntrack: table full'
-# dmesg line; the presence or absence of iptables/ipvs rules for the ClusterIP
-# separates conntrack exhaustion from a missing/stale service program. Each
-# probe distinguishes a failed/forbidden query from a genuinely empty result
-# so a blank line never falsely rules out the signal.
+# The same 'dial tcp <clusterip>: i/o timeout' signature shows up on other
+# in-cluster ClusterIPs in these lanes (for example the MLflow service VIP on
+# :8443), so the dataplane failure is not SeaweedFS-specific. Section (4)
+# therefore probes the node netfilter state for *every* ClusterIP that recorded
+# a dial timeout, not just SeaweedFS's. Pass the already-collected pod-log file
+# via --dial-timeout-log; the script extracts each timed-out VIP from it and
+# always includes the SeaweedFS ClusterIP.
+#
+# Section (4) inspects every Kind node (a ClusterIP dial is DNAT'd and
+# conntrack-tracked on the *client* pod's node, which need not be the service's
+# node). The leading dataplane candidate is conntrack-table saturation: the
+# nested-parallel lanes open a burst of simultaneous connections, and once a
+# node conntrack table fills, new SYNs are dropped and every dial reports 'i/o
+# timeout' while the backing pod's own liveness probe (kubelet -> pod IP) keeps
+# passing, so the pod is never restarted. Per node it dumps the node-global
+# conntrack state once -- the cumulative insert_failed/drop counters in
+# /proc/net/stat/nf_conntrack and any 'nf_conntrack: table full' dmesg line are
+# the durable exhaustion evidence -- then the iptables/ipvs program for each
+# timed-out ClusterIP, whose presence or absence separates conntrack exhaustion
+# from a missing/stale service program. Each probe distinguishes a
+# failed/forbidden query from a genuinely empty result so a blank line never
+# falsely rules out the signal.
 #
 # All commands are best-effort; a missing object never fails the caller.
 
@@ -44,12 +53,16 @@ set -u
 NAMESPACE="kubeflow"
 SELECTOR="app=seaweedfs"
 OUTPUT_FILE=""
+DIAL_TIMEOUT_LOG=""
 
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
         --namespace) NAMESPACE="${2:?--namespace requires a value}"; shift ;;
         --selector) SELECTOR="${2:?--selector requires a value}"; shift ;;
         --output) OUTPUT_FILE="${2:?--output requires a value}"; shift ;;
+        # A log (typically the already-collected pod logs) to scan for
+        # 'dial tcp <ip>:<port>: i/o timeout'; section (4) probes each such VIP.
+        --dial-timeout-log) DIAL_TIMEOUT_LOG="${2:?--dial-timeout-log requires a value}"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -63,6 +76,40 @@ emit() {
         cat
     fi
 }
+
+# Dump the iptables (or ipvs fallback) program for one ClusterIP on one Kind
+# node. Tracks whether a ruleset was actually read so a missing iptables-save /
+# ipvsadm binary reports "cannot confirm", never a false "no rule".
+# Usage: probe_service_rules <node> <ip>
+probe_service_rules() {
+    docker exec "$1" sh -c '
+        ip=$1
+        read_any=0
+        match=""
+        if ipt=$(iptables-save 2>/dev/null); then
+            read_any=1
+            match=$(printf "%s\n" "$ipt" | grep -F "$ip")
+        fi
+        if [ -z "$match" ] && ipvs=$(ipvsadm -Ln 2>/dev/null); then
+            read_any=1
+            match=$(printf "%s\n" "$ipvs" | grep -A4 "$ip")
+        fi
+        if [ -n "$match" ]; then
+            printf "%s\n" "$match"
+        elif [ "$read_any" = 1 ]; then
+            echo "(no iptables/ipvs rule references $ip)"
+        else
+            echo "(iptables-save and ipvsadm both unavailable — cannot confirm rule presence)"
+        fi' _ "$2" 2>/dev/null || echo "(unavailable)"
+}
+
+# ClusterIP VIPs (ip:port) that recorded a dial timeout in the supplied log.
+# Read before the diagnostics block so appended output cannot perturb the scan.
+LOG_VIPS=""
+if [[ -n "$DIAL_TIMEOUT_LOG" && -r "$DIAL_TIMEOUT_LOG" ]]; then
+    LOG_VIPS=$(grep -oE 'dial tcp [0-9.]+:[0-9]+: i/o timeout' "$DIAL_TIMEOUT_LOG" 2>/dev/null \
+        | grep -oE '[0-9.]+:[0-9]+' | sort -u || true)
+fi
 
 {
     echo "================ SeaweedFS failure diagnostics ================"
@@ -110,20 +157,31 @@ emit() {
     # Empty ENDPOINTS here means the Service has no ready backends.
     kubectl get endpoints seaweedfs -n "$NAMESPACE" -o wide 2>/dev/null || true
 
-    # The ClusterIP is the address the failing dials target; section (4) probes
-    # the node's netfilter state for exactly this VIP.
+    # The SeaweedFS ClusterIP is always probed; the service listens on :9000
+    # (DNAT'd to the pod's S3 port), which is the address the failing dials
+    # target.
     CLUSTER_IP=$(kubectl get svc seaweedfs -n "$NAMESPACE" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
     echo "SeaweedFS ClusterIP: ${CLUSTER_IP:-<unresolved>}"
 
+    # Section (4) targets the SeaweedFS VIP plus every other ClusterIP that a
+    # dial timeout was logged against (e.g. the MLflow service VIP), so the
+    # dataplane evidence covers whichever service the workflow pods could not
+    # reach, not only SeaweedFS.
+    TARGET_VIPS=$(
+        { [[ -n "$CLUSTER_IP" ]] && echo "${CLUSTER_IP}:9000"; printf '%s\n' "$LOG_VIPS"; } \
+            | grep -E '^[0-9.]+:[0-9]+$' | sort -u
+    )
+
     echo
-    echo "----- (4) node netfilter state for ClusterIP ${CLUSTER_IP:-<unresolved>} -----"
+    echo "----- (4) node netfilter state for timed-out ClusterIPs -----"
+    echo "ClusterIPs correlated: $(printf '%s ' ${TARGET_VIPS:-<none>})"
     # Kind runs each node as a Docker container named after the Kubernetes node,
     # so 'docker exec <node>' reaches the node's network namespace where
-    # kube-proxy programs the ClusterIP and the kernel tracks connections. A
+    # kube-proxy programs the ClusterIPs and the kernel tracks connections. A
     # ClusterIP dial is DNAT'd and conntrack-tracked on the *client* pod's node,
-    # which need not be the SeaweedFS node, so probe every Kind node rather than
-    # only the destination. Best-effort: nodes that are not Docker containers
-    # (non-Kind / remote runtime) or an unreachable daemon skip individually.
+    # which need not be the service's node, so probe every Kind node rather than
+    # only one. Best-effort: nodes that are not Docker containers (non-Kind /
+    # remote runtime) or an unreachable daemon skip individually.
     if ! command -v docker >/dev/null 2>&1; then
         echo "docker not available from this runner; skipping node-level dataplane probe."
     else
@@ -138,6 +196,9 @@ emit() {
                 continue
             fi
 
+            # Node-global conntrack state: independent of any single VIP, so it
+            # is dumped once per node and answers "is this node's conntrack
+            # table exhausted?" for every timed-out ClusterIP at once.
             echo "conntrack in-use / max:"
             # Point-in-time gauge; may have drained by the time diagnostics run.
             docker exec "$node" sh -c 'cat /proc/sys/net/netfilter/nf_conntrack_count /proc/sys/net/netfilter/nf_conntrack_max 2>/dev/null | paste -sd/ -' 2>/dev/null || echo "(unavailable)"
@@ -160,34 +221,16 @@ emit() {
                     echo "(no table-full event logged)"
                 fi' 2>/dev/null || echo "(unavailable)"
 
-            echo "service program for ${CLUSTER_IP:-<unresolved>} (iptables, then ipvs):"
-            # Rules present + conntrack pressure == exhaustion; rules absent ==
-            # kube-proxy never (re)programmed the VIP. Track whether any ruleset
-            # was actually read so a missing iptables/ipvsadm binary is reported
-            # as "cannot confirm", never as confirmed rule absence.
-            if [[ -z "$CLUSTER_IP" ]]; then
-                echo "ClusterIP unresolved; cannot query service program."
-                continue
+            # Per-VIP service program: rules present + conntrack pressure ==
+            # exhaustion; rules absent == kube-proxy never (re)programmed the VIP.
+            if [[ -z "$TARGET_VIPS" ]]; then
+                echo "service program: no timed-out ClusterIPs to correlate."
+            else
+                for vip in $TARGET_VIPS; do
+                    echo "service program for $vip (iptables, then ipvs):"
+                    probe_service_rules "$node" "${vip%%:*}"
+                done
             fi
-            docker exec "$node" sh -c '
-                ip=$1
-                read_any=0
-                match=""
-                if ipt=$(iptables-save 2>/dev/null); then
-                    read_any=1
-                    match=$(printf "%s\n" "$ipt" | grep -F "$ip")
-                fi
-                if [ -z "$match" ] && ipvs=$(ipvsadm -Ln 2>/dev/null); then
-                    read_any=1
-                    match=$(printf "%s\n" "$ipvs" | grep -A4 "$ip")
-                fi
-                if [ -n "$match" ]; then
-                    printf "%s\n" "$match"
-                elif [ "$read_any" = 1 ]; then
-                    echo "(no iptables/ipvs rule references $ip)"
-                else
-                    echo "(iptables-save and ipvsadm both unavailable — cannot confirm rule presence)"
-                fi' _ "$CLUSTER_IP" 2>/dev/null || echo "(unavailable)"
         done
     fi
 

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -33,18 +33,24 @@
 #
 # Section (4) inspects every Kind node (a ClusterIP dial is DNAT'd and
 # conntrack-tracked on the *client* pod's node, which need not be the service's
-# node). The leading dataplane candidate is conntrack-table saturation: the
+# node). One dataplane candidate is conntrack-table saturation: the
 # nested-parallel lanes open a burst of simultaneous connections, and once a
 # node conntrack table fills, new SYNs are dropped and every dial reports 'i/o
 # timeout' while the backing pod's own liveness probe (kubelet -> pod IP) keeps
 # passing, so the pod is never restarted. Per node it dumps the node-global
-# conntrack state once -- the cumulative insert_failed/drop counters in
-# /proc/net/stat/nf_conntrack and any 'nf_conntrack: table full' dmesg line are
-# the durable exhaustion evidence -- then the iptables/ipvs program for each
-# timed-out ClusterIP, whose presence or absence separates conntrack exhaustion
-# from a missing/stale service program. Each probe distinguishes a
-# failed/forbidden query from a genuinely empty result so a blank line never
-# falsely rules out the signal.
+# conntrack state once -- the durable drop/insert_failed counters (conntrack -S,
+# falling back to /proc/net/stat/nf_conntrack) and any 'nf_conntrack: table
+# full' dmesg line -- then the iptables/ipvs program for each timed-out
+# ClusterIP, followed end to end (KUBE-SERVICES -> KUBE-SVC -> KUBE-SEP DNAT) so
+# a live endpoint DNAT rules out a missing/stale service program.
+#
+# When the conntrack table and the service program are both clean (as first
+# observed live: table ~0.6% full, no table-full event, KUBE-SEP DNAT present),
+# the remaining candidate is accept-queue saturation on the backing pod itself.
+# Section (5) reads the SeaweedFS pod's listen sockets and cumulative
+# ListenOverflows / ListenDrops from inside its netns to confirm or rule that
+# out. Each probe distinguishes a failed/forbidden query from a genuinely empty
+# result so a blank line never falsely rules out the signal.
 #
 # All commands are best-effort; a missing object never fails the caller.
 
@@ -77,30 +83,54 @@ emit() {
     fi
 }
 
-# Dump the iptables (or ipvs fallback) program for one ClusterIP on one Kind
-# node. Tracks whether a ruleset was actually read so a missing iptables-save /
+# Dump the iptables (or ipvs fallback) program for one ClusterIP:port on one
+# Kind node, following the chain end to end: the KUBE-SERVICES match, the
+# KUBE-SVC chain for the port, and the KUBE-SEP DNAT to the backing pod. A live
+# KUBE-SEP DNAT proves kube-proxy programmed a real endpoint (so a dial timeout
+# is not a missing/stale rule); an empty KUBE-SVC chain means no ready backend.
+# Tracks whether a ruleset was actually read so a missing iptables-save /
 # ipvsadm binary reports "cannot confirm", never a false "no rule".
-# Usage: probe_service_rules <node> <ip>
+# Usage: probe_service_rules <node> <ip> <port>
 probe_service_rules() {
     docker exec "$1" sh -c '
-        ip=$1
-        read_any=0
-        match=""
-        if ipt=$(iptables-save 2>/dev/null); then
-            read_any=1
-            match=$(printf "%s\n" "$ipt" | grep -F "$ip")
+        ip=$1; port=$2
+        rules=$(iptables-save 2>/dev/null)
+        if [ -z "$rules" ]; then
+            if ipvs=$(ipvsadm -Ln 2>/dev/null); then
+                printf "%s\n" "$ipvs" | grep -A6 "$ip:$port" \
+                    || echo "(no ipvs entry for $ip:$port)"
+            else
+                echo "(iptables-save and ipvsadm both unavailable — cannot confirm rule presence)"
+            fi
+            exit 0
         fi
-        if [ -z "$match" ] && ipvs=$(ipvsadm -Ln 2>/dev/null); then
-            read_any=1
-            match=$(printf "%s\n" "$ipvs" | grep -A4 "$ip")
-        fi
-        if [ -n "$match" ]; then
-            printf "%s\n" "$match"
-        elif [ "$read_any" = 1 ]; then
-            echo "(no iptables/ipvs rule references $ip)"
+        svc_rules=$(printf "%s\n" "$rules" | grep -F "$ip" | grep -E "KUBE-SERVICES|KUBE-MARK-MASQ")
+        if [ -n "$svc_rules" ]; then
+            printf "%s\n" "$svc_rules"
         else
-            echo "(iptables-save and ipvsadm both unavailable — cannot confirm rule presence)"
-        fi' _ "$2" 2>/dev/null || echo "(unavailable)"
+            echo "(no KUBE-SERVICES rule references $ip)"
+        fi
+        # Resolve the KUBE-SVC chain for this specific port, then its KUBE-SEP
+        # endpoint chain(s) and their DNAT target (the pod the VIP forwards to).
+        svc=$(printf "%s\n" "$rules" | grep -F "$ip" | grep -E -- "--dport $port -j KUBE-SVC-" \
+            | grep -oE "KUBE-SVC-[A-Z0-9]+" | head -1)
+        if [ -z "$svc" ]; then
+            echo "  (no KUBE-SVC chain for $ip:$port — port not programmed)"
+            exit 0
+        fi
+        echo "  endpoint chain $svc ->"
+        printf "%s\n" "$rules" | grep -E -- "-A $svc " | sed "s/^/    /" \
+            || echo "    (chain $svc empty — no ready endpoints)"
+        seps=$(printf "%s\n" "$rules" | grep -E -- "-A $svc .*-j KUBE-SEP-" \
+            | grep -oE "KUBE-SEP-[A-Z0-9]+" | sort -u)
+        if [ -z "$seps" ]; then
+            echo "    (no KUBE-SEP endpoint jump — VIP has no live backend)"
+        else
+            for sep in $seps; do
+                printf "%s\n" "$rules" | grep -E -- "-A $sep .*(DNAT|to-destination)" | sed "s/^/    /" \
+                    || echo "    ($sep: no DNAT rule)"
+            done
+        fi' _ "$2" "$3" 2>/dev/null || echo "(unavailable)"
 }
 
 # ClusterIP VIPs (ip:port) that recorded a dial timeout in the supplied log.
@@ -203,11 +233,19 @@ fi
             # Point-in-time gauge; may have drained by the time diagnostics run.
             docker exec "$node" sh -c 'cat /proc/sys/net/netfilter/nf_conntrack_count /proc/sys/net/netfilter/nf_conntrack_max 2>/dev/null | paste -sd/ -' 2>/dev/null || echo "(unavailable)"
 
-            echo "conntrack stat header + totals (durable; nonzero insert_failed/drop == table pressure):"
-            # /proc/net/stat/nf_conntrack has one row per CPU; the insert_failed
-            # and drop columns are cumulative since boot and survive the burst
-            # draining.
-            docker exec "$node" sh -c 'cat /proc/net/stat/nf_conntrack 2>/dev/null' 2>/dev/null || echo "(unavailable)"
+            echo "conntrack drop / insert_failed counters (durable; nonzero == table pressure):"
+            # Cumulative-since-boot counters survive the burst draining, unlike
+            # the in-use gauge above. 'conntrack -S' is the reliable source;
+            # /proc/net/stat/nf_conntrack is a fallback but was observed absent
+            # on some Kind node kernels, so try the CLI first.
+            docker exec "$node" sh -c '
+                if command -v conntrack >/dev/null 2>&1 && conntrack -S 2>/dev/null; then
+                    :
+                elif [ -r /proc/net/stat/nf_conntrack ]; then
+                    cat /proc/net/stat/nf_conntrack
+                else
+                    echo "(conntrack -S and /proc/net/stat/nf_conntrack both unavailable)"
+                fi' 2>/dev/null || echo "(unavailable)"
 
             echo "kernel 'nf_conntrack: table full' events:"
             # Distinguish a forbidden/failed dmesg from a successful empty query:
@@ -221,18 +259,37 @@ fi
                     echo "(no table-full event logged)"
                 fi' 2>/dev/null || echo "(unavailable)"
 
-            # Per-VIP service program: rules present + conntrack pressure ==
-            # exhaustion; rules absent == kube-proxy never (re)programmed the VIP.
+            # Per-VIP service program end to end (KUBE-SERVICES -> KUBE-SVC ->
+            # KUBE-SEP DNAT): a live DNAT to the pod means the rule is not the
+            # problem; an empty chain means no ready backend.
             if [[ -z "$TARGET_VIPS" ]]; then
                 echo "service program: no timed-out ClusterIPs to correlate."
             else
                 for vip in $TARGET_VIPS; do
                     echo "service program for $vip (iptables, then ipvs):"
-                    probe_service_rules "$node" "${vip%%:*}"
+                    probe_service_rules "$node" "${vip%%:*}" "${vip##*:}"
                 done
             fi
         done
     fi
+
+    echo
+    echo "----- (5) SeaweedFS pod socket / listen-queue state -----"
+    # Once the node conntrack table and the service program are clean, the
+    # leading remaining cause of the ClusterIP dial timeouts is accept-queue
+    # saturation: under the parallel burst the S3 server's listen backlog
+    # overflows and new SYNs are dropped inside the pod netns (the client sees a
+    # dial timeout) while an already-established liveness connection keeps
+    # passing, so the pod is never restarted. ListenOverflows / ListenDrops in
+    # the pod's /proc/net/netstat are cumulative since pod start, so they
+    # survive the burst; 'ss -lnt' shows the live backlog (Recv-Q = pending
+    # connections, Send-Q = backlog limit) when iproute2 is present. Read from
+    # inside the pod netns via kubectl exec; best-effort if the container lacks
+    # a shell or the tools.
+    echo "listen sockets (Recv-Q=pending backlog / Send-Q=backlog limit):"
+    kubectl exec "$POD" -n "$NAMESPACE" -c seaweedfs -- sh -c 'ss -lnt 2>/dev/null || netstat -lnt 2>/dev/null || echo "(ss/netstat not present in container)"' 2>/dev/null || echo "(kubectl exec unavailable)"
+    echo "TcpExt counters (nonzero ListenOverflows / ListenDrops == accept-queue saturation):"
+    kubectl exec "$POD" -n "$NAMESPACE" -c seaweedfs -- sh -c 'grep "^TcpExt" /proc/net/netstat 2>/dev/null || echo "(/proc/net/netstat unavailable)"' 2>/dev/null || echo "(kubectl exec unavailable)"
 
     echo
     echo "----- full describe (events, resource config) -----"

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -23,16 +23,19 @@
 #                                        plus kube-proxy pod state, and probed
 #                                        directly in section (4).
 #
-# Section (4) inspects the Kind node's netfilter state for the failing
-# SeaweedFS ClusterIP. The leading dataplane candidate is conntrack-table
-# saturation: the nested-parallel lanes open a burst of simultaneous
-# connections, and once the node conntrack table fills, new SYNs are dropped
-# and every dial reports 'i/o timeout' while the pod's own liveness probe
-# (kubelet -> pod IP) keeps passing, so the pod is never restarted. The
-# durable evidence is the cumulative insert_failed/drop counters in
-# /proc/net/stat/nf_conntrack and any 'nf_conntrack: table full' dmesg line;
-# the presence or absence of iptables/ipvs rules for the ClusterIP separates
-# conntrack exhaustion from a missing/stale service program.
+# Section (4) inspects every Kind node's netfilter state for the failing
+# SeaweedFS ClusterIP (a ClusterIP dial is DNAT'd and conntrack-tracked on the
+# client pod's node, which need not be the SeaweedFS node). The leading
+# dataplane candidate is conntrack-table saturation: the nested-parallel lanes
+# open a burst of simultaneous connections, and once a node conntrack table
+# fills, new SYNs are dropped and every dial reports 'i/o timeout' while the
+# pod's own liveness probe (kubelet -> pod IP) keeps passing, so the pod is
+# never restarted. The durable evidence is the cumulative insert_failed/drop
+# counters in /proc/net/stat/nf_conntrack and any 'nf_conntrack: table full'
+# dmesg line; the presence or absence of iptables/ipvs rules for the ClusterIP
+# separates conntrack exhaustion from a missing/stale service program. Each
+# probe distinguishes a failed/forbidden query from a genuinely empty result
+# so a blank line never falsely rules out the signal.
 #
 # All commands are best-effort; a missing object never fails the caller.
 
@@ -116,32 +119,76 @@ emit() {
     echo "----- (4) node netfilter state for ClusterIP ${CLUSTER_IP:-<unresolved>} -----"
     # Kind runs each node as a Docker container named after the Kubernetes node,
     # so 'docker exec <node>' reaches the node's network namespace where
-    # kube-proxy programs the ClusterIP and the kernel tracks connections. This
-    # is best-effort: multi-node clusters, non-Docker runtimes, or a locked-down
-    # runner simply skip it.
-    if [[ -z "$NODE" ]]; then
-        echo "Could not resolve SeaweedFS node; skipping node-level dataplane probe."
-    elif ! command -v docker >/dev/null 2>&1 || ! docker inspect "$NODE" >/dev/null 2>&1; then
-        echo "Kind node '$NODE' not inspectable via docker from this runner; skipping node-level dataplane probe."
+    # kube-proxy programs the ClusterIP and the kernel tracks connections. A
+    # ClusterIP dial is DNAT'd and conntrack-tracked on the *client* pod's node,
+    # which need not be the SeaweedFS node, so probe every Kind node rather than
+    # only the destination. Best-effort: nodes that are not Docker containers
+    # (non-Kind / remote runtime) or an unreachable daemon skip individually.
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "docker not available from this runner; skipping node-level dataplane probe."
     else
-        echo "conntrack in-use / max:"
-        # Point-in-time gauge; may have drained by the time diagnostics run.
-        docker exec "$NODE" sh -c 'cat /proc/sys/net/netfilter/nf_conntrack_count /proc/sys/net/netfilter/nf_conntrack_max 2>/dev/null | paste -sd/ -' 2>/dev/null || echo "(unavailable)"
-        echo "conntrack stat header + totals (durable; nonzero insert_failed/drop == table pressure):"
-        # /proc/net/stat/nf_conntrack has one row per CPU; the insert_failed and
-        # drop columns are cumulative since boot and survive the burst draining.
-        docker exec "$NODE" sh -c 'cat /proc/net/stat/nf_conntrack 2>/dev/null' 2>/dev/null || echo "(unavailable)"
-        echo "kernel 'nf_conntrack: table full' events:"
-        docker exec "$NODE" sh -c "dmesg 2>/dev/null | grep -i 'nf_conntrack: table full' | tail -5" 2>/dev/null || true
-        echo "(if the two lines above are blank, no table-full event was logged)"
-        echo "service program for $CLUSTER_IP (iptables, then ipvs fallback):"
-        if [[ -n "$CLUSTER_IP" ]]; then
-            # Rules present + conntrack pressure == exhaustion; rules absent ==
-            # kube-proxy never (re)programmed the VIP (missing/stale service).
-            docker exec "$NODE" sh -c "iptables-save 2>/dev/null | grep -F '$CLUSTER_IP' || ipvsadm -Ln 2>/dev/null | grep -A4 '$CLUSTER_IP' || echo '(no iptables/ipvs rule references $CLUSTER_IP)'" 2>/dev/null || echo "(unavailable)"
-        else
-            echo "ClusterIP unresolved; cannot query service program."
+        NODES=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
+        if [[ -z "$NODES" ]]; then
+            echo "Could not list cluster nodes; skipping node-level dataplane probe."
         fi
+        for node in $NODES; do
+            echo "===== node: $node ====="
+            if ! docker inspect "$node" >/dev/null 2>&1; then
+                echo "Node '$node' is not a Docker container (non-Kind or remote runtime); skipping."
+                continue
+            fi
+
+            echo "conntrack in-use / max:"
+            # Point-in-time gauge; may have drained by the time diagnostics run.
+            docker exec "$node" sh -c 'cat /proc/sys/net/netfilter/nf_conntrack_count /proc/sys/net/netfilter/nf_conntrack_max 2>/dev/null | paste -sd/ -' 2>/dev/null || echo "(unavailable)"
+
+            echo "conntrack stat header + totals (durable; nonzero insert_failed/drop == table pressure):"
+            # /proc/net/stat/nf_conntrack has one row per CPU; the insert_failed
+            # and drop columns are cumulative since boot and survive the burst
+            # draining.
+            docker exec "$node" sh -c 'cat /proc/net/stat/nf_conntrack 2>/dev/null' 2>/dev/null || echo "(unavailable)"
+
+            echo "kernel 'nf_conntrack: table full' events:"
+            # Distinguish a forbidden/failed dmesg from a successful empty query:
+            # a blank line must not read as "no event" and falsely rule out the
+            # main signal this section captures.
+            docker exec "$node" sh -c '
+                out=$(dmesg 2>/dev/null) || { echo "(dmesg unavailable — cannot confirm table-full events)"; exit 0; }
+                if printf "%s\n" "$out" | grep -qi "nf_conntrack: table full"; then
+                    printf "%s\n" "$out" | grep -i "nf_conntrack: table full" | tail -5
+                else
+                    echo "(no table-full event logged)"
+                fi' 2>/dev/null || echo "(unavailable)"
+
+            echo "service program for ${CLUSTER_IP:-<unresolved>} (iptables, then ipvs):"
+            # Rules present + conntrack pressure == exhaustion; rules absent ==
+            # kube-proxy never (re)programmed the VIP. Track whether any ruleset
+            # was actually read so a missing iptables/ipvsadm binary is reported
+            # as "cannot confirm", never as confirmed rule absence.
+            if [[ -z "$CLUSTER_IP" ]]; then
+                echo "ClusterIP unresolved; cannot query service program."
+                continue
+            fi
+            docker exec "$node" sh -c '
+                ip=$1
+                read_any=0
+                match=""
+                if ipt=$(iptables-save 2>/dev/null); then
+                    read_any=1
+                    match=$(printf "%s\n" "$ipt" | grep -F "$ip")
+                fi
+                if [ -z "$match" ] && ipvs=$(ipvsadm -Ln 2>/dev/null); then
+                    read_any=1
+                    match=$(printf "%s\n" "$ipvs" | grep -A4 "$ip")
+                fi
+                if [ -n "$match" ]; then
+                    printf "%s\n" "$match"
+                elif [ "$read_any" = 1 ]; then
+                    echo "(no iptables/ipvs rule references $ip)"
+                else
+                    echo "(iptables-save and ipvsadm both unavailable — cannot confirm rule presence)"
+                fi' _ "$CLUSTER_IP" 2>/dev/null || echo "(unavailable)"
+        done
     fi
 
     echo


### PR DESCRIPTION
## Problem

E2E lanes intermittently fail with bursts of:

```
dial tcp <clusterip>:<port>: i/o timeout
```

while pipelines communicate with in-cluster services. This fingerprint means the TCP connection to the **service ClusterIP** did not establish, while the backing pod's `httpGet /status` liveness probe—run by kubelet against the **pod IP**—can continue passing. The pod therefore remains `Ready` and is not restarted.

#13686 added SeaweedFS restart, pod, and node-contention diagnostics, but it did not inspect the ClusterIP datapath directly.

**This is not necessarily SeaweedFS-specific.** SeaweedFS (`:9000`) and MLflow (`:8443`) service VIPs have both timed out on the same node in the same E2E job, which makes a shared node-level datapath failure one candidate alongside service-specific backend saturation.

## Change

Extend `collect-seaweedfs-diagnostics.sh` with failure-only node and pod datapath probes:

- New `--dial-timeout-log <file>` support scans the already-collected pod logs for every `dial tcp <ip>:<port>: i/o timeout` VIP. Section (4) probes the SeaweedFS ClusterIP plus every discovered VIP, with no additional service names hardcoded.
- The script inspects **every Kind node**, because ClusterIP DNAT and conntrack processing occur on the client pod's node. Per node it captures:
  - the current conntrack count/max;
  - durable `drop` / `insert_failed` counters via `conntrack -S`, falling back to `/proc/net/stat/nf_conntrack`;
  - any `nf_conntrack: table full` kernel messages;
  - the service program for each VIP, followed end to end through KUBE-SERVICES → KUBE-SVC → KUBE-SEP → the DNAT target.
- Section (5) captures the SeaweedFS pod's listen sockets and cumulative `ListenOverflows` / `ListenDrops` counters. Nonzero counters would support accept-queue saturation as the cause of dropped SYNs while the pod remained healthy.

Each probe distinguishes an unavailable or forbidden query from a successful empty result. The collector remains best-effort: missing tools, non-Docker nodes, or failed diagnostic commands do not fail the caller. Passing runs are unchanged because these probes execute only in the existing failure-diagnostics path.

## Live result and remaining evidence gap

An earlier version of section (4) ran on a real SeaweedFS `:9000` dial-timeout failure ([job 86648705812](https://github.com/kubeflow/pipelines/actions/runs/29152867712/job/86648705812), E2EParallelNested v1.36.1, 64 dial timeouts). It found:

```
conntrack in-use / max: 1726/262144
kernel 'nf_conntrack: table full' events: (no table-full event logged)
service program for 10.96.25.77:9000: top-level KUBE-SERVICES rule present
```

That evidence made sustained conntrack exhaustion unlikely and confirmed that the top-level VIP rule existed, but it did **not** conclusively rule out either category:

- the point-in-time conntrack gauge may have drained, and the intended durable `/proc/net/stat/nf_conntrack` source was unavailable;
- the probe did not yet traverse KUBE-SVC/KUBE-SEP or verify the endpoint DNAT.

The current revision adds the missing durable `conntrack -S` counters, complete endpoint-chain traversal, and SeaweedFS accept-queue counters. Those refinements have been exercised with stubs but have not yet captured another real dial-timeout occurrence. This PR is therefore diagnostic instrumentation, not a root-cause fix.

## Verification

- `bash -n` clean.
- Stubbed runs exercised:
  - multi-VIP discovery and deduplication, plus SeaweedFS-only compatibility;
  - the multi-node loop;
  - KUBE-SERVICES → KUBE-SVC → KUBE-SEP → DNAT traversal;
  - `conntrack -S` present, absent, and error paths;
  - SeaweedFS listen-queue counters;
  - unavailable `dmesg` and missing rule-tool distinctions.

Follow-up to #13686.
