### PR TITLE
feat(backend): improve resilience to MLMD server restarts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -703,8 +703,8 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 ### Key environment variables
 
 - `_KFP_RUNTIME=true`: Disables SDK imports during task execution
-- `METADATA_GRPC_MAX_RETRIES=...`: Overrides the MLMD client's gRPC retry budget (default 10 attempts); read by driver/launcher pods, typically set via the optional `metadata-grpc-configmap`
-- `PIPELINE_DRIVER_RETRY_LIMIT=...`: Set on the API server to tune the Argo `retryStrategy` limit compiled into driver templates (default 3; `0` disables driver retries)
+- `METADATA_GRPC_MAX_ATTEMPTS=...`: Overrides the MLMD client's total gRPC attempts per call (default 10; `1` disables retries); read by driver/launcher pods, typically set via the optional `metadata-grpc-configmap`
+- `PIPELINE_DRIVER_RETRY_LIMIT=...`: Set on the API server to opt in to an Argo `retryStrategy` on driver templates (default `0`, disabled — driver replays are not yet idempotent; see `getDriverRetryStrategy`)
 - `VITE_NAMESPACE=...`: Sets the target namespace for the frontend in multi-user mode
 - `LOCAL_API_SERVER=true`: Enables local API server testing mode when running integration tests on a Kind cluster
 - `TENSORBOARD_PROXY_SIGNING_SECRET=...`: Optional shared frontend-server secret for scoped TensorBoard proxy URLs; defaults to `MINIO_SECRET_KEY` when unset

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -703,6 +703,8 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 ### Key environment variables
 
 - `_KFP_RUNTIME=true`: Disables SDK imports during task execution
