### PR TITLE
ci: retry Buildx bootstrap in image builds

### DIFF
--- a/.github/workflows/image-builds.yml
+++ b/.github/workflows/image-builds.yml
@@ -123,8 +123,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        id: setup-buildx
+        shell: bash
+        run: bash ./.github/resources/scripts/setup-buildx-with-retry.sh
 
       - name: Build and save Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary

- use the existing Buildx bootstrap retry helper in the reusable test-image workflow
- retry builder creation and BuildKit bootstrap up to three times with 20-second backoff
- keep the existing image build/rebuild and artifact behavior unchanged

## Root cause

Six image jobs across four master workflows failed before their builds began
when `docker/setup-buildx-action` could not pull
`moby/buildkit:buildx-stable-1` from Docker Hub due to TLS handshake and header
timeouts. The existing rebuild fallback starts after Buildx setup, so it could
not recover these failures.

The repository already uses `setup-buildx-with-retry.sh` for release image
builds. This change reuses that helper at the remaining direct setup call site.

## Verification

- `bash -n .github/resources/scripts/setup-buildx-with-retry.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/image-builds.yml`
- Ruby YAML parsing of `.github/workflows/image-builds.yml`
- `git diff --check`
- fake-Docker execution verifying recovery after two failed BuildKit bootstraps
