### PR TITLE
fix(ci): wait for delayed test readiness

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -31,6 +31,9 @@ on:
       - 'backend/**'
       - 'proxy/**'
       - 'manifests/kustomize/**'
+      # The artifact-proxy E2E script is exercised only by this workflow, so
+      # changes to it must trigger these lanes.
+      - 'test/artifact-proxy/**'
       - 'test_data/sdk_compiled_pipelines/**'
       - '!**/*.md'
       - '!**/OWNERS'

--- a/test/artifact-proxy/test-artifact-proxy.sh
+++ b/test/artifact-proxy/test-artifact-proxy.sh
@@ -12,16 +12,25 @@ kubectl -n "$NAMESPACE" run kfp-proxy-curl --image=curlimages/curl:8.7.1 --resta
 kubectl -n "$NAMESPACE" wait --for=condition=Ready pod/kfp-proxy-curl --timeout=300s
 
 # Test 1: Verify artifact proxy health endpoint
-HEALTH_RESPONSE=$(kubectl -n "$NAMESPACE" exec kfp-proxy-curl -- \
-  curl -fsS -H 'kubeflow-userid: user@example.com' \
-  "http://ml-pipeline-ui-artifact.${NAMESPACE}.svc.cluster.local/apis/v1beta1/healthz")
+HEALTH_RESPONSE=""
+for attempt in $(seq 1 30); do
+  if HEALTH_RESPONSE=$(kubectl -n "$NAMESPACE" exec kfp-proxy-curl -- \
+    curl -fsS -H 'kubeflow-userid: user@example.com' \
+    "http://ml-pipeline-ui-artifact.${NAMESPACE}.svc.cluster.local/apis/v1beta1/healthz") && \
+    jq -e '.apiServerReady == true' >/dev/null <<<"$HEALTH_RESPONSE"; then
+    break
+  fi
 
-if ! echo "$HEALTH_RESPONSE" | grep -q '"apiServerReady":true'; then
-  echo "ERROR: apiServerReady=false"
-  echo "Response: $HEALTH_RESPONSE"
-  kubectl -n "$NAMESPACE" logs deploy/ml-pipeline-ui-artifact -c ml-pipeline-ui-artifact --tail=50 || true
-  exit 1
-fi
+  if [[ "$attempt" -eq 30 ]]; then
+    echo "ERROR: Artifact proxy API server was not ready after 30 attempts"
+    echo "Response: $HEALTH_RESPONSE"
+    kubectl -n "$NAMESPACE" logs deploy/ml-pipeline-ui-artifact -c ml-pipeline-ui-artifact --tail=50 || true
+    exit 1
+  fi
+
+  echo "Waiting for artifact proxy API server to become ready... ($attempt/30)"
+  sleep 5
+done
 
 # Test 2: Verify proxy can list pipelines
 PIPELINES_RESPONSE=$(kubectl -n "$NAMESPACE" exec kfp-proxy-curl -- \

--- a/test/frontend-integration-test/helloworld.spec.js
+++ b/test/frontend-integration-test/helloworld.spec.js
@@ -37,7 +37,7 @@ const runWithoutExperimentDescription =
   'test run without experiment description ' + runWithoutExperimentName;
 const uiTimeout = 5000;
 const runStartTimeout = 30000;
-const runCompletionTimeout = 60000;
+const runCompletionTimeout = 180000;
 const logsLoadTimeout = 60000;
 const outputParameterValue = 'Hello world in test';
 


### PR DESCRIPTION
## Summary

- poll the artifact proxy health endpoint until the API server is ready
- retain the final health response and artifact-proxy logs when readiness times out
- increase the frontend hello-world run completion budget from one to three minutes

## Root cause

The artifact proxy can return a successful health response with
`apiServerReady: false` while its API server dependency is still starting. The
test treated that first response as final. Separately, the frontend integration
test allowed only 60 seconds for a hello-world workflow that can complete
successfully shortly after that deadline under CI load.

## Verification

- `bash -n test/artifact-proxy/test-artifact-proxy.sh`
- `node --check test/frontend-integration-test/helloworld.spec.js`
- `git diff --check`
- fake-kubectl execution covering recovery on a later health response
- fake-kubectl execution covering bounded exhaustion and diagnostic output
