### PR TITLE
ci: capture service SNAT path counters

### DIFF
--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -12,14 +12,14 @@
 #   1. SeaweedFS crashed/restarted   -> pod restart count and last terminated
 #                                        state (OOMKilled, etc.)
 #   2. Node CPU/memory contention    -> node allocated requests vs allocatable
-#                                        and node pressure conditions. The
-#                                        SeaweedFS deployment sets a CPU request
-#                                        (no limit), so scheduling shares only
-#                                        matter when the node is contended.
+#                                        and node pressure conditions. These are
+#                                        scheduling context, not actual CPU-use
+#                                        measurements, so runner telemetry is
+#                                        still needed to assess live contention.
 #   3. Cluster dataplane failure     -> SeaweedFS is Running with no restarts
 #                                        and the node is healthy, yet the
 #                                        ClusterIP path times out (kube-proxy /
-#                                        CNI). Ruled in by 1 and 2 being clean
+#                                        CNI). Narrowed by 1 and 2 being clean
 #                                        plus kube-proxy pod state, and probed
 #                                        directly in sections (4) and (5).
 #
@@ -39,15 +39,17 @@
 # node conntrack table fills, new SYNs are dropped and every dial reports 'i/o
 # timeout' while the backing pod's own liveness probe (kubelet -> pod IP) keeps
 # passing, so the pod is never restarted. Per node it dumps the node-global
-# conntrack state once -- the durable drop/insert_failed counters (conntrack -S,
-# falling back to /proc/net/stat/nf_conntrack) and any 'nf_conntrack: table
-# full' dmesg line -- then the iptables/ipvs program for each failed
-# ClusterIP, followed end to end (KUBE-SERVICES -> KUBE-SVC -> KUBE-SEP DNAT) so
-# a live endpoint DNAT rules out a missing/stale service program.
+# conntrack state once -- the cumulative drop/insert_failed counters (conntrack
+# -S, falling back to /proc/net/stat/nf_conntrack) and any 'nf_conntrack: table
+# full' dmesg line -- then the counter-bearing iptables/ipvs program for each
+# failed ClusterIP. The program is followed end to end (KUBE-SERVICES ->
+# KUBE-SVC -> KUBE-SEP DNAT), including the mark/postrouting rules that show
+# whether matching traffic is eligible for SNAT and whether MASQUERADE uses
+# --random-fully. A live endpoint DNAT rules out a missing/stale service program.
 #
 # When the conntrack table and the service program are both clean (as first
 # observed live: table ~0.6% full, no table-full event, KUBE-SEP DNAT present),
-# the remaining candidate is accept-queue saturation on the backing pod itself.
+# another candidate is accept-queue saturation on the backing pod itself.
 # Section (6) reads the SeaweedFS pod's listen sockets and cumulative
 # ListenOverflows / ListenDrops from inside its netns to confirm or rule that
 # out. Each probe distinguishes a failed/forbidden query from a genuinely empty
