### PR TITLE
ci: add scheduled CI health report for lane and per-test flake trends

### DIFF
--- a/.github/resources/scripts/ci_health_report.py
+++ b/.github/resources/scripts/ci_health_report.py
@@ -129,8 +129,9 @@ def paginate(token, url, key, max_pages=3):
     """Returns (items, may_have_more).
 
     may_have_more is True when the page budget ran out while pages were still
-    full — the caller must surface that as a completeness gap instead of
-    silently publishing partial results.
+    full and the API's total_count confirms that more results exist. The caller
+    must surface that as a completeness gap instead of silently publishing
+    partial results.
     """
     items = []
     page_url = url
@@ -138,6 +139,9 @@ def paginate(token, url, key, max_pages=3):
         payload = api_request(token, page_url)
         chunk = payload.get(key, []) if isinstance(payload, dict) else payload
         items.extend(chunk)
+        total_count = payload.get("total_count") if isinstance(payload, dict) else None
+        if isinstance(total_count, int) and len(items) >= total_count:
+            return items, False
         if len(chunk) < 100:
             return items, False
         separator = "&" if "?" in url else "?"

--- a/.github/resources/scripts/ci_health_report.py
+++ b/.github/resources/scripts/ci_health_report.py
@@ -23,6 +23,14 @@ issue labeled `ci-health` so flake trends live at a stable URL.
 GitHub's built-in Actions performance metrics stop at job granularity and have
 no API; this report adds the per-test layer and a public, automatable record.
 
+Accuracy contract:
+  - Every attempt of re-run workflows is counted, so a flake that passed on
+    re-run still shows its original failure.
+  - Cancelled/skipped jobs are excluded from rates; every other non-success
+    conclusion (failure, timed_out, stale, ...) counts as a failure.
+  - Any truncation (run caps, rate limits, artifact ingestion errors) is
+    surfaced in the report instead of silently publishing partial data.
+
 Environment:
   GITHUB_TOKEN             required, API token
   GITHUB_REPOSITORY        owner/repo (default kubeflow/pipelines)
