### PR TITLE
fix(cache): prevent nil-pointer dereference when pod watcher fails

### DIFF
--- a/backend/src/cache/client/pod_fake.go
+++ b/backend/src/cache/client/pod_fake.go
@@ -130,3 +130,7 @@ type FakeBadPodClient struct {
 func (FakeBadPodClient) Delete(ctx context.Context, name string, options v1.DeleteOptions) error {
 	return errors.New("failed to delete pod")
 }
+
+func (FakeBadPodClient) Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error) {
+	return nil, errors.New("failed to watch pods")
+}

--- a/backend/src/cache/server/watcher.go
+++ b/backend/src/cache/server/watcher.go
@@ -37,7 +37,13 @@ func WatchPods(ctx context.Context, namespaceToWatch string, clientManager Clien
 		watcher, err := k8sCore.PodClient(namespaceToWatch).Watch(ctx, listOptions)
 
 		if err != nil {
-			log.Printf("%s", "Watcher error:"+err.Error())
+			log.Printf("Watcher error: %s. Retrying in 5 seconds.", err.Error())
+			select {
+			case <-time.After(5 * time.Second):
+			case <-ctx.Done():
+				return
+			}
+			continue
 		}
 
 		for event := range watcher.ResultChan() {

--- a/backend/src/cache/server/watcher_test.go
+++ b/backend/src/cache/server/watcher_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	cacheclient "github.com/kubeflow/pipelines/backend/src/cache/client"
+	"github.com/kubeflow/pipelines/backend/src/cache/storage"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+type watchErrorK8sClient struct {
+	podClient v1.PodInterface
+}
+
+func (c *watchErrorK8sClient) PodClient(namespace string) v1.PodInterface {
+	return c.podClient
+}
+
+type watchErrorClientMgr struct {
+	k8sClient cacheclient.KubernetesCoreInterface
+}
+
+func (m *watchErrorClientMgr) CacheStore() storage.ExecutionCacheStoreInterface {
+	return nil
+}
+
+func (m *watchErrorClientMgr) KubernetesCoreClient() cacheclient.KubernetesCoreInterface {
+	return m.k8sClient
+}
+
+func TestWatchPods_WatchErrorDoesNotPanic(t *testing.T) {
+	badPodClient := &cacheclient.FakeBadPodClient{}
+	k8sClient := &watchErrorK8sClient{podClient: badPodClient}
+	clientMgr := &watchErrorClientMgr{k8sClient: k8sClient}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		WatchPods(ctx, "test-ns", clientMgr)
+		close(done)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("WatchPods did not exit after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

When `Watch()` returns an error, the returned `watcher` is `nil`, but execution continues to `watcher.ResultChan()`, resulting in a nil pointer dereference and crashing the cache server.

This change improves the error handling by:

- Logging the `Watch()` error.
- Waiting 5 seconds before retrying.
- Continuing the outer retry loop instead of falling through to `watcher.ResultChan()`.

This prevents nil pointer dereferences during watch initialization failures and makes the watch retry logic more resilient.