+- `METADATA_GRPC_MAX_RETRIES=...`: Overrides the MLMD client's gRPC retry budget (default 10 attempts); read by driver/launcher pods, typically set via the optional `metadata-grpc-configmap`
+- `PIPELINE_DRIVER_RETRY_LIMIT=...`: Set on the API server to tune the Argo `retryStrategy` limit compiled into driver templates (default 3; `0` disables driver retries)
 - `VITE_NAMESPACE=...`: Sets the target namespace for the frontend in multi-user mode
 - `LOCAL_API_SERVER=true`: Enables local API server testing mode when running integration tests on a Kind cluster
 - `TENSORBOARD_PROXY_SIGNING_SECRET=...`: Optional shared frontend-server secret for scoped TensorBoard proxy URLs; defaults to `MINIO_SECRET_KEY` when unset

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -56,12 +56,13 @@ const (
 	PipelineRunAsUserEnvVar = "PIPELINE_RUN_AS_USER"
 	PipelineLogLevelEnvVar  = "PIPELINE_LOG_LEVEL"
 	PublishLogsEnvVar       = "PUBLISH_LOGS"
-	// DriverRetryLimitEnvVar tunes the Argo retryStrategy limit applied to
-	// driver templates. Set it on the API server; "0" disables driver retries.
+	// DriverRetryLimitEnvVar sets the Argo retryStrategy limit applied to
+	// driver templates. Set it on the API server; "0" (the default) disables
+	// driver retries. See getDriverRetryStrategy for why this is opt-in.
 	DriverRetryLimitEnvVar = "PIPELINE_DRIVER_RETRY_LIMIT"
-	// DefaultDriverRetryLimit is the number of times Argo re-runs a failed
-	// driver pod before marking the node failed.
-	DefaultDriverRetryLimit  = 3
+	// DefaultDriverRetryLimit disables driver retries by default: replaying a
+	// driver that already produced side effects is not yet idempotent.
+	DefaultDriverRetryLimit  = 0
 	gcsScratchLocation       = "/gcs"
 	gcsScratchName           = "gcs-scratch"
 	s3ScratchLocation        = "/s3"
@@ -158,9 +159,16 @@ func GetPipelineRunAsUser() *int64 {
 // getDriverRetryStrategy returns the retryStrategy applied to driver
 // templates. Driver pods fail on transient conditions outside the pipeline's
 // control (e.g. the MLMD or API server briefly unavailable, node preemption),
-// and without a retryStrategy any such failure fails the whole run. The retry
-// limit is tunable via the PIPELINE_DRIVER_RETRY_LIMIT environment variable on
-// the API server; 0 disables driver retries and returns nil.
+// and without a retryStrategy any such failure fails the whole run.
+//
+// This is opt-in (default 0, no retryStrategy) because replaying a driver is
+// not yet idempotent: only the root DAG execution has a deterministic MLMD
+// name, so a replayed container/DAG driver whose PutExecution committed before
+// the failure creates a duplicate execution; plugin OnTaskStart hooks re-fire;
+// and createpvc/deletepvc replays can create a second UUID-named PVC or fail
+// on the already-deleted one. Cluster operators who accept those risks can
+// enable retries via the PIPELINE_DRIVER_RETRY_LIMIT environment variable on
+// the API server.
 func getDriverRetryStrategy() *wfapi.RetryStrategy {
 	limit := int32(DefaultDriverRetryLimit)
 	if value, ok := os.LookupEnv(DriverRetryLimitEnvVar); ok {

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -47,15 +47,21 @@ const (
 	// but are overridden by environment variables set via k8s manifests.
 	// For releases, the manifest will have the correct release version set.
 	// this is to avoid hardcoding releases in code here.
-	DefaultLauncherImage     = "ghcr.io/kubeflow/kfp-launcher:latest"
-	LauncherCommandEnvVar    = "V2_LAUNCHER_COMMAND"
-	DefaultLauncherCommand   = "launcher-v2"
-	DefaultDriverImage       = "ghcr.io/kubeflow/kfp-driver:latest"
-	DefaultDriverCommand     = "driver"
-	DriverCommandEnvVar      = "V2_DRIVER_COMMAND"
-	PipelineRunAsUserEnvVar  = "PIPELINE_RUN_AS_USER"
-	PipelineLogLevelEnvVar   = "PIPELINE_LOG_LEVEL"
-	PublishLogsEnvVar        = "PUBLISH_LOGS"
+	DefaultLauncherImage    = "ghcr.io/kubeflow/kfp-launcher:latest"
+	LauncherCommandEnvVar   = "V2_LAUNCHER_COMMAND"
+	DefaultLauncherCommand  = "launcher-v2"
+	DefaultDriverImage      = "ghcr.io/kubeflow/kfp-driver:latest"
+	DefaultDriverCommand    = "driver"
+	DriverCommandEnvVar     = "V2_DRIVER_COMMAND"
+	PipelineRunAsUserEnvVar = "PIPELINE_RUN_AS_USER"
+	PipelineLogLevelEnvVar  = "PIPELINE_LOG_LEVEL"
+	PublishLogsEnvVar       = "PUBLISH_LOGS"
+	// DriverRetryLimitEnvVar tunes the Argo retryStrategy limit applied to
+	// driver templates. Set it on the API server; "0" disables driver retries.
+	DriverRetryLimitEnvVar = "PIPELINE_DRIVER_RETRY_LIMIT"
+	// DefaultDriverRetryLimit is the number of times Argo re-runs a failed
+	// driver pod before marking the node failed.
+	DefaultDriverRetryLimit  = 3
 	gcsScratchLocation       = "/gcs"
 	gcsScratchName           = "gcs-scratch"
 	s3ScratchLocation        = "/s3"
@@ -147,6 +153,43 @@ func GetPipelineRunAsUser() *int64 {
 	}
 
 	return &runAsUser
+}
+
+// getDriverRetryStrategy returns the retryStrategy applied to driver
+// templates. Driver pods fail on transient conditions outside the pipeline's
+// control (e.g. the MLMD or API server briefly unavailable, node preemption),
+// and without a retryStrategy any such failure fails the whole run. The retry
+// limit is tunable via the PIPELINE_DRIVER_RETRY_LIMIT environment variable on
+// the API server; 0 disables driver retries and returns nil.
+func getDriverRetryStrategy() *wfapi.RetryStrategy {
+	limit := int32(DefaultDriverRetryLimit)
+	if value, ok := os.LookupEnv(DriverRetryLimitEnvVar); ok {
+		parsed, err := strconv.ParseInt(value, 10, 32)
+		if err != nil || parsed < 0 {
+			glog.Errorf(
+				"Invalid %s value %q, expected a non-negative integer; using default %d",
+				DriverRetryLimitEnvVar, value, DefaultDriverRetryLimit,
+			)
+		} else {
+			limit = int32(parsed)
+		}
+	}
+	if limit == 0 {
+		return nil
+	}
+	limitValue := intstr.FromInt32(limit)
+	backoffFactor := intstr.FromInt32(2)
+	return &wfapi.RetryStrategy{
+		Limit: &limitValue,
+		// Retry on both Failed (driver exited non-zero, e.g. a metadata RPC
+		// error) and Error (pod-level problems such as node preemption).
+		RetryPolicy: wfapi.RetryPolicyAlways,
+		Backoff: &wfapi.Backoff{
+			Duration:    "5s",
+			Factor:      &backoffFactor,
+			MaxDuration: "1m",
+		},
+	}
 }
 
 func (c *workflowCompiler) containerDriverTask(name string, inputs containerDriverInputs) (*wfapi.DAGTask, *containerDriverOutputs) {
@@ -276,8 +319,10 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 			Command:   c.driverCommand,
 			Args:      args,
 			Resources: driverResources,
+			EnvFrom:   []k8score.EnvFromSource{metadataEnvFrom},
 			Env:       append(proxy.GetConfig().GetEnvVars(), commonEnvs...),
 		},
+		RetryStrategy: getDriverRetryStrategy(),
 	}
 	setRuntimeRole(template, util.ExecutionRuntimeRoleDriver)
 	applySecurityContextToTemplate(template)

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -164,11 +164,14 @@ func GetPipelineRunAsUser() *int64 {
 // This is opt-in (default 0, no retryStrategy) because replaying a driver is
 // not yet idempotent: only the root DAG execution has a deterministic MLMD
 // name, so a replayed container/DAG driver whose PutExecution committed before
-// the failure creates a duplicate execution; plugin OnTaskStart hooks re-fire;
-// and createpvc/deletepvc replays can create a second UUID-named PVC or fail
-// on the already-deleted one. Cluster operators who accept those risks can
-// enable retries via the PIPELINE_DRIVER_RETRY_LIMIT environment variable on
-// the API server.
+// the failure creates a duplicate execution — and GetExecutionsInDAG then
+// fails the whole DAG on the duplicate task name, so a replay can poison the
+// run instead of recovering it. Plugin OnTaskStart hooks also re-fire, and
+// createpvc/deletepvc replays can create a second UUID-named PVC or fail on
+// the already-deleted one. Cluster operators who accept those risks can enable
+// retries via the PIPELINE_DRIVER_RETRY_LIMIT environment variable on the API
+// server. Default-on requires stable execution identities and read-after-error
+// reconciliation across every driver type.
 func getDriverRetryStrategy() *wfapi.RetryStrategy {
 	limit := int32(DefaultDriverRetryLimit)
 	if value, ok := os.LookupEnv(DriverRetryLimitEnvVar); ok {

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -182,11 +182,14 @@ func GetPipelineRunAsUser() *int64 {
 // This is opt-in (default 0, no retryStrategy) because replaying a driver is
 // not yet idempotent: only the root DAG execution has a deterministic MLMD
 // name, so a replayed container/DAG driver whose PutExecution committed before
-// the failure creates a duplicate execution; plugin OnTaskStart hooks re-fire;
-// and createpvc/deletepvc replays can create a second UUID-named PVC or fail
-// on the already-deleted one. Cluster operators who accept those risks can
-// enable retries via the PIPELINE_DRIVER_RETRY_LIMIT environment variable on
-// the API server.
+// the failure creates a duplicate execution — and GetExecutionsInDAG then
+// fails the whole DAG on the duplicate task name, so a replay can poison the
+// run instead of recovering it. Plugin OnTaskStart hooks also re-fire, and
+// createpvc/deletepvc replays can create a second UUID-named PVC or fail on
+// the already-deleted one. Cluster operators who accept those risks can enable
+// retries via the PIPELINE_DRIVER_RETRY_LIMIT environment variable on the API
+// server. Default-on requires stable execution identities and read-after-error
+// reconciliation across every driver type.
 func getDriverRetryStrategy() *wfapi.RetryStrategy {
 	limit := int32(DefaultDriverRetryLimit)
 	if value, ok := os.LookupEnv(DriverRetryLimitEnvVar); ok {

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -55,12 +55,13 @@ const (
 	PipelineRunAsUserEnvVar = "PIPELINE_RUN_AS_USER"
 	PipelineLogLevelEnvVar  = "PIPELINE_LOG_LEVEL"
 	PublishLogsEnvVar       = "PUBLISH_LOGS"
-	// DriverRetryLimitEnvVar tunes the Argo retryStrategy limit applied to
-	// driver templates. Set it on the API server; "0" disables driver retries.
+	// DriverRetryLimitEnvVar sets the Argo retryStrategy limit applied to
+	// driver templates. Set it on the API server; "0" (the default) disables
+	// driver retries. See getDriverRetryStrategy for why this is opt-in.
 	DriverRetryLimitEnvVar = "PIPELINE_DRIVER_RETRY_LIMIT"
-	// DefaultDriverRetryLimit is the number of times Argo re-runs a failed
-	// driver pod before marking the node failed.
-	DefaultDriverRetryLimit  = 3
+	// DefaultDriverRetryLimit disables driver retries by default: replaying a
+	// driver that already produced side effects is not yet idempotent.
+	DefaultDriverRetryLimit  = 0
 	gcsScratchLocation       = "/gcs"
 	gcsScratchName           = "gcs-scratch"
 	s3ScratchLocation        = "/s3"
@@ -176,9 +177,16 @@ func GetPipelineRunAsUser() *int64 {
 // getDriverRetryStrategy returns the retryStrategy applied to driver
 // templates. Driver pods fail on transient conditions outside the pipeline's
 // control (e.g. the MLMD or API server briefly unavailable, node preemption),
-// and without a retryStrategy any such failure fails the whole run. The retry
-// limit is tunable via the PIPELINE_DRIVER_RETRY_LIMIT environment variable on
-// the API server; 0 disables driver retries and returns nil.
+// and without a retryStrategy any such failure fails the whole run.
+//
+// This is opt-in (default 0, no retryStrategy) because replaying a driver is
+// not yet idempotent: only the root DAG execution has a deterministic MLMD
+// name, so a replayed container/DAG driver whose PutExecution committed before
+// the failure creates a duplicate execution; plugin OnTaskStart hooks re-fire;
+// and createpvc/deletepvc replays can create a second UUID-named PVC or fail
+// on the already-deleted one. Cluster operators who accept those risks can
+// enable retries via the PIPELINE_DRIVER_RETRY_LIMIT environment variable on
+// the API server.
 func getDriverRetryStrategy() *wfapi.RetryStrategy {
 	limit := int32(DefaultDriverRetryLimit)
 	if value, ok := os.LookupEnv(DriverRetryLimitEnvVar); ok {

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -46,15 +46,21 @@ const (
 	// but are overridden by environment variables set via k8s manifests.
 	// For releases, the manifest will have the correct release version set.
 	// this is to avoid hardcoding releases in code here.
-	DefaultLauncherImage     = "ghcr.io/kubeflow/kfp-launcher:latest"
-	LauncherCommandEnvVar    = "V2_LAUNCHER_COMMAND"
-	DefaultLauncherCommand   = "launcher-v2"
-	DefaultDriverImage       = "ghcr.io/kubeflow/kfp-driver:latest"
-	DefaultDriverCommand     = "driver"
-	DriverCommandEnvVar      = "V2_DRIVER_COMMAND"
-	PipelineRunAsUserEnvVar  = "PIPELINE_RUN_AS_USER"
-	PipelineLogLevelEnvVar   = "PIPELINE_LOG_LEVEL"
-	PublishLogsEnvVar        = "PUBLISH_LOGS"
+	DefaultLauncherImage    = "ghcr.io/kubeflow/kfp-launcher:latest"
+	LauncherCommandEnvVar   = "V2_LAUNCHER_COMMAND"
+	DefaultLauncherCommand  = "launcher-v2"
+	DefaultDriverImage      = "ghcr.io/kubeflow/kfp-driver:latest"
+	DefaultDriverCommand    = "driver"
+	DriverCommandEnvVar     = "V2_DRIVER_COMMAND"
+	PipelineRunAsUserEnvVar = "PIPELINE_RUN_AS_USER"
+	PipelineLogLevelEnvVar  = "PIPELINE_LOG_LEVEL"
+	PublishLogsEnvVar       = "PUBLISH_LOGS"
+	// DriverRetryLimitEnvVar tunes the Argo retryStrategy limit applied to
+	// driver templates. Set it on the API server; "0" disables driver retries.
+	DriverRetryLimitEnvVar = "PIPELINE_DRIVER_RETRY_LIMIT"
+	// DefaultDriverRetryLimit is the number of times Argo re-runs a failed
+	// driver pod before marking the node failed.
+	DefaultDriverRetryLimit  = 3
 	gcsScratchLocation       = "/gcs"
 	gcsScratchName           = "gcs-scratch"
 	s3ScratchLocation        = "/s3"
@@ -165,6 +171,43 @@ func GetPipelineRunAsUser() *int64 {
 	}
 
 	return &runAsUser
+}
+
+// getDriverRetryStrategy returns the retryStrategy applied to driver
+// templates. Driver pods fail on transient conditions outside the pipeline's
+// control (e.g. the MLMD or API server briefly unavailable, node preemption),
+// and without a retryStrategy any such failure fails the whole run. The retry
+// limit is tunable via the PIPELINE_DRIVER_RETRY_LIMIT environment variable on
+// the API server; 0 disables driver retries and returns nil.
+func getDriverRetryStrategy() *wfapi.RetryStrategy {
+	limit := int32(DefaultDriverRetryLimit)
+	if value, ok := os.LookupEnv(DriverRetryLimitEnvVar); ok {
+		parsed, err := strconv.ParseInt(value, 10, 32)
+		if err != nil || parsed < 0 {
+			glog.Errorf(
+				"Invalid %s value %q, expected a non-negative integer; using default %d",
+				DriverRetryLimitEnvVar, value, DefaultDriverRetryLimit,
+			)
+		} else {
+			limit = int32(parsed)
+		}
+	}
+	if limit == 0 {
+		return nil
+	}
+	limitValue := intstr.FromInt32(limit)
+	backoffFactor := intstr.FromInt32(2)
+	return &wfapi.RetryStrategy{
+		Limit: &limitValue,
+		// Retry on both Failed (driver exited non-zero, e.g. a metadata RPC
+		// error) and Error (pod-level problems such as node preemption).
+		RetryPolicy: wfapi.RetryPolicyAlways,
+		Backoff: &wfapi.Backoff{
+			Duration:    "5s",
+			Factor:      &backoffFactor,
+			MaxDuration: "1m",
+		},
+	}
 }
 
 func (c *workflowCompiler) containerDriverTask(name string, inputs containerDriverInputs) (*wfapi.DAGTask, *containerDriverOutputs) {
@@ -290,8 +333,10 @@ func (c *workflowCompiler) addContainerDriverTemplate() string {
 			Command:   c.driverCommand,
 			Args:      args,
 			Resources: driverResources,
+			EnvFrom:   []k8score.EnvFromSource{metadataEnvFrom},
 			Env:       append(proxy.GetConfig().GetEnvVars(), commonEnvs...),
 		},
+		RetryStrategy: getDriverRetryStrategy(),
 	}
 	setRuntimeRole(template, util.ExecutionRuntimeRoleDriver)
 	applySecurityContextToTemplate(template)

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -642,8 +642,10 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 			Command:   c.driverCommand,
 			Args:      args,
 			Resources: driverResources,
+			EnvFrom:   []k8score.EnvFromSource{metadataEnvFrom},
 			Env:       proxy.GetConfig().GetEnvVars(),
 		},
+		RetryStrategy: getDriverRetryStrategy(),
 	}
 	setRuntimeRole(template, util.ExecutionRuntimeRoleDriver)
 	applySecurityContextToTemplate(template)

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -635,8 +635,10 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 			Command:   c.driverCommand,
 			Args:      args,
 			Resources: driverResources,
+			EnvFrom:   []k8score.EnvFromSource{metadataEnvFrom},
 			Env:       proxy.GetConfig().GetEnvVars(),
 		},
+		RetryStrategy: getDriverRetryStrategy(),
 	}
 	setRuntimeRole(template, util.ExecutionRuntimeRoleDriver)
 	applySecurityContextToTemplate(template)

--- a/backend/src/v2/compiler/argocompiler/driver_retry_test.go
+++ b/backend/src/v2/compiler/argocompiler/driver_retry_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocompiler
+
+import (
+	"testing"
+
+	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDriverRetryStrategy(t *testing.T) {
+	tests := []struct {
+		name string
+		// nil means the environment variable is unset
+		envValue  *string
+		wantNil   bool
+		wantLimit int32
+	}{
+		{
+			name:      "default when unset",
+			wantLimit: DefaultDriverRetryLimit,
+		},
+		{
+			name:      "explicit limit",
+			envValue:  stringPtr("7"),
+			wantLimit: 7,
+		},
+		{
+			name:     "zero disables retries",
+			envValue: stringPtr("0"),
+			wantNil:  true,
+		},
+		{
+			name:      "invalid value falls back to default",
+			envValue:  stringPtr("not-a-number"),
+			wantLimit: DefaultDriverRetryLimit,
+		},
+		{
+			name:      "negative value falls back to default",
+			envValue:  stringPtr("-2"),
+			wantLimit: DefaultDriverRetryLimit,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.envValue != nil {
+				t.Setenv(DriverRetryLimitEnvVar, *test.envValue)
+			}
+			strategy := getDriverRetryStrategy()
+			if test.wantNil {
+				assert.Nil(t, strategy)
+				return
+			}
+			require.NotNil(t, strategy)
+			require.NotNil(t, strategy.Limit)
+			assert.Equal(t, test.wantLimit, strategy.Limit.IntVal)
+			assert.Equal(t, wfapi.RetryPolicyAlways, strategy.RetryPolicy)
+			require.NotNil(t, strategy.Backoff)
+			assert.Equal(t, "5s", strategy.Backoff.Duration)
+			assert.Equal(t, "1m", strategy.Backoff.MaxDuration)
+		})
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/backend/src/v2/compiler/argocompiler/driver_retry_test.go
+++ b/backend/src/v2/compiler/argocompiler/driver_retry_test.go
@@ -31,28 +31,28 @@ func TestGetDriverRetryStrategy(t *testing.T) {
 		wantLimit int32
 	}{
 		{
-			name:      "default when unset",
-			wantLimit: DefaultDriverRetryLimit,
+			name:    "disabled by default when unset",
+			wantNil: true,
 		},
 		{
-			name:      "explicit limit",
+			name:      "explicit limit enables retries",
 			envValue:  stringPtr("7"),
 			wantLimit: 7,
 		},
 		{
-			name:     "zero disables retries",
+			name:     "explicit zero disables retries",
 			envValue: stringPtr("0"),
 			wantNil:  true,
 		},
 		{
-			name:      "invalid value falls back to default",
-			envValue:  stringPtr("not-a-number"),
-			wantLimit: DefaultDriverRetryLimit,
+			name:     "invalid value falls back to disabled default",
+			envValue: stringPtr("not-a-number"),
+			wantNil:  true,
 		},
 		{
-			name:      "negative value falls back to default",
-			envValue:  stringPtr("-2"),
-			wantLimit: DefaultDriverRetryLimit,
+			name:     "negative value falls back to disabled default",
+			envValue: stringPtr("-2"),
+			wantNil:  true,
 		},
 	}
 	for _, test := range tests {

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -55,20 +55,27 @@ const (
 	pipelineRunContextTypeName         = "system.PipelineRun"
 	ImporterExecutionTypeName          = "system.ImporterExecution"
 	ImporterWorkspaceExecutionTypeName = "system.ImporterWorkspaceExecution"
-	// defaultMlmdClientSideMaxRetries is the default number of attempts the MLMD
-	// client makes for a failed gRPC call before returning an error. This is
-	// intentionally higher than a typical RPC retry budget because MySQL
-	// deadlocks (codes.Aborted) on the MLMD server are transient and require
-	// time to resolve under sustained parallel execution.
-	defaultMlmdClientSideMaxRetries = 10
-	mlmdClientSideBackoffBase       = 1 * time.Second
-	mlmdClientSideBackoffJitter     = 0.25
+	// defaultMlmdClientSideMaxAttempts is the default total number of attempts
+	// (the first call plus retries) the MLMD client makes for a failed gRPC
+	// call before returning an error. This is intentionally higher than a
+	// typical RPC retry budget because MySQL deadlocks (codes.Aborted) on the
+	// MLMD server are transient and require time to resolve under sustained
+	// parallel execution.
+	defaultMlmdClientSideMaxAttempts = 10
+	mlmdClientSideBackoffBase        = 1 * time.Second
+	mlmdClientSideBackoffJitter      = 0.25
 	// mlmdClientSideBackoffCap limits the maximum per-attempt wait so a single
 	// deadlock retry never stalls a pod for more than 30 s.
-	mlmdClientSideBackoffCap  = 30 * time.Second
-	defaultMaxGRPCMessageSize = 100 * 1024 * 1024 // 100MB
-	maxGRPCMessageSizeEnv     = "METADATA_GRPC_MESSAGE_SIZE"
-	maxGRPCRetriesEnv         = "METADATA_GRPC_MAX_RETRIES"
+	mlmdClientSideBackoffCap = 30 * time.Second
+	// mlmdClientSideReadPerRetryTimeout bounds each attempt of a read-only RPC
+	// so a connected-but-hung MLMD server cannot stall a driver forever (driver
+	// contexts have no deadline). A timed-out read attempt is retried. Write
+	// attempts are deliberately not bounded: abandoning and replaying a slow
+	// write risks duplicating server-side state.
+	mlmdClientSideReadPerRetryTimeout = 2 * time.Minute
+	defaultMaxGRPCMessageSize         = 100 * 1024 * 1024 // 100MB
+	maxGRPCMessageSizeEnv             = "METADATA_GRPC_MESSAGE_SIZE"
+	maxGRPCAttemptsEnv                = "METADATA_GRPC_MAX_ATTEMPTS"
 )
 
 // MaxGRPCMessageSize is the max gRPC message size for the metadata client.
@@ -77,10 +84,11 @@ const (
 // Configurable via the METADATA_GRPC_MESSAGE_SIZE environment variable (in bytes).
 var MaxGRPCMessageSize = defaultMaxGRPCMessageSize
 
-// mlmdClientSideMaxRetries is the number of attempts the MLMD client makes for
-// a failed gRPC call before returning an error.
-// Configurable via the METADATA_GRPC_MAX_RETRIES environment variable.
-var mlmdClientSideMaxRetries = uint(defaultMlmdClientSideMaxRetries)
+// mlmdClientSideMaxAttempts is the total number of attempts (the first call
+// plus retries) the MLMD client makes for a failed gRPC call before returning
+// an error. Configurable via the METADATA_GRPC_MAX_ATTEMPTS environment
+// variable; 1 disables retries.
+var mlmdClientSideMaxAttempts = uint(defaultMlmdClientSideMaxAttempts)
 
 // positiveIntFromEnv reads envName and parses it as a positive integer.
 // The second return value reports whether the variable was set.
@@ -108,13 +116,13 @@ func init() {
 		MaxGRPCMessageSize = size
 		glog.Infof("MaxGRPCMessageSize set to %d bytes from %s", size, maxGRPCMessageSizeEnv)
 	}
-	retries, ok, err := positiveIntFromEnv(maxGRPCRetriesEnv)
+	attempts, ok, err := positiveIntFromEnv(maxGRPCAttemptsEnv)
 	if err != nil {
 		glog.Fatal(err)
 	}
 	if ok {
-		mlmdClientSideMaxRetries = uint(retries)
-		glog.Infof("MLMD client max retries set to %d from %s", retries, maxGRPCRetriesEnv)
+		mlmdClientSideMaxAttempts = uint(attempts)
+		glog.Infof("MLMD client max attempts set to %d from %s", attempts, maxGRPCAttemptsEnv)
 	}
 }
 
@@ -199,19 +207,22 @@ func isReadOnlyMLMDMethod(fullMethod string) bool {
 }
 
 // newMethodAwareRetryInterceptor returns a unary client interceptor that
-// retries read-only MLMD RPCs on a broader set of gRPC codes than write RPCs.
+// retries read-only MLMD RPCs on a broader set of gRPC codes than write RPCs,
+// and bounds each read attempt with readPerRetryTimeout (0 disables the bound)
+// so a hung server cannot stall callers without a context deadline forever.
 // Use bounded exponential backoff so that high-concurrency deadlock storms are
 // given enough time to resolve without stalling a pod indefinitely.
-func newMethodAwareRetryInterceptor(maxRetries uint, backoffBase time.Duration) grpc.UnaryClientInterceptor {
+func newMethodAwareRetryInterceptor(maxAttempts uint, backoffBase time.Duration, readPerRetryTimeout time.Duration) grpc.UnaryClientInterceptor {
 	backoff := grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitterBounded(
 		backoffBase,
 		mlmdClientSideBackoffJitter,
 		mlmdClientSideBackoffCap,
 	))
 	readInterceptor := grpc_retry.UnaryClientInterceptor(
-		grpc_retry.WithMax(maxRetries), backoff, grpc_retry.WithCodes(mlmdReadRetryableCodes...))
+		grpc_retry.WithMax(maxAttempts), backoff, grpc_retry.WithCodes(mlmdReadRetryableCodes...),
+		grpc_retry.WithPerRetryTimeout(readPerRetryTimeout))
 	writeInterceptor := grpc_retry.UnaryClientInterceptor(
-		grpc_retry.WithMax(maxRetries), backoff, grpc_retry.WithCodes(mlmdWriteRetryableCodes...))
+		grpc_retry.WithMax(maxAttempts), backoff, grpc_retry.WithCodes(mlmdWriteRetryableCodes...))
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		if isReadOnlyMLMDMethod(method) {
 			return readInterceptor(ctx, method, req, reply, cc, invoker, opts...)
@@ -225,7 +236,7 @@ func NewClient(serverAddress, serverPort string, tlsCfg *tls.Config) (*Client, e
 	// All MLMD RPCs are unary; keep the conservative write retry policy for the
 	// stream interceptor in case streaming methods are ever added.
 	streamOpts := []grpc_retry.CallOption{
-		grpc_retry.WithMax(mlmdClientSideMaxRetries),
+		grpc_retry.WithMax(mlmdClientSideMaxAttempts),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitterBounded(
 			mlmdClientSideBackoffBase,
 			mlmdClientSideBackoffJitter,
@@ -246,7 +257,8 @@ func NewClient(serverAddress, serverPort string, tlsCfg *tls.Config) (*Client, e
 			grpc.MaxCallSendMsgSize(MaxGRPCMessageSize),
 		),
 		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor(streamOpts...)),
-		grpc.WithUnaryInterceptor(newMethodAwareRetryInterceptor(mlmdClientSideMaxRetries, mlmdClientSideBackoffBase)),
+		grpc.WithUnaryInterceptor(newMethodAwareRetryInterceptor(
+			mlmdClientSideMaxAttempts, mlmdClientSideBackoffBase, mlmdClientSideReadPerRetryTimeout)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("metadata.NewClient() failed: %w", err)

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -55,19 +55,20 @@ const (
 	pipelineRunContextTypeName         = "system.PipelineRun"
 	ImporterExecutionTypeName          = "system.ImporterExecution"
 	ImporterWorkspaceExecutionTypeName = "system.ImporterWorkspaceExecution"
-	// mlmdClientSideMaxRetries is the number of times the MLMD client will retry
-	// a failed gRPC call before returning an error. This is intentionally higher
-	// than a typical RPC retry budget because MySQL deadlocks (codes.Aborted) on
-	// the MLMD server are transient and require time to resolve under sustained
-	// parallel execution.
-	mlmdClientSideMaxRetries    = 10
-	mlmdClientSideBackoffBase   = 1 * time.Second
-	mlmdClientSideBackoffJitter = 0.25
+	// defaultMlmdClientSideMaxRetries is the default number of attempts the MLMD
+	// client makes for a failed gRPC call before returning an error. This is
+	// intentionally higher than a typical RPC retry budget because MySQL
+	// deadlocks (codes.Aborted) on the MLMD server are transient and require
+	// time to resolve under sustained parallel execution.
+	defaultMlmdClientSideMaxRetries = 10
+	mlmdClientSideBackoffBase       = 1 * time.Second
+	mlmdClientSideBackoffJitter     = 0.25
 	// mlmdClientSideBackoffCap limits the maximum per-attempt wait so a single
 	// deadlock retry never stalls a pod for more than 30 s.
 	mlmdClientSideBackoffCap  = 30 * time.Second
 	defaultMaxGRPCMessageSize = 100 * 1024 * 1024 // 100MB
 	maxGRPCMessageSizeEnv     = "METADATA_GRPC_MESSAGE_SIZE"
+	maxGRPCRetriesEnv         = "METADATA_GRPC_MAX_RETRIES"
 )
 
 // MaxGRPCMessageSize is the max gRPC message size for the metadata client.
@@ -76,17 +77,44 @@ const (
 // Configurable via the METADATA_GRPC_MESSAGE_SIZE environment variable (in bytes).
 var MaxGRPCMessageSize = defaultMaxGRPCMessageSize
 
+// mlmdClientSideMaxRetries is the number of attempts the MLMD client makes for
+// a failed gRPC call before returning an error.
+// Configurable via the METADATA_GRPC_MAX_RETRIES environment variable.
+var mlmdClientSideMaxRetries = uint(defaultMlmdClientSideMaxRetries)
+
+// positiveIntFromEnv reads envName and parses it as a positive integer.
+// The second return value reports whether the variable was set.
+func positiveIntFromEnv(envName string) (int, bool, error) {
+	v := os.Getenv(envName)
+	if v == "" {
+		return 0, false, nil
+	}
+	value, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, false, fmt.Errorf("%s environment variable must be a valid integer: %w", envName, err)
+	}
+	if value <= 0 {
+		return 0, false, fmt.Errorf("%s environment variable must be a positive integer, got %d", envName, value)
+	}
+	return value, true, nil
+}
+
 func init() {
-	if v := os.Getenv(maxGRPCMessageSizeEnv); v != "" {
-		size, err := strconv.Atoi(v)
-		if err != nil {
-			glog.Fatalf("%s environment variable must be a valid integer: %v", maxGRPCMessageSizeEnv, err)
-		}
-		if size <= 0 {
-			glog.Fatalf("%s environment variable must be a positive integer, got %d", maxGRPCMessageSizeEnv, size)
-		}
+	size, ok, err := positiveIntFromEnv(maxGRPCMessageSizeEnv)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	if ok {
 		MaxGRPCMessageSize = size
 		glog.Infof("MaxGRPCMessageSize set to %d bytes from %s", size, maxGRPCMessageSizeEnv)
+	}
+	retries, ok, err := positiveIntFromEnv(maxGRPCRetriesEnv)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	if ok {
+		mlmdClientSideMaxRetries = uint(retries)
+		glog.Infof("MLMD client max retries set to %d from %s", retries, maxGRPCRetriesEnv)
 	}
 }
 
@@ -147,19 +175,63 @@ type Client struct {
 	ctxTypeCache sync.Map
 }
 
+// mlmdWriteRetryableCodes are gRPC codes that are safe to retry on any MLMD
+// RPC, including writes: Aborted (MySQL deadlock on the MLMD server) and
+// Unavailable (transient connectivity, e.g. the MLMD server restarting).
+var mlmdWriteRetryableCodes = []codes.Code{codes.Aborted, codes.Unavailable}
+
+// mlmdReadRetryableCodes additionally covers codes that can be produced when
+// the MLMD server dies mid-request (e.g. OOM kill). These may leave a write in
+// an unknown state, so they are only retried for idempotent read-only RPCs.
+// Note: DeadlineExceeded and Canceled are deliberately excluded; the retry
+// middleware treats them as caller context errors and never retries them.
+var mlmdReadRetryableCodes = append(
+	[]codes.Code{codes.Internal, codes.Unknown},
+	mlmdWriteRetryableCodes...,
+)
+
+// isReadOnlyMLMDMethod reports whether a full gRPC method name (e.g.
+// "/ml_metadata.MetadataStoreService/GetArtifactsByID") is a read-only MLMD
+// RPC. All read-only MetadataStoreService methods are named "Get*".
+func isReadOnlyMLMDMethod(fullMethod string) bool {
+	methodName := fullMethod[strings.LastIndex(fullMethod, "/")+1:]
+	return strings.HasPrefix(methodName, "Get")
+}
+
+// newMethodAwareRetryInterceptor returns a unary client interceptor that
+// retries read-only MLMD RPCs on a broader set of gRPC codes than write RPCs.
+// Use bounded exponential backoff so that high-concurrency deadlock storms are
+// given enough time to resolve without stalling a pod indefinitely.
+func newMethodAwareRetryInterceptor(maxRetries uint, backoffBase time.Duration) grpc.UnaryClientInterceptor {
+	backoff := grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitterBounded(
+		backoffBase,
+		mlmdClientSideBackoffJitter,
+		mlmdClientSideBackoffCap,
+	))
+	readInterceptor := grpc_retry.UnaryClientInterceptor(
+		grpc_retry.WithMax(maxRetries), backoff, grpc_retry.WithCodes(mlmdReadRetryableCodes...))
+	writeInterceptor := grpc_retry.UnaryClientInterceptor(
+		grpc_retry.WithMax(maxRetries), backoff, grpc_retry.WithCodes(mlmdWriteRetryableCodes...))
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		if isReadOnlyMLMDMethod(method) {
+			return readInterceptor(ctx, method, req, reply, cc, invoker, opts...)
+		}
+		return writeInterceptor(ctx, method, req, reply, cc, invoker, opts...)
+	}
+}
+
 // NewClient creates a Client given the MLMD server address and port.
 func NewClient(serverAddress, serverPort string, tlsCfg *tls.Config) (*Client, error) {
-	// Retry on Aborted (MySQL deadlock) and Unavailable (transient connectivity).
-	// Use bounded exponential backoff so that high-concurrency deadlock storms
-	// are given enough time to resolve without stalling a pod indefinitely.
-	opts := []grpc_retry.CallOption{
+	// All MLMD RPCs are unary; keep the conservative write retry policy for the
+	// stream interceptor in case streaming methods are ever added.
+	streamOpts := []grpc_retry.CallOption{
 		grpc_retry.WithMax(mlmdClientSideMaxRetries),
 		grpc_retry.WithBackoff(grpc_retry.BackoffExponentialWithJitterBounded(
 			mlmdClientSideBackoffBase,
 			mlmdClientSideBackoffJitter,
 			mlmdClientSideBackoffCap,
 		)),
-		grpc_retry.WithCodes(codes.Aborted, codes.Unavailable),
+		grpc_retry.WithCodes(mlmdWriteRetryableCodes...),
 	}
 
 	creds := insecure.NewCredentials()
@@ -173,8 +245,8 @@ func NewClient(serverAddress, serverPort string, tlsCfg *tls.Config) (*Client, e
 			grpc.MaxCallRecvMsgSize(MaxGRPCMessageSize),
 			grpc.MaxCallSendMsgSize(MaxGRPCMessageSize),
 		),
-		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor(opts...)),
-		grpc.WithUnaryInterceptor(grpc_retry.UnaryClientInterceptor(opts...)),
+		grpc.WithStreamInterceptor(grpc_retry.StreamClientInterceptor(streamOpts...)),
+		grpc.WithUnaryInterceptor(newMethodAwareRetryInterceptor(mlmdClientSideMaxRetries, mlmdClientSideBackoffBase)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("metadata.NewClient() failed: %w", err)

--- a/backend/src/v2/metadata/client_retry_test.go
+++ b/backend/src/v2/metadata/client_retry_test.go
@@ -76,7 +76,7 @@ func TestMethodAwareRetryInterceptor(t *testing.T) {
 				attempts++
 				return status.Error(test.code, "injected failure")
 			}
-			interceptor := newMethodAwareRetryInterceptor(maxRetries, time.Millisecond)
+			interceptor := newMethodAwareRetryInterceptor(maxRetries, time.Millisecond, 0)
 			err := interceptor(context.Background(), test.method, nil, nil, nil, invoker)
 			require.Error(t, err)
 			assert.Equal(t, test.code, status.Code(err))
@@ -90,8 +90,40 @@ func TestMethodAwareRetryInterceptor(t *testing.T) {
 			attempts++
 			return nil
 		}
-		interceptor := newMethodAwareRetryInterceptor(maxRetries, time.Millisecond)
+		interceptor := newMethodAwareRetryInterceptor(maxRetries, time.Millisecond, 0)
 		require.NoError(t, interceptor(context.Background(), readMethod, nil, nil, nil, invoker))
+		assert.Equal(t, 1, attempts)
+	})
+
+	// A hung server must not stall a read forever: each read attempt is bounded
+	// by the per-retry timeout and a timed-out attempt is retried.
+	t.Run("hung read attempts time out and retry", func(t *testing.T) {
+		attempts := 0
+		hangingInvoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			attempts++
+			<-ctx.Done()
+			return status.FromContextError(ctx.Err()).Err()
+		}
+		interceptor := newMethodAwareRetryInterceptor(maxRetries, time.Millisecond, 5*time.Millisecond)
+		err := interceptor(context.Background(), readMethod, nil, nil, nil, hangingInvoker)
+		require.Error(t, err)
+		assert.Equal(t, maxRetries, attempts)
+	})
+
+	// Writes have no per-retry timeout: a hung write attempt is only bounded by
+	// the caller's context, never abandoned and replayed by the interceptor.
+	t.Run("hung write is bounded by caller context only", func(t *testing.T) {
+		attempts := 0
+		hangingInvoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			attempts++
+			<-ctx.Done()
+			return status.FromContextError(ctx.Err()).Err()
+		}
+		callerCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		interceptor := newMethodAwareRetryInterceptor(maxRetries, time.Millisecond, 5*time.Millisecond)
+		err := interceptor(callerCtx, writeMethod, nil, nil, nil, hangingInvoker)
+		require.Error(t, err)
 		assert.Equal(t, 1, attempts)
 	})
 }

--- a/backend/src/v2/metadata/client_retry_test.go
+++ b/backend/src/v2/metadata/client_retry_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsReadOnlyMLMDMethod(t *testing.T) {
+	tests := []struct {
+		fullMethod string
+		want       bool
+	}{
+		{"/ml_metadata.MetadataStoreService/GetArtifactsByID", true},
+		{"/ml_metadata.MetadataStoreService/GetContextByTypeAndName", true},
+		{"/ml_metadata.MetadataStoreService/GetLineageSubgraph", true},
+		{"/ml_metadata.MetadataStoreService/PutExecution", false},
+		{"/ml_metadata.MetadataStoreService/PutArtifactType", false},
+		{"/ml_metadata.MetadataStoreService/PutContexts", false},
+	}
+	for _, test := range tests {
+		t.Run(test.fullMethod, func(t *testing.T) {
+			assert.Equal(t, test.want, isReadOnlyMLMDMethod(test.fullMethod))
+		})
+	}
+}
+
+func TestMethodAwareRetryInterceptor(t *testing.T) {
+	const maxRetries = 3
+	readMethod := "/ml_metadata.MetadataStoreService/GetArtifactsByID"
+	writeMethod := "/ml_metadata.MetadataStoreService/PutExecution"
+
+	tests := []struct {
+		name         string
+		method       string
+		code         codes.Code
+		wantAttempts int
+	}{
+		{"read retries Internal", readMethod, codes.Internal, maxRetries},
+		{"read retries Unknown", readMethod, codes.Unknown, maxRetries},
+		// The retry middleware treats DeadlineExceeded/Canceled as caller
+		// context errors and never retries them, even if listed in WithCodes.
+		{"read does not retry DeadlineExceeded", readMethod, codes.DeadlineExceeded, 1},
+		{"read retries Unavailable", readMethod, codes.Unavailable, maxRetries},
+		{"read retries Aborted", readMethod, codes.Aborted, maxRetries},
+		{"read does not retry NotFound", readMethod, codes.NotFound, 1},
+		{"write retries Unavailable", writeMethod, codes.Unavailable, maxRetries},
+		{"write retries Aborted", writeMethod, codes.Aborted, maxRetries},
+		{"write does not retry Internal", writeMethod, codes.Internal, 1},
+		{"write does not retry Unknown", writeMethod, codes.Unknown, 1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			attempts := 0
+			invoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+				attempts++
+				return status.Error(test.code, "injected failure")
+			}
+			interceptor := newMethodAwareRetryInterceptor(maxRetries, time.Millisecond)
+			err := interceptor(context.Background(), test.method, nil, nil, nil, invoker)
+			require.Error(t, err)
+			assert.Equal(t, test.code, status.Code(err))
+			assert.Equal(t, test.wantAttempts, attempts)
+		})
+	}
+
+	t.Run("success does not retry", func(t *testing.T) {
+		attempts := 0
+		invoker := func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+			attempts++
+			return nil
+		}
+		interceptor := newMethodAwareRetryInterceptor(maxRetries, time.Millisecond)
+		require.NoError(t, interceptor(context.Background(), readMethod, nil, nil, nil, invoker))
+		assert.Equal(t, 1, attempts)
+	})
+}
+
+func TestPositiveIntFromEnv(t *testing.T) {
+	const envName = "TEST_POSITIVE_INT_FROM_ENV"
+
+	t.Run("unset returns not ok", func(t *testing.T) {
+		_, ok, err := positiveIntFromEnv(envName)
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("valid value is returned", func(t *testing.T) {
+		t.Setenv(envName, "42")
+		value, ok, err := positiveIntFromEnv(envName)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, 42, value)
+	})
+
+	t.Run("non-integer errors", func(t *testing.T) {
+		t.Setenv(envName, "not-a-number")
+		_, _, err := positiveIntFromEnv(envName)
+		require.Error(t, err)
+	})
+
+	t.Run("zero errors", func(t *testing.T) {
+		t.Setenv(envName, "0")
+		_, _, err := positiveIntFromEnv(envName)
+		require.Error(t, err)
+	})
+
+	t.Run("negative errors", func(t *testing.T) {
+		t.Setenv(envName, "-5")
+		_, _, err := positiveIntFromEnv(envName)
+		require.Error(t, err)
+	})
+}

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -36,6 +36,8 @@ Standalone mode is single-user and unauthenticated. Multi-user deployments requi
 | Variable | Purpose |
 | --- | --- |
 | `_KFP_RUNTIME=true` | Runtime mode that disables most SDK imports |
+| `METADATA_GRPC_MAX_RETRIES` | Overrides the MLMD client retry budget (10 attempts by default); driver and launcher pods read it from the optional `metadata-grpc-configmap` |
+| `PIPELINE_DRIVER_RETRY_LIMIT` | Controls the Argo retry limit compiled into driver templates (3 by default; `0` disables retries) |
 | `VITE_NAMESPACE` | Frontend namespace for multi-user development |
 | `LOCAL_API_SERVER=true` | Local API-server integration-test mode |
 | `FRONTEND_SERVER_NAMESPACE` | Namespace used by a local frontend server |

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -36,8 +36,8 @@ Standalone mode is single-user and unauthenticated. Multi-user deployments requi
 | Variable | Purpose |
 | --- | --- |
 | `_KFP_RUNTIME=true` | Runtime mode that disables most SDK imports |
-| `METADATA_GRPC_MAX_RETRIES` | Overrides the MLMD client retry budget (10 attempts by default); driver and launcher pods read it from the optional `metadata-grpc-configmap` |
-| `PIPELINE_DRIVER_RETRY_LIMIT` | Controls the Argo retry limit compiled into driver templates (3 by default; `0` disables retries) |
+| `METADATA_GRPC_MAX_ATTEMPTS` | Overrides total MLMD gRPC attempts per call (10 by default; `1` disables retries); driver and launcher pods read it from the optional `metadata-grpc-configmap` |
+| `PIPELINE_DRIVER_RETRY_LIMIT` | Opts driver templates into an Argo retry strategy (disabled by default because driver replays are not yet idempotent; see `getDriverRetryStrategy`) |
 | `VITE_NAMESPACE` | Frontend namespace for multi-user development |
 | `LOCAL_API_SERVER=true` | Local API-server integration-test mode |
 | `FRONTEND_SERVER_NAMESPACE` | Namespace used by a local frontend server |

--- a/test_data/compiled-workflows/add_numbers.yaml
+++ b/test_data/compiled-workflows/add_numbers.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,13 +389,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/add_numbers.yaml
+++ b/test_data/compiled-workflows/add_numbers.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -332,6 +343,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -381,6 +396,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/add_numbers.yaml
+++ b/test_data/compiled-workflows/add_numbers.yaml
@@ -151,13 +151,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -414,13 +407,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/add_numbers.yaml
+++ b/test_data/compiled-workflows/add_numbers.yaml
@@ -100,6 +100,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -147,6 +151,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -350,6 +361,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -399,6 +414,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/arguments_parameters.yaml
+++ b/test_data/compiled-workflows/arguments_parameters.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -387,13 +380,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/arguments_parameters.yaml
+++ b/test_data/compiled-workflows/arguments_parameters.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -323,6 +334,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -372,6 +387,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/arguments_parameters.yaml
+++ b/test_data/compiled-workflows/arguments_parameters.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/arguments_parameters.yaml
+++ b/test_data/compiled-workflows/arguments_parameters.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifact_cache.yaml
+++ b/test_data/compiled-workflows/artifact_cache.yaml
@@ -110,6 +110,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -157,6 +161,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -351,6 +362,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -400,6 +415,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifact_cache.yaml
+++ b/test_data/compiled-workflows/artifact_cache.yaml
@@ -161,13 +161,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -415,13 +408,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifact_cache.yaml
+++ b/test_data/compiled-workflows/artifact_cache.yaml
@@ -119,6 +119,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -166,6 +170,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -369,6 +380,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -418,6 +433,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifact_cache.yaml
+++ b/test_data/compiled-workflows/artifact_cache.yaml
@@ -170,13 +170,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -433,13 +426,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifact_crust.yaml
+++ b/test_data/compiled-workflows/artifact_crust.yaml
@@ -110,6 +110,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -157,6 +161,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -351,6 +362,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -400,6 +415,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifact_crust.yaml
+++ b/test_data/compiled-workflows/artifact_crust.yaml
@@ -161,13 +161,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -415,13 +408,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifact_crust.yaml
+++ b/test_data/compiled-workflows/artifact_crust.yaml
@@ -119,6 +119,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -166,6 +170,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -369,6 +380,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -418,6 +433,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifact_crust.yaml
+++ b/test_data/compiled-workflows/artifact_crust.yaml
@@ -170,13 +170,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -433,13 +426,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifacts_complex.yaml
+++ b/test_data/compiled-workflows/artifacts_complex.yaml
@@ -187,13 +187,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -522,13 +515,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifacts_complex.yaml
+++ b/test_data/compiled-workflows/artifacts_complex.yaml
@@ -136,6 +136,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -183,6 +187,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -458,6 +469,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -507,6 +522,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifacts_complex.yaml
+++ b/test_data/compiled-workflows/artifacts_complex.yaml
@@ -145,6 +145,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -192,6 +196,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -476,6 +487,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -525,6 +540,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifacts_complex.yaml
+++ b/test_data/compiled-workflows/artifacts_complex.yaml
@@ -196,13 +196,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -540,13 +533,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifacts_simple.yaml
+++ b/test_data/compiled-workflows/artifacts_simple.yaml
@@ -121,6 +121,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -168,6 +172,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -362,6 +373,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -411,6 +426,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifacts_simple.yaml
+++ b/test_data/compiled-workflows/artifacts_simple.yaml
@@ -172,13 +172,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -426,13 +419,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifacts_simple.yaml
+++ b/test_data/compiled-workflows/artifacts_simple.yaml
@@ -130,6 +130,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -177,6 +181,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -380,6 +391,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -429,6 +444,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/artifacts_simple.yaml
+++ b/test_data/compiled-workflows/artifacts_simple.yaml
@@ -181,13 +181,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -444,13 +437,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/collected_artifacts.yaml
+++ b/test_data/compiled-workflows/collected_artifacts.yaml
@@ -202,6 +202,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -249,6 +253,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -443,6 +454,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -492,6 +507,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/collected_artifacts.yaml
+++ b/test_data/compiled-workflows/collected_artifacts.yaml
@@ -253,13 +253,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -507,13 +500,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/collected_artifacts.yaml
+++ b/test_data/compiled-workflows/collected_artifacts.yaml
@@ -211,6 +211,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -258,6 +262,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -461,6 +472,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -510,6 +525,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/collected_artifacts.yaml
+++ b/test_data/compiled-workflows/collected_artifacts.yaml
@@ -262,13 +262,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -525,13 +518,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/collected_parameters.yaml
+++ b/test_data/compiled-workflows/collected_parameters.yaml
@@ -137,6 +137,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -184,6 +188,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -403,6 +414,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -452,6 +467,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/collected_parameters.yaml
+++ b/test_data/compiled-workflows/collected_parameters.yaml
@@ -188,13 +188,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -467,13 +460,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/collected_parameters.yaml
+++ b/test_data/compiled-workflows/collected_parameters.yaml
@@ -146,6 +146,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -193,6 +197,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -421,6 +432,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -470,6 +485,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/collected_parameters.yaml
+++ b/test_data/compiled-workflows/collected_parameters.yaml
@@ -197,13 +197,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -485,13 +478,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_env_variable.yaml
+++ b/test_data/compiled-workflows/component_with_env_variable.yaml
@@ -92,6 +92,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -139,6 +143,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -333,6 +344,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -382,6 +397,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_env_variable.yaml
+++ b/test_data/compiled-workflows/component_with_env_variable.yaml
@@ -143,13 +143,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,13 +390,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_env_variable.yaml
+++ b/test_data/compiled-workflows/component_with_env_variable.yaml
@@ -152,13 +152,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -415,13 +408,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_env_variable.yaml
+++ b/test_data/compiled-workflows/component_with_env_variable.yaml
@@ -101,6 +101,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -148,6 +152,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -351,6 +362,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -400,6 +415,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/component_with_metadata_fields.yaml
@@ -157,13 +157,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -411,13 +404,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/component_with_metadata_fields.yaml
@@ -106,6 +106,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -153,6 +157,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -347,6 +358,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -396,6 +411,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/component_with_metadata_fields.yaml
@@ -166,13 +166,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -429,13 +422,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/component_with_metadata_fields.yaml
@@ -115,6 +115,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -162,6 +166,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -365,6 +376,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -414,6 +429,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_optional_inputs.yaml
+++ b/test_data/compiled-workflows/component_with_optional_inputs.yaml
@@ -146,13 +146,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -400,13 +393,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_optional_inputs.yaml
+++ b/test_data/compiled-workflows/component_with_optional_inputs.yaml
@@ -95,6 +95,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -142,6 +146,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -336,6 +347,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -385,6 +400,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_optional_inputs.yaml
+++ b/test_data/compiled-workflows/component_with_optional_inputs.yaml
@@ -104,6 +104,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -151,6 +155,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -354,6 +365,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -403,6 +418,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_optional_inputs.yaml
+++ b/test_data/compiled-workflows/component_with_optional_inputs.yaml
@@ -155,13 +155,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -418,13 +411,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_index_urls.yaml
+++ b/test_data/compiled-workflows/component_with_pip_index_urls.yaml
@@ -93,6 +93,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -140,6 +144,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -334,6 +345,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -383,6 +398,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_index_urls.yaml
+++ b/test_data/compiled-workflows/component_with_pip_index_urls.yaml
@@ -144,13 +144,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -398,13 +391,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_index_urls.yaml
+++ b/test_data/compiled-workflows/component_with_pip_index_urls.yaml
@@ -153,13 +153,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -416,13 +409,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_index_urls.yaml
+++ b/test_data/compiled-workflows/component_with_pip_index_urls.yaml
@@ -102,6 +102,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -149,6 +153,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -352,6 +363,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -401,6 +416,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_install.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install.yaml
@@ -93,6 +93,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -140,6 +144,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -334,6 +345,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -383,6 +398,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_install.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install.yaml
@@ -144,13 +144,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -398,13 +391,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_install.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install.yaml
@@ -153,13 +153,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -416,13 +409,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_install.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install.yaml
@@ -102,6 +102,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -149,6 +153,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -352,6 +363,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -401,6 +416,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
@@ -145,13 +145,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -399,13 +392,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
@@ -94,6 +94,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -141,6 +145,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -335,6 +346,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -384,6 +399,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
@@ -154,13 +154,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -417,13 +410,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
+++ b/test_data/compiled-workflows/component_with_pip_install_in_venv.yaml
@@ -103,6 +103,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -150,6 +154,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -353,6 +364,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -402,6 +417,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/components_with_optional_artifacts.yaml
+++ b/test_data/compiled-workflows/components_with_optional_artifacts.yaml
@@ -107,6 +107,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -154,6 +158,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -451,6 +462,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -500,6 +515,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/components_with_optional_artifacts.yaml
+++ b/test_data/compiled-workflows/components_with_optional_artifacts.yaml
@@ -158,13 +158,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -515,13 +508,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/components_with_optional_artifacts.yaml
+++ b/test_data/compiled-workflows/components_with_optional_artifacts.yaml
@@ -167,13 +167,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -542,13 +535,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/components_with_optional_artifacts.yaml
+++ b/test_data/compiled-workflows/components_with_optional_artifacts.yaml
@@ -116,6 +116,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -163,6 +167,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -478,6 +489,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -527,6 +542,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/concat_message.yaml
+++ b/test_data/compiled-workflows/concat_message.yaml
@@ -92,6 +92,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -139,6 +143,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -333,6 +344,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -382,6 +397,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/concat_message.yaml
+++ b/test_data/compiled-workflows/concat_message.yaml
@@ -143,13 +143,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,13 +390,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/concat_message.yaml
+++ b/test_data/compiled-workflows/concat_message.yaml
@@ -152,13 +152,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -415,13 +408,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/concat_message.yaml
+++ b/test_data/compiled-workflows/concat_message.yaml
@@ -101,6 +101,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -148,6 +152,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -351,6 +362,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -400,6 +415,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
+++ b/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
@@ -164,13 +164,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -450,13 +443,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
+++ b/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
@@ -113,6 +113,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -160,6 +164,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -386,6 +397,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -435,6 +450,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
+++ b/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
@@ -122,6 +122,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -169,6 +173,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -404,6 +415,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -453,6 +468,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
+++ b/test_data/compiled-workflows/conditional_producer_and_consumers.yaml
@@ -173,13 +173,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -468,13 +461,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_component_with_no_inputs.yaml
+++ b/test_data/compiled-workflows/container_component_with_no_inputs.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -387,13 +380,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_component_with_no_inputs.yaml
+++ b/test_data/compiled-workflows/container_component_with_no_inputs.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -323,6 +334,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -372,6 +387,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_component_with_no_inputs.yaml
+++ b/test_data/compiled-workflows/container_component_with_no_inputs.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_component_with_no_inputs.yaml
+++ b/test_data/compiled-workflows/container_component_with_no_inputs.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_io.yaml
+++ b/test_data/compiled-workflows/container_io.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -387,13 +380,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_io.yaml
+++ b/test_data/compiled-workflows/container_io.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -323,6 +334,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -372,6 +387,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_io.yaml
+++ b/test_data/compiled-workflows/container_io.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_io.yaml
+++ b/test_data/compiled-workflows/container_io.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_no_input.yaml
+++ b/test_data/compiled-workflows/container_no_input.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -387,13 +380,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_no_input.yaml
+++ b/test_data/compiled-workflows/container_no_input.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -323,6 +334,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -372,6 +387,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_no_input.yaml
+++ b/test_data/compiled-workflows/container_no_input.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_no_input.yaml
+++ b/test_data/compiled-workflows/container_no_input.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_artifact_output.yaml
+++ b/test_data/compiled-workflows/container_with_artifact_output.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -387,13 +380,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_artifact_output.yaml
+++ b/test_data/compiled-workflows/container_with_artifact_output.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -323,6 +334,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -372,6 +387,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_artifact_output.yaml
+++ b/test_data/compiled-workflows/container_with_artifact_output.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_artifact_output.yaml
+++ b/test_data/compiled-workflows/container_with_artifact_output.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_concat_placeholder.yaml
@@ -134,13 +134,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -388,13 +381,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_concat_placeholder.yaml
@@ -83,6 +83,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -130,6 +134,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -324,6 +335,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -373,6 +388,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_concat_placeholder.yaml
@@ -92,6 +92,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -139,6 +143,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -342,6 +353,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -391,6 +406,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_concat_placeholder.yaml
@@ -143,13 +143,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -406,13 +399,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_if_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder.yaml
@@ -85,6 +85,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -132,6 +136,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -326,6 +337,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -375,6 +390,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_if_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder.yaml
@@ -136,13 +136,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -390,13 +383,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_if_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder.yaml
@@ -94,6 +94,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -141,6 +145,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -344,6 +355,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -393,6 +408,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_if_placeholder.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder.yaml
@@ -145,13 +145,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -408,13 +401,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
+++ b/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -387,13 +380,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
+++ b/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -323,6 +334,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -372,6 +387,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
+++ b/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
+++ b/test_data/compiled-workflows/container_with_placeholder_in_fstring.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/containerized_python_component.yaml
+++ b/test_data/compiled-workflows/containerized_python_component.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -387,13 +380,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/containerized_python_component.yaml
+++ b/test_data/compiled-workflows/containerized_python_component.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -323,6 +334,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -372,6 +387,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/containerized_python_component.yaml
+++ b/test_data/compiled-workflows/containerized_python_component.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/containerized_python_component.yaml
+++ b/test_data/compiled-workflows/containerized_python_component.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/create_pod_metadata_complex.yaml
+++ b/test_data/compiled-workflows/create_pod_metadata_complex.yaml
@@ -186,13 +186,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -778,13 +771,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/create_pod_metadata_complex.yaml
+++ b/test_data/compiled-workflows/create_pod_metadata_complex.yaml
@@ -135,6 +135,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -182,6 +186,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -714,6 +725,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -763,6 +778,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/create_pod_metadata_complex.yaml
+++ b/test_data/compiled-workflows/create_pod_metadata_complex.yaml
@@ -144,6 +144,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -191,6 +195,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -732,6 +743,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -781,6 +796,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/create_pod_metadata_complex.yaml
+++ b/test_data/compiled-workflows/create_pod_metadata_complex.yaml
@@ -195,13 +195,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -796,13 +789,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/cross_loop_after_topology.yaml
+++ b/test_data/compiled-workflows/cross_loop_after_topology.yaml
@@ -163,13 +163,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -449,13 +442,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/cross_loop_after_topology.yaml
+++ b/test_data/compiled-workflows/cross_loop_after_topology.yaml
@@ -112,6 +112,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -159,6 +163,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -385,6 +396,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -434,6 +449,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/cross_loop_after_topology.yaml
+++ b/test_data/compiled-workflows/cross_loop_after_topology.yaml
@@ -121,6 +121,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -168,6 +172,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -403,6 +414,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -452,6 +467,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/cross_loop_after_topology.yaml
+++ b/test_data/compiled-workflows/cross_loop_after_topology.yaml
@@ -172,13 +172,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -467,13 +460,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/dict_input.yaml
+++ b/test_data/compiled-workflows/dict_input.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,13 +389,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/dict_input.yaml
+++ b/test_data/compiled-workflows/dict_input.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -332,6 +343,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -381,6 +396,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/dict_input.yaml
+++ b/test_data/compiled-workflows/dict_input.yaml
@@ -151,13 +151,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -414,13 +407,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/dict_input.yaml
+++ b/test_data/compiled-workflows/dict_input.yaml
@@ -100,6 +100,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -147,6 +151,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -350,6 +361,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -399,6 +414,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/embedded_artifact.yaml
+++ b/test_data/compiled-workflows/embedded_artifact.yaml
@@ -183,13 +183,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -461,13 +454,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/embedded_artifact.yaml
+++ b/test_data/compiled-workflows/embedded_artifact.yaml
@@ -132,6 +132,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -179,6 +183,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,6 +408,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -446,6 +461,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/embedded_artifact.yaml
+++ b/test_data/compiled-workflows/embedded_artifact.yaml
@@ -141,6 +141,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -188,6 +192,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -415,6 +426,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -464,6 +479,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/embedded_artifact.yaml
+++ b/test_data/compiled-workflows/embedded_artifact.yaml
@@ -192,13 +192,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -479,13 +472,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/env-var.yaml
+++ b/test_data/compiled-workflows/env-var.yaml
@@ -93,6 +93,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -140,6 +144,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -334,6 +345,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -383,6 +398,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/env-var.yaml
+++ b/test_data/compiled-workflows/env-var.yaml
@@ -144,13 +144,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -398,13 +391,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/env-var.yaml
+++ b/test_data/compiled-workflows/env-var.yaml
@@ -153,13 +153,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -416,13 +409,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/env-var.yaml
+++ b/test_data/compiled-workflows/env-var.yaml
@@ -102,6 +102,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -149,6 +153,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -352,6 +363,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -401,6 +416,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/fail_v2.yaml
+++ b/test_data/compiled-workflows/fail_v2.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,13 +389,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/fail_v2.yaml
+++ b/test_data/compiled-workflows/fail_v2.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -332,6 +343,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -381,6 +396,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/fail_v2.yaml
+++ b/test_data/compiled-workflows/fail_v2.yaml
@@ -151,13 +151,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -414,13 +407,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/fail_v2.yaml
+++ b/test_data/compiled-workflows/fail_v2.yaml
@@ -100,6 +100,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -147,6 +151,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -350,6 +361,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -399,6 +414,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/flip_coin.yaml
+++ b/test_data/compiled-workflows/flip_coin.yaml
@@ -148,6 +148,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -195,6 +199,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -425,6 +436,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -474,6 +489,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/flip_coin.yaml
+++ b/test_data/compiled-workflows/flip_coin.yaml
@@ -199,13 +199,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -489,13 +482,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/flip_coin.yaml
+++ b/test_data/compiled-workflows/flip_coin.yaml
@@ -208,13 +208,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -507,13 +500,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/flip_coin.yaml
+++ b/test_data/compiled-workflows/flip_coin.yaml
@@ -157,6 +157,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -204,6 +208,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -443,6 +454,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -492,6 +507,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/hello_world.yaml
+++ b/test_data/compiled-workflows/hello_world.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -387,13 +380,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/hello_world.yaml
+++ b/test_data/compiled-workflows/hello_world.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -323,6 +334,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -372,6 +387,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/hello_world.yaml
+++ b/test_data/compiled-workflows/hello_world.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/hello_world.yaml
+++ b/test_data/compiled-workflows/hello_world.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/identity.yaml
+++ b/test_data/compiled-workflows/identity.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,13 +389,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/identity.yaml
+++ b/test_data/compiled-workflows/identity.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -332,6 +343,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -381,6 +396,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/identity.yaml
+++ b/test_data/compiled-workflows/identity.yaml
@@ -151,13 +151,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -414,13 +407,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/identity.yaml
+++ b/test_data/compiled-workflows/identity.yaml
@@ -100,6 +100,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -147,6 +151,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -350,6 +361,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -399,6 +414,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_elif_else_complex.yaml
+++ b/test_data/compiled-workflows/if_elif_else_complex.yaml
@@ -182,6 +182,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -229,6 +233,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -424,6 +435,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -473,6 +488,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_elif_else_complex.yaml
+++ b/test_data/compiled-workflows/if_elif_else_complex.yaml
@@ -233,13 +233,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -488,13 +481,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_elif_else_complex.yaml
+++ b/test_data/compiled-workflows/if_elif_else_complex.yaml
@@ -242,13 +242,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -506,13 +499,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_elif_else_complex.yaml
+++ b/test_data/compiled-workflows/if_elif_else_complex.yaml
@@ -191,6 +191,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -238,6 +242,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -442,6 +453,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -491,6 +506,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
@@ -188,13 +188,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -508,13 +501,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
@@ -137,6 +137,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -184,6 +188,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -444,6 +455,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -493,6 +508,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
@@ -197,13 +197,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -526,13 +519,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_elif_else_with_oneof_parameters.yaml
@@ -146,6 +146,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -193,6 +197,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -462,6 +473,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -511,6 +526,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
@@ -128,6 +128,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -175,6 +179,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -401,6 +412,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -450,6 +465,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
@@ -179,13 +179,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -465,13 +458,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
@@ -188,13 +188,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -483,13 +476,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_artifacts.yaml
@@ -137,6 +137,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -184,6 +188,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -419,6 +430,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -468,6 +483,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
@@ -166,13 +166,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -454,13 +447,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
@@ -115,6 +115,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -162,6 +166,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -390,6 +401,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -439,6 +454,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
@@ -124,6 +124,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -171,6 +175,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -408,6 +419,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -457,6 +472,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
+++ b/test_data/compiled-workflows/if_else_with_oneof_parameters.yaml
@@ -175,13 +175,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -472,13 +465,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/input_artifact.yaml
+++ b/test_data/compiled-workflows/input_artifact.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,13 +389,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/input_artifact.yaml
+++ b/test_data/compiled-workflows/input_artifact.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -332,6 +343,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -381,6 +396,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/input_artifact.yaml
+++ b/test_data/compiled-workflows/input_artifact.yaml
@@ -151,13 +151,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -414,13 +407,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/input_artifact.yaml
+++ b/test_data/compiled-workflows/input_artifact.yaml
@@ -100,6 +100,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -147,6 +151,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -350,6 +361,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -399,6 +414,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/iris_pipeline_compiled.yaml
+++ b/test_data/compiled-workflows/iris_pipeline_compiled.yaml
@@ -144,6 +144,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -191,6 +195,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -435,6 +446,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -484,6 +499,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/iris_pipeline_compiled.yaml
+++ b/test_data/compiled-workflows/iris_pipeline_compiled.yaml
@@ -195,13 +195,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -499,13 +492,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/iris_pipeline_compiled.yaml
+++ b/test_data/compiled-workflows/iris_pipeline_compiled.yaml
@@ -204,13 +204,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -517,13 +510,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/iris_pipeline_compiled.yaml
+++ b/test_data/compiled-workflows/iris_pipeline_compiled.yaml
@@ -153,6 +153,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -200,6 +204,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -453,6 +464,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -502,6 +517,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
@@ -146,6 +146,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -193,6 +197,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -412,6 +423,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -461,6 +476,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
@@ -197,13 +197,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -476,13 +469,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
@@ -155,6 +155,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -202,6 +206,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -430,6 +441,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -479,6 +494,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_pipeline.yaml
@@ -206,13 +206,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -494,13 +487,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
@@ -189,13 +189,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -517,13 +510,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
@@ -138,6 +138,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -185,6 +189,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -453,6 +464,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -502,6 +517,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
@@ -147,6 +147,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -194,6 +198,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -471,6 +482,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -520,6 +535,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
+++ b/test_data/compiled-workflows/lightweight_python_functions_with_outputs.yaml
@@ -198,13 +198,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -535,13 +528,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_exit_handler.yaml
@@ -106,6 +106,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -153,6 +157,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -379,6 +390,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -428,6 +443,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_exit_handler.yaml
@@ -157,13 +157,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -443,13 +436,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_exit_handler.yaml
@@ -166,13 +166,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -461,13 +454,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_exit_handler.yaml
@@ -115,6 +115,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -162,6 +166,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,6 +408,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -446,6 +461,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_ignore_upstream_failure.yaml
@@ -105,6 +105,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -152,6 +156,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -385,6 +396,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -434,6 +449,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_ignore_upstream_failure.yaml
@@ -156,13 +156,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -449,13 +442,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_ignore_upstream_failure.yaml
@@ -114,6 +114,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -161,6 +165,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -403,6 +414,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -452,6 +467,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_ignore_upstream_failure.yaml
@@ -165,13 +165,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -467,13 +460,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_k8s_only_methods.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_k8s_only_methods.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,13 +389,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_k8s_only_methods.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_k8s_only_methods.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -332,6 +343,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -381,6 +396,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_k8s_only_methods.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_k8s_only_methods.yaml
@@ -151,13 +151,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -414,13 +407,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_k8s_only_methods.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_k8s_only_methods.yaml
@@ -100,6 +100,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -147,6 +151,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -350,6 +361,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -399,6 +414,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_oneof.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_oneof.yaml
@@ -176,13 +176,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -462,13 +455,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_oneof.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_oneof.yaml
@@ -125,6 +125,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -172,6 +176,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -398,6 +409,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -447,6 +462,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_oneof.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_oneof.yaml
@@ -134,6 +134,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -181,6 +185,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -416,6 +427,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -465,6 +480,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_oneof.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_oneof.yaml
@@ -185,13 +185,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -480,13 +473,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_retry.yaml
@@ -95,6 +95,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -142,6 +146,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -372,6 +383,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -421,6 +436,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_retry.yaml
@@ -146,13 +146,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -436,13 +429,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_retry.yaml
@@ -104,6 +104,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -151,6 +155,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -390,6 +401,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -439,6 +454,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/local_execution_pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/local_execution_pipeline_with_retry.yaml
@@ -155,13 +155,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -454,13 +447,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/log_streaming_compiled.yaml
+++ b/test_data/compiled-workflows/log_streaming_compiled.yaml
@@ -146,13 +146,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -400,13 +393,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/log_streaming_compiled.yaml
+++ b/test_data/compiled-workflows/log_streaming_compiled.yaml
@@ -95,6 +95,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -142,6 +146,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -336,6 +347,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -385,6 +400,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/log_streaming_compiled.yaml
+++ b/test_data/compiled-workflows/log_streaming_compiled.yaml
@@ -104,6 +104,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -151,6 +155,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -354,6 +365,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -403,6 +418,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/log_streaming_compiled.yaml
+++ b/test_data/compiled-workflows/log_streaming_compiled.yaml
@@ -155,13 +155,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -418,13 +411,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/long-running.yaml
+++ b/test_data/compiled-workflows/long-running.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -348,6 +359,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -397,6 +412,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/long-running.yaml
+++ b/test_data/compiled-workflows/long-running.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -412,13 +405,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/long-running.yaml
+++ b/test_data/compiled-workflows/long-running.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -366,6 +377,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -415,6 +430,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/long-running.yaml
+++ b/test_data/compiled-workflows/long-running.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -430,13 +423,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/loop_consume_upstream.yaml
+++ b/test_data/compiled-workflows/loop_consume_upstream.yaml
@@ -190,13 +190,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -471,13 +464,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/loop_consume_upstream.yaml
+++ b/test_data/compiled-workflows/loop_consume_upstream.yaml
@@ -139,6 +139,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -186,6 +190,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -407,6 +418,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -456,6 +471,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/loop_consume_upstream.yaml
+++ b/test_data/compiled-workflows/loop_consume_upstream.yaml
@@ -199,13 +199,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -489,13 +482,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/loop_consume_upstream.yaml
+++ b/test_data/compiled-workflows/loop_consume_upstream.yaml
@@ -148,6 +148,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -195,6 +199,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -425,6 +436,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -474,6 +489,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/metrics_visualization_v2.yaml
+++ b/test_data/compiled-workflows/metrics_visualization_v2.yaml
@@ -183,6 +183,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -230,6 +234,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -520,6 +531,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -569,6 +584,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/metrics_visualization_v2.yaml
+++ b/test_data/compiled-workflows/metrics_visualization_v2.yaml
@@ -234,13 +234,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -584,13 +577,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/metrics_visualization_v2.yaml
+++ b/test_data/compiled-workflows/metrics_visualization_v2.yaml
@@ -192,6 +192,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -239,6 +243,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -538,6 +549,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -587,6 +602,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/metrics_visualization_v2.yaml
+++ b/test_data/compiled-workflows/metrics_visualization_v2.yaml
@@ -243,13 +243,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -602,13 +595,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
+++ b/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
@@ -94,6 +94,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -141,6 +145,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -338,6 +349,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -387,6 +402,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
+++ b/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
@@ -145,13 +145,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -402,13 +395,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
+++ b/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
@@ -154,13 +154,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -420,13 +413,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
+++ b/test_data/compiled-workflows/missing_kubernetes_optional_inputs.yaml
@@ -103,6 +103,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -150,6 +154,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -356,6 +367,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -405,6 +420,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mixed_parameters.yaml
+++ b/test_data/compiled-workflows/mixed_parameters.yaml
@@ -159,13 +159,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -413,13 +406,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mixed_parameters.yaml
+++ b/test_data/compiled-workflows/mixed_parameters.yaml
@@ -108,6 +108,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -155,6 +159,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -349,6 +360,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -398,6 +413,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mixed_parameters.yaml
+++ b/test_data/compiled-workflows/mixed_parameters.yaml
@@ -117,6 +117,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -164,6 +168,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -367,6 +378,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -416,6 +431,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mixed_parameters.yaml
+++ b/test_data/compiled-workflows/mixed_parameters.yaml
@@ -168,13 +168,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -431,13 +424,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/modelcar.yaml
+++ b/test_data/compiled-workflows/modelcar.yaml
@@ -167,13 +167,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -529,13 +522,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/modelcar.yaml
+++ b/test_data/compiled-workflows/modelcar.yaml
@@ -116,6 +116,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -163,6 +167,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -465,6 +476,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -514,6 +529,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/modelcar.yaml
+++ b/test_data/compiled-workflows/modelcar.yaml
@@ -176,13 +176,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -556,13 +549,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/modelcar.yaml
+++ b/test_data/compiled-workflows/modelcar.yaml
@@ -125,6 +125,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -172,6 +176,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -492,6 +503,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -541,6 +556,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
@@ -138,13 +138,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -412,13 +405,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
@@ -84,6 +84,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -134,6 +138,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -345,6 +356,10 @@ spec:
       - /kfp/certs/ca.crt
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -397,6 +412,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
@@ -145,13 +145,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -426,13 +419,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_configmap.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -141,6 +145,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -359,6 +370,10 @@ spec:
       - /kfp/certs/ca.crt
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -411,6 +426,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mounted_cabundle_secret.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_secret.yaml
@@ -138,13 +138,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -412,13 +405,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mounted_cabundle_secret.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_secret.yaml
@@ -84,6 +84,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -134,6 +138,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -345,6 +356,10 @@ spec:
       - /kfp/certs/ca.crt
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -397,6 +412,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mounted_cabundle_secret.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_secret.yaml
@@ -145,13 +145,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -426,13 +419,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/mounted_cabundle_secret.yaml
+++ b/test_data/compiled-workflows/mounted_cabundle_secret.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -141,6 +145,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -359,6 +370,10 @@ spec:
       - /kfp/certs/ca.crt
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -411,6 +426,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
@@ -112,6 +112,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -159,6 +163,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -353,6 +364,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -402,6 +417,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
@@ -163,13 +163,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -417,13 +410,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
@@ -172,13 +172,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -435,13 +428,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_artifacts_namedtuple.yaml
@@ -121,6 +121,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -168,6 +172,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -371,6 +382,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -420,6 +435,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
@@ -111,6 +111,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -158,6 +162,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -352,6 +363,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -401,6 +416,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
@@ -162,13 +162,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -416,13 +409,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
@@ -120,6 +120,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -167,6 +171,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -370,6 +381,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -419,6 +434,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
+++ b/test_data/compiled-workflows/multiple_parameters_namedtuple.yaml
@@ -171,13 +171,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -434,13 +427,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/nested_parallel_for_secret.yaml
@@ -163,13 +163,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -419,13 +412,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/nested_parallel_for_secret.yaml
@@ -112,6 +112,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -159,6 +163,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -355,6 +366,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -404,6 +419,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/nested_parallel_for_secret.yaml
@@ -121,6 +121,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -168,6 +172,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -373,6 +384,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -422,6 +437,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/nested_parallel_for_secret.yaml
@@ -172,13 +172,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -437,13 +430,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
@@ -222,13 +222,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -596,13 +589,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
@@ -171,6 +171,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -218,6 +222,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -532,6 +543,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -581,6 +596,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
@@ -180,6 +180,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -227,6 +231,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -550,6 +561,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -599,6 +614,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_input_child_level_compiled.yaml
@@ -231,13 +231,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -614,13 +607,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
@@ -122,6 +122,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -169,6 +173,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -411,6 +422,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -460,6 +475,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
@@ -173,13 +173,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -475,13 +468,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
@@ -131,6 +131,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -178,6 +182,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -429,6 +440,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -478,6 +493,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_nil_compiled.yaml
@@ -182,13 +182,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -493,13 +486,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
@@ -174,6 +174,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -221,6 +225,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -543,6 +554,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -592,6 +607,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
@@ -225,13 +225,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -607,13 +600,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
@@ -183,6 +183,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -230,6 +234,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -561,6 +572,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -610,6 +625,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
+++ b/test_data/compiled-workflows/nested_pipeline_opt_inputs_parent_level_compiled.yaml
@@ -234,13 +234,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -625,13 +618,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_return.yaml
+++ b/test_data/compiled-workflows/nested_return.yaml
@@ -92,6 +92,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -139,6 +143,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -333,6 +344,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -382,6 +397,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_return.yaml
+++ b/test_data/compiled-workflows/nested_return.yaml
@@ -143,13 +143,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,13 +390,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_return.yaml
+++ b/test_data/compiled-workflows/nested_return.yaml
@@ -152,13 +152,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -415,13 +408,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_return.yaml
+++ b/test_data/compiled-workflows/nested_return.yaml
@@ -101,6 +101,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -148,6 +152,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -351,6 +362,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -400,6 +415,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_with_parameters.yaml
+++ b/test_data/compiled-workflows/nested_with_parameters.yaml
@@ -124,6 +124,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -171,6 +175,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -414,6 +425,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -463,6 +478,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_with_parameters.yaml
+++ b/test_data/compiled-workflows/nested_with_parameters.yaml
@@ -175,13 +175,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -478,13 +471,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_with_parameters.yaml
+++ b/test_data/compiled-workflows/nested_with_parameters.yaml
@@ -133,6 +133,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -180,6 +184,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -432,6 +443,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -481,6 +496,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nested_with_parameters.yaml
+++ b/test_data/compiled-workflows/nested_with_parameters.yaml
@@ -184,13 +184,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -496,13 +489,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/notebook_component_mixed.yaml
+++ b/test_data/compiled-workflows/notebook_component_mixed.yaml
@@ -371,13 +371,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -675,13 +668,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/notebook_component_mixed.yaml
+++ b/test_data/compiled-workflows/notebook_component_mixed.yaml
@@ -320,6 +320,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -367,6 +371,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -611,6 +622,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -660,6 +675,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/notebook_component_mixed.yaml
+++ b/test_data/compiled-workflows/notebook_component_mixed.yaml
@@ -380,13 +380,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -693,13 +686,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/notebook_component_mixed.yaml
+++ b/test_data/compiled-workflows/notebook_component_mixed.yaml
@@ -329,6 +329,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -376,6 +380,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -629,6 +640,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -678,6 +693,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/notebook_component_simple.yaml
+++ b/test_data/compiled-workflows/notebook_component_simple.yaml
@@ -189,6 +189,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -236,6 +240,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -430,6 +441,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -479,6 +494,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/notebook_component_simple.yaml
+++ b/test_data/compiled-workflows/notebook_component_simple.yaml
@@ -240,13 +240,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -494,13 +487,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/notebook_component_simple.yaml
+++ b/test_data/compiled-workflows/notebook_component_simple.yaml
@@ -249,13 +249,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -512,13 +505,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/notebook_component_simple.yaml
+++ b/test_data/compiled-workflows/notebook_component_simple.yaml
@@ -198,6 +198,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -245,6 +249,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -448,6 +459,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -497,6 +512,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/nvidia_gpu_scheduling_check.yaml
+++ b/test_data/compiled-workflows/nvidia_gpu_scheduling_check.yaml
@@ -93,6 +93,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -345,6 +349,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/output_metrics.yaml
+++ b/test_data/compiled-workflows/output_metrics.yaml
@@ -93,6 +93,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -140,6 +144,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -334,6 +345,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -383,6 +398,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/output_metrics.yaml
+++ b/test_data/compiled-workflows/output_metrics.yaml
@@ -144,13 +144,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -398,13 +391,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/output_metrics.yaml
+++ b/test_data/compiled-workflows/output_metrics.yaml
@@ -153,13 +153,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -416,13 +409,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/output_metrics.yaml
+++ b/test_data/compiled-workflows/output_metrics.yaml
@@ -102,6 +102,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -149,6 +153,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -352,6 +363,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -401,6 +416,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_after_dependency.yaml
+++ b/test_data/compiled-workflows/parallel_for_after_dependency.yaml
@@ -145,13 +145,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -399,13 +392,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_after_dependency.yaml
+++ b/test_data/compiled-workflows/parallel_for_after_dependency.yaml
@@ -94,6 +94,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -141,6 +145,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -335,6 +346,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -384,6 +399,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_after_dependency.yaml
+++ b/test_data/compiled-workflows/parallel_for_after_dependency.yaml
@@ -154,13 +154,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -417,13 +410,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_after_dependency.yaml
+++ b/test_data/compiled-workflows/parallel_for_after_dependency.yaml
@@ -103,6 +103,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -150,6 +154,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -353,6 +364,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -402,6 +417,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
+++ b/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
@@ -118,6 +118,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -165,6 +169,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -361,6 +372,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -410,6 +425,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
+++ b/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
@@ -169,13 +169,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -425,13 +418,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
+++ b/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
@@ -178,13 +178,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -443,13 +436,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
+++ b/test_data/compiled-workflows/parallel_for_mount_pvc.yaml
@@ -127,6 +127,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -174,6 +178,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -379,6 +390,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -428,6 +443,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/parallel_for_secret.yaml
@@ -98,6 +98,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -145,6 +149,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/parallel_for_secret.yaml
@@ -149,13 +149,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/parallel_for_secret.yaml
@@ -107,6 +107,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -154,6 +158,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -359,6 +370,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -408,6 +423,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parallel_for_secret.yaml
+++ b/test_data/compiled-workflows/parallel_for_secret.yaml
@@ -158,13 +158,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -423,13 +416,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameter_cache.yaml
+++ b/test_data/compiled-workflows/parameter_cache.yaml
@@ -159,13 +159,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -413,13 +406,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameter_cache.yaml
+++ b/test_data/compiled-workflows/parameter_cache.yaml
@@ -108,6 +108,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -155,6 +159,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -349,6 +360,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -398,6 +413,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameter_cache.yaml
+++ b/test_data/compiled-workflows/parameter_cache.yaml
@@ -117,6 +117,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -164,6 +168,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -367,6 +378,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -416,6 +431,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameter_cache.yaml
+++ b/test_data/compiled-workflows/parameter_cache.yaml
@@ -168,13 +168,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -431,13 +424,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameter_oneof.yaml
+++ b/test_data/compiled-workflows/parameter_oneof.yaml
@@ -198,13 +198,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -486,13 +479,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameter_oneof.yaml
+++ b/test_data/compiled-workflows/parameter_oneof.yaml
@@ -147,6 +147,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -194,6 +198,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -422,6 +433,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -471,6 +486,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameter_oneof.yaml
+++ b/test_data/compiled-workflows/parameter_oneof.yaml
@@ -207,13 +207,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -504,13 +497,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameter_oneof.yaml
+++ b/test_data/compiled-workflows/parameter_oneof.yaml
@@ -156,6 +156,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -203,6 +207,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -440,6 +451,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -489,6 +504,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameters_complex.yaml
+++ b/test_data/compiled-workflows/parameters_complex.yaml
@@ -141,6 +141,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -188,6 +192,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -382,6 +393,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -431,6 +446,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameters_complex.yaml
+++ b/test_data/compiled-workflows/parameters_complex.yaml
@@ -192,13 +192,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -446,13 +439,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameters_complex.yaml
+++ b/test_data/compiled-workflows/parameters_complex.yaml
@@ -201,13 +201,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -464,13 +457,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameters_complex.yaml
+++ b/test_data/compiled-workflows/parameters_complex.yaml
@@ -150,6 +150,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -197,6 +201,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -400,6 +411,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -449,6 +464,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameters_simple.yaml
+++ b/test_data/compiled-workflows/parameters_simple.yaml
@@ -112,6 +112,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -159,6 +163,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -353,6 +364,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -402,6 +417,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameters_simple.yaml
+++ b/test_data/compiled-workflows/parameters_simple.yaml
@@ -163,13 +163,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -417,13 +410,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameters_simple.yaml
+++ b/test_data/compiled-workflows/parameters_simple.yaml
@@ -172,13 +172,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -435,13 +428,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/parameters_simple.yaml
+++ b/test_data/compiled-workflows/parameters_simple.yaml
@@ -121,6 +121,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -168,6 +172,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -371,6 +382,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -420,6 +435,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_as_exit_task.yaml
+++ b/test_data/compiled-workflows/pipeline_as_exit_task.yaml
@@ -179,13 +179,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -434,13 +427,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_as_exit_task.yaml
+++ b/test_data/compiled-workflows/pipeline_as_exit_task.yaml
@@ -128,6 +128,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -175,6 +179,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -370,6 +381,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -419,6 +434,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_as_exit_task.yaml
+++ b/test_data/compiled-workflows/pipeline_as_exit_task.yaml
@@ -137,6 +137,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -184,6 +188,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -388,6 +399,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -437,6 +452,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_as_exit_task.yaml
+++ b/test_data/compiled-workflows/pipeline_as_exit_task.yaml
@@ -188,13 +188,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -452,13 +445,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline.yaml
@@ -148,13 +148,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -427,13 +420,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline.yaml
@@ -97,6 +97,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -144,6 +148,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -363,6 +374,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -412,6 +427,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline.yaml
@@ -106,6 +106,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -153,6 +157,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -381,6 +392,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -430,6 +445,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline.yaml
@@ -157,13 +157,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -445,13 +438,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
@@ -106,6 +106,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -153,6 +157,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -379,6 +390,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -428,6 +443,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
@@ -157,13 +157,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -443,13 +436,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
@@ -166,13 +166,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -461,13 +454,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_complex.yaml
@@ -115,6 +115,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -162,6 +166,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,6 +408,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -446,6 +461,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
@@ -113,6 +113,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -160,6 +164,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -379,6 +390,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -428,6 +443,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
@@ -164,13 +164,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -443,13 +436,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
@@ -122,6 +122,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -169,6 +173,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,6 +408,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -446,6 +461,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_in_pipeline_loaded_from_yaml.yaml
@@ -173,13 +173,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -461,13 +454,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_producer_consumer.yaml
+++ b/test_data/compiled-workflows/pipeline_producer_consumer.yaml
@@ -195,13 +195,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -449,13 +442,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_producer_consumer.yaml
+++ b/test_data/compiled-workflows/pipeline_producer_consumer.yaml
@@ -144,6 +144,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -191,6 +195,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -385,6 +396,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -434,6 +449,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_producer_consumer.yaml
+++ b/test_data/compiled-workflows/pipeline_producer_consumer.yaml
@@ -153,6 +153,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -200,6 +204,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -403,6 +414,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -452,6 +467,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_producer_consumer.yaml
+++ b/test_data/compiled-workflows/pipeline_producer_consumer.yaml
@@ -204,13 +204,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -467,13 +460,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_after.yaml
+++ b/test_data/compiled-workflows/pipeline_with_after.yaml
@@ -85,6 +85,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -132,6 +136,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -379,6 +390,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -428,6 +443,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_after.yaml
+++ b/test_data/compiled-workflows/pipeline_with_after.yaml
@@ -136,13 +136,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -443,13 +436,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_after.yaml
+++ b/test_data/compiled-workflows/pipeline_with_after.yaml
@@ -145,13 +145,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -461,13 +454,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_after.yaml
+++ b/test_data/compiled-workflows/pipeline_with_after.yaml
@@ -94,6 +94,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -141,6 +145,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,6 +408,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -446,6 +461,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
@@ -113,6 +113,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -160,6 +164,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -379,6 +390,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -428,6 +443,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
@@ -164,13 +164,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -443,13 +436,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
@@ -122,6 +122,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -169,6 +173,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,6 +408,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -446,6 +461,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_custom_path.yaml
@@ -173,13 +173,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -461,13 +454,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
@@ -112,6 +112,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -159,6 +163,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -378,6 +389,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -427,6 +442,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
@@ -163,13 +163,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -442,13 +435,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
@@ -172,13 +172,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -460,13 +453,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
+++ b/test_data/compiled-workflows/pipeline_with_artifact_upload_download.yaml
@@ -121,6 +121,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -168,6 +172,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,6 +407,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -445,6 +460,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_caching.yaml
+++ b/test_data/compiled-workflows/pipeline_with_caching.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,13 +389,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_caching.yaml
+++ b/test_data/compiled-workflows/pipeline_with_caching.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -332,6 +343,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -381,6 +396,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_caching.yaml
+++ b/test_data/compiled-workflows/pipeline_with_caching.yaml
@@ -151,13 +151,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -414,13 +407,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_caching.yaml
+++ b/test_data/compiled-workflows/pipeline_with_caching.yaml
@@ -100,6 +100,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -147,6 +151,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -350,6 +361,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -399,6 +414,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_collected_artifacts.yaml
+++ b/test_data/compiled-workflows/pipeline_with_collected_artifacts.yaml
@@ -110,6 +110,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -157,6 +161,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -351,6 +362,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -400,6 +415,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_collected_artifacts.yaml
+++ b/test_data/compiled-workflows/pipeline_with_collected_artifacts.yaml
@@ -161,13 +161,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -415,13 +408,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_collected_artifacts.yaml
+++ b/test_data/compiled-workflows/pipeline_with_collected_artifacts.yaml
@@ -119,6 +119,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -166,6 +170,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -369,6 +380,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -418,6 +433,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_collected_artifacts.yaml
+++ b/test_data/compiled-workflows/pipeline_with_collected_artifacts.yaml
@@ -170,13 +170,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -433,13 +426,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
@@ -84,6 +84,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -131,6 +135,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -325,6 +336,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -374,6 +389,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
@@ -135,13 +135,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -389,13 +382,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
@@ -93,6 +93,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -140,6 +144,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -343,6 +354,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -392,6 +407,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
+++ b/test_data/compiled-workflows/pipeline_with_concat_placeholder.yaml
@@ -144,13 +144,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -407,13 +400,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_condition.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition.yaml
@@ -161,13 +161,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -464,13 +457,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_condition.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition.yaml
@@ -110,6 +110,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -157,6 +161,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -400,6 +411,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -449,6 +464,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_condition.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition.yaml
@@ -119,6 +119,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -166,6 +170,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -418,6 +429,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -467,6 +482,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_condition.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition.yaml
@@ -170,13 +170,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -482,13 +475,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
@@ -258,13 +258,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -512,13 +505,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
@@ -207,6 +207,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -254,6 +258,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -448,6 +459,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -497,6 +512,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
@@ -267,13 +267,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -530,13 +523,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_condition_dynamic_task_output_custom_training_job.yaml
@@ -216,6 +216,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -263,6 +267,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -466,6 +477,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -515,6 +530,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
@@ -221,13 +221,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -499,13 +492,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
@@ -170,6 +170,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -217,6 +221,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -435,6 +446,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -484,6 +499,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
@@ -239,13 +239,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -526,13 +519,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_importer_metadata.yaml
@@ -188,6 +188,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -235,6 +239,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -462,6 +473,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -511,6 +526,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
@@ -169,6 +169,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -216,6 +220,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -483,6 +494,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -532,6 +547,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
@@ -220,13 +220,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -547,13 +540,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
@@ -178,6 +178,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -225,6 +229,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -501,6 +512,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -550,6 +565,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
+++ b/test_data/compiled-workflows/pipeline_with_dynamic_task_output_custom_training_job.yaml
@@ -229,13 +229,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -565,13 +558,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_env.yaml
@@ -148,13 +148,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -426,13 +419,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_env.yaml
@@ -97,6 +97,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -144,6 +148,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -362,6 +373,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -411,6 +426,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_env.yaml
@@ -106,6 +106,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -153,6 +157,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -380,6 +391,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -429,6 +444,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_env.yaml
@@ -157,13 +157,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -444,13 +437,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
@@ -109,6 +109,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -156,6 +160,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -408,6 +419,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -457,6 +472,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
@@ -160,13 +160,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -472,13 +465,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
@@ -169,13 +169,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -490,13 +483,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
+++ b/test_data/compiled-workflows/pipeline_with_exit_handler.yaml
@@ -118,6 +118,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -165,6 +169,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -426,6 +437,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -475,6 +490,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
+++ b/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
@@ -188,6 +188,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -235,6 +239,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -466,6 +477,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -515,6 +530,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
+++ b/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
@@ -239,13 +239,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -530,13 +523,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
+++ b/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
@@ -257,13 +257,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -557,13 +550,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
+++ b/test_data/compiled-workflows/pipeline_with_google_artifact_type.yaml
@@ -206,6 +206,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -253,6 +257,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -493,6 +504,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -542,6 +557,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer.yaml
@@ -229,13 +229,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -496,13 +489,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer.yaml
@@ -178,6 +178,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -225,6 +229,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -432,6 +443,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -481,6 +496,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer.yaml
@@ -196,6 +196,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -243,6 +247,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -459,6 +470,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -508,6 +523,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer.yaml
@@ -247,13 +247,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -523,13 +516,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
@@ -137,13 +137,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -475,13 +468,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
@@ -86,6 +86,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -133,6 +137,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -411,6 +422,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -460,6 +475,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
@@ -95,6 +95,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -142,6 +146,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -438,6 +449,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -487,6 +502,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_and_gcpc_types.yaml
@@ -146,13 +146,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -502,13 +495,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
@@ -252,6 +252,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -299,6 +303,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -543,6 +554,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -592,6 +607,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
@@ -303,13 +303,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -607,13 +600,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
@@ -321,13 +321,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -634,13 +627,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_importer_workspace.yaml
@@ -270,6 +270,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -317,6 +321,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -570,6 +581,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -619,6 +634,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
+++ b/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
@@ -109,6 +109,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -156,6 +160,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -382,6 +393,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -431,6 +446,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
+++ b/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
@@ -160,13 +160,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -446,13 +439,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
+++ b/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
@@ -118,6 +118,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -165,6 +169,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -400,6 +411,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -449,6 +464,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
+++ b/test_data/compiled-workflows/pipeline_with_input_status_state.yaml
@@ -169,13 +169,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -464,13 +457,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops.yaml
@@ -176,13 +176,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -590,13 +583,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops.yaml
@@ -125,6 +125,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -172,6 +176,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -526,6 +537,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -575,6 +590,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops.yaml
@@ -185,13 +185,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -608,13 +601,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops.yaml
@@ -134,6 +134,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -181,6 +185,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -544,6 +555,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -593,6 +608,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
@@ -222,13 +222,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -540,13 +533,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
@@ -171,6 +171,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -218,6 +222,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -476,6 +487,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -525,6 +540,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
@@ -180,6 +180,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -227,6 +231,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -494,6 +505,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -543,6 +558,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_loops_and_conditions.yaml
@@ -231,13 +231,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -558,13 +551,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
@@ -122,6 +122,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -169,6 +173,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -388,6 +399,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -437,6 +452,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
@@ -173,13 +173,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -452,13 +445,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
@@ -131,6 +131,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -178,6 +182,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -406,6 +417,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -455,6 +470,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metadata_fields.yaml
@@ -182,13 +182,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -470,13 +463,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
@@ -147,13 +147,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -401,13 +394,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
@@ -96,6 +96,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -143,6 +147,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -337,6 +348,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -386,6 +401,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
@@ -105,6 +105,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -152,6 +156,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -355,6 +366,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -404,6 +419,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_metrics_outputs.yaml
@@ -156,13 +156,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -419,13 +412,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
+++ b/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
@@ -166,13 +166,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -608,13 +601,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
+++ b/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
@@ -115,6 +115,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -162,6 +166,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -544,6 +555,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -593,6 +608,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
+++ b/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
@@ -175,13 +175,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -626,13 +619,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
+++ b/test_data/compiled-workflows/pipeline_with_multiple_exit_handlers.yaml
@@ -124,6 +124,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -171,6 +175,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -562,6 +573,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -611,6 +626,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
@@ -112,6 +112,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -159,6 +163,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -378,6 +389,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -427,6 +442,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
@@ -163,13 +163,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -442,13 +435,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
@@ -172,13 +172,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -460,13 +453,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions.yaml
@@ -121,6 +121,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -168,6 +172,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,6 +407,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -445,6 +460,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
@@ -175,13 +175,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -465,13 +458,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
@@ -124,6 +124,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -171,6 +175,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -401,6 +412,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -450,6 +465,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
@@ -184,13 +184,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -483,13 +476,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_conditions_yaml.yaml
@@ -133,6 +133,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -180,6 +184,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -419,6 +430,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -468,6 +483,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
@@ -102,6 +102,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -149,6 +153,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -343,6 +354,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -392,6 +407,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
@@ -153,13 +153,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -407,13 +400,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
@@ -111,6 +111,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -158,6 +162,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -361,6 +372,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -410,6 +425,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
+++ b/test_data/compiled-workflows/pipeline_with_nested_loops.yaml
@@ -162,13 +162,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -425,13 +418,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -387,13 +380,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -323,6 +334,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -372,6 +387,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_only_display_name.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_outputs.yaml
@@ -98,6 +98,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -145,6 +149,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -364,6 +375,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -413,6 +428,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_outputs.yaml
@@ -149,13 +149,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -428,13 +421,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_outputs.yaml
@@ -158,13 +158,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -446,13 +439,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_outputs.yaml
+++ b/test_data/compiled-workflows/pipeline_with_outputs.yaml
@@ -107,6 +107,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -154,6 +158,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -382,6 +393,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -431,6 +446,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
@@ -189,6 +189,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -236,6 +240,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -430,6 +441,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -479,6 +494,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
@@ -240,13 +240,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -494,13 +487,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
@@ -249,13 +249,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -512,13 +505,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_parallelism.yaml
@@ -198,6 +198,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -245,6 +249,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -448,6 +459,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -497,6 +512,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
@@ -165,13 +165,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -483,13 +476,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
@@ -114,6 +114,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -161,6 +165,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -419,6 +430,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -468,6 +483,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
@@ -174,13 +174,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -501,13 +494,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
+++ b/test_data/compiled-workflows/pipeline_with_parallelfor_pipeline_param.yaml
@@ -123,6 +123,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -170,6 +174,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -437,6 +448,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -486,6 +501,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
+++ b/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
@@ -111,6 +111,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -158,6 +162,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -353,6 +364,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -402,6 +417,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
+++ b/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
@@ -162,13 +162,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -417,13 +410,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
+++ b/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
@@ -171,13 +171,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -435,13 +428,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
+++ b/test_data/compiled-workflows/pipeline_with_params_containing_format.yaml
@@ -120,6 +120,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -167,6 +171,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -371,6 +382,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -420,6 +435,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_placeholders.yaml
+++ b/test_data/compiled-workflows/pipeline_with_placeholders.yaml
@@ -98,6 +98,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -145,6 +149,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -339,6 +350,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -388,6 +403,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_placeholders.yaml
+++ b/test_data/compiled-workflows/pipeline_with_placeholders.yaml
@@ -149,13 +149,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -403,13 +396,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_placeholders.yaml
+++ b/test_data/compiled-workflows/pipeline_with_placeholders.yaml
@@ -107,6 +107,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -154,6 +158,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -357,6 +368,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -406,6 +421,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_placeholders.yaml
+++ b/test_data/compiled-workflows/pipeline_with_placeholders.yaml
@@ -158,13 +158,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -421,13 +414,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
@@ -213,6 +213,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -260,6 +264,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -1198,6 +1209,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -1247,6 +1262,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
@@ -264,13 +264,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -1262,13 +1255,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
@@ -273,13 +273,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -1280,13 +1273,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
+++ b/test_data/compiled-workflows/pipeline_with_pod_metadata.yaml
@@ -222,6 +222,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -269,6 +273,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -1216,6 +1227,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -1265,6 +1280,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -368,6 +379,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -417,6 +432,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -432,13 +425,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry.yaml
@@ -151,13 +151,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -450,13 +443,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_retry.yaml
+++ b/test_data/compiled-workflows/pipeline_with_retry.yaml
@@ -100,6 +100,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -147,6 +151,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -386,6 +397,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -435,6 +450,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_reused_component.yaml
+++ b/test_data/compiled-workflows/pipeline_with_reused_component.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -382,6 +393,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -431,6 +446,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_reused_component.yaml
+++ b/test_data/compiled-workflows/pipeline_with_reused_component.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -446,13 +439,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_reused_component.yaml
+++ b/test_data/compiled-workflows/pipeline_with_reused_component.yaml
@@ -100,6 +100,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -147,6 +151,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -400,6 +411,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -449,6 +464,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_reused_component.yaml
+++ b/test_data/compiled-workflows/pipeline_with_reused_component.yaml
@@ -151,13 +151,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -464,13 +457,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
@@ -161,13 +161,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -442,13 +435,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
@@ -110,6 +110,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -157,6 +161,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -378,6 +389,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -427,6 +442,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
@@ -170,13 +170,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -460,13 +453,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_env.yaml
@@ -119,6 +119,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -166,6 +170,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,6 +407,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -445,6 +460,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
@@ -98,6 +98,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -145,6 +149,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -341,6 +352,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -390,6 +405,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
@@ -149,13 +149,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -405,13 +398,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
@@ -107,6 +107,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -154,6 +158,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -359,6 +370,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -408,6 +423,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_secret_as_volume.yaml
@@ -158,13 +158,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -423,13 +416,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -396,13 +389,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -332,6 +343,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -381,6 +396,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
@@ -151,13 +151,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -414,13 +407,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_pipeline_input.yaml
@@ -100,6 +100,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -147,6 +151,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -350,6 +361,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -399,6 +414,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
@@ -71,7 +71,7 @@ spec:
         kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
         sum_numbers(a: int, b: int) -\u003e int:\n    return a + b\n\n"],"image":"python:3.11","resources":{"accelerator":{"resourceCount":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}","resourceType":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"},"resourceCpuLimit":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}","resourceMemoryLimit":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}}'
     - name: components-root
-      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","cpu-limit","accelerator-limit","memory-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
+      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","memory-limit","accelerator-limit","cpu-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
   entrypoint: entrypoint
   podMetadata:
     annotations:
@@ -194,13 +194,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -418,15 +411,15 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","cpu-limit","accelerator-limit","memory-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","memory-limit","accelerator-limit","cpu-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
           - name: container
             value: '{{workflow.parameters.implementations-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task-name
             value: sum-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
-        depends: accelerator-type.Succeeded && cpu-limit.Succeeded && accelerator-limit.Succeeded
-          && memory-limit.Succeeded
+        depends: accelerator-type.Succeeded && memory-limit.Succeeded && accelerator-limit.Succeeded
+          && cpu-limit.Succeeded
         name: sum-numbers-driver
         template: system-container-driver
       - arguments:
@@ -546,13 +539,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
@@ -71,7 +71,7 @@ spec:
         kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import *\n\ndef
         sum_numbers(a: int, b: int) -\u003e int:\n    return a + b\n\n"],"image":"python:3.11","resources":{"accelerator":{"resourceCount":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}","resourceType":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"},"resourceCpuLimit":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}","resourceMemoryLimit":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}}'
     - name: components-root
-      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","memory-limit","accelerator-limit","cpu-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
+      value: '{"dag":{"tasks":{"accelerator-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-limit"},"taskInfo":{"name":"accelerator-limit"}},"accelerator-type":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-accelerator-type"},"taskInfo":{"name":"accelerator-type"}},"cpu-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-cpu-limit"},"taskInfo":{"name":"cpu-limit"}},"memory-limit":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-memory-limit"},"taskInfo":{"name":"memory-limit"}},"sum-numbers":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","cpu-limit","accelerator-limit","memory-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}}}}'
   entrypoint: entrypoint
   podMetadata:
     annotations:
@@ -143,6 +143,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -190,6 +194,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -407,15 +418,15 @@ spec:
           - name: component
             value: '{{workflow.parameters.components-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task
-            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","memory-limit","accelerator-limit","cpu-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-sum-numbers"},"dependentTasks":["accelerator-type","cpu-limit","accelerator-limit","memory-limit"],"inputs":{"parameters":{"a":{"runtimeValue":{"constant":1}},"accelerator_count":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-limit-Output'']}}"}},"accelerator_type":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--accelerator-type-Output'']}}"}},"b":{"runtimeValue":{"constant":2}},"cpu_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--cpu-limit-Output'']}}"}},"memory_limit":{"runtimeValue":{"constant":"{{$.inputs.parameters[''pipelinechannel--memory-limit-Output'']}}"}},"pipelinechannel--accelerator-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-limit"}},"pipelinechannel--accelerator-type-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"accelerator-type"}},"pipelinechannel--cpu-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"cpu-limit"}},"pipelinechannel--memory-limit-Output":{"taskOutputParameter":{"outputParameterKey":"Output","producerTask":"memory-limit"}}}},"taskInfo":{"name":"sum-numbers"}}'
           - name: container
             value: '{{workflow.parameters.implementations-49f9a898b718a077f30b7fd8c02d39767cff91ff0bbda4379daf866a91dbdb1b}}'
           - name: task-name
             value: sum-numbers
           - name: parent-dag-id
             value: '{{inputs.parameters.parent-dag-id}}'
