### PR TITLE
fix(backend): append CANCELLING to StateHistory in TerminateRun

### DIFF
--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -821,13 +821,33 @@ func NewRunStore(db *DB, time util.TimeInterface) *RunStore {
 }
 
 func (s *RunStore) TerminateRun(runId string) error {
-	// TODO(gkcalat): append CANCELLING to StateHistory
+	run, err := s.GetRun(runId)
+	if err != nil {
+		return err
+	}
+
+	cancelling := model.RuntimeStateCancelling
+	if len(run.RunDetails.StateHistory) == 0 ||
+		run.RunDetails.StateHistory[len(run.RunDetails.StateHistory)-1].State != cancelling {
+		run.RunDetails.StateHistory = append(run.RunDetails.StateHistory, &model.RuntimeStatus{
+			UpdateTimeInSec: s.time.Now().Unix(),
+			State:           cancelling,
+		})
+	}
+	stateHistoryString := ""
+	if historyString, err := json.Marshal(run.RunDetails.StateHistory); err == nil {
+		stateHistoryString = string(historyString)
+	} else {
+		return util.NewInternalServerError(err, "Failed to marshal state history while terminating run %s", runId)
+	}
+
 	result, err := s.db.Exec(`
 		UPDATE run_details
-		SET Conditions = ?, State = ?
+		SET Conditions = ?, State = ?, StateHistory = ?
 		WHERE UUID = ? AND (State = ? OR State = ? OR State = ? OR State = ?)`,
 		string(model.RuntimeStateCancelling.ToV1()),
 		model.RuntimeStateCancelling.ToString(),
+		stateHistoryString,
 		runId,
 		model.RuntimeStatePaused.ToString(),
 		model.RuntimeStatePending.ToString(),


### PR DESCRIPTION
## Summary

`TerminateRun` set `State`/`Conditions` to CANCELLING but never updated
`StateHistory`, while `CreateRun`/`UpdateRun` always append a
`RuntimeStatus` entry on state change. This PR loads the run, appends
CANCELLING to history (same pattern as `UpdateRun`), and persists
`StateHistory` in the same UPDATE.

Fixes #13786

## Test plan

- [x] Matches CreateRun/UpdateRun history-append pattern
- [ ] CI unit tests for run store