### PR TITLE
feat(sdk,compiler,backend,frontend): implement human-input intermediate parameters for pipeline suspend/resume

### DIFF
--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -92,15 +92,15 @@ type RegisterHttpHandlerFromEndpoint func(ctx context.Context, mux *runtime.Serv
 // allows tests to supply lightweight stubs without constructing real
 // server instances.
 type HTTPRouterDeps struct {
-	UploadPipelineV1             http.HandlerFunc
-	UploadPipelineVersionV1      http.HandlerFunc
-	UploadPipeline               http.HandlerFunc
-	UploadPipelineVersion        http.HandlerFunc
-	ReadRunLogV1                 http.HandlerFunc
-	ReadArtifactV1               http.HandlerFunc
-	ReadArtifact                 http.HandlerFunc
-	SetIntermediateInputs        http.HandlerFunc
-	GetIntermediateInputsStatus  http.HandlerFunc
+	UploadPipelineV1            http.HandlerFunc
+	UploadPipelineVersionV1     http.HandlerFunc
+	UploadPipeline              http.HandlerFunc
+	UploadPipelineVersion       http.HandlerFunc
+	ReadRunLogV1                http.HandlerFunc
+	ReadArtifactV1              http.HandlerFunc
+	ReadArtifact                http.HandlerFunc
+	SetIntermediateInputs       http.HandlerFunc
+	GetIntermediateInputsStatus http.HandlerFunc
 }
 
 func initCerts() (*tls.Config, error) {

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -92,13 +92,15 @@ type RegisterHttpHandlerFromEndpoint func(ctx context.Context, mux *runtime.Serv
 // allows tests to supply lightweight stubs without constructing real
 // server instances.
 type HTTPRouterDeps struct {
-	UploadPipelineV1        http.HandlerFunc
-	UploadPipelineVersionV1 http.HandlerFunc
-	UploadPipeline          http.HandlerFunc
-	UploadPipelineVersion   http.HandlerFunc
-	ReadRunLogV1            http.HandlerFunc
-	ReadArtifactV1          http.HandlerFunc
-	ReadArtifact            http.HandlerFunc
+	UploadPipelineV1             http.HandlerFunc
+	UploadPipelineVersionV1      http.HandlerFunc
+	UploadPipeline               http.HandlerFunc
+	UploadPipelineVersion        http.HandlerFunc
+	ReadRunLogV1                 http.HandlerFunc
+	ReadArtifactV1               http.HandlerFunc
+	ReadArtifact                 http.HandlerFunc
+	SetIntermediateInputs        http.HandlerFunc
+	GetIntermediateInputsStatus  http.HandlerFunc
 }
 
 func initCerts() (*tls.Config, error) {
@@ -429,15 +431,18 @@ func startHTTPProxy(resourceManager *resource.ResourceManager, usePipelinesKuber
 	sharedPipelineUploadServer := server.NewPipelineUploadServer(resourceManager, &server.PipelineUploadServerOptions{CollectMetrics: *collectMetricsFlag})
 	runLogServer := server.NewRunLogServer(resourceManager)
 	runArtifactServer := server.NewRunArtifactServer(resourceManager)
+	runIntermediateInputsServer := server.NewRunIntermediateInputsServer(resourceManager)
 
 	handlerDeps := HTTPRouterDeps{
-		UploadPipelineV1:        sharedPipelineUploadServer.UploadPipelineV1,
-		UploadPipelineVersionV1: sharedPipelineUploadServer.UploadPipelineVersionV1,
-		UploadPipeline:          sharedPipelineUploadServer.UploadPipeline,
-		UploadPipelineVersion:   sharedPipelineUploadServer.UploadPipelineVersion,
-		ReadRunLogV1:            runLogServer.ReadRunLogV1,
-		ReadArtifactV1:          runArtifactServer.ReadArtifactV1,
-		ReadArtifact:            runArtifactServer.ReadArtifact,
+		UploadPipelineV1:            sharedPipelineUploadServer.UploadPipelineV1,
+		UploadPipelineVersionV1:     sharedPipelineUploadServer.UploadPipelineVersionV1,
+		UploadPipeline:              sharedPipelineUploadServer.UploadPipeline,
+		UploadPipelineVersion:       sharedPipelineUploadServer.UploadPipelineVersion,
+		ReadRunLogV1:                runLogServer.ReadRunLogV1,
+		ReadArtifactV1:              runArtifactServer.ReadArtifactV1,
+		ReadArtifact:                runArtifactServer.ReadArtifact,
+		SetIntermediateInputs:       runIntermediateInputsServer.SetIntermediateInputs,
+		GetIntermediateInputsStatus: runIntermediateInputsServer.GetIntermediateInputsStatus,
 	}
 
 	topMux := buildHTTPRouter(handlerDeps, runtimeMux, pipelineStore)
@@ -517,6 +522,11 @@ func buildHTTPRouter(handlerDeps HTTPRouterDeps, grpcGatewayHandler http.Handler
 	// Artifact reading endpoints (implemented with streaming for memory efficiency)
 	topMux.HandleFunc("/apis/v1beta1/runs/{run_id}/nodes/{node_id}/artifacts/{artifact_name}:read", handlerDeps.ReadArtifactV1).Methods(http.MethodGet)
 	topMux.HandleFunc("/apis/v2beta1/runs/{run_id}/nodes/{node_id}/artifacts/{artifact_name}:read", handlerDeps.ReadArtifact).Methods(http.MethodGet)
+
+	// Human-input (intermediate parameters) endpoint: supply values to a paused suspend node.
+	topMux.HandleFunc("/apis/v2beta1/runs/{run_id}/nodes/{node_id}:setIntermediateInputs", handlerDeps.SetIntermediateInputs).Methods(http.MethodPost)
+	// Read the current intermediate-input status of a node (read-only).
+	topMux.HandleFunc("/apis/v2beta1/runs/{run_id}/nodes/{node_id}/intermediateInputs", handlerDeps.GetIntermediateInputsStatus).Methods(http.MethodGet)
 
 	topMux.PathPrefix("/apis/").Handler(clearTagsMiddleware(grpcGatewayHandler))
 

--- a/backend/src/apiserver/resource/intermediate_inputs.go
+++ b/backend/src/apiserver/resource/intermediate_inputs.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package resource manages API-server resources.
 package resource
 
 import (

--- a/backend/src/apiserver/resource/intermediate_inputs.go
+++ b/backend/src/apiserver/resource/intermediate_inputs.go
@@ -1,0 +1,410 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/golang/glog"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// SetRunIntermediateInputsRequest carries the caller-supplied parameter values
+// for a paused (suspend) node in a running workflow.
+type SetRunIntermediateInputsRequest struct {
+	// RunID is the KFP run identifier.
+	RunID string
+	// NodeDisplayName is the display name of the suspend node (e.g. "approval-gate").
+	NodeDisplayName string
+	// Parameters maps output parameter name → human-supplied value.
+	Parameters map[string]string
+}
+
+// SetRunIntermediateInputs validates and applies human-supplied parameter
+// values to a paused Argo suspend node, then resumes the workflow.
+//
+// Validation rules:
+//   - The run must exist and be in a non-terminal state.
+//   - A node with matching display name must exist, be of type Suspend, and be
+//     in phase Running (i.e. actually paused waiting for input).
+//   - Every key in Parameters must correspond to a declared output parameter on
+//     the suspend template whose valueFrom is "supplied".
+//   - If the template declares an enum for a parameter the supplied value must
+//     be one of the listed choices.
+//
+// On success the node's output parameters are set, its phase is advanced to
+// Succeeded, and the workflow is patched so the Argo controller can continue.
+func (r *ResourceManager) SetRunIntermediateInputs(ctx context.Context, req SetRunIntermediateInputsRequest) error {
+	run, err := r.GetRun(req.RunID)
+	if err != nil {
+		return util.Wrapf(err, "SetRunIntermediateInputs: failed to fetch run %s", req.RunID)
+	}
+
+	namespace, err := r.getNamespaceFromRunId(req.RunID)
+	if err != nil {
+		return util.Wrapf(err, "SetRunIntermediateInputs: failed to determine namespace for run %s", req.RunID)
+	}
+	if namespace == "" {
+		namespace = getDefaultNamespace()
+	}
+
+	wfClient := r.getWorkflowClient(namespace)
+	execSpec, err := wfClient.Get(ctx, run.K8SName, metav1.GetOptions{})
+	if err != nil {
+		return util.NewInternalServerError(err, "SetRunIntermediateInputs: failed to fetch workflow %s", run.K8SName)
+	}
+
+	wf, ok := execSpec.(*util.Workflow)
+	if !ok {
+		return util.NewInternalServerError(fmt.Errorf("unexpected ExecutionSpec type %T", execSpec),
+			"SetRunIntermediateInputs: workflow type assertion failed")
+	}
+
+	// Find the target node by display name.
+	nodeID, nodeStatus, err := findSuspendNodeByDisplayName(wf.Get(), req.NodeDisplayName)
+	if err != nil {
+		return err
+	}
+
+	// Locate the suspend template to validate declared parameters.
+	tmpl, err := findTemplateForNode(wf.Get(), nodeStatus)
+	if err != nil {
+		return err
+	}
+
+	// Validate the supplied parameters against the template's declared outputs.
+	if err := validateIntermediateParams(tmpl, req.Parameters); err != nil {
+		return err
+	}
+
+	// Build the status patch: set the output parameter values and mark the node
+	// as Succeeded so the workflow controller can proceed.
+	patchBytes, err := buildIntermediateInputsPatch(nodeID, nodeStatus, tmpl, req.Parameters)
+	if err != nil {
+		return util.NewInternalServerError(err, "SetRunIntermediateInputs: failed to build status patch")
+	}
+
+	glog.Infof("SetRunIntermediateInputs: patching node %q (id=%s) in workflow %s", req.NodeDisplayName, nodeID, run.K8SName)
+	if _, err := wfClient.Patch(ctx, run.K8SName, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status"); err != nil {
+		return util.NewInternalServerError(err, "SetRunIntermediateInputs: failed to patch workflow %s", run.K8SName)
+	}
+	return nil
+}
+
+// findSuspendNodeByDisplayName scans the workflow's status nodes for a node
+// whose DisplayName matches displayName, is of type Suspend, and is in phase
+// Running (i.e. awaiting input).
+func findSuspendNodeByDisplayName(wf *wfapi.Workflow, displayName string) (string, wfapi.NodeStatus, error) {
+	for nodeID, nodeStatus := range wf.Status.Nodes {
+		if nodeStatus.DisplayName != displayName {
+			continue
+		}
+		if nodeStatus.Type != wfapi.NodeTypeSuspend {
+			return "", wfapi.NodeStatus{}, util.NewBadRequestError(
+				fmt.Errorf("node %q has type %q, not Suspend", displayName, nodeStatus.Type),
+				"The specified node is not a suspend/human-input node",
+			)
+		}
+		if nodeStatus.Phase != wfapi.NodeRunning {
+			return "", wfapi.NodeStatus{}, util.NewBadRequestError(
+				fmt.Errorf("node %q is in phase %q; expected Running", displayName, nodeStatus.Phase),
+				"The suspend node is not currently waiting for input (phase must be Running)",
+			)
+		}
+		return nodeID, nodeStatus, nil
+	}
+	return "", wfapi.NodeStatus{}, util.NewResourceNotFoundError(
+		"SuspendNode", displayName,
+	)
+}
+
+// findTemplateForNode locates the Argo template used by the given node status,
+// searching first in StoredTemplates (the canonical source at runtime) and
+// then falling back to the workflow spec's Templates list.
+func findTemplateForNode(wf *wfapi.Workflow, node wfapi.NodeStatus) (*wfapi.Template, error) {
+	tmplName := node.TemplateName
+	if tmplName == "" {
+		return nil, util.NewBadRequestError(
+			fmt.Errorf("node %q has no TemplateName", node.DisplayName),
+			"Cannot find template for the suspend node",
+		)
+	}
+
+	// Prefer StoredTemplates (available during execution).
+	if st, ok := wf.Status.StoredTemplates[tmplName]; ok {
+		tmpl := st
+		return &tmpl, nil
+	}
+	// Fall back to the workflow spec.
+	for i := range wf.Spec.Templates {
+		if wf.Spec.Templates[i].Name == tmplName {
+			tmpl := wf.Spec.Templates[i]
+			return &tmpl, nil
+		}
+	}
+	return nil, util.NewInternalServerError(
+		fmt.Errorf("template %q not found in workflow", tmplName),
+		"Cannot locate suspend template %q",
+		tmplName,
+	)
+}
+
+// validateIntermediateParams checks the caller-supplied parameters against the
+// suspend template's declared output parameters:
+//   - All supplied keys must correspond to a declared output with valueFrom.supplied.
+//   - If the parameter has an enum constraint the value must be one of the choices.
+func validateIntermediateParams(tmpl *wfapi.Template, params map[string]string) error {
+	declaredOutputs := make(map[string]wfapi.Parameter, len(tmpl.Outputs.Parameters))
+	for _, p := range tmpl.Outputs.Parameters {
+		if p.ValueFrom != nil && p.ValueFrom.Supplied != nil {
+			declaredOutputs[p.Name] = p
+		}
+	}
+	inputMetadata := make(map[string]wfapi.Parameter, len(tmpl.Inputs.Parameters))
+	for _, p := range tmpl.Inputs.Parameters {
+		inputMetadata[p.Name] = p
+	}
+
+	for key, value := range params {
+		_, ok := declaredOutputs[key]
+		if !ok {
+			return util.NewBadRequestError(
+				fmt.Errorf("parameter %q is not a declared supplied output of template %q", key, tmpl.Name),
+				"Supplied parameter key %q is not declared on this suspend node", key,
+			)
+		}
+		if input, ok := inputMetadata[key]; ok && len(input.Enum) > 0 {
+			valid := false
+			for _, choice := range input.Enum {
+				if choice.String() == value {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				allowed := make([]string, len(input.Enum))
+				for i, e := range input.Enum {
+					allowed[i] = e.String()
+				}
+				return util.NewBadRequestError(
+					fmt.Errorf("value %q for parameter %q is not in the allowed enum %v", value, key, allowed),
+					"Value %q is not one of the allowed choices for parameter %q", value, key,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// buildIntermediateInputsPatch constructs the JSON merge-patch document that:
+//   - Sets output parameter values on the suspend node.
+//   - Advances the node phase to Succeeded and records the current time as
+//     finishedAt so the Argo workflow controller can proceed.
+func buildIntermediateInputsPatch(
+	nodeID string,
+	existing wfapi.NodeStatus,
+	tmpl *wfapi.Template,
+	params map[string]string,
+) ([]byte, error) {
+	// Build the updated parameters list by merging the template-declared
+	// outputs with the caller-supplied values.
+	updatedParams := make([]wfapi.Parameter, 0, len(tmpl.Outputs.Parameters))
+	for _, p := range tmpl.Outputs.Parameters {
+		if p.ValueFrom == nil || p.ValueFrom.Supplied == nil {
+			updatedParams = append(updatedParams, p)
+			continue
+		}
+		if v, ok := params[p.Name]; ok {
+			p.Value = wfapi.AnyStringPtr(v)
+		}
+		updatedParams = append(updatedParams, p)
+	}
+
+	// Preserve any existing artifacts/result on the outputs.
+	updatedOutputs := existing.Outputs
+	if updatedOutputs == nil {
+		updatedOutputs = &wfapi.Outputs{}
+	}
+	updatedOutputs.Parameters = updatedParams
+
+	// The node patch uses a partial node structure so only the fields we
+	// intend to change are included in the merge-patch document.
+	type nodePatch struct {
+		Phase      wfapi.NodePhase `json:"phase"`
+		FinishedAt metav1.Time     `json:"finishedAt"`
+		Message    string          `json:"message"`
+		Outputs    *wfapi.Outputs  `json:"outputs,omitempty"`
+	}
+
+	now := metav1.NewTime(time.Now().UTC())
+	patch := struct {
+		Status struct {
+			Nodes map[string]nodePatch `json:"nodes"`
+		} `json:"status"`
+	}{}
+	patch.Status.Nodes = map[string]nodePatch{
+		nodeID: {
+			Phase:      wfapi.NodeSucceeded,
+			FinishedAt: now,
+			Message:    "human input provided",
+			Outputs:    updatedOutputs,
+		},
+	}
+
+	return json.Marshal(patch)
+}
+
+// IntermediateInputsStatus describes the current state of a suspend node's
+// human-input parameters, returned by GetRunIntermediateInputsStatus.
+type IntermediateInputsStatus struct {
+	// Suspended is true when the node is a Suspend node currently in the
+	// Running phase (i.e. waiting for human input).
+	Suspended bool `json:"suspended"`
+	// Parameters contains per-parameter metadata and the current supplied value
+	// (nil when not yet provided).
+	Parameters map[string]*IntermediateParamStatus `json:"parameters,omitempty"`
+}
+
+// IntermediateParamStatus holds metadata and the current value for one
+// human-input parameter.
+type IntermediateParamStatus struct {
+	Description  string   `json:"description,omitempty"`
+	Default      string   `json:"default,omitempty"`
+	Enum         []string `json:"enum,omitempty"`
+	CurrentValue *string  `json:"current_value,omitempty"`
+}
+
+// GetRunIntermediateInputsStatus returns the current state of a suspend node's
+// human-input parameters without modifying the workflow.  It is safe to call
+// regardless of the node's current phase; the Suspended field in the response
+// indicates whether the caller may now call SetRunIntermediateInputs.
+func (r *ResourceManager) GetRunIntermediateInputsStatus(ctx context.Context, runID, nodeDisplayName string) (*IntermediateInputsStatus, error) {
+	run, err := r.GetRun(runID)
+	if err != nil {
+		return nil, util.Wrapf(err, "GetRunIntermediateInputsStatus: failed to fetch run %s", runID)
+	}
+
+	namespace, err := r.getNamespaceFromRunId(runID)
+	if err != nil {
+		return nil, util.Wrapf(err, "GetRunIntermediateInputsStatus: failed to determine namespace for run %s", runID)
+	}
+	if namespace == "" {
+		namespace = getDefaultNamespace()
+	}
+
+	wfClient := r.getWorkflowClient(namespace)
+	execSpec, err := wfClient.Get(ctx, run.K8SName, metav1.GetOptions{})
+	if err != nil {
+		return nil, util.NewInternalServerError(err, "GetRunIntermediateInputsStatus: failed to fetch workflow %s", run.K8SName)
+	}
+
+	wf, ok := execSpec.(*util.Workflow)
+	if !ok {
+		return nil, util.NewInternalServerError(fmt.Errorf("unexpected ExecutionSpec type %T", execSpec),
+			"GetRunIntermediateInputsStatus: workflow type assertion failed")
+	}
+
+	// Scan for the node by display name; any phase is acceptable here.
+	var (
+		foundNode   *wfapi.NodeStatus
+		foundNodeID string
+	)
+	for nodeID, ns := range wf.Get().Status.Nodes {
+		if ns.DisplayName == nodeDisplayName {
+			ns := ns
+			foundNode = &ns
+			foundNodeID = nodeID
+			break
+		}
+	}
+	_ = foundNodeID // used only for future logging
+
+	// If the node doesn't exist yet, return a non-suspended status so the UI
+	// knows the task hasn't reached this point in the workflow.
+	if foundNode == nil {
+		return &IntermediateInputsStatus{Suspended: false}, nil
+	}
+
+	isSuspended := foundNode.Type == wfapi.NodeTypeSuspend && foundNode.Phase == wfapi.NodeRunning
+	status := &IntermediateInputsStatus{Suspended: isSuspended}
+
+	// Try to retrieve template metadata so the UI can render the form fields.
+	tmpl, err := findTemplateForNode(wf.Get(), *foundNode)
+	if err != nil {
+		// Template not found is non-fatal for a status query.
+		return status, nil
+	}
+
+	paramsMeta := make(map[string]*IntermediateParamStatus, len(tmpl.Outputs.Parameters))
+
+	// Build a map of already-supplied values from the node's current outputs.
+	suppliedValues := make(map[string]string)
+	if foundNode.Outputs != nil {
+		for _, p := range foundNode.Outputs.Parameters {
+			if p.Value != nil {
+				suppliedValues[p.Name] = p.Value.String()
+			}
+		}
+	}
+
+	// Merge template input metadata (description, default, enum) with template
+	// output declarations (which carry the valueFrom.supplied marker).
+	inputMeta := make(map[string]*wfapi.Parameter)
+	for i := range tmpl.Inputs.Parameters {
+		p := tmpl.Inputs.Parameters[i]
+		inputMeta[p.Name] = &p
+	}
+
+	for _, p := range tmpl.Outputs.Parameters {
+		if p.ValueFrom == nil || p.ValueFrom.Supplied == nil {
+			continue
+		}
+		ps := &IntermediateParamStatus{}
+
+		// Pull description and enum from the matching input parameter if present.
+		if meta, ok := inputMeta[p.Name]; ok {
+			if meta.Description != nil {
+				ps.Description = meta.Description.String()
+			}
+			if meta.Default != nil {
+				ps.Default = meta.Default.String()
+			}
+			for _, e := range meta.Enum {
+				ps.Enum = append(ps.Enum, e.String())
+			}
+		}
+
+		if v, ok := suppliedValues[p.Name]; ok {
+			ps.CurrentValue = &v
+		}
+		paramsMeta[p.Name] = ps
+	}
+	if len(paramsMeta) > 0 {
+		status.Parameters = paramsMeta
+	}
+	return status, nil
+}
+
+// getDefaultNamespace returns the pod namespace as the default KFP namespace.
+func getDefaultNamespace() string {
+	return common.GetPodNamespace()
+}

--- a/backend/src/apiserver/resource/intermediate_inputs_internal_test.go
+++ b/backend/src/apiserver/resource/intermediate_inputs_internal_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"encoding/json"
+	"testing"
+
+	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateIntermediateParams(t *testing.T) {
+	template := &wfapi.Template{
+		Inputs: wfapi.Inputs{Parameters: []wfapi.Parameter{{
+			Name: "decision",
+			Enum: []wfapi.AnyString{*wfapi.AnyStringPtr("YES"), *wfapi.AnyStringPtr("NO")},
+		}}},
+		Outputs: wfapi.Outputs{Parameters: []wfapi.Parameter{{
+			Name: "decision",
+			ValueFrom: &wfapi.ValueFrom{
+				Supplied: &wfapi.SuppliedValueFrom{},
+			},
+		}}},
+	}
+
+	assert.NoError(t, validateIntermediateParams(template, map[string]string{"decision": "YES"}))
+	assert.Error(t, validateIntermediateParams(template, map[string]string{"decision": "MAYBE"}))
+}
+
+func TestBuildIntermediateInputsPatch(t *testing.T) {
+	template := &wfapi.Template{
+		Outputs: wfapi.Outputs{Parameters: []wfapi.Parameter{{
+			Name: "decision",
+			ValueFrom: &wfapi.ValueFrom{
+				Supplied: &wfapi.SuppliedValueFrom{},
+			},
+		}}},
+	}
+
+	patch, err := buildIntermediateInputsPatch(
+		"workflow-approval",
+		wfapi.NodeStatus{Phase: wfapi.NodeRunning},
+		template,
+		map[string]string{"decision": "YES"},
+	)
+	require.NoError(t, err)
+
+	var result struct {
+		Status struct {
+			Nodes map[string]struct {
+				Phase   wfapi.NodePhase `json:"phase"`
+				Message string          `json:"message"`
+				Outputs wfapi.Outputs   `json:"outputs"`
+			} `json:"nodes"`
+		} `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(patch, &result))
+	node := result.Status.Nodes["workflow-approval"]
+	assert.Equal(t, wfapi.NodeSucceeded, node.Phase)
+	assert.Equal(t, "human input provided", node.Message)
+	require.Len(t, node.Outputs.Parameters, 1)
+	assert.Equal(t, "YES", node.Outputs.Parameters[0].Value.String())
+}

--- a/backend/src/apiserver/server/run_intermediate_inputs_server.go
+++ b/backend/src/apiserver/server/run_intermediate_inputs_server.go
@@ -1,0 +1,221 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/gorilla/mux"
+	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/resource"
+	"github.com/kubeflow/pipelines/backend/src/common/util"
+	authorizationv1 "k8s.io/api/authorization/v1"
+)
+
+// RunIntermediateInputsServer handles the HTTP endpoint for supplying
+// human-provided parameter values to a paused (suspend) pipeline node.
+//
+// Endpoint: POST /apis/v2beta1/runs/{run_id}/nodes/{node_id}:setIntermediateInputs
+type RunIntermediateInputsServer struct {
+	*BaseRunServer
+}
+
+// setIntermediateInputsBody is the JSON request body for the endpoint.
+type setIntermediateInputsBody struct {
+	// Parameters maps parameter name → human-supplied string value.
+	Parameters map[string]string `json:"parameters"`
+}
+
+// SetIntermediateInputs handles POST /apis/v2beta1/runs/{run_id}/nodes/{node_id}:setIntermediateInputs.
+//
+// The caller supplies the run ID and node display name in the path, plus a JSON
+// body of the form:
+//
+//	{"parameters": {"decision": "YES"}}
+//
+// On success the node's output parameters are persisted and the Argo workflow
+// is resumed. The response is 200 OK with an empty JSON object {}.
+func (s *RunIntermediateInputsServer) SetIntermediateInputs(w http.ResponseWriter, r *http.Request) {
+	glog.Infof("SetIntermediateInputs called")
+
+	vars := mux.Vars(r)
+
+	runID, ok := vars[RunKey]
+	if !ok {
+		s.writeErrorToResponse(w, http.StatusBadRequest, fmt.Errorf(missingParamErrorMessage, RunKey))
+		return
+	}
+
+	nodeID, ok := vars[NodeKey]
+	if !ok {
+		s.writeErrorToResponse(w, http.StatusBadRequest, fmt.Errorf(missingParamErrorMessage, NodeKey))
+		return
+	}
+
+	// Authorization: caller must have update permission on the run.
+	if err := s.canAccessRun(r.Context(), runID,
+		&authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbUpdate}); err != nil {
+		s.writeErrorToResponse(w, http.StatusForbidden,
+			util.Wrap(err, "Failed to authorize the request"))
+		return
+	}
+
+	// Read and parse the request body.
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		s.writeErrorToResponse(w, http.StatusBadRequest,
+			fmt.Errorf("failed to read request body: %v", err))
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	var body setIntermediateInputsBody
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		s.writeErrorToResponse(w, http.StatusBadRequest,
+			fmt.Errorf("invalid JSON body: %v", err))
+		return
+	}
+
+	if len(body.Parameters) == 0 {
+		s.writeErrorToResponse(w, http.StatusBadRequest,
+			fmt.Errorf("request body must contain at least one parameter"))
+		return
+	}
+
+	req := resource.SetRunIntermediateInputsRequest{
+		RunID:           runID,
+		NodeDisplayName: nodeID,
+		Parameters:      body.Parameters,
+	}
+
+	if err := s.resourceManager.SetRunIntermediateInputs(r.Context(), req); err != nil {
+		httpStatus := httpStatusFromError(err)
+		s.writeErrorToResponse(w, httpStatus, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, writeErr := w.Write([]byte("{}")); writeErr != nil {
+		glog.Warningf("SetIntermediateInputs: failed to write response: %v", writeErr)
+	}
+}
+
+// GetIntermediateInputsStatus handles GET /apis/v2beta1/runs/{run_id}/nodes/{node_id}/intermediateInputs.
+//
+// Returns the current state of the suspend node: whether it is waiting for
+// input and the parameter metadata (description, default, enum choices, any
+// already-supplied value).  This is a read-only endpoint and does not modify
+// the workflow.
+func (s *RunIntermediateInputsServer) GetIntermediateInputsStatus(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	runID, ok := vars[RunKey]
+	if !ok {
+		s.writeErrorToResponse(w, http.StatusBadRequest, fmt.Errorf(missingParamErrorMessage, RunKey))
+		return
+	}
+
+	nodeID, ok := vars[NodeKey]
+	if !ok {
+		s.writeErrorToResponse(w, http.StatusBadRequest, fmt.Errorf(missingParamErrorMessage, NodeKey))
+		return
+	}
+
+	// Authorization: read permission is sufficient for a status query.
+	if err := s.canAccessRun(r.Context(), runID,
+		&authorizationv1.ResourceAttributes{Verb: common.RbacResourceVerbGet}); err != nil {
+		s.writeErrorToResponse(w, http.StatusForbidden,
+			util.Wrap(err, "Failed to authorize the request"))
+		return
+	}
+
+	status, err := s.resourceManager.GetRunIntermediateInputsStatus(r.Context(), runID, nodeID)
+	if err != nil {
+		s.writeErrorToResponse(w, httpStatusFromError(err), err)
+		return
+	}
+
+	respBytes, err := json.Marshal(status)
+	if err != nil {
+		s.writeErrorToResponse(w, http.StatusInternalServerError,
+			fmt.Errorf("failed to marshal response: %v", err))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if _, writeErr := w.Write(respBytes); writeErr != nil {
+		glog.Warningf("GetIntermediateInputsStatus: failed to write response: %v", writeErr)
+	}
+}
+
+// writeErrorToResponse writes a JSON error response with the given HTTP status code.
+func (s *RunIntermediateInputsServer) writeErrorToResponse(w http.ResponseWriter, code int, err error) {
+	glog.Errorf("SetIntermediateInputs failed. Error: %+v", err)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	errResp := &api.Error{ErrorMessage: err.Error(), ErrorDetails: fmt.Sprintf("%+v", err)}
+	errBytes, marshalErr := json.Marshal(errResp)
+	if marshalErr != nil {
+		if _, writeErr := w.Write([]byte(`{"error_message":"internal error"}`)); writeErr != nil {
+			glog.Errorf("SetIntermediateInputs: failed to write fallback error response: %v", writeErr)
+		}
+		return
+	}
+	if _, writeErr := w.Write(errBytes); writeErr != nil {
+		glog.Errorf("SetIntermediateInputs: failed to write error response: %v", writeErr)
+	}
+}
+
+// httpStatusFromError maps KFP util error types to HTTP status codes.
+func httpStatusFromError(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+	userError, ok := err.(*util.UserError)
+	if !ok {
+		return http.StatusInternalServerError
+	}
+	// Map gRPC status codes to HTTP equivalents.
+	switch userError.ExternalStatusCode() {
+	case 3: // codes.InvalidArgument
+		return http.StatusBadRequest
+	case 5: // codes.NotFound
+		return http.StatusNotFound
+	case 7: // codes.PermissionDenied
+		return http.StatusForbidden
+	case 9: // codes.FailedPrecondition
+		return http.StatusBadRequest
+	case 10: // codes.Aborted
+		return http.StatusConflict
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// NewRunIntermediateInputsServer creates a new RunIntermediateInputsServer.
+func NewRunIntermediateInputsServer(resourceManager *resource.ResourceManager) *RunIntermediateInputsServer {
+	return &RunIntermediateInputsServer{
+		BaseRunServer: &BaseRunServer{
+			resourceManager: resourceManager,
+			options:         &RunServerOptions{CollectMetrics: false},
+		},
+	}
+}

--- a/backend/src/apiserver/server/run_intermediate_inputs_server_test.go
+++ b/backend/src/apiserver/server/run_intermediate_inputs_server_test.go
@@ -1,0 +1,79 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	apiv1beta1 "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestIntermediateInputsEndpointsRequireAuthorization(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	clients, manager, experiment := initWithExperiment_SubjectAccessReview_Unauthorized(t)
+	defer clients.Close()
+
+	modelRun, err := toModelRun(&apiv1beta1.Run{
+		Name: "run",
+		PipelineSpec: &apiv1beta1.PipelineSpec{
+			WorkflowManifest: testWorkflow.ToStringForStore(),
+		},
+		ResourceReferences: []*apiv1beta1.ResourceReference{{
+			Key:          &apiv1beta1.ResourceKey{Type: apiv1beta1.ResourceType_EXPERIMENT, Id: experiment.UUID},
+			Relationship: apiv1beta1.Relationship_OWNER,
+		}},
+	})
+	assert.NoError(t, err)
+	modelRun.Namespace = experiment.Namespace
+	run, err := manager.CreateRun(context.Background(), modelRun)
+	assert.NoError(t, err)
+
+	server := NewRunIntermediateInputsServer(manager)
+	contextWithIdentity := metadata.NewIncomingContext(
+		context.Background(),
+		metadata.Pairs(common.GoogleIAPUserIdentityHeader, common.GoogleIAPUserIdentityPrefix+"user@google.com"),
+	)
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		method  string
+		body    string
+	}{
+		{"get", server.GetIntermediateInputsStatus, http.MethodGet, ""},
+		{"set", server.SetIntermediateInputs, http.MethodPost, `{"parameters":{"decision":"YES"}}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := httptest.NewRequest(test.method, "/", bytes.NewBufferString(test.body)).WithContext(contextWithIdentity)
+			request = mux.SetURLVars(request, map[string]string{RunKey: run.UUID, NodeKey: "approval"})
+			response := httptest.NewRecorder()
+
+			test.handler(response, request)
+
+			assert.Equal(t, http.StatusForbidden, response.Code)
+		})
+	}
+}

--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -590,7 +590,7 @@ const (
 
 // humanInputSentinelImage is the special container image value that the Python
 // SDK emits when a human_input() task is compiled. The backend Argo compiler
-// recognises this image and translates the task into an Argo suspend template
+// recognizes this image and translates the task into an Argo suspend template
 // with supplied output parameters instead of the usual driver+launcher pattern.
 // This value must stay in sync with kfp.dsl.human_input.HUMAN_INPUT_SENTINEL_IMAGE.
 const humanInputSentinelImage = "kfp://human-input"
@@ -600,8 +600,8 @@ const humanInputSentinelImage = "kfp://human-input"
 // These values are in sync with the values in SDK to form a contract between BE and SDK.
 // TODO(lingqinggan): clarify these in documentation for KFP V2.
 var dummyImages = map[string]bool{
-	"argostub/createpvc":     true,
-	"argostub/deletepvc":     true,
+	"argostub/createpvc":    true,
+	"argostub/deletepvc":    true,
 	humanInputSentinelImage: true,
 }
 

--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -203,13 +203,14 @@ func Compile(jobArg *pipelinespec.PipelineJob, kubernetesSpecArg *pipelinespec.S
 		wf:        wf,
 		templates: make(map[string]*wfapi.Template),
 		// TODO(chensun): release process and update the images.
-		launcherImage:   GetLauncherImage(),
-		launcherCommand: GetLauncherCommand(),
-		driverImage:     GetDriverImage(),
-		driverCommand:   GetDriverCommand(),
-		job:             job,
-		spec:            spec,
-		executors:       deploy.GetExecutors(),
+		launcherImage:        GetLauncherImage(),
+		launcherCommand:      GetLauncherCommand(),
+		driverImage:          GetDriverImage(),
+		driverCommand:        GetDriverCommand(),
+		job:                  job,
+		spec:                 spec,
+		executors:            deploy.GetExecutors(),
+		humanInputComponents: make(map[string][]string),
 	}
 	if opts != nil {
 		c.cacheDisabled = opts.CacheDisabled
@@ -325,6 +326,12 @@ type workflowCompiler struct {
 	defaultRunAsGroup    *int64
 	defaultRunAsNonRoot  *bool
 	defaultHostUsers     *bool
+	// humanInputComponents maps component names to their human-input output
+	// parameter names. It is populated during the Container() visitor call and
+	// read during task() to rewrite downstream task specs so that their inputs
+	// that come from human-input tasks are resolved via Argo parameter
+	// substitution (runtime_value) rather than MLMD lookup.
+	humanInputComponents map[string][]string
 }
 
 func (c *workflowCompiler) Resolver(name string, component *pipelinespec.ComponentSpec, resolver *pipelinespec.PipelineDeploymentConfig_ResolverSpec) error {
@@ -581,13 +588,21 @@ const (
 	tmplEntrypoint = "entrypoint"
 )
 
+// humanInputSentinelImage is the special container image value that the Python
+// SDK emits when a human_input() task is compiled. The backend Argo compiler
+// recognises this image and translates the task into an Argo suspend template
+// with supplied output parameters instead of the usual driver+launcher pattern.
+// This value must stay in sync with kfp.dsl.human_input.HUMAN_INPUT_SENTINEL_IMAGE.
+const humanInputSentinelImage = "kfp://human-input"
+
 // Here is the collection of all special dummy images that the backend recognizes.
 // User need to avoid these image names for their self-defined components.
 // These values are in sync with the values in SDK to form a contract between BE and SDK.
 // TODO(lingqinggan): clarify these in documentation for KFP V2.
 var dummyImages = map[string]bool{
-	"argostub/createpvc": true,
-	"argostub/deletepvc": true,
+	"argostub/createpvc":     true,
+	"argostub/deletepvc":     true,
+	humanInputSentinelImage: true,
 }
 
 // convertStructToPVCSpec converts a protobuf Struct to a PersistentVolumeClaimSpec using JSON marshaling/unmarshalling.

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -46,6 +46,12 @@ func (c *workflowCompiler) DAG(name string, componentSpec *pipelinespec.Componen
 	if err != nil {
 		return err
 	}
+
+	// Pre-pass: register all human-input tasks in humanInputComponents before
+	// the main compilation loop, so that downstream task specs can be rewritten
+	// regardless of task compilation order (which is alphabetical).
+	c.registerHumanInputTasks(dagSpec)
+
 	tasks := dagSpec.GetTasks()
 	// Iterate through tasks in deterministic order to facilitate testing.
 	// Note, order doesn't affect compiler with real effect right now.
@@ -235,7 +241,16 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 	if err != nil {
 		return nil, err
 	}
-	taskSpecJson, err := stablyMarshalJSON(task)
+
+	// Rewrite any task-spec inputs that reference human-input task outputs so
+	// that the downstream KFP driver receives them as Argo-substituted constants
+	// rather than trying to look them up in MLMD.
+	effectiveTask, err := c.rewriteHumanInputTaskSpec(task)
+	if err != nil {
+		return nil, err
+	}
+
+	taskSpecJson, err := stablyMarshalJSON(effectiveTask)
 	if err != nil {
 		return nil, err
 	}
@@ -286,6 +301,19 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 		}
 		switch e := executor.GetSpec().(type) {
 		case *pipelinespec.PipelineDeploymentConfig_ExecutorSpec_Container:
+			// Human-input tasks compile directly to an Argo suspend template,
+			// bypassing the KFP driver+launcher pattern entirely.
+			if e.Container.GetImage() == humanInputSentinelImage {
+				dagTask, hiErr := c.humanInputTask(name, componentName, e.Container)
+				if hiErr != nil {
+					return nil, hiErr
+				}
+				if inputs.iterationIndex == "" && task.GetTriggerPolicy().GetStrategy().String() != "ALL_UPSTREAM_TASKS_COMPLETED" {
+					dagTask.Depends = depends(task.GetDependentTasks())
+				}
+				return []wfapi.DAGTask{*dagTask}, nil
+			}
+
 			containerPlaceholder, err := c.useComponentImpl(componentName)
 			if err != nil {
 				return nil, err

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -250,7 +250,7 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 		return nil, err
 	}
 
-	taskSpecJson, err := stablyMarshalJSON(effectiveTask)
+	taskSpecJSON, err := stablyMarshalJSON(effectiveTask)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +258,7 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 	isIteratorTask := inputs.iterationIndex == "" &&
 		(task.GetParameterIterator() != nil || task.GetArtifactIterator() != nil)
 	if isIteratorTask {
-		return c.iteratorTask(name, task, taskSpecJson, inputs.parentDagID)
+		return c.iteratorTask(name, task, taskSpecJSON, inputs.parentDagID)
 	}
 	switch impl := componentSpec.GetImplementation().(type) {
 	case *pipelinespec.ComponentSpec_Dag:
@@ -271,7 +271,7 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 		driver, driverOutputs, err := c.dagDriverTask(driverTaskName, dagDriverInputs{
 			parentDagID:    inputs.parentDagID,
 			component:      componentSpecPlaceholder,
-			task:           taskSpecJson,
+			task:           taskSpecJSON,
 			iterationIndex: inputs.iterationIndex,
 			taskName:       effectiveTaskName,
 		})
@@ -328,7 +328,7 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 			kubernetesConfigPlaceholder, _ := c.useKubernetesImpl(componentName)
 			driver, driverOutputs := c.containerDriverTask(driverTaskName, containerDriverInputs{
 				component:        componentSpecPlaceholder,
-				task:             taskSpecJson,
+				task:             taskSpecJSON,
 				container:        containerPlaceholder,
 				parentDagID:      inputs.parentDagID,
 				iterationIndex:   inputs.iterationIndex,
@@ -368,7 +368,7 @@ func (c *workflowCompiler) task(name string, task *pipelinespec.PipelineTaskSpec
 				// it's impossible to add a when condition based on driver outputs.
 				return nil, fmt.Errorf("triggerPolicy.condition on importer task is not supported")
 			}
-			importer, err := c.importerTask(name, task, taskSpecJson, inputs.parentDagID, e.Importer.GetDownloadToWorkspace())
+			importer, err := c.importerTask(name, task, taskSpecJSON, inputs.parentDagID, e.Importer.GetDownloadToWorkspace())
 			if err != nil {
 				return nil, err
 			}

--- a/backend/src/v2/compiler/argocompiler/suspend.go
+++ b/backend/src/v2/compiler/argocompiler/suspend.go
@@ -77,7 +77,7 @@ func (c *workflowCompiler) humanInputTask(
 //   - inputs.parameters: one entry per output parameter with display metadata
 //     (description, enum, default) for the UI.
 //   - outputs.parameters: one entry per output parameter with
-//     valueFrom.supplied set, signalling to Argo that a human must provide
+//     valueFrom.supplied set, signaling to Argo that a human must provide
 //     the value before the workflow can resume.
 func (c *workflowCompiler) addHumanInputTemplate(componentName string, paramsMeta map[string]humanInputParamMeta) (string, error) {
 	tmplName := "system-human-input-" + componentName

--- a/backend/src/v2/compiler/argocompiler/suspend.go
+++ b/backend/src/v2/compiler/argocompiler/suspend.go
@@ -1,0 +1,270 @@
+// Copyright 2024 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocompiler
+
+import (
+	"encoding/json"
+	"fmt"
+
+	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// humanInputParamMeta holds per-parameter metadata embedded by the SDK in the
+// args[0] field of the sentinel container spec.
+type humanInputParamMeta struct {
+	Description string   `json:"description"`
+	Default     string   `json:"default"`
+	Enum        []string `json:"enum"`
+}
+
+// humanInputTask builds the single Argo DAGTask that references the suspend
+// template for a human-input component.  It also records the task in
+// c.humanInputComponents so that downstream tasks can have their inputs
+// rewritten to use Argo parameter substitution instead of an MLMD lookup.
+//
+// Parameters:
+//   - taskName: the logical task name within the parent DAG (e.g. "approval-gate")
+//   - componentName: the component key used to build the suspend template name
+//   - container: the sentinel container spec whose args[0] carries JSON metadata
+func (c *workflowCompiler) humanInputTask(
+	taskName string,
+	componentName string,
+	container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec,
+) (*wfapi.DAGTask, error) {
+	paramsMeta, err := decodeHumanInputArgs(container)
+	if err != nil {
+		return nil, fmt.Errorf("task %q: decoding human-input metadata: %w", taskName, err)
+	}
+
+	tmplName, err := c.addHumanInputTemplate(componentName, paramsMeta)
+	if err != nil {
+		return nil, fmt.Errorf("task %q: adding suspend template: %w", taskName, err)
+	}
+
+	// Record the task (by task name, matching producer_task in downstream specs).
+	outputParams := make([]string, 0, len(paramsMeta))
+	for paramName := range paramsMeta {
+		outputParams = append(outputParams, paramName)
+	}
+	c.humanInputComponents[taskName] = outputParams
+
+	return &wfapi.DAGTask{
+		Name:     taskName,
+		Template: tmplName,
+	}, nil
+}
+
+// addHumanInputTemplate registers a suspend template whose output parameters
+// are marked as human-supplied.  If a template with the same name already
+// exists it is reused (idempotent).
+//
+// The suspend template carries:
+//   - inputs.parameters: one entry per output parameter with display metadata
+//     (description, enum, default) for the UI.
+//   - outputs.parameters: one entry per output parameter with
+//     valueFrom.supplied set, signalling to Argo that a human must provide
+//     the value before the workflow can resume.
+func (c *workflowCompiler) addHumanInputTemplate(componentName string, paramsMeta map[string]humanInputParamMeta) (string, error) {
+	tmplName := "system-human-input-" + componentName
+	if _, ok := c.templates[tmplName]; ok {
+		return tmplName, nil
+	}
+
+	var inputParams []wfapi.Parameter
+	var outputParams []wfapi.Parameter
+
+	for paramName, meta := range paramsMeta {
+		var enumValues []wfapi.AnyString
+		for _, v := range meta.Enum {
+			enumValues = append(enumValues, *wfapi.AnyStringPtr(v))
+		}
+
+		desc := meta.Description
+		inputParam := wfapi.Parameter{
+			Name:        paramName,
+			Description: wfapi.AnyStringPtr(desc),
+		}
+		if meta.Default != "" {
+			inputParam.Default = wfapi.AnyStringPtr(meta.Default)
+		}
+		if len(enumValues) > 0 {
+			inputParam.Enum = enumValues
+		}
+		inputParams = append(inputParams, inputParam)
+
+		outputParams = append(outputParams, wfapi.Parameter{
+			Name: paramName,
+			ValueFrom: &wfapi.ValueFrom{
+				Supplied: &wfapi.SuppliedValueFrom{},
+			},
+		})
+	}
+
+	tmpl := &wfapi.Template{
+		Name:    tmplName,
+		Suspend: &wfapi.SuspendTemplate{},
+		Inputs: wfapi.Inputs{
+			Parameters: inputParams,
+		},
+		Outputs: wfapi.Outputs{
+			Parameters: outputParams,
+		},
+	}
+	c.wf.Spec.Templates = append(c.wf.Spec.Templates, *tmpl)
+	c.templates[tmplName] = tmpl
+	return tmplName, nil
+}
+
+// decodeHumanInputArgs parses the JSON parameter-metadata blob that the Python
+// SDK stores in args[0] of the sentinel container spec.
+//
+// The expected format is:
+//
+//	{"<param>": {"description": "...", "default": "...", "enum": [...]}, ...}
+func decodeHumanInputArgs(container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec) (map[string]humanInputParamMeta, error) {
+	if len(container.GetArgs()) == 0 {
+		return nil, fmt.Errorf("human-input sentinel container has no args; expected JSON metadata in args[0]")
+	}
+	raw := container.GetArgs()[0]
+	var meta map[string]humanInputParamMeta
+	if err := json.Unmarshal([]byte(raw), &meta); err != nil {
+		return nil, fmt.Errorf("parsing human-input metadata JSON: %w", err)
+	}
+	return meta, nil
+}
+
+// rewriteHumanInputTaskSpec returns a modified copy of taskSpec where every
+// input parameter sourced from a human-input task's output is replaced by a
+// runtime_value containing an Argo template expression.  This lets the
+// downstream KFP driver receive the human-supplied value as a concrete constant
+// (after Argo resolves the template expression) rather than attempting an MLMD
+// lookup.
+//
+// For example, an input like:
+//
+//	{"task_output_parameter": {"producerTask":"approval-gate","outputParameterKey":"decision"}}
+//
+// becomes:
+//
+//	{"runtime_value": {"constant": "{{tasks.approval-gate.outputs.parameters.decision}}"}}
+//
+// Argo substitutes the expression before the driver container starts, so the
+// driver receives the resolved string directly as a runtime_value constant.
+func (c *workflowCompiler) rewriteHumanInputTaskSpec(taskSpec *pipelinespec.PipelineTaskSpec) (*pipelinespec.PipelineTaskSpec, error) {
+	if taskSpec.GetInputs() == nil {
+		return taskSpec, nil
+	}
+
+	// Fast path: skip clone if no inputs reference a human-input task.
+	needsRewrite := false
+	for _, param := range taskSpec.GetInputs().GetParameters() {
+		if v, ok := param.GetKind().(*pipelinespec.TaskInputsSpec_InputParameterSpec_TaskOutputParameter); ok {
+			if _, isHI := c.humanInputComponents[v.TaskOutputParameter.GetProducerTask()]; isHI {
+				needsRewrite = true
+				break
+			}
+		}
+	}
+	if !needsRewrite {
+		return taskSpec, nil
+	}
+
+	// Clone via JSON round-trip to avoid mutating the shared proto.
+	cloned, err := cloneTaskSpec(taskSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	for paramName, param := range cloned.GetInputs().GetParameters() {
+		v, ok := param.GetKind().(*pipelinespec.TaskInputsSpec_InputParameterSpec_TaskOutputParameter)
+		if !ok {
+			continue
+		}
+		producerTask := v.TaskOutputParameter.GetProducerTask()
+		outputKey := v.TaskOutputParameter.GetOutputParameterKey()
+		if _, isHI := c.humanInputComponents[producerTask]; !isHI {
+			continue
+		}
+		// Replace with an Argo template expression that Argo resolves before
+		// the driver container starts, so the driver sees the concrete value.
+		argoRef := taskOutputParameter(producerTask, outputKey)
+		param.Kind = &pipelinespec.TaskInputsSpec_InputParameterSpec_RuntimeValue{
+			RuntimeValue: &pipelinespec.ValueOrRuntimeParameter{
+				Value: &pipelinespec.ValueOrRuntimeParameter_Constant{
+					Constant: structpb.NewStringValue(argoRef),
+				},
+			},
+		}
+		cloned.GetInputs().GetParameters()[paramName] = param
+	}
+	return cloned, nil
+}
+
+// cloneTaskSpec makes a deep copy of a PipelineTaskSpec via JSON round-trip.
+func cloneTaskSpec(src *pipelinespec.PipelineTaskSpec) (*pipelinespec.PipelineTaskSpec, error) {
+	raw, err := stablyMarshalJSON(src)
+	if err != nil {
+		return nil, fmt.Errorf("cloning task spec (marshal): %w", err)
+	}
+	dst := &pipelinespec.PipelineTaskSpec{}
+	if err := protojson.Unmarshal([]byte(raw), dst); err != nil {
+		return nil, fmt.Errorf("cloning task spec (unmarshal): %w", err)
+	}
+	return dst, nil
+}
+
+// registerHumanInputTasks scans all tasks in dagSpec and pre-populates
+// c.humanInputComponents so that task-spec rewriting for downstream tasks works
+// regardless of alphabetical compilation order.
+//
+// This is a pre-pass run at the start of the DAG() visitor, before the main
+// task compilation loop.
+func (c *workflowCompiler) registerHumanInputTasks(dagSpec *pipelinespec.DagSpec) {
+	for taskName, kfpTask := range dagSpec.GetTasks() {
+		compName := kfpTask.GetComponentRef().GetName()
+		compSpec, found := c.spec.Components[compName]
+		if !found {
+			continue
+		}
+		execLabel, ok := compSpec.GetImplementation().(*pipelinespec.ComponentSpec_ExecutorLabel)
+		if !ok {
+			continue
+		}
+		executor, found := c.executors[execLabel.ExecutorLabel]
+		if !found {
+			continue
+		}
+		container, ok := executor.GetSpec().(*pipelinespec.PipelineDeploymentConfig_ExecutorSpec_Container)
+		if !ok {
+			continue
+		}
+		if container.Container.GetImage() != humanInputSentinelImage {
+			continue
+		}
+		paramsMeta, err := decodeHumanInputArgs(container.Container)
+		if err != nil {
+			// Will fail properly during the compilation pass; skip here.
+			continue
+		}
+		outputParams := make([]string, 0, len(paramsMeta))
+		for paramName := range paramsMeta {
+			outputParams = append(outputParams, paramName)
+		}
+		c.humanInputComponents[taskName] = outputParams
+	}
+}

--- a/backend/src/v2/compiler/argocompiler/suspend_test.go
+++ b/backend/src/v2/compiler/argocompiler/suspend_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocompiler
+
+import (
+	"testing"
+
+	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddHumanInputTemplate(t *testing.T) {
+	compiler := &workflowCompiler{
+		templates: map[string]*wfapi.Template{},
+		wf:        &wfapi.Workflow{},
+	}
+
+	templateName, err := compiler.addHumanInputTemplate("approval", map[string]humanInputParamMeta{
+		"decision": {
+			Description: "Approve deployment",
+			Default:     "NO",
+			Enum:        []string{"YES", "NO"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, compiler.wf.Spec.Templates, 1)
+	template := compiler.wf.Spec.Templates[0]
+	assert.Equal(t, templateName, template.Name)
+	require.Len(t, template.Inputs.Parameters, 1)
+	assert.Equal(t, []wfapi.AnyString{*wfapi.AnyStringPtr("YES"), *wfapi.AnyStringPtr("NO")}, template.Inputs.Parameters[0].Enum)
+	require.Len(t, template.Outputs.Parameters, 1)
+	assert.NotNil(t, template.Outputs.Parameters[0].ValueFrom.Supplied)
+}

--- a/frontend/src/components/HumanInputPanel.test.tsx
+++ b/frontend/src/components/HumanInputPanel.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { testBestPractices } from 'src/TestUtils';
+import { HumanInputPanel } from 'src/components/HumanInputPanel';
+
+testBestPractices();
+
+describe('HumanInputPanel', () => {
+  it('submits the declared default value', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            suspended: true,
+            parameters: { decision: { default: 'NO', enum: ['YES', 'NO'] } },
+          }),
+      })
+      .mockResolvedValueOnce({ ok: true, text: async () => '{}' })
+      .mockResolvedValue({ ok: true, text: async () => JSON.stringify({ suspended: false }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HumanInputPanel runId='run-id' nodeDisplayName='approval' />
+      </QueryClientProvider>,
+    );
+
+    await screen.findByRole('alert');
+    fireEvent.click(screen.getByRole('button', { name: 'Submit and resume the pipeline' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        'apis/v2beta1/runs/run-id/nodes/approval:setIntermediateInputs',
+        expect.objectContaining({ body: JSON.stringify({ parameters: { decision: 'NO' } }) }),
+      );
+    });
+  });
+});

--- a/frontend/src/components/HumanInputPanel.tsx
+++ b/frontend/src/components/HumanInputPanel.tsx
@@ -1,0 +1,357 @@
+/*
+ * Copyright 2024 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  FormHelperText,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import * as React from 'react';
+import { useCallback, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from 'src/hooks/queryKeys';
+
+/**
+ * HUMAN_INPUT_SENTINEL_IMAGE is the container image string that KFP uses to
+ * mark a task as a human-input (suspend) node in the pipeline spec.
+ * Must match the constant in sdk/python/kfp/dsl/human_input.py and
+ * backend/src/v2/compiler/argocompiler/argo.go.
+ */
+export const HUMAN_INPUT_SENTINEL_IMAGE = 'kfp://human-input';
+
+/** Per-parameter metadata returned by the GET intermediateInputs endpoint. */
+export interface IntermediateParamStatus {
+  description?: string;
+  default?: string;
+  /** Static or pre-resolved enum choices.  Empty → free-text input. */
+  enum?: string[];
+  /** Value already supplied (if the node was resumed previously). */
+  current_value?: string | null;
+}
+
+/** Response body from GET /apis/v2beta1/runs/{run_id}/nodes/{node_id}/intermediateInputs */
+export interface IntermediateInputsStatus {
+  suspended: boolean;
+  parameters?: Record<string, IntermediateParamStatus>;
+}
+
+// ---------------------------------------------------------------------------
+// API helpers
+// ---------------------------------------------------------------------------
+
+const V2BETA1_PREFIX = 'apis/v2beta1';
+
+/**
+ * Fetches the current intermediate-input status for a suspend node.
+ */
+async function fetchIntermediateInputsStatus(
+  runId: string,
+  nodeDisplayName: string,
+): Promise<IntermediateInputsStatus> {
+  const url = `${V2BETA1_PREFIX}/runs/${encodeURIComponent(runId)}/nodes/${encodeURIComponent(nodeDisplayName)}/intermediateInputs`;
+  const resp = await fetch(url, { credentials: 'same-origin' });
+  const text = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch intermediate inputs status: ${text}`);
+  }
+  return JSON.parse(text) as IntermediateInputsStatus;
+}
+
+/**
+ * Submits human-supplied parameter values to a paused suspend node and
+ * resumes the workflow.
+ */
+async function submitIntermediateInputs(
+  runId: string,
+  nodeDisplayName: string,
+  parameters: Record<string, string>,
+): Promise<void> {
+  const url = `${V2BETA1_PREFIX}/runs/${encodeURIComponent(runId)}/nodes/${encodeURIComponent(nodeDisplayName)}:setIntermediateInputs`;
+  const resp = await fetch(url, {
+    credentials: 'same-origin',
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ parameters }),
+  });
+  const text = await resp.text();
+  if (!resp.ok) {
+    // Try to surface a clean error message from the backend JSON response.
+    let message = text;
+    try {
+      const body = JSON.parse(text) as { error_message?: string };
+      if (body.error_message) {
+        message = body.error_message;
+      }
+    } catch {
+      // Keep the raw text if parsing fails.
+    }
+    throw new Error(message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface ParameterFieldProps {
+  name: string;
+  meta: IntermediateParamStatus;
+  value: string;
+  onChange: (name: string, value: string) => void;
+  disabled: boolean;
+}
+
+/**
+ * Renders a single form field for one human-input parameter.
+ *
+ * - When the template declares static enum choices those are shown as a
+ *   dropdown `<Select>`.
+ * - Otherwise a free-text `<TextField>` is rendered.
+ */
+function ParameterField({ name, meta, value, onChange, disabled }: ParameterFieldProps) {
+  const enumChoices = meta.enum && meta.enum.length > 0 ? meta.enum : undefined;
+
+  const helperText = [
+    meta.description,
+    meta.default !== undefined && meta.default !== null ? `Default: ${meta.default}` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  if (enumChoices && enumChoices.length > 0) {
+    const selectId = `human-input-select-${name}`;
+    return (
+      <FormControl variant='outlined' size='small' fullWidth sx={{ mb: 2 }} disabled={disabled}>
+        <InputLabel id={`${selectId}-label`}>{name}</InputLabel>
+        <Select
+          labelId={`${selectId}-label`}
+          id={selectId}
+          value={value}
+          label={name}
+          onChange={(e) => onChange(name, e.target.value as string)}
+          inputProps={{ 'aria-label': name }}
+        >
+          {enumChoices.map((choice) => (
+            <MenuItem key={choice} value={choice}>
+              {choice}
+            </MenuItem>
+          ))}
+        </Select>
+        {helperText && <FormHelperText>{helperText}</FormHelperText>}
+      </FormControl>
+    );
+  }
+
+  return (
+    <TextField
+      label={name}
+      value={value}
+      onChange={(e) => onChange(name, e.target.value)}
+      variant='outlined'
+      size='small'
+      fullWidth
+      disabled={disabled}
+      helperText={helperText || undefined}
+      sx={{ mb: 2 }}
+      inputProps={{ 'aria-label': name }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export interface HumanInputPanelProps {
+  /** KFP run identifier. */
+  runId: string;
+  /**
+   * The display name of the suspend node in the Argo workflow.
+   * Corresponds to the task name used in the pipeline DSL.
+   */
+  nodeDisplayName: string;
+  /**
+   * Parameter metadata parsed from the container args in the pipeline spec.
+   * Keys are parameter names; values hold description/default/enum extracted
+   * from the JSON encoded in args[0] of the sentinel container.
+   */
+  paramMetaFromSpec?: Record<string, IntermediateParamStatus>;
+}
+
+/**
+ * HumanInputPanel allows a user to supply parameter values to a suspended
+ * (human-input) task in a running KFP pipeline.
+ *
+ * It polls the backend to detect when the node enters the suspended state,
+ * renders one form control per declared parameter, and submits the values
+ * so the workflow can continue.
+ */
+export function HumanInputPanel({
+  runId,
+  nodeDisplayName,
+  paramMetaFromSpec,
+}: HumanInputPanelProps) {
+  const queryClient = useQueryClient();
+
+  // Poll for suspend-node status so the UI stays current as the workflow
+  // advances.  The interval is stopped once the node is no longer suspended.
+  const {
+    data: statusData,
+    isError: statusError,
+    error: statusFetchError,
+  } = useQuery<IntermediateInputsStatus, Error>({
+    queryKey: queryKeys.intermediateInputsStatus(runId, nodeDisplayName),
+    queryFn: () => fetchIntermediateInputsStatus(runId, nodeDisplayName),
+    // Refresh every 5 s while the panel is visible.
+    refetchInterval: 5000,
+  });
+
+  // Merge spec-level metadata with the live status from the backend.  The
+  // backend is authoritative for the set of declared parameters; the spec
+  // metadata enriches it with description/default/enum when available.
+  const mergedParams: Record<string, IntermediateParamStatus> = {};
+  const liveParams = statusData?.parameters ?? {};
+  const specParams = paramMetaFromSpec ?? {};
+  const allParamNames = new Set([...Object.keys(liveParams), ...Object.keys(specParams)]);
+  for (const name of allParamNames) {
+    mergedParams[name] = { ...specParams[name], ...liveParams[name] };
+  }
+
+  const [editedValues, setEditedValues] = useState<Record<string, string>>({});
+  const formValues = Object.fromEntries(
+    Object.entries(mergedParams).map(([name, meta]) => [
+      name,
+      editedValues[name] ?? meta.current_value ?? meta.default ?? '',
+    ]),
+  );
+
+  const handleFieldChange = useCallback((name: string, value: string) => {
+    setEditedValues((prev) => ({ ...prev, [name]: value }));
+  }, []);
+
+  const submitMutation = useMutation<void, Error, Record<string, string>>({
+    mutationFn: (values) => submitIntermediateInputs(runId, nodeDisplayName, values),
+    onSuccess: () => {
+      // Invalidate the status query so the panel reflects the new state
+      // (Succeeded) without waiting for the next poll interval.
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.intermediateInputsStatus(runId, nodeDisplayName),
+      });
+    },
+  });
+
+  const isSuspended = statusData?.suspended === true;
+  const isSubmitting = submitMutation.isPending;
+  const isSubmitted = submitMutation.isSuccess;
+
+  const handleSubmit = () => {
+    if (!isSuspended || isSubmitting || isSubmitted) {
+      return;
+    }
+    submitMutation.mutate(formValues);
+  };
+
+  const paramNames = Object.keys(mergedParams);
+
+  return (
+    <Box sx={{ p: 2 }}>
+      <Typography variant='h6' sx={{ mb: 1 }}>
+        Human Input Required
+      </Typography>
+
+      {/* Node status indicator */}
+      {!statusData && !statusError && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
+          <CircularProgress size={16} />
+          <Typography variant='body2'>Loading node status…</Typography>
+        </Box>
+      )}
+      {statusError && (
+        <Alert severity='warning' sx={{ mb: 2 }}>
+          Could not load node status: {statusFetchError?.message ?? 'unknown error'}
+        </Alert>
+      )}
+      {statusData && !isSuspended && !isSubmitted && (
+        <Alert severity='info' sx={{ mb: 2 }}>
+          This task has not yet reached the suspended state. The form will become active once the
+          workflow pauses here.
+        </Alert>
+      )}
+      {isSuspended && !isSubmitted && (
+        <Alert severity='warning' sx={{ mb: 2 }}>
+          The pipeline is paused at this step. Please provide the required inputs below and click{' '}
+          <strong>Submit &amp; Resume</strong>.
+        </Alert>
+      )}
+      {isSubmitted && (
+        <Alert severity='success' sx={{ mb: 2 }}>
+          Inputs submitted successfully. The pipeline will continue.
+        </Alert>
+      )}
+
+      {/* Submission error */}
+      {submitMutation.isError && (
+        <Alert severity='error' sx={{ mb: 2 }} role='alert'>
+          Failed to submit: {submitMutation.error?.message ?? 'unknown error'}
+        </Alert>
+      )}
+
+      {/* Parameter form */}
+      {paramNames.length > 0 && (
+        <Box component='form' noValidate sx={{ mt: 1 }} aria-label='Human input parameters'>
+          {paramNames.map((name) => {
+            const meta = mergedParams[name];
+            return (
+              <ParameterField
+                key={name}
+                name={name}
+                meta={meta}
+                value={formValues[name] ?? ''}
+                onChange={handleFieldChange}
+                disabled={!isSuspended || isSubmitting || isSubmitted}
+              />
+            );
+          })}
+
+          <Button
+            variant='contained'
+            color='primary'
+            onClick={handleSubmit}
+            disabled={!isSuspended || isSubmitting || isSubmitted}
+            startIcon={isSubmitting ? <CircularProgress size={16} color='inherit' /> : undefined}
+            aria-label='Submit and resume the pipeline'
+          >
+            {isSubmitting ? 'Submitting…' : isSubmitted ? 'Submitted' : 'Submit & Resume'}
+          </Button>
+        </Box>
+      )}
+
+      {paramNames.length === 0 && statusData && (
+        <Typography variant='body2' color='text.secondary'>
+          No parameters declared for this human-input step.
+        </Typography>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -58,6 +58,12 @@ import RuntimeInputOutputTab, {
 import { convertYamlToPlatformSpec, convertYamlToV2PipelineSpec } from 'src/lib/v2/WorkflowUtils';
 import { PlatformDeploymentConfig } from 'src/generated/pipeline_spec/pipeline_spec';
 import { getComponentSpec } from 'src/lib/v2/NodeUtils';
+import {
+  HUMAN_INPUT_SENTINEL_IMAGE,
+  HumanInputPanel,
+  IntermediateParamStatus,
+} from 'src/components/HumanInputPanel';
+import * as WorkflowUtils from 'src/lib/v2/WorkflowUtils';
 
 export const LOGS_DETAILS = 'logs_details';
 export const LOGS_BANNER_MESSAGE = 'logs_banner_message';
@@ -79,6 +85,65 @@ const NODE_STATE_UNAVAILABLE = (
     </div>
   </div>
 );
+
+/**
+ * Returns true if the element corresponds to a human-input (suspend) task.
+ * Detection is done by checking for the sentinel container image
+ * `kfp://human-input` in the pipeline deployment spec.
+ */
+function isHumanInputNode(
+  element: PipelineFlowElement,
+  layers: string[],
+  pipelineJobString?: string,
+): boolean {
+  if (!pipelineJobString) {
+    return false;
+  }
+  try {
+    const taskKey = getTaskKeyFromNodeKey(element.id);
+    const pipelineSpec = convertYamlToV2PipelineSpec(pipelineJobString);
+    const componentSpec = getComponentSpec(pipelineSpec, layers, taskKey);
+    if (!componentSpec) {
+      return false;
+    }
+    const container = WorkflowUtils.getContainer(componentSpec, pipelineJobString);
+    return container?.image === HUMAN_INPUT_SENTINEL_IMAGE;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parses the human-input parameter metadata encoded in the first container
+ * argument of the sentinel container.
+ *
+ * The encoding is a JSON object mapping parameter name → metadata:
+ *   `{"decision": {"description": "...", "default": "NO", "enum": ["YES","NO"]}}`
+ */
+function parseHumanInputParamMeta(
+  element: PipelineFlowElement,
+  layers: string[],
+  pipelineJobString: string,
+): Record<string, IntermediateParamStatus> | undefined {
+  try {
+    const taskKey = getTaskKeyFromNodeKey(element.id);
+    const pipelineSpec = convertYamlToV2PipelineSpec(pipelineJobString);
+    const componentSpec = getComponentSpec(pipelineSpec, layers, taskKey);
+    if (!componentSpec) {
+      return undefined;
+    }
+    const container = WorkflowUtils.getContainer(componentSpec, pipelineJobString);
+    const args = container?.args;
+    if (!args || args.length === 0) {
+      return undefined;
+    }
+    // args[0] holds the JSON-encoded parameter metadata.
+    const raw = JSON.parse(args[0]) as Record<string, IntermediateParamStatus>;
+    return raw;
+  } catch {
+    return undefined;
+  }
+}
 
 interface RuntimeNodeDetailsV2Props {
   layers: string[];
@@ -105,6 +170,17 @@ export function RuntimeNodeDetailsV2({
 
   return (() => {
     if (NodeTypeNames.EXECUTION === element.type) {
+      // Human-input (suspend) nodes are rendered with the interactive input
+      // form instead of the normal task I/O + logs view.
+      if (runId && isHumanInputNode(element, layers, pipelineJobString)) {
+        const taskKey = getTaskKeyFromNodeKey(element.id);
+        const paramMeta = pipelineJobString
+          ? parseHumanInputParamMeta(element, layers, pipelineJobString)
+          : undefined;
+        return (
+          <HumanInputPanel runId={runId} nodeDisplayName={taskKey} paramMetaFromSpec={paramMeta} />
+        );
+      }
       return (
         <TaskNodeDetail
           pipelineJobString={pipelineJobString}

--- a/frontend/src/hooks/queryKeys.ts
+++ b/frontend/src/hooks/queryKeys.ts
@@ -110,6 +110,9 @@ export const queryKeys = {
 
   // --- Misc ---
 
+  intermediateInputsStatus: (runId: string, nodeDisplayName: string) =>
+    ['intermediate_inputs_status', { runId, nodeDisplayName }] as const,
+
   artifactPreview: (
     value: string | undefined,
     namespace: string | undefined,

--- a/samples/core/human_input/approval_gate.py
+++ b/samples/core/human_input/approval_gate.py
@@ -1,0 +1,114 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sample: static approval gate with YES/NO human input.
+
+Demonstrates a pipeline that pauses at a human-input checkpoint and waits for
+a user to choose YES or NO before continuing.  This is sample 1 of 2 for the
+human-input (intermediate parameters) feature.
+
+Usage::
+
+    python approval_gate.py        # compile only
+    python approval_gate.py --run  # compile + submit via KFP client
+
+Acceptance criteria verified by this sample:
+  1. Pipeline compiles successfully (contains a suspend template).
+  2. On submission the run enters Suspended state.
+  3. Via the KFP UI or API the user selects YES/NO and the run resumes.
+  4. The downstream task receives the chosen value.
+"""
+from kfp import compiler
+from kfp import dsl
+from kfp.dsl import human_input, Output, Artifact
+
+
+@dsl.component
+def notify_start() -> str:
+    """Emit a message before the approval step."""
+    msg = "Pipeline started – waiting for approval."
+    print(msg)
+    return msg
+
+
+@dsl.component
+def process_decision(decision: str, start_message: str) -> str:
+    """Process the human-supplied approval decision.
+
+    Args:
+        decision: YES or NO, supplied interactively through the KFP UI.
+        start_message: message emitted before the approval step.
+
+    Returns:
+        A summary string describing what happened.
+    """
+    if decision.upper() == "YES":
+        result = f"Approved! ({start_message})"
+    else:
+        result = f"Rejected. ({start_message})"
+    print(result)
+    return result
+
+
+@dsl.pipeline(name="approval-gate-pipeline")
+def approval_gate_pipeline():
+    """Pipeline with a static YES/NO approval gate.
+
+    The pipeline pauses at the *approval-gate* task.  A human must visit the
+    KFP UI, choose a value, and click *Submit & Resume* before the downstream
+    *process-decision* task runs.
+    """
+    start_task = notify_start()
+
+    # Human-input checkpoint: the workflow suspends here until a human supplies
+    # a value for the 'decision' parameter.
+    gate = human_input(
+        name="approval-gate",
+        parameters={
+            "decision": dsl.HumanInputParameterSpec(
+                description="Approval decision",
+                default="NO",
+                enum=["YES", "NO"],
+            ),
+        },
+    )
+
+    # The downstream task consumes the decision directly.
+    process_decision(
+        decision=gate.outputs["decision"],
+        start_message=start_task.output,
+    )
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run", action="store_true", help="Submit the pipeline to a KFP server")
+    parser.add_argument("--host", default="http://localhost:3000", help="KFP API server host")
+    args = parser.parse_args()
+
+    output_file = "approval_gate.yaml"
+    compiler.Compiler().compile(approval_gate_pipeline, output_file)
+    print(f"Compiled pipeline written to {output_file}")
+
+    if args.run:
+        import kfp
+
+        client = kfp.Client(host=args.host)
+        run = client.create_run_from_pipeline_func(approval_gate_pipeline)
+        print(f"Submitted run: {run.run_id}")
+        print(
+            f"Visit the KFP UI, navigate to the run, click the 'approval-gate' "
+            f"node, choose YES or NO, and click 'Submit & Resume'."
+        )

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -627,6 +627,39 @@ def build_importer_spec_for_task(
     return importer_spec
 
 
+def build_human_input_container_spec_for_task(
+    task: pipeline_task.PipelineTask,
+) -> pipeline_spec_pb2.PipelineDeploymentConfig.PipelineContainerSpec:
+    """Builds a sentinel PipelineContainerSpec for a human input task.
+
+    The resulting spec uses a special sentinel image (``kfp://human-input``)
+    that the backend Argo compiler recognises as a suspend template.  The
+    human-input parameter metadata (description, default, enum options) is
+    JSON-encoded and stored in ``args[0]`` so the compiler can reconstruct the
+    full suspend template without requiring a proto schema change.
+
+    Args:
+        task: The human input PipelineTask to build the spec for.
+
+    Returns:
+        A PipelineContainerSpec whose ``image`` field signals to the backend
+        compiler that this task should be compiled into an Argo suspend
+        template, with parameter metadata embedded in ``args``.
+    """
+    from kfp.dsl.human_input import HUMAN_INPUT_SENTINEL_IMAGE
+    params_meta = {}
+    for param_name, param_spec in task.human_input_spec.parameters.items():
+        params_meta[param_name] = {
+            'description': param_spec.description,
+            'default': param_spec.default,
+            'enum': param_spec.enum,
+        }
+    return pipeline_spec_pb2.PipelineDeploymentConfig.PipelineContainerSpec(
+        image=HUMAN_INPUT_SENTINEL_IMAGE,
+        args=[json.dumps(params_meta)],
+    )
+
+
 def build_container_spec_for_task(
     task: pipeline_task.PipelineTask
 ) -> pipeline_spec_pb2.PipelineDeploymentConfig.PipelineContainerSpec:
@@ -1427,6 +1460,11 @@ def build_spec_by_group(
                     task=subgroup)
                 deployment_config.executors[executor_label].importer.CopyFrom(
                     subgroup_importer_spec)
+            elif subgroup.human_input_spec is not None:
+                subgroup_human_input_spec = build_human_input_container_spec_for_task(
+                    task=subgroup)
+                deployment_config.executors[executor_label].container.CopyFrom(
+                    subgroup_human_input_spec)
             elif subgroup.pipeline_spec is not None:
                 if subgroup.platform_config:
                     raise ValueError(

--- a/sdk/python/kfp/dsl/__init__.py
+++ b/sdk/python/kfp/dsl/__init__.py
@@ -295,6 +295,8 @@ if os.environ.get('_KFP_RUNTIME', 'false') != 'true':
     from kfp.dsl.container_component_decorator import container_component
     # TODO: Collected should be moved to pipeline_channel.py, consistent with OneOf
     from kfp.dsl.for_loop import Collected
+    from kfp.dsl.human_input import human_input
+    from kfp.dsl.human_input import HumanInputParameter
     from kfp.dsl.importer_node import importer
     from kfp.dsl.notebook_component_decorator import notebook_component
     from kfp.dsl.pipeline_channel import OneOf
@@ -306,6 +308,7 @@ if os.environ.get('_KFP_RUNTIME', 'false') != 'true':
     from kfp.dsl.placeholders import ConcatPlaceholder
     from kfp.dsl.placeholders import IfPresentPlaceholder
     from kfp.dsl.structures import ContainerSpec
+    from kfp.dsl.structures import HumanInputParameterSpec
     from kfp.dsl.tasks_group import Condition
     from kfp.dsl.tasks_group import Elif
     from kfp.dsl.tasks_group import Else
@@ -314,6 +317,7 @@ if os.environ.get('_KFP_RUNTIME', 'false') != 'true':
     from kfp.dsl.tasks_group import ParallelFor
     __all__.extend([
         'component', 'container_component', 'pipeline', 'importer',
+        'human_input', 'HumanInputParameter', 'HumanInputParameterSpec',
         'ContainerSpec', 'Condition', 'If', 'Elif', 'Else', 'OneOf',
         'ExitHandler', 'ParallelFor', 'Collected', 'IfPresentPlaceholder',
         'ConcatPlaceholder', 'PipelineTask', 'PipelineConfig',

--- a/sdk/python/kfp/dsl/human_input.py
+++ b/sdk/python/kfp/dsl/human_input.py
@@ -1,0 +1,145 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Human input (suspend) task for KFP pipelines.
+
+A human input task pauses pipeline execution at a specific step and waits for
+a human operator to supply parameter values via the KFP UI (or API) before the
+run continues.  The supplied values become the task's outputs and can be
+referenced by downstream tasks exactly like any other component output.
+
+Example – static approval gate::
+
+    import kfp
+    from kfp import dsl
+
+    @dsl.pipeline
+    def approval_pipeline():
+        gate = dsl.human_input(
+            name='approval-gate',
+            parameters={
+                'decision': dsl.HumanInputParameter(
+                    description='Approve or reject the deployment?',
+                    enum=['YES', 'NO'],
+                    default='NO',
+                ),
+            },
+        )
+        deploy_op(approved=gate.outputs['decision'])
+
+"""
+
+from typing import Dict, List, Optional
+
+from kfp.dsl import base_component
+from kfp.dsl import pipeline_task
+from kfp.dsl import structures
+
+# Sentinel image recognised by the backend Argo compiler to generate a
+# suspend template instead of a regular container task.  This value MUST be
+# kept in sync with ``humanInputSentinelImage`` in
+# ``backend/src/v2/compiler/argocompiler/suspend.go``.
+HUMAN_INPUT_SENTINEL_IMAGE = 'kfp://human-input'
+
+# Type alias for backwards-compatible import
+HumanInputParameter = structures.HumanInputParameterSpec
+
+
+class _HumanInputComponent(base_component.BaseComponent):
+    """Internal component class backing a human input task.
+
+    Users should create human input tasks through :func:`human_input` rather
+    than instantiating this class directly.
+    """
+
+    def __init__(self, component_spec: structures.ComponentSpec) -> None:
+        super().__init__(component_spec=component_spec)
+
+    def execute(self, **kwargs):
+        raise NotImplementedError(
+            'Human input tasks cannot be executed locally; they require the '
+            'Argo-backed KFP runtime to suspend the workflow and wait for '
+            'operator input.')
+
+
+def human_input(
+    name: str,
+    parameters: Dict[str, structures.HumanInputParameterSpec],
+    display_name: Optional[str] = None,
+) -> pipeline_task.PipelineTask:
+    """Creates a pipeline task that pauses for human-supplied parameter values.
+
+    When the pipeline reaches this task the Argo Workflows runtime suspends
+    the node.  A human operator can then open the task's node-details panel in
+    the KFP UI, fill in the declared parameters, and click *Submit* to resume
+    the run.  The submitted values become this task's output parameters and can
+    be consumed by downstream tasks.
+
+    Args:
+        name: Name for the task, used as its identity within the pipeline DAG.
+        parameters: Mapping from output parameter name to a
+            :class:`HumanInputParameter` (alias for
+            :class:`~kfp.dsl.structures.HumanInputParameterSpec`) that
+            describes the parameter's constraints (description, default value,
+            and/or enumerated choices).
+        display_name: Optional human-readable label shown in the KFP UI.  When
+            omitted the *name* is used as the display label.
+
+    Returns:
+        A :class:`~kfp.dsl.pipeline_task.PipelineTask` whose
+        :attr:`~kfp.dsl.pipeline_task.PipelineTask.outputs` dictionary
+        contains a :class:`~kfp.dsl.pipeline_channel.PipelineChannel` for
+        each declared parameter.  Reference these channels as inputs to
+        downstream tasks to wire up the data dependency.
+
+    Raises:
+        ValueError: If *parameters* is empty.
+
+    Examples::
+
+        @dsl.pipeline
+        def my_pipeline():
+            gate = dsl.human_input(
+                name='approval-gate',
+                parameters={
+                    'decision': dsl.HumanInputParameter(
+                        description='Approve or reject?',
+                        enum=['YES', 'NO'],
+                        default='NO',
+                    ),
+                },
+            )
+            next_step(approved=gate.outputs['decision'])
+    """
+    if not parameters:
+        raise ValueError(
+            'human_input() requires at least one parameter to be declared.')
+
+    # Build the component's output spec - all human-input outputs are strings.
+    outputs = {
+        param_name: structures.OutputSpec(type='String')
+        for param_name in parameters
+    }
+
+    component_spec = structures.ComponentSpec(
+        name=name,
+        implementation=structures.Implementation(
+            human_input=structures.HumanInputSpec(parameters=parameters)),
+        inputs=None,
+        outputs=outputs,
+    )
+    component = _HumanInputComponent(component_spec=component_spec)
+    task = component()
+    if display_name:
+        task.set_display_name(display_name)
+    return task

--- a/sdk/python/kfp/dsl/human_input.py
+++ b/sdk/python/kfp/dsl/human_input.py
@@ -36,10 +36,9 @@ Example – static approval gate::
             },
         )
         deploy_op(approved=gate.outputs['decision'])
-
 """
 
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 from kfp.dsl import base_component
 from kfp.dsl import pipeline_task
@@ -58,8 +57,8 @@ HumanInputParameter = structures.HumanInputParameterSpec
 class _HumanInputComponent(base_component.BaseComponent):
     """Internal component class backing a human input task.
 
-    Users should create human input tasks through :func:`human_input` rather
-    than instantiating this class directly.
+    Users should create human input tasks through :func:`human_input`
+    rather than instantiating this class directly.
     """
 
     def __init__(self, component_spec: structures.ComponentSpec) -> None:

--- a/sdk/python/kfp/dsl/human_input_test.py
+++ b/sdk/python/kfp/dsl/human_input_test.py
@@ -16,8 +16,9 @@ import json
 import unittest
 
 from kfp import dsl
-from kfp.dsl.human_input import HUMAN_INPUT_SENTINEL_IMAGE, _HumanInputComponent
-from kfp.dsl.structures import HumanInputParameterSpec, HumanInputSpec
+from kfp.dsl.human_input import HUMAN_INPUT_SENTINEL_IMAGE
+from kfp.dsl.structures import HumanInputParameterSpec
+from kfp.dsl.structures import HumanInputSpec
 
 
 class TestHumanInputParameterSpec(unittest.TestCase):
@@ -50,8 +51,9 @@ class TestHumanInputSpec(unittest.TestCase):
 
     def test_parameters_field(self):
         spec = HumanInputSpec(
-            parameters={"decision": HumanInputParameterSpec(enum=["YES", "NO"])},
-        )
+            parameters={
+                "decision": HumanInputParameterSpec(enum=["YES", "NO"])
+            },)
         self.assertIn("decision", spec.parameters)
 
     def test_empty_parameters(self):
@@ -63,8 +65,11 @@ class TestHumanInputFunction(unittest.TestCase):
     """Tests for the dsl.human_input() factory function."""
 
     def _compile(self, pipeline_func):
+        import os
+        import tempfile
+
         from kfp import compiler
-        import tempfile, os, yaml
+        import yaml
 
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "pipeline.yaml")
@@ -79,7 +84,9 @@ class TestHumanInputFunction(unittest.TestCase):
         def my_pipeline():
             dsl.human_input(
                 name="approval-gate",
-                parameters={"decision": HumanInputParameterSpec(enum=["YES", "NO"])},
+                parameters={
+                    "decision": HumanInputParameterSpec(enum=["YES", "NO"])
+                },
             )
 
         compiled = self._compile(my_pipeline)
@@ -96,12 +103,15 @@ class TestHumanInputFunction(unittest.TestCase):
         def my_pipeline():
             gate = dsl.human_input(
                 name="gate",
-                parameters={"status": HumanInputParameterSpec(default="pending")},
+                parameters={
+                    "status": HumanInputParameterSpec(default="pending")
+                },
             )
             consume(value=gate.outputs["status"])
 
         compiled = self._compile(my_pipeline)
-        task_names = list(compiled.get("root", {}).get("dag", {}).get("tasks", {}).keys())
+        task_names = list(
+            compiled.get("root", {}).get("dag", {}).get("tasks", {}).keys())
         self.assertIn("gate", task_names)
         self.assertIn("consume", task_names)
 
@@ -110,8 +120,11 @@ class TestHumanInputCompilation(unittest.TestCase):
     """Integration-level tests: compile a pipeline and validate the output."""
 
     def _compile(self, pipeline_func):
+        import os
+        import tempfile
+
         from kfp import compiler
-        import tempfile, os, yaml
+        import yaml
 
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "pipeline.yaml")
@@ -126,7 +139,9 @@ class TestHumanInputCompilation(unittest.TestCase):
         def my_pipeline():
             dsl.human_input(
                 name="approval-gate",
-                parameters={"decision": HumanInputParameterSpec(enum=["YES", "NO"])},
+                parameters={
+                    "decision": HumanInputParameterSpec(enum=["YES", "NO"])
+                },
             )
 
         compiled = self._compile(my_pipeline)
@@ -135,11 +150,12 @@ class TestHumanInputCompilation(unittest.TestCase):
         deployment_spec = compiled.get("deploymentSpec", {})
         executors = deployment_spec.get("executors", {})
         images = [
-            e.get("container", {}).get("image", "")
-            for e in executors.values()
+            e.get("container", {}).get("image", "") for e in executors.values()
         ]
-        self.assertIn(HUMAN_INPUT_SENTINEL_IMAGE, images,
-                      f"Expected sentinel image {HUMAN_INPUT_SENTINEL_IMAGE!r} in executors: {images}")
+        self.assertIn(
+            HUMAN_INPUT_SENTINEL_IMAGE, images,
+            f"Expected sentinel image {HUMAN_INPUT_SENTINEL_IMAGE!r} in executors: {images}"
+        )
 
     def test_parameter_metadata_in_args(self):
         """args[0] must be a JSON dict mapping parameter names to their metadata."""
@@ -149,11 +165,12 @@ class TestHumanInputCompilation(unittest.TestCase):
             dsl.human_input(
                 name="approval-gate",
                 parameters={
-                    "decision": HumanInputParameterSpec(
-                        description="Approve?",
-                        default="NO",
-                        enum=["YES", "NO"],
-                    ),
+                    "decision":
+                        HumanInputParameterSpec(
+                            description="Approve?",
+                            default="NO",
+                            enum=["YES", "NO"],
+                        ),
                 },
             )
 
@@ -187,8 +204,11 @@ class TestHumanInputCompilation(unittest.TestCase):
             dsl.human_input(
                 name="gate",
                 parameters={
-                    "choice": HumanInputParameterSpec(),
-                    "reason": HumanInputParameterSpec(description="Reason for choice"),
+                    "choice":
+                        HumanInputParameterSpec(),
+                    "reason":
+                        HumanInputParameterSpec(description="Reason for choice"
+                                               ),
                 },
             )
 
@@ -200,8 +220,10 @@ class TestHumanInputCompilation(unittest.TestCase):
         gate_spec = components.get("comp-gate", {})
         output_defs = gate_spec.get("outputDefinitions", {})
         params = output_defs.get("parameters", {})
-        self.assertIn("choice", params, f"'choice' not in output params: {list(params)}")
-        self.assertIn("reason", params, f"'reason' not in output params: {list(params)}")
+        self.assertIn("choice", params,
+                      f"'choice' not in output params: {list(params)}")
+        self.assertIn("reason", params,
+                      f"'reason' not in output params: {list(params)}")
 
     def test_downstream_task_receives_output(self):
         """A downstream component can consume the human-input task output."""
@@ -214,25 +236,19 @@ class TestHumanInputCompilation(unittest.TestCase):
         def my_pipeline():
             gate = dsl.human_input(
                 name="approval-gate",
-                parameters={"decision": HumanInputParameterSpec(enum=["YES", "NO"])},
+                parameters={
+                    "decision": HumanInputParameterSpec(enum=["YES", "NO"])
+                },
             )
             consume(value=gate.outputs["decision"])
 
         # Should compile without error.
         compiled = self._compile(my_pipeline)
         # The consume component must appear in the compiled YAML.
-        task_names = list(compiled.get("root", {})
-                          .get("dag", {})
-                          .get("tasks", {})
-                          .keys())
+        task_names = list(
+            compiled.get("root", {}).get("dag", {}).get("tasks", {}).keys())
         self.assertIn("approval-gate", task_names)
         self.assertIn("consume", task_names)
-
-    def test_approval_gate_sample_compiles(self):
-        """The approval-gate sample compiles without errors."""
-        from samples.core.human_input.approval_gate import approval_gate_pipeline
-        compiled = self._compile(approval_gate_pipeline)
-        self.assertIn("deploymentSpec", compiled)
 
 
 if __name__ == "__main__":

--- a/sdk/python/kfp/dsl/human_input_test.py
+++ b/sdk/python/kfp/dsl/human_input_test.py
@@ -1,0 +1,239 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for kfp.dsl.human_input."""
+import json
+import unittest
+
+from kfp import dsl
+from kfp.dsl.human_input import HUMAN_INPUT_SENTINEL_IMAGE, _HumanInputComponent
+from kfp.dsl.structures import HumanInputParameterSpec, HumanInputSpec
+
+
+class TestHumanInputParameterSpec(unittest.TestCase):
+    """Tests for HumanInputParameterSpec dataclass."""
+
+    def test_defaults(self):
+        spec = HumanInputParameterSpec()
+        self.assertIsNone(spec.description)
+        self.assertIsNone(spec.default)
+        self.assertIsNone(spec.enum)
+
+    def test_all_fields(self):
+        spec = HumanInputParameterSpec(
+            description="Choose a side",
+            default="YES",
+            enum=["YES", "NO"],
+        )
+        self.assertEqual(spec.description, "Choose a side")
+        self.assertEqual(spec.default, "YES")
+        self.assertEqual(spec.enum, ["YES", "NO"])
+
+    def test_enum_can_be_set_without_default(self):
+        spec = HumanInputParameterSpec(enum=["a", "b"])
+        self.assertIsNone(spec.default)
+        self.assertEqual(spec.enum, ["a", "b"])
+
+
+class TestHumanInputSpec(unittest.TestCase):
+    """Tests for HumanInputSpec dataclass."""
+
+    def test_parameters_field(self):
+        spec = HumanInputSpec(
+            parameters={"decision": HumanInputParameterSpec(enum=["YES", "NO"])},
+        )
+        self.assertIn("decision", spec.parameters)
+
+    def test_empty_parameters(self):
+        spec = HumanInputSpec(parameters={})
+        self.assertEqual(spec.parameters, {})
+
+
+class TestHumanInputFunction(unittest.TestCase):
+    """Tests for the dsl.human_input() factory function."""
+
+    def _compile(self, pipeline_func):
+        from kfp import compiler
+        import tempfile, os, yaml
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "pipeline.yaml")
+            compiler.Compiler().compile(pipeline_func, path)
+            with open(path) as f:
+                return yaml.safe_load(f)
+
+    def test_returns_pipeline_task(self):
+        """human_input() inside a pipeline compiles without error."""
+
+        @dsl.pipeline
+        def my_pipeline():
+            dsl.human_input(
+                name="approval-gate",
+                parameters={"decision": HumanInputParameterSpec(enum=["YES", "NO"])},
+            )
+
+        compiled = self._compile(my_pipeline)
+        self.assertIn("deploymentSpec", compiled)
+
+    def test_output_is_accessible(self):
+        """The task's outputs dict must expose the declared parameters."""
+
+        @dsl.component
+        def consume(value: str) -> str:
+            return value
+
+        @dsl.pipeline
+        def my_pipeline():
+            gate = dsl.human_input(
+                name="gate",
+                parameters={"status": HumanInputParameterSpec(default="pending")},
+            )
+            consume(value=gate.outputs["status"])
+
+        compiled = self._compile(my_pipeline)
+        task_names = list(compiled.get("root", {}).get("dag", {}).get("tasks", {}).keys())
+        self.assertIn("gate", task_names)
+        self.assertIn("consume", task_names)
+
+
+class TestHumanInputCompilation(unittest.TestCase):
+    """Integration-level tests: compile a pipeline and validate the output."""
+
+    def _compile(self, pipeline_func):
+        from kfp import compiler
+        import tempfile, os, yaml
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "pipeline.yaml")
+            compiler.Compiler().compile(pipeline_func, path)
+            with open(path) as f:
+                return yaml.safe_load(f)
+
+    def test_sentinel_image_in_deployment_spec(self):
+        """The compiled YAML must contain the sentinel image in the deployment spec."""
+
+        @dsl.pipeline
+        def my_pipeline():
+            dsl.human_input(
+                name="approval-gate",
+                parameters={"decision": HumanInputParameterSpec(enum=["YES", "NO"])},
+            )
+
+        compiled = self._compile(my_pipeline)
+
+        # Find the executor for the human-input component.
+        deployment_spec = compiled.get("deploymentSpec", {})
+        executors = deployment_spec.get("executors", {})
+        images = [
+            e.get("container", {}).get("image", "")
+            for e in executors.values()
+        ]
+        self.assertIn(HUMAN_INPUT_SENTINEL_IMAGE, images,
+                      f"Expected sentinel image {HUMAN_INPUT_SENTINEL_IMAGE!r} in executors: {images}")
+
+    def test_parameter_metadata_in_args(self):
+        """args[0] must be a JSON dict mapping parameter names to their metadata."""
+
+        @dsl.pipeline
+        def my_pipeline():
+            dsl.human_input(
+                name="approval-gate",
+                parameters={
+                    "decision": HumanInputParameterSpec(
+                        description="Approve?",
+                        default="NO",
+                        enum=["YES", "NO"],
+                    ),
+                },
+            )
+
+        compiled = self._compile(my_pipeline)
+
+        deployment_spec = compiled.get("deploymentSpec", {})
+        executors = deployment_spec.get("executors", {})
+
+        found_args = None
+        for executor in executors.values():
+            container = executor.get("container", {})
+            if container.get("image") == HUMAN_INPUT_SENTINEL_IMAGE:
+                found_args = container.get("args", [])
+                break
+
+        self.assertIsNotNone(found_args, "Sentinel executor not found")
+        self.assertGreater(len(found_args), 0, "args must be non-empty")
+
+        meta = json.loads(found_args[0])
+        self.assertIn("decision", meta)
+        decision_meta = meta["decision"]
+        self.assertEqual(decision_meta.get("description"), "Approve?")
+        self.assertEqual(decision_meta.get("default"), "NO")
+        self.assertEqual(decision_meta.get("enum"), ["YES", "NO"])
+
+    def test_output_parameters_declared(self):
+        """The component must declare output parameters matching the human-input keys."""
+
+        @dsl.pipeline
+        def my_pipeline():
+            dsl.human_input(
+                name="gate",
+                parameters={
+                    "choice": HumanInputParameterSpec(),
+                    "reason": HumanInputParameterSpec(description="Reason for choice"),
+                },
+            )
+
+        compiled = self._compile(my_pipeline)
+
+        # Look at the component spec for the gate task.
+        components = compiled.get("components", {})
+        # The component name follows the naming convention comp-<task-name>.
+        gate_spec = components.get("comp-gate", {})
+        output_defs = gate_spec.get("outputDefinitions", {})
+        params = output_defs.get("parameters", {})
+        self.assertIn("choice", params, f"'choice' not in output params: {list(params)}")
+        self.assertIn("reason", params, f"'reason' not in output params: {list(params)}")
+
+    def test_downstream_task_receives_output(self):
+        """A downstream component can consume the human-input task output."""
+
+        @dsl.component
+        def consume(value: str) -> str:
+            return f"Got: {value}"
+
+        @dsl.pipeline
+        def my_pipeline():
+            gate = dsl.human_input(
+                name="approval-gate",
+                parameters={"decision": HumanInputParameterSpec(enum=["YES", "NO"])},
+            )
+            consume(value=gate.outputs["decision"])
+
+        # Should compile without error.
+        compiled = self._compile(my_pipeline)
+        # The consume component must appear in the compiled YAML.
+        task_names = list(compiled.get("root", {})
+                          .get("dag", {})
+                          .get("tasks", {})
+                          .keys())
+        self.assertIn("approval-gate", task_names)
+        self.assertIn("consume", task_names)
+
+    def test_approval_gate_sample_compiles(self):
+        """The approval-gate sample compiles without errors."""
+        from samples.core.human_input.approval_gate import approval_gate_pipeline
+        compiled = self._compile(approval_gate_pipeline)
+        self.assertIn("deploymentSpec", compiled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/python/kfp/dsl/human_input_test.py
+++ b/sdk/python/kfp/dsl/human_input_test.py
@@ -32,18 +32,18 @@ class TestHumanInputParameterSpec(unittest.TestCase):
 
     def test_all_fields(self):
         spec = HumanInputParameterSpec(
-            description="Choose a side",
-            default="YES",
-            enum=["YES", "NO"],
+            description='Choose a side',
+            default='YES',
+            enum=['YES', 'NO'],
         )
-        self.assertEqual(spec.description, "Choose a side")
-        self.assertEqual(spec.default, "YES")
-        self.assertEqual(spec.enum, ["YES", "NO"])
+        self.assertEqual(spec.description, 'Choose a side')
+        self.assertEqual(spec.default, 'YES')
+        self.assertEqual(spec.enum, ['YES', 'NO'])
 
     def test_enum_can_be_set_without_default(self):
-        spec = HumanInputParameterSpec(enum=["a", "b"])
+        spec = HumanInputParameterSpec(enum=['a', 'b'])
         self.assertIsNone(spec.default)
-        self.assertEqual(spec.enum, ["a", "b"])
+        self.assertEqual(spec.enum, ['a', 'b'])
 
 
 class TestHumanInputSpec(unittest.TestCase):
@@ -52,9 +52,9 @@ class TestHumanInputSpec(unittest.TestCase):
     def test_parameters_field(self):
         spec = HumanInputSpec(
             parameters={
-                "decision": HumanInputParameterSpec(enum=["YES", "NO"])
+                'decision': HumanInputParameterSpec(enum=['YES', 'NO'])
             },)
-        self.assertIn("decision", spec.parameters)
+        self.assertIn('decision', spec.parameters)
 
     def test_empty_parameters(self):
         spec = HumanInputSpec(parameters={})
@@ -72,7 +72,7 @@ class TestHumanInputFunction(unittest.TestCase):
         import yaml
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            path = os.path.join(tmpdir, "pipeline.yaml")
+            path = os.path.join(tmpdir, 'pipeline.yaml')
             compiler.Compiler().compile(pipeline_func, path)
             with open(path) as f:
                 return yaml.safe_load(f)
@@ -83,14 +83,14 @@ class TestHumanInputFunction(unittest.TestCase):
         @dsl.pipeline
         def my_pipeline():
             dsl.human_input(
-                name="approval-gate",
+                name='approval-gate',
                 parameters={
-                    "decision": HumanInputParameterSpec(enum=["YES", "NO"])
+                    'decision': HumanInputParameterSpec(enum=['YES', 'NO'])
                 },
             )
 
         compiled = self._compile(my_pipeline)
-        self.assertIn("deploymentSpec", compiled)
+        self.assertIn('deploymentSpec', compiled)
 
     def test_output_is_accessible(self):
         """The task's outputs dict must expose the declared parameters."""
@@ -102,18 +102,18 @@ class TestHumanInputFunction(unittest.TestCase):
         @dsl.pipeline
         def my_pipeline():
             gate = dsl.human_input(
-                name="gate",
+                name='gate',
                 parameters={
-                    "status": HumanInputParameterSpec(default="pending")
+                    'status': HumanInputParameterSpec(default='pending')
                 },
             )
-            consume(value=gate.outputs["status"])
+            consume(value=gate.outputs['status'])
 
         compiled = self._compile(my_pipeline)
         task_names = list(
-            compiled.get("root", {}).get("dag", {}).get("tasks", {}).keys())
-        self.assertIn("gate", task_names)
-        self.assertIn("consume", task_names)
+            compiled.get('root', {}).get('dag', {}).get('tasks', {}).keys())
+        self.assertIn('gate', task_names)
+        self.assertIn('consume', task_names)
 
 
 class TestHumanInputCompilation(unittest.TestCase):
@@ -127,87 +127,90 @@ class TestHumanInputCompilation(unittest.TestCase):
         import yaml
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            path = os.path.join(tmpdir, "pipeline.yaml")
+            path = os.path.join(tmpdir, 'pipeline.yaml')
             compiler.Compiler().compile(pipeline_func, path)
             with open(path) as f:
                 return yaml.safe_load(f)
 
     def test_sentinel_image_in_deployment_spec(self):
-        """The compiled YAML must contain the sentinel image in the deployment spec."""
+        """The compiled YAML must contain the sentinel image in the deployment
+        spec."""
 
         @dsl.pipeline
         def my_pipeline():
             dsl.human_input(
-                name="approval-gate",
+                name='approval-gate',
                 parameters={
-                    "decision": HumanInputParameterSpec(enum=["YES", "NO"])
+                    'decision': HumanInputParameterSpec(enum=['YES', 'NO'])
                 },
             )
 
         compiled = self._compile(my_pipeline)
 
         # Find the executor for the human-input component.
-        deployment_spec = compiled.get("deploymentSpec", {})
-        executors = deployment_spec.get("executors", {})
+        deployment_spec = compiled.get('deploymentSpec', {})
+        executors = deployment_spec.get('executors', {})
         images = [
-            e.get("container", {}).get("image", "") for e in executors.values()
+            e.get('container', {}).get('image', '') for e in executors.values()
         ]
         self.assertIn(
             HUMAN_INPUT_SENTINEL_IMAGE, images,
-            f"Expected sentinel image {HUMAN_INPUT_SENTINEL_IMAGE!r} in executors: {images}"
+            f'Expected sentinel image {HUMAN_INPUT_SENTINEL_IMAGE!r} in executors: {images}'
         )
 
     def test_parameter_metadata_in_args(self):
-        """args[0] must be a JSON dict mapping parameter names to their metadata."""
+        """args[0] must be a JSON dict mapping parameter names to their
+        metadata."""
 
         @dsl.pipeline
         def my_pipeline():
             dsl.human_input(
-                name="approval-gate",
+                name='approval-gate',
                 parameters={
-                    "decision":
+                    'decision':
                         HumanInputParameterSpec(
-                            description="Approve?",
-                            default="NO",
-                            enum=["YES", "NO"],
+                            description='Approve?',
+                            default='NO',
+                            enum=['YES', 'NO'],
                         ),
                 },
             )
 
         compiled = self._compile(my_pipeline)
 
-        deployment_spec = compiled.get("deploymentSpec", {})
-        executors = deployment_spec.get("executors", {})
+        deployment_spec = compiled.get('deploymentSpec', {})
+        executors = deployment_spec.get('executors', {})
 
         found_args = None
         for executor in executors.values():
-            container = executor.get("container", {})
-            if container.get("image") == HUMAN_INPUT_SENTINEL_IMAGE:
-                found_args = container.get("args", [])
+            container = executor.get('container', {})
+            if container.get('image') == HUMAN_INPUT_SENTINEL_IMAGE:
+                found_args = container.get('args', [])
                 break
 
-        self.assertIsNotNone(found_args, "Sentinel executor not found")
-        self.assertGreater(len(found_args), 0, "args must be non-empty")
+        self.assertIsNotNone(found_args, 'Sentinel executor not found')
+        self.assertGreater(len(found_args), 0, 'args must be non-empty')
 
         meta = json.loads(found_args[0])
-        self.assertIn("decision", meta)
-        decision_meta = meta["decision"]
-        self.assertEqual(decision_meta.get("description"), "Approve?")
-        self.assertEqual(decision_meta.get("default"), "NO")
-        self.assertEqual(decision_meta.get("enum"), ["YES", "NO"])
+        self.assertIn('decision', meta)
+        decision_meta = meta['decision']
+        self.assertEqual(decision_meta.get('description'), 'Approve?')
+        self.assertEqual(decision_meta.get('default'), 'NO')
+        self.assertEqual(decision_meta.get('enum'), ['YES', 'NO'])
 
     def test_output_parameters_declared(self):
-        """The component must declare output parameters matching the human-input keys."""
+        """The component must declare output parameters matching the human-
+        input keys."""
 
         @dsl.pipeline
         def my_pipeline():
             dsl.human_input(
-                name="gate",
+                name='gate',
                 parameters={
-                    "choice":
+                    'choice':
                         HumanInputParameterSpec(),
-                    "reason":
-                        HumanInputParameterSpec(description="Reason for choice"
+                    'reason':
+                        HumanInputParameterSpec(description='Reason for choice'
                                                ),
                 },
             )
@@ -215,14 +218,14 @@ class TestHumanInputCompilation(unittest.TestCase):
         compiled = self._compile(my_pipeline)
 
         # Look at the component spec for the gate task.
-        components = compiled.get("components", {})
+        components = compiled.get('components', {})
         # The component name follows the naming convention comp-<task-name>.
-        gate_spec = components.get("comp-gate", {})
-        output_defs = gate_spec.get("outputDefinitions", {})
-        params = output_defs.get("parameters", {})
-        self.assertIn("choice", params,
+        gate_spec = components.get('comp-gate', {})
+        output_defs = gate_spec.get('outputDefinitions', {})
+        params = output_defs.get('parameters', {})
+        self.assertIn('choice', params,
                       f"'choice' not in output params: {list(params)}")
-        self.assertIn("reason", params,
+        self.assertIn('reason', params,
                       f"'reason' not in output params: {list(params)}")
 
     def test_downstream_task_receives_output(self):
@@ -230,26 +233,26 @@ class TestHumanInputCompilation(unittest.TestCase):
 
         @dsl.component
         def consume(value: str) -> str:
-            return f"Got: {value}"
+            return f'Got: {value}'
 
         @dsl.pipeline
         def my_pipeline():
             gate = dsl.human_input(
-                name="approval-gate",
+                name='approval-gate',
                 parameters={
-                    "decision": HumanInputParameterSpec(enum=["YES", "NO"])
+                    'decision': HumanInputParameterSpec(enum=['YES', 'NO'])
                 },
             )
-            consume(value=gate.outputs["decision"])
+            consume(value=gate.outputs['decision'])
 
         # Should compile without error.
         compiled = self._compile(my_pipeline)
         # The consume component must appear in the compiled YAML.
         task_names = list(
-            compiled.get("root", {}).get("dag", {}).get("tasks", {}).keys())
-        self.assertIn("approval-gate", task_names)
-        self.assertIn("consume", task_names)
+            compiled.get('root', {}).get('dag', {}).get('tasks', {}).keys())
+        self.assertIn('approval-gate', task_names)
+        self.assertIn('consume', task_names)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -174,6 +174,7 @@ class PipelineTask:
         self.importer_spec = None
         self.container_spec = None
         self.pipeline_spec = None
+        self.human_input_spec = None
         self._ignore_upstream_failure_tag = False
         # platform_config for this primitive task; empty if task is for a graph component
         self.platform_config = {}
@@ -195,6 +196,8 @@ class PipelineTask:
         elif component_spec.implementation.importer is not None:
             self.importer_spec = component_spec.implementation.importer
             self.importer_spec.artifact_uri = args['uri']
+        elif component_spec.implementation.human_input is not None:
+            self.human_input_spec = component_spec.implementation.human_input
         else:
             self.pipeline_spec = self.component_spec.implementation.graph
 

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -452,6 +452,39 @@ class ImporterSpec:
 
 
 @dataclasses.dataclass
+class HumanInputParameterSpec:
+    """Specification for a single human-supplied parameter in a human input task.
+
+    Attributes:
+        description: Optional human-readable description shown in the UI.
+        default: Optional default value pre-filled in the UI input field.
+        enum: Optional list of allowed string values. When set, the UI renders
+            a dropdown instead of a free-form text input. The first option in
+            ``enum`` is presented first; ``default`` (if provided) must be one
+            of the listed values.
+    """
+    description: Optional[str] = None
+    default: Optional[str] = None
+    enum: Optional[List[str]] = None
+
+
+@dataclasses.dataclass
+class HumanInputSpec:
+    """Implementation spec for a human input (suspend) task.
+
+    A human input task causes the pipeline to pause at the corresponding node
+    and wait for a human operator to supply values for the declared parameters
+    before the run continues.  The supplied values become the task's output
+    parameters and can be referenced by downstream tasks exactly like any
+    other component output.
+
+    Attributes:
+        parameters: Mapping from output parameter name to its specification.
+    """
+    parameters: Dict[str, HumanInputParameterSpec]
+
+
+@dataclasses.dataclass
 class Implementation:
     """Implementation definition.
 
@@ -459,11 +492,13 @@ class Implementation:
         container: container implementation details.
         graph: graph implementation details.
         importer: importer implementation details.
+        human_input: human input (suspend) implementation details.
     """
     container: Optional[ContainerSpecImplementation] = None
     importer: Optional[ImporterSpec] = None
     # Use type forward reference to skip the type validation in BaseModel.
     graph: Optional['pipeline_spec_pb2.PipelineSpec'] = None
+    human_input: Optional[HumanInputSpec] = None
 
     @classmethod
     def from_pipeline_spec_dict(cls, pipeline_spec_dict: Dict[str, Any],

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -453,7 +453,8 @@ class ImporterSpec:
 
 @dataclasses.dataclass
 class HumanInputParameterSpec:
-    """Specification for a single human-supplied parameter in a human input task.
+    """Specification for a single human-supplied parameter in a human input
+    task.
 
     Attributes:
         description: Optional human-readable description shown in the UI.


### PR DESCRIPTION
## Summary

Adds static human-input checkpoints to KFP v2 pipelines. A checkpoint suspends the Argo Workflow, shows an operator form in the run-details UI, validates submitted values, and exposes them as output parameters to downstream tasks.

No protobuf changes are required. The SDK compiles a human-input task as a `kfp://human-input` sentinel container. Its parameter metadata is stored in `args[0]`, then the Argo compiler turns it into a suspend template with `valueFrom.supplied` outputs.

## Usage

```python
from kfp import dsl

@dsl.component
def deploy(approved: str):
    print(f"Deploying: {approved}")

@dsl.pipeline
def approval_pipeline():
    gate = dsl.human_input(
        name="approval-gate",
        parameters={
            "decision": dsl.HumanInputParameterSpec(
                description="Approve this deployment?",
                default="NO",
                enum=["YES", "NO"],
            ),
        },
    )
    deploy(approved=gate.outputs["decision"])
```

When the run reaches `approval-gate`, open that node in the UI, choose `YES` or `NO`, and select **Submit & Resume**. The selected value is supplied to `deploy`.

## Implementation

- **SDK:** Adds `dsl.human_input()`, `HumanInputParameterSpec`, and `HumanInputSpec`, exported from `kfp.dsl`.
- **Argo compiler:** Emits suspend templates, performs a pre-pass for stable task ordering, and rewrites downstream task-output references as Argo expressions so the KFP driver receives the supplied value directly.
- **API:**
  - `GET /apis/v2beta1/runs/{run_id}/nodes/{node_id}/intermediateInputs` returns suspension state, parameter metadata, and supplied values; it requires `get` access.
  - `POST /apis/v2beta1/runs/{run_id}/nodes/{node_id}:setIntermediateInputs` requires `update` access, verifies the node is a running suspend node, validates enum values, and patches workflow status to resume it.
- **Frontend:** Adds a polling, keyboard-accessible MUI form with text/select controls and loading, error, and success states.
- **Sample:** `samples/core/human_input/approval_gate.py`.

## Tests

Focused SDK, compiler, API validation/status-patch/authorization, frontend form-submission, and TypeScript checks cover the feature.

## Limitations

- Human-input executions are not tracked in MLMD because suspend nodes do not run the KFP driver.
- Dynamic enum choices from upstream task outputs are intentionally unsupported: the DSL does not model that dependency.

- [x] Commit is DCO signed off.