@@ -89,18 +91,26 @@ emit() {
 
 # Dump the iptables (or ipvs fallback) program for one ClusterIP:port on one
 # Kind node, following the chain end to end: the KUBE-SERVICES match, the
-# KUBE-SVC chain for the port, and the KUBE-SEP DNAT to the backing pod. A live
-# KUBE-SEP DNAT proves kube-proxy programmed a real endpoint (so a dial timeout
-# is not a missing/stale rule); an empty KUBE-SVC chain means no ready backend.
+# KUBE-SVC chain for the port, and each KUBE-SEP rule for the backing pod. With
+# iptables-save -c, every printed rule carries its cumulative packet/byte
+# counters. A live KUBE-SEP DNAT proves kube-proxy programmed a real endpoint
+# (so a dial timeout is not a missing/stale rule); an empty KUBE-SVC chain means
+# no ready backend. Node-wide KUBE-MARK-MASQ and KUBE-POSTROUTING rules are
+# printed once separately rather than repeated for every failed VIP.
 # Tracks whether a ruleset was actually read so a missing iptables-save /
 # ipvsadm binary reports "cannot confirm", never a false "no rule".
 # Usage: probe_service_rules <node> <ip> <port>
 probe_service_rules() {
     docker exec "$1" sh -c '
         ip=$1; port=$2
-        rules=$(iptables-save 2>/dev/null)
+        if rules=$(iptables-save -c 2>/dev/null) && [ -n "$rules" ]; then
+            counter_note="iptables counters: cumulative [packets:bytes] values"
+        else
+            rules=$(iptables-save 2>/dev/null)
+            counter_note="iptables packet counters unavailable"
+        fi
         if [ -z "$rules" ]; then
-            if ipvs=$(ipvsadm -Ln 2>/dev/null); then
+            if ipvs=$(ipvsadm -Ln --stats 2>/dev/null || ipvsadm -Ln 2>/dev/null); then
                 printf "%s\n" "$ipvs" | grep -A6 "$ip:$port" \
                     || echo "(no ipvs entry for $ip:$port)"
             else
@@ -108,7 +118,8 @@ probe_service_rules() {
             fi
             exit 0
         fi
-        svc_rules=$(printf "%s\n" "$rules" | grep -F "$ip" | grep -E "KUBE-SERVICES|KUBE-MARK-MASQ")
+        echo "  $counter_note"
+        svc_rules=$(printf "%s\n" "$rules" | grep -F "$ip" | grep -E -- "-A KUBE-SERVICES ")
         if [ -n "$svc_rules" ]; then
             printf "%s\n" "$svc_rules"
         else
@@ -131,10 +142,53 @@ probe_service_rules() {
             echo "    (no KUBE-SEP endpoint jump — VIP has no live backend)"
         else
             for sep in $seps; do
-                printf "%s\n" "$rules" | grep -E -- "-A $sep .*(DNAT|to-destination)" | sed "s/^/    /" \
-                    || echo "    ($sep: no DNAT rule)"
+                sep_rules=$(printf "%s\n" "$rules" | grep -E -- "-A $sep ")
+                if [ -n "$sep_rules" ]; then
+                    printf "%s\n" "$sep_rules" | sed "s/^/    /"
+                else
+                    echo "    ($sep: no endpoint rules)"
+                fi
             done
         fi' _ "$2" "$3" 2>/dev/null || echo "(unavailable)"
+}
+
+# Dump the node-wide SNAT plumbing once. Per-VIP KUBE-SVC/KUBE-SEP counters
+# above show whether a matching flow jumped to KUBE-MARK-MASQ; these global
+# rules only show what happens after that mark is set.
+# Usage: probe_masquerade_rules <node>
+probe_masquerade_rules() {
+    docker exec "$1" sh -c '
+        if rules=$(iptables-save -c 2>/dev/null) && [ -n "$rules" ]; then
+            echo "iptables counters: cumulative [packets:bytes] values"
+        else
+            rules=$(iptables-save 2>/dev/null)
+            echo "iptables packet counters unavailable"
+        fi
+        if [ -z "$rules" ]; then
+            echo "(iptables-save unavailable — cannot inspect masquerade rules)"
+            exit 0
+        fi
+
+        mark_rules=$(printf "%s\n" "$rules" | grep -E -- "-A KUBE-MARK-MASQ ")
+        if [ -n "$mark_rules" ]; then
+            printf "%s\n" "$mark_rules"
+        else
+            echo "(KUBE-MARK-MASQ rule unavailable)"
+        fi
+
+        postrouting_rules=$(printf "%s\n" "$rules" \
+            | grep -E -- "-A KUBE-POSTROUTING .*MASQUERADE")
+        if [ -n "$postrouting_rules" ]; then
+            printf "%s\n" "$postrouting_rules"
+            if printf "%s\n" "$postrouting_rules" | grep -q -- "--random-fully"; then
+                echo "MASQUERADE --random-fully: enabled"
+            else
+                echo "MASQUERADE --random-fully: not present"
+            fi
+        else
+            echo "(KUBE-POSTROUTING MASQUERADE rule unavailable)"
+            echo "MASQUERADE --random-fully: cannot determine"
+        fi' 2>/dev/null || echo "(unavailable)"
 }
 
 # Snapshot the Kubernetes objects behind one failed ClusterIP. Unlike the
@@ -407,11 +461,14 @@ fi
             # Point-in-time gauge; may have drained by the time diagnostics run.
             docker exec "$node" sh -c 'cat /proc/sys/net/netfilter/nf_conntrack_count /proc/sys/net/netfilter/nf_conntrack_max 2>/dev/null | paste -sd/ -' 2>/dev/null || echo "(unavailable)"
 
-            echo "conntrack drop / insert_failed counters (durable; nonzero == table pressure):"
+            echo "conntrack insertion/drop counters (cumulative node-wide; nonzero requires correlation):"
             # Cumulative-since-boot counters survive the burst draining, unlike
-            # the in-use gauge above. 'conntrack -S' is the reliable source;
-            # /proc/net/stat/nf_conntrack is a fallback but was observed absent
-            # on some Kind node kernels, so try the CLI first.
+            # the in-use gauge above, but are not attributed to a VIP or time
+            # window. insert_failed/drop can indicate unresolved tuple clashes
+            # or other insertion failures; table pressure requires supporting
+            # early_drop/table-full evidence. 'conntrack -S' is the reliable
+            # source; /proc/net/stat/nf_conntrack is a fallback but was observed
+            # absent on some Kind node kernels, so try the CLI first.
             docker exec "$node" sh -c '
                 if command -v conntrack >/dev/null 2>&1 && conntrack -S 2>/dev/null; then
                     :
@@ -432,6 +489,10 @@ fi
                 else
                     echo "(no table-full event logged)"
                 fi' 2>/dev/null || echo "(unavailable)"
+
+            echo "node-wide SNAT / masquerade plumbing:"
+            echo "(only flows whose KUBE-SVC/KUBE-SEP rule jumps to KUBE-MARK-MASQ use this path)"
+            probe_masquerade_rules "$node"
 
             # Per-VIP service program end to end (KUBE-SERVICES -> KUBE-SVC ->
             # KUBE-SEP DNAT): a live DNAT to the pod means the rule is not the

--- a/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
+++ b/.github/resources/scripts/collect-seaweedfs-diagnostics.sh
@@ -111,7 +111,7 @@ probe_service_rules() {
         fi
         if [ -z "$rules" ]; then
             if ipvs=$(ipvsadm -Ln --stats 2>/dev/null || ipvsadm -Ln 2>/dev/null); then
-                printf "%s\n" "$ipvs" | grep -A6 "$ip:$port" \
+                printf "%s\n" "$ipvs" | grep -F -A6 -- "$ip:$port" \
                     || echo "(no ipvs entry for $ip:$port)"
             else
                 echo "(iptables-save and ipvsadm both unavailable — cannot confirm rule presence)"

--- a/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
+++ b/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
@@ -245,12 +245,26 @@ class CollectSeaweedfsDiagnosticsTest(unittest.TestCase):
                     output.count('node-wide SNAT / masquerade plumbing:'), 1
                 )
 
+    def test_ipvs_fallback_matches_vip_and_port_literally(self):
+        result = self._run_with_fake_cluster(
+            'dial tcp 10.96.1.1:9000: i/o timeout\n',
+            {'FAKE_KIND_NODES': 'true'},
+            docker_script=_FAKE_DOCKER,
+            iptables_save_script='#!/usr/bin/env bash\nexit 1\n',
+            ipvsadm_script=_FAKE_IPVSADM,
+        )
+
+        self.assertIn('10.96.1.1:9000', result.stdout)
+        self.assertIn('10.244.0.20:8333', result.stdout)
+        self.assertNotIn('regex-decoy', result.stdout)
+
     def _run_with_fake_cluster(
         self,
         failure_text: str,
         extra_environment=None,
         docker_script='#!/usr/bin/env bash\nexit 1\n',
         iptables_save_script=None,
+        ipvsadm_script=None,
     ):
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)
@@ -264,6 +278,8 @@ class CollectSeaweedfsDiagnosticsTest(unittest.TestCase):
                 self._write_executable(
                     bin_directory / 'iptables-save', iptables_save_script
                 )
+            if ipvsadm_script is not None:
+                self._write_executable(bin_directory / 'ipvsadm', ipvsadm_script)
             environment = os.environ.copy()
             environment['PATH'] = f'{bin_directory}:{environment["PATH"]}'
             environment.update(extra_environment or {})
@@ -407,6 +423,22 @@ cat <<EOF
 [11:660] -A KUBE-SEP-SEAWEED -p tcp -j DNAT --to-destination 10.244.0.20:8333
 [0:0] -A KUBE-MARK-MASQ -j MARK --set-xmark 0x4000/0x4000
 [0:0] -A KUBE-POSTROUTING -m mark --mark 0x4000/0x4000 -j MASQUERADE${random_fully}
+EOF
+'''
+
+_FAKE_IPVSADM = r'''#!/usr/bin/env bash
+cat <<'EOF'
+TCP  10x96x1x1:9000 rr
+  -> regex-decoy:8333           Masq    1      0          0
+decoy-context-1
+decoy-context-2
+decoy-context-3
+decoy-context-4
+decoy-context-5
+decoy-context-6
+decoy-context-7
+TCP  10.96.1.1:9000 rr
+  -> 10.244.0.20:8333           Masq    1      0          0
 EOF
 '''
 

--- a/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
+++ b/.github/resources/scripts/collect_seaweedfs_diagnostics_test.py
@@ -190,7 +190,68 @@ class CollectSeaweedfsDiagnosticsTest(unittest.TestCase):
         self.assertIn('(EndpointSlice backend lookup unavailable)', result.stdout)
         self.assertNotIn('(no EndpointSlice backends found)', result.stdout)
 
-    def _run_with_fake_cluster(self, failure_text: str, extra_environment=None):
+    def test_reports_counted_service_and_masquerade_rules(self):
+        for random_fully, expected_status in (
+            ('true', 'enabled'),
+            ('false', 'not present'),
+        ):
+            with self.subTest(random_fully=random_fully):
+                result = self._run_with_fake_cluster(
+                    'dial tcp 10.96.1.1:9000: i/o timeout\n',
+                    {
+                        'FAKE_KIND_NODES': 'true',
+                        'RANDOM_FULLY': random_fully,
+                    },
+                    docker_script=_FAKE_DOCKER,
+                    iptables_save_script=_FAKE_IPTABLES_SAVE,
+                )
+                output = result.stdout
+
+                self.assertIn(
+                    'conntrack insertion/drop counters '
+                    '(cumulative node-wide; nonzero requires correlation)',
+                    output,
+                )
+                self.assertNotIn('nonzero == table pressure', output)
+                self.assertIn(
+                    'iptables counters: cumulative [packets:bytes] values',
+                    output,
+                )
+                self.assertIn(
+                    '[11:660] -A KUBE-SERVICES -d 10.96.1.1/32', output
+                )
+                self.assertIn(
+                    '[0:0] -A KUBE-SVC-SEAWEED ! -s 10.244.0.0/16', output
+                )
+                self.assertIn(
+                    '[0:0] -A KUBE-SEP-SEAWEED -s 10.244.0.20/32', output
+                )
+                self.assertIn(
+                    '[11:660] -A KUBE-SEP-SEAWEED -p tcp', output
+                )
+                self.assertIn(
+                    '[0:0] -A KUBE-POSTROUTING -m mark --mark 0x4000/0x4000',
+                    output,
+                )
+                self.assertIn(
+                    '[0:0] -A KUBE-MARK-MASQ -j MARK '
+                    '--set-xmark 0x4000/0x4000',
+                    output,
+                )
+                self.assertIn(
+                    f'MASQUERADE --random-fully: {expected_status}', output
+                )
+                self.assertEqual(
+                    output.count('node-wide SNAT / masquerade plumbing:'), 1
+                )
+
+    def _run_with_fake_cluster(
+        self,
+        failure_text: str,
+        extra_environment=None,
+        docker_script='#!/usr/bin/env bash\nexit 1\n',
+        iptables_save_script=None,
+    ):
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)
             bin_directory = temporary_path / 'bin'
@@ -198,10 +259,11 @@ class CollectSeaweedfsDiagnosticsTest(unittest.TestCase):
             failure_log = temporary_path / 'failures.log'
             failure_log.write_text(failure_text, encoding='utf-8')
             self._write_executable(bin_directory / 'kubectl', _FAKE_KUBECTL)
-            self._write_executable(
-                bin_directory / 'docker',
-                '#!/usr/bin/env bash\nexit 1\n',
-            )
+            self._write_executable(bin_directory / 'docker', docker_script)
+            if iptables_save_script is not None:
+                self._write_executable(
+                    bin_directory / 'iptables-save', iptables_save_script
+                )
             environment = os.environ.copy()
             environment['PATH'] = f'{bin_directory}:{environment["PATH"]}'
             environment.update(extra_environment or {})
@@ -300,11 +362,52 @@ case "$args" in
     echo "container=metadata ready=true restarts=0"
     ;;
   *"describe pod metadata-0 -n kubeflow"*) echo "Events:  <none>" ;;
-  *"get nodes -o jsonpath="*) echo "" ;;
+  *"get nodes -o jsonpath="*)
+    [[ "${FAKE_KIND_NODES:-false}" == "true" ]] && echo "kind-control-plane"
+    ;;
   *"exec seaweedfs-0"*) echo "socket diagnostics" ;;
   *"describe pod seaweedfs-0 -n kubeflow"*) echo "Events:  <none>" ;;
   *) true ;;
 esac
+'''
+
+_FAKE_DOCKER = r'''#!/usr/bin/env bash
+if [[ "$1" == "inspect" ]]; then
+  exit 0
+fi
+if [[ "$1" != "exec" || "$3" != "sh" || "$4" != "-c" ]]; then
+  exit 1
+fi
+
+script="$5"
+case "$script" in
+  *"nf_conntrack_count"*) echo "20/262144" ;;
+  *"command -v conntrack"*)
+    echo "cpu=0 insert_failed=2 drop=2 early_drop=0"
+    ;;
+  *"dmesg"*) echo "(no table-full event logged)" ;;
+  *)
+    shift 5
+    sh -c "$script" "$@"
+    ;;
+esac
+'''
+
+_FAKE_IPTABLES_SAVE = r'''#!/usr/bin/env bash
+[[ "${1:-}" == "-c" ]] || exit 1
+random_fully=""
+if [[ "${RANDOM_FULLY:-false}" == "true" ]]; then
+  random_fully=" --random-fully"
+fi
+cat <<EOF
+[11:660] -A KUBE-SERVICES -d 10.96.1.1/32 -p tcp --dport 9000 -j KUBE-SVC-SEAWEED
+[0:0] -A KUBE-SVC-SEAWEED ! -s 10.244.0.0/16 -d 10.96.1.1/32 -p tcp --dport 9000 -j KUBE-MARK-MASQ
+[11:660] -A KUBE-SVC-SEAWEED -j KUBE-SEP-SEAWEED
+[0:0] -A KUBE-SEP-SEAWEED -s 10.244.0.20/32 -j KUBE-MARK-MASQ
+[11:660] -A KUBE-SEP-SEAWEED -p tcp -j DNAT --to-destination 10.244.0.20:8333
+[0:0] -A KUBE-MARK-MASQ -j MARK --set-xmark 0x4000/0x4000
+[0:0] -A KUBE-POSTROUTING -m mark --mark 0x4000/0x4000 -j MASQUERADE${random_fully}
+EOF
 '''
 
 


### PR DESCRIPTION
## Summary

- capture cumulative packet/byte counters for the complete
  `KUBE-SERVICES -> KUBE-SVC -> KUBE-SEP` path of each failed ClusterIP
- print node-wide `KUBE-MARK-MASQ` and `KUBE-POSTROUTING` rules once per node
  and report whether MASQUERADE uses `--random-fully`
- describe conntrack insertion/drop counters as cumulative, node-wide evidence
  rather than treating any nonzero value as proof of table pressure
- exercise the real collector shell through a fake Kind node for both present
  and absent `--random-fully` states
- match IPVS fallback targets literally so dotted VIPs cannot select regex-like
  decoy addresses

## Why

Recent E2E failures show SeaweedFS ClusterIP dial timeouts alongside healthy
backends, valid EndpointSlices, programmed DNAT rules, and low conntrack-table
occupancy. The existing diagnostics record conntrack insert failures, but they
cannot show whether the failed Service path used SNAT or whether kube-proxy's
MASQUERADE rule enabled full source-port randomization.

The added counters make that distinction explicit without changing test
concurrency or cluster networking. In particular, a zero-count Service or
endpoint jump to `KUBE-MARK-MASQ` shows that `--random-fully` is not relevant to
that traffic even when the node-wide MASQUERADE rule supports it.

Supports #13724.

## Verification

- `python3 -m unittest discover -s .github/resources/scripts -p '*_test.py'`
  (27 tests)
- `bash -n .github/resources/scripts/collect-seaweedfs-diagnostics.sh`
- `python3 -m py_compile .github/resources/scripts/collect_seaweedfs_diagnostics_test.py`
- parsed `.github/workflows/ci-scripts-tests.yml` with Ruby YAML
- `git diff --check`