-        depends: accelerator-type.Succeeded && memory-limit.Succeeded && accelerator-limit.Succeeded
-          && cpu-limit.Succeeded
+        depends: accelerator-type.Succeeded && cpu-limit.Succeeded && accelerator-limit.Succeeded
+          && memory-limit.Succeeded
         name: sum-numbers-driver
         template: system-container-driver
       - arguments:
@@ -482,6 +493,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -531,6 +546,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
+++ b/test_data/compiled-workflows/pipeline_with_string_machine_fields_task_output.yaml
@@ -152,6 +152,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -500,6 +504,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:

--- a/test_data/compiled-workflows/pipeline_with_submit_request.yaml
+++ b/test_data/compiled-workflows/pipeline_with_submit_request.yaml
@@ -102,6 +102,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -149,6 +153,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -367,6 +378,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -416,6 +431,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_submit_request.yaml
+++ b/test_data/compiled-workflows/pipeline_with_submit_request.yaml
@@ -153,13 +153,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -431,13 +424,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_submit_request.yaml
+++ b/test_data/compiled-workflows/pipeline_with_submit_request.yaml
@@ -111,6 +111,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -158,6 +162,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -385,6 +396,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -434,6 +449,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_submit_request.yaml
+++ b/test_data/compiled-workflows/pipeline_with_submit_request.yaml
@@ -162,13 +162,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -449,13 +442,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
@@ -176,13 +176,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -487,13 +480,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
@@ -125,6 +125,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -172,6 +176,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -423,6 +434,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -472,6 +487,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
@@ -134,6 +134,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -181,6 +185,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -441,6 +452,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -490,6 +505,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status.yaml
@@ -185,13 +185,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -505,13 +498,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
@@ -141,13 +141,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -427,13 +420,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
@@ -90,6 +90,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -137,6 +141,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -363,6 +374,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -412,6 +427,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
@@ -150,13 +150,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -445,13 +438,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_final_status_yaml.yaml
@@ -99,6 +99,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -146,6 +150,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -381,6 +392,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -430,6 +445,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -105,6 +105,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -152,6 +156,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -385,6 +396,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -434,6 +449,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -156,13 +156,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -449,13 +442,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -114,6 +114,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -161,6 +165,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -403,6 +414,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -452,6 +467,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
+++ b/test_data/compiled-workflows/pipeline_with_task_using_ignore_upstream_failure.yaml
@@ -165,13 +165,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -467,13 +460,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_utils.yaml
+++ b/test_data/compiled-workflows/pipeline_with_utils.yaml
@@ -146,13 +146,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -400,13 +393,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_utils.yaml
+++ b/test_data/compiled-workflows/pipeline_with_utils.yaml
@@ -95,6 +95,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -142,6 +146,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -336,6 +347,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -385,6 +400,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_utils.yaml
+++ b/test_data/compiled-workflows/pipeline_with_utils.yaml
@@ -104,6 +104,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -151,6 +155,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -354,6 +365,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -403,6 +418,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_utils.yaml
+++ b/test_data/compiled-workflows/pipeline_with_utils.yaml
@@ -155,13 +155,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -418,13 +411,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
@@ -137,13 +137,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -416,13 +409,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
@@ -86,6 +86,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -133,6 +137,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -352,6 +363,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -401,6 +416,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
@@ -95,6 +95,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -142,6 +146,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -370,6 +381,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -419,6 +434,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
+++ b/test_data/compiled-workflows/pipeline_with_various_io_types.yaml
@@ -146,13 +146,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -434,13 +427,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume.yaml
@@ -139,6 +139,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -186,6 +190,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -439,6 +450,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -488,6 +503,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume.yaml
@@ -190,13 +190,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -503,13 +496,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume.yaml
@@ -199,13 +199,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -521,13 +514,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume.yaml
@@ -148,6 +148,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -195,6 +199,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -457,6 +468,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -506,6 +521,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
@@ -164,13 +164,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -432,13 +425,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
@@ -113,6 +113,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -160,6 +164,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -368,6 +379,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -417,6 +432,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
@@ -122,6 +122,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -169,6 +173,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -386,6 +397,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -435,6 +450,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_long_name.yaml
@@ -173,13 +173,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -450,13 +443,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
@@ -139,6 +139,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -186,6 +190,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -439,6 +450,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -488,6 +503,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
@@ -190,13 +190,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -503,13 +496,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
@@ -199,13 +199,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -521,13 +514,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
+++ b/test_data/compiled-workflows/pipeline_with_volume_no_cache.yaml
@@ -148,6 +148,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -195,6 +199,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -457,6 +468,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -506,6 +521,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_workspace.yaml
@@ -115,6 +115,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -162,6 +166,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -381,6 +392,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -430,6 +445,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_workspace.yaml
@@ -166,13 +166,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -445,13 +438,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_workspace.yaml
@@ -124,6 +124,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -171,6 +175,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -399,6 +410,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -448,6 +463,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pipeline_with_workspace.yaml
+++ b/test_data/compiled-workflows/pipeline_with_workspace.yaml
@@ -175,13 +175,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -463,13 +456,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
+++ b/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
@@ -85,6 +85,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -132,6 +136,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -326,6 +337,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -375,6 +390,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
+++ b/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
@@ -136,13 +136,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -390,13 +383,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
+++ b/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
@@ -94,6 +94,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -141,6 +145,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -344,6 +355,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -393,6 +408,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
+++ b/test_data/compiled-workflows/placeholder_with_if_placeholder_none_input_value.yaml
@@ -145,13 +145,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -408,13 +401,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/preprocess.yaml
+++ b/test_data/compiled-workflows/preprocess.yaml
@@ -164,13 +164,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -418,13 +411,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/preprocess.yaml
+++ b/test_data/compiled-workflows/preprocess.yaml
@@ -113,6 +113,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -160,6 +164,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -354,6 +365,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -403,6 +418,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/preprocess.yaml
+++ b/test_data/compiled-workflows/preprocess.yaml
@@ -173,13 +173,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -436,13 +429,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/preprocess.yaml
+++ b/test_data/compiled-workflows/preprocess.yaml
@@ -122,6 +122,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -169,6 +173,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -372,6 +383,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -421,6 +436,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
+++ b/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
@@ -140,13 +140,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -419,13 +412,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
+++ b/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
@@ -89,6 +89,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -136,6 +140,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -355,6 +366,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -404,6 +419,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
+++ b/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
@@ -98,6 +98,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -145,6 +149,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -373,6 +384,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -422,6 +437,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
+++ b/test_data/compiled-workflows/producer_consumer_param_pipeline.yaml
@@ -149,13 +149,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -437,13 +430,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pvc_mount.yaml
+++ b/test_data/compiled-workflows/pvc_mount.yaml
@@ -109,6 +109,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -156,6 +160,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -379,6 +390,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -428,6 +443,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pvc_mount.yaml
+++ b/test_data/compiled-workflows/pvc_mount.yaml
@@ -160,13 +160,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -443,13 +436,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pvc_mount.yaml
+++ b/test_data/compiled-workflows/pvc_mount.yaml
@@ -169,13 +169,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -461,13 +454,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pvc_mount.yaml
+++ b/test_data/compiled-workflows/pvc_mount.yaml
@@ -118,6 +118,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -165,6 +169,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,6 +408,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -446,6 +461,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
+++ b/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
@@ -173,6 +173,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -220,6 +224,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -427,6 +438,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -476,6 +491,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
+++ b/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
@@ -224,13 +224,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -491,13 +484,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
+++ b/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
@@ -242,13 +242,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -518,13 +511,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
+++ b/test_data/compiled-workflows/pythonic_artifact_with_single_return.yaml
@@ -191,6 +191,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -238,6 +242,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -454,6 +465,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -503,6 +518,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
@@ -161,13 +161,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -440,13 +433,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
@@ -110,6 +110,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -157,6 +161,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -376,6 +387,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -425,6 +440,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
@@ -170,13 +170,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -458,13 +451,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_test_pipeline.yaml
@@ -119,6 +119,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -166,6 +170,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -394,6 +405,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -443,6 +458,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
@@ -111,6 +111,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -158,6 +162,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -352,6 +363,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -401,6 +416,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
@@ -162,13 +162,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -416,13 +409,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
@@ -120,6 +120,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -167,6 +171,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -370,6 +381,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -419,6 +434,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_list_of_artifacts.yaml
@@ -171,13 +171,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -434,13 +427,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
@@ -167,13 +167,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -421,13 +414,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
@@ -116,6 +116,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -163,6 +167,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -357,6 +368,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -406,6 +421,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
@@ -176,13 +176,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -439,13 +432,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
+++ b/test_data/compiled-workflows/pythonic_artifacts_with_multiple_returns.yaml
@@ -125,6 +125,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -172,6 +176,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -375,6 +386,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -424,6 +439,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/ray_integration_compiled.yaml
+++ b/test_data/compiled-workflows/ray_integration_compiled.yaml
@@ -207,13 +207,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -461,13 +454,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/ray_integration_compiled.yaml
+++ b/test_data/compiled-workflows/ray_integration_compiled.yaml
@@ -156,6 +156,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -203,6 +207,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -397,6 +408,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -446,6 +461,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/ray_integration_compiled.yaml
+++ b/test_data/compiled-workflows/ray_integration_compiled.yaml
@@ -165,6 +165,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -212,6 +216,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -415,6 +426,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -464,6 +479,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/ray_integration_compiled.yaml
+++ b/test_data/compiled-workflows/ray_integration_compiled.yaml
@@ -216,13 +216,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -479,13 +472,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
@@ -136,13 +136,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -394,13 +387,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
@@ -85,6 +85,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -132,6 +136,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -330,6 +341,10 @@ spec:
       - "3"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -379,6 +394,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
