### PR TITLE
fix(frontend): fix s3 artifact download with secret-backed providerInfo

### DIFF
--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -1451,5 +1451,53 @@ describe('/artifacts', () => {
         .get('/artifacts/minio/ml-pipeline/hello/world.txt') // url
         .expect(200, tarGzBuffer.toString());
     });
+
+    it('downloads an s3-compatible artifact using secret-backed providerInfo from the query string', async () => {
+      // The download link (path-based route) must honor providerInfo so that
+      // secret-backed S3-compatible credentials are used instead of falling
+      // through to the AWS instance-profile chain.
+      const mockedMinioClient: Mock = minio.Client as any;
+      const mockedGetK8sSecret: Mock = getK8sSecret as any;
+      mockedGetK8sSecret.mockResolvedValue('someSecret');
+      const configs = loadConfigs(argv, {});
+      app = new UIServer(configs);
+      const request = requests(app.app);
+      const providerInfo = {
+        Params: {
+          accessKeyKey: 'accesskey',
+          disableSSL: 'true',
+          endpoint: 'seaweedfs.kubeflow.svc.cluster.local:9000',
+          fromEnv: 'false',
+          region: 'us-east-1',
+          secretKeyKey: 'secretkey',
+          secretName: 'mlpipeline-minio-artifact',
+        },
+        Provider: 's3',
+      };
+      // Provider Secret access is only permitted in the server's own namespace.
+      const namespace = 'kubeflow';
+      await request
+        .get(
+          `/artifacts/s3/ml-pipeline/hello/world.txt?namespace=${namespace}&providerInfo=${JSON.stringify(
+            providerInfo,
+          )}`,
+        )
+        .expect(200, artifactContent);
+      expect(mockedMinioClient).toBeCalledWith({
+        accessKey: 'someSecret',
+        endPoint: 'seaweedfs.kubeflow.svc.cluster.local',
+        port: 9000,
+        region: 'us-east-1',
+        secretKey: 'someSecret',
+        useSSL: false,
+      });
+      expect(mockedMinioClient).toBeCalledTimes(1);
+      expect(mockedGetK8sSecret).toBeCalledWith(
+        'mlpipeline-minio-artifact',
+        'accesskey',
+        namespace,
+      );
+      expect(mockedGetK8sSecret).toBeCalledTimes(2);
+    });
   });
 });

--- a/frontend/server/integration-tests/artifact-proxy.test.ts
+++ b/frontend/server/integration-tests/artifact-proxy.test.ts
@@ -138,6 +138,30 @@ describe('/artifacts/get namespaced proxy', () => {
     );
   });
 
