### PR TITLE
ci: capture service state on connection failures

### DIFF
--- a/.github/actions/test-and-report/action.yml
+++ b/.github/actions/test-and-report/action.yml
@@ -391,15 +391,14 @@ runs:
         if [ "${{ inputs.proxy }}" = "true" ]; then
           ./.github/resources/scripts/collect-logs.sh --ns tinyproxy --output /tmp/tmp_pod_log.txt
         fi
-        # Dataplane diagnostics: E2E lanes intermittently fail with dial-timeout
+        # Dataplane diagnostics: E2E lanes intermittently fail with connection
         # errors to in-cluster ClusterIPs (SeaweedFS :9000, the MLflow service
         # VIP, ...). This captures SeaweedFS restart/contention evidence plus,
         # per Kind node, the conntrack table state and the iptables/ipvs program
-        # for every ClusterIP the just-collected pod logs recorded a dial
-        # timeout against -- distinguishing conntrack exhaustion from a
-        # missing/stale service program. --dial-timeout-log points at the pod
-        # logs gathered above so the probe self-targets whichever VIP failed.
-        ./.github/resources/scripts/collect-seaweedfs-diagnostics.sh --namespace "$NAMESPACE" --dial-timeout-log /tmp/tmp_pod_log.txt --output /tmp/tmp_pod_log.txt
+        # for every ClusterIP the just-collected pod logs recorded a timeout,
+        # refusal, or reset against -- distinguishing backend lifecycle from
+        # conntrack exhaustion or a missing/stale service program.
+        ./.github/resources/scripts/collect-seaweedfs-diagnostics.sh --namespace "$NAMESPACE" --connection-failure-log /tmp/tmp_pod_log.txt --output /tmp/tmp_pod_log.txt
       continue-on-error: true
 
     - name: Summarize failure signatures

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -226,32 +226,38 @@ fi
     # new pod is the one whose state matters.
     POD=$(kubectl get pod -n "$NAMESPACE" -l "$SELECTOR" --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}' 2>/dev/null || true)
     if [[ -z "$POD" ]]; then
-        echo "No SeaweedFS pod (selector '$SELECTOR') found in namespace '$NAMESPACE'; skipping."
-        echo "=============================================================="
-        exit 0
-    fi
-    echo "SeaweedFS pod: $POD"
-
-    echo
-    echo "----- (1) restarts / last terminated state -----"
-    # A non-zero restart count or an OOMKilled/Error last state means the dial
-    # timeouts are the pod being down, and the CPU request is not the lever.
-    kubectl get pod "$POD" -n "$NAMESPACE" -o wide 2>/dev/null || true
-    kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='restartCount={.status.containerStatuses[0].restartCount}{"\n"}lastState={.status.containerStatuses[0].lastState}{"\n"}qosClass={.status.qosClass}{"\n"}' 2>/dev/null || true
-
-    NODE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)
-
-    echo
-    echo "----- (2) node contention on $NODE -----"
-    # 'Allocated resources' shows summed CPU requests vs allocatable. If CPU
-    # requests approach allocatable, SeaweedFS competes for shares under load
-    # and a larger request helps; if the node is idle, contention is not the
-    # cause and a request bump will not help.
-    if [[ -n "$NODE" ]]; then
-        kubectl describe node "$NODE" 2>/dev/null \
-            | sed -n '/Conditions:/,/Addresses:/p;/Allocated resources:/,/Events:/p' || true
+        # Pod-independent probes (Service inventory, sections 4-5) must still
+        # run: other Services' logged connection failures (e.g. the MLflow
+        # VIP) deserve their snapshots even when SeaweedFS itself is absent.
+        echo "No SeaweedFS pod (selector '$SELECTOR') found in namespace '$NAMESPACE'; skipping pod-scoped sections (1, 2, 6)."
     else
-        echo "Could not resolve SeaweedFS node."
+        echo "SeaweedFS pod: $POD"
+    fi
+
+    NODE=""
+    if [[ -n "$POD" ]]; then
+        echo
+        echo "----- (1) restarts / last terminated state -----"
+        # A non-zero restart count or an OOMKilled/Error last state means the
+        # dial timeouts are the pod being down, and the CPU request is not the
+        # lever.
+        kubectl get pod "$POD" -n "$NAMESPACE" -o wide 2>/dev/null || true
+        kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='restartCount={.status.containerStatuses[0].restartCount}{"\n"}lastState={.status.containerStatuses[0].lastState}{"\n"}qosClass={.status.qosClass}{"\n"}' 2>/dev/null || true
+
+        NODE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)
+
+        echo
+        echo "----- (2) node contention on $NODE -----"
+        # 'Allocated resources' shows summed CPU requests vs allocatable. If
+        # CPU requests approach allocatable, SeaweedFS competes for shares
+        # under load and a larger request helps; if the node is idle,
+        # contention is not the cause and a request bump will not help.
+        if [[ -n "$NODE" ]]; then
+            kubectl describe node "$NODE" 2>/dev/null \
+                | sed -n '/Conditions:/,/Addresses:/p;/Allocated resources:/,/Events:/p' || true
+        else
+            echo "Could not resolve SeaweedFS node."
+        fi
     fi
 
     echo
@@ -396,6 +402,9 @@ fi
 
     echo
     echo "----- (6) SeaweedFS pod socket / listen-queue state -----"
+    if [[ -z "$POD" ]]; then
+        echo "No SeaweedFS pod; skipping socket state."
+    else
     # Once the node conntrack table and the service program are clean, the
     # leading remaining cause of the ClusterIP dial timeouts is accept-queue
     # saturation: under the parallel burst the S3 server's listen backlog
