### PR TITLE
fix(sdk): include trusted hosts when pip_index_urls is not set

### DIFF
--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -91,30 +91,32 @@ def make_index_url_options(pip_index_urls: Optional[List[str]],
 
     Returns:
         str:
-            - An empty string if pip_index_urls is empty or None.
+            - An empty string if pip_index_urls and pip_trusted_hosts are empty or None.
             - '--index-url url ' if pip_index_urls contains 1 URL.
             - The above followed by '--extra-index-url url ' for each additional URL in pip_index_urls
             if pip_index_urls contains more than 1 URL.
             - If pip_trusted_hosts is None or an empty List:
                 - No --trusted-host information will be added.
             - If pip_trusted_hosts contains any hosts:
-                - The above followed by '--trusted-host host ' for each host in pip_trusted_hosts.
+                - '--trusted-host host ' for each host in pip_trusted_hosts.
     Note:
-        In case pip_index_urls is not empty, the returned string will contain a space at the end.
+        In case pip_index_urls or pip_trusted_hosts is provided, the returned string will contain a space at the end.
     """
-    if not pip_index_urls:
-        return ''
+    options = []
+    if pip_index_urls:
+        index_url = pip_index_urls[0]
+        extra_index_urls = pip_index_urls[1:]
 
-    index_url = pip_index_urls[0]
-    extra_index_urls = pip_index_urls[1:]
-
-    options = [f'--index-url {index_url}']
-    options.extend(f'--extra-index-url {extra_index_url}'
-                   for extra_index_url in extra_index_urls)
+        options.append(f'--index-url {index_url}')
+        options.extend(f'--extra-index-url {extra_index_url}'
+                       for extra_index_url in extra_index_urls)
 
     if pip_trusted_hosts:
         options.extend(f'--trusted-host {trusted_host}'
                        for trusted_host in pip_trusted_hosts)
+
+    if not options:
+        return ''
 
     return ' '.join(options) + ' '
 

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -92,30 +92,32 @@ def make_index_url_options(pip_index_urls: Optional[List[str]],
 
     Returns:
         str:
-            - An empty string if pip_index_urls is empty or None.
+            - An empty string if pip_index_urls and pip_trusted_hosts are empty or None.
             - '--index-url url ' if pip_index_urls contains 1 URL.
             - The above followed by '--extra-index-url url ' for each additional URL in pip_index_urls
             if pip_index_urls contains more than 1 URL.
             - If pip_trusted_hosts is None or an empty List:
                 - No --trusted-host information will be added.
             - If pip_trusted_hosts contains any hosts:
-                - The above followed by '--trusted-host host ' for each host in pip_trusted_hosts.
+                - '--trusted-host host ' for each host in pip_trusted_hosts.
     Note:
-        In case pip_index_urls is not empty, the returned string will contain a space at the end.
+        In case pip_index_urls or pip_trusted_hosts is provided, the returned string will contain a space at the end.
     """
-    if not pip_index_urls:
-        return ''
+    options = []
+    if pip_index_urls:
+        index_url = pip_index_urls[0]
+        extra_index_urls = pip_index_urls[1:]
 
-    index_url = pip_index_urls[0]
-    extra_index_urls = pip_index_urls[1:]
-
-    options = [f'--index-url {index_url}']
-    options.extend(f'--extra-index-url {extra_index_url}'
-                   for extra_index_url in extra_index_urls)
+        options.append(f'--index-url {index_url}')
+        options.extend(f'--extra-index-url {extra_index_url}'
+                       for extra_index_url in extra_index_urls)
 
     if pip_trusted_hosts:
         options.extend(f'--trusted-host {trusted_host}'
                        for trusted_host in pip_trusted_hosts)
+
+    if not options:
+        return ''
 
     return ' '.join(options) + ' '
 

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -247,6 +247,56 @@ class TestGetPackagesToInstallCommand(unittest.TestCase):
                 '\'typing-extensions>=3.7.4,<5; python_version<"3.9"\' && "$0" "$@"\n'
             ]))
 
+    def test_with_packages_to_install_with_trusted_host_only(self):
+        packages_to_install = ['package1', 'package2']
+        pip_trusted_hosts = ['myurl.org']
+
+        command = component_factory._get_packages_to_install_command(
+            packages_to_install=packages_to_install,
+            pip_index_urls=None,
+            pip_trusted_hosts=pip_trusted_hosts,
+        )
+
+        self.assertEqual(
+            strip_kfp_version(command),
+            strip_kfp_version([
+                'sh', '-c', '\n'
+                'if ! [ -x "$(command -v pip)" ]; then\n'
+                '    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install '
+                'python3-pip\n'
+                'fi\n'
+                '\n'
+                'PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet '
+                '--no-warn-script-location '
+                "--trusted-host myurl.org 'package1' 'package2'  &&  python3 -m pip install "
+                '--quiet --no-warn-script-location '
+                "--trusted-host myurl.org kfp '--no-deps' 'typing-extensions>=3.7.4,<5; "
+                'python_version<"3.9"\' && "$0" "$@"\n'
+            ]))
+
+    def test_make_index_url_options(self):
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=None, pip_trusted_hosts=None), '')
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=[], pip_trusted_hosts=[]), '')
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=['https://pypi.org/simple'],
+                pip_trusted_hosts=None),
+            '--index-url https://pypi.org/simple ')
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=None, pip_trusted_hosts=['pypi.org']),
+            '--trusted-host pypi.org ')
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=['https://pypi.org/simple', 'https://extra.org/simple'],
+                pip_trusted_hosts=['pypi.org', 'extra.org']),
+            '--index-url https://pypi.org/simple --extra-index-url https://extra.org/simple --trusted-host pypi.org --trusted-host extra.org '
+        )
+
 
 class TestInvalidParameterName(unittest.TestCase):
 


### PR DESCRIPTION
**Description of your changes:**
Fixes a bug in `make_index_url_options` (`sdk/python/kfp/dsl/component_factory.py`) where `pip_trusted_hosts` was silently ignored if `pip_index_urls` was `None` or empty due to an early `return ''` check.

With this change:
- `pip_index_urls` and `pip_trusted_hosts` are evaluated independently so `--trusted-host` flags are generated whenever `pip_trusted_hosts` is specified.
- Unit tests added in `component_factory_test.py` covering all combinations of index URLs and trusted hosts.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