@@ -92,6 +92,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -139,6 +143,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -342,6 +353,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -391,6 +406,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_disabled.yaml
@@ -143,13 +143,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -406,13 +399,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
@@ -136,13 +136,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -394,13 +387,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
@@ -85,6 +85,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -132,6 +136,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -330,6 +341,10 @@ spec:
       - "3"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -379,6 +394,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
@@ -92,6 +92,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -139,6 +143,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -342,6 +353,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -391,6 +406,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
+++ b/test_data/compiled-workflows/run_as_user_cache_enabled.yaml
@@ -143,13 +143,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -406,13 +399,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/sequential_v1.yaml
+++ b/test_data/compiled-workflows/sequential_v1.yaml
@@ -82,6 +82,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -129,6 +133,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -347,6 +358,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -396,6 +411,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/sequential_v1.yaml
+++ b/test_data/compiled-workflows/sequential_v1.yaml
@@ -133,13 +133,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -411,13 +404,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/sequential_v1.yaml
+++ b/test_data/compiled-workflows/sequential_v1.yaml
@@ -91,6 +91,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -138,6 +142,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -365,6 +376,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -414,6 +429,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/sequential_v1.yaml
+++ b/test_data/compiled-workflows/sequential_v1.yaml
@@ -142,13 +142,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -429,13 +422,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/sequential_v2.yaml
+++ b/test_data/compiled-workflows/sequential_v2.yaml
@@ -137,13 +137,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -416,13 +409,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/sequential_v2.yaml
+++ b/test_data/compiled-workflows/sequential_v2.yaml
@@ -86,6 +86,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -133,6 +137,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -352,6 +363,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -401,6 +416,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/sequential_v2.yaml
+++ b/test_data/compiled-workflows/sequential_v2.yaml
@@ -95,6 +95,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -142,6 +146,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -370,6 +381,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -419,6 +434,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/sequential_v2.yaml
+++ b/test_data/compiled-workflows/sequential_v2.yaml
@@ -146,13 +146,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -434,13 +427,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/take_nap_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_compiled.yaml
@@ -158,13 +158,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -437,13 +430,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/take_nap_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_compiled.yaml
@@ -107,6 +107,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -154,6 +158,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -373,6 +384,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -422,6 +437,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/take_nap_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_compiled.yaml
@@ -116,6 +116,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -163,6 +167,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -391,6 +402,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -440,6 +455,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/take_nap_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_compiled.yaml
@@ -167,13 +167,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -455,13 +448,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
@@ -158,13 +158,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -437,13 +430,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
@@ -107,6 +107,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -154,6 +158,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -373,6 +384,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -422,6 +437,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
@@ -116,6 +116,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -163,6 +167,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -391,6 +402,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -440,6 +455,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
+++ b/test_data/compiled-workflows/take_nap_pipeline_root_compiled.yaml
@@ -167,13 +167,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -455,13 +448,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/two_step_pipeline.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline.yaml
@@ -138,13 +138,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -417,13 +410,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/two_step_pipeline.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline.yaml
@@ -87,6 +87,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -134,6 +138,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -353,6 +364,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -402,6 +417,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/two_step_pipeline.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline.yaml
@@ -147,13 +147,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -435,13 +428,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/two_step_pipeline.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline.yaml
@@ -96,6 +96,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -143,6 +147,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -371,6 +382,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -420,6 +435,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
@@ -139,13 +139,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -418,13 +411,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
@@ -88,6 +88,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -135,6 +139,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -354,6 +365,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -403,6 +418,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
@@ -97,6 +97,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -144,6 +148,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -372,6 +383,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -421,6 +436,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
+++ b/test_data/compiled-workflows/two_step_pipeline_containerized.yaml
@@ -148,13 +148,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -436,13 +429,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/upload_download_compiled.yaml
+++ b/test_data/compiled-workflows/upload_download_compiled.yaml
@@ -197,13 +197,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -501,13 +494,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/upload_download_compiled.yaml
+++ b/test_data/compiled-workflows/upload_download_compiled.yaml
@@ -146,6 +146,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -193,6 +197,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -437,6 +448,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -486,6 +501,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/upload_download_compiled.yaml
+++ b/test_data/compiled-workflows/upload_download_compiled.yaml
@@ -206,13 +206,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -519,13 +512,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/upload_download_compiled.yaml
+++ b/test_data/compiled-workflows/upload_download_compiled.yaml
@@ -155,6 +155,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -202,6 +206,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -455,6 +466,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -504,6 +519,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
+++ b/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
@@ -401,13 +401,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -831,13 +824,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
+++ b/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
@@ -350,6 +350,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -397,6 +401,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -767,6 +778,10 @@ spec:
       - "8080"
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -816,6 +831,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
+++ b/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
@@ -410,13 +410,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -849,13 +842,6 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
-    retryStrategy:
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 1m
-      limit: 3
-      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:

