### PR TITLE
ci: limit Kubernetes-auth MLflow parallelism

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -333,6 +333,27 @@ jobs:
           s3_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
           s3_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
 
+      - name: Scale MLflow request workers
+        if: ${{ steps.deploy-mlflow.outcome == 'success' }}
+        shell: bash
+        run: |
+          kubectl patch mlflow mlflow -n opendatahub \
+            --type merge \
+            --patch '{"spec":{"workers":2}}'
+
+          reconcile_deadline=$((SECONDS + 180))
+          until kubectl get deployment/mlflow -n opendatahub \
+            -o jsonpath='{.spec.template.spec.containers[?(@.name=="mlflow")].args}' \
+            | grep -q -- '--workers=2'; do
+            if ((SECONDS >= reconcile_deadline)); then
+              echo "Timed out waiting for the MLflow operator to configure two workers"
+              kubectl get deployment/mlflow -n opendatahub -o yaml
+              exit 1
+            fi
+            sleep 5
+          done
+          kubectl rollout status deployment/mlflow -n opendatahub --timeout=180s
+
       - name: Deploy MLflow directly
         id: deploy_direct_mlflow
         shell: bash

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -333,27 +333,6 @@ jobs:
           s3_access_key: ${{ env.AWS_ACCESS_KEY_ID }}
           s3_secret_key: ${{ env.AWS_SECRET_ACCESS_KEY }}
 
-      - name: Scale MLflow request workers
-        if: ${{ steps.deploy-mlflow.outcome == 'success' }}
-        shell: bash
-        run: |
-          kubectl patch mlflow mlflow -n opendatahub \
-            --type merge \
-            --patch '{"spec":{"workers":2}}'
-
-          reconcile_deadline=$((SECONDS + 180))
-          until kubectl get deployment/mlflow -n opendatahub \
-            -o jsonpath='{.spec.template.spec.containers[?(@.name=="mlflow")].args}' \
-            | grep -q -- '--workers=2'; do
-            if ((SECONDS >= reconcile_deadline)); then
-              echo "Timed out waiting for the MLflow operator to configure two workers"
-              kubectl get deployment/mlflow -n opendatahub -o yaml
-              exit 1
-            fi
-            sleep 5
-          done
-          kubectl rollout status deployment/mlflow -n opendatahub --timeout=180s
-
       - name: Deploy MLflow directly
         id: deploy_direct_mlflow
         shell: bash
@@ -386,6 +365,10 @@ jobs:
           NUMBER_OF_NODES=${{ env.NUMBER_OF_PARALLEL_NODES }}
           TEST_LABEL=${{ matrix.test_label }}
           NAMESPACE=${{ env.NAMESPACE }}
+          # TODO(#13724): Restore higher concurrency after increasing shared Kind capacity.
+          if [ "${{ matrix.mlflow_auth_type }}" == "kubernetes" ]; then
+            NUMBER_OF_NODES=2
+          fi
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             NUMBER_OF_NODES=${{ inputs.number_of_parallel_tests }}
             TEST_LABEL=${{ inputs.test_label }}


### PR DESCRIPTION
## Summary

- cap operator-managed Kubernetes-auth MLflow E2E lanes at two Ginkgo nodes
- retain the MLflow operator's default of one request worker
- preserve the existing `workflow_dispatch` node-count override for manual capacity testing
- leave direct basic-auth/none MLflow lanes unchanged

## Why

The Kubernetes-auth MLflow lanes run nine specs concurrently on a shared single-node Kind cluster. Recent failures span MLflow requests, KFP API deadlines, MLMD deadlines, and SeaweedFS I/O, so increasing only the MLflow worker count does not address the full bottleneck.

A post-deployment two-worker experiment also caused S3 lanes to stall during their rolling update because it temporarily required a second MLflow pod. File-backed lanes avoided that rollout failure, but one still failed all nine tests with KFP API and SeaweedFS timeouts.

Reducing only the Kubernetes-auth lane parallelism lowers pressure across the shared services while retaining concurrency coverage. Follow-up work to restore higher concurrency is tracked in #13724.

Observed run: https://github.com/kubeflow/pipelines/actions/runs/29351827657

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/e2e-test.yml`
- `git diff --check`
- YAML and embedded Bash syntax checks

The full MLflow E2E matrix requires the GitHub Actions Kind environment and will be validated by this PR's checks.
