### PR TITLE
ci: build API generator from source in CI to prevent stale files

### DIFF
--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -14,10 +14,13 @@ on:
       - 'backend/api/**/go_client/**'
       - 'backend/api/**/python_http_client/**'
       - 'backend/api/**/swagger/**'
+      - 'api/Makefile'
       - 'api/**/*.proto'
       - 'api/**/*.go'
+      - 'kubernetes_platform/Makefile'
       - 'kubernetes_platform/**/*.proto'
       - 'kubernetes_platform/**/*.go'
+      - 'sdk/Makefile'
       - 'backend/src/crd/kubernetes/**/*.go'
       - 'manifests/kustomize/base/crds/*.yaml'
       - 'sdk/**/*.py'
@@ -33,6 +36,8 @@ concurrency:
 jobs:
   validate-generated-files:
     runs-on: ubuntu-latest
+    env:
+      USE_PREBUILT_IMAGE: false
     strategy:
       fail-fast: false
 
@@ -49,6 +54,10 @@ jobs:
           cache-scope: validate-generated-files
           cache-dependency-hash: ${{ hashFiles('sdk/python/requirements*.txt', 'kubernetes_platform/python/requirements*.txt') }}
 
+      - name: Set up Docker Buildx with caching
+        shell: bash
+        run: bash ./.github/resources/scripts/setup-buildx-with-retry.sh
+
       - name: Install protobuf dependencies & kfp-pipeline-spec
         id: install-protobuf-deps
         uses: ./.github/actions/protobuf
@@ -61,10 +70,6 @@ jobs:
         with:
           generate_golang_proto: "true"
 
-      - name: Set up Docker Buildx with caching
-        shell: bash
-        run: bash ./.github/resources/scripts/setup-buildx-with-retry.sh
-
       - name: Generate K8s Native API CRDs
         working-directory: ./backend/src/crd/kubernetes
         run: make generate manifests
@@ -73,28 +78,24 @@ jobs:
         working-directory: ./backend/api
         env:
           API_VERSION: v2beta1
-          USE_PREBUILT_IMAGE: false
         run: make generate
 
       - name: Generate backend proto code v1beta1
         working-directory: ./backend/api
         env:
           API_VERSION: v1beta1
-          USE_PREBUILT_IMAGE: false
         run: make generate
 
       - name: Generate backend proto code v2beta1
         working-directory: ./backend/api
         env:
           API_VERSION: v2beta1
-          USE_PREBUILT_IMAGE: false
         run: make generate-kfp-server-api-package
 
       - name: Generate backend proto code v1beta1
         working-directory: ./backend/api
         env:
           API_VERSION: v1beta1
-          USE_PREBUILT_IMAGE: false
         run: make generate-kfp-server-api-package
 
       - name: Check for Changes

--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -61,6 +61,10 @@ jobs:
         with:
           generate_golang_proto: "true"
 
+      - name: Set up Docker Buildx with caching
+        shell: bash
+        run: bash ./.github/resources/scripts/setup-buildx-with-retry.sh
+
       - name: Generate K8s Native API CRDs
         working-directory: ./backend/src/crd/kubernetes
         run: make generate manifests
@@ -69,24 +73,28 @@ jobs:
         working-directory: ./backend/api
         env:
           API_VERSION: v2beta1
-        run: make generate-from-scratch
+          USE_PREBUILT_IMAGE: false
+        run: make generate
 
       - name: Generate backend proto code v1beta1
         working-directory: ./backend/api
         env:
           API_VERSION: v1beta1
-        run: make generate-from-scratch
+          USE_PREBUILT_IMAGE: false
+        run: make generate
 
       - name: Generate backend proto code v2beta1
         working-directory: ./backend/api
         env:
           API_VERSION: v2beta1
+          USE_PREBUILT_IMAGE: false
         run: make generate-kfp-server-api-package
 
       - name: Generate backend proto code v1beta1
         working-directory: ./backend/api
         env:
           API_VERSION: v1beta1
+          USE_PREBUILT_IMAGE: false
         run: make generate-kfp-server-api-package
 
       - name: Check for Changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-26
+- Last updated: 2026-07-27
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -324,8 +324,9 @@ The following files are generated; edit their sources and regenerate:
   `backend/api/{v1beta1,v2beta1}/go_http_client`, and the generated Swagger files
   under `backend/api/{v1beta1,v2beta1}/swagger`
   - Sources: `backend/api/{v1beta1,v2beta1}/*.proto` and `backend/api/Dockerfile`
