### PR TITLE
test(backend): stop TerminateRun assertions racing on the transient terminating state (v1 + v2)

### DIFF
--- a/backend/test/integration/run_api_test.go
+++ b/backend/test/integration/run_api_test.go
@@ -368,11 +368,19 @@ func (s *RunApiTestSuite) checkTerminatedRunDetail(t *testing.T, runDetail *run_
 	// Check runtime workflow manifest is not empty
 	assert.Contains(t, runDetail.PipelineRuntime.WorkflowManifest, "wait-awhile")
 
+	// A terminate request moves the run from "Terminating" to "Failed" (the v1
+	// status a canceled run maps to) as the workflow stops. Depending on timing
+	// before this Get either is a valid post-terminate status, so assert
+	// membership and copy the actual status into the expected run below rather
+	// than racing on the transient "Terminating".
+	assert.Contains(t, []string{"Terminating", "Failed"}, runDetail.Run.Status,
+		"terminated run should be Terminating or Failed")
+
 	expectedRun := &run_model.APIRun{
 		ID:             runDetail.Run.ID,
 		Name:           "long running",
 		Description:    "this pipeline will run long enough for us to manually terminate it before it finishes",
-		Status:         "Terminating",
+		Status:         runDetail.Run.Status,
 		ServiceAccount: test.GetDefaultPipelineRunnerServiceAccount(*isKubeflowMode),
 		PipelineSpec: &run_model.APIPipelineSpec{
 			PipelineID:       runDetail.Run.PipelineSpec.PipelineID,

--- a/backend/test/v2/integration/run_api_test.go
+++ b/backend/test/v2/integration/run_api_test.go
@@ -350,11 +350,28 @@ func (s *RunAPITestSuite) TestRunAPIs() {
 
 func (s *RunAPITestSuite) checkTerminatedRunDetail(t *testing.T, run *run_model.V2beta1Run, experimentID string, pipelineID string, pipelineVersionID string) {
 
+	// A terminate request moves the run from CANCELING to CANCELED as the
+	// workflow controller reacts. Depending on timing before this Get, either is
+	// a valid post-terminate state, so assert membership rather than racing on
+	// the transient CANCELING. State and RunDetails are then copied into the
+	// expected struct below so the equality check focuses on the stable,
+	// test-owned fields (like the already-copied CreatedAt/StateHistory).
+	if assert.NotNil(t, run.State, "terminated run should have a State") {
+		assert.Contains(t,
+			[]run_model.V2beta1RuntimeState{
+				run_model.V2beta1RuntimeStateCANCELING,
+				run_model.V2beta1RuntimeStateCANCELED,
+			},
+			*run.State,
+			"terminated run should be CANCELING or CANCELED")
+	}
+
 	expectedRun := &run_model.V2beta1Run{
 		RunID:          run.RunID,
 		DisplayName:    "long running",
 		Description:    "this pipeline will run long enough for us to manually terminate it before it finishes",
-		State:          run_model.V2beta1RuntimeStateCANCELING.Pointer(),
+		State:          run.State,
+		RunDetails:     run.RunDetails,
 		StateHistory:   run.StateHistory,
 		StorageState:   run.StorageState,
 		ServiceAccount: test.GetDefaultPipelineRunnerServiceAccount(*isKubeflowMode),


### PR DESCRIPTION
## Problem

The TerminateRun integration assertions compare the whole run object against a struct that **hardcodes the transient terminating state**, so they race the workflow controller:

- **v2** (`backend/test/v2/integration/run_api_test.go`) — `checkTerminatedRunDetail` hardcodes `State: CANCELING` and leaves `RunDetails` nil, then `assert.Equal`. A terminate moves the run `CANCELING → CANCELED` and populates `RunDetails` as it winds down.
- **v1** (`backend/test/integration/run_api_test.go`) — `checkTerminatedRunDetail` hardcodes `Status: "Terminating"`, then `cmp.Diff`. A terminated v1 run moves `"Terminating" → "Failed"` (`RuntimeState.ToV1` maps a `CANCELED` run to `Failed`).

Depending on timing before the `Get`, the run can already be in the terminal state, so the exact-equality assertion is inherently flaky. Observed on the v1.36.1 `pod_to_pod_tls_enabled=true` API-integration lane (`run_api_test.go:374`), where the diff was purely the lifecycle fields (`State`/`RunDetails`). Surfaced while investigating an unrelated rebased PR's CI; this test predates it.

## Change

Both helpers now assert the terminal-transition state is a **member of the valid set** and copy the volatile fields from the actual run into the expected struct, so the equality keeps covering the stable, test-owned fields exactly as before (the same treatment already applied to `CreatedAt`/`ScheduledAt`/`FinishedAt`/`StateHistory`):

- **v2**: assert `State ∈ {CANCELING, CANCELED}`; copy `State` and `RunDetails`.
- **v1**: assert `Status ∈ {"Terminating", "Failed"}`; copy `Status`.

No production code changes; test-only. The field coverage of each equality check is unchanged apart from the intentionally-volatile lifecycle fields.

## Scope note

I also reviewed the sibling equality helpers: `checkHelloWorldRunDetail` / `checkArgParamsRunDetail` (v2) already copy `State` from the actual run and are asserted at create time (before any lifecycle action), and the recurring-run helpers copy `Status`/`Trigger` and only hardcode the deterministic `Mode: ENABLE` — none of those race, so they are left unchanged.

## Verification

- `gofmt` clean; both integration packages compile under `-tags=integration` (`ok … [no tests to run]`).
- Full run needs a live cluster; the change is a strict relaxation of the volatile lifecycle fields plus an explicit membership assertion on the terminate state.