### PR TITLE
fix(backend): validate driver pod configuration from one read of one source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-27
+- Last updated: 2026-07-28
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -731,6 +731,7 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 - `TENSORBOARD_PROXY_SIGNING_SECRET=...`: Optional shared frontend-server secret for scoped TensorBoard proxy URLs; defaults to `MINIO_SECRET_KEY` when unset
 - `FRONTEND_SERVER_NAMESPACE=...`: Sets the namespace used by the local frontend Node server for Kubernetes lookups when it is not running inside a cluster pod. `npm run start:proxy-and-server` derives this from `NAMESPACE`.
 - `MINIO_ENDPOINT_REWRITE=from=to[,from=to]`: Rewrites explicit object-store endpoints for local proxy mode, for example from `seaweedfs.kubeflow:9000` to `localhost:9000`.
+- `DRIVER_POD_LABELS=...` and `DRIVER_POD_ANNOTATIONS=...`: API server deployment settings, each a JSON object written as a string, applied to driver pods. Wired in from the `pipeline-install-config` ConfigMap by the API server Deployment and validated at startup. See [API Server Configuration](backend/README.md#driver-pod-labels-and-annotations).
 
 ## Troubleshooting and pitfalls
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -71,15 +71,19 @@ The API server supports configuring custom labels and annotations for driver pod
 **Configuration via config.json:**
 ```json
 {
-  "DRIVER_POD_LABELS": {
-    "sidecar.istio.io/inject": "true",
-    "app": "ml-pipeline-driver"
-  },
-  "DRIVER_POD_ANNOTATIONS": {
-    "proxy.istio.io/config": "{\"holdApplicationUntilProxyStarts\":true}"
-  }
+  "DRIVER_POD_LABELS": "{\"sidecar.istio.io/inject\":\"true\",\"app\":\"ml-pipeline-driver\"}",
+  "DRIVER_POD_ANNOTATIONS": "{\"proxy.istio.io/config\":\"{\\\"holdApplicationUntilProxyStarts\\\":true}\"}"
 }
 ```
+
+Write each value as a JSON string, not as a JSON object. A JSON object is refused at startup,
+because the configuration loader folds its keys to lower case and merges keys that differ only
+in case.
+
+This file is baked into the image and supplies the built in default. On a standard install the
+Deployment always passes both keys in from the ConfigMap as environment variables, and those
+take precedence over this file even when empty, so use the ConfigMap below unless you build
+your own image.
 
 **Configuration via Kubernetes ConfigMap (`pipeline-install-config`):**
 ```yaml
@@ -87,9 +91,26 @@ DRIVER_POD_LABELS: '{"sidecar.istio.io/inject":"true"}'
 DRIVER_POD_ANNOTATIONS: '{"proxy.istio.io/config":"{\"holdApplicationUntilProxyStarts\":true}"}'
 ```
 
-When configured via the ConfigMap, every value must be a JSON string. Write `"true"` rather than the bare boolean `true`, and never `null`. The configuration is validated at API server startup: malformed JSON, any value that is not a JSON string, and label keys, label values, or annotation keys that Kubernetes would reject all cause startup to fail with a descriptive error rather than being silently ignored. Annotation values are free form, so a value such as an inline JSON document is accepted.
+Every entry must have a string value: write `"true"` rather than the bare boolean `true`, and never `null`. The configuration is validated at API server startup, so malformed JSON, a value that is not a string, and label keys, label values or annotation keys that Kubernetes would reject all fail startup with a descriptive error rather than being silently ignored. Annotation values are free form, so an inline JSON document is accepted. Annotations are also held to the 256 KiB Kubernetes allows per object, and each setting travels as one environment variable, which Linux caps at 32 memory pages (around 128 KiB with 4 KiB pages).
 
-Note: Labels and annotations with the prefix `pipelines.kubeflow.org/` are reserved and will be filtered out to prevent overriding system metadata. Changes to driver pod configuration require an API server restart.
+**Terminating an injected Istio sidecar:**
+
+Argo shuts an injected sidecar down with `/bin/sh -c 'kill 1'`, which the Istio proxy does not
+act on, so the proxy outlives the driver and the pod stays in `Running`. Argo's per container
+kill command handles it, and the default install already grants the `pods/exec` permission it
+needs through the `pipeline-runner` Role. Grant `pods/exec` too if the driver runs under a
+service account with narrower permissions.
+
+```yaml
+DRIVER_POD_LABELS: '{"sidecar.istio.io/inject":"true"}'
+DRIVER_POD_ANNOTATIONS: '{"proxy.istio.io/config":"{\"holdApplicationUntilProxyStarts\":true}","workflows.argoproj.io/kill-cmd-istio-proxy":"[\"pilot-agent\", \"request\", \"POST\", \"quitquitquit\"]"}'
+```
+
+The compiler annotates every template with `sidecar.istio.io/inject: "false"`, which does not disable the label above, since Istio prefers the label and treats the annotation form as deprecated. See the Argo Workflows [sidecar injection](https://argo-workflows.readthedocs.io/en/latest/sidecar-injection/) guide for the full description of the problem.
+
+Note: Labels and annotations with the prefix `pipelines.kubeflow.org/` are reserved and will be filtered out to prevent overriding system metadata.
+
+Changes require an API server restart, and each API server reads the configuration once as it starts. An unpinned recurring run picks the change up when it next triggers, once the restart has finished; during a rolling restart both the old and new API server serve for a short window. A pinned recurring run is recompiled by the reconciliation that runs at startup, which stops at the first recurring run it cannot process and is not retried, so the ones after a failure keep their previous specification until the next restart.
 
 ## API Server Development
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -71,15 +71,12 @@ The API server supports configuring custom labels and annotations for driver pod
 **Configuration via config.json:**
 ```json
 {
-  "DRIVER_POD_LABELS": {
-    "sidecar.istio.io/inject": "true",
-    "app": "ml-pipeline-driver"
-  },
-  "DRIVER_POD_ANNOTATIONS": {
-    "proxy.istio.io/config": "{\"holdApplicationUntilProxyStarts\":true}"
-  }
+  "DRIVER_POD_LABELS": "{\"sidecar.istio.io/inject\":\"true\",\"app\":\"ml-pipeline-driver\"}",
+  "DRIVER_POD_ANNOTATIONS": "{\"proxy.istio.io/config\":\"{\\\"holdApplicationUntilProxyStarts\\\":true}\"}"
 }
 ```
+
+Write each value as a JSON string, not a JSON object (rejected at startup). The ConfigMap takes precedence over this file.
 
 **Configuration via Kubernetes ConfigMap (`pipeline-install-config`):**
 ```yaml
@@ -87,9 +84,24 @@ DRIVER_POD_LABELS: '{"sidecar.istio.io/inject":"true"}'
 DRIVER_POD_ANNOTATIONS: '{"proxy.istio.io/config":"{\"holdApplicationUntilProxyStarts\":true}"}'
 ```
 
-When configured via the ConfigMap, every value must be a JSON string. Write `"true"` rather than the bare boolean `true`, and never `null`. The configuration is validated at API server startup: malformed JSON, any value that is not a JSON string, and label keys, label values, or annotation keys that Kubernetes would reject all cause startup to fail with a descriptive error rather than being silently ignored. Annotation values are free form, so a value such as an inline JSON document is accepted.
+Every entry must have a string value: write `"true"` rather than the bare boolean `true`, and never `null`. The configuration is validated at API server startup, so malformed JSON, a value that is not a string, and label keys, label values or annotation keys that Kubernetes would reject all fail startup with a descriptive error rather than being silently ignored. Annotation values are free form, so an inline JSON document is accepted. Annotations are also held to the 256 KiB limit Kubernetes allows per object.
 
-Note: Labels and annotations with the prefix `pipelines.kubeflow.org/` are reserved and will be filtered out to prevent overriding system metadata. Changes to driver pod configuration require an API server restart.
+**Terminating an injected Istio sidecar:**
+
+Argo's default sidecar kill command leaves the Istio proxy running, so the pod stays in
+`Running`. Argo's per container kill command handles it and needs `pods/exec`, which the
+default `pipeline-runner` Role already grants.
+
+```yaml
+DRIVER_POD_LABELS: '{"sidecar.istio.io/inject":"true"}'
+DRIVER_POD_ANNOTATIONS: '{"proxy.istio.io/config":"{\"holdApplicationUntilProxyStarts\":true}","workflows.argoproj.io/kill-cmd-istio-proxy":"[\"pilot-agent\", \"request\", \"POST\", \"quitquitquit\"]"}'
+```
+
+The compiler's `sidecar.istio.io/inject: "false"` annotation does not disable the label above, since Istio prefers the label. See the Argo Workflows [sidecar injection](https://argo-workflows.readthedocs.io/en/latest/sidecar-injection/) guide.
+
+Note: Labels and annotations with the prefix `pipelines.kubeflow.org/` are reserved and will be filtered out to prevent overriding system metadata.
+
+Changes require an API server restart.
 
 ## API Server Development
 

--- a/backend/src/apiserver/common/driver_config.go
+++ b/backend/src/apiserver/common/driver_config.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/viper"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const (
@@ -88,20 +90,22 @@ func InitDriverPodConfig() error {
 // construction separate from the cache swap guarantees the update is applied
 // completely or not at all.
 func newDriverPodConfig() (*DriverPodConfig, error) {
-	if err := validateMapConfig(DriverPodLabels); err != nil {
+	rawLabels, err := parseMapConfig(DriverPodLabels)
+	if err != nil {
 		return nil, err
 	}
-	if err := validateMapConfig(DriverPodAnnotations); err != nil {
+	rawAnnotations, err := parseMapConfig(DriverPodAnnotations)
+	if err != nil {
 		return nil, err
 	}
 
-	labels := filterReservedEntries(GetMapConfig(DriverPodLabels))
+	labels := filterReservedEntries(rawLabels)
 	if err := validateLabels(labels); err != nil {
 		return nil, err
 	}
 
-	annotations := filterReservedEntries(GetMapConfig(DriverPodAnnotations))
-	if err := validateAnnotationKeys(annotations); err != nil {
+	annotations := filterReservedEntries(rawAnnotations)
+	if err := validateAnnotations(annotations); err != nil {
 		return nil, err
 	}
 
@@ -126,45 +130,65 @@ func validateLabels(labels map[string]string) error {
 	return nil
 }
 
-// validateAnnotationKeys rejects annotation keys that Kubernetes would not accept.
-// Annotation values are free form, so only the keys are checked.
-func validateAnnotationKeys(annotations map[string]string) error {
-	for k := range annotations {
-		if errs := validation.IsQualifiedName(k); len(errs) > 0 {
-			return fmt.Errorf("%s has an invalid annotation key %q: %s", DriverPodAnnotations, k, strings.Join(errs, "; "))
-		}
-	}
-	return nil
+// validateAnnotations uses the Kubernetes annotation validator, which lowers keys before
+// checking syntax (so Example.com/Name is valid unlike for labels) and enforces the 256 KiB
+// total size limit. Only the configured annotations are measured; compiler-added ones are not.
+func validateAnnotations(annotations map[string]string) error {
+	// The field path already names the setting, so the result is returned unwrapped.
+	return apivalidation.ValidateAnnotations(annotations, field.NewPath(DriverPodAnnotations)).ToAggregate()
 }
 
-// validateMapConfig rejects a ConfigMap value that Viper would not turn into the map the
-// operator meant. On the ConfigMap string path viper.GetStringMapString swallows problems
-// in two different ways, and neither produces an error: a boolean or a number makes it
-// drop the whole map, while a JSON null is quietly coerced to an empty string. Both leave
-// the operator with a configuration that looks accepted but silently does not do what
-// they asked for, so the raw value is probed here and every entry must be a JSON string.
-func validateMapConfig(name string) error {
-	if !viper.IsSet(name) {
-		return nil
-	}
-
-	// A native map (config.json) reports an empty string here, and a blank or whitespace
-	// only value means no configuration. Neither needs probing.
-	raw := strings.TrimSpace(viper.GetString(name))
-	if raw == "" {
-		return nil
-	}
-
-	var probe map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &probe); err != nil {
-		return fmt.Errorf("%s could not be parsed as a JSON object: %w (raw value: %q)", name, err, raw)
-	}
-	for k, v := range probe {
-		if _, ok := v.(string); !ok {
-			return fmt.Errorf("%s has a value that is not a JSON string for key %q; every value must be quoted, for example \"true\" rather than true or null (raw value: %q)", name, k, raw)
+// parseMapConfig reads and parses the configured value in one step so the validated map is
+// the one cached. A JSON object in the config file is refused because Viper lowercases its
+// keys, silently merging case-differing entries; the string form keeps keys as written.
+func parseMapConfig(name string) (map[string]string, error) {
+	switch value := viper.Get(name).(type) {
+	case nil:
+		return nil, nil
+	case string:
+		parsed, err := jsonToMap(value)
+		if err != nil {
+			return nil, fmt.Errorf("%s %w", name, err)
 		}
+		return parsed, nil
+	case map[string]string:
+		return value, nil
+	case map[string]any:
+		return nil, fmt.Errorf("%s must be a JSON string, not an object; write it as \"{\\\"app\\\":\\\"driver\\\"}\"", name)
+	default:
+		return nil, fmt.Errorf("%s must be a JSON string, but it is a %T", name, value)
 	}
-	return nil
+}
+
+// jsonToMap parses a JSON object whose values are all strings. Unmarshalling straight into a
+// map[string]string would turn a null into an empty string without an error, so the values are
+// checked before conversion.
+func jsonToMap(value string) (map[string]string, error) {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return nil, nil
+	}
+
+	var probe map[string]any
+	if err := json.Unmarshal([]byte(raw), &probe); err != nil {
+		return nil, fmt.Errorf("could not be parsed as a JSON object: %w (raw value: %q)", err, raw)
+	}
+	if probe == nil {
+		return nil, fmt.Errorf("must be a JSON object, not null (raw value: %q)", raw)
+	}
+
+	parsed := make(map[string]string, len(probe))
+	for k, v := range probe {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("has a value that is not a string for key %q; quote it, for example \"true\" rather than true or null (raw value: %q)", k, raw)
+		}
+		parsed[k] = s
+	}
+	if len(parsed) == 0 {
+		return nil, nil
+	}
+	return parsed, nil
 }
 
 // GetDriverPodConfig returns a copy of the cached driver pod configuration, or nil when

--- a/backend/src/apiserver/common/driver_config.go
+++ b/backend/src/apiserver/common/driver_config.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/spf13/viper"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 const (
@@ -88,20 +90,22 @@ func InitDriverPodConfig() error {
 // construction separate from the cache swap guarantees the update is applied
 // completely or not at all.
 func newDriverPodConfig() (*DriverPodConfig, error) {
-	if err := validateMapConfig(DriverPodLabels); err != nil {
+	rawLabels, err := parseMapConfig(DriverPodLabels)
+	if err != nil {
 		return nil, err
 	}
-	if err := validateMapConfig(DriverPodAnnotations); err != nil {
+	rawAnnotations, err := parseMapConfig(DriverPodAnnotations)
+	if err != nil {
 		return nil, err
 	}
 
-	labels := filterReservedEntries(GetMapConfig(DriverPodLabels))
+	labels := filterReservedEntries(rawLabels)
 	if err := validateLabels(labels); err != nil {
 		return nil, err
 	}
 
-	annotations := filterReservedEntries(GetMapConfig(DriverPodAnnotations))
-	if err := validateAnnotationKeys(annotations); err != nil {
+	annotations := filterReservedEntries(rawAnnotations)
+	if err := validateAnnotations(annotations); err != nil {
 		return nil, err
 	}
 
@@ -126,45 +130,63 @@ func validateLabels(labels map[string]string) error {
 	return nil
 }
 
-// validateAnnotationKeys rejects annotation keys that Kubernetes would not accept.
-// Annotation values are free form, so only the keys are checked.
-func validateAnnotationKeys(annotations map[string]string) error {
-	for k := range annotations {
-		if errs := validation.IsQualifiedName(k); len(errs) > 0 {
-			return fmt.Errorf("%s has an invalid annotation key %q: %s", DriverPodAnnotations, k, strings.Join(errs, "; "))
-		}
-	}
-	return nil
+// validateAnnotations uses the Kubernetes annotation validator, which lowers keys before
+// checking syntax (so Example.com/Name is valid unlike for labels) and enforces the 256 KiB
+// total size limit. Only the configured annotations are measured; compiler-added ones are not.
+func validateAnnotations(annotations map[string]string) error {
+	// The field path already names the setting, so the result is returned unwrapped.
+	return apivalidation.ValidateAnnotations(annotations, field.NewPath(DriverPodAnnotations)).ToAggregate()
 }
 
-// validateMapConfig rejects a ConfigMap value that Viper would not turn into the map the
-// operator meant. On the ConfigMap string path viper.GetStringMapString swallows problems
-// in two different ways, and neither produces an error: a boolean or a number makes it
-// drop the whole map, while a JSON null is quietly coerced to an empty string. Both leave
-// the operator with a configuration that looks accepted but silently does not do what
-// they asked for, so the raw value is probed here and every entry must be a JSON string.
-func validateMapConfig(name string) error {
-	if !viper.IsSet(name) {
-		return nil
-	}
-
-	// A native map (config.json) reports an empty string here, and a blank or whitespace
-	// only value means no configuration. Neither needs probing.
-	raw := strings.TrimSpace(viper.GetString(name))
-	if raw == "" {
-		return nil
-	}
-
-	var probe map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &probe); err != nil {
-		return fmt.Errorf("%s could not be parsed as a JSON object: %w (raw value: %q)", name, err, raw)
-	}
-	for k, v := range probe {
-		if _, ok := v.(string); !ok {
-			return fmt.Errorf("%s has a value that is not a JSON string for key %q; every value must be quoted, for example \"true\" rather than true or null (raw value: %q)", name, k, raw)
+// parseMapConfig reads and parses the configured value in one step so the validated map is
+// the one cached. A JSON object in the config file is refused because Viper lowercases its
+// keys, silently merging case-differing entries; the string form keeps keys as written.
+func parseMapConfig(name string) (map[string]string, error) {
+	switch value := viper.Get(name).(type) {
+	case nil:
+		return nil, nil
+	case string:
+		parsed, err := jsonToMap(value)
+		if err != nil {
+			return nil, fmt.Errorf("%s %w", name, err)
 		}
+		return parsed, nil
+	case map[string]string:
+		return value, nil
+	case map[string]any:
+		return nil, fmt.Errorf("%s must be a JSON string, not an object; write it as \"{\\\"app\\\":\\\"driver\\\"}\"", name)
+	default:
+		return nil, fmt.Errorf("%s must be a JSON string, but it is a %T", name, value)
 	}
-	return nil
+}
+
+// jsonToMap parses a JSON object whose values are all strings. Unmarshalling straight into a
+// map[string]string would turn a null into an empty string without an error, so the values are
+// checked before conversion.
+func jsonToMap(value string) (map[string]string, error) {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return nil, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err != nil {
+		return nil, fmt.Errorf("could not be parsed as a JSON object: %w (raw value: %q)", err, raw)
+	}
+	if m == nil {
+		return nil, fmt.Errorf("must be a JSON object, not null (raw value: %q)", raw)
+	}
+	parsed := make(map[string]string, len(m))
+	for k, v := range m {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("value for key %q must be a string (raw value: %q)", k, raw)
+		}
+		parsed[k] = s
+	}
+	if len(parsed) == 0 {
+		return nil, nil
+	}
+	return parsed, nil
 }
 
 // GetDriverPodConfig returns a copy of the cached driver pod configuration, or nil when

--- a/backend/src/apiserver/common/driver_config_test.go
+++ b/backend/src/apiserver/common/driver_config_test.go
@@ -16,6 +16,8 @@
 package common
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -23,6 +25,41 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// writeConfigFile loads a config.json without the environment lookup, since an environment
+// variable would take precedence over the file.
+func writeConfigFile(t *testing.T, contents string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte(contents), 0o600))
+
+	viper.Reset()
+	resetDriverConfig()
+	t.Cleanup(func() {
+		viper.Reset()
+		resetDriverConfig()
+	})
+
+	viper.SetConfigName("config")
+	viper.AddConfigPath(dir)
+	require.NoError(t, viper.ReadInConfig())
+}
+
+// t.Setenv can only set a value, so a test needing a variable absent has to
+// unset it and put back whatever was there.
+func unsetEnvForTest(t *testing.T, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		if previous, ok := os.LookupEnv(name); ok {
+			t.Cleanup(func() { _ = os.Setenv(name, previous) })
+		} else {
+			t.Cleanup(func() { _ = os.Unsetenv(name) })
+		}
+		require.NoError(t, os.Unsetenv(name))
+	}
+}
 
 // resetDriverConfig resets the driver config state for testing
 func resetDriverConfig() {
@@ -248,9 +285,7 @@ func TestInitDriverPodConfigFromJSONString(t *testing.T) {
 	}, annotations)
 }
 
-// TestInitDriverPodConfig_NonStringJSONValues verifies that a ConfigMap value whose
-// JSON contains a value that is not a string (for example a boolean) fails startup
-// instead of being silently swallowed as an empty map by viper.GetStringMapString.
+// viper.GetStringMapString swallows a non-string value as an empty map.
 func TestInitDriverPodConfig_NonStringJSONValues(t *testing.T) {
 	viper.Reset()
 	resetDriverConfig()
@@ -264,11 +299,8 @@ func TestInitDriverPodConfig_NonStringJSONValues(t *testing.T) {
 	assert.Contains(t, err.Error(), DriverPodLabels)
 }
 
-// TestInitDriverPodConfig_NullJSONValue guards a case that is easy to miss. Viper does not
-// drop a JSON null the way it drops a boolean or a number. It quietly turns null into an
-// empty string, so without an explicit check the operator would get a label with an empty
-// value and no warning at all. Someone writing null for the Istio injection flag would
-// believe injection was enabled while the driver pod carried an empty value instead.
+// Viper turns a null into an empty string rather than dropping it, so this one
+// needs a check of its own.
 func TestInitDriverPodConfig_NullJSONValue(t *testing.T) {
 	viper.Reset()
 	resetDriverConfig()
@@ -294,6 +326,75 @@ func TestInitDriverPodConfig_NullMixedWithValidValue(t *testing.T) {
 
 	require.Error(t, err, "a JSON null mixed with a valid value should still fail startup")
 	assert.Contains(t, err.Error(), "sidecar.istio.io/inject")
+}
+
+// A bare null unmarshals into a nil map without an error, so the per entry check never runs.
+func TestInitDriverPodConfig_TopLevelNull(t *testing.T) {
+	for _, name := range []string{DriverPodLabels, DriverPodAnnotations} {
+		t.Run(name, func(t *testing.T) {
+			viper.Reset()
+			resetDriverConfig()
+
+			viper.Set(name, "null")
+
+			err := InitDriverPodConfig()
+
+			require.Error(t, err, "a null document should fail startup rather than be accepted")
+			assert.Contains(t, err.Error(), name)
+			assert.Nil(t, GetDriverPodConfig(), "a rejected value must not reach the cache")
+		})
+	}
+}
+
+// The same check on the path a real install takes, where the value arrives as an
+// environment variable rather than being set on Viper.
+func TestInitDriverPodConfig_TopLevelNullFromEnvVar(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+	t.Cleanup(func() {
+		viper.Reset()
+		resetDriverConfig()
+	})
+
+	// Same Viper setup as initConfig() in main.go.
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+	viper.AllowEmptyEnv(true)
+
+	t.Setenv(strings.ToUpper(DriverPodLabels), "null")
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "a null delivered as an environment variable should fail startup")
+	assert.Contains(t, err.Error(), DriverPodLabels)
+}
+
+// TestInitDriverPodConfig_NotAJSONObject checks the whole family of values that parse as JSON
+// but are not an object, so the rejection is not limited to the null that prompted it.
+func TestInitDriverPodConfig_NotAJSONObject(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		raw  string
+	}{
+		{"null", "null"},
+		{"boolean", "true"},
+		{"number", "42"},
+		{"string", `"a string"`},
+		{"array", `["a","b"]`},
+		{"array of objects", `[{"app":"driver"}]`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			resetDriverConfig()
+
+			viper.Set(DriverPodLabels, tt.raw)
+
+			err := InitDriverPodConfig()
+
+			require.Error(t, err, "%s is not a JSON object and should fail startup", tt.raw)
+			assert.Contains(t, err.Error(), DriverPodLabels)
+		})
+	}
 }
 
 // TestInitDriverPodConfig_MalformedJSON verifies that a syntactically invalid JSON
@@ -324,9 +425,7 @@ func TestInitDriverPodConfig_EmptyJSONObjectIsValid(t *testing.T) {
 	assert.Nil(t, GetDriverPodAnnotations())
 }
 
-// TestInitDriverPodConfig_BlankValuesAreValid guards the manifest default, where the
-// ConfigMap ships DriverPodLabels and DriverPodAnnotations as empty strings. A blank or
-// whitespace value must initialize cleanly with no configuration and never fail startup.
+// The manifest default ships both keys as empty strings.
 func TestInitDriverPodConfig_BlankValuesAreValid(t *testing.T) {
 	for _, raw := range []string{"", "   "} {
 		viper.Reset()
@@ -339,12 +438,9 @@ func TestInitDriverPodConfig_BlankValuesAreValid(t *testing.T) {
 	}
 }
 
-// TestInitDriverPodConfig_FromEnvVarWiring locks the contract between the API server
-// Deployment and Viper. The Deployment wires the pipeline-install-config keys into the
-// container as the environment variables DRIVERPODLABELS and DRIVERPODANNOTATIONS,
-// which are the uppercased forms of the Viper keys below. Without that wiring the
-// ConfigMap values never reach the API server. If the Viper keys are ever renamed, the
-// Deployment must be updated to match, and this test is what will catch it.
+// The Deployment passes the ConfigMap keys as the uppercased forms of the Viper
+// keys. Renaming one without the other silently stops the values arriving, and
+// this is what catches it.
 func TestInitDriverPodConfig_FromEnvVarWiring(t *testing.T) {
 	viper.Reset()
 	resetDriverConfig()
@@ -367,11 +463,8 @@ func TestInitDriverPodConfig_FromEnvVarWiring(t *testing.T) {
 	assert.Equal(t, map[string]string{"proxy.istio.io/config": "hold"}, GetDriverPodAnnotations())
 }
 
-// TestInitDriverPodConfig_EmptyEnvVarIsValid guards the default install. Every manifest
-// ships DriverPodLabels and DriverPodAnnotations as empty strings, and the Deployment
-// passes them to the container as empty environment variables. Viper runs with
-// AllowEmptyEnv, so an empty variable still counts as set. Startup must succeed with no
-// configuration, otherwise every default install would fail to start.
+// Viper runs with AllowEmptyEnv, so the empty variable every default install sets
+// still counts as set.
 func TestInitDriverPodConfig_EmptyEnvVarIsValid(t *testing.T) {
 	viper.Reset()
 	resetDriverConfig()
@@ -431,12 +524,65 @@ func TestInitDriverPodConfig_InvalidAnnotationKey(t *testing.T) {
 	err := InitDriverPodConfig()
 
 	require.Error(t, err, "an invalid annotation key should fail startup")
-	assert.Contains(t, err.Error(), "invalid annotation key")
+	assert.Contains(t, err.Error(), DriverPodAnnotations)
+	assert.Contains(t, err.Error(), "bad key!", "the error should name the key that was refused")
 }
 
-// TestInitDriverPodConfig_IstioMetadataAccepted guards the primary use case. Annotation
-// values are free form and often carry JSON, so validation must check annotation keys
-// only and must never reject a value like the Istio proxy config below.
+func TestInitDriverPodConfig_AnnotationKeyCaseFollowsKubernetes(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodAnnotations, map[string]string{"Example.com/Name": "value"})
+
+	require.NoError(t, InitDriverPodConfig(), "Kubernetes accepts this annotation key, so it must not fail startup")
+	assert.Equal(t, "value", GetDriverPodAnnotations()["Example.com/Name"])
+}
+
+// Each key and value is acceptable on its own, so only the total catches this.
+func TestInitDriverPodConfig_AnnotationsTooLarge(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodAnnotations, map[string]string{
+		"example.com/payload": strings.Repeat("x", 300*1024),
+	})
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "annotations larger than the Kubernetes limit should fail startup")
+	assert.Contains(t, err.Error(), DriverPodAnnotations)
+	assert.Nil(t, GetDriverPodConfig(), "a rejected value must not reach the cache")
+}
+
+func TestInitDriverPodConfig_AnnotationsAtLimitAccepted(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	const key = "example.com/payload"
+	value := strings.Repeat("x", 256*1024-len(key))
+	viper.Set(DriverPodAnnotations, map[string]string{key: value})
+
+	require.NoError(t, InitDriverPodConfig(),
+		"the configured annotations alone are within the limit, so startup validation must accept them")
+	assert.Len(t, GetDriverPodAnnotations()[key], len(value))
+}
+
+// TestInitDriverPodConfig_ReservedAnnotationsNotCounted pins the order of the two checks:
+// reserved entries never reach the pod, so they must be dropped before the size is measured.
+func TestInitDriverPodConfig_ReservedAnnotationsNotCounted(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodAnnotations, map[string]string{
+		ReservedLabelPrefix + "oversized": strings.Repeat("x", 300*1024),
+		"example.com/kept":                "value",
+	})
+
+	require.NoError(t, InitDriverPodConfig(), "a reserved entry must not count toward the limit")
+	assert.Equal(t, map[string]string{"example.com/kept": "value"}, GetDriverPodAnnotations())
+}
+
+// Annotation values are free form, so only the keys are checked.
 func TestInitDriverPodConfig_IstioMetadataAccepted(t *testing.T) {
 	viper.Reset()
 	resetDriverConfig()
@@ -450,6 +596,148 @@ func TestInitDriverPodConfig_IstioMetadataAccepted(t *testing.T) {
 
 	assert.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"])
 	assert.Equal(t, `{"holdApplicationUntilProxyStarts":true}`, GetDriverPodAnnotations()["proxy.istio.io/config"])
+}
+
+// The example from backend/README.md verbatim, so its escaping fails here rather
+// than in an install.
+func TestInitDriverPodConfig_ConfigFileExample(t *testing.T) {
+	writeConfigFile(t, `{
+  "DRIVER_POD_LABELS": "{\"sidecar.istio.io/inject\":\"true\",\"app\":\"ml-pipeline-driver\"}",
+  "DRIVER_POD_ANNOTATIONS": "{\"proxy.istio.io/config\":\"{\\\"holdApplicationUntilProxyStarts\\\":true}\"}"
+}`)
+
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"])
+	assert.Equal(t, "ml-pipeline-driver", GetDriverPodLabels()["app"])
+	assert.Equal(t, `{"holdApplicationUntilProxyStarts":true}`,
+		GetDriverPodAnnotations()["proxy.istio.io/config"])
+}
+
+func TestInitDriverPodConfig_ConfigFileStringFormKeepsKeyCase(t *testing.T) {
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": "{\"example.com/BuildID\":\"123\"}"}`)
+
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Equal(t, map[string]string{"example.com/BuildID": "123"}, GetDriverPodLabels())
+}
+
+func TestInitDriverPodConfig_ConfigFileStringFormKeepsBothCases(t *testing.T) {
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": "{\"example.com/BuildID\":\"123\",\"example.com/buildid\":\"456\"}"}`)
+
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Equal(t, map[string]string{
+		"example.com/BuildID": "123",
+		"example.com/buildid": "456",
+	}, GetDriverPodLabels())
+}
+
+func TestInitDriverPodConfig_ConfigFileObjectRefused(t *testing.T) {
+	for _, tt := range []struct{ name, body string }{
+		{"all values are strings", `{"sidecar.istio.io/inject": "true"}`},
+		{"null", `{"sidecar.istio.io/inject": null}`},
+		{"boolean", `{"enabled": true}`},
+		{"number", `{"replicas": 3}`},
+		{"list", `{"items": ["a","b"]}`},
+		{"nested object", `{"outer": {"inner": "v"}}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, key := range []string{DriverPodLabels, DriverPodAnnotations} {
+				writeConfigFile(t, `{"`+key+`": `+tt.body+`}`)
+
+				err := InitDriverPodConfig()
+
+				require.Error(t, err, "%s written as an object in %s should fail startup", tt.name, key)
+				assert.Contains(t, err.Error(), key)
+				assert.Contains(t, err.Error(), "must be a JSON string",
+					"the error should name the form the operator must use instead")
+				assert.Nil(t, GetDriverPodConfig(), "a refused value must not reach the cache")
+			}
+		})
+	}
+}
+
+func TestInitDriverPodConfig_ConfigFileObjectHidesValues(t *testing.T) {
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": {"Team": "ml", "team": null}}`)
+
+	got, ok := viper.Get(DriverPodLabels).(map[string]any)
+	require.True(t, ok, "Viper should return a map for a JSON object")
+	assert.Len(t, got, 1, "case-differing keys merge, proving one value is hidden")
+	_, hasTeam := got["team"]
+	assert.True(t, hasTeam, "the surviving key should be lowercased")
+}
+
+func TestInitDriverPodConfig_StringFormSeesBothCases(t *testing.T) {
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": "{\"Team\":\"ml\",\"team\":null}"}`)
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "the null must be seen even though another key differs only in case")
+	assert.Contains(t, err.Error(), "team")
+}
+
+func TestInitDriverPodConfig_EmptyEnvVarShadowsConfigFile(t *testing.T) {
+	// The first half asserts what happens with no variable set, so a variable inherited from
+	// whoever started the test would quietly invalidate it.
+	unsetEnvForTest(t, strings.ToUpper(DriverPodLabels), strings.ToUpper(DriverPodAnnotations))
+
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": "{\"sidecar.istio.io/inject\":\"true\"}"}`)
+
+	// Same Viper setup as initConfig() in main.go, which the configuration file tests above
+	// leave out because they exercise the file on its own.
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+	viper.AllowEmptyEnv(true)
+
+	require.NoError(t, InitDriverPodConfig())
+	require.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"],
+		"without the Deployment variables the configuration file applies")
+
+	t.Setenv(strings.ToUpper(DriverPodLabels), "")
+	resetDriverConfig()
+
+	require.NoError(t, InitDriverPodConfig())
+	assert.Nil(t, GetDriverPodLabels(), "the empty Deployment variable takes precedence over the configuration file")
+}
+
+func TestInitDriverPodConfig_ConfigFileNativeNullMeansUnset(t *testing.T) {
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": null}`)
+
+	require.False(t, viper.IsSet(DriverPodLabels), "Viper reports a native null as not set")
+	require.NoError(t, InitDriverPodConfig())
+	assert.Nil(t, GetDriverPodConfig())
+}
+
+// A configuration file cannot produce this shape, so its keys arrive as written.
+func TestInitDriverPodConfig_ProgrammaticMapAccepted(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodLabels, map[string]string{"sidecar.istio.io/inject": "true"})
+
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"])
+}
+
+// Argo's default sidecar kill command is one the Istio proxy does not answer, so
+// an operator using both needs this annotation to survive key validation.
+func TestInitDriverPodConfig_ArgoKillCommandAccepted(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	// Copied verbatim from the ConfigMap example in backend/README.md, so the escaping an
+	// operator is told to write stays under test.
+	viper.Set(DriverPodLabels, `{"sidecar.istio.io/inject":"true"}`)
+	viper.Set(DriverPodAnnotations, `{"proxy.istio.io/config":"{\"holdApplicationUntilProxyStarts\":true}","workflows.argoproj.io/kill-cmd-istio-proxy":"[\"pilot-agent\", \"request\", \"POST\", \"quitquitquit\"]"}`)
+
+	require.NoError(t, InitDriverPodConfig())
+
+	annotations := GetDriverPodAnnotations()
+	assert.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"])
+	assert.Equal(t, `{"holdApplicationUntilProxyStarts":true}`, annotations["proxy.istio.io/config"])
+	assert.Equal(t, `["pilot-agent", "request", "POST", "quitquitquit"]`, annotations["workflows.argoproj.io/kill-cmd-istio-proxy"])
 }
 
 func TestGetDriverPodLabelsNotInitialized(t *testing.T) {

--- a/backend/src/apiserver/common/driver_config_test.go
+++ b/backend/src/apiserver/common/driver_config_test.go
@@ -16,6 +16,8 @@
 package common
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -23,6 +25,44 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// writeConfigFile writes a config.json into a temporary directory and loads it through Viper
+// so tests can exercise the configuration file on its own. It deliberately does not set up the
+// environment lookup the API server also enables, because an environment variable takes
+// precedence over the file; TestInitDriverPodConfig_EmptyEnvVarShadowsConfigFile covers that.
+func writeConfigFile(t *testing.T, contents string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), []byte(contents), 0o600))
+
+	viper.Reset()
+	resetDriverConfig()
+	t.Cleanup(func() {
+		viper.Reset()
+		resetDriverConfig()
+	})
+
+	viper.SetConfigName("config")
+	viper.AddConfigPath(dir)
+	require.NoError(t, viper.ReadInConfig())
+}
+
+// unsetEnvForTest removes the named variables for the duration of the test and puts back
+// whatever was there before. t.Setenv can only set a value, so a test that needs a variable to
+// be absent has to do this itself or inherit whatever started it.
+func unsetEnvForTest(t *testing.T, names ...string) {
+	t.Helper()
+
+	for _, name := range names {
+		if previous, ok := os.LookupEnv(name); ok {
+			t.Cleanup(func() { _ = os.Setenv(name, previous) })
+		} else {
+			t.Cleanup(func() { _ = os.Unsetenv(name) })
+		}
+		require.NoError(t, os.Unsetenv(name))
+	}
+}
 
 // resetDriverConfig resets the driver config state for testing
 func resetDriverConfig() {
@@ -296,6 +336,80 @@ func TestInitDriverPodConfig_NullMixedWithValidValue(t *testing.T) {
 	assert.Contains(t, err.Error(), "sidecar.istio.io/inject")
 }
 
+// TestInitDriverPodConfig_TopLevelNull covers the document itself being null rather than one
+// of its values. A bare null unmarshals into a nil map without error, so the per entry check
+// has nothing to walk and the value used to be accepted while the feature stayed off. That is
+// the same silent outcome the README promises will never happen, so it must fail startup for
+// both keys.
+func TestInitDriverPodConfig_TopLevelNull(t *testing.T) {
+	for _, name := range []string{DriverPodLabels, DriverPodAnnotations} {
+		t.Run(name, func(t *testing.T) {
+			viper.Reset()
+			resetDriverConfig()
+
+			viper.Set(name, "null")
+
+			err := InitDriverPodConfig()
+
+			require.Error(t, err, "a null document should fail startup rather than be accepted")
+			assert.Contains(t, err.Error(), name)
+			assert.Nil(t, GetDriverPodConfig(), "a rejected value must not reach the cache")
+		})
+	}
+}
+
+// TestInitDriverPodConfig_TopLevelNullFromEnvVar repeats the check on the path a real install
+// actually uses. The ConfigMap value reaches the API server as an environment variable, so the
+// rejection has to hold there and not only for a value set directly on Viper.
+func TestInitDriverPodConfig_TopLevelNullFromEnvVar(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+	t.Cleanup(func() {
+		viper.Reset()
+		resetDriverConfig()
+	})
+
+	// Same Viper setup as initConfig() in main.go.
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+	viper.AllowEmptyEnv(true)
+
+	t.Setenv(strings.ToUpper(DriverPodLabels), "null")
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "a null delivered as an environment variable should fail startup")
+	assert.Contains(t, err.Error(), DriverPodLabels)
+}
+
+// TestInitDriverPodConfig_NotAJSONObject checks the whole family of values that parse as JSON
+// but are not an object, so the rejection is not limited to the null that prompted it.
+func TestInitDriverPodConfig_NotAJSONObject(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		raw  string
+	}{
+		{"null", "null"},
+		{"boolean", "true"},
+		{"number", "42"},
+		{"string", `"a string"`},
+		{"array", `["a","b"]`},
+		{"array of objects", `[{"app":"driver"}]`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			resetDriverConfig()
+
+			viper.Set(DriverPodLabels, tt.raw)
+
+			err := InitDriverPodConfig()
+
+			require.Error(t, err, "%s is not a JSON object and should fail startup", tt.raw)
+			assert.Contains(t, err.Error(), DriverPodLabels)
+		})
+	}
+}
+
 // TestInitDriverPodConfig_MalformedJSON verifies that a syntactically invalid JSON
 // string in the ConfigMap fails startup with a clear error.
 func TestInitDriverPodConfig_MalformedJSON(t *testing.T) {
@@ -341,7 +455,7 @@ func TestInitDriverPodConfig_BlankValuesAreValid(t *testing.T) {
 
 // TestInitDriverPodConfig_FromEnvVarWiring locks the contract between the API server
 // Deployment and Viper. The Deployment wires the pipeline-install-config keys into the
-// container as the environment variables DRIVERPODLABELS and DRIVERPODANNOTATIONS,
+// container as the environment variables named by DriverPodLabels and DriverPodAnnotations,
 // which are the uppercased forms of the Viper keys below. Without that wiring the
 // ConfigMap values never reach the API server. If the Viper keys are ever renamed, the
 // Deployment must be updated to match, and this test is what will catch it.
@@ -431,7 +545,72 @@ func TestInitDriverPodConfig_InvalidAnnotationKey(t *testing.T) {
 	err := InitDriverPodConfig()
 
 	require.Error(t, err, "an invalid annotation key should fail startup")
-	assert.Contains(t, err.Error(), "invalid annotation key")
+	assert.Contains(t, err.Error(), DriverPodAnnotations)
+	assert.Contains(t, err.Error(), "bad key!", "the error should name the key that was refused")
+}
+
+// TestInitDriverPodConfig_AnnotationKeyCaseFollowsKubernetes pins the rule that annotation keys
+// have their syntax validated case insensitively. Kubernetes lowers the key before checking it,
+// which labels do
+// not do, so a prefix such as Example.com is a valid annotation key and an invalid label key.
+// Reimplementing the check by hand quietly refused these, which would have failed startup for a
+// configuration Kubernetes itself accepts.
+func TestInitDriverPodConfig_AnnotationKeyCaseFollowsKubernetes(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodAnnotations, map[string]string{"Example.com/Name": "value"})
+
+	require.NoError(t, InitDriverPodConfig(), "Kubernetes accepts this annotation key, so it must not fail startup")
+	assert.Equal(t, "value", GetDriverPodAnnotations()["Example.com/Name"])
+}
+
+// TestInitDriverPodConfig_AnnotationsTooLarge covers the limit Kubernetes puts on the
+// combined annotations of one object. Keys and values are each individually acceptable
+// here, so only the total catches it. Without this check the API server would start, the
+// workflow would compile, and the failure would surface only when Argo asked Kubernetes to
+// create the driver pod.
+func TestInitDriverPodConfig_AnnotationsTooLarge(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodAnnotations, map[string]string{
+		"example.com/payload": strings.Repeat("x", 300*1024),
+	})
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "annotations larger than the Kubernetes limit should fail startup")
+	assert.Contains(t, err.Error(), DriverPodAnnotations)
+	assert.Nil(t, GetDriverPodConfig(), "a rejected value must not reach the cache")
+}
+
+func TestInitDriverPodConfig_AnnotationsAtLimitAccepted(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	const key = "example.com/payload"
+	value := strings.Repeat("x", 256*1024-len(key))
+	viper.Set(DriverPodAnnotations, map[string]string{key: value})
+
+	require.NoError(t, InitDriverPodConfig(),
+		"the configured annotations alone are within the limit, so startup validation must accept them")
+	assert.Len(t, GetDriverPodAnnotations()[key], len(value))
+}
+
+// TestInitDriverPodConfig_ReservedAnnotationsNotCounted pins the order of the two checks:
+// reserved entries never reach the pod, so they must be dropped before the size is measured.
+func TestInitDriverPodConfig_ReservedAnnotationsNotCounted(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodAnnotations, map[string]string{
+		ReservedLabelPrefix + "oversized": strings.Repeat("x", 300*1024),
+		"example.com/kept":                "value",
+	})
+
+	require.NoError(t, InitDriverPodConfig(), "a reserved entry must not count toward the limit")
+	assert.Equal(t, map[string]string{"example.com/kept": "value"}, GetDriverPodAnnotations())
 }
 
 // TestInitDriverPodConfig_IstioMetadataAccepted guards the primary use case. Annotation
@@ -450,6 +629,168 @@ func TestInitDriverPodConfig_IstioMetadataAccepted(t *testing.T) {
 
 	assert.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"])
 	assert.Equal(t, `{"holdApplicationUntilProxyStarts":true}`, GetDriverPodAnnotations()["proxy.istio.io/config"])
+}
+
+// TestInitDriverPodConfig_ConfigFileExample loads the configuration file example from
+// backend/README.md verbatim, so a mistake in its three layers of escaping fails here rather
+// than in an install with no driver metadata.
+func TestInitDriverPodConfig_ConfigFileExample(t *testing.T) {
+	writeConfigFile(t, `{
+  "DRIVER_POD_LABELS": "{\"sidecar.istio.io/inject\":\"true\",\"app\":\"ml-pipeline-driver\"}",
+  "DRIVER_POD_ANNOTATIONS": "{\"proxy.istio.io/config\":\"{\\\"holdApplicationUntilProxyStarts\\\":true}\"}"
+}`)
+
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"])
+	assert.Equal(t, "ml-pipeline-driver", GetDriverPodLabels()["app"])
+	assert.Equal(t, `{"holdApplicationUntilProxyStarts":true}`,
+		GetDriverPodAnnotations()["proxy.istio.io/config"])
+}
+
+// TestInitDriverPodConfig_ConfigFileStringFormKeepsKeyCase is the reason the configuration
+// file example is written as a JSON string. Viper folds the keys of a nested JSON object to
+// lower case, which would rewrite an operator's metadata on the way through and silently drop
+// one of two keys that differ only in case. Parsing the string ourselves avoids both.
+func TestInitDriverPodConfig_ConfigFileStringFormKeepsKeyCase(t *testing.T) {
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": "{\"example.com/BuildID\":\"123\"}"}`)
+
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Equal(t, map[string]string{"example.com/BuildID": "123"}, GetDriverPodLabels())
+}
+
+// TestInitDriverPodConfig_ConfigFileStringFormKeepsBothCases is the case the nested object cannot
+// express at all. Two keys differing only in case survive as two keys through the string form,
+// where folding them to lower case would merge them and leave whichever value happened to be
+// written last.
+func TestInitDriverPodConfig_ConfigFileStringFormKeepsBothCases(t *testing.T) {
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": "{\"example.com/BuildID\":\"123\",\"example.com/buildid\":\"456\"}"}`)
+
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Equal(t, map[string]string{
+		"example.com/BuildID": "123",
+		"example.com/buildid": "456",
+	}, GetDriverPodLabels())
+}
+
+// TestInitDriverPodConfig_ConfigFileObjectRefused covers the shape this configuration cannot
+// check and therefore no longer accepts. The configuration loader lowers the keys of a JSON
+// object written directly in the file, before any of this code runs, so a value that would be
+// refused can be merged away and never seen. TestInitDriverPodConfig_ConfigFileObjectHidesValues
+// below demonstrates that. Refusing the shape and naming the string form is the only answer that
+// keeps the promise that every value is checked.
+func TestInitDriverPodConfig_ConfigFileObjectRefused(t *testing.T) {
+	for _, tt := range []struct{ name, body string }{
+		{"all values are strings", `{"sidecar.istio.io/inject": "true"}`},
+		{"null", `{"sidecar.istio.io/inject": null}`},
+		{"boolean", `{"enabled": true}`},
+		{"number", `{"replicas": 3}`},
+		{"list", `{"items": ["a","b"]}`},
+		{"nested object", `{"outer": {"inner": "v"}}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, key := range []string{DriverPodLabels, DriverPodAnnotations} {
+				writeConfigFile(t, `{"`+key+`": `+tt.body+`}`)
+
+				err := InitDriverPodConfig()
+
+				require.Error(t, err, "%s written as an object in %s should fail startup", tt.name, key)
+				assert.Contains(t, err.Error(), key)
+				assert.Contains(t, err.Error(), "must be a JSON string",
+					"the error should name the form the operator must use instead")
+				assert.Nil(t, GetDriverPodConfig(), "a refused value must not reach the cache")
+			}
+		})
+	}
+}
+
+func TestInitDriverPodConfig_ConfigFileObjectHidesValues(t *testing.T) {
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": {"Team": "ml", "team": null}}`)
+
+	assert.Equal(t, map[string]any{"team": "ml"}, viper.Get(DriverPodLabels))
+}
+
+// TestInitDriverPodConfig_StringFormSeesBothCases is the other half of the argument. The string
+// form is parsed here rather than by the configuration loader, so the keys arrive as written and
+// a refused value cannot hide behind one that is accepted.
+func TestInitDriverPodConfig_StringFormSeesBothCases(t *testing.T) {
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": "{\"Team\":\"ml\",\"team\":null}"}`)
+
+	err := InitDriverPodConfig()
+
+	require.Error(t, err, "the null must be seen even though another key differs only in case")
+	assert.Contains(t, err.Error(), "team")
+}
+
+func TestInitDriverPodConfig_EmptyEnvVarShadowsConfigFile(t *testing.T) {
+	// The first half asserts what happens with no variable set, so a variable inherited from
+	// whoever started the test would quietly invalidate it.
+	unsetEnvForTest(t, strings.ToUpper(DriverPodLabels), strings.ToUpper(DriverPodAnnotations))
+
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": "{\"sidecar.istio.io/inject\":\"true\"}"}`)
+
+	// Same Viper setup as initConfig() in main.go, which the configuration file tests above
+	// leave out because they exercise the file on its own.
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+	viper.AllowEmptyEnv(true)
+
+	require.NoError(t, InitDriverPodConfig())
+	require.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"],
+		"without the Deployment variables the configuration file applies")
+
+	t.Setenv(strings.ToUpper(DriverPodLabels), "")
+	resetDriverConfig()
+
+	require.NoError(t, InitDriverPodConfig())
+	assert.Nil(t, GetDriverPodLabels(), "the empty Deployment variable takes precedence over the configuration file")
+}
+
+func TestInitDriverPodConfig_ConfigFileNativeNullMeansUnset(t *testing.T) {
+	writeConfigFile(t, `{"DRIVER_POD_LABELS": null}`)
+
+	require.False(t, viper.IsSet(DriverPodLabels), "Viper reports a native null as not set")
+	require.NoError(t, InitDriverPodConfig())
+	assert.Nil(t, GetDriverPodConfig())
+}
+
+// TestInitDriverPodConfig_ProgrammaticMapAccepted keeps the shape a caller can set directly.
+// A configuration file cannot produce it, so its keys are as written and its values are already
+// strings, which is what separates it from the object form refused above.
+func TestInitDriverPodConfig_ProgrammaticMapAccepted(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	viper.Set(DriverPodLabels, map[string]string{"sidecar.istio.io/inject": "true"})
+
+	require.NoError(t, InitDriverPodConfig())
+
+	assert.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"])
+}
+
+// TestInitDriverPodConfig_ArgoKillCommandAccepted covers the annotation an operator needs
+// alongside sidecar injection. Argo kills an injected sidecar with /bin/sh -c 'kill 1' by
+// default, which the Istio proxy does not answer, and a driver pod whose proxy keeps running
+// never completes. The remedy is the per container kill command annotation documented by
+// Argo, so this configuration has to survive key validation and reach the driver pod intact.
+// backend/README.md points operators at exactly this value.
+func TestInitDriverPodConfig_ArgoKillCommandAccepted(t *testing.T) {
+	viper.Reset()
+	resetDriverConfig()
+
+	// Copied verbatim from the ConfigMap example in backend/README.md, so the escaping an
+	// operator is told to write stays under test.
+	viper.Set(DriverPodLabels, `{"sidecar.istio.io/inject":"true"}`)
+	viper.Set(DriverPodAnnotations, `{"proxy.istio.io/config":"{\"holdApplicationUntilProxyStarts\":true}","workflows.argoproj.io/kill-cmd-istio-proxy":"[\"pilot-agent\", \"request\", \"POST\", \"quitquitquit\"]"}`)
+
+	require.NoError(t, InitDriverPodConfig())
+
+	annotations := GetDriverPodAnnotations()
+	assert.Equal(t, "true", GetDriverPodLabels()["sidecar.istio.io/inject"])
+	assert.Equal(t, `{"holdApplicationUntilProxyStarts":true}`, annotations["proxy.istio.io/config"])
+	assert.Equal(t, `["pilot-agent", "request", "POST", "quitquitquit"]`, annotations["workflows.argoproj.io/kill-cmd-istio-proxy"])
 }
 
 func TestGetDriverPodLabelsNotInitialized(t *testing.T) {

--- a/backend/src/apiserver/main.go
+++ b/backend/src/apiserver/main.go
@@ -717,17 +717,6 @@ func initConfig() error {
 		glog.Fatalf("Invalid plugin limits configuration: %v", err)
 	}
 
-	// Watch for configuration change
-	viper.WatchConfig()
-	viper.OnConfigChange(func(e fsnotify.Event) {
-		if err := viper.ReadInConfig(); err != nil {
-			glog.Errorf("Failed to reload config: %v", err)
-		}
-		if _, err := common.GetPluginLimitsConfig(); err != nil {
-			glog.Fatalf("Invalid plugin limits configuration: %v", err)
-		}
-	})
-
 	proxy.InitializeConfigWithEnv()
 
 	// Initialize driver pod configuration after Viper config is loaded.
@@ -737,6 +726,17 @@ func initConfig() error {
 	if err := common.InitDriverPodConfig(); err != nil {
 		return fmt.Errorf("driver pod config: %w", err)
 	}
+
+	// Start the watcher after all startup reads. Viper's watcher reloads on its own goroutine
+	// and is not safe for concurrent reads, so starting it earlier races with the reads above.
+	// Register the callback first — WatchConfig blocks until the watcher is live.
+	viper.OnConfigChange(func(e fsnotify.Event) {
+		if _, err := common.GetPluginLimitsConfig(); err != nil {
+			glog.Fatalf("Invalid plugin limits configuration: %v", err)
+		}
+	})
+	viper.WatchConfig()
+
 	return nil
 }
 


### PR DESCRIPTION
**Description of your changes:**

## Summary

- **behavior change**: a JSON object written directly in `config.json` is now refused at startup, with an error naming the string form to write instead. The ConfigMap path, which every standard install uses, is not affected
- read and parse the configuration once, so the map that was checked is the map that reaches the cache
- start the configuration watcher after startup finishes rather than in the middle of it, register its callback before starting it, and stop the callback re-reading a file the watcher has already read. This orders startup only; reads that happen while serving still overlap with the watcher
- reject a top level JSON `null` on the string path, and record in a test that a bare `null` in the configuration file reads as an absent key
- validate annotations with the validator Kubernetes itself applies, which stops refusing keys Kubernetes accepts and brings the total size limit that was not checked at all
- say in the README that the configuration file supplies the built in default rather than the setting an operator changes, and pin that precedence in a test
- document the Argo kill command an injected Istio proxy needs, and the compiler annotation that sits beside the injection label
- correct the note about restarting the API server, which described the opposite of what happens to existing recurring runs
- list the two variables in `AGENTS.md` and refresh its date, as its maintenance section asks for when environment variables change

## Why

#12417 added driver pod labels and annotations. The review that followed turned up several corrections. Only the first changes what an existing configuration does, and it affects the configuration file alone.

That form cannot be checked, which is why it is refused rather than validated more carefully. The configuration loader lowers the keys of a JSON object while reading the file, before any of this code runs. Two keys differing only in case are merged into one and a value is dropped, so a value this configuration would refuse can vanish before it is ever seen. Where both keys need lowering, which one survives follows map iteration order, so the same file starts the API server on one restart and stops it on the next. Both outcomes are covered by tests. Refusing the shape and naming the string form is the only answer that keeps the promise that every value is checked, and the string form is what the ConfigMap already uses, so the two sources finally parse the same way. Anyone affected has built a custom image and can quote the object.

The value is also read once now instead of twice, once to check it and again to convert it, which had left a window for the watcher to reload in between and cache something no check had seen. For the same reason `viper.WatchConfig` now runs after startup finishes rather than in the middle of it. Viper is not safe for concurrent reads and writes, the watcher reloads on its own goroutine, and the race detector reports that overlap both for the driver configuration and for the cluster domain the proxy configuration reads, which sat after the watcher until now. Moving the watcher rather than each reader covers whatever is added to startup later.

Two smaller things in the same block go with it. The change callback is registered before the watcher rather than after: `WatchConfig` only returns once its watcher is live, so registering afterwards left a gap in which an event found no callback and skipped it, on a field written and read without synchronization. Viper's own example registers first. The callback also no longer re-reads the file, because the watcher reads it before calling in, so reading again replaced the configuration a second time for one event and could validate a different version than the one just loaded.

That fixes the ordering of startup and nothing more, and the code says so where the watcher is started. Configuration is also read while serving, when a run is created for instance, and those reads still overlap with the watcher. Making reloading itself safe needs either synchronization around every configuration read or no watcher at all, which is a decision for whoever owns that layer rather than something to settle here.

On the string path a bare `null` was getting through, since it unmarshals into a nil map without an error and left the loop over its entries with nothing to walk. A configuration file key whose value is a bare `null` still reads as an absent key, because Viper reports it that way and offers no means to tell the two apart, `InConfig` included, and the shipped default depends on exactly that. A test records the boundary rather than putting a second reader of the file beside Viper for one input.

Annotation validation was written by hand and refused keys Kubernetes accepts, since Kubernetes lowers an annotation key before checking its syntax. Calling `apivalidation.ValidateAnnotations` fixes that, drops the duplicated rule, and brings the total size limit that was missing, which had let an oversized value through until Argo asked Kubernetes to create the pod. Labels keep their own validation, since Kubernetes does not lower label keys. The startup check measures the configured annotations alone, and the test at the boundary says so, because the pod carries compiler added annotations too and a value near that size could not be delivered anyway: each setting arrives as one environment variable holding its whole JSON document, and Linux caps a single environment string at 32 memory pages, around 128 KiB on the usual 4 KiB page size. The README now mentions that, since a value over the cap stops the API server from starting at all.

The README also says plainly what the configuration file is for. The Deployment always passes both keys in from the ConfigMap, and an environment variable takes precedence over the file even when it is empty, so on a standard install the file supplies the built in default and the ConfigMap is what an operator controls. A test pins that precedence. Removing the two empty defaults from the shipped ConfigMap would let the file apply again, and I have left that decision to the manifest owners rather than changing what was just reviewed.

Two things about sidecar injection were missing. Argo shuts an injected sidecar down with `/bin/sh -c 'kill 1'`, which the Istio proxy ignores, so the proxy outlives the driver and the pod stays in `Running`; Argo's per container kill command handles it, and the default install already grants the `pods/exec` that needs. Separately the compiler annotates every template with `sidecar.istio.io/inject: "false"`, which lands beside the injection label without disabling it.

The note about restarting the API server was wrong in the other direction and is corrected, though not as simply as either version suggested, since each API server reads the configuration once as it starts and what a run gets depends on which one compiles it. A recurring run that did not pin its pipeline is compiled through the runs API when it triggers, by whichever API server takes that call, which is the new configuration once the restart has finished but not necessarily during it, because the default rollout brings a replacement up before retiring the one it replaces and both serve for a short window. A pinned one is recompiled by the reconciliation an API server runs once as it starts, and that reconciliation stops at the first recurring run it cannot process and is not retried, so the ones after a failure keep their previous specification until the next restart. The README says all of this rather than promising that every recurring run updates.

Both injection claims were checked on a cluster rather than read off the source. With Argo, a pod built from a template carrying the configured labels and annotations held all of them, the kill command included and its escaping intact. With Istio, a pod holding the label `true` and the annotation `false` was injected, and the reverse combination was not. The environment variable limit was reproduced separately. `golangci-lint` v2.10.1 and the race detector were run in a Linux container and report nothing in the changed files.

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
