### PR TITLE
fix(ci): make SDK docs requirements Dependabot-compatible

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,8 @@ sphinx:
 python:
   install:
     - requirements: docs/sdk/requirements.txt
+    - method: pip
+      path: sdk/python/
 build:
   os: ubuntu-22.04
   tools:

--- a/docs/sdk/build_docs_locally.sh
+++ b/docs/sdk/build_docs_locally.sh
@@ -16,6 +16,7 @@
 
 pushd ../..
 pip install -r docs/sdk/requirements.txt
+pip install sdk/python
 popd
 
 # build docs

--- a/docs/sdk/requirements.txt
+++ b/docs/sdk/requirements.txt
@@ -1,5 +1,4 @@
 autodocsumm==0.2.9
-sdk/python
 setuptools<81
 sphinx==5.0.2
 sphinx-click==4.3.0


### PR DESCRIPTION
## Summary

- keep `docs/sdk/requirements.txt` limited to third-party packages
- install the repository SDK explicitly through Read the Docs' supported `path` configuration
- preserve the local documentation helper by installing `sdk/python` as a separate step

## Why

Dependabot's security updater evaluates `docs/sdk/requirements.txt` from
`/docs/sdk`. The repository-relative `sdk/python` entry is therefore
interpreted as `/docs/sdk/sdk/python`, and the update aborts with
`dependency_file_not_evaluatable` before it can update `setuptools`.

Separating the local package install from the dependency manifest keeps
documentation behavior unchanged while allowing Dependabot to evaluate the
third-party requirements.

Example failing run:
https://github.com/kubeflow/pipelines/actions/runs/29891955528

## Verification

- `bash -n docs/sdk/build_docs_locally.sh`
- parsed `.readthedocs.yml` with Ruby/Psych
- asserted that the requirements file contains `setuptools<81` and no local SDK path
- rebased onto current `master`