@@ -411,10 +420,13 @@ fi
     kubectl exec "$POD" -n "$NAMESPACE" -c seaweedfs -- sh -c 'ss -lnt 2>/dev/null || netstat -lnt 2>/dev/null || echo "(ss/netstat not present in container)"' 2>/dev/null || echo "(kubectl exec unavailable)"
     echo "TcpExt counters (nonzero ListenOverflows / ListenDrops == accept-queue saturation):"
     kubectl exec "$POD" -n "$NAMESPACE" -c seaweedfs -- sh -c 'grep "^TcpExt" /proc/net/netstat 2>/dev/null || echo "(/proc/net/netstat unavailable)"' 2>/dev/null || echo "(kubectl exec unavailable)"
+    fi
 
-    echo
-    echo "----- full describe (events, resource config) -----"
-    kubectl describe pod "$POD" -n "$NAMESPACE" 2>/dev/null || true
+    if [[ -n "$POD" ]]; then
+        echo
+        echo "----- full describe (events, resource config) -----"
+        kubectl describe pod "$POD" -n "$NAMESPACE" 2>/dev/null || true
+    fi
 
     echo "=============================================================="
 } | emit

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -21,17 +21,18 @@
 #                                        ClusterIP path times out (kube-proxy /
 #                                        CNI). Ruled in by 1 and 2 being clean
 #                                        plus kube-proxy pod state, and probed
-#                                        directly in section (4).
+#                                        directly in sections (4) and (5).
 #
-# The same 'dial tcp <clusterip>: i/o timeout' signature shows up on other
-# in-cluster ClusterIPs in these lanes (for example the MLflow service VIP on
-# :8443), so the dataplane failure is not SeaweedFS-specific. Section (4)
-# therefore probes the node netfilter state for *every* ClusterIP that recorded
-# a dial timeout, not just SeaweedFS's. Pass the already-collected pod-log file
-# via --dial-timeout-log; the script extracts each timed-out VIP from it and
-# always includes the SeaweedFS ClusterIP.
+# The same connection failures show up on other in-cluster ClusterIPs in these
+# lanes (for example the MLflow service VIP on :8443), so the dataplane failure
+# is not SeaweedFS-specific. Sections (4) and (5) therefore inspect *every*
+# ClusterIP that recorded a timeout, refusal, or reset, not just SeaweedFS's.
+# Pass the already-collected pod-log file via --connection-failure-log (the old
+# --dial-timeout-log name remains an alias); the script extracts each failed VIP
+# from it and always includes the SeaweedFS ClusterIP.
 #
-# Section (4) inspects every Kind node (a ClusterIP dial is DNAT'd and
+# Section (4) snapshots the matched Service, EndpointSlices, and backing-pod
+# state. Section (5) then inspects every Kind node (a ClusterIP dial is DNAT'd and
 # conntrack-tracked on the *client* pod's node, which need not be the service's
 # node). One dataplane candidate is conntrack-table saturation: the
 # nested-parallel lanes open a burst of simultaneous connections, and once a
@@ -40,14 +41,14 @@
 # passing, so the pod is never restarted. Per node it dumps the node-global
 # conntrack state once -- the durable drop/insert_failed counters (conntrack -S,
 # falling back to /proc/net/stat/nf_conntrack) and any 'nf_conntrack: table
-# full' dmesg line -- then the iptables/ipvs program for each timed-out
+# full' dmesg line -- then the iptables/ipvs program for each failed
 # ClusterIP, followed end to end (KUBE-SERVICES -> KUBE-SVC -> KUBE-SEP DNAT) so
 # a live endpoint DNAT rules out a missing/stale service program.
 #
 # When the conntrack table and the service program are both clean (as first
 # observed live: table ~0.6% full, no table-full event, KUBE-SEP DNAT present),
 # the remaining candidate is accept-queue saturation on the backing pod itself.
-# Section (5) reads the SeaweedFS pod's listen sockets and cumulative
+# Section (6) reads the SeaweedFS pod's listen sockets and cumulative
 # ListenOverflows / ListenDrops from inside its netns to confirm or rule that
 # out. Each probe distinguishes a failed/forbidden query from a genuinely empty
 # result so a blank line never falsely rules out the signal.
@@ -59,16 +60,19 @@ set -u
 NAMESPACE="kubeflow"
 SELECTOR="app=seaweedfs"
 OUTPUT_FILE=""
-DIAL_TIMEOUT_LOG=""
+CONNECTION_FAILURE_LOG=""
+SERVICE_INVENTORY=""
+SERVICE_INVENTORY_AVAILABLE=false
 
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
         --namespace) NAMESPACE="${2:?--namespace requires a value}"; shift ;;
         --selector) SELECTOR="${2:?--selector requires a value}"; shift ;;
         --output) OUTPUT_FILE="${2:?--output requires a value}"; shift ;;
-        # A log (typically the already-collected pod logs) to scan for
-        # 'dial tcp <ip>:<port>: i/o timeout'; section (4) probes each such VIP.
-        --dial-timeout-log) DIAL_TIMEOUT_LOG="${2:?--dial-timeout-log requires a value}"; shift ;;
+        # A log (typically the already-collected pod logs) to scan for network
+        # failures. Keep --dial-timeout-log as a compatibility alias.
+        --connection-failure-log|--dial-timeout-log)
+            CONNECTION_FAILURE_LOG="${2:?$1 requires a value}"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -133,12 +137,85 @@ probe_service_rules() {
         fi' _ "$2" "$3" 2>/dev/null || echo "(unavailable)"
 }
 
