### PR TITLE
fix: avoid duplicate processReportMetricResult call for failed metrics

### DIFF
--- a/backend/src/agent/persistence/worker/metrics_reporter.go
+++ b/backend/src/agent/persistence/worker/metrics_reporter.go
@@ -74,7 +74,7 @@ func processReportMetricResults(
 	for _, result := range reportMetricsResponse.GetResults() {
 		err := processReportMetricResult(result)
 		if err != nil {
-			errors = append(errors, processReportMetricResult(result))
+			errors = append(errors,err)
 		}
 	}
 	return errors

--- a/backend/src/agent/persistence/worker/metrics_reporter_test.go
+++ b/backend/src/agent/persistence/worker/metrics_reporter_test.go
@@ -569,3 +569,57 @@ func TestReportMetrics_Unauthorized(t *testing.T) {
 	assert.NotNil(t, err1)
 	assert.Contains(t, err1.Error(), "failed to read artifacts")
 }
+func TestProcessReportMetricResults_MixedStatuses(t *testing.T) {
+	results := []*api.ReportRunMetricsResponse_ReportRunMetricResult{
+		{
+			MetricNodeId: "node-1",
+			MetricName:   "accuracy",
+			Status:       api.ReportRunMetricsResponse_ReportRunMetricResult_OK,
+		},
+		{
+			MetricNodeId: "node-1",
+			MetricName:   "logloss",
+			Status:       api.ReportRunMetricsResponse_ReportRunMetricResult_INVALID_ARGUMENT,
+			Message:      "invalid metric value",
+		},
+		{
+			MetricNodeId: "node-2",
+			MetricName:   "precision",
+			Status:       api.ReportRunMetricsResponse_ReportRunMetricResult_INTERNAL_ERROR,
+			Message:      "server unavailable",
+		},
+	}
+	reportMetricsResponse := &api.ReportRunMetricsResponse{Results: results}
+
+	errs := processReportMetricResults(reportMetricsResponse)
+
+	assert.Len(t, errs, 2)
+
+	assert.True(t, util.HasCustomCode(errs[0], util.CUSTOM_CODE_PERMANENT))
+	assert.Contains(t, errs[0].Error(), "invalid arguments")
+	assert.Contains(t, errs[0].Error(), "logloss")
+
+	assert.True(t, util.HasCustomCode(errs[1], util.CUSTOM_CODE_TRANSIENT))
+	assert.Contains(t, errs[1].Error(), "internal error")
+	assert.Contains(t, errs[1].Error(), "precision")
+}
+
+func TestProcessReportMetricResults_AllOK_NoErrors(t *testing.T) {
+	results := []*api.ReportRunMetricsResponse_ReportRunMetricResult{
+		{
+			MetricNodeId: "node-1",
+			MetricName:   "accuracy",
+			Status:       api.ReportRunMetricsResponse_ReportRunMetricResult_OK,
+		},
+		{
+			MetricNodeId: "node-1",
+			MetricName:   "logloss",
+			Status:       api.ReportRunMetricsResponse_ReportRunMetricResult_DUPLICATE_REPORTING,
+		},
+	}
+	reportMetricsResponse := &api.ReportRunMetricsResponse{Results: results}
+
+	errs := processReportMetricResults(reportMetricsResponse)
+
+	assert.Empty(t, errs)
+}


### PR DESCRIPTION
Fixes #13763
`processReportMetricResults` in `backend/src/agent/persistence/worker/metrics_reporter.go`computed `err` from `processReportMetricResult(result)` on line 75, then discardedit and called `processReportMetricResult(result)` a second time on line 77 when appending to the errors slice.

This is currently unobservable externally since `processReportMetricResult` is a pure function with no side effects — both calls return equivalent errors — but it does unnecessary redundant work and is a correctness risk for any future change
to `processReportMetricResult` that introduces side effects (e.g. logging, a metrics counter).

This PR:
- Fixes the duplicate call by appending the already-computed `err` variable instead of calling the function again.
- Adds a direct unit test for `processReportMetricResults` (previously only exercised indirectly through `ReportMetrics()` in the existing test suite), covering the case of multiple results with a mix of OK/INVALID_ARGUMENT/ INTERNAL_ERROR statuses, asserting the returned error count and messages.
