### PR TITLE
chore: apply gofmt formatting corrections in backend Go files

### DIFF
--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -42,13 +42,13 @@ import (
 )
 
 const (
-	FormFileKey               = "uploadfile"
-	NameQueryStringKey        = "name"
-	DisplayNameQueryStringKey = "display_name"
-	DescriptionQueryStringKey = "description"
-	NamespaceStringQuery      = "namespace"
-	TagsQueryStringKey           = "tags"
-	CodeSourceURLQueryStringKey  = "code_source_url"
+	FormFileKey                 = "uploadfile"
+	NameQueryStringKey          = "name"
+	DisplayNameQueryStringKey   = "display_name"
+	DescriptionQueryStringKey   = "description"
+	NamespaceStringQuery        = "namespace"
+	TagsQueryStringKey          = "tags"
+	CodeSourceURLQueryStringKey = "code_source_url"
 	// Pipeline Id in the query string specifies a pipeline when creating versions.
 	PipelineKey = "pipelineid"
 )

--- a/backend/src/apiserver/storage/job_store_test.go
+++ b/backend/src/apiserver/storage/job_store_test.go
@@ -775,10 +775,10 @@ func TestUpdateJob_Success(t *testing.T) {
 		Status: swfapi.ScheduledWorkflowStatus{
 			Conditions: []swfapi.ScheduledWorkflowCondition{
 				{
-					Type:               swfapi.ScheduledWorkflowEnabled,
-					Status:             corev1.ConditionTrue,
-					Reason:             string(swfapi.ScheduledWorkflowEnabled),
-					Message:            "The schedule is enabled",
+					Type:    swfapi.ScheduledWorkflowEnabled,
+					Status:  corev1.ConditionTrue,
+					Reason:  string(swfapi.ScheduledWorkflowEnabled),
+					Message: "The schedule is enabled",
 				},
 			},
 		},

--- a/backend/src/common/util/scheduled_workflow_test.go
+++ b/backend/src/common/util/scheduled_workflow_test.go
@@ -72,10 +72,10 @@ func TestScheduledWorkflow_ConditionSummary(t *testing.T) {
 		Status: swfapi.ScheduledWorkflowStatus{
 			Conditions: []swfapi.ScheduledWorkflowCondition{
 				{
-					Type:               swfapi.ScheduledWorkflowEnabled,
-					Status:             corev1.ConditionTrue,
-					Reason:             string(swfapi.ScheduledWorkflowEnabled),
-					Message:            "The schedule is enabled.",
+					Type:    swfapi.ScheduledWorkflowEnabled,
+					Status:  corev1.ConditionTrue,
+					Reason:  string(swfapi.ScheduledWorkflowEnabled),
+					Message: "The schedule is enabled.",
 				},
 			},
 		},
@@ -87,15 +87,15 @@ func TestScheduledWorkflow_ConditionSummary(t *testing.T) {
 		Status: swfapi.ScheduledWorkflowStatus{
 			Conditions: []swfapi.ScheduledWorkflowCondition{
 				{
-					Type:               swfapi.ScheduledWorkflowEnabled,
-					Status:             corev1.ConditionTrue,
-					Reason:             string(swfapi.ScheduledWorkflowEnabled),
-					Message:            "The schedule is enabled.",
+					Type:    swfapi.ScheduledWorkflowEnabled,
+					Status:  corev1.ConditionTrue,
+					Reason:  string(swfapi.ScheduledWorkflowEnabled),
+					Message: "The schedule is enabled.",
 				}, {
-					Type:               swfapi.ScheduledWorkflowDisabled,
-					Status:             corev1.ConditionTrue,
-					Reason:             string(swfapi.ScheduledWorkflowDisabled),
-					Message:            "The schedule is disabled.",
+					Type:    swfapi.ScheduledWorkflowDisabled,
+					Status:  corev1.ConditionTrue,
+					Reason:  string(swfapi.ScheduledWorkflowDisabled),
+					Message: "The schedule is disabled.",
 				},
 			},
 		},

--- a/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow_test.go
@@ -558,10 +558,10 @@ func TestScheduledWorkflow_GetNextScheduledEpoch_UpdateStatus_NoWorkflow(t *test
 		},
 		Status: swfapi.ScheduledWorkflowStatus{
 			Conditions: []swfapi.ScheduledWorkflowCondition{{
-				Type:               swfapi.ScheduledWorkflowEnabled,
-				Status:             corev1.ConditionTrue,
-				Reason:             string(swfapi.ScheduledWorkflowEnabled),
-				Message:            "The schedule is enabled.",
+				Type:    swfapi.ScheduledWorkflowEnabled,
+				Status:  corev1.ConditionTrue,
+				Reason:  string(swfapi.ScheduledWorkflowEnabled),
+				Message: "The schedule is enabled.",
 			},
 			},
 			WorkflowHistory: &swfapi.WorkflowHistory{
@@ -635,10 +635,10 @@ func TestScheduledWorkflow_GetNextScheduledEpoch_UpdateStatus_WithWorkflow(t *te
 		},
 		Status: swfapi.ScheduledWorkflowStatus{
 			Conditions: []swfapi.ScheduledWorkflowCondition{{
-				Type:               swfapi.ScheduledWorkflowEnabled,
-				Status:             corev1.ConditionTrue,
-				Reason:             string(swfapi.ScheduledWorkflowEnabled),
-				Message:            "The schedule is enabled.",
+				Type:    swfapi.ScheduledWorkflowEnabled,
+				Status:  corev1.ConditionTrue,
+				Reason:  string(swfapi.ScheduledWorkflowEnabled),
+				Message: "The schedule is enabled.",
 			}},
 			WorkflowHistory: &swfapi.WorkflowHistory{
 				Active:    []swfapi.WorkflowStatus{*status3, *status1, *status2},


### PR DESCRIPTION
## Description

Four backend Go files contain over-aligned struct field / const block formatting that does not match `gofmt` output. This PR runs `gofmt -w` on them so they conform to the standard formatting.

Files:
- \`backend/src/apiserver/server/pipeline_upload_server.go\`
- \`backend/src/apiserver/storage/job_store_test.go\`
- \`backend/src/common/util/scheduled_workflow_test.go\`
- \`backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow_test.go\`

## Notes

Whitespace-only change with **no functional impact** — \`git diff --ignore-all-space\` is empty. \`golangci-lint\` (including \`golangci-lint fmt\`) passes.