### PR TITLE
fix(sdk): validate create_run_from_pipeline_func argument names

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -24,7 +24,7 @@ import tarfile
 import tempfile
 import time
 from types import ModuleType
-from typing import Any, Dict, List, Optional, TextIO
+from typing import Any, Dict, Iterable, List, Optional, TextIO
 import warnings
 import zipfile
 
@@ -1025,7 +1025,7 @@ class Client:
         Returns:
             ``RunPipelineResult`` object containing information about the pipeline run.
         """
-        #TODO: Check arguments against the pipeline function
+        validate_pipeline_arguments(pipeline_func._component_inputs, arguments)
         pipeline_name = pipeline_func.name
         run_name = run_name or pipeline_name + ' ' + datetime.datetime.now(
         ).strftime('%Y-%m-%d %H-%M-%S')
@@ -1712,6 +1712,29 @@ def validate_pipeline_display_name(name: str) -> None:
         raise ValueError(
             f'Invalid pipeline name. Pipeline name cannot be empty or contain only whitespace.'
         )
+
+
+def validate_pipeline_arguments(
+    known_parameters: Iterable[str],
+    arguments: Optional[Dict[str, Any]],
+) -> None:
+    """Validate run arguments against known pipeline parameter names.
+
+    Args:
+        known_parameters: Iterable of accepted pipeline parameter names.
+        arguments: Arguments mapping passed to the run, or None.
+
+    Raises:
+        ValueError: If any argument name is not a known pipeline parameter.
+    """
+    if not arguments:
+        return
+    known = set(known_parameters)
+    unknown = sorted(set(arguments) - known)
+    if unknown:
+        raise ValueError(
+            f'Unknown argument(s): {unknown}. '
+            f'Expected pipeline parameters: {sorted(known)}')
 
 
 def _extract_pipeline_yaml(package_file: str) -> _PipelineDoc:

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -58,6 +58,53 @@ class TestValidatePipelineName(parameterized.TestCase):
             client.validate_pipeline_display_name(name)
 
 
+class TestValidatePipelineArguments(unittest.TestCase):
+
+    def test_none_or_empty_arguments_ok(self):
+        client.validate_pipeline_arguments({'a'}, None)
+        client.validate_pipeline_arguments({'a'}, {})
+
+    def test_known_arguments_ok(self):
+        client.validate_pipeline_arguments({'a', 'b'}, {'a': 1, 'b': 2})
+
+    def test_unknown_argument_raises(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Unknown argument\(s\): \['ab'\]. Expected pipeline parameters: \['a'\]"
+        ):
+            client.validate_pipeline_arguments({'a'}, {'ab': 5})
+
+    def test_multiple_unknown_sorted(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Unknown argument\(s\): \['x', 'z'\]"):
+            client.validate_pipeline_arguments({'a'}, {'z': 1, 'x': 2, 'a': 0})
+
+    def test_create_run_from_pipeline_func_rejects_unknown_before_compile(self):
+        """Issue #13682: typo args should fail immediately."""
+
+        @component
+        def nop(a: int) -> int:
+            return a
+
+        @pipeline(name='arg-validation-pipeline')
+        def my_pipeline(a: int):
+            nop(a=a)
+
+        mock_client = MagicMock(spec=client.Client)
+        # Bind the real method for validation path.
+        mock_client.create_run_from_pipeline_func = (
+            client.Client.create_run_from_pipeline_func.__get__(
+                mock_client, client.Client))
+        mock_client.create_run_from_pipeline_package = MagicMock()
+
+        with self.assertRaisesRegex(ValueError, r"Unknown argument\(s\): \['ab'\]"):
+            mock_client.create_run_from_pipeline_func(
+                my_pipeline, arguments={'ab': 5})
+
+        mock_client.create_run_from_pipeline_package.assert_not_called()
+
+
 class TestOverrideCachingOptions(parameterized.TestCase):
 
     def test_override_caching_of_multiple_components(self):


### PR DESCRIPTION
## Description of your changes

`create_run_from_pipeline_func` accepted unknown keys in the `arguments`
dict (e.g. a typo `"ab"` for parameter `a`) and only failed later on the
backend.

Validate argument names against the pipeline component inputs before
compile/submit and raise a clear `ValueError`.

Implements the existing TODO and matches the issue suggestion.

## Checklist

- [x] You have signed off your commits
- [x] Unit tests: `TestValidatePipelineArguments` in `sdk/python/kfp/client/client_test.py`
- [x] Red-green: without the validate call, `test_create_run_from_pipeline_func_rejects_unknown_before_compile` fails; with it, all 5 tests pass

Fixes #13682