### PR TITLE
ci: mirror observability output to logs and fix conntrack self-match

### DIFF
--- a/.github/resources/scripts/failure-signature-summary.sh
+++ b/.github/resources/scripts/failure-signature-summary.sh
@@ -30,7 +30,15 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-OUT="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+# Job summaries are not retrievable through the logs API, so mirror the
+# output to stdout: the job log stays the machine-readable record.
+publish() {
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        tee -a "$GITHUB_STEP_SUMMARY"
+    else
+        cat
+    fi
+}
 
 # Signature scan corpus: the collected pod logs PLUS the JUnit failure/error
 # bodies. Client-side failures (MLflow timeouts, connection refused from the
@@ -102,7 +110,10 @@ count_signature() {
         echo "| HTTP 429 rate limit | $(count_signature 'status 429|429 Too Many Requests') | upstream rate limiting |"
         echo "| OOMKilled | $(count_signature 'OOMKilled') | pod memory limits |"
         echo "| CrashLoopBackOff | $(count_signature 'CrashLoopBackOff') | pod lifecycle |"
-        echo "| conntrack table full | $(count_signature 'nf_conntrack: table full') | node conntrack exhaustion |"
+        # Match the kernel's message form, not just the phrase: the SeaweedFS
+        # diagnostics script tees its own "kernel 'nf_conntrack: table full'
+        # events:" header into the pod log, which must not count as a hit.
+        echo "| conntrack table full | $(count_signature 'nf_conntrack: table full, dropping packet') | node conntrack exhaustion |"
 
         # Per-VIP breakdown makes multi-service dataplane failures (SeaweedFS
         # :9000 vs MLflow :8443 ...) visible at a glance.
@@ -148,7 +159,7 @@ PY
         fi
     fi
     echo ""
-} >> "$OUT"
+} | publish
 
 [[ -n "$JUNIT_TEXT" ]] && rm -f "$JUNIT_TEXT"
 exit 0

