### PR TITLE
ci: harden image artifact readiness and API retries

### DIFF
--- a/.github/resources/scripts/wait-for-image-artifacts.sh
+++ b/.github/resources/scripts/wait-for-image-artifacts.sh
@@ -21,7 +21,9 @@ set -euo pipefail
 
 # Many matrix jobs can reach this barrier together. Poll slowly enough to keep
 # their shared GITHUB_TOKEN comfortably below the repository API rate limit.
-WAIT_ATTEMPTS="${WAIT_ATTEMPTS:-20}"
+# Forty attempts at the default interval allow roughly 20 minutes for image
+# builders delayed by GitHub-hosted runner availability.
+WAIT_ATTEMPTS="${WAIT_ATTEMPTS:-40}"
 WAIT_INTERVAL_SECONDS="${WAIT_INTERVAL_SECONDS:-30}"
 if ! [[ "$WAIT_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
   echo "WAIT_ATTEMPTS must be a positive integer, got: ${WAIT_ATTEMPTS}" >&2

--- a/.github/resources/scripts/wait_for_image_artifacts_test.py
+++ b/.github/resources/scripts/wait_for_image_artifacts_test.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import subprocess
 import tempfile
 import textwrap
+from typing import Optional
 import unittest
 
 SCRIPT = Path(__file__).with_name('wait-for-image-artifacts.sh')
@@ -40,10 +41,12 @@ ARTIFACTS = (
 
 class WaitForImageArtifactsTest(unittest.TestCase):
 
-    def _run(self,
-             *,
-             ready_after: int,
-             attempts: int = 2) -> tuple[subprocess.CompletedProcess[str], int]:
+    def _run(
+        self,
+        *,
+        ready_after: int,
+        attempts: Optional[int] = 2,
+    ) -> tuple[subprocess.CompletedProcess[str], int]:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             fake_bin = root / 'bin'
@@ -75,9 +78,10 @@ class WaitForImageArtifactsTest(unittest.TestCase):
                 'GITHUB_RUN_ID': '123',
                 'PATH': f'{fake_bin}{os.pathsep}{environment["PATH"]}',
                 'READY_AFTER': str(ready_after),
-                'WAIT_ATTEMPTS': str(attempts),
                 'WAIT_INTERVAL_SECONDS': '0',
             })
+            if attempts is not None:
+                environment['WAIT_ATTEMPTS'] = str(attempts)
             result = subprocess.run(
                 ['bash', str(SCRIPT)],
                 capture_output=True,
@@ -101,6 +105,14 @@ class WaitForImageArtifactsTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn('Waiting for branch image artifacts', result.stdout)
         self.assertEqual(attempts, 2)
+
+    def test_default_wait_exceeds_previous_ten_minute_budget(self):
+        result, attempts = self._run(ready_after=21, attempts=None)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('Waiting for branch image artifacts (20/40)',
+                      result.stdout)
+        self.assertEqual(attempts, 21)
 
     def test_fails_with_missing_artifact_names(self):
         result, attempts = self._run(ready_after=3, attempts=2)

--- a/.github/resources/scripts/wait_for_image_artifacts_test.py
+++ b/.github/resources/scripts/wait_for_image_artifacts_test.py
@@ -20,6 +20,7 @@ import tempfile
 import textwrap
 from typing import Optional
 import unittest
+from unittest import mock
 
 SCRIPT = Path(__file__).with_name('wait-for-image-artifacts.sh')
 ARTIFACTS = (
@@ -71,6 +72,7 @@ class WaitForImageArtifactsTest(unittest.TestCase):
             fake_gh.chmod(0o755)
 
             environment = os.environ.copy()
+            environment.pop('WAIT_ATTEMPTS', None)
             environment.update({
                 'ARTIFACT_NAMES': ' '.join(ARTIFACTS),
                 'GH_COUNTER': str(counter),
@@ -106,6 +108,7 @@ class WaitForImageArtifactsTest(unittest.TestCase):
         self.assertIn('Waiting for branch image artifacts', result.stdout)
         self.assertEqual(attempts, 2)
 
+    @mock.patch.dict(os.environ, {'WAIT_ATTEMPTS': '1'})
     def test_default_wait_exceeds_previous_ten_minute_budget(self):
         result, attempts = self._run(ready_after=21, attempts=None)
 

--- a/.github/workflows/add-ci-passed-label.yml
+++ b/.github/workflows/add-ci-passed-label.yml
@@ -35,6 +35,7 @@ jobs:
         id: download_result
         uses: actions/github-script@v8
         with:
+          retries: 3
           script: |
             core.setOutput("artifact_found", "false");
 
@@ -87,6 +88,7 @@ jobs:
         if: steps.download_result.outputs.artifact_found == 'true'
         uses: actions/github-script@v8
         with:
+          retries: 3
           script: |
             core.setOutput("pr_number", "");
             core.setOutput("eligible", "false");


### PR DESCRIPTION
## Summary

- extend the default image-artifact readiness wait from 20 to 40 attempts
- keep the 30-second polling cadence, for a roughly 20-minute maximum wait
- add regression coverage for artifacts becoming available after the former 20-attempt limit
- retry transient GitHub API failures up to three times in both read-only CI-passed eligibility steps

## Why

On the master push for #13760, 18 SDK, API, and E2E lane jobs exhausted the existing readiness barrier while image builders were still queued. The final missing artifacts appeared roughly one to two minutes after those consumers failed, so the failures did not reach deployment or test execution.

Separately, the Add CI Passed Label workflow failed when GitHub returned a transient 503 while listing CI-result artifacts. `actions/github-script` does not retry by default. Setting `retries: 3` uses its exponential-backoff retry behavior for retryable failures, including 5xx responses, while retaining the action's default non-retryable client-status exclusions.

The longer artifact budget does not add time to healthy runs because the barrier exits as soon as all artifacts are available.

## Verification

- `python3 -m unittest wait_for_image_artifacts_test`
- `python3 -m unittest discover -p '*_test.py'` (123 tests)
- `bash -n .github/resources/scripts/wait-for-image-artifacts.sh`
- parsed `.github/workflows/add-ci-passed-label.yml` as YAML
- `git diff --check`
