### PR TITLE
Make backend/api Dockerfile architecture-aware

### DIFF
--- a/backend/Dockerfile.visualization
+++ b/backend/Dockerfile.visualization
@@ -21,20 +21,25 @@
 FROM python:3.11-slim
 
 ARG CLOUD_SDK_VERSION=557.0.0
-ARG CLOUD_SDK_SHA256=6b048c0cb3057517a2a71e94a5a2a712fe7d30c6928f73e458bd5946187ca470
+ARG TARGETARCH
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget curl tar openssl \
-  && rm -rf /var/lib/apt/lists/* \
-  && curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" \
-       -o /tmp/google-cloud-sdk.tar.gz \
-  && echo "${CLOUD_SDK_SHA256}  /tmp/google-cloud-sdk.tar.gz" | sha256sum -c - \
-  && mkdir -p /usr/local/gcloud \
-  && tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz \
-  && /usr/local/gcloud/google-cloud-sdk/install.sh \
-  && rm /tmp/google-cloud-sdk.tar.gz
+    && apt-get install -y --no-install-recommends wget curl tar openssl \
+    && rm -rf /var/lib/apt/lists/* \
+    && case "${TARGETARCH}" in \
+        amd64) CLOUD_SDK_ARCH=x86_64; CLOUD_SDK_SHA256=6b048c0cb3057517a2a71e94a5a2a712fe7d30c6928f73e458bd5946187ca470 ;; \
+        arm64) CLOUD_SDK_ARCH=arm; CLOUD_SDK_SHA256=0059a759868aa1229c42dabf1e0f91a39ccbbb43035917280daa9e4b2bf495cd ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac \
+    && curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-${CLOUD_SDK_VERSION}-linux-${CLOUD_SDK_ARCH}.tar.gz" \
+    -o /tmp/google-cloud-sdk.tar.gz \
+    && echo "${CLOUD_SDK_SHA256}  /tmp/google-cloud-sdk.tar.gz" | sha256sum -c - \
+    && mkdir -p /usr/local/gcloud \
+    && tar -C /usr/local/gcloud -xf /tmp/google-cloud-sdk.tar.gz \
+    && /usr/local/gcloud/google-cloud-sdk/install.sh \
+    && rm /tmp/google-cloud-sdk.tar.gz
 
-ENV PATH $PATH:/usr/local/gcloud/google-cloud-sdk/bin
+ENV PATH=$PATH:/usr/local/gcloud/google-cloud-sdk/bin
 
 WORKDIR /src
 

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -19,6 +19,7 @@ ENV GO_SWAGGER_VERSION=v0.32.3
 ENV GRPC_VERSION=v1.80.0
 ENV PROTOC_VERSION=31.1
 ENV GOBIN=/go/bin
+ARG TARGETARCH
 # The googleapis repo doesn't use GitHub releases or version tags,
 # so we pin a specific commit to make the clone reproducible.
 ENV GOOGLEAPIS_COMMIT=68d5196a529174df97c28c70622ffc1c3721815f
@@ -42,7 +43,13 @@ ENV PROTOBUF_GO=v1.36.11
 
 # Install protoc.
 RUN apt-get update -y && apt-get install -y jq sed unzip
-RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+RUN case "${TARGETARCH}" in \
+      amd64) PROTOC_ARCH=x86_64 ;; \
+      arm64) PROTOC_ARCH=aarch_64 ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -L -o protoc.zip \
+    "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip"
 RUN unzip -o protoc.zip -d /tmp/protoc && \
     mv /tmp/protoc/bin/protoc /usr/bin/protoc && \
     chmod +x /usr/bin/protoc
@@ -67,8 +74,11 @@ RUN mkdir -p /protoc-gen-openapiv2 && \
     cp -r /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway/v2@${GRPC_GATEWAY_VERSION}/protoc-gen-openapiv2/options /protoc-gen-openapiv2/options
 
 # Download go-swagger binary.
-RUN curl -LO "https://github.com/go-swagger/go-swagger/releases/download/${GO_SWAGGER_VERSION}/swagger_linux_amd64"
-RUN chmod +x swagger_linux_amd64 && mv swagger_linux_amd64 /usr/bin/swagger
+RUN curl -LO \
+"https://github.com/go-swagger/go-swagger/releases/download/${GO_SWAGGER_VERSION}/swagger_linux_${TARGETARCH}"
+
+RUN chmod +x swagger_linux_${TARGETARCH} && \
+    mv swagger_linux_${TARGETARCH} /usr/bin/swagger
 
 # Need protobuf source code for -I in protoc command.
 # Install protoc-gen-go.

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -16,6 +16,7 @@
 FROM golang:1.26.5@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 AS generator
 ENV PROTOC_VERSION=31.1
 ENV GOBIN=/go/bin
+ARG TARGETARCH
 # The googleapis repo doesn't use GitHub releases or version tags,
 # so we pin a specific commit to make the clone reproducible.
 ENV GOOGLEAPIS_COMMIT=68d5196a529174df97c28c70622ffc1c3721815f
@@ -27,8 +28,17 @@ COPY go.mod /tmp/kfp-module/go.mod
 COPY backend/api/tools/go.mod /tmp/api-generator-tools/go.mod
 
 # Install protoc and Java (needed for KFP server API package generation).
+
 RUN apt-get update -y && apt-get install -y jq sed unzip default-jdk
-RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+
+RUN case "${TARGETARCH}" in \
+    amd64) PROTOC_ARCH=x86_64 ;; \
+    arm64) PROTOC_ARCH=aarch_64 ;; \
+    *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -L -o protoc.zip \
+    "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip"
+
 RUN unzip -o protoc.zip -d /tmp/protoc && \
     mv /tmp/protoc/bin/protoc /usr/bin/protoc && \
     chmod +x /usr/bin/protoc
@@ -61,7 +71,7 @@ RUN git init /googleapis && \
 # Download go-swagger binary.
 RUN set -eu; \
     go_swagger_version="$(cd /tmp/api-generator-tools && go mod edit -json | jq -er '.Require[] | select(.Path == "github.com/go-swagger/go-swagger") | .Version')"; \
-    curl -fL -o /usr/bin/swagger "https://github.com/go-swagger/go-swagger/releases/download/${go_swagger_version}/swagger_linux_amd64"; \
+    curl -fL -o /usr/bin/swagger "https://github.com/go-swagger/go-swagger/releases/download/${go_swagger_version}/swagger_linux_${TARGETARCH}"; \
     chmod +x /usr/bin/swagger
 
 # Needed for buildling python packages requiring protoc

--- a/release/Dockerfile.release
+++ b/release/Dockerfile.release
@@ -18,6 +18,8 @@
 ARG BASE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:master
 FROM ${BASE_IMAGE}
 
+ARG TARGETARCH
+
 # Install nvm and the Node version pinned in frontend/.nvmrc.
 # Pass it in at build time with:
 #   --build-arg NODE_VERSION=$(tr -d 'v' < frontend/.nvmrc)
@@ -42,7 +44,8 @@ RUN apt-get update \
 
 # install yq==3
 # Released in https://github.com/mikefarah/yq/releases/tag/3.4.1
-RUN curl -L -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64 && \
+RUN curl -L -o /usr/local/bin/yq \
+    https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_${TARGETARCH} && \
     chmod +x /usr/local/bin/yq
 
 # Make all files accessible to non-root users.
@@ -52,6 +55,11 @@ RUN chmod -R 777 $NVM_DIR && \
 # Configure npm cache location
 RUN npm config set cache /tmp/.npm --global
 
-RUN curl -L -H "Accept: application/octet-stream" \
-        https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz \
+RUN case "${TARGETARCH}" in \
+        amd64) GIT_CLIFF_ARCH=x86_64 ;; \
+        arm64) GIT_CLIFF_ARCH=aarch64 ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -L -H "Accept: application/octet-stream" \
+        "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-${GIT_CLIFF_ARCH}-unknown-linux-gnu.tar.gz" \
     | tar -xz --strip-components=1 -C /usr/local/bin git-cliff-${GIT_CLIFF_VERSION}/git-cliff

--- a/release/Dockerfile.release
+++ b/release/Dockerfile.release
@@ -44,7 +44,7 @@ RUN apt-get update \
 
 # install yq==3
 # Released in https://github.com/mikefarah/yq/releases/tag/3.4.1
-RUN curl -L -o /usr/local/bin/yq \
+RUN curl -fL -o /usr/local/bin/yq \
     https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_${TARGETARCH} && \
     chmod +x /usr/local/bin/yq
 


### PR DESCRIPTION
## Summary

This change makes the `backend/api` Dockerfile architecture-aware by replacing hardcoded architecture-specific downloads with `TARGETARCH`-based selection.

### Changes

- Add `ARG TARGETARCH`.
- Replace the hardcoded `protoc` download with architecture-aware asset selection:
  - `amd64` → `x86_64`
  - `arm64` → `aarch_64`
- Replace the hardcoded `go-swagger` download with `swagger_linux_${TARGETARCH}`.

## Testing

Verified successful Docker Buildx builds for:

- ✅ `linux/amd64`
- ✅ `linux/arm64`