--- a/.github/resources/scripts/observability_output_test.py
+++ b/.github/resources/scripts/observability_output_test.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for failure-signature-summary.sh and runner-telemetry.sh.
+
+Covers the conntrack signature classification (the collect-seaweedfs
+diagnostics header must never count as a kernel table-full event) and the
+stdout/summary mirroring contract (job summaries have no API, so the job log
+must carry byte-identical output).
+
+Run with:  cd .github/resources/scripts && python3 -m unittest -v observability_output_test
+"""
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).parent
+SIGNATURE_SCRIPT = SCRIPTS_DIR / 'failure-signature-summary.sh'
+TELEMETRY_SCRIPT = SCRIPTS_DIR / 'runner-telemetry.sh'
+
+
+def run_signature(log_text, summary_path=None):
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        log_file = Path(temporary_directory) / 'pod.log'
+        log_file.write_text(log_text, encoding='utf-8')
+        environment = os.environ.copy()
+        environment.pop('GITHUB_STEP_SUMMARY', None)
+        if summary_path is not None:
+            environment['GITHUB_STEP_SUMMARY'] = str(summary_path)
+        return subprocess.run(
+            ['bash', str(SIGNATURE_SCRIPT), '--log-file', str(log_file),
+             '--reports-dir', str(Path(temporary_directory) / 'none')],
+            check=True, capture_output=True, text=True, env=environment,
+        ).stdout
+
+
+def conntrack_count(output):
+    for line in output.splitlines():
+        if line.startswith('| conntrack table full |'):
+            return int(line.split('|')[2].strip())
+    raise AssertionError(f'conntrack row missing in:\n{output}')
+
+
+class ConntrackClassificationTest(unittest.TestCase):
+
+    def test_diagnostics_header_counts_zero(self):
+        # collect-seaweedfs-diagnostics tees this header into the pod log; it
+        # must never be classified as a kernel table-full event.
+        output = run_signature(textwrap.dedent('''\
+            kernel 'nf_conntrack: table full' events:
+            (no table-full event logged)
+        '''))
+        self.assertEqual(conntrack_count(output), 0)
+
+    def test_real_kernel_messages_count_correctly(self):
+        output = run_signature(textwrap.dedent('''\
+            kernel 'nf_conntrack: table full' events:
+            [111.1] nf_conntrack: table full, dropping packet
+            [222.2] nf_conntrack: table full, dropping packet
+        '''))
+        self.assertEqual(conntrack_count(output), 2)
+
+
+class OutputMirroringTest(unittest.TestCase):
+    """stdout must be byte-identical to what gets appended to the summary."""
+
+    def test_signature_stdout_matches_summary(self):
+        with tempfile.NamedTemporaryFile('r', suffix='.md') as summary:
+            stdout = run_signature(
+                'dial tcp 10.96.1.1:9000: i/o timeout\n',
+                summary_path=summary.name,
+            )
+            self.assertEqual(stdout, Path(summary.name).read_text())
+            self.assertIn('Failure signature summary', stdout)
+
+    def test_telemetry_stdout_matches_summary(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            csv = Path(temporary_directory) / 't.csv'
+            csv.write_text(
+                'epoch,cpu_pct,mem_used_mb,load1\n'
+                + ''.join(f'{1700000000 + i * 5},{i * 10},1000,1.0\n'
+                          for i in range(5)),
+                encoding='utf-8',
+            )
+            summary = Path(temporary_directory) / 'summary.md'
+            environment = os.environ.copy()
+            environment['GITHUB_STEP_SUMMARY'] = str(summary)
+            # The render step kills any recorded sampler pid; point the pid
+            # file lookup at a path that does not exist.
+            result = subprocess.run(
+                ['bash', str(TELEMETRY_SCRIPT), 'render', str(csv)],
+                check=True, capture_output=True, text=True, env=environment,
+            )
+            self.assertEqual(result.stdout, summary.read_text())
+            self.assertIn('Runner telemetry', result.stdout)
+            self.assertIn('CPU busy %', result.stdout)
+
+    def test_telemetry_stdout_only_without_summary(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            csv = Path(temporary_directory) / 't.csv'
+            csv.write_text(
+                'epoch,cpu_pct,mem_used_mb,load1\n'
+                '1700000000,10,1000,1.0\n1700000005,20,1000,1.0\n'
+                '1700000010,30,1000,1.0\n',
+                encoding='utf-8',
+            )
+            environment = os.environ.copy()
+            environment.pop('GITHUB_STEP_SUMMARY', None)
+            result = subprocess.run(
+                ['bash', str(TELEMETRY_SCRIPT), 'render', str(csv)],
+                check=True, capture_output=True, text=True, env=environment,
+            )
+            self.assertIn('Runner telemetry', result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/resources/scripts/runner-telemetry.sh
+++ b/.github/resources/scripts/runner-telemetry.sh
@@ -18,6 +18,16 @@ set -u
 INTERVAL_SECONDS=5
 PID_FILE="/tmp/runner-telemetry.pid"
 
+# Job summaries are not retrievable through the logs API; mirror rendered
+# output to stdout so the job log carries the numbers too.
+publish() {
+    if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+        tee -a "$GITHUB_STEP_SUMMARY"
+    else
+        cat
+    fi
+}
+
 cpu_totals() {
     # Prints "<busy> <total>" jiffies from the aggregate cpu line.
     awk '/^cpu / {
@@ -56,16 +66,15 @@ render() {
         kill "$(cat "$PID_FILE")" 2>/dev/null || true
         rm -f "$PID_FILE"
     fi
-    local out="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
     if [[ ! -r "$csv" ]] || [[ $(wc -l < "$csv") -lt 3 ]]; then
-        echo "_Runner telemetry: no samples collected._" >> "$out"
+        echo "_Runner telemetry: no samples collected._" | publish
         return 0
     fi
     if ! command -v python3 >/dev/null 2>&1; then
-        echo "_Runner telemetry: python3 unavailable; raw samples in ${csv}._" >> "$out"
+        echo "_Runner telemetry: python3 unavailable; raw samples in ${csv}._" | publish
         return 0
     fi
-    python3 - "$csv" >> "$out" <<'PY'
+    python3 - "$csv" <<'PY' | publish
 import sys
 
 rows = []

--- a/.github/workflows/ci-scripts-tests.yml
+++ b/.github/workflows/ci-scripts-tests.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
     paths:
       - '.github/resources/scripts/*.py'
-      - '.github/resources/scripts/collect-seaweedfs-diagnostics.sh'
+      # The observability shell scripts are covered by Python-driven tests.
+      - '.github/resources/scripts/*.sh'
       - '.github/workflows/ci-scripts-tests.yml'
 
 permissions:
@@ -23,3 +24,6 @@ jobs:
       - name: Run CI script unit tests
         working-directory: .github/resources/scripts
         run: python3 -m unittest -v collect_seaweedfs_diagnostics_test ci_health_report_test
+      - name: Run observability output tests
+        working-directory: .github/resources/scripts
+        run: python3 -m unittest -v observability_output_test


### PR DESCRIPTION
## Problem

Two defects surfaced by the first fully-instrumented failure on master (run [29385440051](https://github.com/kubeflow/pipelines/actions/runs/29385440051), follow-ups to #13715/#13706):

1. **The observability output is invisible to automation.** The failure-signature table and runner-telemetry stats render only into `GITHUB_STEP_SUMMARY`, which has no API — the telemetry that finally evidenced runner CPU oversubscription (load avg 16.9 / peak **28.1 on a 4-CPU runner** during the SeaweedFS dial-timeout window) could only be read by a human opening the job-summary page. Log-based consumers (tooling, the CI health report, anyone triaging via `gh api`) get nothing.

2. **A signature self-match.** The table reported `conntrack table full | 1` on a run whose dmesg read said "no table-full event logged": `collect-seaweedfs-diagnostics.sh` tees its own header line — `kernel 'nf_conntrack: table full' events:` — into the collected pod log, and the signature regex matched the header text.

## Change

- Both `failure-signature-summary.sh` and `runner-telemetry.sh` now **mirror their rendered output to stdout** (tee) in addition to the step summary, so the job log is a machine-readable record of the same data. Without `GITHUB_STEP_SUMMARY` set they write to stdout only, as before.
- The conntrack signature matches the kernel's actual message form, `nf_conntrack: table full, dropping packet`, so the diagnostics' own headers can never count as hits.

## Verification

- A fixture pod log containing the diagnostics header **plus one real kernel table-full line** now counts **1** (was 2).
- With `GITHUB_STEP_SUMMARY` set, both scripts emit identical content to the summary file and stdout; without it, stdout only. `bash -n` clean on both.

Context: the mirrored telemetry is what evidenced the current leading root cause for the `dial tcp <vip>: i/o timeout` family — sustained 4–7× CPU oversubscription of the shared runner — complementing #13720's parallelism reduction.