### PR TITLE
ci(e2e): capture softirq backlog drops in dataplane diagnostics

### DIFF
--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -203,6 +203,41 @@ fi
     )
 
     echo
+    echo "----- runner-kernel softirq backlog (shared by every Kind node) -----"
+    # veth traffic is delivered through the per-CPU softirq backlog queue;
+    # when ksoftirqd is starved on a CPU-saturated runner the queue overflows
+    # and packets are dropped silently — upstream of every counter this script
+    # checks (conntrack, accept queue). Kind nodes are containers sharing the
+    # runner kernel and /proc/net/softnet_stat is kernel-global per-CPU state,
+    # so it is read once here on the runner host: reading it inside each node
+    # container would print identical counters under different node headings.
+    # Counters are cumulative, and runner VMs are ephemeral, so they are
+    # naturally scoped to this job. Current limits are recorded so the failure
+    # states what the backlog/budget were at the time.
+    if [[ -r /proc/net/softnet_stat ]]; then
+        row=0
+        while read -r -a fields; do
+            # Newer kernels omit offline CPUs from the file and expose the
+            # actual CPU id in field 13; the row ordinal is only a fallback
+            # for older 11-column kernels.
+            if [[ ${#fields[@]} -ge 13 ]]; then
+                cpu=$((16#${fields[12]}))
+            else
+                cpu=$row
+            fi
+            printf 'cpu%d processed=%d dropped=%d time_squeeze=%d\n' \
+                "$cpu" "$((16#${fields[0]}))" "$((16#${fields[1]}))" "$((16#${fields[2]}))"
+            row=$((row + 1))
+        done < /proc/net/softnet_stat
+        printf 'netdev_max_backlog=%s netdev_budget=%s netdev_budget_usecs=%s\n' \
+            "$(cat /proc/sys/net/core/netdev_max_backlog 2>/dev/null || echo '?')" \
+            "$(cat /proc/sys/net/core/netdev_budget 2>/dev/null || echo '?')" \
+            "$(cat /proc/sys/net/core/netdev_budget_usecs 2>/dev/null || echo '?')"
+    else
+        echo "(/proc/net/softnet_stat unavailable)"
+    fi
+
+    echo
     echo "----- (4) node netfilter state for timed-out ClusterIPs -----"
     echo "ClusterIPs correlated: $(printf '%s ' ${TARGET_VIPS:-<none>})"
     # Kind runs each node as a Docker container named after the Kubernetes node,
@@ -258,34 +293,6 @@ fi
                 else
                     echo "(no table-full event logged)"
                 fi' 2>/dev/null || echo "(unavailable)"
-
-            echo "softirq backlog (per CPU: processed / dropped / time_squeeze; nonzero dropped == packets lost before conntrack/socket):"
-            # veth traffic is delivered through the per-CPU softirq backlog
-            # queue; when ksoftirqd is starved on a CPU-saturated runner the
-            # queue overflows and packets are dropped silently — upstream of
-            # every counter this script already checks (conntrack, accept
-            # queue). /proc/net/softnet_stat column 2 is that drop counter
-            # (hex, cumulative — runners are ephemeral VMs so it is scoped to
-            # the job); column 3 counts budget exhaustion (time_squeeze).
-            # Current limits are recorded so the failure states what the
-            # backlog/budget were at the time.
-            docker exec "$node" sh -c '
-                if [ ! -r /proc/net/softnet_stat ]; then
-                    echo "(/proc/net/softnet_stat unavailable)"
-                    exit 0
-                fi
-                # Fields are hex; POSIX $((0x...)) conversion avoids relying
-                # on gawk-only strtonum (node images ship mawk).
-                i=0
-                while read -r c1 c2 c3 _; do
-                    printf "cpu%d processed=%d dropped=%d time_squeeze=%d\n" \
-                        "$i" "$((0x$c1))" "$((0x$c2))" "$((0x$c3))"
-                    i=$((i + 1))
-                done < /proc/net/softnet_stat
-                printf "netdev_max_backlog=%s netdev_budget=%s netdev_budget_usecs=%s\n" \
-                    "$(cat /proc/sys/net/core/netdev_max_backlog 2>/dev/null || echo "?")" \
-                    "$(cat /proc/sys/net/core/netdev_budget 2>/dev/null || echo "?")" \
-                    "$(cat /proc/sys/net/core/netdev_budget_usecs 2>/dev/null || echo "?")"' 2>/dev/null || echo "(unavailable)"
 
             # Per-VIP service program end to end (KUBE-SERVICES -> KUBE-SVC ->
             # KUBE-SEP DNAT): a live DNAT to the pod means the rule is not the

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -259,6 +259,34 @@ fi
                     echo "(no table-full event logged)"
                 fi' 2>/dev/null || echo "(unavailable)"
 
+            echo "softirq backlog (per CPU: processed / dropped / time_squeeze; nonzero dropped == packets lost before conntrack/socket):"
+            # veth traffic is delivered through the per-CPU softirq backlog
+            # queue; when ksoftirqd is starved on a CPU-saturated runner the
+            # queue overflows and packets are dropped silently — upstream of
+            # every counter this script already checks (conntrack, accept
+            # queue). /proc/net/softnet_stat column 2 is that drop counter
+            # (hex, cumulative — runners are ephemeral VMs so it is scoped to
+            # the job); column 3 counts budget exhaustion (time_squeeze).
+            # Current limits are recorded so the failure states what the
+            # backlog/budget were at the time.
+            docker exec "$node" sh -c '
+                if [ ! -r /proc/net/softnet_stat ]; then
+                    echo "(/proc/net/softnet_stat unavailable)"
+                    exit 0
+                fi
+                # Fields are hex; POSIX $((0x...)) conversion avoids relying
+                # on gawk-only strtonum (node images ship mawk).
+                i=0
+                while read -r c1 c2 c3 _; do
+                    printf "cpu%d processed=%d dropped=%d time_squeeze=%d\n" \
+                        "$i" "$((0x$c1))" "$((0x$c2))" "$((0x$c3))"
+                    i=$((i + 1))
+                done < /proc/net/softnet_stat
+                printf "netdev_max_backlog=%s netdev_budget=%s netdev_budget_usecs=%s\n" \
+                    "$(cat /proc/sys/net/core/netdev_max_backlog 2>/dev/null || echo "?")" \
+                    "$(cat /proc/sys/net/core/netdev_budget 2>/dev/null || echo "?")" \
+                    "$(cat /proc/sys/net/core/netdev_budget_usecs 2>/dev/null || echo "?")"' 2>/dev/null || echo "(unavailable)"
+
             # Per-VIP service program end to end (KUBE-SERVICES -> KUBE-SVC ->
             # KUBE-SEP DNAT): a live DNAT to the pod means the rule is not the
             # problem; an empty chain means no ready backend.


### PR DESCRIPTION
## Problem

Runner telemetry from the first fully-instrumented SeaweedFS `dial tcp <vip>:9000: i/o timeout` failure (run [29385440051](https://github.com/kubeflow/pipelines/actions/runs/29385440051)) showed the 4-CPU runner at **load 17–28 for the whole 12-minute window**, while every drop point instrumented so far came back clean: conntrack at 0.7% with no table-full events and negligible `insert_failed`, KUBE-SEP DNAT present, and `ListenOverflows=0` inside the pod (accept queue never overflowed — disproving the previous leading hypothesis).

The one drop point **upstream of all of those** is the per-CPU softirq backlog: veth traffic is delivered through it, and when `ksoftirqd` is starved on a saturated host, the queue (default cap 1000) overflows and packets are dropped silently — before conntrack, before iptables, before the socket. That matches the failure signature exactly: SYNs to the ClusterIP vanish while every k8s-level health check passes.

## Change

Extend the node-dataplane section of `collect-seaweedfs-diagnostics.sh` to capture, per Kind node:

- `/proc/net/softnet_stat` decoded per CPU — `processed / dropped / time_squeeze` (`dropped` = backlog overflow, the direct counter for this mechanism; `time_squeeze` = softirq budget exhaustion). Hex fields are converted with POSIX `$((0x…))` arithmetic — node images ship mawk, which lacks gawk's `strtonum`.
- The current `netdev_max_backlog` / `netdev_budget` / `netdev_budget_usecs` values, so each failure records what the limits were at the time.

Runner VMs are ephemeral, so the cumulative counters are naturally scoped to the job.

## Why diagnostics-only (no sysctl bump yet)

Raising the limits in the same change would confound the experiment: a zero `dropped` counter could mean either "hypothesis wrong" or "the bump absorbed the drops." This captures one clean read of the untouched system first:

- **`dropped` > 0 on the next failure** → mechanism confirmed; a follow-up raises `netdev_max_backlog`/budget with confidence and the CI health report measures the delta.
- **`dropped` = 0 while dial-timeouts persist** → hypothesis refuted; investigation redirects (pod-side veth, SYN-ACK direction).

Same falsify-or-confirm pattern that eliminated the conntrack (#13686/#13706) and accept-queue (#13706) theories.

## Verification

- `bash -n` clean.
- Hex decoding verified against a realistic `softnet_stat` fixture (`0x4a1 → dropped=1185`, `0x155 → time_squeeze=341`); best-effort guards for missing `/proc` files preserved.

Follow-up to #13706; complements #13720's load reduction.