### PR TITLE
fix(sdk): preserve set_retry(backoff_factor=0.0) during compilation and local run

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -1818,6 +1818,26 @@ class TestSetRetryCompilation(unittest.TestCase):
         self.assertEqual(retry_policy.backoff_factor, 1.0)
         self.assertEqual(retry_policy.backoff_max_duration.seconds, 10800)
 
+    def test_set_retry_zero_backoff_factor(self):
+
+        @dsl.pipeline(name='zero-backoff-pipeline')
+        def zero_backoff_pipeline():
+            hello_world(text='hello').set_retry(
+                num_retries=3,
+                backoff_duration='30s',
+                backoff_factor=0.0,
+                backoff_max_duration='120s',
+            )
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            package_path = os.path.join(tempdir, 'pipeline.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=zero_backoff_pipeline, package_path=package_path)
+            pipeline_spec = pipeline_spec_from_file(package_path)
+
+        retry_policy = pipeline_spec.root.dag.tasks['hello-world'].retry_policy
+        self.assertEqual(retry_policy.backoff_factor, 0.0)
+
 
 from google.protobuf import json_format
 

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -375,10 +375,10 @@ class RetryPolicy:
 
     def to_proto(self) -> pipeline_spec_pb2.PipelineTaskSpec.RetryPolicy:
         # include defaults so that IR is more reflective of runtime behavior
-        max_retry_count = self.max_retry_count or 0
-        backoff_duration = self.backoff_duration or '0s'
-        backoff_factor = self.backoff_factor or 2.0
-        backoff_max_duration = self.backoff_max_duration or '3600s'
+        max_retry_count = self.max_retry_count if self.max_retry_count is not None else 0
+        backoff_duration = self.backoff_duration if self.backoff_duration is not None else '0s'
+        backoff_factor = self.backoff_factor if self.backoff_factor is not None else 2.0
+        backoff_max_duration = self.backoff_max_duration if self.backoff_max_duration is not None else '3600s'
 
         backoff_duration_seconds = f'{convert_duration_to_seconds(backoff_duration)}s'
         backoff_max_duration_seconds = f'{convert_duration_to_seconds(backoff_max_duration)}s'

--- a/sdk/python/kfp/dsl/structures_test.py
+++ b/sdk/python/kfp/dsl/structures_test.py
@@ -915,6 +915,16 @@ class TestRetryPolicy(unittest.TestCase):
         self.assertEqual(retry_policy_proto.backoff_max_duration.seconds,
                          1209600)
 
+    def test_to_proto_with_zero_backoff_factor(self):
+        retry_policy_struct = structures.RetryPolicy(
+            max_retry_count=3,
+            backoff_duration='30s',
+            backoff_factor=0.0,
+            backoff_max_duration='120s',
+        )
+        retry_policy_proto = retry_policy_struct.to_proto()
+        self.assertEqual(retry_policy_proto.backoff_factor, 0.0)
+
 
 class TestDeserializeV1ComponentYamlDefaults(unittest.TestCase):
 

--- a/sdk/python/kfp/local/orchestrator/task_executor.py
+++ b/sdk/python/kfp/local/orchestrator/task_executor.py
@@ -125,7 +125,7 @@ def execute_single_task(
     max_retries = retry_policy.max_retry_count if retry_policy.max_retry_count > 0 else 0
     backoff_duration = retry_policy.backoff_duration.seconds if retry_policy.HasField(
         'backoff_duration') else 0
-    backoff_factor = retry_policy.backoff_factor if retry_policy.backoff_factor > 0 else 2.0
+    backoff_factor = retry_policy.backoff_factor if retry_policy.backoff_factor >= 0 else 2.0
     backoff_max_duration = retry_policy.backoff_max_duration.seconds if retry_policy.HasField(
         'backoff_max_duration') else 3600
 

--- a/sdk/python/kfp/local/subprocess_task_handler.py
+++ b/sdk/python/kfp/local/subprocess_task_handler.py
@@ -191,7 +191,11 @@ def environment(use_venv: bool,
 
                 # Install setuptools and wheel in the venv to ensure build dependencies are available
                 # This is required for Python 3.13+ where setuptools is not included by default
-                python_path = os.path.join(tempdir, 'bin', 'python')
+                python_path = (
+                    os.path.join(tempdir, 'Scripts', 'python.exe')
+                    if os.name == 'nt'
+                    else os.path.join(tempdir, 'bin', 'python')
+                )
                 try:
                     # First upgrade pip itself to ensure we have a compatible version
                     subprocess.run([

--- a/sdk/python/kfp/local/task_dispatcher_test.py
+++ b/sdk/python/kfp/local/task_dispatcher_test.py
@@ -467,6 +467,37 @@ class TestRetryLogic(testing_utilities.LocalRunnerEnvironmentTestCase):
         result = retry_fail_pipeline()
         self.assertDictEqual(result.outputs, {})
 
+    def test_retry_with_zero_backoff_factor(self):
+        """Test that retry policy with backoff_factor=0.0 compiles and runs successfully."""
+        local.init(runner=local.SubprocessRunner(use_venv=True))
+
+        import tempfile
+        counter_file = os.path.join(tempfile.mkdtemp(), 'counter.txt')
+
+        @dsl.component
+        def flaky_component(counter_path: str) -> str:
+            import os
+            count = 0
+            if os.path.exists(counter_path):
+                with open(counter_path, 'r') as f:
+                    count = int(f.read().strip())
+            count += 1
+            with open(counter_path, 'w') as f:
+                f.write(str(count))
+            if count < 2:
+                raise RuntimeError(f'Attempt {count}: not yet!')
+            return f'succeeded on attempt {count}'
+
+        @dsl.pipeline
+        def retry_pipeline(counter_path: str) -> str:
+            task = flaky_component(counter_path=counter_path)
+            task.set_retry(
+                num_retries=2, backoff_duration='0s', backoff_factor=0.0)
+            return task.output
+
+        result = retry_pipeline(counter_path=counter_file)
+        self.assertEqual(result.output, 'succeeded on attempt 2')
+
 
 class TestExitHandler(testing_utilities.LocalRunnerEnvironmentTestCase):
     """Tests for dsl.ExitHandler support in local execution."""


### PR DESCRIPTION
**Description of your changes:**
When using `.set_retry(..., backoff_factor=0.0)`, Python's falsy fallback checks silently replaced the explicitly configured `0.0` backoff factor with the default `2.0` during pipeline compilation (`RetryPolicy.to_proto()`) and local execution (`task_executor.py`).

This PR:
- Replaces `or` truthy fallbacks in `RetryPolicy.to_proto()` with explicit `None` checks.
- Changes the fallback check in local orchestrator `task_executor.py` from `> 0` to `>= 0`.
- Fixes Windows environment execution by resolving the python executable to `Scripts/python.exe` instead of hardcoding `bin/python`.
- Adds unit, compiler, and local execution tests to verify that `backoff_factor=0.0` is correctly compiled and executed.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