--- a/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
+++ b/test_data/compiled-workflows/xgboost_sample_pipeline.yaml
@@ -359,6 +359,10 @@ spec:
         valueFrom:
           fieldRef:
             fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -406,6 +410,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:
@@ -785,6 +796,10 @@ spec:
       - ""
       command:
       - driver
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
       image: ghcr.io/kubeflow/kfp-driver:latest
       name: ""
       resources:
@@ -834,6 +849,13 @@ spec:
         valueFrom:
           default: "true"
           path: /tmp/outputs/condition
+    retryStrategy:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+      limit: 3
+      retryPolicy: Always
     securityContext:
       runAsNonRoot: true
       seccompProfile:


### PR DESCRIPTION
## Description

At scale, the MLMD gRPC server (`metadata-grpc-deployment`) can be OOM-killed or restarted while runs are in flight. Since #13179 the MLMD client retries `Unavailable`, but gaps remain that still turn a restart into failed runs:

1. A server killed mid-request can surface `Internal` or `Unknown` instead of `Unavailable`, which are not retried.
2. A connected-but-hung server stalls drivers forever: driver contexts have no deadline and the retry interceptor has no per-attempt timeout.
3. The client-side retry budget is hardcoded, so operators cannot widen the window to cover slower recoveries.
4. Driver pods have no Argo `retryStrategy`, so any driver failure — including an exhausted metadata retry or node preemption — fails the whole run (`.set_retry()` only covers executor templates).

