### PR TITLE
fix(sdk): raise ValueError for empty dict component I/O types

### DIFF
--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -227,6 +227,7 @@ def get_parameter_type(
       The enum value of the mapped IR I/O primitive type.
 
     Raises:
+      ValueError: if param_type is an empty dict.
       AttributeError: if type_name is not a string type.
     """
     # Special handling for PipelineTaskFinalStatus and TaskConfig, treat them as Dict type.

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -171,6 +171,14 @@ def is_task_config_type(type_name: Optional[Union[str, dict]]) -> bool:
     return isinstance(type_name, str) and (type_name == TaskConfig.__name__)
 
 
+def _get_dict_type_key(type_dict: dict) -> str:
+    """Returns the type name key from a v1 struct-style type dict."""
+    if not type_dict:
+        raise ValueError(
+            'Component I/O type cannot be an empty dict. Got invalid type {}.')
+    return next(iter(type_dict))
+
+
 def is_parameter_type(type_name: Optional[Union[str, dict]]) -> bool:
     """Check if a ComponentSpec I/O type is considered as a parameter type.
 
@@ -183,7 +191,7 @@ def is_parameter_type(type_name: Optional[Union[str, dict]]) -> bool:
     if isinstance(type_name, str):
         type_name = type_annotations.get_short_type_name(type_name)
     elif isinstance(type_name, dict):
-        type_name = list(type_name.keys())[0]
+        type_name = _get_dict_type_key(type_name)
     else:
         return False
 
@@ -227,7 +235,7 @@ def get_parameter_type(
     if type(param_type) == type:
         type_name = param_type.__name__
     elif isinstance(param_type, dict):
-        type_name = list(param_type.keys())[0]
+        type_name = _get_dict_type_key(param_type)
     else:
         type_name = type_annotations.get_short_type_name(str(param_type))
     return PARAMETER_TYPES_MAPPING.get(type_name.lower())
@@ -405,8 +413,10 @@ def _check_dict_types(
     given_type: dict,
     expected_type: dict,
 ) -> bool:
-    given_type_name, _ = list(given_type.items())[0]
-    expected_type_name, _ = list(expected_type.items())[0]
+    given_type_name = _get_dict_type_key(given_type)
+    expected_type_name = _get_dict_type_key(expected_type)
+    given_type_properties = given_type[given_type_name]
+    expected_type_properties = expected_type[expected_type_name]
     if given_type_name == '' or expected_type_name == '':
         # If the type name is empty, it matches any types
         return True
@@ -415,16 +425,16 @@ def _check_dict_types(
               ' is different from expected: ' + str(expected_type_name))
         return False
     type_name = given_type_name
-    for type_property in given_type[type_name]:
-        if type_property not in expected_type[type_name]:
+    for type_property in given_type_properties:
+        if type_property not in expected_type_properties:
             print(type_name + ' has a property ' + str(type_property) +
                   ' that the latter does not.')
             return False
-        if given_type[type_name][type_property] != expected_type[type_name][
+        if given_type_properties[type_property] != expected_type_properties[
                 type_property]:
             print(type_name + ' has a property ' + str(type_property) +
-                  ' with value: ' + str(given_type[type_name][type_property]) +
-                  ' and ' + str(expected_type[type_name][type_property]))
+                  ' with value: ' + str(given_type_properties[type_property]) +
+                  ' and ' + str(expected_type_properties[type_property]))
             return False
     return True
 

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -14,6 +14,7 @@
 import os
 import sys
 import tempfile
+import textwrap
 from typing import Any, Dict, List, Union
 import unittest
 
@@ -90,6 +91,34 @@ class TypeUtilsTest(parameterized.TestCase):
     def test_is_parameter_type_true(self, type_name, expected_result):
         self.assertEqual(expected_result,
                          type_utils.is_parameter_type(type_name))
+
+    def test_is_parameter_type_empty_dict_raises(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Component I/O type cannot be an empty dict'):
+            type_utils.is_parameter_type({})
+
+    def test_get_parameter_type_empty_dict_raises(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Component I/O type cannot be an empty dict'):
+            type_utils.get_parameter_type({})
+
+    def test_load_v1_yaml_empty_output_type_with_output_path_raises(self):
+        component_yaml = textwrap.dedent("""\
+        name: bad-comp
+        outputs:
+        - {name: out, type: {}}
+        implementation:
+          container:
+            image: python:3.11
+            command: [sh, -c]
+            args: [cp, {outputPath: out}, /tmp/x]
+        """)
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Component I/O type cannot be an empty dict'):
+            structures.ComponentSpec.from_yaml_documents(component_yaml)
 
     @parameterized.parameters(
         {

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -94,29 +94,25 @@ class TypeUtilsTest(parameterized.TestCase):
 
     def test_is_parameter_type_empty_dict_raises(self):
         with self.assertRaisesRegex(
-                ValueError,
-                r'Component I/O type cannot be an empty dict'):
+                ValueError, r'Component I/O type cannot be an empty dict'):
             type_utils.is_parameter_type({})
 
     def test_get_parameter_type_empty_dict_raises(self):
         with self.assertRaisesRegex(
-                ValueError,
-                r'Component I/O type cannot be an empty dict'):
+                ValueError, r'Component I/O type cannot be an empty dict'):
             type_utils.get_parameter_type({})
 
     def test_check_v1_struct_parameter_type_compatibility_empty_given_type_raises(
             self):
         with self.assertRaisesRegex(
-                ValueError,
-                r'Component I/O type cannot be an empty dict'):
+                ValueError, r'Component I/O type cannot be an empty dict'):
             type_utils.check_v1_struct_parameter_type_compatibility(
                 {}, {'JsonObject': {}})
 
     def test_check_v1_struct_parameter_type_compatibility_empty_expected_type_raises(
             self):
         with self.assertRaisesRegex(
-                ValueError,
-                r'Component I/O type cannot be an empty dict'):
+                ValueError, r'Component I/O type cannot be an empty dict'):
             type_utils.check_v1_struct_parameter_type_compatibility(
                 {'JsonObject': {}}, {})
 
@@ -132,8 +128,7 @@ class TypeUtilsTest(parameterized.TestCase):
             args: [cp, {outputPath: out}, /tmp/x]
         """)
         with self.assertRaisesRegex(
-                ValueError,
-                r'Component I/O type cannot be an empty dict'):
+                ValueError, r'Component I/O type cannot be an empty dict'):
             structures.ComponentSpec.from_yaml_documents(component_yaml)
 
     @parameterized.parameters(

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -104,6 +104,22 @@ class TypeUtilsTest(parameterized.TestCase):
                 r'Component I/O type cannot be an empty dict'):
             type_utils.get_parameter_type({})
 
+    def test_check_v1_struct_parameter_type_compatibility_empty_given_type_raises(
+            self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Component I/O type cannot be an empty dict'):
+            type_utils.check_v1_struct_parameter_type_compatibility(
+                {}, {'JsonObject': {}})
+
+    def test_check_v1_struct_parameter_type_compatibility_empty_expected_type_raises(
+            self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Component I/O type cannot be an empty dict'):
+            type_utils.check_v1_struct_parameter_type_compatibility(
+                {'JsonObject': {}}, {})
+
     def test_load_v1_yaml_empty_output_type_with_output_path_raises(self):
         component_yaml = textwrap.dedent("""\
         name: bad-comp


### PR DESCRIPTION


Fixes #13745

**Description of your changes:**

Loading a legacy v1 YAML component with an empty dict output type (`type: {}`) and an `{outputPath: ...}` placeholder previously raised an unhandled `IndexError` in `type_utils.is_parameter_type()`.

This PR adds a `_get_dict_type_key()` helper that validates v1 struct-style type dicts and raises a clear `ValueError` when the dict is empty. The helper is used in `is_parameter_type()`, `get_parameter_type()`, and `_check_dict_types()` so all code paths that read the first key from a type dict fail consistently with a helpful message.

Added unit tests covering:
- `is_parameter_type({})`
- `get_parameter_type({})`
- Loading a v1 YAML component with `type: {}` and `{outputPath: out}`

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).



