### PR TITLE
ci: retry BuildKit and Kind tool downloads

### DIFF
--- a/.github/actions/create-cluster/action.yml
+++ b/.github/actions/create-cluster/action.yml
@@ -42,6 +42,8 @@ runs:
       uses: helm/kind-action@v1.13.0
       id: cluster-create
       continue-on-error: true
+      env:
+        CURL_HOME: ${{ github.workspace }}/.github/resources/curl-retry
       with:
         cluster_name: ${{ inputs.cluster_name }}
         kubectl_version: ${{ inputs.k8s_version }}
@@ -51,6 +53,8 @@ runs:
     - name: Retry Create k8s Kind Cluster
       uses: helm/kind-action@v1.13.0
       if: ${{ steps.cluster-create.outcome == 'failure' }}
+      env:
+        CURL_HOME: ${{ github.workspace }}/.github/resources/curl-retry
       with:
         cluster_name: ${{ inputs.cluster_name }}
         kubectl_version: ${{ inputs.k8s_version }}

--- a/.github/resources/curl-retry/.curlrc
+++ b/.github/resources/curl-retry/.curlrc
@@ -1,0 +1,19 @@
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Five total attempts, including the initial request. This is scoped to actions
+# that explicitly set CURL_HOME to this directory.
+retry = 4
+retry-delay = 20
+retry-all-errors

