### PR TITLE
fix(backend): record CANCELLING transition in TerminateRun state history

### DIFF
--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -821,13 +821,30 @@ func NewRunStore(db *DB, time util.TimeInterface) *RunStore {
 }
 
 func (s *RunStore) TerminateRun(runId string) error {
-	// TODO(gkcalat): append CANCELLING to StateHistory
+	run, err := s.GetRun(runId)
+	if err != nil {
+		return util.Wrapf(err, "Failed to terminate run %s: could not fetch existing state", runId)
+	}
+
+	stateHistory := run.RunDetails.StateHistory
+	if len(stateHistory) == 0 || stateHistory[len(stateHistory)-1].State != model.RuntimeStateCancelling {
+		stateHistory = append(stateHistory, &model.RuntimeStatus{
+			UpdateTimeInSec: s.time.Now().Unix(),
+			State:           model.RuntimeStateCancelling,
+		})
+	}
+	stateHistoryBytes, err := json.Marshal(stateHistory)
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to marshal state history while terminating run %s", runId)
+	}
+
 	result, err := s.db.Exec(`
 		UPDATE run_details
-		SET Conditions = ?, State = ?
+		SET Conditions = ?, State = ?, StateHistory = ?
 		WHERE UUID = ? AND (State = ? OR State = ? OR State = ? OR State = ?)`,
 		string(model.RuntimeStateCancelling.ToV1()),
 		model.RuntimeStateCancelling.ToString(),
+		string(stateHistoryBytes),
 		runId,
 		model.RuntimeStatePaused.ToString(),
 		model.RuntimeStatePending.ToString(),

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -1033,6 +1033,10 @@ func TestTerminateRun(t *testing.T) {
 					UpdateTimeInSec: 1,
 					State:           model.RuntimeStateRunning,
 				},
+				{
+					UpdateTimeInSec: 4,
+					State:           model.RuntimeStateCancelling,
+				},
 			},
 		},
 		Metrics: []*model.RunMetric{
@@ -1063,7 +1067,7 @@ func TestTerminateRun_RunDoesNotExist(t *testing.T) {
 
 	err := runStore.TerminateRun("does-not-exist")
 	assert.NotNil(t, err)
-	assert.Contains(t, err.Error(), "Row not found")
+	assert.Contains(t, err.Error(), "could not fetch existing state")
 }
 
 func TestTerminateRun_RunHasAlreadyFinished(t *testing.T) {


### PR DESCRIPTION
## Description

`RunStore.TerminateRun` transitions a run to the `CANCELLING` state using a direct SQL `UPDATE`, but unlike `CreateRun` and `UpdateRun`, it does not record this transition in `StateHistory`.

As a result, the run's state history skips the user-initiated `CANCELLING` state, making the recorded timeline inconsistent with other state transitions.

This PR updates `TerminateRun` to:

- Load the existing `StateHistory`
- Append a `CANCELLING` entry if it is not already the latest recorded state
- Persist the updated `StateHistory` together with the existing state transition

This keeps `TerminateRun` consistent with the other run state update paths and preserves a complete state transition history.

## Testing

- Updated `TestTerminateRun` to verify that `StateHistory` contains a `CANCELLING` entry after termination.
- Updated `TestTerminateRun_RunDoesNotExist`.
- Ran the `backend/src/apiserver/storage` test suite successfully.

## Checklist

- [x] I have signed off my commits.
- [x] The PR title follows the project's title convention.