-  - Generate with the published toolchain: `make -C backend/api API_VERSION=<version> generate`
-  - Generate after changing the toolchain: `make -C backend/api API_VERSION=<version> generate-from-scratch`
+  - Generate: `make -C backend/api API_VERSION=<version> generate` (uses pre-built image, fast)
+  - Source build: `USE_PREBUILT_IMAGE=false make -C backend/api API_VERSION=<version> generate` (accurate)
+  - Legacy target: `make -C backend/api API_VERSION=<version> generate-from-scratch` (always builds from source)
 - Frontend OpenAPI clients under `frontend/src/apis`, `frontend/src/apisv2beta1`, `frontend/server/src/generated/apis`, and `frontend/server/src/generated/apisv2beta1`, with shared runtime/model support under `frontend/src/generated/openapi` and `frontend/server/src/generated/openapi`
   - Sources: Swagger specs under `backend/api/**/swagger/*.json`
   - Generate: `cd frontend && npm run apis` / `npm run apis:v2beta1` / `npm run apis:all` (uses pinned Docker image `openapitools/openapi-generator-cli:v7.19.0`)
@@ -704,7 +705,8 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 ### Essential commands
 
 - Compile pipeline: `kfp dsl compile --py pipeline.py --output pipeline.yaml`
-- Generate protos: `make -C api python && make -C api golang`
+- Generate protos: `make -C api python && make -C api golang` (fast with pre-built images)
+- Generate protos (accurate): `USE_PREBUILT_IMAGE=false make -C api python && USE_PREBUILT_IMAGE=false make -C api golang`
 - Deploy local cluster (standalone): `make -C backend kind-cluster-agnostic`
 - Deploy local cluster (development) and run the API server in the IDE: `make -C backend dev-kind-cluster`
 - Run SDK tests: `pytest -v sdk/python/kfp`

--- a/api/Makefile
+++ b/api/Makefile
@@ -49,7 +49,7 @@ endif
 
 # Generate proto packages by building api-generator image from source.
 .PHONY: golang-from-source
