### PR TITLE
fix: check generated Python protobuf output path Fixes #13712

### DIFF
--- a/api/v2alpha1/python/generate_proto.py
+++ b/api/v2alpha1/python/generate_proto.py
@@ -44,7 +44,10 @@ def generate_proto(source):
       source: The source proto file that needs to be compiled.
     """
 
-    output = source.replace(".proto", "_pb2.py")
+    output = os.path.join(
+        PKG_DIR,
+        os.path.basename(source).replace(".proto", "_pb2.py"),
+    )
 
     if not os.path.exists(output) or (
             os.path.exists(source) and


### PR DESCRIPTION
**Description of your changes:**

Updates `generate_proto.py` to check the generated Python protobuf file in `PKG_DIR`, matching the directory passed to `protoc` through `--python_out`.

Previously, the script checked for `pipeline_spec_pb2.py` next to the source `.proto` file. This caused it to attempt regeneration even when the actual generated output was already up to date.

**Testing:**

* `python -m py_compile api/v2alpha1/python/generate_proto.py`
* `python -m yapf --diff api/v2alpha1/python/generate_proto.py`
* `git diff --check`
* Verified that an up-to-date output in `PKG_DIR` skips generation.
* Verified that a missing output attempts generation using the corrected path. Full generation was not run locally because `protoc` is not installed.

Fixes #13712

**Checklist:**

* [x] I have signed off my commits.
* [x] The pull request title follows the repository title convention.