-# ClusterIP VIPs (ip:port) that recorded a dial timeout in the supplied log.
+# Snapshot the Kubernetes objects behind one failed ClusterIP. Unlike the
+# node-level service program below, this exposes a temporarily missing endpoint,
+# restarting backend, or last termination reason. The snapshot is post-failure,
+# so recovered state is evidence but not proof that the endpoint was ready when
+# the connection failed.
+# Usage: probe_service_backends <ip> <port>
+probe_service_backends() {
+    local ip="$1"
+    local port="$2"
+    if [[ "$SERVICE_INVENTORY_AVAILABLE" != "true" ]]; then
+        echo "Service lookup unavailable for $ip:$port."
+        return
+    fi
+
+    local services
+    services=$(printf '%s\n' "$SERVICE_INVENTORY" \
+        | awk -F '\t' -v ip="$ip" '$3 == ip {print $1 "\t" $2}' || true)
+
+    if [[ -z "$services" ]]; then
+        echo "No Kubernetes Service currently owns $ip:$port."
+        return
+    fi
+
+    while IFS=$'\t' read -r service_namespace service_name; do
+        [[ -n "$service_namespace" && -n "$service_name" ]] || continue
+        echo "Service: $service_namespace/$service_name (failed VIP $ip:$port)"
+        kubectl get service "$service_name" -n "$service_namespace" -o wide 2>/dev/null \
+            || echo "(service snapshot unavailable)"
+
+        echo "EndpointSlices:"
+        kubectl get endpointslice -n "$service_namespace" \
+            -l "kubernetes.io/service-name=$service_name" -o wide 2>/dev/null \
+            || echo "(EndpointSlice snapshot unavailable)"
+
+        local targets
+        if ! targets=$(kubectl get endpointslice -n "$service_namespace" \
+            -l "kubernetes.io/service-name=$service_name" \
+            -o jsonpath='{range .items[*].endpoints[*]}{.addresses[0]}{"|"}{.conditions.ready}{"|"}{.conditions.serving}{"|"}{.conditions.terminating}{"|"}{.targetRef.kind}{"|"}{.targetRef.namespace}{"|"}{.targetRef.name}{"\n"}{end}' \
+            2>/dev/null); then
+            echo "(EndpointSlice backend lookup unavailable)"
+            continue
+        fi
+        if [[ -z "$targets" ]]; then
+            echo "(no EndpointSlice backends found)"
+            continue
+        fi
+
+        echo "Backing endpoints (address, ready, serving, terminating, target):"
+        printf '%s\n' "$targets"
+        while IFS='|' read -r address ready serving terminating target_kind target_namespace target_name; do
+            [[ "$target_kind" == "Pod" && -n "$target_name" ]] || continue
+            target_namespace="${target_namespace:-$service_namespace}"
+            echo "Backing pod: $target_namespace/$target_name ($address; ready=$ready serving=$serving terminating=$terminating)"
+            kubectl get pod "$target_name" -n "$target_namespace" -o wide 2>/dev/null \
+                || echo "(backing pod snapshot unavailable)"
+            kubectl get pod "$target_name" -n "$target_namespace" \
+                -o jsonpath='{range .status.containerStatuses[*]}container={.name} ready={.ready} restarts={.restartCount} state={.state} lastState={.lastState}{"\n"}{end}' \
+                2>/dev/null || echo "(backing pod status unavailable)"
+            echo "Backing pod events:"
+            local pod_description
+            if pod_description=$(kubectl describe pod "$target_name" -n "$target_namespace" 2>/dev/null); then
+                printf '%s\n' "$pod_description" | sed -n '/Events:/,$p'
+            else
+                echo "(backing pod events unavailable)"
+            fi
+        done <<< "$targets"
+    done <<< "$services"
+}
+
+# ClusterIP VIPs (ip:port) that recorded a timeout, refusal, or reset in the
+# supplied log. For established TCP resets, select the destination after '->'
+# rather than the client address.
 # Read before the diagnostics block so appended output cannot perturb the scan.
 LOG_VIPS=""