-golang-from-source: .api-generator-built v2alpha1/*.proto
+golang-from-source: ensure-api-generator-image v2alpha1/*.proto
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
 		--mount type=bind,source="$$(pwd)/..",target=/go/src/github.com/kubeflow/pipelines \
@@ -82,7 +82,7 @@ endif
 
 # Build Python package by building api-generator image from source.
 .PHONY: python-from-source
-python-from-source: .api-generator-built fetch-protos
+python-from-source: ensure-api-generator-image fetch-protos
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
 		-e HOME=/tmp \
@@ -186,8 +186,7 @@ clean-protobuf-tmp:
 protoc-gen-go:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go
 
-# Build the API generator image locally to ensure current tool versions
-.api-generator-built: ../backend/api/Dockerfile
-	DOCKER_BUILDKIT=1 docker build .. -t $(IMAGE_TAG) -f ../backend/api/Dockerfile \
-		--cache-from $(IMAGE_TAG):latest
-	touch .api-generator-built
+# Build the API generator image via the canonical target in backend/api
+.PHONY: ensure-api-generator-image
+ensure-api-generator-image:
+	$(MAKE) -C ../backend/api image

--- a/api/Makefile
+++ b/api/Makefile
@@ -12,8 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Contact one of chensun, HumairAK if this remote image needs an update.
+# Pre-built images for faster development (default: enabled for speed)
+# Set USE_PREBUILT_IMAGE=false when:
+# - Dockerfile dependencies have been updated
+# - CI validation fails due to tool version mismatches
+# - Working on API generation toolchain changes
+USE_PREBUILT_IMAGE ?= true
+# Validate USE_PREBUILT_IMAGE value
+ifneq ($(USE_PREBUILT_IMAGE),true)
+ifneq ($(USE_PREBUILT_IMAGE),false)
+$(error USE_PREBUILT_IMAGE must be 'true' or 'false', got '$(USE_PREBUILT_IMAGE)')
+endif
+endif
 PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:master
+IMAGE_TAG=kfp-api-generator
 
 .PHONY: all
 all: golang python
@@ -21,13 +33,27 @@ all: golang python
 .PHONY: clean
 clean: clean-go clean-python
 
-# Generate proto packages using a pre-built api-generator image.
+# Generate proto packages using either pre-built image (fast) or source build (accurate).
+# Use USE_PREBUILT_IMAGE=false to build from source for guaranteed accuracy.
 .PHONY: golang
 golang: v2alpha1/*.proto
+ifeq ($(USE_PREBUILT_IMAGE),true)
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
 		--mount type=bind,source="$$(pwd)/..",target=/go/src/github.com/kubeflow/pipelines \
 		$(PREBUILT_REMOTE_IMAGE)  \
+		sh -c 'cd /go/src/github.com/kubeflow/pipelines/api && make generate'
+else
+	$(MAKE) golang-from-source
+endif
+
+# Generate proto packages by building api-generator image from source.
+.PHONY: golang-from-source
+golang-from-source: .api-generator-built v2alpha1/*.proto
+	docker run --interactive --rm \
+		--user $$(id -u):$$(id -g) \
+		--mount type=bind,source="$$(pwd)/..",target=/go/src/github.com/kubeflow/pipelines \
+		$(IMAGE_TAG)  \
 		sh -c 'cd /go/src/github.com/kubeflow/pipelines/api && make generate'
 
 # Delete all generated proto go packages.
@@ -36,14 +62,32 @@ clean-go:
 	rm -rf v2alpha1/go
 	rm -f v2alpha1/google/rpc/status.proto
 
-# Build Python package using pre-built image
+# Build Python package using either pre-built image (fast) or source build (accurate).
+# Use USE_PREBUILT_IMAGE=false to build from source for guaranteed accuracy.
 .PHONY: python
-python: python fetch-protos
+python: fetch-protos
+ifeq ($(USE_PREBUILT_IMAGE),true)
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
 		-e HOME=/tmp \
 		-v "$$(pwd)/..":"/go/src/github.com/kubeflow/pipelines":z \
 		$(PREBUILT_REMOTE_IMAGE) \
+		sh -c 'cd /go/src/github.com/kubeflow/pipelines/api/v2alpha1/python && \
+		    python3 -m pip install --user --break-system-packages -r requirements.txt && \
+		    python3 generate_proto.py && \
+            python3 setup.py sdist && pip wheel --no-deps dist/*.tar.gz -w dist'
+else
+	$(MAKE) python-from-source
+endif
+
+# Build Python package by building api-generator image from source.
+.PHONY: python-from-source
+python-from-source: .api-generator-built fetch-protos
+	docker run --interactive --rm \
+		--user $$(id -u):$$(id -g) \
+		-e HOME=/tmp \
+		-v "$$(pwd)/..":"/go/src/github.com/kubeflow/pipelines":z \
+		$(IMAGE_TAG) \
 		sh -c 'cd /go/src/github.com/kubeflow/pipelines/api/v2alpha1/python && \
 		    python3 -m pip install --user --break-system-packages -r requirements.txt && \
 		    python3 generate_proto.py && \
@@ -141,3 +185,9 @@ clean-protobuf-tmp:
 
 protoc-gen-go:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go
+
+# Build the API generator image locally to ensure current tool versions
+.api-generator-built: ../backend/api/Dockerfile
+	DOCKER_BUILDKIT=1 docker build .. -t $(IMAGE_TAG) -f ../backend/api/Dockerfile \
+		--cache-from $(IMAGE_TAG):latest
+	touch .api-generator-built

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -40,8 +40,8 @@ ENV GOOGLEAPIS_COMMIT=68d5196a529174df97c28c70622ffc1c3721815f
 ENV PROTOC_GEN_GO_GRPC=v1.6.2
 ENV PROTOBUF_GO=v1.36.12-0.20260120151049-f2248ac996af
 
-# Install protoc.
-RUN apt-get update -y && apt-get install -y jq sed unzip
+# Install protoc and Java (needed for KFP server API package generation).
+RUN apt-get update -y && apt-get install -y jq sed unzip default-jdk
 RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
 RUN unzip -o protoc.zip -d /tmp/protoc && \
     mv /tmp/protoc/bin/protoc /usr/bin/protoc && \

--- a/backend/api/Makefile
+++ b/backend/api/Makefile
@@ -15,34 +15,74 @@
 # Makefile to generate KFP api clients from proto.
 
 IMAGE_TAG=kfp-api-generator
-# Contact chensun or HumairAK if this remote image needs an update.
+# Remote image for publishing (used by CI)
 REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator
 # Assume the latest API version by default.
 API_VERSION ?= v2beta1
 
-# Keep in sync with the version used in release/Dockerfile.release
+# Pre-built images for faster development (default: enabled for speed)
+# Set USE_PREBUILT_IMAGE=false when:
+# - Dockerfile dependencies have been updated
+# - CI validation fails due to tool version mismatches
+# - Working on API generation toolchain changes
+USE_PREBUILT_IMAGE ?= true
+# Validate USE_PREBUILT_IMAGE value
+ifneq ($(USE_PREBUILT_IMAGE),true)
+ifneq ($(USE_PREBUILT_IMAGE),false)
+$(error USE_PREBUILT_IMAGE must be 'true' or 'false', got '$(USE_PREBUILT_IMAGE)')
+endif
+endif
 PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:master
 RELEASE_IMAGE=ghcr.io/kubeflow/kfp-release:master
 CONTAINER_ENGINE ?= docker
 
-# Generate clients using a pre-built api-generator image.
+# Generate clients using either pre-built image (fast) or source build (current tools).
+# Use USE_PREBUILT_IMAGE=false when pre-built image may have outdated dependencies.
 .PHONY: generate
 generate: fetch-dependencies hack/generator.sh $(API_VERSION)/*.proto
+ifeq ($(USE_PREBUILT_IMAGE),true)
 	${CONTAINER_ENGINE} run --interactive --rm \
 		-e API_VERSION=$(API_VERSION) \
 		--user $$(id -u):$$(id -g) \
 		--mount type=bind,source="$$(pwd)/../..",target=/go/src/github.com/kubeflow/pipelines \
 		$(PREBUILT_REMOTE_IMAGE) /go/src/github.com/kubeflow/pipelines/backend/api/hack/generator.sh
+else
+	$(MAKE) generate-from-source
+endif
 
-# Use the release image since it has some additional dependencies
-# required by kfp-pipeline-ser generation
+# Generate clients by building api-generator image from source.
+# This ensures generated files always use current tool versions.
+.PHONY: generate-from-source
+generate-from-source: fetch-dependencies .image-built hack/generator.sh $(API_VERSION)/*.proto
+	${CONTAINER_ENGINE} run --interactive --rm \
+		-e API_VERSION=$(API_VERSION) \
+		--user $$(id -u):$$(id -g) \
+		--mount type=bind,source="$$(pwd)/../..",target=/go/src/github.com/kubeflow/pipelines \
+		$(IMAGE_TAG) /go/src/github.com/kubeflow/pipelines/backend/api/hack/generator.sh
+
+# Generate KFP server API package using either pre-built image (fast) or source build (current tools).
+# Use USE_PREBUILT_IMAGE=false when pre-built image may have outdated dependencies.
 .PHONY: generate-kfp-server-api-package
 generate-kfp-server-api-package:
+ifeq ($(USE_PREBUILT_IMAGE),true)
 	${CONTAINER_ENGINE} run --interactive --rm \
 		-e API_VERSION=$(API_VERSION) \
 		--user $$(id -u):$$(id -g) \
 		--mount type=bind,source="$$(pwd)/../..",target=/go/src/github.com/kubeflow/pipelines \
 		$(RELEASE_IMAGE) /go/src/github.com/kubeflow/pipelines/backend/api/build_kfp_server_api_python_package.sh
+else
+	$(MAKE) generate-kfp-server-api-package-from-source
+endif
+
+# Generate KFP server API package by building api-generator image from source.
+# The API generator image now includes Java for OpenAPI generator.
+.PHONY: generate-kfp-server-api-package-from-source
+generate-kfp-server-api-package-from-source: .image-built
+	${CONTAINER_ENGINE} run --interactive --rm \
+		-e API_VERSION=$(API_VERSION) \
+		--user $$(id -u):$$(id -g) \
+		--mount type=bind,source="$$(pwd)/../..",target=/go/src/github.com/kubeflow/pipelines \
+		$(IMAGE_TAG) /go/src/github.com/kubeflow/pipelines/backend/api/build_kfp_server_api_python_package.sh
 
 
 # Fetch dependency proto
@@ -69,16 +109,9 @@ v2beta1/google/rpc/status.proto:
 	fi; \
 	exit $$status
 
-# Generate clients starting by building api-generator image locally.
-# Note, this should only be used for local development purposes. Once any change is made to the Dockerfile,
-# we should push the new image remotely to ensure everyone is using the same tools.
+# Legacy target - always builds from source for backward compatibility.
 .PHONY: generate-from-scratch
-generate-from-scratch: .image-built hack/generator.sh $(API_VERSION)/*.proto
-	${CONTAINER_ENGINE} run --interactive --rm \
-		-e API_VERSION=$(API_VERSION) \
-	    --user $$(id -u):$$(id -g) \
-		--mount type=bind,source="$$(pwd)/../..",target=/go/src/github.com/kubeflow/pipelines \
-		$(IMAGE_TAG) /go/src/github.com/kubeflow/pipelines/backend/api/hack/generator.sh
+generate-from-scratch: generate-from-source
 
 # Build a local api-generator image.
 .PHONY: image
@@ -91,6 +124,8 @@ push: image
 	${CONTAINER_ENGINE} push $(REMOTE_IMAGE)
 
 # .image-built is a local token file to help Make determine the latest successful build.
+# Uses Docker layer caching for improved performance.
 .image-built: Dockerfile
-	${CONTAINER_ENGINE} build ../.. -t $(IMAGE_TAG) -f Dockerfile
+	DOCKER_BUILDKIT=1 ${CONTAINER_ENGINE} build ../.. -t $(IMAGE_TAG) -f Dockerfile \
+		--cache-from $(IMAGE_TAG):latest
 	touch .image-built

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -138,8 +138,7 @@ USE_PREBUILT_IMAGE=false make generate-kfp-server-api-package   # Builds from so
 
 ### Docker Requirements
 
-- **Docker**: Required for all API generation operations
-- **Docker Buildx**: Automatically set up for improved caching performance
+- **Docker**: Required for all API generation operations (BuildKit is enabled automatically for layer caching)
 
 ### Manual API Generator Image Publishing
 

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -17,10 +17,22 @@ export API_VERSION="v2beta1"
 
 ## Compiling `.proto` files to Go client and swagger definitions
 
-Use `make generate` command to generate clients using a pre-built api-generator image:
+Use `make generate` command to generate clients:
 ```bash
 make generate
 ```
+
+**Default behavior (fast):** Uses pre-built image for faster development.
+
+**When pre-built images may be outdated:** Force building from source:
+```bash
+USE_PREBUILT_IMAGE=false make generate
+```
+
+The source build automatically:
+1. Builds the API generator Docker image from `backend/api/Dockerfile`
+2. Runs the generator inside the container to create client libraries
+3. Caches the built image for subsequent runs (using `.image-built` target)
 
 Go client library will be placed into:
 
@@ -33,7 +45,25 @@ Go client library will be placed into:
 
 ## Compiling Python client
 
-To generate the Python client, run the following bash script (requires `java` and `python3`).
+To generate the Python client, use the `generate-kfp-server-api-package` Make target:
+
+```bash
+make generate-kfp-server-api-package
+```
+
+**Default behavior (fast):** Uses pre-built image for faster development.
+
+**When pre-built images may be outdated:** Force building from source:
+```bash
+USE_PREBUILT_IMAGE=false make generate-kfp-server-api-package
+```
+
+The source build automatically:
+1. Builds the API generator Docker image (with Java) from source if needed
+2. Runs the Python client generation script inside the container
+3. The image already includes Java required for the OpenAPI generator
+
+Alternatively, you can run the script directly if you have Java and Python3 installed locally:
 
 ```bash
 ./build_kfp_server_api_python_package.sh
@@ -77,18 +107,44 @@ API definitions in this folder are used to generate [`v1beta1`](https://www.kube
 
 4. Create a PR with the changes in [kubeflow.org website repository](https://github.com/kubeflow/website). See an example [here](https://github.com/kubeflow/website/pull/3444).
 
-## Updating API generator image (Manual)
+## Local development and Docker image management
 
-This is now automatic on pushes to GitHub branches, but the instructions are kept here in case you need to do it
-manually.
+### Development Workflow Options
 
-API generator image is defined in [Dockerfile](`./Dockerfile`). If you need to update the container, follow these steps:
+The API generation workflow supports two modes:
 
-1. Login to GHCR container registry: `echo "<PAT>" | docker login ghcr.io -u <USERNAME> --password-stdin` 
-   * Replace `<PAT>` with a GitHub Personal Access Token (PAT) with the write:packages and `read:packages` scopes, as well as `delete:packages` if needed. 
-1. Update the [Dockerfile](`./Dockerfile`) and build the image by running `docker build -t ghcr.io/kubeflow/kfp-api-generator:$BRANCH .`
-1. Push the new container by running `docker push ghcr.io/kubeflow/kfp-api-generator:$BRANCH`.
-1. Update the `PREBUILT_REMOTE_IMAGE` variable in the [Makefile](./Makefile) to point to your new image.
-1. Similarly, build and push a new release tools image from
-   [`release/Dockerfile.release`](../../release/Dockerfile.release) to
-   `ghcr.io/kubeflow/kfp-release:$BRANCH`.
+**1. Fast Development (default):** Uses pre-built images
+```bash
+make generate                           # Uses pre-built image (fast)
+make generate-kfp-server-api-package   # Uses pre-built image (fast)
+```
+
+**2. Source Build (accurate):** Builds from current source
+```bash
+USE_PREBUILT_IMAGE=false make generate                           # Builds from source
+USE_PREBUILT_IMAGE=false make generate-kfp-server-api-package   # Builds from source
+```
+
+**CI/Validation:** Always builds from source to ensure accuracy.
+
+### When to Use Each Mode
+
+- **Pre-built images**: Regular development, prototyping, testing
+- **Source build**: When pre-built images may have outdated tool versions, when changing API generation tools, updating dependencies, or before committing API changes
+
+### Legacy Targets
+
+- `make generate-from-scratch`: Legacy target, always builds from source
+
+### Docker Requirements
+
+- **Docker**: Required for all API generation operations
+- **Docker Buildx**: Automatically set up for improved caching performance
+
+### Manual API Generator Image Publishing
+
+The `build-tools-images.yml` CI workflow automatically publishes API generator images to GitHub Container Registry. Manual publishing is typically not needed, but if required:
+
+1. Update the [Dockerfile](./Dockerfile) with your changes
+2. The image will be built and published automatically on the next push to a tracked branch
+3. For manual publishing, see the `build-tools-images.yml` workflow for the exact commands

--- a/kubernetes_platform/Makefile
+++ b/kubernetes_platform/Makefile
@@ -12,7 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Pre-built images for faster development (default: enabled for speed)
+# Set USE_PREBUILT_IMAGE=false when:
+# - Dockerfile dependencies have been updated
+# - CI validation fails due to tool version mismatches
+# - Working on API generation toolchain changes
+USE_PREBUILT_IMAGE ?= true
+# Validate USE_PREBUILT_IMAGE value
+ifneq ($(USE_PREBUILT_IMAGE),true)
+ifneq ($(USE_PREBUILT_IMAGE),false)
+$(error USE_PREBUILT_IMAGE must be 'true' or 'false', got '$(USE_PREBUILT_IMAGE)')
+endif
+endif
 PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:master
+IMAGE_TAG=kfp-api-generator
 
 # Set USE_FIND_LINKS=true to use local sdk and pipeline_spec for buildling python builds rather than pulling from pypi
 # applies to `make python` and make pythone-dev` commands.
@@ -25,13 +38,27 @@ all: golang python
 .PHONY: clean
 clean: clean-go clean-python
 
-# Generate proto packages using a pre-built api-generator image.
+# Generate proto packages using either pre-built image (fast) or source build (accurate).
+# Use USE_PREBUILT_IMAGE=false to build from source for guaranteed accuracy.
 .PHONY: golang
 golang: proto/*.proto
+ifeq ($(USE_PREBUILT_IMAGE),true)
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
 		-v "$$(pwd)/..":"/go/src/github.com/kubeflow/pipelines":z \
 		$(PREBUILT_REMOTE_IMAGE)  \
+		sh -c 'cd /go/src/github.com/kubeflow/pipelines/kubernetes_platform && make generate-go-in-container'
+else
+	$(MAKE) golang-from-source
+endif
+
+# Generate proto packages by building api-generator image from source.
+.PHONY: golang-from-source
+golang-from-source: .api-generator-built proto/*.proto
+	docker run --interactive --rm \
+		--user $$(id -u):$$(id -g) \
+		-v "$$(pwd)/..":"/go/src/github.com/kubeflow/pipelines":z \
+		$(IMAGE_TAG)  \
 		sh -c 'cd /go/src/github.com/kubeflow/pipelines/kubernetes_platform && make generate-go-in-container'
 
 # Delete all generated proto go packages.
@@ -43,15 +70,34 @@ clean-go:
 fetch-protos:
 		make -C ../api fetch-protos
 
-# Build Python package using pre-built image
+# Build Python package using either pre-built image (fast) or source build (accurate).
+# Use USE_PREBUILT_IMAGE=false to build from source for guaranteed accuracy.
 .PHONY: python
 python: proto/kubernetes_executor_config.proto fetch-protos
+ifeq ($(USE_PREBUILT_IMAGE),true)
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
 		-e HOME=/tmp \
 		$(if $(USE_FIND_LINKS),-e PIP_FIND_LINKS="$(FIND_LINKS_PATH)") \
 		-v "$$(pwd)/..":"/go/src/github.com/kubeflow/pipelines":z \
 		$(PREBUILT_REMOTE_IMAGE) \
+		sh -c 'cd /go/src/github.com/kubeflow/pipelines/kubernetes_platform/python && \
+		    python3 -m pip install --user --break-system-packages -r requirements.txt && \
+		    python3 generate_proto.py && \
+		    python3 setup.py sdist && pip wheel --no-deps dist/*.tar.gz -w dist'
+else
+	$(MAKE) python-from-source
+endif
+
+# Build Python package by building api-generator image from source.
+.PHONY: python-from-source
+python-from-source: .api-generator-built proto/kubernetes_executor_config.proto fetch-protos
+	docker run --interactive --rm \
+		--user $$(id -u):$$(id -g) \
+		-e HOME=/tmp \
+		$(if $(USE_FIND_LINKS),-e PIP_FIND_LINKS="$(FIND_LINKS_PATH)") \
+		-v "$$(pwd)/..":"/go/src/github.com/kubeflow/pipelines":z \
+		$(IMAGE_TAG) \
 		sh -c 'cd /go/src/github.com/kubeflow/pipelines/kubernetes_platform/python && \
 		    python3 -m pip install --user --break-system-packages -r requirements.txt && \
 		    python3 generate_proto.py && \
@@ -81,3 +127,9 @@ generate-go-in-container:
 		--go_out=../go/kubernetesplatform \
 		--go_opt=paths=source_relative \
 		kubernetes_executor_config.proto
+
+# Build the API generator image locally to ensure current tool versions
+.api-generator-built: ../backend/api/Dockerfile
+	DOCKER_BUILDKIT=1 docker build .. -t $(IMAGE_TAG) -f ../backend/api/Dockerfile \
+		--cache-from $(IMAGE_TAG):latest
+	touch .api-generator-built

--- a/kubernetes_platform/Makefile
+++ b/kubernetes_platform/Makefile
@@ -54,7 +54,7 @@ endif
 
 # Generate proto packages by building api-generator image from source.
 .PHONY: golang-from-source
-golang-from-source: .api-generator-built proto/*.proto
+golang-from-source: ensure-api-generator-image proto/*.proto
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
 		-v "$$(pwd)/..":"/go/src/github.com/kubeflow/pipelines":z \
@@ -91,7 +91,7 @@ endif
 
 # Build Python package by building api-generator image from source.
 .PHONY: python-from-source
-python-from-source: .api-generator-built proto/kubernetes_executor_config.proto fetch-protos
+python-from-source: ensure-api-generator-image proto/kubernetes_executor_config.proto fetch-protos
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
 		-e HOME=/tmp \
@@ -128,8 +128,7 @@ generate-go-in-container:
 		--go_opt=paths=source_relative \
 		kubernetes_executor_config.proto
 
-# Build the API generator image locally to ensure current tool versions
-.api-generator-built: ../backend/api/Dockerfile
-	DOCKER_BUILDKIT=1 docker build .. -t $(IMAGE_TAG) -f ../backend/api/Dockerfile \
-		--cache-from $(IMAGE_TAG):latest
-	touch .api-generator-built
+# Build the API generator image via the canonical target in backend/api
+.PHONY: ensure-api-generator-image
+ensure-api-generator-image:
+	$(MAKE) -C ../backend/api image

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -45,7 +45,7 @@ endif
 
 # Build Python package by building api-generator image from source.
 .PHONY: python-from-source
-python-from-source: .api-generator-built
+python-from-source: ensure-api-generator-image
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
 		-e HOME=/tmp \
@@ -60,8 +60,7 @@ clean-python:
 	rm -rf python/dist
 	rm -rf python/kfp.egg-info
 
-# Build the API generator image locally to ensure current tool versions
-.api-generator-built: ../backend/api/Dockerfile
-	DOCKER_BUILDKIT=1 docker build .. -t $(IMAGE_TAG) -f ../backend/api/Dockerfile \
-		--cache-from $(IMAGE_TAG):latest
-	touch .api-generator-built
+# Build the API generator image via the canonical target in backend/api
+.PHONY: ensure-api-generator-image
+ensure-api-generator-image:
+	$(MAKE) -C ../backend/api image

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -12,16 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Contact one of chensun, HumairAK if this remote image needs an update.
+# Pre-built images for faster development (default: enabled for speed)
+# Set USE_PREBUILT_IMAGE=false when:
+# - Dockerfile dependencies have been updated
+# - CI validation fails due to tool version mismatches
+# - Working on API generation toolchain changes
+USE_PREBUILT_IMAGE ?= true
+# Validate USE_PREBUILT_IMAGE value
+ifneq ($(USE_PREBUILT_IMAGE),true)
+ifneq ($(USE_PREBUILT_IMAGE),false)
+$(error USE_PREBUILT_IMAGE must be 'true' or 'false', got '$(USE_PREBUILT_IMAGE)')
+endif
+endif
 PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:master
+IMAGE_TAG=kfp-api-generator
 
+# Build Python package using either pre-built image (fast) or source build (accurate).
+# Use USE_PREBUILT_IMAGE=false to build from source for guaranteed accuracy.
 .PHONY: python
-python: python
+python:
+ifeq ($(USE_PREBUILT_IMAGE),true)
 	docker run --interactive --rm \
 		--user $$(id -u):$$(id -g) \
 		-e HOME=/tmp \
 		-v "$$(pwd)/..":"/go/src/github.com/kubeflow/pipelines":z \
 		$(PREBUILT_REMOTE_IMAGE) \
+		sh -c 'cd /go/src/github.com/kubeflow/pipelines/sdk/python && \
+			python3 setup.py sdist && pip wheel --no-deps dist/*.tar.gz -w dist'
+else
+	$(MAKE) python-from-source
+endif
+
+# Build Python package by building api-generator image from source.
+.PHONY: python-from-source
+python-from-source: .api-generator-built
+	docker run --interactive --rm \
+		--user $$(id -u):$$(id -g) \
+		-e HOME=/tmp \
+		-v "$$(pwd)/..":"/go/src/github.com/kubeflow/pipelines":z \
+		$(IMAGE_TAG) \
 		sh -c 'cd /go/src/github.com/kubeflow/pipelines/sdk/python && \
 			python3 setup.py sdist && pip wheel --no-deps dist/*.tar.gz -w dist'
 
@@ -30,3 +59,9 @@ clean-python:
 	rm -rf python/build
 	rm -rf python/dist
 	rm -rf python/kfp.egg-info
+
+# Build the API generator image locally to ensure current tool versions
+.api-generator-built: ../backend/api/Dockerfile
+	DOCKER_BUILDKIT=1 docker build .. -t $(IMAGE_TAG) -f ../backend/api/Dockerfile \
+		--cache-from $(IMAGE_TAG):latest
+	touch .api-generator-built


### PR DESCRIPTION
## Problem

API code generation (`backend/api/Makefile`) uses pre-built Docker images (`ghcr.io/kubeflow/kfp-api-generator:master`) that contain pinned tool versions. When dependencies like gRPC-Gateway are upgraded in the repo, the pre-built image still contains the old versions, causing generated files to become stale. This is what happened in #13561 — the grpc-gateway v2.28.0 bump changed output formats, but the pre-built image still had the old version, so the CI validation workflow (`validate-generated-files.yml`) failed on master.

The root cause is that `validate-generated-files.yml` used `make generate-from-scratch` which built the image from source, but the checked-in files were generated with the stale pre-built image. There's no mechanism to ensure CI and local development use the same toolchain.

## Solution

Add a `USE_PREBUILT_IMAGE` environment variable (default `true`) to all API generation Makefiles. Developers get fast pre-built images by default, while CI sets `USE_PREBUILT_IMAGE=false` to always build from source, guaranteeing generated files match the current toolchain.

- Add `USE_PREBUILT_IMAGE` flag to `api/`, `backend/api/`, `kubernetes_platform/`, and `sdk/` Makefiles with input validation and source-build targets
- CI `validate-generated-files` workflow now sets `USE_PREBUILT_IMAGE=false`
- Add Java (`default-jdk`) to the API generator Dockerfile so `generate-kfp-server-api-package` can run without the separate release image
- Fix self-referencing Make prerequisites in `api/Makefile` and `sdk/Makefile`
- Keep `generate-from-scratch` as a legacy alias to `generate-from-source`

Prevents issues like #13561