### PR TITLE
fix(backend):Make kind-cluster-agnostic timeouts configurable

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -26,6 +26,9 @@ IMG_TAG_DRIVER            ?= kfp-driver
 IMG_TAG_LAUNCHER          ?= kfp-launcher
 IMG_TAG_WEBHOOK_PROXY     ?= domain.local/kfp/webhook-proxy:latest
 
+
+MYSQL_WAIT_TIMEOUT ?= 10m
+
 # Whenever build command for any of the binaries change, we should update them both here and in backend/Dockerfiles.
 
 .PHONY: all
@@ -99,7 +102,7 @@ kind-cluster-agnostic:
     	else \
     		kubectl apply -k $(CURDIR)/../manifests/kustomize/env/platform-agnostic; \
      fi
-	kubectl -n kubeflow wait --for condition=Available --timeout=10m deployment/mysql
+	kubectl -n kubeflow wait --for condition=Available --timeout=$(MYSQL_WAIT_TIMEOUT) deployment/mysql
 	kubectl -n kubeflow wait --for condition=Available --timeout=3m deployment/metadata-grpc-deployment
 	kubectl -n kubeflow wait --for condition=Available --timeout=3m deployment/ml-pipeline
 	# Switch to Kubeflow namespace context


### PR DESCRIPTION
**Description of your changes:**
Makes the kubectl wait timeout in the kind-cluster-agnostic Makefile target configurable via MYSQL_WAIT_TIMEOUT variable, instead of hardcoded values. Default remain unchanged (10m), so existing behavior (CI, fast connections) is unaffected.

solves #13772

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 

