### PR TITLE
fix(sdk): reject reserved oci-prepull-<N> init container names in add_init_container

### DIFF
--- a/kubernetes_platform/python/kfp/kubernetes/init_container.py
+++ b/kubernetes_platform/python/kfp/kubernetes/init_container.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import re
 from typing import Dict, List, Optional
 
 from google.protobuf import json_format
@@ -43,7 +44,9 @@ def add_init_container(
 
     Args:
         task: Pipeline task.
-        name: Name of the init container. Must be unique within the pod.
+        name: Name of the init container. Must be unique within the pod. The
+            following names are reserved by Kubeflow Pipelines and must not be used:
+            ``kfp-launcher``, ``oci-prepull-<N>`` (where N is a non-negative integer).
         image: Container image of the init container.
         command: Entrypoint array. Corresponds to the ``command`` field.
         args: Arguments to the entrypoint. Corresponds to the ``args`` field.
@@ -72,6 +75,11 @@ def add_init_container(
     if name == 'kfp-launcher':
         raise ValueError(
             'Init container name "kfp-launcher" is reserved by Kubeflow Pipelines.'
+        )
+    if re.match(r'^oci-prepull-\d+$', name):
+        raise ValueError(
+            'Init container names matching "oci-prepull-<N>" are reserved by '
+            'Kubeflow Pipelines for Modelcar OCI artifact pre-pull containers.'
         )
     if not image:
         raise ValueError('Argument for "image" must be a non-empty string.')

--- a/kubernetes_platform/python/test/unit/test_init_container.py
+++ b/kubernetes_platform/python/test/unit/test_init_container.py
@@ -134,6 +134,21 @@ class TestAddInitContainer:
                     image='busybox:1.36',
                 )
 
+    def test_add_init_container_reserved_oci_prepull_name(self):
+        with pytest.raises(
+                ValueError,
+                match=r'Init container names matching "oci-prepull-<N>" are reserved',
+        ):
+
+            @dsl.pipeline
+            def my_pipeline():
+                task = print_greeting()
+                kubernetes.add_init_container(
+                    task,
+                    name='oci-prepull-0',
+                    image='busybox:1.36',
+                )
+
     def test_add_init_container_empty_name(self):
         with pytest.raises(
                 ValueError,


### PR DESCRIPTION
**Description of your changes:**

When calling `add_init_container()`, the Python SDK previously only rejected the literal name `kfp-launcher`. However, Kubeflow Pipelines backend drivers also inject `oci-prepull-0`, `oci-prepull-1`, etc., init containers when Modelcar OCI artifacts are used as pipeline inputs. 

Because `add_init_container` did not check for `oci-prepull-<N>` at compile time, pipelines using these names passed SDK compilation silently but failed at runtime with:
`init container name "oci-prepull-0" conflicts with an existing container in the pod`

This PR updates `add_init_container()` in `kubernetes_platform/python/kfp/kubernetes/init_container.py` to:
1. Reject init container names matching the regex `^oci-prepull-\d+$` at compile time with a descriptive `ValueError`.
2. Update the docstring of `name` to document all reserved init container names (`kfp-launcher` and `oci-prepull-<N>`).
3. Add unit test coverage in `kubernetes_platform/python/test/unit/test_init_container.py`.

Fixes #13802

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
