### PR TITLE
fix(sdk): quote YAML-boolean I/O names in v1 component YAML

### DIFF
--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -1083,6 +1083,8 @@ def load_documents_from_yaml(component_yaml: str) -> Tuple[dict, dict]:
 
 
 # PyYAML (YAML 1.1) coerces unquoted scalars like on/off/yes/no to bool.
+_TOP_LEVEL_IO_SECTION_PATTERN = re.compile(r'^(inputs|outputs)\s*:')
+_TOP_LEVEL_KEY_PATTERN = re.compile(r'^[A-Za-z_][\w-]*\s*:')
 _FLOW_STYLE_IO_NAME_PATTERN = re.compile(
     r'(?P<prefix>\bname:\s*)'
     r'(?P<val>on|off|yes|no|true|false)'
@@ -1092,22 +1094,50 @@ _FLOW_STYLE_IO_NAME_PATTERN = re.compile(
 _BLOCK_STYLE_IO_NAME_PATTERN = re.compile(
     r'(?P<prefix>^\s*(?:-\s*)?name:\s*)'
     r'(?P<val>on|off|yes|no|true|false)'
-    r'\s*$',
-    re.IGNORECASE | re.MULTILINE,
+    r'(?P<suffix>\s*(?:#.*)?)\s*$',
+    re.IGNORECASE,
 )
 
 
-def _quote_v1_component_yaml_boolean_io_names(text: str) -> str:
-    """Quotes I/O names that PyYAML would parse as booleans."""
-    text = _FLOW_STYLE_IO_NAME_PATTERN.sub(
+def _quote_io_name_on_line(line: str) -> str:
+    """Quotes boolean-like I/O names on a single inputs/outputs list line."""
+    line = _FLOW_STYLE_IO_NAME_PATTERN.sub(
         lambda match: (f'{match.group("prefix")}"{match.group("val")}"'
                        f'{match.group("suffix")}'),
-        text,
+        line,
     )
     return _BLOCK_STYLE_IO_NAME_PATTERN.sub(
-        lambda match: f'{match.group("prefix")}"{match.group("val")}"',
-        text,
+        lambda match: (f'{match.group("prefix")}"{match.group("val")}"'
+                       f'{match.group("suffix")}'),
+        line,
     )
+
+
+def _quote_v1_component_yaml_boolean_io_names(text: str) -> str:
+    """Quotes I/O names under top-level inputs/outputs that PyYAML parses as bool."""
+    lines = text.splitlines(keepends=True)
+    if not lines:
+        return text
+
+    quoted_lines = []
+    in_io_section = False
+    for line in lines:
+        if _TOP_LEVEL_IO_SECTION_PATTERN.match(line):
+            in_io_section = True
+            quoted_lines.append(line)
+            continue
+
+        stripped = line.lstrip()
+        if (in_io_section and stripped and not stripped.startswith('-')
+                and _TOP_LEVEL_KEY_PATTERN.match(stripped)):
+            in_io_section = False
+
+        if in_io_section and stripped:
+            line = _quote_io_name_on_line(line)
+
+        quoted_lines.append(line)
+
+    return ''.join(quoted_lines)
 
 
 def _load_component_spec_from_component_text(

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -1082,8 +1082,39 @@ def load_documents_from_yaml(component_yaml: str) -> Tuple[dict, dict]:
     return pipeline_spec_dict, platform_spec_dict
 
 
+# PyYAML (YAML 1.1) coerces unquoted scalars like on/off/yes/no to bool.
+_FLOW_STYLE_IO_NAME_PATTERN = re.compile(
+    r'(?P<prefix>\bname:\s*)'
+    r'(?P<val>on|off|yes|no|true|false)'
+    r'(?P<suffix>\s*[,}])',
+    re.IGNORECASE,
+)
+_BLOCK_STYLE_IO_NAME_PATTERN = re.compile(
+    r'(?P<prefix>^\s*(?:-\s*)?name:\s*)'
+    r'(?P<val>on|off|yes|no|true|false)'
+    r'\s*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _quote_v1_component_yaml_boolean_io_names(text: str) -> str:
+    """Quotes I/O names that PyYAML would parse as booleans."""
+    text = _FLOW_STYLE_IO_NAME_PATTERN.sub(
+        lambda match: (f'{match.group("prefix")}"{match.group("val")}"'
+                       f'{match.group("suffix")}'),
+        text,
+    )
+    return _BLOCK_STYLE_IO_NAME_PATTERN.sub(
+        lambda match: f'{match.group("prefix")}"{match.group("val")}"',
+        text,
+    )
+
+
 def _load_component_spec_from_component_text(
         text) -> v1_structures.ComponentSpec:
+    if isinstance(text, bytes):
+        text = text.decode('utf-8')
+    text = _quote_v1_component_yaml_boolean_io_names(text)
     component_dict = yaml.safe_load(text)
     component_spec = v1_structures.ComponentSpec.from_dict(component_dict)
 

--- a/sdk/python/kfp/dsl/structures_test.py
+++ b/sdk/python/kfp/dsl/structures_test.py
@@ -1113,6 +1113,64 @@ implementation:
         self.assertEqual(outputs['output4'].type, 'Dict')
 
 
+class TestV1YamlBooleanIoNames(parameterized.TestCase):
+
+    @parameterized.parameters(['on', 'off', 'yes', 'no'])
+    def test_flow_style_input_name(self, name):
+        comp_text = textwrap.dedent(f"""\
+        name: test
+        inputs:
+        - {{name: {name}, type: String}}
+        implementation:
+          container:
+            image: alpine
+            command: [echo]
+        """)
+        comp = components.load_component_from_text(comp_text)
+        self.assertIn(name, comp.component_spec.inputs)
+
+    @parameterized.parameters(['on', 'off', 'yes', 'no'])
+    def test_block_style_input_name(self, name):
+        comp_text = textwrap.dedent(f"""\
+        name: test
+        inputs:
+        - name: {name}
+          type: String
+        implementation:
+          container:
+            image: alpine
+            command: [echo]
+        """)
+        comp = components.load_component_from_text(comp_text)
+        self.assertIn(name, comp.component_spec.inputs)
+
+    def test_flow_style_output_name(self):
+        comp_text = textwrap.dedent("""\
+        name: test
+        outputs:
+        - {name: off, type: String}
+        implementation:
+          container:
+            image: alpine
+            command: [echo]
+        """)
+        comp = components.load_component_from_text(comp_text)
+        self.assertIn('off', comp.component_spec.outputs)
+
+    def test_boolean_default_still_parsed(self):
+        comp_text = textwrap.dedent("""\
+        name: test
+        inputs:
+        - {name: flag, type: Boolean, default: true}
+        implementation:
+          container:
+            image: alpine
+            command: [echo]
+        """)
+        comp = components.load_component_from_text(comp_text)
+        self.assertEqual(comp.component_spec.inputs['flag'].default, True)
+
+
 class TestLoadDocumentsFromYAML(unittest.TestCase):
 
     def test_no_documents(self):

--- a/sdk/python/kfp/dsl/structures_test.py
+++ b/sdk/python/kfp/dsl/structures_test.py
@@ -1170,6 +1170,35 @@ class TestV1YamlBooleanIoNames(parameterized.TestCase):
         comp = components.load_component_from_text(comp_text)
         self.assertEqual(comp.component_spec.inputs['flag'].default, True)
 
+    def test_block_style_input_name_with_inline_comment(self):
+        comp_text = textwrap.dedent("""\
+        name: test
+        inputs:
+        - name: off # feature switch
+          type: String
+        implementation:
+          container:
+            image: alpine
+            command: [echo]
+        """)
+        comp = components.load_component_from_text(comp_text)
+        self.assertIn('off', comp.component_spec.inputs)
+
+    def test_command_string_with_name_off_unchanged(self):
+        comp_text = textwrap.dedent("""\
+        name: test
+        inputs:
+        - {name: flag, type: String}
+        implementation:
+          container:
+            image: alpine
+            command: ['echo name: off, now']
+        """)
+        comp = components.load_component_from_text(comp_text)
+        self.assertIn('flag', comp.component_spec.inputs)
+        container = comp.component_spec.implementation.container
+        self.assertEqual(container.command, ['echo name: off, now'])
+
 
 class TestLoadDocumentsFromYAML(unittest.TestCase):
 


### PR DESCRIPTION

Fixes #13756 

**Description of your changes:**

Loading legacy v1 component YAML with unquoted input/output names like `on`, `off`, `yes`, or `no` failed with `TypeError` because PyYAML (YAML 1.1) coerced those values to Python booleans before `ComponentSpec.from_dict()` ran.

This PR adds `_quote_v1_component_yaml_boolean_io_names()` in `structures.py` to quote boolean-like `name:` values in both flow-style (`{name: off, type: String}`) and block-style (`- name: off`) syntax before `yaml.safe_load()`. Boolean **defaults** (e.g. `default: true`) are unchanged since only `name:` fields are quoted.

Added tests in `TestV1YamlBooleanIoNames` covering flow-style inputs, block-style inputs, flow-style outputs, and a regression check that Boolean defaults still parse correctly.

**Testing performed:**
```bash
pytest -q sdk/python/kfp/dsl/structures_test.py::TestV1YamlBooleanIoNames   # 12 passed
pytest -q sdk/python/kfp/dsl/structures_test.py                           # all passed
pytest -q sdk/python/kfp/dsl/                                               # 616 passed
pytest -q sdk/python/kfp/compiler/ sdk/python/kfp/components/               # 294 passed
```

Manual repro (before: all four names failed; after: all load correctly):
```
on: OK -> keys=['on']
off: OK -> keys=['off']
yes: OK -> keys=['yes']
no: OK -> keys=['no']
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).