--- a/.github/resources/scripts/external_bootstrap_retry_test.py
+++ b/.github/resources/scripts/external_bootstrap_retry_test.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import http.server
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import threading
+import unittest
+
+
+SCRIPTS_DIR = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS_DIR.parents[2]
+SETUP_BUILDX_SCRIPT = SCRIPTS_DIR / 'setup-buildx-with-retry.sh'
+CURL_CONFIG = REPO_ROOT / '.github/resources/curl-retry/.curlrc'
+CREATE_CLUSTER_ACTION = REPO_ROOT / '.github/actions/create-cluster/action.yml'
+BUILDKIT_IMAGE = 'moby/buildkit:buildx-stable-1'
+
+
+class _RetryHandler(http.server.BaseHTTPRequestHandler):
+
+    request_count = 0
+
+    def do_GET(self):
+        type(self).request_count += 1
+        if type(self).request_count < 3:
+            self.send_response(503)
+            self.end_headers()
+            return
+
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'ok')
+
+    def log_message(self, format, *args):
+        pass
+
+
+class ExternalBootstrapRetryTest(unittest.TestCase):
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_path = pathlib.Path(self.temp_dir.name)
+        self.bin_dir = self.temp_path / 'bin'
+        self.bin_dir.mkdir()
+        self.command_log = self.temp_path / 'docker.log'
+        self.sleep_log = self.temp_path / 'sleep.log'
+        self.pull_state = self.temp_path / 'pull-count'
+        self.github_output = self.temp_path / 'github-output'
+        self._write_fake_commands()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _write_fake_commands(self):
+        docker = self.bin_dir / 'docker'
+        docker.write_text(
+            '#!/usr/bin/env bash\n'
+            'printf \'%s\\n\' "$*" >> "$COMMAND_LOG"\n'
+            'if [[ "$1" == "pull" ]]; then\n'
+            '  count=0\n'
+            '  [[ -f "$PULL_STATE" ]] && count=$(<"$PULL_STATE")\n'
+            '  count=$((count + 1))\n'
+            '  printf \'%s\' "$count" > "$PULL_STATE"\n'
+            '  [[ "$count" -le "$FAIL_PULLS" ]] && exit 1\n'
+            'fi\n'
+            'exit 0\n')
+        docker.chmod(0o755)
+
+        sleep = self.bin_dir / 'sleep'
+        sleep.write_text(
+            '#!/usr/bin/env bash\n'
+            'printf \'%s\\n\' "$1" >> "$SLEEP_LOG"\n')
+        sleep.chmod(0o755)
+
+    def _run_setup_buildx(self, failed_pulls):
+        environment = os.environ.copy()
+        environment.update({
+            'COMMAND_LOG': str(self.command_log),
+            'FAIL_PULLS': str(failed_pulls),
+            'GITHUB_OUTPUT': str(self.github_output),
+            'PATH': f'{self.bin_dir}:{environment["PATH"]}',
+            'PULL_STATE': str(self.pull_state),
+            'SLEEP_LOG': str(self.sleep_log),
+        })
+        return subprocess.run(
+            ['bash', str(SETUP_BUILDX_SCRIPT), 'test-builder'],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+
+    def test_buildkit_pull_uses_long_backoff_before_bootstrap(self):
+        result = self._run_setup_buildx(failed_pulls=3)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = self.command_log.read_text().splitlines()
+        self.assertEqual(commands[:4], [f'pull {BUILDKIT_IMAGE}'] * 4)
+        self.assertIn(
+            f'buildx create --name test-builder --driver docker-container '
+            f'--driver-opt image={BUILDKIT_IMAGE} --use', commands)
+        self.assertEqual(self.sleep_log.read_text().splitlines(),
+                         ['20', '40', '60'])
+        self.assertEqual(self.github_output.read_text(),
+                         'builder_name=test-builder\n')
+
+    def test_buildkit_pull_exhaustion_stops_before_bootstrap(self):
+        result = self._run_setup_buildx(failed_pulls=99)
+
+        self.assertNotEqual(result.returncode, 0)
+        commands = self.command_log.read_text().splitlines()
+        self.assertEqual(commands, [f'pull {BUILDKIT_IMAGE}'] * 5)
+        self.assertEqual(self.sleep_log.read_text().splitlines(),
+                         ['20', '40', '60', '80'])
+        self.assertNotIn('buildx create', '\n'.join(commands))
+
+    @unittest.skipUnless(shutil.which('curl'), 'curl is required')
+    def test_kind_curl_config_retries_transient_http_failures(self):
+        _RetryHandler.request_count = 0
+        server = http.server.HTTPServer(('127.0.0.1', 0), _RetryHandler)
+        server_thread = threading.Thread(target=server.serve_forever)
+        server_thread.start()
+        try:
+            result = subprocess.run(
+                [
+                    'curl', '--retry-delay', '0', '--fail', '--silent',
+                    '--show-error',
+                    f'http://127.0.0.1:{server.server_port}/tool',
+                ],
+                capture_output=True,
+                check=False,
+                env={
+                    **os.environ,
+                    'CURL_HOME': str(CURL_CONFIG.parent),
+                },
+                text=True,
+                timeout=10,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, 'ok')
+        self.assertEqual(_RetryHandler.request_count, 3)
+
+    def test_kind_action_scopes_curl_retry_config_to_both_attempts(self):
+        action = CREATE_CLUSTER_ACTION.read_text()
+        curl_home = (
+            'CURL_HOME: ${{ github.workspace }}/.github/resources/curl-retry')
+        self.assertEqual(action.count(curl_home), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/resources/scripts/setup-buildx-with-retry.sh
+++ b/.github/resources/scripts/setup-buildx-with-retry.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 BUILDER_NAME="${1:-kfp-buildx-${GITHUB_RUN_ID:-local}-${GITHUB_JOB:-job}-${RANDOM}}"
+BUILDKIT_IMAGE="${BUILDKIT_IMAGE:-moby/buildkit:buildx-stable-1}"
 
 C_DIR="${BASH_SOURCE%/*}"
 if [[ ! -d "$C_DIR" ]]; then
@@ -12,10 +13,15 @@ source "${C_DIR}/helper-functions.sh"
 
 setup_builder() {
   docker buildx rm "$BUILDER_NAME" >/dev/null 2>&1 || true
-  docker buildx create --name "$BUILDER_NAME" --driver docker-container --use
+  docker buildx create --name "$BUILDER_NAME" --driver docker-container \
+    --driver-opt "image=$BUILDKIT_IMAGE" --use
   docker buildx inspect "$BUILDER_NAME" --bootstrap >/dev/null
 }
 
+# Pull separately so registry outages get the longer five-attempt backoff used
+# for other runtime images. Once cached, builder bootstrap no longer depends on
+# a fresh registry connection.
+pull_image_with_backoff "$BUILDKIT_IMAGE"
 retry 3 20 setup_builder
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then

--- a/.github/workflows/ci-scripts-tests.yml
+++ b/.github/workflows/ci-scripts-tests.yml
@@ -6,6 +6,8 @@ name: CI Scripts Tests
 on:
   pull_request:
     paths:
+      - '.github/actions/create-cluster/**'
+      - '.github/resources/curl-retry/**'
       - '.github/resources/scripts/*.py'
       # The observability shell scripts are covered by Python-driven tests.
       - '.github/resources/scripts/*.sh'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-21
+- Last updated: 2026-07-22
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -530,7 +530,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 - Workflows: `.github/workflows/` (build, test, lint, release)
 - `ci-health-report.yml` runs daily (and on dispatch): aggregates master-branch lane failure rates and per-test flake counts from `junit-xml - *` artifacts, publishing to the job summary and a tracking issue labeled `ci-health`.
-- `ci-scripts-tests.yml` runs the stdlib unit tests for CI tooling, diagnostics, and meta-workflow concurrency on PRs touching `.github/resources/scripts/*.py`, `.github/resources/scripts/*.sh`, `ci-checks.yml`, `gh-workflow-approve.yml`, or the test workflow itself (run locally with `cd .github/resources/scripts && python3 -m unittest discover -v -p '*_test.py'`).
+- `ci-scripts-tests.yml` runs the stdlib unit tests for CI tooling, diagnostics, and meta-workflow concurrency on PRs touching `.github/resources/scripts/*.py`, `.github/resources/scripts/*.sh`, `ci-checks.yml`, `gh-workflow-approve.yml`, the create-cluster action, the scoped curl retry configuration, or the test workflow itself (run locally with `cd .github/resources/scripts && python3 -m unittest discover -v -p '*_test.py'`).
 - The `CI Check` and `Approve Workflow Runs` meta-workflows filter unrelated label events before entering per-PR job concurrency. Only `synchronize` events cancel an active run, so Dependabot/Prow label bursts do not leave cancelled checks on the current head SHA.
 - Composite actions: `.github/actions/` (e.g., `kfp-k8s`, `create-cluster`, `deploy`, `test-and-report`)
 - Typical checks: Go unit tests (backend), Python SDK tests, frontend tests/lint, image builds.
@@ -564,7 +564,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 - Multi-user deploy applies the profile controller before KFP and joins its readiness after the main KFP rollout, overlapping independent startup while preserving the IAM and Profile-creation gates.
 - KFP deployment readiness captures one bounded pod describe/events snapshot when a regular or init container remains in `ContainerCreating` for more than 60 seconds, including when the pod eventually becomes ready.
 - Workflows that deploy CI-built KFP images start Kind cluster setup concurrently with current-branch image builds. The shared deploy action waits for the complete image-artifact inventory immediately before downloading and loading the images; upgrade tests overlap old-release deployment and preparation behind the same barrier.
-- CI Docker-sensitive paths use shell retry wrappers with sleeps for image builds, Buildx bootstrap, and runtime base-image pulls; Kind node image bootstrap also falls back to `gcr.io/k8s-staging-kind/node` when Docker Hub flakes, and Kind cluster creation retries once when the action's initial tool download or setup fails.
+- CI Docker-sensitive paths use shell retry wrappers with sleeps for image builds, Buildx bootstrap, and runtime base-image pulls. Buildx setup pre-pulls its BuildKit image with five-attempt backoff, Kind tool downloads use a scoped curl retry policy, Kind node image bootstrap falls back to `gcr.io/k8s-staging-kind/node` when Docker Hub flakes, and Kind cluster creation retries once after an initial setup failure.
 - The `test-and-report` action pins Go via `go.mod` and restores a dedicated `go-test-lanes-*` module/build cache (weekly-rotating key with restore-keys) so Ginkgo test lanes do not cold-compile the suites each run.
 - The `runtime-base-images.yml` workflow is the single registry-pull producer for the runtime base-image archive. Trusted master runs explicitly save the daily `actions/cache` entry and prune every superseded runtime-image cache after verifying the current master key exists; reusable image-build callers wait for the producer's generation-fingerprinted artifact and re-upload it into their own run instead of pulling independently.
 - The `test-and-report` action port-forwards MLMD on port `8080` only when `ARGO_COMPATIBILITY_TESTS=true`, allowing the canonical Argo compatibility API job to validate execution/artifact metadata without adding another test lane.


### PR DESCRIPTION
## Summary

- pre-pull the BuildKit image with the existing five-attempt linear backoff before creating the Buildx builder
- bind the builder to that pre-pulled image so bootstrap does not require a fresh registry connection
- give the pinned Kind action's `curl` downloads five total attempts, scoped only to the two cluster-creation attempts through `CURL_HOME`
- add stdlib regression coverage for BuildKit retry/exhaustion behavior and the Kind curl policy

## Why

The master upgrade run below exhausted all three Buildx bootstrap attempts while
Docker Hub timed out waiting for response headers. Because the image producer
never completed, downstream deployment correctly waited for the missing
artifact but could not recover it.

An earlier E2E run also retried the pinned Kind action immediately after a
`curl` connection reset, so both attempts failed inside the same short outage.
The scoped curl policy lets each tool download ride through a longer transient
failure without changing curl behavior elsewhere in the job.

- Buildx failure: https://github.com/kubeflow/pipelines/actions/runs/29885155062
- Kind download failure: https://github.com/kubeflow/pipelines/actions/runs/29885165882

This PR intentionally does not change workload image pulls performed by
containerd inside Kind; those are a distinct failure path.

## Verification

- full `.github/resources/scripts` stdlib unittest suite
- four focused external-bootstrap retry tests
- `bash -n .github/resources/scripts/setup-buildx-with-retry.sh`
- parsed the changed action and workflow YAML with Ruby/Psych
- `git diff --check`
- rebased onto current `master`
