### PR TITLE
fix: Key processedPipelines by pipeline UUID instead of version name

### DIFF
--- a/backend/src/apiserver/config/config.go
+++ b/backend/src/apiserver/config/config.go
@@ -251,7 +251,7 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 					glog.Info(fmt.Sprintf("Successfully uploaded PipelineVersion %s.", pvName))
 				}
 
-				if processedPipelines[pvName] {
+				if processedPipelines[p.UUID] {
 					// Since the default sorting is by create time,
 					// Sleep one second makes sure the samples are
 					// showing up in the same order as they are added.
@@ -266,7 +266,7 @@ func LoadSamples(resourceManager *resource.ResourceManager, sampleConfigPath str
 			continue
 		}
 
-		processedPipelines[pvName] = true
+		processedPipelines[p.UUID] = true
 	}
 
 	if !haveSamplesLoaded {


### PR DESCRIPTION
## Summary

- The `processedPipelines` map in `LoadSamples()` is keyed by `pvName` (pipeline version name) and controls a 1-second sleep between version creations to ensure deterministic ordering by create time
- When multiple pipelines share the same version name (e.g., two pipelines both with `VersionName: "v1.0"`), the sleep triggers for every pipeline after the first — adding N-1 unnecessary seconds to API server startup
- Key by pipeline UUID instead so the sleep only triggers for multiple versions under the same pipeline, which is the intended behavior

## Test plan

- [x] All existing unit tests pass (`go test ./backend/src/apiserver/config/...`)
- [x] `TestLoadSamples_SameVersionNameDifferentPipelines` already exercises the shared-version-name scenario and passes with this change