### PR TITLE
fix(sdk): relax exact requests pin to a compatible range. Fixes #13723

### DIFF
--- a/kubernetes_platform/python/requirements.in
+++ b/kubernetes_platform/python/requirements.in
@@ -7,9 +7,11 @@
 protobuf>=6.33.5,<7.0
 kfp>=2.14.5,<3
 # requests 2.33.0 drops Python 3.9 support. Keep Python 3.9 on the
-# compatible line and use the patched line where supported.
-requests==2.32.5; python_version < "3.10"
-requests==2.33.0; python_version >= "3.10"
+# compatible 2.32.x line and use the patched line where supported.
+# Ranges (not exact pins) so downstream consumers can take patch/security
+# updates to requests without conflicting with kfp (see #13723).
+requests>=2.32.5,<2.33; python_version < "3.10"
+requests>=2.33.0,<3; python_version >= "3.10"
 # urllib3 2.7.0 drops Python 3.9 support. Keep Python 3.9 on the
 # compatible line and use the patched line where supported.
 urllib3==2.6.3; python_version < "3.10"

--- a/sdk/python/requirements.in
+++ b/sdk/python/requirements.in
@@ -27,9 +27,11 @@ kubernetes>=8.0.0,<31
 protobuf>=6.31.1,<7.0
 PyYAML>=5.3,<7
 # requests 2.33.0 drops Python 3.9 support. Keep Python 3.9 on the
-# compatible line and use the patched line where supported.
-requests==2.32.5; python_version < "3.10"
-requests==2.33.0; python_version >= "3.10"
+# compatible 2.32.x line and use the patched line where supported.
+# Ranges (not exact pins) so downstream consumers can take patch/security
+# updates to requests without conflicting with kfp (see #13723).
+requests>=2.32.5,<2.33; python_version < "3.10"
+requests>=2.33.0,<3; python_version >= "3.10"
 requests-toolbelt>=0.8.0,<2
 tabulate>=0.8.6,<1
 # urllib3 2.7.0 drops Python 3.9 support. Keep Python 3.9 on the


### PR DESCRIPTION
**Description of your changes:**

`kfp` pins `requests` exactly (`==2.32.5` on Python 3.9, `==2.33.0` on Python 3.10+), which makes it uninstallable next to any other `requests` version and blocks downstream patch/security updates:

```
uv pip install kfp==2.17.0 requests==2.34.2
  × No solution found when resolving dependencies:
  ╰─▶ Because kfp==2.17.0 depends on requests==2.33.0 …
```

This PR keeps the Python-version boundary introduced in #13661 (requests 2.33.0 drops Python 3.9) but expresses both branches as ranges in `requirements.in` for the SDK and the kubernetes_platform package:

- `python_version < "3.10"`: `requests>=2.32.5,<2.33`
- `python_version >= "3.10"`: `requests>=2.33.0,<3`

The generated `requirements.txt` lock files are intentionally unchanged — the locked versions already satisfy the new ranges, so CI and reproducible installs keep resolving exactly as before. Only the wheel metadata (`install_requires`, read from `requirements.in` by `setup.py`) becomes range-based.

**Verified:**
- On master: `pip install --dry-run ./sdk/python "requests==2.34.2"` → `ResolutionImpossible` (reproduces the issue)
- With this change: same command resolves and would install `requests-2.34.2` alongside `kfp`

Fixes #13723

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
