### PR TITLE
fix(sdk): stop interpolating condition values into local eval()

### DIFF
--- a/sdk/python/kfp/local/orchestrator/enhanced_dag_orchestrator.py
+++ b/sdk/python/kfp/local/orchestrator/enhanced_dag_orchestrator.py
@@ -132,6 +132,20 @@ class ConditionEvaluator:
         try:
             safe_condition = condition
 
+            # Resolved channel/parameter values are bound as eval() variables
+            # rather than interpolated into the expression text. A task output
+            # can carry data from outside the pipeline (a fetched URL, a file, a
+            # message), and textual substitution let such a value break out of
+            # its string literal and inject arbitrary Python into the eval'd
+            # source (`__builtins__` being empty does not contain that). Binding
+            # keeps values as opaque data that cannot alter expression structure.
+            resolved_values: Dict[str, Any] = {}
+
+            def bind_value(value: Any) -> str:
+                name = f'__kfp_value_{len(resolved_values)}'
+                resolved_values[name] = value
+                return name
+
             # Handle CEL-style inputs.parameter_values['param_name'] references
             cel_pattern = r"inputs\.parameter_values\['([^']+)'\]"
             cel_matches = re.findall(cel_pattern, condition)
@@ -139,12 +153,9 @@ class ConditionEvaluator:
                 value = ConditionEvaluator._resolve_pipeline_channel(
                     param_name, io_store)
                 if value is not None:
-                    if isinstance(value, str):
-                        replacement = f"'{value}'"
-                    else:
-                        replacement = str(value)
                     safe_condition = safe_condition.replace(
-                        f"inputs.parameter_values['{param_name}']", replacement)
+                        f"inputs.parameter_values['{param_name}']",
+                        bind_value(value))
                 else:
                     logging.warning(
                         f'Could not resolve CEL parameter: {param_name}')
@@ -157,12 +168,8 @@ class ConditionEvaluator:
                 value = ConditionEvaluator._resolve_pipeline_channel(
                     channel_ref, io_store)
                 if value is not None:
-                    if isinstance(value, str):
-                        safe_condition = safe_condition.replace(
-                            channel_ref, f"'{value}'")
-                    else:
-                        safe_condition = safe_condition.replace(
-                            channel_ref, str(value))
+                    safe_condition = safe_condition.replace(
+                        channel_ref, bind_value(value))
                 else:
                     logging.warning(
                         f'Could not resolve channel reference: {channel_ref}')
@@ -195,7 +202,7 @@ class ConditionEvaluator:
                 'max': max,
             }
 
-            result = eval(safe_condition, allowed_names, {})
+            result = eval(safe_condition, allowed_names, resolved_values)
             return bool(result)
 
         except Exception as e:

--- a/sdk/python/kfp/local/orchestrator/enhanced_dag_orchestrator_test.py
+++ b/sdk/python/kfp/local/orchestrator/enhanced_dag_orchestrator_test.py
@@ -1,0 +1,87 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for enhanced_dag_orchestrator.py."""
+import unittest
+
+from kfp.local import io
+from kfp.local.orchestrator import enhanced_dag_orchestrator
+
+ConditionEvaluator = enhanced_dag_orchestrator.ConditionEvaluator
+
+
+class TestConditionEvaluator(unittest.TestCase):
+
+    def _store_with_output(self, value):
+        io_store = io.IOStore()
+        io_store.put_task_output('t', 'Output', value)
+        return io_store
+
+    def test_empty_condition_is_true(self):
+        self.assertTrue(ConditionEvaluator.evaluate_condition('', io.IOStore()))
+
+    def test_channel_equality_match(self):
+        self.assertTrue(
+            ConditionEvaluator.evaluate_condition(
+                "pipelinechannel--t-Output == 'expected'",
+                self._store_with_output('expected')))
+
+    def test_channel_equality_no_match(self):
+        self.assertFalse(
+            ConditionEvaluator.evaluate_condition(
+                "pipelinechannel--t-Output == 'expected'",
+                self._store_with_output('other')))
+
+    def test_int_value_preserved(self):
+        self.assertTrue(
+            ConditionEvaluator.evaluate_condition(
+                'pipelinechannel--t-Output == 5', self._store_with_output(5)))
+
+    def test_bool_value_preserved(self):
+        self.assertTrue(
+            ConditionEvaluator.evaluate_condition(
+                'pipelinechannel--t-Output', self._store_with_output(True)))
+
+    def test_cel_parameter_reference(self):
+        io_store = io.IOStore()
+        io_store.put_parent_input('p', 'a')
+        self.assertTrue(
+            ConditionEvaluator.evaluate_condition(
+                "inputs.parameter_values['p'] == 'a'", io_store))
+
+    def test_quote_breakout_is_not_injected(self):
+        # A task output that carries data from outside the pipeline must be
+        # compared as a literal, never spliced into the evaluated expression.
+        # Before binding values, this payload closed the string literal and
+        # OR-ed in `True`, forcing the branch to run regardless of the value.
+        payload = "x' or True or 'x"
+        self.assertFalse(
+            ConditionEvaluator.evaluate_condition(
+                "pipelinechannel--t-Output == 'expected'",
+                self._store_with_output(payload)))
+
+    def test_sandbox_escape_payload_is_treated_as_data(self):
+        # `__builtins__` being empty does not stop object-graph traversal such
+        # as ().__class__.__base__.__subclasses__(); if the value reached the
+        # expression text this would evaluate. Bound as data, it stays inert
+        # and the equality is simply False.
+        payload = ("x' == '' or [c for c in "
+                   "().__class__.__base__.__subclasses__()] or 'x")
+        self.assertFalse(
+            ConditionEvaluator.evaluate_condition(
+                "pipelinechannel--t-Output == 'expected'",
+                self._store_with_output(payload)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of your changes:**

Repro: run a local pipeline with a control-flow branch (`dsl.If`/`dsl.Condition`) whose predicate compares a task output, and let that output carry a value from outside the pipeline. A value such as `x' or True or 'x` reaches `ConditionEvaluator.evaluate_condition`.
Cause: resolved channel/parameter values are string-interpolated into the condition text before `eval()`, so a value can close its own string literal and inject Python into the evaluated source. The empty `__builtins__` does not contain this: object-graph traversal via `().__class__.__base__.__subclasses__()` still runs, so it is code execution in the orchestrator process, not just a wrong branch.
Fix: bind resolved values as named `eval()` variables (opaque data) instead of splicing them into the source. The CEL/channel structure that the compiler emits is author-defined and unchanged, so valid conditions evaluate identically while a value can no longer alter expression structure. Added a unit test that fails on the old code (both the boolean-subversion and the subclass-traversal payloads) and passes now.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