## Changes

- **Method-aware retry codes** (`backend/src/v2/metadata/client.go`): read-only MLMD RPCs (`Get*`) are idempotent and now additionally retry `Internal` and `Unknown`. Write RPCs keep the conservative `Aborted`/`Unavailable` set. `DeadlineExceeded` is deliberately excluded: the retry middleware treats it as a caller context error and never retries it.
- **Per-attempt timeout for reads**: each read-only attempt is bounded to 2 minutes and retried on timeout, so a hung server cannot stall a driver indefinitely. Write attempts are deliberately unbounded — abandoning and replaying a slow write risks duplicating server-side state.
- **Configurable attempt budget**: `METADATA_GRPC_MAX_ATTEMPTS` overrides the default 10 total attempts per call (`1` disables retries), following the existing `METADATA_GRPC_MESSAGE_SIZE` pattern. Driver templates now include the optional `metadata-grpc-configmap` `envFrom` (executors already had it), so these variables actually reach driver pods.
- **Opt-in driver retryStrategy** (`backend/src/v2/compiler/argocompiler`): setting `PIPELINE_DRIVER_RETRY_LIMIT` on the API server compiles a `retryStrategy` (`retryPolicy: Always`, exponential backoff 5s–1m) into driver templates. This is **disabled by default** because driver replays are not yet idempotent: only the root DAG execution has a deterministic MLMD name (a replayed container/DAG driver whose `PutExecution` committed creates a duplicate execution), plugin `OnTaskStart` hooks re-fire, and `createpvc`/`deletepvc` replays can create a second UUID-named PVC or fail on an already-deleted one. The caveats are documented at `getDriverRetryStrategy`; clusters that accept them (e.g. to survive MLMD instability or node preemption) can opt in, and `0` remains the rollback value. Making driver replays idempotent (stable execution names for all driver types, replay-safe hooks and PVC operations) is a prerequisite for a default-on follow-up.

Most of the diff is compiled-workflow goldens (two driver templates per workflow gain the `envFrom`).

## Verification

- New unit tests: `backend/src/v2/metadata/client_retry_test.go` (per-method retry dispatch against injected gRPC codes, hung-read timeout-and-retry, hung-write bounded only by caller context, env parsing), `backend/src/v2/compiler/argocompiler/driver_retry_test.go` (disabled default, explicit enable, zero/invalid handling).
- `ginkgo ./backend/test/compiler -- -updateCompiledFiles=true`: 299 specs pass, goldens regenerated.
- Full backend unit suite (per repo guidelines, excluding integration/API/compiler/E2E): pass.

## Checklist

- [x] The title of your PR is a summary of its changes and uses [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/)