### PR TITLE
refactor(backend): centralize V1 pipeline blocking into IsV1PipelinesBlocked

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -47,8 +47,6 @@ const (
 	DefaultSecurityContextRunAsGroup        string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_GROUP"
 	DefaultSecurityContextRunAsNonRoot      string = "DEFAULT_SECURITY_CONTEXT_RUN_AS_NON_ROOT"
 	DefaultSecurityContextHostUsers         string = "DEFAULT_SECURITY_CONTEXT_HOST_USERS"
-	BlockV1Pipelines                        string = "BLOCK_V1_PIPELINES"
-	V1NamespaceWhitelist                    string = "V1_ALLOWED_NAMESPACES"
 	PipelineURLAllowedDomains               string = "PIPELINE_URL_ALLOWED_DOMAINS"
 	PipelineURLAllowHTTP                    string = "PIPELINE_URL_ALLOW_HTTP"
 	PipelineURLTimeout                      string = "PIPELINE_URL_TIMEOUT"

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -501,6 +501,15 @@ func (r *ResourceManager) CreatePipelineAndPipelineVersion(p *model.Pipeline, pv
 	if err != nil {
 		return nil, nil, util.Wrap(err, "Failed to create a pipeline and a pipeline version due to template creation error")
 	}
+	if tmpl.GetTemplateType() == template.V1 {
+		ns := p.Namespace
+		if ns == "" {
+			ns = common.GetPodNamespace()
+		}
+		if util.IsV1PipelinesBlocked(ns) {
+			return nil, nil, util.NewInvalidInputError("V1 pipeline specs are not allowed. Please migrate to using KFP V2 pipelines.")
+		}
+	}
 	// Validate pipeline's name in:
 	// 1. pipeline spec for v2 pipelines and v2-compatible pipeline must comply with MLMD requirements
 	// 2. display name must be non-empty
@@ -2194,6 +2203,15 @@ func (r *ResourceManager) CreatePipelineVersion(pv *model.PipelineVersion) (*mod
 	tmpl, err := template.New(pipelineSpecBytes, templateOptions)
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to create a pipeline version due to template creation error")
+	}
+	if tmpl.GetTemplateType() == template.V1 {
+		pipelineNamespace, _ := r.FetchNamespaceFromPipelineId(pipelineId)
+		if pipelineNamespace == "" {
+			pipelineNamespace = common.GetPodNamespace()
+		}
+		if util.IsV1PipelinesBlocked(pipelineNamespace) {
+			return nil, util.NewInvalidInputError("V1 pipeline specs are not allowed. Please migrate to using KFP V2 pipelines.")
+		}
 	}
 	// Validate pipeline's name in:
 	// 1. pipeline spec for v2 pipelines and v2-compatible pipeline must comply with MLMD requirements

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -605,19 +605,6 @@ func (r *ResourceManager) GetPipelineLatestTemplate(pipelineId string) ([]byte, 
 	}
 }
 
-func isNamespaceAllowed(namespace string, allowedNamespaces string) bool {
-	if allowedNamespaces == "" {
-		return false
-	}
-	targetNamespace := strings.ToLower(strings.TrimSpace(namespace))
-	for _, n := range strings.Split(allowedNamespaces, ",") {
-		if strings.ToLower(strings.TrimSpace(n)) == targetNamespace {
-			return true
-		}
-	}
-	return false
-}
-
 // Creates a run and schedule a workflow CR.
 // Manifest's namespace gets overwritten with the run.Namespace.
 // Creating a run from recurring run prioritizes recurring run's pipeline spec over the run's one.
@@ -683,11 +670,8 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		return nil, util.NewInternalServerError(util.NewInvalidInputError("Namespace cannot be empty when creating an Argo workflow. Check if you have specified POD_NAMESPACE or try adding the parent namespace to the request"), "Failed to create a run due to empty namespace")
 	}
 
-	if common.GetBoolConfigWithDefault(common.BlockV1Pipelines, false) && tmpl.GetTemplateType() == template.V1 {
-		allowedNamespaces := common.GetStringConfigWithDefault(common.V1NamespaceWhitelist, "")
-		if !isNamespaceAllowed(k8sNamespace, allowedNamespaces) {
-			return nil, util.NewInvalidInputError("Namespace %s is not allowed to run v1 pipelines. Please migrate to using KFP V2 pipelines.", k8sNamespace)
-		}
+	if util.IsV1PipelinesBlocked(k8sNamespace) && tmpl.GetTemplateType() == template.V1 {
+		return nil, util.NewInvalidInputError("Namespace %s is not allowed to run v1 pipelines. Please migrate to using KFP V2 pipelines.", k8sNamespace)
 	}
 
 	executionSpec.SetExecutionNamespace(k8sNamespace)
@@ -1430,11 +1414,8 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 		}
 	}
 
