### PR TITLE
fix(sdk): do not automatically add --trusted-host to pip commands by default. Fixes #11155

### DIFF
--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -529,7 +529,7 @@ class Test(unittest.TestCase):
                 COPY runtime-requirements.txt runtime-requirements.txt
                 RUN pip install --index-url https://pypi.org/simple --no-cache-dir -r runtime-requirements.txt
 
-                RUN pip install --index-url https://pypi.org/simple --no-cache-dir kfp==1.2.3
+                RUN pip install --index-url https://pypi.org/simple --no-cache-dir kfp==2.17.0
                 COPY . .
                 '''))
 
@@ -560,7 +560,7 @@ class Test(unittest.TestCase):
                 COPY runtime-requirements.txt runtime-requirements.txt
                 RUN pip install --index-url https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --no-cache-dir -r runtime-requirements.txt
 
-                RUN pip install --index-url https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --no-cache-dir kfp==1.2.3
+                RUN pip install --index-url https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --no-cache-dir kfp==2.17.0
                 COPY . .
                 '''))
 

--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -529,7 +529,7 @@ class Test(unittest.TestCase):
                 COPY runtime-requirements.txt runtime-requirements.txt
                 RUN pip install --index-url https://pypi.org/simple --no-cache-dir -r runtime-requirements.txt
 
-                RUN pip install --index-url https://pypi.org/simple --no-cache-dir kfp==2.17.0
+                RUN pip install --index-url https://pypi.org/simple --no-cache-dir kfp==1.2.3
                 COPY . .
                 '''))
 
@@ -560,7 +560,7 @@ class Test(unittest.TestCase):
                 COPY runtime-requirements.txt runtime-requirements.txt
                 RUN pip install --index-url https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --no-cache-dir -r runtime-requirements.txt
 
-                RUN pip install --index-url https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --no-cache-dir kfp==2.17.0
+                RUN pip install --index-url https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --no-cache-dir kfp==1.2.3
                 COPY . .
                 '''))
 

--- a/sdk/python/kfp/cli/component_test.py
+++ b/sdk/python/kfp/cli/component_test.py
@@ -527,9 +527,9 @@ class Test(unittest.TestCase):
 
                 WORKDIR /usr/local/src/kfp/components
                 COPY runtime-requirements.txt runtime-requirements.txt
-                RUN pip install --index-url https://pypi.org/simple --trusted-host https://pypi.org/simple --no-cache-dir -r runtime-requirements.txt
+                RUN pip install --index-url https://pypi.org/simple --no-cache-dir -r runtime-requirements.txt
 
-                RUN pip install --index-url https://pypi.org/simple --trusted-host https://pypi.org/simple --no-cache-dir kfp==1.2.3
+                RUN pip install --index-url https://pypi.org/simple --no-cache-dir kfp==1.2.3
                 COPY . .
                 '''))
 
@@ -558,9 +558,9 @@ class Test(unittest.TestCase):
 
                 WORKDIR /usr/local/src/kfp/components
                 COPY runtime-requirements.txt runtime-requirements.txt
-                RUN pip install --index-url https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --trusted-host https://pypi.org/simple --trusted-host https://example.com/pypi/simple --no-cache-dir -r runtime-requirements.txt
+                RUN pip install --index-url https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --no-cache-dir -r runtime-requirements.txt
 
-                RUN pip install --index-url https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --trusted-host https://pypi.org/simple --trusted-host https://example.com/pypi/simple --no-cache-dir kfp==1.2.3
+                RUN pip install --index-url https://pypi.org/simple --extra-index-url https://example.com/pypi/simple --no-cache-dir kfp==1.2.3
                 COPY . .
                 '''))
 

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -95,12 +95,10 @@ def make_index_url_options(pip_index_urls: Optional[List[str]],
             - '--index-url url ' if pip_index_urls contains 1 URL.
             - The above followed by '--extra-index-url url ' for each additional URL in pip_index_urls
             if pip_index_urls contains more than 1 URL.
-            - If pip_trusted_hosts is None:
-                - The above followed by '--trusted-host url ' for each URL in pip_index_urls.
-            - If pip_trusted_hosts is an empty List.
-                - No --trusted-host information will be added
-            - If pip_trusted_hosts contains any URLs:
-                - The above followed by '--trusted-host url ' for each URL in pip_trusted_hosts.
+            - If pip_trusted_hosts is None or an empty List:
+                - No --trusted-host information will be added.
+            - If pip_trusted_hosts contains any hosts:
+                - The above followed by '--trusted-host host ' for each host in pip_trusted_hosts.
     Note:
         In case pip_index_urls is not empty, the returned string will contain a space at the end.
     """
@@ -114,11 +112,7 @@ def make_index_url_options(pip_index_urls: Optional[List[str]],
     options.extend(f'--extra-index-url {extra_index_url}'
                    for extra_index_url in extra_index_urls)
 
-    if pip_trusted_hosts is None:
-        options.extend([f'--trusted-host {index_url}'])
-        options.extend(f'--trusted-host {extra_index_url}'
-                       for extra_index_url in extra_index_urls)
-    elif len(pip_trusted_hosts) > 0:
+    if pip_trusted_hosts:
         options.extend(f'--trusted-host {trusted_host}'
                        for trusted_host in pip_trusted_hosts)
 

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -185,9 +185,9 @@ class TestGetPackagesToInstallCommand(unittest.TestCase):
                 '\n'
                 'PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet '
                 '--no-warn-script-location --index-url https://myurl.org/simple '
-                "--trusted-host https://myurl.org/simple 'package1' 'package2'  &&  python3 "
+                "'package1' 'package2'  &&  python3 "
                 '-m pip install --quiet --no-warn-script-location --index-url '
-                'https://myurl.org/simple --trusted-host https://myurl.org/simple kfp '
+                'https://myurl.org/simple kfp '
                 '\'--no-deps\' \'typing-extensions>=3.7.4,<5; python_version<"3.9"\' && "$0" '
                 '"$@"\n'
             ]))


### PR DESCRIPTION
**Description of your changes:**

`make_index_url_options` auto-added `--trusted-host` for every pip index URL whenever `pip_trusted_hosts` was unset (`None`), silently disabling SSL certificate validation. This affects both `@dsl.component` pip installs and `kfp component build` Dockerfiles, since both route through this helper. The injected value was also the full index URL (`https://.../simple`) where pip expects a bare host, so the default was malformed as well as insecure.

#11151 already added the opt-in secure path (`pip_trusted_hosts=[]`). This makes the **default** secure: `--trusted-host` is emitted only when the user explicitly lists hosts via `pip_trusted_hosts`. `None` now behaves like `[]`.

**Note backward compatibility:** this is an intentional behavior change. Users relying on the implicit `--trusted-host` (e.g. a private mirror with a self-signed cert) must now set `pip_trusted_hosts` explicitly. Requested by maintainers in the issue thread (@droctothorpe, @HumairAK).

**Testing:** `make_index_url_options` with `None`/`[]` → no `--trusted-host`; explicit hosts still honored. Updated `component_factory_test.py` and `cli/component_test.py`; explicit/empty-host tests unchanged.

Fixes #11155

**Checklist:**
- [x] You have signed off your commits
- [x] The title for your pull request (PR) follows our title convention