-if [[ -n "$DIAL_TIMEOUT_LOG" && -r "$DIAL_TIMEOUT_LOG" ]]; then
-    LOG_VIPS=$(grep -oE 'dial tcp [0-9.]+:[0-9]+: i/o timeout' "$DIAL_TIMEOUT_LOG" 2>/dev/null \
-        | grep -oE '[0-9.]+:[0-9]+' | sort -u || true)
+if [[ -n "$CONNECTION_FAILURE_LOG" && -r "$CONNECTION_FAILURE_LOG" ]]; then
+    LOG_VIPS=$(sed -nE \
+        -e 's/.*dial tcp ([0-9.]+:[0-9]+): (i\/o timeout|connect: connection refused|connect: connection reset by peer).*/\1/p' \
+        -e 's/.*(read|write) tcp [0-9.]+:[0-9]+->([0-9.]+:[0-9]+): .*connection reset by peer.*/\2/p' \
+        "$CONNECTION_FAILURE_LOG" 2>/dev/null | sort -u || true)
 fi
 
 {
@@ -193,17 +270,61 @@ fi
     CLUSTER_IP=$(kubectl get svc seaweedfs -n "$NAMESPACE" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
     echo "SeaweedFS ClusterIP: ${CLUSTER_IP:-<unresolved>}"
 
-    # Section (4) targets the SeaweedFS VIP plus every other ClusterIP that a
-    # dial timeout was logged against (e.g. the MLflow service VIP), so the
-    # dataplane evidence covers whichever service the workflow pods could not
-    # reach, not only SeaweedFS.
+    # Snapshot Services once so all later sections use one consistent mapping,
+    # and so historical startup-probe failures to Pod IPs in describe output do
+    # not get mislabeled and probed as ClusterIP failures.
+    if SERVICE_INVENTORY=$(kubectl get service -A \
+        -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.clusterIP}{"\n"}{end}' \
+        2>/dev/null); then
+        SERVICE_INVENTORY_AVAILABLE=true
+    else
+        SERVICE_INVENTORY_AVAILABLE=false
+    fi
+    FAILED_SERVICE_VIPS=""
+    IGNORED_CONNECTION_TARGETS=""
+    if [[ "$SERVICE_INVENTORY_AVAILABLE" == "true" ]]; then
+        for vip in $LOG_VIPS; do
+            if printf '%s\n' "$SERVICE_INVENTORY" \
+                | awk -F '\t' -v ip="${vip%%:*}" '$3 == ip {found=1} END {exit !found}'; then
+                FAILED_SERVICE_VIPS+="${vip}"$'\n'
+            else
+                IGNORED_CONNECTION_TARGETS+="${vip}"$'\n'
+            fi
+        done
+    else
+        # Preserve node-level evidence when the API is unavailable; do not
+        # misclassify lookup failure as proof that these Services do not exist.
+        FAILED_SERVICE_VIPS="$LOG_VIPS"
+    fi
+
+    # Sections (4) and (5) target the SeaweedFS VIP plus every other ClusterIP
+    # that logged a timeout, refusal, or reset (e.g. the MLflow service VIP), so
+    # the dataplane evidence covers whichever service the workflow pods could
+    # not reach, not only SeaweedFS.
     TARGET_VIPS=$(
-        { [[ -n "$CLUSTER_IP" ]] && echo "${CLUSTER_IP}:9000"; printf '%s\n' "$LOG_VIPS"; } \
+        { [[ -n "$CLUSTER_IP" ]] && echo "${CLUSTER_IP}:9000"; printf '%s' "$FAILED_SERVICE_VIPS"; } \
             | grep -E '^[0-9.]+:[0-9]+$' | sort -u
     )
 
     echo
-    echo "----- (4) node netfilter state for timed-out ClusterIPs -----"
+    echo "----- (4) service and backend state for failed ClusterIPs -----"
+    echo "ClusterIPs correlated: $(printf '%s ' ${TARGET_VIPS:-<none>})"
+    if [[ "$SERVICE_INVENTORY_AVAILABLE" != "true" ]]; then
+        echo "Service inventory unavailable; ClusterIP ownership cannot be confirmed."
+    fi
+    if [[ -n "$IGNORED_CONNECTION_TARGETS" ]]; then
+        echo "Non-Service connection targets ignored: $(printf '%s ' $IGNORED_CONNECTION_TARGETS)"
+    fi
+    if [[ -z "$TARGET_VIPS" ]]; then
+        echo "No failed ClusterIPs to correlate."
+    else
+        for vip in $TARGET_VIPS; do
+            probe_service_backends "${vip%%:*}" "${vip##*:}"
+        done
+    fi
+
+    echo
+    echo "----- (5) node netfilter state for failed ClusterIPs -----"
     echo "ClusterIPs correlated: $(printf '%s ' ${TARGET_VIPS:-<none>})"
     # Kind runs each node as a Docker container named after the Kubernetes node,
     # so 'docker exec <node>' reaches the node's network namespace where
@@ -263,7 +384,7 @@ fi
             # KUBE-SEP DNAT): a live DNAT to the pod means the rule is not the
             # problem; an empty chain means no ready backend.
             if [[ -z "$TARGET_VIPS" ]]; then
-                echo "service program: no timed-out ClusterIPs to correlate."
+                echo "service program: no failed ClusterIPs to correlate."
             else
                 for vip in $TARGET_VIPS; do
                     echo "service program for $vip (iptables, then ipvs):"
@@ -274,7 +395,7 @@ fi
     fi
 
     echo
-    echo "----- (5) SeaweedFS pod socket / listen-queue state -----"
+    echo "----- (6) SeaweedFS pod socket / listen-queue state -----"
     # Once the node conntrack table and the service program are clean, the
     # leading remaining cause of the ClusterIP dial timeouts is accept-queue
     # saturation: under the parallel burst the S3 server's listen backlog

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -330,6 +330,41 @@ fi
     fi
 
     echo
+    echo "----- runner-kernel softirq backlog (shared by every Kind node) -----"
+    # veth traffic is delivered through the per-CPU softirq backlog queue;
+    # when ksoftirqd is starved on a CPU-saturated runner the queue overflows
+    # and packets are dropped silently — upstream of every counter this script
+    # checks (conntrack, accept queue). Kind nodes are containers sharing the
+    # runner kernel and /proc/net/softnet_stat is kernel-global per-CPU state,
+    # so it is read once here on the runner host: reading it inside each node
+    # container would print identical counters under different node headings.
+    # Counters are cumulative, and runner VMs are ephemeral, so they are
+    # naturally scoped to this job. Current limits are recorded so the failure
+    # states what the backlog/budget were at the time.
+    if [[ -r /proc/net/softnet_stat ]]; then
+        row=0
+        while read -r -a fields; do
+            # Newer kernels omit offline CPUs from the file and expose the
+            # actual CPU id in field 13; the row ordinal is only a fallback
+            # for older 11-column kernels.
+            if [[ ${#fields[@]} -ge 13 ]]; then
+                cpu=$((16#${fields[12]}))
+            else
+                cpu=$row
+            fi
+            printf 'cpu%d processed=%d dropped=%d time_squeeze=%d\n' \
+                "$cpu" "$((16#${fields[0]}))" "$((16#${fields[1]}))" "$((16#${fields[2]}))"
+            row=$((row + 1))
+        done < /proc/net/softnet_stat
+        printf 'netdev_max_backlog=%s netdev_budget=%s netdev_budget_usecs=%s\n' \
+            "$(cat /proc/sys/net/core/netdev_max_backlog 2>/dev/null || echo '?')" \
+            "$(cat /proc/sys/net/core/netdev_budget 2>/dev/null || echo '?')" \
+            "$(cat /proc/sys/net/core/netdev_budget_usecs 2>/dev/null || echo '?')"
+    else
+        echo "(/proc/net/softnet_stat unavailable)"
+    fi
+
+    echo
     echo "----- (5) node netfilter state for failed ClusterIPs -----"
     echo "ClusterIPs correlated: $(printf '%s ' ${TARGET_VIPS:-<none>})"
     # Kind runs each node as a Docker container named after the Kubernetes node,

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -287,14 +287,14 @@ fi
         SERVICE_INVENTORY_AVAILABLE=false
     fi
     FAILED_SERVICE_VIPS=""
-    IGNORED_CONNECTION_TARGETS=""
+    UNOWNED_CONNECTION_TARGETS=""
     if [[ "$SERVICE_INVENTORY_AVAILABLE" == "true" ]]; then
         for vip in $LOG_VIPS; do
             if printf '%s\n' "$SERVICE_INVENTORY" \
                 | awk -F '\t' -v ip="${vip%%:*}" '$3 == ip {found=1} END {exit !found}'; then
                 FAILED_SERVICE_VIPS+="${vip}"$'\n'
             else
-                IGNORED_CONNECTION_TARGETS+="${vip}"$'\n'
+                UNOWNED_CONNECTION_TARGETS+="${vip}"$'\n'
             fi
         done
     else
@@ -318,8 +318,12 @@ fi
     if [[ "$SERVICE_INVENTORY_AVAILABLE" != "true" ]]; then
         echo "Service inventory unavailable; ClusterIP ownership cannot be confirmed."
     fi
-    if [[ -n "$IGNORED_CONNECTION_TARGETS" ]]; then
-        echo "Non-Service connection targets ignored: $(printf '%s ' $IGNORED_CONNECTION_TARGETS)"
+    if [[ -n "$UNOWNED_CONNECTION_TARGETS" ]]; then
+        # A Service deleted, recreated, or re-IP'd after the failure leaves its
+        # old VIP absent from the current inventory — exactly the stale-Service
+        # scenario the node probe exists to catch. Skip only the backend-object
+        # lookups for these; section (5) still probes their node programs.
+        echo "Targets not in the current Service inventory (backend lookup skipped; node program probed in section 5): $(printf '%s ' $UNOWNED_CONNECTION_TARGETS)"
     fi
     if [[ -z "$TARGET_VIPS" ]]; then
         echo "No failed ClusterIPs to correlate."
@@ -364,9 +368,17 @@ fi
         echo "(/proc/net/softnet_stat unavailable)"
     fi
 
+    # Node-level targets include logged addresses missing from the current
+    # Service inventory: a stale/deleted Service's old VIP must still get its
+    # iptables/ipvs snapshot even though there is no backend object to query.
+    NODE_TARGET_VIPS=$(
+        { printf '%s\n' "$TARGET_VIPS"; printf '%s' "$UNOWNED_CONNECTION_TARGETS"; } \
+            | grep -E '^[0-9.]+:[0-9]+$' | sort -u
+    )
+
     echo
     echo "----- (5) node netfilter state for failed ClusterIPs -----"
-    echo "ClusterIPs correlated: $(printf '%s ' ${TARGET_VIPS:-<none>})"
+    echo "ClusterIPs correlated: $(printf '%s ' ${NODE_TARGET_VIPS:-<none>})"
     # Kind runs each node as a Docker container named after the Kubernetes node,
     # so 'docker exec <node>' reaches the node's network namespace where
     # kube-proxy programs the ClusterIPs and the kernel tracks connections. A
@@ -424,10 +436,10 @@ fi
             # Per-VIP service program end to end (KUBE-SERVICES -> KUBE-SVC ->
             # KUBE-SEP DNAT): a live DNAT to the pod means the rule is not the
             # problem; an empty chain means no ready backend.
-            if [[ -z "$TARGET_VIPS" ]]; then
+            if [[ -z "$NODE_TARGET_VIPS" ]]; then
                 echo "service program: no failed ClusterIPs to correlate."
             else
-                for vip in $TARGET_VIPS; do
+                for vip in $NODE_TARGET_VIPS; do
                     echo "service program for $vip (iptables, then ipvs):"
                     probe_service_rules "$node" "${vip%%:*}" "${vip##*:}"
                 done

--- a/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
+++ b/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
@@ -95,13 +95,23 @@ class CollectSeaweedfsDiagnosticsTest(unittest.TestCase):
             output,
         )
         self.assertIn(
-            'Non-Service connection targets ignored: 10.244.0.99:9090', output
+            'Targets not in the current Service inventory (backend lookup '
+            'skipped; node program probed in section 5): 10.244.0.99:9090',
+            output,
         )
         # Host-level capture: rendered once, regardless of docker/node state.
         self.assertIn(
             'runner-kernel softirq backlog (shared by every Kind node)', output
         )
-        self.assertNotIn('service program for 10.244.0.99:9090', output)
+        # Unowned targets keep their node-level probe (a deleted/re-IP'd
+        # Service's stale VIP is exactly that evidence) but never get a
+        # backend-object lookup: absent from section (4)'s correlated list,
+        # present in section (5)'s.
+        section_four_correlated = output.split('----- (4)')[1].splitlines()[1]
+        section_five_correlated = output.split('----- (5)')[1].splitlines()[1]
+        self.assertNotIn('10.244.0.99:9090', section_four_correlated)
+        self.assertIn('10.244.0.99:9090', section_five_correlated)
+        self.assertNotIn('Service:  (failed VIP 10.244.0.99:9090)', output)
         self.assertEqual(
             output.count(
                 'Service: opendatahub/mlflow (failed VIP 10.96.2.2:8443)'

--- a/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
+++ b/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
@@ -1,0 +1,265 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPT = Path(__file__).with_name('collect-seaweedfs-diagnostics.sh')
+
+
+class CollectSeaweedfsDiagnosticsTest(unittest.TestCase):
+
+    def test_correlates_connection_failures_with_service_backends(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            bin_directory = temporary_path / 'bin'
+            bin_directory.mkdir()
+            failure_log = temporary_path / 'failures.log'
+            failure_log.write_text(
+                textwrap.dedent('''\
+                    dial tcp 10.96.1.1:9000: i/o timeout
+                    dial tcp 10.96.2.2:8443: connect: connection refused
+                    dial tcp 10.96.2.2:8443: connect: connection refused
+                    dial tcp 10.96.3.3:443: connect: connection reset by peer
+                    read tcp 10.244.0.7:43120->10.96.4.4:8080: read: connection reset by peer
+                    dial tcp 10.244.0.99:9090: connect: connection refused
+                    connection refused without a numeric destination
+                '''),
+                encoding='utf-8',
+            )
+            self._write_executable(bin_directory / 'kubectl', _FAKE_KUBECTL)
+            self._write_executable(
+                bin_directory / 'docker',
+                '#!/usr/bin/env bash\nexit 1\n',
+            )
+
+            environment = os.environ.copy()
+            environment['PATH'] = f'{bin_directory}:{environment["PATH"]}'
+            result = subprocess.run(
+                [
+                    'bash',
+                    str(SCRIPT),
+                    '--namespace',
+                    'kubeflow',
+                    '--connection-failure-log',
+                    str(failure_log),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+
+        output = result.stdout
+        self.assertIn(
+            'ClusterIPs correlated: 10.96.1.1:9000 10.96.2.2:8443 '
+            '10.96.3.3:443 10.96.4.4:8080',
+            output,
+        )
+        self.assertIn(
+            'Service: opendatahub/mlflow (failed VIP 10.96.2.2:8443)',
+            output,
+        )
+        self.assertIn('mlflow-slice  10.244.0.30', output)
+        self.assertIn(
+            'Backing pod: opendatahub/mlflow-0 '
+            '(10.244.0.30; ready=true serving=true terminating=false)',
+            output,
+        )
+        self.assertIn(
+            'container=mlflow ready=true restarts=2 state=running '
+            'lastState=terminated:Error',
+            output,
+        )
+        self.assertIn('Warning  Unhealthy  MLflow readiness probe failed', output)
+        self.assertIn(
+            'Service: kubeflow/metadata-grpc '
+            '(failed VIP 10.96.4.4:8080)',
+            output,
+        )
+        self.assertIn(
+            'Non-Service connection targets ignored: 10.244.0.99:9090', output
+        )
+        self.assertNotIn('service program for 10.244.0.99:9090', output)
+        self.assertEqual(
+            output.count(
+                'Service: opendatahub/mlflow (failed VIP 10.96.2.2:8443)'
+            ),
+            1,
+        )
+        self.assertNotIn('without a numeric destination', output)
+
+    def test_legacy_dial_timeout_log_option_remains_supported(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            bin_directory = temporary_path / 'bin'
+            bin_directory.mkdir()
+            failure_log = temporary_path / 'failures.log'
+            failure_log.write_text(
+                'dial tcp 10.96.2.2:8443: connect: connection refused\n',
+                encoding='utf-8',
+            )
+            self._write_executable(bin_directory / 'kubectl', _FAKE_KUBECTL)
+            self._write_executable(
+                bin_directory / 'docker',
+                '#!/usr/bin/env bash\nexit 1\n',
+            )
+            environment = os.environ.copy()
+            environment['PATH'] = f'{bin_directory}:{environment["PATH"]}'
+
+            result = subprocess.run(
+                [
+                    'bash',
+                    str(SCRIPT),
+                    '--dial-timeout-log',
+                    str(failure_log),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+
+        self.assertIn('10.96.2.2:8443', result.stdout)
+
+    def test_reports_service_inventory_api_failure_as_unavailable(self):
+        result = self._run_with_fake_cluster(
+            'dial tcp 10.96.2.2:8443: connect: connection refused\n',
+            {'FAIL_SERVICE_LOOKUP': 'true'},
+        )
+
+        self.assertIn('Service inventory unavailable', result.stdout)
+        self.assertIn(
+            'Service lookup unavailable for 10.96.2.2:8443.', result.stdout
+        )
+        self.assertNotIn('No Kubernetes Service currently owns', result.stdout)
+
+    def test_reports_endpointslice_api_failure_as_unavailable(self):
+        result = self._run_with_fake_cluster(
+            'dial tcp 10.96.2.2:8443: connect: connection refused\n',
+            {'FAIL_ENDPOINTSLICE_LOOKUP': 'true'},
+        )
+
+        self.assertIn('(EndpointSlice backend lookup unavailable)', result.stdout)
+        self.assertNotIn('(no EndpointSlice backends found)', result.stdout)
+
+    def _run_with_fake_cluster(self, failure_text: str, extra_environment=None):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            bin_directory = temporary_path / 'bin'
+            bin_directory.mkdir()
+            failure_log = temporary_path / 'failures.log'
+            failure_log.write_text(failure_text, encoding='utf-8')
+            self._write_executable(bin_directory / 'kubectl', _FAKE_KUBECTL)
+            self._write_executable(
+                bin_directory / 'docker',
+                '#!/usr/bin/env bash\nexit 1\n',
+            )
+            environment = os.environ.copy()
+            environment['PATH'] = f'{bin_directory}:{environment["PATH"]}'
+            environment.update(extra_environment or {})
+            return subprocess.run(
+                [
+                    'bash',
+                    str(SCRIPT),
+                    '--connection-failure-log',
+                    str(failure_log),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+
+    @staticmethod
+    def _write_executable(path: Path, contents: str):
+        path.write_text(contents, encoding='utf-8')
+        path.chmod(0o755)
+
+
+_FAKE_KUBECTL = r'''#!/usr/bin/env bash
+args="$*"
+
+case "$args" in
+  *"get pod -n kubeflow -l app=seaweedfs"*) echo "seaweedfs-0" ;;
+  *"get pod seaweedfs-0 -n kubeflow -o wide"*)
+    echo "seaweedfs-0  1/1  Running  0  10m  10.244.0.20"
+    ;;
+  *"get pod seaweedfs-0 -n kubeflow -o jsonpath="*"restartCount="*)
+    printf 'restartCount=0\nlastState={}\nqosClass=Burstable\n'
+    ;;
+  *"get pod seaweedfs-0 -n kubeflow -o jsonpath="*) echo "kind-control-plane" ;;
+  *"describe node kind-control-plane"*) echo "Conditions:" ;;
+  *"get pod -n kube-system -l k8s-app=kube-proxy"*)
+    echo "kube-proxy  1/1  Running"
+    ;;
+  *"get endpoints seaweedfs -n kubeflow"*)
+    echo "seaweedfs  10.244.0.20:8333"
+    ;;
+  *"get svc seaweedfs -n kubeflow"*) echo "10.96.1.1" ;;
+  *"get service -A"*)
+    [[ "${FAIL_SERVICE_LOOKUP:-false}" != "true" ]] || exit 1
+    printf 'kubeflow\tseaweedfs\t10.96.1.1\n'
+    printf 'opendatahub\tmlflow\t10.96.2.2\n'
+    printf 'default\tkubernetes\t10.96.3.3\n'
+    printf 'kubeflow\tmetadata-grpc\t10.96.4.4\n'
+    ;;
+  *"get service mlflow -n opendatahub"*)
+    echo "mlflow  ClusterIP  10.96.2.2  8443/TCP"
+    ;;
+  *"get service seaweedfs -n kubeflow"*)
+    echo "seaweedfs  ClusterIP  10.96.1.1  9000/TCP"
+    ;;
+  *"get service kubernetes -n default"*)
+    echo "kubernetes  ClusterIP  10.96.3.3  443/TCP"
+    ;;
+  *"get service metadata-grpc -n kubeflow"*)
+    echo "metadata-grpc  ClusterIP  10.96.4.4  8080/TCP"
+    ;;
+  *"get endpointslice -n opendatahub"*"-o wide"*)
+    echo "mlflow-slice  10.244.0.30"
+    ;;
+  *"get endpointslice -n opendatahub"*"-o jsonpath="*)
+    [[ "${FAIL_ENDPOINTSLICE_LOOKUP:-false}" != "true" ]] || exit 1
+    echo '10.244.0.30|true|true|false|Pod|opendatahub|mlflow-0'
+    ;;
+  *"get endpointslice -n kubeflow"*"service-name=seaweedfs"*"-o wide"*)
+    echo "seaweedfs-slice  10.244.0.20"
+    ;;
+  *"get endpointslice -n kubeflow"*"service-name=seaweedfs"*"-o jsonpath="*)
+    echo '10.244.0.20|true|true|false|Pod|kubeflow|seaweedfs-0'
+    ;;
+  *"get endpointslice -n kubeflow"*"service-name=metadata-grpc"*"-o wide"*)
+    echo "metadata-slice  10.244.0.40"
+    ;;
+  *"get endpointslice -n kubeflow"*"service-name=metadata-grpc"*"-o jsonpath="*)
+    echo '10.244.0.40|true|true|false|Pod|kubeflow|metadata-0'
+    ;;
+  *"get endpointslice -n default"*"-o wide"*) echo "kubernetes-slice  172.18.0.2" ;;
+  *"get endpointslice -n default"*"-o jsonpath="*) echo "" ;;
+  *"get pod mlflow-0 -n opendatahub -o wide"*)
+    echo "mlflow-0  1/1  Running  2  10m  10.244.0.30"
+    ;;
+  *"get pod mlflow-0 -n opendatahub -o jsonpath="*)
+    echo "container=mlflow ready=true restarts=2 state=running lastState=terminated:Error"
+    ;;
+  *"describe pod mlflow-0 -n opendatahub"*)
+    printf 'Events:\nWarning  Unhealthy  MLflow readiness probe failed\n'
+    ;;
+  *"get pod metadata-0 -n kubeflow -o wide"*) echo "metadata-0  1/1  Running" ;;
+  *"get pod metadata-0 -n kubeflow -o jsonpath="*)
+    echo "container=metadata ready=true restarts=0"
+    ;;
+  *"describe pod metadata-0 -n kubeflow"*) echo "Events:  <none>" ;;
+  *"get nodes -o jsonpath="*) echo "" ;;
+  *"exec seaweedfs-0"*) echo "socket diagnostics" ;;
+  *"describe pod seaweedfs-0 -n kubeflow"*) echo "Events:  <none>" ;;
+  *) true ;;
+esac
+'''
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
+++ b/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
@@ -1,3 +1,18 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from pathlib import Path
 import subprocess

--- a/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
+++ b/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
@@ -97,6 +97,10 @@ class CollectSeaweedfsDiagnosticsTest(unittest.TestCase):
         self.assertIn(
             'Non-Service connection targets ignored: 10.244.0.99:9090', output
         )
+        # Host-level capture: rendered once, regardless of docker/node state.
+        self.assertIn(
+            'runner-kernel softirq backlog (shared by every Kind node)', output
+        )
         self.assertNotIn('service program for 10.244.0.99:9090', output)
         self.assertEqual(
             output.count(

--- a/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
+++ b/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
@@ -139,6 +139,22 @@ class CollectSeaweedfsDiagnosticsTest(unittest.TestCase):
 
         self.assertIn('10.96.2.2:8443', result.stdout)
 
+    def test_missing_seaweedfs_pod_still_probes_other_service_vips(self):
+        # The generic inventory and sections 4-5 must not depend on the
+        # SeaweedFS pod: an MLflow VIP failure deserves its Service/backend
+        # snapshot even when SeaweedFS is absent.
+        result = self._run_with_fake_cluster(
+            'dial tcp 10.96.2.2:8443: connect: connection refused\n',
+            {'NO_SEAWEEDFS_POD': 'true'},
+        )
+        output = result.stdout
+        self.assertIn('skipping pod-scoped sections', output)
+        self.assertIn(
+            'Service: opendatahub/mlflow (failed VIP 10.96.2.2:8443)', output
+        )
+        self.assertIn('ClusterIPs correlated: 10.96.1.1:9000 10.96.2.2:8443', output)
+        self.assertIn('No SeaweedFS pod; skipping socket state.', output)
+
     def test_reports_service_inventory_api_failure_as_unavailable(self):
         result = self._run_with_fake_cluster(
             'dial tcp 10.96.2.2:8443: connect: connection refused\n',
@@ -198,7 +214,9 @@ _FAKE_KUBECTL = r'''#!/usr/bin/env bash
 args="$*"
 
 case "$args" in
-  *"get pod -n kubeflow -l app=seaweedfs"*) echo "seaweedfs-0" ;;
+  *"get pod -n kubeflow -l app=seaweedfs"*)
+    [[ "${NO_SEAWEEDFS_POD:-false}" == "true" ]] || echo "seaweedfs-0"
+    ;;
   *"get pod seaweedfs-0 -n kubeflow -o wide"*)
     echo "seaweedfs-0  1/1  Running  0  10m  10.244.0.20"
     ;;

--- a/.github/workflows/ci-scripts-tests.yml
+++ b/.github/workflows/ci-scripts-tests.yml
@@ -1,12 +1,13 @@
-# Presubmit gate for the Python tooling under .github/resources/scripts: the
-# unit tests are stdlib-only and the file name (ci_health_report_test.py) is
-# not matched by default `unittest discover` patterns, so run them explicitly.
+# Presubmit gate for tooling under .github/resources/scripts: the
+# unit tests are stdlib-only and their file names are not matched by default
+# `unittest discover` patterns, so run them explicitly.
 name: CI Scripts Tests
 
 on:
   pull_request:
     paths:
       - '.github/resources/scripts/*.py'
+      - '.github/resources/scripts/collect-seaweedfs-diagnostics.sh'
       - '.github/workflows/ci-scripts-tests.yml'
 
 permissions:
@@ -19,6 +20,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - name: Run ci_health_report unit tests
+      - name: Run CI script unit tests
         working-directory: .github/resources/scripts
-        run: python3 -m unittest -v ci_health_report_test
+        run: python3 -m unittest -v collect_seaweedfs_diagnostics_test ci_health_report_test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-14
+- Last updated: 2026-07-15
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -518,7 +518,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 - Workflows: `.github/workflows/` (build, test, lint, release)
 - `ci-health-report.yml` runs daily (and on dispatch): aggregates master-branch lane failure rates and per-test flake counts from `junit-xml - *` artifacts, publishing to the job summary and a tracking issue labeled `ci-health`.
-- `ci-scripts-tests.yml` runs the stdlib unit tests for `.github/resources/scripts/*.py` on PRs touching those files (run locally with `cd .github/resources/scripts && python3 -m unittest ci_health_report_test`).
+- `ci-scripts-tests.yml` runs the stdlib unit tests for the Python CI tooling and ClusterIP diagnostic collector on PRs touching `.github/resources/scripts/*.py`, `collect-seaweedfs-diagnostics.sh`, or the workflow itself (run locally with `cd .github/resources/scripts && python3 -m unittest -v collect_seaweedfs_diagnostics_test ci_health_report_test`).
 - Composite actions: `.github/actions/` (e.g., `kfp-k8s`, `create-cluster`, `deploy`, `test-and-report`)
 - Typical checks: Go unit tests (backend), Python SDK tests, frontend tests/lint, image builds.
 - Frontend workflow (`frontend.yml`) verifies generated API clients are up to date by running `npm run apis:all` and failing on diff.


### PR DESCRIPTION
## Summary

- correlate ClusterIP connection refusals and resets in addition to dial timeouts
- snapshot the matched Service, EndpointSlices, backing pod readiness, restart state, and events
- keep node conntrack and iptables/IPVS evidence while filtering historical Pod-IP probe noise
- distinguish Kubernetes API lookup failures from genuinely absent Services or endpoints
- add stdlib regression tests and run them in the CI Scripts Tests workflow

## Why

The failed Kubernetes-auth MLflow lane in #13720 logged `connection refused` for the MLflow ClusterIP. The existing collector only recognized `i/o timeout`, so it inspected SeaweedFS but missed the Service and backend that actually refused the connection.

This change makes a future occurrence show whether the matched Service had ready endpoints, whether its backing pod restarted or became unready, and whether the node service program remained valid. It supports the capacity investigation tracked in #13724.

## Verification

- `bash -n .github/resources/scripts/collect-seaweedfs-diagnostics.sh`
- `cd .github/resources/scripts && python3 -m unittest -v collect_seaweedfs_diagnostics_test ci_health_report_test` (24 tests)
- parsed the changed workflow and composite action as YAML
- `git diff --check`



## Also folded in: runner-kernel softirq backlog capture (from #13729)

Telemetry from the first fully-instrumented SeaweedFS dial-timeout failure showed the 4-CPU runner at **load 17–28** while every instrumented drop point was clean (conntrack ~0.7% with no table-full, live KUBE-SEP DNAT, pod `ListenOverflows=0`). The remaining drop point upstream of all of those is the **per-CPU softirq backlog** — veth traffic queues there, and when `ksoftirqd` is starved the queue overflows and packets drop silently.

A new host-level section reads `/proc/net/softnet_stat` **once on the runner** (it's kernel-global state shared by every Kind node), decoding `processed / dropped / time_squeeze` per CPU using the kernel's CPU-id field (13-column format; row-ordinal fallback for 11-column kernels), plus the current `netdev_max_backlog` / `netdev_budget` / `netdev_budget_usecs` limits so each failure records what the queue limits were.

Deliberately diagnostics-only (no sysctl bump), so the counter gives one unconfounded read: **`dropped > 0`** on the next failure confirms the softirq-backlog mechanism and justifies a follow-up bump; **zero** refutes it and redirects the investigation. Both changes rewrite this script, so they ship together; #13729 is closed in favor of this PR. The test harness asserts the section renders in the fake-cluster run.