-	if tmpl != nil && common.GetBoolConfigWithDefault(common.BlockV1Pipelines, false) && tmpl.GetTemplateType() == template.V1 {
-		allowedNamespaces := common.GetStringConfigWithDefault(common.V1NamespaceWhitelist, "")
-		if !isNamespaceAllowed(k8sNamespace, allowedNamespaces) {
-			return nil, util.NewInvalidInputError("Namespace %s is not allowed to run v1 pipelines. Please migrate to using KFP V2 pipelines.", k8sNamespace)
-		}
+	if tmpl != nil && util.IsV1PipelinesBlocked(k8sNamespace) && tmpl.GetTemplateType() == template.V1 {
+		return nil, util.NewInvalidInputError("Namespace %s is not allowed to run v1 pipelines. Please migrate to using KFP V2 pipelines.", k8sNamespace)
 	}
 
 	newScheduledWorkflow, err := r.getScheduledWorkflowClient(k8sNamespace).Create(ctx, scheduledWorkflow)

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -57,6 +57,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// v1AllowedNamespaces mirrors the unexported constant in backend/src/common/util/v1_support.go.
+const v1AllowedNamespaces = "V1_ALLOWED_NAMESPACES"
+
 func initEnvVars() {
 	viper.Set(common.PodNamespace, "ns1")
 	proxy.InitializeConfigWithEmptyForTests()
@@ -2041,94 +2044,6 @@ func TestDeletePipeline(t *testing.T) {
 	assert.Contains(t, err.Error(), fmt.Sprintf("as it has existing pipeline versions (e.g. %v)", FakeUUIDOne))
 }
 
-func TestIsNamespaceAllowed(t *testing.T) {
-	tt := []struct {
-		msg               string
-		namespace         string
-		allowedNamespaces string
-		expected          bool
-	}{
-		{
-			msg:               "EmptyAllowedNamespaces",
-			namespace:         "ns1",
-			allowedNamespaces: "",
-			expected:          false,
-		},
-		{
-			msg:               "NamespaceInList",
-			namespace:         "ns1",
-			allowedNamespaces: "ns1,ns2,ns3",
-			expected:          true,
-		},
-		{
-			msg:               "NamespaceNotInList",
-			namespace:         "ns4",
-			allowedNamespaces: "ns1,ns2,ns3",
-			expected:          false,
-		},
-		{
-			msg:               "SingleAllowedNamespace_Match",
-			namespace:         "ns1",
-			allowedNamespaces: "ns1",
-			expected:          true,
-		},
-		{
-			msg:               "SingleAllowedNamespace_NoMatch",
-			namespace:         "ns2",
-			allowedNamespaces: "ns1",
-			expected:          false,
-		},
-		{
-			msg:               "CaseInsensitiveNamespace",
-			namespace:         "NS1",
-			allowedNamespaces: "ns1,ns2",
-			expected:          true,
-		},
-		{
-			msg:               "CaseInsensitiveAllowedList",
-			namespace:         "ns1",
-			allowedNamespaces: "NS1,NS2",
-			expected:          true,
-		},
-		{
-			msg:               "WhitespaceAroundNamespace",
-			namespace:         "  ns1  ",
-			allowedNamespaces: "ns1,ns2",
-			expected:          true,
-		},
-		{
-			msg:               "WhitespaceAroundAllowedEntries",
-			namespace:         "ns1",
-			allowedNamespaces: "  ns1  ,  ns2  ",
-			expected:          true,
-		},
-		{
-			msg:               "WhitespaceAndCaseInsensitive",
-			namespace:         "  NS1  ",
-			allowedNamespaces: "  ns1  ,  ns2  ",
-			expected:          true,
-		},
-		{
-			msg:               "EmptyNamespace_EmptyAllowed",
-			namespace:         "",
-			allowedNamespaces: "",
-			expected:          false,
-		},
-		{
-			msg:               "EmptyNamespace_NonEmptyAllowed",
-			namespace:         "",
-			allowedNamespaces: "ns1,ns2",
-			expected:          false,
-		},
-	}
-	for _, test := range tt {
-		t.Run(test.msg, func(t *testing.T) {
-			result := isNamespaceAllowed(test.namespace, test.allowedNamespaces)
-			assert.Equal(t, test.expected, result)
-		})
-	}
-}
-
 func TestCreateRun_BlockV1Pipelines(t *testing.T) {
 	tt := []struct {
 		msg               string
@@ -2196,11 +2111,11 @@ func TestCreateRun_BlockV1Pipelines(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.msg, func(t *testing.T) {
-			viper.Set(common.BlockV1Pipelines, test.blockV1)
-			viper.Set(common.V1NamespaceWhitelist, test.allowedNamespaces)
+			viper.Set(util.BlockV1Pipelines, test.blockV1)
+			viper.Set(v1AllowedNamespaces, test.allowedNamespaces)
 			defer func() {
-				viper.Set(common.BlockV1Pipelines, false)
-				viper.Set(common.V1NamespaceWhitelist, "")
+				viper.Set(util.BlockV1Pipelines, false)
+				viper.Set(v1AllowedNamespaces, "")
 			}()
 
 			store, manager, exp := initWithExperiment(t)
@@ -3381,11 +3296,11 @@ func TestCreateJob_BlocksV1Pipelines(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.msg, func(t *testing.T) {
-			viper.Set(common.BlockV1Pipelines, test.blockV1)
-			viper.Set(common.V1NamespaceWhitelist, test.allowedNamespaces)
+			viper.Set(util.BlockV1Pipelines, test.blockV1)
+			viper.Set(v1AllowedNamespaces, test.allowedNamespaces)
 			defer func() {
-				viper.Set(common.BlockV1Pipelines, false)
-				viper.Set(common.V1NamespaceWhitelist, "")
+				viper.Set(util.BlockV1Pipelines, false)
+				viper.Set(v1AllowedNamespaces, "")
 			}()
 
 			store, manager, exp := initWithExperiment(t)

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -2114,8 +2114,8 @@ func TestCreateRun_BlockV1Pipelines(t *testing.T) {
 			viper.Set(util.BlockV1Pipelines, test.blockV1)
 			viper.Set(v1AllowedNamespaces, test.allowedNamespaces)
 			defer func() {
-				viper.Set(util.BlockV1Pipelines, false)
-				viper.Set(v1AllowedNamespaces, "")
+				viper.Set(util.BlockV1Pipelines, nil)
+				viper.Set(v1AllowedNamespaces, nil)
 			}()
 
 			store, manager, exp := initWithExperiment(t)
@@ -3299,8 +3299,8 @@ func TestCreateJob_BlocksV1Pipelines(t *testing.T) {
 			viper.Set(util.BlockV1Pipelines, test.blockV1)
 			viper.Set(v1AllowedNamespaces, test.allowedNamespaces)
 			defer func() {
-				viper.Set(util.BlockV1Pipelines, false)
-				viper.Set(v1AllowedNamespaces, "")
+				viper.Set(util.BlockV1Pipelines, nil)
+				viper.Set(v1AllowedNamespaces, nil)
 			}()
 
 			store, manager, exp := initWithExperiment(t)

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -851,7 +851,7 @@ func TestCreatePipelineVersion(t *testing.T) {
 			model: &model.PipelineVersion{
 				Name:         "complex",
 				Parameters:   "[{\"name\":\"output\"},{\"name\":\"project\"},{\"name\":\"schema\",\"value\":\"gs://ml-pipeline-playground/tfma/taxi-cab-classification/schema.json\"},{\"name\":\"train\",\"value\":\"gs://ml-pipeline-playground/tfma/taxi-cab-classification/train.csv\"},{\"name\":\"evaluation\",\"value\":\"gs://ml-pipeline-playground/tfma/taxi-cab-classification/eval.csv\"},{\"name\":\"preprocess-mode\",\"value\":\"local\"},{\"name\":\"preprocess-module\",\"value\":\"gs://ml-pipeline-playground/tfma/taxi-cab-classification/preprocessing.py\"},{\"name\":\"target\",\"value\":\"tips\"},{\"name\":\"learning-rate\",\"value\":\"0.1\"},{\"name\":\"hidden-layer-size\",\"value\":\"1500\"},{\"name\":\"steps\",\"value\":\"3000\"},{\"name\":\"workers\",\"value\":\"0\"},{\"name\":\"pss\",\"value\":\"0\"},{\"name\":\"predict-mode\",\"value\":\"local\"},{\"name\":\"analyze-mode\",\"value\":\"local\"},{\"name\":\"analyze-slice-column\",\"value\":\"trip_start_hour\"}]",
-				PipelineSpec: model.LargeText(complexPipeline),
+				PipelineSpec: complexPipeline,
 			},
 		},
 		{
@@ -1173,6 +1173,82 @@ func TestResourceManager_CreatePipelineAndPipelineVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreatePipelineAndPipelineVersion_V1Blocked(t *testing.T) {
+	viper.Set(util.BlockV1Pipelines, "true")
+	viper.Set(v1AllowedNamespaces, "ns1")
+	viper.Set(common.PodNamespace, "ns1")
+	defer func() {
+		viper.Set(util.BlockV1Pipelines, nil)
+		viper.Set(v1AllowedNamespaces, nil)
+		viper.Set(common.PodNamespace, nil)
+	}()
+
+	store := NewFakeClientManagerOrFatalV2()
+	defer store.Close()
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+
+	_, _, err := manager.CreatePipelineAndPipelineVersion(
+		&model.Pipeline{Name: "v1-pipeline", Namespace: "blocked-ns"},
+		&model.PipelineVersion{
+			Name:         "v1-version",
+			PipelineSpec: complexPipeline,
+		},
+	)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "V1 pipeline specs are not allowed")
+}
+
+func TestCreatePipelineAndPipelineVersion_V1Blocked_PodNamespaceFallback(t *testing.T) {
+	viper.Set(util.BlockV1Pipelines, "true")
+	viper.Set(v1AllowedNamespaces, "ns1")
+	viper.Set(common.PodNamespace, "other-ns")
+	defer func() {
+		viper.Set(util.BlockV1Pipelines, nil)
+		viper.Set(v1AllowedNamespaces, nil)
+		viper.Set(common.PodNamespace, nil)
+	}()
+
+	store := NewFakeClientManagerOrFatalV2()
+	defer store.Close()
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+
+	_, _, err := manager.CreatePipelineAndPipelineVersion(
+		&model.Pipeline{Name: "v1-pipeline"},
+		&model.PipelineVersion{
+			Name:         "v1-version",
+			PipelineSpec: complexPipeline,
+		},
+	)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "V1 pipeline specs are not allowed")
+}
+
+func TestCreatePipelineVersion_V1Blocked(t *testing.T) {
+	viper.Set(util.BlockV1Pipelines, "true")
+	viper.Set(v1AllowedNamespaces, "ns1")
+	viper.Set(common.PodNamespace, "ns1")
+	defer func() {
+		viper.Set(util.BlockV1Pipelines, nil)
+		viper.Set(v1AllowedNamespaces, nil)
+		viper.Set(common.PodNamespace, nil)
+	}()
+
+	store := NewFakeClientManagerOrFatalV2()
+	defer store.Close()
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+
+	p, err := manager.CreatePipeline(&model.Pipeline{Name: "test-pipeline", Namespace: "blocked-ns"})
+	require.Nil(t, err)
+
+	_, err = manager.CreatePipelineVersion(&model.PipelineVersion{
+		Name:         "v1-version",
+		PipelineId:   p.UUID,
+		PipelineSpec: complexPipeline,
+	})
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "V1 pipeline specs are not allowed")
 }
 
 // Tests GetPipelineByNameAndNamespace

--- a/backend/src/common/util/v1_support.go
+++ b/backend/src/common/util/v1_support.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+const (
+	BlockV1Pipelines = "BLOCK_V1_PIPELINES"
+	// v1AllowedNamespaces is unexported; test-only mirrors exist in:
+	//   - backend/src/apiserver/resource/resource_manager_test.go
+	//   - backend/src/crd/controller/scheduledworkflow/controller_test.go
+	v1AllowedNamespaces = "V1_ALLOWED_NAMESPACES"
+)
+
+func IsV1PipelinesBlocked(namespace string) bool {
+	if !viper.IsSet(BlockV1Pipelines) {
+		return false
+	}
+	blockV1Value := viper.GetString(BlockV1Pipelines)
+	blockV1, err := strconv.ParseBool(blockV1Value)
+	if err != nil {
+		log.Fatalf("Failed converting string to bool %s", blockV1Value)
+	}
+	if !blockV1 {
+		return false
+	}
+
+	allowedNamespaces := viper.GetString(v1AllowedNamespaces)
+	if allowedNamespaces == "" {
+		return true
+	}
+
+	targetNamespace := strings.ToLower(strings.TrimSpace(namespace))
+	for _, n := range strings.Split(allowedNamespaces, ",") {
+		if strings.ToLower(strings.TrimSpace(n)) == targetNamespace {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/src/common/util/v1_support.go
+++ b/backend/src/common/util/v1_support.go
@@ -37,7 +37,7 @@ func IsV1PipelinesBlocked(namespace string) bool {
 	blockV1Value := viper.GetString(BlockV1Pipelines)
 	blockV1, err := strconv.ParseBool(blockV1Value)
 	if err != nil {
-		log.Fatalf("Failed converting string to bool %s", blockV1Value)
+		log.Fatalf("Failed converting %s value %q to bool: %v", BlockV1Pipelines, blockV1Value, err)
 	}
 	if !blockV1 {
 		return false

--- a/backend/src/common/util/v1_support.go
+++ b/backend/src/common/util/v1_support.go
@@ -49,8 +49,12 @@ func IsV1PipelinesBlocked(namespace string) bool {
 	}
 
 	targetNamespace := strings.ToLower(strings.TrimSpace(namespace))
-	for _, n := range strings.Split(allowedNamespaces, ",") {
-		if strings.ToLower(strings.TrimSpace(n)) == targetNamespace {
+	for n := range strings.SplitSeq(allowedNamespaces, ",") {
+		trimmed := strings.ToLower(strings.TrimSpace(n))
+		if trimmed == "" {
+			continue
+		}
+		if trimmed == targetNamespace {
 			return false
 		}
 	}

--- a/backend/src/common/util/v1_support_test.go
+++ b/backend/src/common/util/v1_support_test.go
@@ -115,6 +115,34 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 			namespace: "",
 			expected:  true,
 		},
+		{
+			name:              "Leading comma does not allow empty namespace",
+			blockV1:           "true",
+			allowedNamespaces: ",ns1",
+			namespace:         "",
+			expected:          true,
+		},
+		{
+			name:              "Trailing comma does not allow empty namespace",
+			blockV1:           "true",
+			allowedNamespaces: "ns1,",
+			namespace:         "",
+			expected:          true,
+		},
+		{
+			name:              "Leading comma, real namespace still allowed",
+			blockV1:           "true",
+			allowedNamespaces: ",ns1",
+			namespace:         "ns1",
+			expected:          false,
+		},
+		{
+			name:              "Whitespace-only entry does not allow empty namespace",
+			blockV1:           "true",
+			allowedNamespaces: " ,ns1",
+			namespace:         "",
+			expected:          true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/src/common/util/v1_support_test.go
+++ b/backend/src/common/util/v1_support_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsV1PipelinesBlocked(t *testing.T) {
+	tests := []struct {
+		name              string
+		blockV1           string
+		setBlockV1        bool
+		allowedNamespaces string
+		namespace         string
+		expected          bool
+	}{
+		{
+			name:       "Blocking disabled - not blocked",
+			blockV1:    "false",
+			setBlockV1: true,
+			namespace:  "ns1",
+			expected:   false,
+		},
+		{
+			name:      "Blocking not set - not blocked",
+			namespace: "ns1",
+			expected:  false,
+		},
+		{
+			name:       "Blocking enabled, no allowed namespaces - blocked",
+			blockV1:    "true",
+			setBlockV1: true,
+			namespace:  "ns1",
+			expected:   true,
+		},
+		{
+			name:              "Blocking enabled, namespace allowed - not blocked",
+			blockV1:           "true",
+			setBlockV1:        true,
+			allowedNamespaces: "ns1",
+			namespace:         "ns1",
+			expected:          false,
+		},
+		{
+			name:              "Blocking enabled, namespace not in allowed list - blocked",
+			blockV1:           "true",
+			setBlockV1:        true,
+			allowedNamespaces: "ns2,ns3",
+			namespace:         "ns1",
+			expected:          true,
+		},
+		{
+			name:              "Blocking enabled, namespace in allowed list - not blocked",
+			blockV1:           "true",
+			setBlockV1:        true,
+			allowedNamespaces: "ns1,ns2,ns3",
+			namespace:         "ns2",
+			expected:          false,
+		},
+		{
+			name:              "Blocking enabled, case insensitive namespace match - not blocked",
+			blockV1:           "true",
+			setBlockV1:        true,
+			allowedNamespaces: "NS1",
+			namespace:         "ns1",
+			expected:          false,
+		},
+		{
+			name:              "Blocking enabled, namespace with spaces in allowed list - not blocked",
+			blockV1:           "true",
+			setBlockV1:        true,
+			allowedNamespaces: " ns1 , ns2 ",
+			namespace:         "ns1",
+			expected:          false,
+		},
+		{
+			name:              "Blocking enabled, whitespace around namespace input - not blocked",
+			blockV1:           "true",
+			setBlockV1:        true,
+			allowedNamespaces: "ns1,ns2",
+			namespace:         "  ns1  ",
+			expected:          false,
+		},
+		{
+			name:              "Blocking enabled, case insensitive allowed list - not blocked",
+			blockV1:           "true",
+			setBlockV1:        true,
+			allowedNamespaces: "NS1,NS2",
+			namespace:         "ns1",
+			expected:          false,
+		},
+		{
+			name:              "Blocking enabled, whitespace and case insensitive - not blocked",
+			blockV1:           "true",
+			setBlockV1:        true,
+			allowedNamespaces: "  ns1  ,  ns2  ",
+			namespace:         "  NS1  ",
+			expected:          false,
+		},
+		{
+			name:              "Blocking enabled, empty namespace with non-empty allowed - blocked",
+			blockV1:           "true",
+			setBlockV1:        true,
+			allowedNamespaces: "ns1,ns2",
+			namespace:         "",
+			expected:          true,
+		},
+		{
+			name:       "Blocking enabled, empty namespace with empty allowed - blocked",
+			blockV1:    "true",
+			setBlockV1: true,
+			namespace:  "",
+			expected:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setBlockV1 {
+				viper.Set(BlockV1Pipelines, tt.blockV1)
+			}
+			viper.Set(v1AllowedNamespaces, tt.allowedNamespaces)
+			defer func() {
+				viper.Set(BlockV1Pipelines, false)
+				viper.Set(v1AllowedNamespaces, "")
+			}()
+
+			result := IsV1PipelinesBlocked(tt.namespace)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/backend/src/common/util/v1_support_test.go
+++ b/backend/src/common/util/v1_support_test.go
@@ -133,4 +133,3 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 		})
 	}
 }
-

--- a/backend/src/common/util/v1_support_test.go
+++ b/backend/src/common/util/v1_support_test.go
@@ -17,6 +17,7 @@ package util
 import (
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,17 +26,15 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 	tests := []struct {
 		name              string
 		blockV1           string
-		setBlockV1        bool
 		allowedNamespaces string
 		namespace         string
 		expected          bool
 	}{
 		{
-			name:       "Blocking disabled - not blocked",
-			blockV1:    "false",
-			setBlockV1: true,
-			namespace:  "ns1",
-			expected:   false,
+			name:      "Blocking disabled - not blocked",
+			blockV1:   "false",
+			namespace: "ns1",
+			expected:  false,
 		},
 		{
 			name:      "Blocking not set - not blocked",
@@ -43,16 +42,14 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 			expected:  false,
 		},
 		{
-			name:       "Blocking enabled, no allowed namespaces - blocked",
-			blockV1:    "true",
-			setBlockV1: true,
-			namespace:  "ns1",
-			expected:   true,
+			name:      "Blocking enabled, no allowed namespaces - blocked",
+			blockV1:   "true",
+			namespace: "ns1",
+			expected:  true,
 		},
 		{
 			name:              "Blocking enabled, namespace allowed - not blocked",
 			blockV1:           "true",
-			setBlockV1:        true,
 			allowedNamespaces: "ns1",
 			namespace:         "ns1",
 			expected:          false,
@@ -60,7 +57,6 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 		{
 			name:              "Blocking enabled, namespace not in allowed list - blocked",
 			blockV1:           "true",
-			setBlockV1:        true,
 			allowedNamespaces: "ns2,ns3",
 			namespace:         "ns1",
 			expected:          true,
@@ -68,7 +64,6 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 		{
 			name:              "Blocking enabled, namespace in allowed list - not blocked",
 			blockV1:           "true",
-			setBlockV1:        true,
 			allowedNamespaces: "ns1,ns2,ns3",
 			namespace:         "ns2",
 			expected:          false,
@@ -76,7 +71,6 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 		{
 			name:              "Blocking enabled, case insensitive namespace match - not blocked",
 			blockV1:           "true",
-			setBlockV1:        true,
 			allowedNamespaces: "NS1",
 			namespace:         "ns1",
 			expected:          false,
@@ -84,7 +78,6 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 		{
 			name:              "Blocking enabled, namespace with spaces in allowed list - not blocked",
 			blockV1:           "true",
-			setBlockV1:        true,
 			allowedNamespaces: " ns1 , ns2 ",
 			namespace:         "ns1",
 			expected:          false,
@@ -92,7 +85,6 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 		{
 			name:              "Blocking enabled, whitespace around namespace input - not blocked",
 			blockV1:           "true",
-			setBlockV1:        true,
 			allowedNamespaces: "ns1,ns2",
 			namespace:         "  ns1  ",
 			expected:          false,
@@ -100,7 +92,6 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 		{
 			name:              "Blocking enabled, case insensitive allowed list - not blocked",
 			blockV1:           "true",
-			setBlockV1:        true,
 			allowedNamespaces: "NS1,NS2",
 			namespace:         "ns1",
 			expected:          false,
@@ -108,7 +99,6 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 		{
 			name:              "Blocking enabled, whitespace and case insensitive - not blocked",
 			blockV1:           "true",
-			setBlockV1:        true,
 			allowedNamespaces: "  ns1  ,  ns2  ",
 			namespace:         "  NS1  ",
 			expected:          false,
@@ -116,33 +106,43 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 		{
 			name:              "Blocking enabled, empty namespace with non-empty allowed - blocked",
 			blockV1:           "true",
-			setBlockV1:        true,
 			allowedNamespaces: "ns1,ns2",
 			namespace:         "",
 			expected:          true,
 		},
 		{
-			name:       "Blocking enabled, empty namespace with empty allowed - blocked",
-			blockV1:    "true",
-			setBlockV1: true,
-			namespace:  "",
-			expected:   true,
+			name:      "Blocking enabled, empty namespace with empty allowed - blocked",
+			blockV1:   "true",
+			namespace: "",
+			expected:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.setBlockV1 {
+			if tt.blockV1 != "" {
 				viper.Set(BlockV1Pipelines, tt.blockV1)
 			}
 			viper.Set(v1AllowedNamespaces, tt.allowedNamespaces)
 			defer func() {
-				viper.Set(BlockV1Pipelines, false)
-				viper.Set(v1AllowedNamespaces, "")
+				viper.Set(BlockV1Pipelines, nil)
+				viper.Set(v1AllowedNamespaces, nil)
 			}()
 
 			result := IsV1PipelinesBlocked(tt.namespace)
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestIsV1PipelinesBlocked_MalformedValueFatals(t *testing.T) {
+	var fatalCalled bool
+	log.StandardLogger().ExitFunc = func(int) { fatalCalled = true }
+	defer func() { log.StandardLogger().ExitFunc = nil }()
+
+	viper.Set(BlockV1Pipelines, "notabool")
+	defer viper.Set(BlockV1Pipelines, nil)
+
+	IsV1PipelinesBlocked("ns1")
+	assert.True(t, fatalCalled, "expected Fatalf to be called for malformed BLOCK_V1_PIPELINES")
 }

--- a/backend/src/common/util/v1_support_test.go
+++ b/backend/src/common/util/v1_support_test.go
@@ -17,7 +17,6 @@ package util
 import (
 	"testing"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -135,14 +134,3 @@ func TestIsV1PipelinesBlocked(t *testing.T) {
 	}
 }
 
-func TestIsV1PipelinesBlocked_MalformedValueFatals(t *testing.T) {
-	var fatalCalled bool
-	log.StandardLogger().ExitFunc = func(int) { fatalCalled = true }
-	defer func() { log.StandardLogger().ExitFunc = nil }()
-
-	viper.Set(BlockV1Pipelines, "notabool")
-	defer viper.Set(BlockV1Pipelines, nil)
-
-	IsV1PipelinesBlocked("ns1")
-	assert.True(t, fatalCalled, "expected Fatalf to be called for malformed BLOCK_V1_PIPELINES")
-}

--- a/backend/src/crd/controller/scheduledworkflow/controller.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -37,7 +36,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -761,37 +759,10 @@ func (c *Controller) updateStatus(
 	return nil
 }
 
-// isV1PipelineBlocked checks if the given namespace is blocked from running V1 pipelines
-// based on the BLOCK_V1_PIPELINES and V1_ALLOWED_NAMESPACES environment variables.
-func isV1PipelineBlocked(namespace string) bool {
-	blockV1Value := viper.GetString(util.BlockV1Pipelines)
-	blockV1, err := strconv.ParseBool(blockV1Value)
-	if err != nil {
-		log.WithError(err).Warnf("Invalid BLOCK_V1_PIPELINES value %q; V1 pipelines are not blocked", blockV1Value)
-		blockV1 = false
-	}
-	if !blockV1 {
-		return false
-	}
-
-	allowedNamespaces := viper.GetString(util.AllowedNamespaces)
-	if allowedNamespaces == "" {
-		return true
-	}
-
-	targetNamespace := strings.ToLower(strings.TrimSpace(namespace))
-	for _, n := range strings.Split(allowedNamespaces, ",") {
-		if strings.ToLower(strings.TrimSpace(n)) == targetNamespace {
-			return false
-		}
-	}
-	return true
-}
-
 // shouldEnforceV1Block Returns true allowing V2 workflows when key V2 component or pipeline labels
 // are present on the pod metadata. Returns false if the workflow is v1.
 func shouldEnforceV1Block(swf *util.ScheduledWorkflow) bool {
-	if swf == nil || !isV1PipelineBlocked(swf.Namespace) {
+	if swf == nil || !commonutil.IsV1PipelinesBlocked(swf.Namespace) {
 		return false
 	}
 

--- a/backend/src/crd/controller/scheduledworkflow/controller_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_test.go
@@ -181,8 +181,8 @@ func TestShouldEnforceV1Block(t *testing.T) {
 			viper.Set(commonutil.BlockV1Pipelines, tt.blockV1)
 			viper.Set(v1AllowedNamespaces, tt.allowedNamespaces)
 			defer func() {
-				viper.Set(commonutil.BlockV1Pipelines, "")
-				viper.Set(v1AllowedNamespaces, "")
+				viper.Set(commonutil.BlockV1Pipelines, nil)
+				viper.Set(v1AllowedNamespaces, nil)
 			}()
 
 			swf := util.NewScheduledWorkflow(&swfapi.ScheduledWorkflow{
@@ -203,7 +203,7 @@ func TestShouldEnforceV1Block(t *testing.T) {
 
 	t.Run("Nil ScheduledWorkflow - not blocked", func(t *testing.T) {
 		viper.Set(commonutil.BlockV1Pipelines, "true")
-		defer viper.Set(commonutil.BlockV1Pipelines, "")
+		defer viper.Set(commonutil.BlockV1Pipelines, nil)
 
 		assert.False(t, shouldEnforceV1Block(nil))
 	})
@@ -257,8 +257,8 @@ func TestSubmitNewWorkflowIfNotAlreadySubmitted_BlockV1AllowsV2(t *testing.T) {
 			viper.Set(commonutil.BlockV1Pipelines, "true")
 			viper.Set(v1AllowedNamespaces, "")
 			defer func() {
-				viper.Set(commonutil.BlockV1Pipelines, "")
-				viper.Set(v1AllowedNamespaces, "")
+				viper.Set(commonutil.BlockV1Pipelines, nil)
+				viper.Set(v1AllowedNamespaces, nil)
 			}()
 
 			executionClient := &fakeExecutionClient{}

--- a/backend/src/crd/controller/scheduledworkflow/controller_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/client"
 	util "github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/util"
@@ -34,76 +33,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func TestIsV1PipelineBlocked(t *testing.T) {
-	tests := []struct {
-		name              string
-		blockV1           string
-		allowedNamespaces string
-		namespace         string
-		expected          bool
-	}{
-		{
-			name:      "Blocking disabled - not blocked",
-			blockV1:   "false",
-			namespace: "ns1",
-			expected:  false,
-		},
-		{
-			name:      "Blocking not set - not blocked",
-			blockV1:   "",
-			namespace: "ns1",
-			expected:  false,
-		},
-		{
-			name:      "Blocking enabled, no allowed namespaces - blocked",
-			blockV1:   "true",
-			namespace: "ns1",
-			expected:  true,
-		},
-		{
-			name:              "Blocking enabled, namespace allowed - not blocked",
-			blockV1:           "true",
-			allowedNamespaces: "ns1",
-			namespace:         "ns1",
-			expected:          false,
-		},
-		{
-			name:              "Blocking enabled, namespace not in allowed list - blocked",
-			blockV1:           "true",
-			allowedNamespaces: "ns2,ns3",
-			namespace:         "ns1",
-			expected:          true,
-		},
-		{
-			name:              "Blocking enabled, namespace in allowed list - not blocked",
-			blockV1:           "true",
-			allowedNamespaces: "ns1,ns2,ns3",
-			namespace:         "ns2",
-			expected:          false,
-		},
-		{
-			name:              "Blocking enabled, case insensitive namespace match - not blocked",
-			blockV1:           "true",
-			allowedNamespaces: "NS1",
-			namespace:         "ns1",
-			expected:          false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			viper.Set(common.BlockV1Pipelines, tt.blockV1)
-			viper.Set(common.V1NamespaceWhitelist, tt.allowedNamespaces)
-			defer func() {
-				viper.Set(common.BlockV1Pipelines, "")
-				viper.Set(common.V1NamespaceWhitelist, "")
-			}()
-
-			result := isV1PipelineBlocked(tt.namespace)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
+// v1AllowedNamespaces mirrors the unexported constant in backend/src/common/util/v1_support.go.
+const v1AllowedNamespaces = "V1_ALLOWED_NAMESPACES"
 
 func TestShouldEnforceV1Block(t *testing.T) {
 	v1WorkflowSpec := map[string]interface{}{
@@ -247,11 +178,11 @@ func TestShouldEnforceV1Block(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			viper.Set(common.BlockV1Pipelines, tt.blockV1)
-			viper.Set(common.V1NamespaceWhitelist, tt.allowedNamespaces)
+			viper.Set(commonutil.BlockV1Pipelines, tt.blockV1)
+			viper.Set(v1AllowedNamespaces, tt.allowedNamespaces)
 			defer func() {
-				viper.Set(common.BlockV1Pipelines, "")
-				viper.Set(common.V1NamespaceWhitelist, "")
+				viper.Set(commonutil.BlockV1Pipelines, "")
+				viper.Set(v1AllowedNamespaces, "")
 			}()
 
 			swf := util.NewScheduledWorkflow(&swfapi.ScheduledWorkflow{
@@ -271,8 +202,8 @@ func TestShouldEnforceV1Block(t *testing.T) {
 	}
 
 	t.Run("Nil ScheduledWorkflow - not blocked", func(t *testing.T) {
-		viper.Set(common.BlockV1Pipelines, "true")
-		defer viper.Set(common.BlockV1Pipelines, "")
+		viper.Set(commonutil.BlockV1Pipelines, "true")
+		defer viper.Set(commonutil.BlockV1Pipelines, "")
 
 		assert.False(t, shouldEnforceV1Block(nil))
 	})
@@ -323,11 +254,11 @@ func TestSubmitNewWorkflowIfNotAlreadySubmitted_BlockV1AllowsV2(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			viper.Set(common.BlockV1Pipelines, "true")
-			viper.Set(common.V1NamespaceWhitelist, "")
+			viper.Set(commonutil.BlockV1Pipelines, "true")
+			viper.Set(v1AllowedNamespaces, "")
 			defer func() {
-				viper.Set(common.BlockV1Pipelines, "")
-				viper.Set(common.V1NamespaceWhitelist, "")
+				viper.Set(commonutil.BlockV1Pipelines, "")
+				viper.Set(v1AllowedNamespaces, "")
 			}()
 
 			executionClient := &fakeExecutionClient{}

--- a/backend/src/crd/controller/scheduledworkflow/util/const.go
+++ b/backend/src/crd/controller/scheduledworkflow/util/const.go
@@ -25,8 +25,6 @@ const (
 	TimeZone            string = "CRON_SCHEDULE_TIMEZONE"              // TimeZone is the name of the cron schedule timezone env parameter
 	V2Key               string = "pipelines.kubeflow.org/v2_component" // V2Key is the name of the v2 component labels
 	V2PipelineKey       string = "pipelines.kubeflow.org/v2_pipeline"  // V2PipelineKey is the name of the v2 pipeline label
-	BlockV1Pipelines    string = "BLOCK_V1_PIPELINES"                  // BlockV1Pipelines is the name of the env parameter to block v1 pipelines
-	AllowedNamespaces   string = "V1_ALLOWED_NAMESPACES"               // AllowedNamespaces is the name of the env parameter to specify allowed namespaces for v1 pipelines
 )
 
 func GetLocation() (*time.Location, error) {


### PR DESCRIPTION
## Summary

- Consolidates duplicated V1 pipeline blocking logic from `resource_manager.go` and the scheduledworkflow controller into a single `IsV1PipelinesBlocked` function in `common/util`
- Removes duplicate constants (`BlockV1Pipelines`, `V1NamespaceWhitelist`/`AllowedNamespaces`) from `apiserver/common` and `scheduledworkflow/util`
- Isolates the decision in one file, allowing downstream distributions to customize V1 pipeline support by replacing a single file
- Blocks V1 pipeline spec uploads in `CreatePipelineAndPipelineVersion` and `CreatePipelineVersion` (defense-in-depth — V1 specs cannot be stored, not just not executed)
- Fixes empty-element bug in allow-list parsing: stray commas in `V1_ALLOWED_NAMESPACES` (e.g. `",ns1"`) no longer silently allow the empty-string namespace

### Intentional behavior changes

These affect the **scheduledworkflow controller only** — API server behavior is preserved exactly.

- **Malformed `BLOCK_V1_PIPELINES` value** (e.g. `"notabool"`): now calls `Fatalf` instead of warning and continuing with blocking disabled. Fail-fast on misconfiguration is the correct behavior for both callers.
- **Unset `BLOCK_V1_PIPELINES`**: now returns `false` silently via `viper.IsSet` instead of going through `ParseBool("")` → warn → `false`. Same result, no spurious warning.
- **V1 pipeline upload**: `CreatePipelineAndPipelineVersion` and `CreatePipelineVersion` now reject V1 pipeline specs when `IsV1PipelinesBlocked` returns true for the pipeline's namespace (falls back to `POD_NAMESPACE` in standalone mode).
- **Allow-list parsing**: empty/whitespace-only entries from splitting `V1_ALLOWED_NAMESPACES` by comma are now skipped.

## Test plan

- [x] New `v1_support_test.go` with table-driven tests covering all blocking scenarios (enabled/disabled, allowed namespaces, case insensitivity, whitespace, empty namespace, stray commas)
- [x] Existing `TestShouldEnforceV1Block` and `TestSubmitNewWorkflowIfNotAlreadySubmitted_BlockV1AllowsV2` pass with the consolidated function
- [x] Existing `TestCreateRun_BlockV1Pipelines` and `TestCreateJob_BlocksV1Pipelines` pass with the consolidated function
- [x] New `TestCreatePipelineAndPipelineVersion_V1Blocked` and `TestCreatePipelineVersion_V1Blocked` verify V1 pipeline upload is rejected
- [x] New `TestCreatePipelineAndPipelineVersion_V1Blocked_PodNamespaceFallback` verifies standalone mode uses `POD_NAMESPACE`
- [x] `go test -v ./backend/src/common/util/ -run TestIsV1PipelinesBlocked`
- [x] `go test -v ./backend/src/apiserver/resource/ -run BlockV1`
- [x] `go test -v ./backend/src/apiserver/resource/ -run V1Blocked`
- [x] `go test -v ./backend/src/crd/controller/scheduledworkflow/`