+  it('preserves providerInfo when proxying a download request (issue #13717)', async () => {
+    const { receivedUrls } = await setUpNamespacedArtifactService({
+      namespace: 'ns2',
+    });
+    const configs = loadConfigs(argv, {
+      ARTIFACTS_SERVICE_PROXY_NAME: 'artifact-svc',
+      ARTIFACTS_SERVICE_PROXY_PORT: '80',
+      ARTIFACTS_SERVICE_PROXY_ENABLED: 'true',
+    });
+    app = new UIServer(configs);
+    await requests(app.app)
+      .get(
+        `/artifacts/s3/mlpipeline/model${buildQuery({
+          namespace: 'ns2',
+          providerInfo: '{"Provider":"s3"}',
+        })}`,
+      )
+      .expect(200, 'artifact service in ns2');
+    expect(receivedUrls).toEqual(
+      // same url, except the namespace query is omitted and providerInfo is kept
+      ['/artifacts/s3/mlpipeline/model?providerInfo=%7B%22Provider%22%3A%22s3%22%7D'],
+    );
+  });
+
   it('does not proxy requests without namespace argument', async () => {
     setupMinioArtifactDeps({ content: 'text-data2' });
     const configs = loadConfigs(argv, { ARTIFACTS_SERVICE_PROXY_ENABLED: 'true' });

--- a/frontend/src/components/ArtifactPreview.test.tsx
+++ b/frontend/src/components/ArtifactPreview.test.tsx
@@ -88,6 +88,24 @@ describe('ArtifactPreview', () => {
     );
   });
 
+  it('carries providerInfo from the session map into download and view links', async () => {
+    vi.spyOn(Apis, 'readFile').mockResolvedValueOnce('s3 content');
+    const sessionMap = new Map([['s3://bucket/key', '{"Provider":"s3"}']]);
+    render(
+      <CommonTestWrapper>
+        <ArtifactPreview value={'s3://bucket/key'} namespace={'kubeflow'} sessionMap={sessionMap} />
+      </CommonTestWrapper>,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('View All').getAttribute('href')).toEqual(
+        'artifacts/get?source=s3&namespace=kubeflow&providerInfo=%7B%22Provider%22%3A%22s3%22%7D&bucket=bucket&key=key',
+      ),
+    );
+    expect(screen.getByText('s3://bucket/key').getAttribute('href')).toEqual(
+      'artifacts/s3/bucket/key?namespace=kubeflow&providerInfo=%7B%22Provider%22%3A%22s3%22%7D',
+    );
+  });
+
   it('handles artifact that previews with maxlines', async () => {
     const data = `012\n345\n678\n910`;
     vi.spyOn(Apis, 'readFile').mockResolvedValueOnce(data);

--- a/frontend/src/components/ArtifactPreview.tsx
+++ b/frontend/src/components/ArtifactPreview.tsx
@@ -95,9 +95,10 @@ const ArtifactPreview: React.FC<ArtifactPreviewProps> = ({
   const artifactDownloadUrl = Apis.buildReadFileUrl({
     path: storage,
     namespace,
+    providerInfo,
     isDownload: true,
   });
-  const artifactViewUrl = Apis.buildReadFileUrl({ path: storage, namespace });
+  const artifactViewUrl = Apis.buildReadFileUrl({ path: storage, namespace, providerInfo });
 
   return (
     <div className={css.root}>

--- a/frontend/src/lib/Apis.test.ts
+++ b/frontend/src/lib/Apis.test.ts
@@ -169,6 +169,23 @@ describe('Apis', () => {
     );
   });
 
+  it('buildReadFileUrl for download carries providerInfo', () => {
+    expect(
+      Apis.buildReadFileUrl({
+        path: {
+          bucket: 'testbucket',
+          key: 'testkey',
+          source: StorageService.S3,
+        },
+        namespace: 'testnamespace',
+        providerInfo: '{"Provider":"s3"}',
+        isDownload: true,
+      }),
+    ).toEqual(
+      'artifacts/s3/testbucket/testkey?namespace=testnamespace&providerInfo=%7B%22Provider%22%3A%22s3%22%7D',
+    );
+  });
+
   it('buildArtifactLinkText', () => {
     expect(
       Apis.buildArtifactLinkText({


### PR DESCRIPTION
## Description

For an `s3://` pipeline root with secret-backed credentials (`fromEnv: false` and `secretRef`), clicking an artifact fails to download with `Unable to get aws instance profile credentials: CredentialsProviderError` in the artifact pod, when `ARTIFACTS_PROXY_ENABLED=true`.

Closes #13717 

## Root cause

In `ArtifactPreview.tsx`, `providerInfo` is resolved from the session map and passed to the inline preview fetch, but not to the two `Apis.buildReadFileUrl` calls that build the download link and the "View All" link. The request reaches the server without `providerInfo`, so `createMinioClient` skips the secret-backed branch and, for an `s3` source, falls through to the AWS credential chain.

## Fix

Pass `providerInfo` into both `buildReadFileUrl` calls. `buildReadFileUrl` already appends it on both the path-based and query-based routes, and the server already reads it from the query string on both — so this is the only change needed. Both links are fixed since they share the same omission.

## Testing

- `Apis.test.ts` — `buildReadFileUrl` carries `providerInfo` on the download route
- `ArtifactPreview.test.tsx` — `providerInfo` flows into both hrefs
- `artifact-get.test.ts` — server honors `providerInfo` on the path-based download route and builds the client from the Secret
- `artifact-proxy.test.ts` — the namespaced proxy strips `namespace` but preserves `providerInfo`

Verified by the tests above; a live multi-user cluster run is not included.