@@ -61,6 +69,12 @@ TARGET_WORKFLOWS = [
 
 ISSUE_TITLE = "CI Health Report (automated)"
 ISSUE_LABEL = "ci-health"
+
+# Job conclusions that are not results at all: master-push workflows cancel
+# in-progress runs, so counting cancellations as either success or failure
+# biases rates. Everything not listed here and not "success" is a failure
+# (failure, timed_out, stale, ...).
+NON_RESULT_CONCLUSIONS = {None, "", "skipped", "cancelled", "neutral", "action_required"}
 
 
 class RateLimited(Exception):
@@ -134,14 +148,41 @@ def duration_minutes(job):
     return minutes if minutes >= 0 else None
 
 
+def is_failure_conclusion(conclusion):
+    return conclusion not in NON_RESULT_CONCLUSIONS and conclusion != "success"
+
+
+def run_attempt_job_urls(repo, run):
+    """Job listing URLs covering every attempt of a run.
+
+    `filter=latest` alone would hide the original failed jobs of re-run
+    workflows — exactly the flakes this report exists to measure.
+    """
+    attempts = run.get("run_attempt", 1) or 1
+    if attempts <= 1:
+        return [
+            f"{API_ROOT}/repos/{repo}/actions/runs/{run['id']}/jobs"
+            "?filter=latest&per_page=100"
+        ]
+    return [
+        f"{API_ROOT}/repos/{repo}/actions/runs/{run['id']}/attempts/{attempt}/jobs"
+        "?per_page=100"
+        for attempt in range(1, attempts + 1)
+    ]
+
+
 def collect_lane_stats(token, repo, since, max_runs):
-    """Returns (lane stats dict, failed run ids, rerun count, truncated flag)."""
-    lanes = collections.defaultdict(
-        lambda: {"total": 0, "failed": 0, "cancelled": 0, "durations": []}
-    )
-    failed_run_ids = []
+    """Aggregates per-lane job outcomes across every attempt of each run.
+
+    Returns (lanes, failed_runs, reruns, notes) where failed_runs is a list of
+    (created_at, run_id) for runs with a failed job in any attempt, and notes
+    is a list of data-completeness warnings for the report header.
+    """
+    lanes = collections.defaultdict(lambda: {"total": 0, "failed": 0, "durations": []})
+    failed_runs = []
     reruns = 0
-    truncated = False
+    notes = []
+    capped_workflows = []
 
     for workflow in TARGET_WORKFLOWS:
         url = (
@@ -149,54 +190,77 @@ def collect_lane_stats(token, repo, since, max_runs):
             f"?branch=master&created=>={since}&per_page=100"
         )
         try:
-            runs = paginate(token, url, "workflow_runs", max_pages=1)[:max_runs]
+            runs = paginate(token, url, "workflow_runs", max_pages=1)
         except urllib.error.HTTPError as error:
             if error.code == 404:  # workflow renamed/removed
                 continue
             raise
         except RateLimited:
-            truncated = True
+            notes.append(
+                f"rate-limited while listing `{workflow}` runs; later workflows omitted"
+            )
             break
 
+        if len(runs) > max_runs:
+            capped_workflows.append(f"`{workflow}` ({len(runs)}→{max_runs})")
+            runs = runs[:max_runs]
+
+        rate_limited = False
         for run in runs:
             if run.get("status") != "completed":
                 continue
-            if run.get("run_attempt", 1) > 1:
+            if (run.get("run_attempt", 1) or 1) > 1:
                 reruns += 1
-            if run.get("conclusion") == "failure":
-                failed_run_ids.append(run["id"])
-            try:
-                jobs = paginate(
-                    token,
-                    f"{API_ROOT}/repos/{repo}/actions/runs/{run['id']}/jobs"
-                    "?filter=latest&per_page=100",
-                    "jobs",
-                )
-            except RateLimited:
-                truncated = True
+            run_had_failure = False
+            for jobs_url in run_attempt_job_urls(repo, run):
+                try:
+                    jobs = paginate(token, jobs_url, "jobs")
+                except RateLimited:
+                    notes.append(
+                        f"rate-limited while reading jobs for `{workflow}`; "
+                        "results truncated"
+                    )
+                    rate_limited = True
+                    break
+                except urllib.error.HTTPError:
+                    continue  # attempt data can expire; skip just this attempt
+                for job in jobs:
+                    conclusion = job.get("conclusion")
+                    if conclusion in NON_RESULT_CONCLUSIONS:
+                        continue
+                    lane = lanes[(run.get("name") or workflow, job["name"])]
+                    lane["total"] += 1
+                    if is_failure_conclusion(conclusion):
+                        lane["failed"] += 1
+                        run_had_failure = True
+                    minutes = duration_minutes(job)
+                    if minutes is not None:
+                        lane["durations"].append(minutes)
+            if run_had_failure:
+                failed_runs.append((run.get("created_at") or "", run["id"]))
+            if rate_limited:
                 break
-            for job in jobs:
-                if job.get("conclusion") in (None, "skipped"):
-                    continue
-                lane = lanes[(run.get("name") or workflow, job["name"])]
-                lane["total"] += 1
-                if job["conclusion"] == "failure":
-                    lane["failed"] += 1
-                elif job["conclusion"] == "cancelled":
-                    lane["cancelled"] += 1
-                minutes = duration_minutes(job)
-                if minutes is not None:
-                    lane["durations"].append(minutes)
-        if truncated:
+        if rate_limited:
             break
-    return lanes, failed_run_ids, reruns, truncated
+
+    if capped_workflows:
+        notes.append("run cap applied: " + ", ".join(capped_workflows))
+    return lanes, failed_runs, reruns, notes
 
 
-def collect_failed_tests(token, repo, failed_run_ids, max_junit_runs):
-    """Tallies failed testcases from junit-xml artifacts of failed runs."""
+def collect_failed_tests(token, repo, failed_runs, max_junit_runs):
+    """Tallies failed testcases from junit-xml artifacts of failed runs.
+
+    Newest failed runs first, across all workflows, so one busy workflow
+    cannot monopolize the artifact budget. Returns
+    (failed_tests, artifacts_parsed, ingestion_errors).
+    """
     failed_tests = collections.Counter()
-    artifact_runs_seen = 0
-    for run_id in failed_run_ids[:max_junit_runs]:
+    artifacts_parsed = 0
+    ingestion_errors = 0
+
+    newest_first = [run_id for _, run_id in sorted(failed_runs, reverse=True)]
+    for run_id in newest_first[:max_junit_runs]:
         try:
             artifacts = paginate(
                 token,
@@ -204,7 +268,8 @@ def collect_failed_tests(token, repo, failed_run_ids, max_junit_runs):
                 "artifacts",
                 max_pages=1,
             )
-        except (urllib.error.HTTPError, RateLimited):
+        except (urllib.error.HTTPError, RateLimited, OSError):
+            ingestion_errors += 1
             continue
         for artifact in artifacts:
             if not artifact.get("name", "").startswith("junit-xml - "):
@@ -212,35 +277,40 @@ def collect_failed_tests(token, repo, failed_run_ids, max_junit_runs):
             if artifact.get("expired"):
                 continue
             try:
-                content = api_request(
-                    token, artifact["archive_download_url"], raw=True
-                )
+                content = api_request(token, artifact["archive_download_url"], raw=True)
                 archive = zipfile.ZipFile(io.BytesIO(content))
             except Exception:  # noqa: BLE001 - best-effort artifact ingestion
+                ingestion_errors += 1
                 continue
-            artifact_runs_seen += 1
+            artifacts_parsed += 1
             for member in archive.namelist():
                 if not member.endswith(".xml"):
                     continue
                 try:
                     root = ET.fromstring(archive.read(member))
                 except ET.ParseError:
+                    ingestion_errors += 1
                     continue
                 for case in root.iter("testcase"):
                     if case.find("failure") is not None or case.find("error") is not None:
-                        failed_tests[case.get("name") or "<unnamed>"] += 1
-    return failed_tests, artifact_runs_seen
+                        # name alone is only unique within a suite/class;
+                        # include classname so unrelated tests do not merge.
+                        name = case.get("name") or "<unnamed>"
+                        classname = case.get("classname") or ""
+                        key = f"{classname} :: {name}" if classname else name
+                        failed_tests[key] += 1
+    return failed_tests, artifacts_parsed, ingestion_errors
 
 
-def render_report(lanes, failed_tests, artifact_runs_seen, reruns, days, truncated):
+def render_report(
+    lanes, failed_tests, artifacts_parsed, ingestion_errors, reruns, days, notes
+):
     lines = []
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    lines.append(f"# CI Health Report\n")
-    lines.append(
-        f"_Master-branch runs, last {days} days. Generated {now}."
-        + (" **Rate-limited: results truncated.**" if truncated else "")
-        + "_\n"
-    )
+    lines.append("# CI Health Report\n")
+    lines.append(f"_Master-branch runs, last {days} days. Generated {now}._\n")
+    if notes:
+        lines.append("> **Data completeness:** " + "; ".join(notes) + "\n")
 
     ranked = sorted(
         lanes.items(), key=lambda item: (item[1]["failed"], item[1]["total"]), reverse=True
@@ -271,22 +341,30 @@ def render_report(lanes, failed_tests, artifact_runs_seen, reruns, days, truncat
     total_failures = sum(stats["failed"] for stats in lanes.values())
     lines.append(
         f"**Window totals:** {total_jobs} lane runs across {total_lanes} lanes, "
-        f"{total_failures} failures, {reruns} workflow re-runs.\n"
+        f"{total_failures} failures, {reruns} workflow re-runs "
+        "(all attempts counted; cancelled/skipped excluded).\n"
     )
 
     lines.append("## Flakiest tests (from junit-xml artifacts of failed runs)\n")
+    if ingestion_errors:
+        lines.append(
+            f"> **Note:** {ingestion_errors} artifact/XML ingestion error(s); "
+            "per-test counts are a lower bound.\n"
+        )
     if failed_tests:
-        lines.append(f"_Parsed junit artifacts from {artifact_runs_seen} artifact(s)._\n")
+        lines.append(f"_Parsed {artifacts_parsed} junit artifact(s)._\n")
         lines.append("| Test | Failures |")
         lines.append("|---|---:|")
         for name, count in failed_tests.most_common(15):
             lines.append(f"| {name} | {count} |")
         lines.append("")
-    else:
+    elif not ingestion_errors:
         lines.append(
             "_No `junit-xml - *` artifacts found on failed runs in the window; "
             "per-test data populates as runs upload them (see test-and-report)._\n"
         )
+    else:
+        lines.append("_No junit artifacts could be ingested this window._\n")
     return "\n".join(lines) + "\n"
 
 
@@ -296,7 +374,11 @@ def upsert_issue(token, repo, report):
             token,
             f"{API_ROOT}/repos/{repo}/labels",
             method="POST",
-            body={"name": ISSUE_LABEL, "color": "1d76db", "description": "Automated CI health reports"},
+            body={
+                "name": ISSUE_LABEL,
+                "color": "1d76db",
+                "description": "Automated CI health reports",
+            },
         )
     except urllib.error.HTTPError as error:
         if error.code != 422:  # 422 = label already exists
@@ -330,14 +412,12 @@ def main():
     max_junit_runs = int(os.environ.get("MAX_JUNIT_RUNS", "15"))
     since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
 
-    lanes, failed_run_ids, reruns, truncated = collect_lane_stats(
-        token, repo, since, max_runs
-    )
-    failed_tests, artifact_runs_seen = collect_failed_tests(
-        token, repo, failed_run_ids, max_junit_runs
+    lanes, failed_runs, reruns, notes = collect_lane_stats(token, repo, since, max_runs)
+    failed_tests, artifacts_parsed, ingestion_errors = collect_failed_tests(
+        token, repo, failed_runs, max_junit_runs
     )
     report = render_report(
-        lanes, failed_tests, artifact_runs_seen, reruns, days, truncated
+        lanes, failed_tests, artifacts_parsed, ingestion_errors, reruns, days, notes
     )
 
     print(report)

--- a/.github/resources/scripts/ci_health_report.py
+++ b/.github/resources/scripts/ci_health_report.py
@@ -183,6 +183,7 @@ def collect_lane_stats(token, repo, since, max_runs):
     reruns = 0
     notes = []
     capped_workflows = []
+    job_fetch_errors = 0
 
     for workflow in TARGET_WORKFLOWS:
         url = (
@@ -223,7 +224,11 @@ def collect_lane_stats(token, repo, since, max_runs):
                     rate_limited = True
                     break
                 except urllib.error.HTTPError:
-                    continue  # attempt data can expire; skip just this attempt
+                    # Attempt data can expire; skip just this attempt, but a
+                    # silently dropped job listing must not read as a healthy
+                    # lane — surface the gap in the completeness notes.
+                    job_fetch_errors += 1
+                    continue
                 for job in jobs:
                     conclusion = job.get("conclusion")
                     if conclusion in NON_RESULT_CONCLUSIONS:
@@ -245,6 +250,11 @@ def collect_lane_stats(token, repo, since, max_runs):
 
     if capped_workflows:
         notes.append("run cap applied: " + ", ".join(capped_workflows))
+    if job_fetch_errors:
+        notes.append(
+            f"{job_fetch_errors} job listing(s) failed with HTTP errors; "
+            "lane rates may undercount failures"
+        )
     return lanes, failed_runs, reruns, notes
 
 
@@ -253,14 +263,15 @@ def collect_failed_tests(token, repo, failed_runs, max_junit_runs):
 
     Newest failed runs first, across all workflows, so one busy workflow
     cannot monopolize the artifact budget. Returns
-    (failed_tests, artifacts_parsed, ingestion_errors).
+    (failed_tests, artifacts_parsed, ingestion_errors, scanned_run_count).
     """
     failed_tests = collections.Counter()
     artifacts_parsed = 0
     ingestion_errors = 0
 
     newest_first = [run_id for _, run_id in sorted(failed_runs, reverse=True)]
-    for run_id in newest_first[:max_junit_runs]:
+    scanned_runs = newest_first[:max_junit_runs]
+    for run_id in scanned_runs:
         try:
             artifacts = paginate(
                 token,
@@ -299,11 +310,19 @@ def collect_failed_tests(token, repo, failed_runs, max_junit_runs):
                         classname = case.get("classname") or ""
                         key = f"{classname} :: {name}" if classname else name
                         failed_tests[key] += 1
-    return failed_tests, artifacts_parsed, ingestion_errors
+    return failed_tests, artifacts_parsed, ingestion_errors, len(scanned_runs)
 
 
 def render_report(
-    lanes, failed_tests, artifacts_parsed, ingestion_errors, reruns, days, notes
+    lanes,
+    failed_tests,
+    artifacts_parsed,
+    ingestion_errors,
+    reruns,
+    days,
+    notes,
+    junit_scanned=0,
+    junit_total=0,
 ):
     lines = []
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
@@ -346,6 +365,16 @@ def render_report(
     )
 
     lines.append("## Flakiest tests (from junit-xml artifacts of failed runs)\n")
+    # Name the actual scan scope: the artifact budget covers only the newest
+    # failed runs, and describing a capped scan as the whole window would let
+    # artifact-less infrastructure failures mask real junit data on older runs.
+    if junit_total > junit_scanned:
+        lines.append(
+            f"_Scanned the newest {junit_scanned} of {junit_total} failed runs "
+            "for junit artifacts._\n"
+        )
+    else:
+        lines.append(f"_Scanned {junit_scanned} failed run(s) for junit artifacts._\n")
     if ingestion_errors:
         lines.append(
             f"> **Note:** {ingestion_errors} artifact/XML ingestion error(s); "
@@ -360,11 +389,11 @@ def render_report(
         lines.append("")
     elif not ingestion_errors:
         lines.append(
-            "_No `junit-xml - *` artifacts found on failed runs in the window; "
+            "_No `junit-xml - *` artifacts found on the scanned failed runs; "
             "per-test data populates as runs upload them (see test-and-report)._\n"
         )
     else:
-        lines.append("_No junit artifacts could be ingested this window._\n")
+        lines.append("_No junit artifacts could be ingested from the scanned runs._\n")
     return "\n".join(lines) + "\n"
 
 
@@ -384,10 +413,17 @@ def upsert_issue(token, repo, report):
         if error.code != 422:  # 422 = label already exists
             raise
 
-    issues = api_request(
+    listed = api_request(
         token,
         f"{API_ROOT}/repos/{repo}/issues?labels={ISSUE_LABEL}&state=open&per_page=10",
     )
+    # The issues endpoint also returns pull requests, and a label alone could
+    # match unrelated content; only ever overwrite the bot's own report issue.
+    issues = [
+        item
+        for item in listed
+        if "pull_request" not in item and item.get("title") == ISSUE_TITLE
+    ]
     body = {"title": ISSUE_TITLE, "body": report[:65000], "labels": [ISSUE_LABEL]}
     if issues:
         number = issues[0]["number"]
@@ -413,11 +449,19 @@ def main():
     since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
 
     lanes, failed_runs, reruns, notes = collect_lane_stats(token, repo, since, max_runs)
-    failed_tests, artifacts_parsed, ingestion_errors = collect_failed_tests(
-        token, repo, failed_runs, max_junit_runs
+    failed_tests, artifacts_parsed, ingestion_errors, junit_scanned = (
+        collect_failed_tests(token, repo, failed_runs, max_junit_runs)
     )
     report = render_report(
-        lanes, failed_tests, artifacts_parsed, ingestion_errors, reruns, days, notes
+        lanes,
+        failed_tests,
+        artifacts_parsed,
+        ingestion_errors,
+        reruns,
+        days,
+        notes,
+        junit_scanned=junit_scanned,
+        junit_total=len(failed_runs),
     )
 
     print(report)

--- a/.github/resources/scripts/ci_health_report.py
+++ b/.github/resources/scripts/ci_health_report.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generates a CI health report for master-branch workflow runs.
+
+Aggregates job-level failure rates and durations across the heavy test
+workflows, and per-test failure counts from `junit-xml - *` artifacts uploaded
+by failed runs (see test-and-report). Writes markdown to stdout and, when
+available, to the GitHub job summary; optionally upserts a single tracking
+issue labeled `ci-health` so flake trends live at a stable URL.
+
+GitHub's built-in Actions performance metrics stop at job granularity and have
+no API; this report adds the per-test layer and a public, automatable record.
+
+Environment:
+  GITHUB_TOKEN             required, API token
+  GITHUB_REPOSITORY        owner/repo (default kubeflow/pipelines)
+  DAYS                     lookback window in days (default 14)
+  MAX_RUNS_PER_WORKFLOW    cap per workflow (default 40)
+  MAX_JUNIT_RUNS           failed runs to pull junit artifacts from (default 15)
+  UPDATE_ISSUE             "true" to upsert the ci-health issue (default false)
+
+Uses only the Python standard library.
+"""
+
+import collections
+import io
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+import zipfile
+from datetime import datetime, timedelta, timezone
+
+API_ROOT = "https://api.github.com"
+
+# Heavy master-branch test workflows worth tracking for flake health.
+TARGET_WORKFLOWS = [
+    "e2e-test.yml",
+    "api-server-tests.yml",
+    "integration-tests-v1.yml",
+    "legacy-v2-api-integration-tests.yml",
+    "kfp-kubernetes-execution-tests.yml",
+    "sdk-execution.yml",
+    "upgrade-test.yml",
+    "kfp-webhooks.yml",
+]
+
+ISSUE_TITLE = "CI Health Report (automated)"
+ISSUE_LABEL = "ci-health"
+
+
+class RateLimited(Exception):
+    pass
+
+
+def build_opener_without_redirects():
+    """Opener that surfaces redirects instead of following them.
+
+    Artifact downloads redirect to blob storage; forwarding the GitHub
+    Authorization header there makes the storage backend reject the request,
+    so the redirect target must be fetched without it.
+    """
+
+    class NoRedirect(urllib.request.HTTPRedirectHandler):
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            return None
+
+    return urllib.request.build_opener(NoRedirect)
+
+
+def api_request(token, url, method="GET", body=None, raw=False):
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    data = json.dumps(body).encode() if body is not None else None
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    opener = build_opener_without_redirects()
+    try:
+        with opener.open(request, timeout=60) as response:
+            content = response.read()
+            return content if raw else json.loads(content or b"{}")
+    except urllib.error.HTTPError as error:
+        if error.code in (301, 302, 303, 307, 308):
+            location = error.headers.get("Location")
+            if location:
+                # Redirect target (blob storage) must not receive the token.
+                with urllib.request.urlopen(
+                    urllib.request.Request(location), timeout=120
+                ) as redirected:
+                    return redirected.read()
+        if error.code == 403 and error.headers.get("X-RateLimit-Remaining") == "0":
+            raise RateLimited(url) from error
+        raise
+
+
+def paginate(token, url, key, max_pages=3):
+    items = []
+    page_url = url
+    for _ in range(max_pages):
+        payload = api_request(token, page_url)
+        chunk = payload.get(key, []) if isinstance(payload, dict) else payload
+        items.extend(chunk)
+        if len(chunk) < 100:
+            break
+        separator = "&" if "?" in url else "?"
+        page_number = len(items) // 100 + 1
+        page_url = f"{url}{separator}page={page_number}"
+    return items
+
+
+def duration_minutes(job):
+    started, completed = job.get("started_at"), job.get("completed_at")
+    if not started or not completed:
+        return None
+    fmt = "%Y-%m-%dT%H:%M:%SZ"
+    delta = datetime.strptime(completed, fmt) - datetime.strptime(started, fmt)
+    minutes = delta.total_seconds() / 60
+    return minutes if minutes >= 0 else None
+
+
+def collect_lane_stats(token, repo, since, max_runs):
+    """Returns (lane stats dict, failed run ids, rerun count, truncated flag)."""
+    lanes = collections.defaultdict(
+        lambda: {"total": 0, "failed": 0, "cancelled": 0, "durations": []}
+    )
+    failed_run_ids = []
+    reruns = 0
+    truncated = False
+
+    for workflow in TARGET_WORKFLOWS:
+        url = (
+            f"{API_ROOT}/repos/{repo}/actions/workflows/{workflow}/runs"
+            f"?branch=master&created=>={since}&per_page=100"
+        )
+        try:
+            runs = paginate(token, url, "workflow_runs", max_pages=1)[:max_runs]
+        except urllib.error.HTTPError as error:
+            if error.code == 404:  # workflow renamed/removed
+                continue
+            raise
+        except RateLimited:
+            truncated = True
+            break
+
+        for run in runs:
+            if run.get("status") != "completed":
+                continue
+            if run.get("run_attempt", 1) > 1:
+                reruns += 1
+            if run.get("conclusion") == "failure":
+                failed_run_ids.append(run["id"])
+            try:
+                jobs = paginate(
+                    token,
+                    f"{API_ROOT}/repos/{repo}/actions/runs/{run['id']}/jobs"
+                    "?filter=latest&per_page=100",
+                    "jobs",
+                )
+            except RateLimited:
+                truncated = True
+                break
+            for job in jobs:
+                if job.get("conclusion") in (None, "skipped"):
+                    continue
+                lane = lanes[(run.get("name") or workflow, job["name"])]
+                lane["total"] += 1
+                if job["conclusion"] == "failure":
+                    lane["failed"] += 1
+                elif job["conclusion"] == "cancelled":
+                    lane["cancelled"] += 1
+                minutes = duration_minutes(job)
+                if minutes is not None:
+                    lane["durations"].append(minutes)
+        if truncated:
+            break
+    return lanes, failed_run_ids, reruns, truncated
+
+
+def collect_failed_tests(token, repo, failed_run_ids, max_junit_runs):
+    """Tallies failed testcases from junit-xml artifacts of failed runs."""
+    failed_tests = collections.Counter()
+    artifact_runs_seen = 0
+    for run_id in failed_run_ids[:max_junit_runs]:
+        try:
+            artifacts = paginate(
+                token,
+                f"{API_ROOT}/repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100",
+                "artifacts",
+                max_pages=1,
+            )
+        except (urllib.error.HTTPError, RateLimited):
+            continue
+        for artifact in artifacts:
+            if not artifact.get("name", "").startswith("junit-xml - "):
+                continue
+            if artifact.get("expired"):
+                continue
+            try:
+                content = api_request(
+                    token, artifact["archive_download_url"], raw=True
+                )
+                archive = zipfile.ZipFile(io.BytesIO(content))
+            except Exception:  # noqa: BLE001 - best-effort artifact ingestion
+                continue
+            artifact_runs_seen += 1
+            for member in archive.namelist():
+                if not member.endswith(".xml"):
+                    continue
+                try:
+                    root = ET.fromstring(archive.read(member))
+                except ET.ParseError:
+                    continue
+                for case in root.iter("testcase"):
+                    if case.find("failure") is not None or case.find("error") is not None:
+                        failed_tests[case.get("name") or "<unnamed>"] += 1
+    return failed_tests, artifact_runs_seen
+
+
+def render_report(lanes, failed_tests, artifact_runs_seen, reruns, days, truncated):
+    lines = []
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines.append(f"# CI Health Report\n")
+    lines.append(
+        f"_Master-branch runs, last {days} days. Generated {now}."
+        + (" **Rate-limited: results truncated.**" if truncated else "")
+        + "_\n"
+    )
+
+    ranked = sorted(
+        lanes.items(), key=lambda item: (item[1]["failed"], item[1]["total"]), reverse=True
+    )
+    failing = [(key, stats) for key, stats in ranked if stats["failed"] > 0][:25]
+
+    lines.append("## Failing lanes (top 25 by failure count)\n")
+    if not failing:
+        lines.append("No failing lanes in the window. 🎉\n")
+    else:
+        lines.append("| Workflow | Lane | Runs | Failures | Fail % | Avg min |")
+        lines.append("|---|---|---:|---:|---:|---:|")
+        for (workflow, lane), stats in failing:
+            rate = 100 * stats["failed"] / stats["total"]
+            avg = (
+                sum(stats["durations"]) / len(stats["durations"])
+                if stats["durations"]
+                else 0
+            )
+            lines.append(
+                f"| {workflow} | {lane} | {stats['total']} | {stats['failed']}"
+                f" | {rate:.0f}% | {avg:.0f} |"
+            )
+        lines.append("")
+
+    total_lanes = len(lanes)
+    total_jobs = sum(stats["total"] for stats in lanes.values())
+    total_failures = sum(stats["failed"] for stats in lanes.values())
+    lines.append(
+        f"**Window totals:** {total_jobs} lane runs across {total_lanes} lanes, "
+        f"{total_failures} failures, {reruns} workflow re-runs.\n"
+    )
+
+    lines.append("## Flakiest tests (from junit-xml artifacts of failed runs)\n")
+    if failed_tests:
+        lines.append(f"_Parsed junit artifacts from {artifact_runs_seen} artifact(s)._\n")
+        lines.append("| Test | Failures |")
+        lines.append("|---|---:|")
+        for name, count in failed_tests.most_common(15):
+            lines.append(f"| {name} | {count} |")
+        lines.append("")
+    else:
+        lines.append(
+            "_No `junit-xml - *` artifacts found on failed runs in the window; "
+            "per-test data populates as runs upload them (see test-and-report)._\n"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def upsert_issue(token, repo, report):
+    try:
+        api_request(
+            token,
+            f"{API_ROOT}/repos/{repo}/labels",
+            method="POST",
+            body={"name": ISSUE_LABEL, "color": "1d76db", "description": "Automated CI health reports"},
+        )
+    except urllib.error.HTTPError as error:
+        if error.code != 422:  # 422 = label already exists
+            raise
+
+    issues = api_request(
+        token,
+        f"{API_ROOT}/repos/{repo}/issues?labels={ISSUE_LABEL}&state=open&per_page=10",
+    )
+    body = {"title": ISSUE_TITLE, "body": report[:65000], "labels": [ISSUE_LABEL]}
+    if issues:
+        number = issues[0]["number"]
+        api_request(
+            token, f"{API_ROOT}/repos/{repo}/issues/{number}", method="PATCH", body=body
+        )
+        return issues[0]["html_url"]
+    created = api_request(
+        token, f"{API_ROOT}/repos/{repo}/issues", method="POST", body=body
+    )
+    return created["html_url"]
+
+
+def main():
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GITHUB_TOKEN is required", file=sys.stderr)
+        return 1
+    repo = os.environ.get("GITHUB_REPOSITORY", "kubeflow/pipelines")
+    days = int(os.environ.get("DAYS", "14"))
+    max_runs = int(os.environ.get("MAX_RUNS_PER_WORKFLOW", "40"))
+    max_junit_runs = int(os.environ.get("MAX_JUNIT_RUNS", "15"))
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+
+    lanes, failed_run_ids, reruns, truncated = collect_lane_stats(
+        token, repo, since, max_runs
+    )
+    failed_tests, artifact_runs_seen = collect_failed_tests(
+        token, repo, failed_run_ids, max_junit_runs
+    )
+    report = render_report(
+        lanes, failed_tests, artifact_runs_seen, reruns, days, truncated
+    )
+
+    print(report)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as summary:
+            summary.write(report)
+
+    if os.environ.get("UPDATE_ISSUE", "").lower() == "true":
+        url = upsert_issue(token, repo, report)
+        print(f"Updated tracking issue: {url}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/resources/scripts/ci_health_report.py
+++ b/.github/resources/scripts/ci_health_report.py
@@ -56,13 +56,15 @@ from datetime import datetime, timedelta, timezone
 API_ROOT = "https://api.github.com"
 
 # Heavy master-branch test workflows worth tracking for flake health.
+# Missing entries are surfaced in the report notes rather than silently
+# skipped, so workflow renames/deletions get noticed instead of permanently
+# dropping a suite from the health data.
 TARGET_WORKFLOWS = [
     "e2e-test.yml",
     "api-server-tests.yml",
     "integration-tests-v1.yml",
     "legacy-v2-api-integration-tests.yml",
-    "kfp-kubernetes-execution-tests.yml",
-    "sdk-execution.yml",
+    "kfp-sdk-client-tests.yml",
     "upgrade-test.yml",
     "kfp-webhooks.yml",
 ]
@@ -124,6 +126,12 @@ def api_request(token, url, method="GET", body=None, raw=False):
 
 
 def paginate(token, url, key, max_pages=3):
+    """Returns (items, may_have_more).
+
+    may_have_more is True when the page budget ran out while pages were still
+    full — the caller must surface that as a completeness gap instead of
+    silently publishing partial results.
+    """
     items = []
     page_url = url
     for _ in range(max_pages):
@@ -131,11 +139,11 @@ def paginate(token, url, key, max_pages=3):
         chunk = payload.get(key, []) if isinstance(payload, dict) else payload
         items.extend(chunk)
         if len(chunk) < 100:
-            break
+            return items, False
         separator = "&" if "?" in url else "?"
         page_number = len(items) // 100 + 1
         page_url = f"{url}{separator}page={page_number}"
-    return items
+    return items, True
 
 
 def duration_minutes(job):
@@ -183,7 +191,9 @@ def collect_lane_stats(token, repo, since, max_runs):
     reruns = 0
     notes = []
     capped_workflows = []
+    missing_workflows = []
     job_fetch_errors = 0
+    job_page_truncations = 0
 
     for workflow in TARGET_WORKFLOWS:
         url = (
@@ -191,9 +201,12 @@ def collect_lane_stats(token, repo, since, max_runs):
             f"?branch=master&created=>={since}&per_page=100"
         )
         try:
-            runs = paginate(token, url, "workflow_runs", max_pages=1)
+            runs, more_runs = paginate(token, url, "workflow_runs", max_pages=1)
         except urllib.error.HTTPError as error:
-            if error.code == 404:  # workflow renamed/removed
+            if error.code == 404:
+                # A renamed/deleted workflow silently dropping out would
+                # permanently omit that suite's health; make it visible.
+                missing_workflows.append(f"`{workflow}`")
                 continue
             raise
         except RateLimited:
@@ -205,6 +218,8 @@ def collect_lane_stats(token, repo, since, max_runs):
         if len(runs) > max_runs:
             capped_workflows.append(f"`{workflow}` ({len(runs)}→{max_runs})")
             runs = runs[:max_runs]
+        elif more_runs:
+            capped_workflows.append(f"`{workflow}` (page budget)")
 
         rate_limited = False
         for run in runs:
@@ -215,7 +230,9 @@ def collect_lane_stats(token, repo, since, max_runs):
             run_had_failure = False
             for jobs_url in run_attempt_job_urls(repo, run):
                 try:
-                    jobs = paginate(token, jobs_url, "jobs")
+                    jobs, more_jobs = paginate(token, jobs_url, "jobs")
+                    if more_jobs:
+                        job_page_truncations += 1
                 except RateLimited:
                     notes.append(
                         f"rate-limited while reading jobs for `{workflow}`; "
@@ -248,12 +265,22 @@ def collect_lane_stats(token, repo, since, max_runs):
         if rate_limited:
             break
 
+    if missing_workflows:
+        notes.append(
+            "tracked workflow(s) not found (renamed/removed — update "
+            "TARGET_WORKFLOWS): " + ", ".join(missing_workflows)
+        )
     if capped_workflows:
         notes.append("run cap applied: " + ", ".join(capped_workflows))
     if job_fetch_errors:
         notes.append(
             f"{job_fetch_errors} job listing(s) failed with HTTP errors; "
             "lane rates may undercount failures"
+        )
+    if job_page_truncations:
+        notes.append(
+            f"{job_page_truncations} job listing(s) exceeded the page budget; "
+            "lane rates may undercount"
         )
     return lanes, failed_runs, reruns, notes
 
@@ -273,12 +300,16 @@ def collect_failed_tests(token, repo, failed_runs, max_junit_runs):
     scanned_runs = newest_first[:max_junit_runs]
     for run_id in scanned_runs:
         try:
-            artifacts = paginate(
+            artifacts, more_artifacts = paginate(
                 token,
                 f"{API_ROOT}/repos/{repo}/actions/runs/{run_id}/artifacts?per_page=100",
                 "artifacts",
                 max_pages=1,
             )
+            if more_artifacts:
+                # Artifacts beyond the first page are invisible; that is an
+                # ingestion gap, not a clean zero.
+                ingestion_errors += 1
         except (urllib.error.HTTPError, RateLimited, OSError):
             ingestion_errors += 1
             continue
@@ -377,8 +408,9 @@ def render_report(
         lines.append(f"_Scanned {junit_scanned} failed run(s) for junit artifacts._\n")
     if ingestion_errors:
         lines.append(
-            f"> **Note:** {ingestion_errors} artifact/XML ingestion error(s); "
-            "per-test counts are a lower bound.\n"
+            f"> **Note:** {ingestion_errors} artifact ingestion gap(s) "
+            "(errors or page-budget truncation); per-test counts are a lower "
+            "bound.\n"
         )
     if failed_tests:
         lines.append(f"_Parsed {artifacts_parsed} junit artifact(s)._\n")

--- a/.github/resources/scripts/ci_health_report_test.py
+++ b/.github/resources/scripts/ci_health_report_test.py
@@ -176,6 +176,20 @@ class StaleWorkflowTest(unittest.TestCase):
 
 
 class PageBudgetTest(unittest.TestCase):
+    def test_exact_full_page_uses_total_count_to_avoid_false_truncation(self):
+        payload = {"total_count": 100, "artifacts": [{"id": i} for i in range(100)]}
+        with mock.patch.object(chr_mod, "api_request", return_value=payload):
+            items, may_have_more = chr_mod.paginate("t", "u", "artifacts", max_pages=1)
+        self.assertEqual(len(items), 100)
+        self.assertFalse(may_have_more)
+
+    def test_full_page_below_total_count_is_truncated(self):
+        payload = {"total_count": 101, "artifacts": [{"id": i} for i in range(100)]}
+        with mock.patch.object(chr_mod, "api_request", return_value=payload):
+            items, may_have_more = chr_mod.paginate("t", "u", "artifacts", max_pages=1)
+        self.assertEqual(len(items), 100)
+        self.assertTrue(may_have_more)
+
     def test_job_page_budget_truncation_is_surfaced(self):
         def fake_paginate(token, url, key, max_pages=3):
             if "workflows/" in url:

--- a/.github/resources/scripts/ci_health_report_test.py
+++ b/.github/resources/scripts/ci_health_report_test.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ci_health_report.py (stdlib only).
+
+Run with:  python3 -m unittest .github/resources/scripts/ci_health_report_test.py
+       or: python3 .github/resources/scripts/ci_health_report_test.py
+"""
+
+import io
+import unittest
+import zipfile
+from unittest import mock
+
+import ci_health_report as chr_mod
+
+
+def make_run(run_id, conclusion="failure", attempts=1, created="2026-07-13T00:00:00Z"):
+    return {
+        "id": run_id,
+        "status": "completed",
+        "conclusion": conclusion,
+        "run_attempt": attempts,
+        "created_at": created,
+        "name": "WF",
+    }
+
+
+def make_job(name, conclusion, minutes=10):
+    return {
+        "name": name,
+        "conclusion": conclusion,
+        "started_at": "2026-07-13T00:00:00Z",
+        "completed_at": f"2026-07-13T00:{minutes:02d}:00Z",
+    }
+
+
+def junit_zip(*xml_bodies):
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for index, body in enumerate(xml_bodies):
+            archive.writestr(f"report{index}.xml", body)
+    return buffer.getvalue()
+
+
+class ConclusionHandlingTest(unittest.TestCase):
+    """Cancelled/skipped are non-results; other non-success are failures."""
+
+    def collect(self, jobs):
+        def fake_paginate(token, url, key, max_pages=3):
+            if "workflows/" in url:
+                return [make_run(1)] if "e2e-test.yml" in url else []
+            return jobs
+
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
+            return chr_mod.collect_lane_stats("t", "o/r", "2026-07-01", 40)
+
+    def test_cancelled_and_skipped_excluded_from_denominator(self):
+        lanes, _, _, _ = self.collect(
+            [
+                make_job("lane", "success"),
+                make_job("lane", "cancelled"),
+                make_job("lane", "skipped"),
+            ]
+        )
+        self.assertEqual(lanes[("WF", "lane")]["total"], 1)
+        self.assertEqual(lanes[("WF", "lane")]["failed"], 0)
+
+    def test_timed_out_and_stale_count_as_failures(self):
+        lanes, failed_runs, _, _ = self.collect(
+            [make_job("lane", "timed_out"), make_job("lane", "stale")]
+        )
+        self.assertEqual(lanes[("WF", "lane")]["total"], 2)
+        self.assertEqual(lanes[("WF", "lane")]["failed"], 2)
+        self.assertEqual([run_id for _, run_id in failed_runs], [1])
+
+
+class RerunHandlingTest(unittest.TestCase):
+    """Every attempt is counted, so re-run-then-green still shows the flake."""
+
+    def test_rerun_attempts_all_counted_and_run_marked_failed(self):
+        def fake_paginate(token, url, key, max_pages=3):
+            if "workflows/" in url:
+                # Overall conclusion success: the re-run went green.
+                return (
+                    [make_run(7, conclusion="success", attempts=2)]
+                    if "e2e-test.yml" in url
+                    else []
+                )
+            if "/attempts/1/" in url:
+                return [make_job("lane", "failure")]
+            if "/attempts/2/" in url:
+                return [make_job("lane", "success")]
+            raise AssertionError(f"unexpected jobs url {url}")
+
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
+            lanes, failed_runs, reruns, _ = chr_mod.collect_lane_stats(
+                "t", "o/r", "2026-07-01", 40
+            )
+        self.assertEqual(lanes[("WF", "lane")]["total"], 2)
+        self.assertEqual(lanes[("WF", "lane")]["failed"], 1)
+        self.assertEqual(reruns, 1)
+        # The run is a junit candidate even though its final conclusion is green.
+        self.assertEqual([run_id for _, run_id in failed_runs], [7])
+
+
+class TruncationFlagTest(unittest.TestCase):
+    def test_run_cap_is_surfaced_in_notes(self):
+        runs = [make_run(i) for i in range(3)]
+
+        def fake_paginate(token, url, key, max_pages=3):
+            if "workflows/" in url:
+                return runs if "e2e-test.yml" in url else []
+            return [make_job("lane", "success")]
+
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
+            _, _, _, notes = chr_mod.collect_lane_stats("t", "o/r", "2026-07-01", 2)
+        self.assertTrue(any("run cap applied" in note for note in notes))
+
+    def test_rate_limit_is_surfaced_in_notes(self):
+        def fake_paginate(token, url, key, max_pages=3):
+            raise chr_mod.RateLimited(url)
+
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
+            lanes, _, _, notes = chr_mod.collect_lane_stats("t", "o/r", "2026-07-01", 2)
+        self.assertEqual(len(lanes), 0)
+        self.assertTrue(any("rate-limited" in note for note in notes))
+
+
+class JunitIngestionTest(unittest.TestCase):
+    GOOD_XML = (
+        '<testsuite><testcase classname="SuiteA" name="flaky test">'
+        "<failure>boom</failure></testcase>"
+        '<testcase classname="SuiteB" name="flaky test"><error>err</error></testcase>'
+        '<testcase classname="SuiteA" name="green test"/></testsuite>'
+    )
+
+    def test_classname_disambiguates_and_malformed_counts_as_error(self):
+        payload = junit_zip(self.GOOD_XML, "<not-closed")
+        artifacts = [
+            {"name": "junit-xml - lane", "archive_download_url": "u", "expired": False}
+        ]
+
+        def fake_paginate(token, url, key, max_pages=3):
+            return artifacts
+
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate), \
+                mock.patch.object(chr_mod, "api_request", return_value=payload):
+            tests, parsed, errors = chr_mod.collect_failed_tests(
+                "t", "o/r", [("2026-07-13T00:00:00Z", 1)], 5
+            )
+        self.assertEqual(tests["SuiteA :: flaky test"], 1)
+        self.assertEqual(tests["SuiteB :: flaky test"], 1)
+        self.assertNotIn("SuiteA :: green test", tests)
+        self.assertEqual(parsed, 1)
+        self.assertEqual(errors, 1)  # the malformed member
+
+    def test_newest_failed_runs_win_the_budget_across_workflows(self):
+        seen = []
+
+        def fake_paginate(token, url, key, max_pages=3):
+            seen.append(url)
+            return []
+
+        failed_runs = [
+            ("2026-07-01T00:00:00Z", 111),  # oldest (from the first workflow)
+            ("2026-07-13T00:00:00Z", 999),  # newest (from a later workflow)
+        ]
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
+            chr_mod.collect_failed_tests("t", "o/r", failed_runs, 1)
+        self.assertEqual(len(seen), 1)
+        self.assertIn("/runs/999/", seen[0])
+
+    def test_artifact_api_error_is_reported_not_silent(self):
+        def fake_paginate(token, url, key, max_pages=3):
+            raise chr_mod.RateLimited(url)
+
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
+            tests, parsed, errors = chr_mod.collect_failed_tests(
+                "t", "o/r", [("2026-07-13T00:00:00Z", 1)], 5
+            )
+        self.assertEqual(len(tests), 0)
+        self.assertEqual(parsed, 0)
+        self.assertEqual(errors, 1)
+
+
+class RenderTest(unittest.TestCase):
+    def test_notes_and_ingestion_errors_are_visible(self):
+        lanes = {("WF", "lane"): {"total": 4, "failed": 2, "durations": [10.0, 20.0]}}
+        report = chr_mod.render_report(
+            lanes, {}, 0, 3, reruns=1, days=7, notes=["run cap applied: `e2e` (50→40)"]
+        )
+        self.assertIn("Data completeness", report)
+        self.assertIn("run cap applied", report)
+        self.assertIn("3 artifact/XML ingestion error(s)", report)
+        self.assertIn("| WF | lane | 4 | 2 | 50% | 15 |", report)
+
+    def test_zero_artifacts_message_distinct_from_errors(self):
+        clean = chr_mod.render_report({}, {}, 0, 0, 0, 7, [])
+        self.assertIn("No `junit-xml - *` artifacts found", clean)
+        errored = chr_mod.render_report({}, {}, 0, 2, 0, 7, [])
+        self.assertNotIn("No `junit-xml - *` artifacts found", errored)
+        self.assertIn("No junit artifacts could be ingested", errored)
+
+
+class UpsertIssueTest(unittest.TestCase):
+    def test_updates_existing_issue(self):
+        calls = []
+
+        def fake_api(token, url, method="GET", body=None, raw=False):
+            calls.append((method, url))
+            if method == "POST" and url.endswith("/labels"):
+                return {}
+            if "issues?labels=" in url:
+                return [{"number": 42, "html_url": "issue-url"}]
+            if method == "PATCH":
+                return {}
+            raise AssertionError(f"unexpected call {method} {url}")
+
+        with mock.patch.object(chr_mod, "api_request", side_effect=fake_api):
+            url = chr_mod.upsert_issue("t", "o/r", "report")
+        self.assertEqual(url, "issue-url")
+        self.assertIn(("PATCH", f"{chr_mod.API_ROOT}/repos/o/r/issues/42"), calls)
+
+    def test_creates_issue_when_none_open(self):
+        def fake_api(token, url, method="GET", body=None, raw=False):
+            if method == "POST" and url.endswith("/labels"):
+                return {}
+            if "issues?labels=" in url:
+                return []
+            if method == "POST" and url.endswith("/issues"):
+                return {"html_url": "new-issue-url"}
+            raise AssertionError(f"unexpected call {method} {url}")
+
+        with mock.patch.object(chr_mod, "api_request", side_effect=fake_api):
+            url = chr_mod.upsert_issue("t", "o/r", "report")
+        self.assertEqual(url, "new-issue-url")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/resources/scripts/ci_health_report_test.py
+++ b/.github/resources/scripts/ci_health_report_test.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 """Unit tests for ci_health_report.py (stdlib only).
 
-Run with:  python3 -m unittest .github/resources/scripts/ci_health_report_test.py
-       or: python3 .github/resources/scripts/ci_health_report_test.py
+Run with:  cd .github/resources/scripts && python3 -m unittest -v ci_health_report_test
+(the leading-dot directory prevents unittest path-to-module conversion from the
+repo root, and default `unittest discover` only matches test*.py). CI runs this
+via .github/workflows/ci-scripts-tests.yml on changes to these scripts.
 """
 
 import io
@@ -138,6 +140,24 @@ class TruncationFlagTest(unittest.TestCase):
         self.assertTrue(any("rate-limited" in note for note in notes))
 
 
+class JobFetchErrorTest(unittest.TestCase):
+    def test_job_listing_http_error_is_surfaced_not_healthy(self):
+        import urllib.error
+
+        def fake_paginate(token, url, key, max_pages=3):
+            if "workflows/" in url:
+                return [make_run(1)] if "e2e-test.yml" in url else []
+            raise urllib.error.HTTPError(url, 500, "boom", {}, io.BytesIO(b""))
+
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
+            lanes, _, _, notes = chr_mod.collect_lane_stats("t", "o/r", "2026-07-01", 40)
+        self.assertEqual(len(lanes), 0)
+        self.assertTrue(
+            any("job listing(s) failed" in note for note in notes),
+            f"expected job-fetch note in {notes}",
+        )
+
+
 class JunitIngestionTest(unittest.TestCase):
     GOOD_XML = (
         '<testsuite><testcase classname="SuiteA" name="flaky test">'
@@ -157,9 +177,10 @@ class JunitIngestionTest(unittest.TestCase):
 
         with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate), \
                 mock.patch.object(chr_mod, "api_request", return_value=payload):
-            tests, parsed, errors = chr_mod.collect_failed_tests(
+            tests, parsed, errors, scanned = chr_mod.collect_failed_tests(
                 "t", "o/r", [("2026-07-13T00:00:00Z", 1)], 5
             )
+        self.assertEqual(scanned, 1)
         self.assertEqual(tests["SuiteA :: flaky test"], 1)
         self.assertEqual(tests["SuiteB :: flaky test"], 1)
         self.assertNotIn("SuiteA :: green test", tests)
@@ -187,7 +208,7 @@ class JunitIngestionTest(unittest.TestCase):
             raise chr_mod.RateLimited(url)
 
         with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
-            tests, parsed, errors = chr_mod.collect_failed_tests(
+            tests, parsed, errors, scanned = chr_mod.collect_failed_tests(
                 "t", "o/r", [("2026-07-13T00:00:00Z", 1)], 5
             )
         self.assertEqual(len(tests), 0)
@@ -213,6 +234,18 @@ class RenderTest(unittest.TestCase):
         self.assertNotIn("No `junit-xml - *` artifacts found", errored)
         self.assertIn("No junit artifacts could be ingested", errored)
 
+    def test_junit_scan_scope_is_named_not_whole_window(self):
+        capped = chr_mod.render_report(
+            {}, {}, 0, 0, 0, 7, [], junit_scanned=15, junit_total=20
+        )
+        self.assertIn("newest 15 of 20 failed runs", capped)
+        # the zero-artifact message must not claim the whole window
+        self.assertIn("on the scanned failed runs", capped)
+        uncapped = chr_mod.render_report(
+            {}, {}, 0, 0, 0, 7, [], junit_scanned=3, junit_total=3
+        )
+        self.assertIn("Scanned 3 failed run(s)", uncapped)
+
 
 class UpsertIssueTest(unittest.TestCase):
     def test_updates_existing_issue(self):
@@ -223,7 +256,7 @@ class UpsertIssueTest(unittest.TestCase):
             if method == "POST" and url.endswith("/labels"):
                 return {}
             if "issues?labels=" in url:
-                return [{"number": 42, "html_url": "issue-url"}]
+                return [{"number": 42, "title": chr_mod.ISSUE_TITLE, "html_url": "issue-url"}]
             if method == "PATCH":
                 return {}
             raise AssertionError(f"unexpected call {method} {url}")
@@ -232,6 +265,31 @@ class UpsertIssueTest(unittest.TestCase):
             url = chr_mod.upsert_issue("t", "o/r", "report")
         self.assertEqual(url, "issue-url")
         self.assertIn(("PATCH", f"{chr_mod.API_ROOT}/repos/o/r/issues/42"), calls)
+
+    def test_skips_pull_requests_and_wrong_titles(self):
+        patched = []
+
+        def fake_api(token, url, method="GET", body=None, raw=False):
+            if method == "POST" and url.endswith("/labels"):
+                return {}
+            if "issues?labels=" in url:
+                return [
+                    {"number": 1, "title": chr_mod.ISSUE_TITLE,
+                     "pull_request": {}, "html_url": "pr-url"},
+                    {"number": 2, "title": "Something else entirely",
+                     "html_url": "other-url"},
+                ]
+            if method == "PATCH":
+                patched.append(url)
+                return {}
+            if method == "POST" and url.endswith("/issues"):
+                return {"html_url": "new-issue-url"}
+            raise AssertionError(f"unexpected call {method} {url}")
+
+        with mock.patch.object(chr_mod, "api_request", side_effect=fake_api):
+            url = chr_mod.upsert_issue("t", "o/r", "report")
+        self.assertEqual(patched, [])  # neither the PR nor the unrelated issue
+        self.assertEqual(url, "new-issue-url")
 
     def test_creates_issue_when_none_open(self):
         def fake_api(token, url, method="GET", body=None, raw=False):

--- a/.github/resources/scripts/ci_health_report_test.py
+++ b/.github/resources/scripts/ci_health_report_test.py
@@ -62,8 +62,8 @@ class ConclusionHandlingTest(unittest.TestCase):
     def collect(self, jobs):
         def fake_paginate(token, url, key, max_pages=3):
             if "workflows/" in url:
-                return [make_run(1)] if "e2e-test.yml" in url else []
-            return jobs
+                return ([make_run(1)], False) if "e2e-test.yml" in url else ([], False)
+            return jobs, False
 
         with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
             return chr_mod.collect_lane_stats("t", "o/r", "2026-07-01", 40)
@@ -96,14 +96,14 @@ class RerunHandlingTest(unittest.TestCase):
             if "workflows/" in url:
                 # Overall conclusion success: the re-run went green.
                 return (
-                    [make_run(7, conclusion="success", attempts=2)]
+                    ([make_run(7, conclusion="success", attempts=2)], False)
                     if "e2e-test.yml" in url
-                    else []
+                    else ([], False)
                 )
             if "/attempts/1/" in url:
-                return [make_job("lane", "failure")]
+                return [make_job("lane", "failure")], False
             if "/attempts/2/" in url:
-                return [make_job("lane", "success")]
+                return [make_job("lane", "success")], False
             raise AssertionError(f"unexpected jobs url {url}")
 
         with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
@@ -123,8 +123,8 @@ class TruncationFlagTest(unittest.TestCase):
 
         def fake_paginate(token, url, key, max_pages=3):
             if "workflows/" in url:
-                return runs if "e2e-test.yml" in url else []
-            return [make_job("lane", "success")]
+                return (runs, False) if "e2e-test.yml" in url else ([], False)
+            return [make_job("lane", "success")], False
 
         with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
             _, _, _, notes = chr_mod.collect_lane_stats("t", "o/r", "2026-07-01", 2)
@@ -146,7 +146,7 @@ class JobFetchErrorTest(unittest.TestCase):
 
         def fake_paginate(token, url, key, max_pages=3):
             if "workflows/" in url:
-                return [make_run(1)] if "e2e-test.yml" in url else []
+                return ([make_run(1)], False) if "e2e-test.yml" in url else ([], False)
             raise urllib.error.HTTPError(url, 500, "boom", {}, io.BytesIO(b""))
 
         with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
@@ -156,6 +156,48 @@ class JobFetchErrorTest(unittest.TestCase):
             any("job listing(s) failed" in note for note in notes),
             f"expected job-fetch note in {notes}",
         )
+
+
+class StaleWorkflowTest(unittest.TestCase):
+    def test_missing_workflow_404_is_surfaced(self):
+        import urllib.error
+
+        def fake_paginate(token, url, key, max_pages=3):
+            if "workflows/" in url:
+                raise urllib.error.HTTPError(url, 404, "gone", {}, io.BytesIO(b""))
+            raise AssertionError("no jobs should be fetched")
+
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
+            _, _, _, notes = chr_mod.collect_lane_stats("t", "o/r", "2026-07-01", 40)
+        self.assertTrue(
+            any("not found" in note and "TARGET_WORKFLOWS" in note for note in notes),
+            f"expected missing-workflow note in {notes}",
+        )
+
+
+class PageBudgetTest(unittest.TestCase):
+    def test_job_page_budget_truncation_is_surfaced(self):
+        def fake_paginate(token, url, key, max_pages=3):
+            if "workflows/" in url:
+                return ([make_run(1)], False) if "e2e-test.yml" in url else ([], False)
+            return [make_job("lane", "success")], True  # budget exhausted
+
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
+            _, _, _, notes = chr_mod.collect_lane_stats("t", "o/r", "2026-07-01", 40)
+        self.assertTrue(
+            any("page budget" in note for note in notes),
+            f"expected page-budget note in {notes}",
+        )
+
+    def test_artifact_page_budget_counts_as_ingestion_gap(self):
+        def fake_paginate(token, url, key, max_pages=3):
+            return [], True  # more artifacts exist beyond page 1
+
+        with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate):
+            _, _, errors, _ = chr_mod.collect_failed_tests(
+                "t", "o/r", [("2026-07-13T00:00:00Z", 1)], 5
+            )
+        self.assertEqual(errors, 1)
 
 
 class JunitIngestionTest(unittest.TestCase):
@@ -173,7 +215,7 @@ class JunitIngestionTest(unittest.TestCase):
         ]
 
         def fake_paginate(token, url, key, max_pages=3):
-            return artifacts
+            return artifacts, False
 
         with mock.patch.object(chr_mod, "paginate", side_effect=fake_paginate), \
                 mock.patch.object(chr_mod, "api_request", return_value=payload):
@@ -192,7 +234,7 @@ class JunitIngestionTest(unittest.TestCase):
 
         def fake_paginate(token, url, key, max_pages=3):
             seen.append(url)
-            return []
+            return [], False
 
         failed_runs = [
             ("2026-07-01T00:00:00Z", 111),  # oldest (from the first workflow)
@@ -224,7 +266,7 @@ class RenderTest(unittest.TestCase):
         )
         self.assertIn("Data completeness", report)
         self.assertIn("run cap applied", report)
-        self.assertIn("3 artifact/XML ingestion error(s)", report)
+        self.assertIn("3 artifact ingestion gap(s)", report)
         self.assertIn("| WF | lane | 4 | 2 | 50% | 15 |", report)
 
     def test_zero_artifacts_message_distinct_from_errors(self):

--- a/.github/workflows/ci-health-report.yml
+++ b/.github/workflows/ci-health-report.yml
@@ -20,6 +20,13 @@ permissions:
   contents: read
   issues: write
 
+# One report generation at a time: overlapping schedule/dispatch runs could
+# race the issue upsert (duplicate issues, or an older report overwriting a
+# newer one). Queue instead of cancel so a manual dispatch is never lost.
+concurrency:
+  group: ci-health-report
+  cancel-in-progress: false
+
 jobs:
   report:
     name: Generate CI health report

--- a/.github/workflows/ci-health-report.yml
+++ b/.github/workflows/ci-health-report.yml
@@ -1,0 +1,39 @@
+# Daily CI health report: aggregates master-branch lane failure rates and
+# per-test flake counts (from junit-xml artifacts uploaded by failed runs) and
+# publishes them to the job summary and a single tracking issue labeled
+# `ci-health`. Complements GitHub's built-in Actions performance metrics,
+# which stop at job granularity, are UI-only, and require write access to view.
+name: CI Health Report
+
+on:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Lookback window in days"
+        required: false
+        default: "14"
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+jobs:
+  report:
+    name: Generate CI health report
+    # Scheduled analytics only make sense on the canonical repo; forks would
+    # burn API quota reporting on their own (usually empty) master.
+    if: github.repository == 'kubeflow/pipelines'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate report and update tracking issue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          DAYS: ${{ inputs.days || '14' }}
+          UPDATE_ISSUE: "true"
+        run: python3 ./.github/resources/scripts/ci_health_report.py

--- a/.github/workflows/ci-scripts-tests.yml
+++ b/.github/workflows/ci-scripts-tests.yml
@@ -1,0 +1,24 @@
+# Presubmit gate for the Python tooling under .github/resources/scripts: the
+# unit tests are stdlib-only and the file name (ci_health_report_test.py) is
+# not matched by default `unittest discover` patterns, so run them explicitly.
+name: CI Scripts Tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/resources/scripts/*.py'
+      - '.github/workflows/ci-scripts-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  python-script-tests:
+    name: Run .github scripts unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run ci_health_report unit tests
+        working-directory: .github/resources/scripts
+        run: python3 -m unittest -v ci_health_report_test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-02
+- Last updated: 2026-07-13
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -517,6 +517,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 ## CI/CD (GitHub Actions)
 
 - Workflows: `.github/workflows/` (build, test, lint, release)
+- `ci-health-report.yml` runs daily (and on dispatch): aggregates master-branch lane failure rates and per-test flake counts from `junit-xml - *` artifacts, publishing to the job summary and a tracking issue labeled `ci-health`.
 - Composite actions: `.github/actions/` (e.g., `kfp-k8s`, `create-cluster`, `deploy`, `test-and-report`)
 - Typical checks: Go unit tests (backend), Python SDK tests, frontend tests/lint, image builds.
 - Frontend workflow (`frontend.yml`) verifies generated API clients are up to date by running `npm run apis:all` and failing on diff.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -518,6 +518,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 - Workflows: `.github/workflows/` (build, test, lint, release)
 - `ci-health-report.yml` runs daily (and on dispatch): aggregates master-branch lane failure rates and per-test flake counts from `junit-xml - *` artifacts, publishing to the job summary and a tracking issue labeled `ci-health`.
+- `ci-scripts-tests.yml` runs the stdlib unit tests for `.github/resources/scripts/*.py` on PRs touching those files (run locally with `cd .github/resources/scripts && python3 -m unittest ci_health_report_test`).
 - Composite actions: `.github/actions/` (e.g., `kfp-k8s`, `create-cluster`, `deploy`, `test-and-report`)
 - Typical checks: Go unit tests (backend), Python SDK tests, frontend tests/lint, image builds.
 - Frontend workflow (`frontend.yml`) verifies generated API clients are up to date by running `npm run apis:all` and failing on diff.


### PR DESCRIPTION
## Problem

Flake triage today is manual Actions-API archaeology: answering "is this lane's failure rate new?", "which tests drive it?", or "did last week's fix help?" requires bespoke queries every time. GitHub's built-in Actions performance metrics (repo → Actions → Metrics) help but stop at **job** granularity, are UI-only (no API to automate against), and require write access — contributors can't see them.

## Change

A daily scheduled workflow (`ci-health-report.yml`, also manually dispatchable with a configurable lookback) plus a stdlib-only Python reporter that:

1. **Lane health** — aggregates master-branch runs of the heavy test workflows (`e2e-test`, `api-server-tests`, v1/legacy integration, `kfp-kubernetes-execution-tests`, `sdk-execution`, `upgrade-test`, `kfp-webhooks`) into per-lane totals, failure counts/rates, and average durations, ranking the top failing lanes.
2. **Per-test flake counts** — parses the `junit-xml - *` artifacts uploaded by failed runs (added in #13715), naming the flakiest **tests**, not just the reddest lanes. This is the layer GitHub's built-in metrics cannot provide.
3. **Publishing** — writes the report to the job summary and upserts a single tracking issue labeled `ci-health`, so trends live at one stable, public URL.

Rate-limit aware (caps runs per workflow, marks results truncated instead of failing), redirect-safe artifact downloads, `issues: write`/`actions: read` only, and gated to the canonical repo so forks don't burn API quota.

## Verification

- Workflow YAML parses; `python3 -m py_compile` clean.
- **20 stdlib unit tests pass**, including exact-full-page (`100/100`) and true-truncation (`100/101`) pagination boundaries, rerun accounting, conclusion handling, ingestion gaps, and issue upsert behavior.
- **Live dry-run against kubeflow/pipelines** (7-day window, 12 runs/workflow, no issue update) produced a correct report. Excerpt:

| Workflow | Lane | Runs | Failures | Fail % | Avg min |
|---|---|---:|---:|---:|---:|
| KFP E2E Pipeline tests | End to End Critical Scenario Multi User Tests - K8s v1.36.1 … artifactProxy=true | 12 | 2 | 17% | 18 |
| KFP E2E Pipeline tests | End to End Critical Scenario MLflow Tests - K8s v1.36.1 … authType=basic-auth | 12 | 2 | 17% | 16 |
| KFP E2E Pipeline tests | End to End E2EParallelNested Tests - K8s v1.36.1 … argoVersion=v3.7.14 | 12 | 2 | 17% | 25 |

_Window totals: 1596 lane runs across 133 lanes, 26 failures._ — matching the known flake landscape (v1.36.1 MLflow / ParallelNested / multi-user lanes leading). The per-test section correctly reports that no `junit-xml` artifacts exist yet; it populates automatically once #13715 lands.

Stacked conceptually on #13715 (which supplies the junit artifacts) but functional independently — lane-level reporting works from day one.
