### PR TITLE
ci: avoid cancelled meta-check rollups

### DIFF
--- a/.github/resources/scripts/meta_workflow_concurrency_test.py
+++ b/.github/resources/scripts/meta_workflow_concurrency_test.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class MetaWorkflowConcurrencyTest(unittest.TestCase):
+
+    def _read_workflow(self, name: str) -> str:
+        return (ROOT / '.github/workflows' / name).read_text(encoding='utf-8')
+
+    def test_ci_check_filters_label_events_before_job_concurrency(self):
+        workflow = self._read_workflow('ci-checks.yml')
+        workflow_header, jobs = workflow.split('\njobs:', maxsplit=1)
+
+        self.assertNotIn('\nconcurrency:', workflow_header)
+        self.assertIn("github.event.label.name == 'ok-to-test'", jobs)
+        self.assertIn("github.event.label.name == 'needs-ok-to-test'", jobs)
+        self.assertIn('    concurrency:\n', jobs)
+        self.assertIn("&& 'head-update' || github.run_id", jobs)
+        self.assertIn(
+            "cancel-in-progress: ${{ github.event.action == 'synchronize' }}",
+            jobs,
+        )
+
+    def test_approval_runs_on_open_but_skips_unrelated_labels(self):
+        workflow = self._read_workflow('gh-workflow-approve.yml')
+        workflow_header, jobs = workflow.split('\njobs:', maxsplit=1)
+
+        self.assertIn('      - opened\n', workflow_header)
+        self.assertNotIn('\nconcurrency:', workflow_header)
+        self.assertIn("github.event.label.name == 'ok-to-test'", jobs)
+        self.assertIn('    concurrency:\n', jobs)
+        self.assertIn("&& 'head-update' || github.run_id", jobs)
+        self.assertIn(
+            "cancel-in-progress: ${{ github.event.action == 'synchronize' }}",
+            jobs,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/resources/scripts/meta_workflow_concurrency_test.py
+++ b/.github/resources/scripts/meta_workflow_concurrency_test.py
@@ -53,6 +53,14 @@ def _mapping_block(document: str, key: str, indentation: int) -> str:
     return '\n'.join(lines[start:end]) + '\n'
 
 
+def _before_mapping(document: str, key: str, indentation: int) -> str:
+    lines = document.splitlines()
+    marker = _mapping_marker(key, indentation)
+    end = next(index for index, line in enumerate(lines)
+               if marker.match(line))
+    return '\n'.join(lines[:end]) + '\n'
+
+
 def _folded_scalar(document: str, key: str, indentation: int) -> str:
     lines = document.splitlines()
     marker = re.compile(r'^' + (' ' * indentation) + re.escape(key) +
@@ -138,9 +146,17 @@ class MetaWorkflowConcurrencyTest(unittest.TestCase):
         workflow = self._read_workflow('ci-checks.yml')
         jobs = _mapping_block(workflow, 'jobs', 0)
         job = _mapping_block(jobs, 'check_ci_status', 2)
-        condition = _folded_scalar(job, 'if', 4)
+        pre_concurrency = _before_mapping(job, 'concurrency', 4)
+        condition = _folded_scalar(pre_concurrency, 'if', 4)
         concurrency = _mapping_block(job, 'concurrency', 4)
         concurrency_group = _folded_scalar(concurrency, 'group', 6)
+
+        self.assertEqual(
+            condition,
+            "(github.event.action != 'labeled' && github.event.action != 'unlabeled') || "
+            "(github.event.action == 'labeled' && github.event.label.name == 'ok-to-test') || "
+            "(github.event.action == 'unlabeled' && github.event.label.name == 'needs-ok-to-test')",
+        )
 
         expected_results = {
             ('opened', ''): True,
@@ -170,9 +186,15 @@ class MetaWorkflowConcurrencyTest(unittest.TestCase):
         workflow_header = workflow.split('\njobs:', 1)[0]
         jobs = _mapping_block(workflow, 'jobs', 0)
         job = _mapping_block(jobs, 'ok-to-test', 2)
-        condition = _folded_scalar(job, 'if', 4)
+        pre_concurrency = _before_mapping(job, 'concurrency', 4)
+        condition = _folded_scalar(pre_concurrency, 'if', 4)
         concurrency = _mapping_block(job, 'concurrency', 4)
         concurrency_group = _folded_scalar(concurrency, 'group', 6)
+
+        self.assertEqual(
+            condition,
+            "github.event.action != 'labeled' || github.event.label.name == 'ok-to-test'",
+        )
 
         expected_results = {
             ('opened', ''): True,

--- a/.github/resources/scripts/meta_workflow_concurrency_test.py
+++ b/.github/resources/scripts/meta_workflow_concurrency_test.py
@@ -13,10 +13,120 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ast
 from pathlib import Path
+import re
 import unittest
 
 ROOT = Path(__file__).resolve().parents[3]
+
+# CI Scripts Tests intentionally runs without third-party packages. These
+# helpers parse only the small YAML subset needed to locate job-level scalars.
+
+
+def _mapping_marker(key: str, indentation: int) -> re.Pattern:
+    return re.compile(r'^' + (' ' * indentation) + re.escape(key) +
+                      r':\s*(?:#.*)?$')
+
+
+def _has_mapping(document: str, key: str, indentation: int) -> bool:
+    marker = _mapping_marker(key, indentation)
+    return any(marker.match(line) for line in document.splitlines())
+
+
+def _mapping_block(document: str, key: str, indentation: int) -> str:
+    lines = document.splitlines()
+    marker = _mapping_marker(key, indentation)
+    start = next(index for index, line in enumerate(lines)
+                 if marker.match(line))
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if not line.strip() or line.lstrip().startswith('#'):
+            continue
+        current_indentation = len(line) - len(line.lstrip())
+        if current_indentation <= indentation:
+            end = index
+            break
+
+    return '\n'.join(lines[start:end]) + '\n'
+
+
+def _folded_scalar(document: str, key: str, indentation: int) -> str:
+    lines = document.splitlines()
+    marker = re.compile(r'^' + (' ' * indentation) + re.escape(key) +
+                        r':\s*[>|][-+]?\s*$')
+    start = next(index for index, line in enumerate(lines)
+                 if marker.match(line))
+
+    values = []
+    for line in lines[start + 1:]:
+        if not line.strip():
+            continue
+        current_indentation = len(line) - len(line.lstrip())
+        if current_indentation <= indentation:
+            break
+        values.append(line.strip())
+
+    return ' '.join(values)
+
+
+def _plain_scalar(document: str, key: str, indentation: int) -> str:
+    marker = re.compile(r'^' + (' ' * indentation) + re.escape(key) +
+                        r':\s*(.*?)\s*$')
+    for line in document.splitlines():
+        match = marker.match(line)
+        if match:
+            return match.group(1)
+    raise ValueError(f'Missing scalar {key!r} at indentation {indentation}')
+
+
+def _evaluate_condition_node(node, values):
+    if isinstance(node, ast.Expression):
+        return _evaluate_condition_node(node.body, values)
+    if isinstance(node, ast.BoolOp):
+        operands = (_evaluate_condition_node(value, values)
+                    for value in node.values)
+        if isinstance(node.op, ast.And):
+            return all(operands)
+        if isinstance(node.op, ast.Or):
+            return any(operands)
+    if isinstance(node, ast.Compare):
+        left = _evaluate_condition_node(node.left, values)
+        for operator, comparator_node in zip(node.ops, node.comparators):
+            right = _evaluate_condition_node(comparator_node, values)
+            if isinstance(operator, ast.Eq):
+                matches = left == right
+            elif isinstance(operator, ast.NotEq):
+                matches = left != right
+            else:
+                raise AssertionError(
+                    f'Unsupported comparison: {ast.dump(operator)}')
+            if not matches:
+                return False
+            left = right
+        return True
+    if isinstance(node, ast.Name) and node.id in values:
+        return values[node.id]
+    if isinstance(node, ast.Constant):
+        return node.value
+    raise AssertionError(f'Unsupported condition syntax: {ast.dump(node)}')
+
+
+def _evaluate_label_condition(expression: str, action: str,
+                              label_name: str) -> bool:
+    python_expression = expression.replace('github.event.action', 'action')
+    python_expression = python_expression.replace('github.event.label.name',
+                                                  'label_name')
+    python_expression = python_expression.replace('&&', ' and ')
+    python_expression = python_expression.replace('||', ' or ')
+    parsed = ast.parse(python_expression, mode='eval')
+    return bool(
+        _evaluate_condition_node(parsed, {
+            'action': action,
+            'label_name': label_name,
+        }))
 
 
 class MetaWorkflowConcurrencyTest(unittest.TestCase):
@@ -26,31 +136,79 @@ class MetaWorkflowConcurrencyTest(unittest.TestCase):
 
     def test_ci_check_filters_label_events_before_job_concurrency(self):
         workflow = self._read_workflow('ci-checks.yml')
-        workflow_header, jobs = workflow.split('\njobs:', maxsplit=1)
+        jobs = _mapping_block(workflow, 'jobs', 0)
+        job = _mapping_block(jobs, 'check_ci_status', 2)
+        condition = _folded_scalar(job, 'if', 4)
+        concurrency = _mapping_block(job, 'concurrency', 4)
+        concurrency_group = _folded_scalar(concurrency, 'group', 6)
 
-        self.assertNotIn('\nconcurrency:', workflow_header)
-        self.assertIn("github.event.label.name == 'ok-to-test'", jobs)
-        self.assertIn("github.event.label.name == 'needs-ok-to-test'", jobs)
-        self.assertIn('    concurrency:\n', jobs)
-        self.assertIn("&& 'head-update' || github.run_id", jobs)
-        self.assertIn(
-            "cancel-in-progress: ${{ github.event.action == 'synchronize' }}",
-            jobs,
+        expected_results = {
+            ('opened', ''): True,
+            ('synchronize', ''): True,
+            ('reopened', ''): True,
+            ('labeled', 'ok-to-test'): True,
+            ('unlabeled', 'needs-ok-to-test'): True,
+            ('labeled', 'dependencies'): False,
+            ('labeled', 'size/M'): False,
+            ('labeled', 'needs-ok-to-test'): False,
+            ('unlabeled', 'ok-to-test'): False,
+        }
+        for event, expected in expected_results.items():
+            with self.subTest(action=event[0], label=event[1]):
+                self.assertEqual(
+                    _evaluate_label_condition(condition, *event), expected)
+
+        self.assertFalse(_has_mapping(workflow, 'concurrency', 0))
+        self.assertIn("&& 'head-update' || github.run_id", concurrency_group)
+        self.assertEqual(
+            _plain_scalar(concurrency, 'cancel-in-progress', 6),
+            "${{ github.event.action == 'synchronize' }}",
         )
 
     def test_approval_runs_on_open_but_skips_unrelated_labels(self):
         workflow = self._read_workflow('gh-workflow-approve.yml')
-        workflow_header, jobs = workflow.split('\njobs:', maxsplit=1)
+        workflow_header = workflow.split('\njobs:', 1)[0]
+        jobs = _mapping_block(workflow, 'jobs', 0)
+        job = _mapping_block(jobs, 'ok-to-test', 2)
+        condition = _folded_scalar(job, 'if', 4)
+        concurrency = _mapping_block(job, 'concurrency', 4)
+        concurrency_group = _folded_scalar(concurrency, 'group', 6)
+
+        expected_results = {
+            ('opened', ''): True,
+            ('synchronize', ''): True,
+            ('reopened', ''): True,
+            ('labeled', 'ok-to-test'): True,
+            ('labeled', 'dependencies'): False,
+            ('labeled', 'size/M'): False,
+        }
+        for event, expected in expected_results.items():
+            with self.subTest(action=event[0], label=event[1]):
+                self.assertEqual(
+                    _evaluate_label_condition(condition, *event), expected)
 
         self.assertIn('      - opened\n', workflow_header)
-        self.assertNotIn('\nconcurrency:', workflow_header)
-        self.assertIn("github.event.label.name == 'ok-to-test'", jobs)
-        self.assertIn('    concurrency:\n', jobs)
-        self.assertIn("&& 'head-update' || github.run_id", jobs)
-        self.assertIn(
-            "cancel-in-progress: ${{ github.event.action == 'synchronize' }}",
-            jobs,
+        self.assertFalse(_has_mapping(workflow, 'concurrency', 0))
+        self.assertIn("&& 'head-update' || github.run_id", concurrency_group)
+        self.assertEqual(
+            _plain_scalar(concurrency, 'cancel-in-progress', 6),
+            "${{ github.event.action == 'synchronize' }}",
         )
+
+    def test_eligibility_shell_receives_label_name_through_environment(self):
+        workflow = self._read_workflow('ci-checks.yml')
+        step_start = workflow.index(
+            '      - name: Determine whether CI polling is needed')
+        step_end = workflow.index(
+            '      - name: Wait for action_required workflow runs to be approved'
+        )
+        eligibility_step = workflow[step_start:step_end]
+        shell_script = eligibility_step.split('        run: |', 1)[1]
+
+        self.assertIn('LABEL_NAME: ${{ github.event.label.name }}',
+                      eligibility_step)
+        self.assertNotIn('${{ github.event.label.name }}', shell_script)
+        self.assertIn("reason=\"Added label '${LABEL_NAME}'", shell_script)
 
 
 if __name__ == '__main__':

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - name: Determine whether CI polling is needed
         id: eligibility
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
         shell: bash
         run: |
           should_poll=false
@@ -43,10 +46,10 @@ jobs:
             reason="PR is not yet labeled ok-to-test."
           elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'needs-ok-to-test') }}" == "true" ]]; then
             reason="PR still has the needs-ok-to-test label."
-          elif [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.label.name }}" != "ok-to-test" ]]; then
-            reason="Added label '${{ github.event.label.name }}' does not change CI eligibility."
-          elif [[ "${{ github.event.action }}" == "unlabeled" && "${{ github.event.label.name }}" != "needs-ok-to-test" ]]; then
-            reason="Removed label '${{ github.event.label.name }}' does not change CI eligibility."
+          elif [[ "${EVENT_ACTION}" == "labeled" && "${LABEL_NAME}" != "ok-to-test" ]]; then
+            reason="Added label '${LABEL_NAME}' does not change CI eligibility."
+          elif [[ "${EVENT_ACTION}" == "unlabeled" && "${LABEL_NAME}" != "needs-ok-to-test" ]]; then
+            reason="Removed label '${LABEL_NAME}' does not change CI eligibility."
           else
             should_poll=true
             reason="PR is eligible; running CI status polling."

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -7,13 +7,26 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   check_ci_status:
+    # GitHub Actions cannot filter pull_request_target events by label name.
+    # Skip unrelated labels before entering concurrency so Dependabot/Prow label
+    # bursts cannot leave cancelled checks on the current head SHA.
+    if: >-
+      (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'ok-to-test') ||
+      (github.event.action == 'unlabeled' && github.event.label.name == 'needs-ok-to-test')
+    concurrency:
+      # Label and reopen events use a unique group because cancelling a run for
+      # the same head SHA would make that commit's check rollup red.
+      group: >-
+        ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{
+          (github.event.action == 'opened' || github.event.action == 'synchronize')
+          && 'head-update' || github.run_id
+        }}
+      # A synchronize event moves the PR to a new head SHA, so cancelling the
+      # prior run cannot make the current commit's check rollup red.
+      cancel-in-progress: ${{ github.event.action == 'synchronize' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/ci-scripts-tests.yml
+++ b/.github/workflows/ci-scripts-tests.yml
@@ -10,7 +10,9 @@ on:
       # The observability shell scripts are covered by Python-driven tests.
       - '.github/resources/scripts/*.sh'
       - '.github/resources/scripts/kfp-readiness/**'
+      - '.github/workflows/ci-checks.yml'
       - '.github/workflows/ci-scripts-tests.yml'
+      - '.github/workflows/gh-workflow-approve.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/gh-workflow-approve.yml
+++ b/.github/workflows/gh-workflow-approve.yml
@@ -7,17 +7,29 @@ permissions:
 on:
   pull_request_target:
     types:
+      - opened
       - labeled
       - synchronize
       - reopened
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
-  cancel-in-progress: true
-
 jobs:
   ok-to-test:
-    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test') || github.event_name == 'pull_request_target'
+    # Run immediately for trusted authors and when an external contributor is
+    # approved. Other labels do not affect workflow-run approval.
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'ok-to-test'
+    concurrency:
+      # Label and reopen events use a unique group because cancelling a run for
+      # the same head SHA would make that commit's check rollup red.
+      group: >-
+        ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{
+          (github.event.action == 'opened' || github.event.action == 'synchronize')
+          && 'head-update' || github.run_id
+        }}
+      # A synchronize event moves the PR to a new head SHA, so cancelling the
+      # prior run cannot make the current commit's check rollup red.
+      cancel-in-progress: ${{ github.event.action == 'synchronize' }}
     runs-on: ubuntu-latest
     continue-on-error: true
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-20
+- Last updated: 2026-07-21
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -530,7 +530,8 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 - Workflows: `.github/workflows/` (build, test, lint, release)
 - `ci-health-report.yml` runs daily (and on dispatch): aggregates master-branch lane failure rates and per-test flake counts from `junit-xml - *` artifacts, publishing to the job summary and a tracking issue labeled `ci-health`.
-- `ci-scripts-tests.yml` runs the stdlib unit tests for CI tooling and diagnostics on PRs touching `.github/resources/scripts/*.py`, `.github/resources/scripts/*.sh`, or the workflow itself (run locally with `cd .github/resources/scripts && python3 -m unittest discover -v -p '*_test.py'`).
+- `ci-scripts-tests.yml` runs the stdlib unit tests for CI tooling, diagnostics, and meta-workflow concurrency on PRs touching `.github/resources/scripts/*.py`, `.github/resources/scripts/*.sh`, `ci-checks.yml`, `gh-workflow-approve.yml`, or the test workflow itself (run locally with `cd .github/resources/scripts && python3 -m unittest discover -v -p '*_test.py'`).
+- The `CI Check` and `Approve Workflow Runs` meta-workflows filter unrelated label events before entering per-PR job concurrency. Only `synchronize` events cancel an active run, so Dependabot/Prow label bursts do not leave cancelled checks on the current head SHA.
 - Composite actions: `.github/actions/` (e.g., `kfp-k8s`, `create-cluster`, `deploy`, `test-and-report`)
 - Typical checks: Go unit tests (backend), Python SDK tests, frontend tests/lint, image builds.
 - `validate-generated-files.yml` builds the API generator from the pull request's


### PR DESCRIPTION
## Summary

- filter unrelated Dependabot/Prow label events before the CI meta-jobs enter concurrency
- give same-head label and reopen runs unique concurrency groups while retaining cancellation for new commits
- run workflow approval directly on PR open instead of relying on incidental label events
- pass event action and label values into Bash through `env` rather than direct expression interpolation
- add behavior-focused regression coverage and run it whenever either meta-workflow changes

## Why

The open Dependabot PR list showed red CI rollups even when every substantive test passed. Rapid label events started multiple `CI Check` and `Approve Workflow Runs` jobs, and workflow-level `cancel-in-progress: true` left the superseded jobs with `cancelled` conclusions on the current head SHA. GitHub treats those conclusions as non-success in the PR list rollup.

GitHub Actions cannot filter `pull_request_target` events by label name at trigger time. This change therefore filters at the job level, before concurrency is evaluated. Only `synchronize` can cancel an active run, and its cancelled run belongs to the previous head SHA. Same-SHA eligibility events use unique groups so they cannot make the current rollup red.

## Verification

- `python3 -m unittest discover -q -p '*_test.py'`
- `python3 -m py_compile .github/resources/scripts/meta_workflow_concurrency_test.py`
- `actionlint` v1.7.7 on all three changed workflow files
- Ruby YAML parsing for all three changed workflow files
- `git diff --check`
