### PR TITLE
fix(backend): validate pipeline ownership in GetPipelineVersion

### DIFF
--- a/backend/src/apiserver/server/pipeline_server.go
+++ b/backend/src/apiserver/server/pipeline_server.go
@@ -966,6 +966,9 @@ func (s *PipelineServer) GetPipelineVersion(ctx context.Context, request *apiv2b
 	if err != nil {
 		return nil, util.Wrapf(err, "Failed to get a pipeline version %s", request.GetPipelineVersionId())
 	}
+	if pipelineVersion.PipelineId != request.GetPipelineId() {
+		return nil, util.NewInvalidInputError("Pipeline version %v belongs to pipeline %v (not %v)", request.GetPipelineVersionId(), pipelineVersion.PipelineId, request.GetPipelineId())
+	}
 	return toApiPipelineVersion(pipelineVersion), nil
 }
 

--- a/backend/src/apiserver/server/pipeline_server_test.go
+++ b/backend/src/apiserver/server/pipeline_server_test.go
@@ -982,6 +982,63 @@ func TestPipelineServer_CreatePipelineAndVersion_v2(t *testing.T) {
 	}
 }
 
+func TestGetPipelineVersion_RejectsMismatchedPipelineID(t *testing.T) {
+	httpServer := getMockServer(t)
+	defer httpServer.Close()
+
+	clientManager := resource.NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	resourceManager := resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+	pipelineServer := createPipelineServer(resourceManager, httpServer.Client())
+
+	pipelineA, err := pipelineServer.CreatePipelineAndVersion(context.Background(), &apiv2.CreatePipelineAndVersionRequest{
+		Pipeline: &apiv2.Pipeline{
+			DisplayName: "pipeline-a",
+			Description: "first pipeline",
+		},
+		PipelineVersion: &apiv2.PipelineVersion{
+			PackageUrl: &apiv2.Url{
+				PipelineUrl: httpServer.URL + "/arguments-parameters.yaml",
+			},
+		},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, pipelineA)
+	assert.Equal(t, DefaultFakeUUID, pipelineA.GetPipelineId())
+
+	versionA, err := resourceManager.GetLatestPipelineVersion(DefaultFakeUUID)
+	assert.Nil(t, err)
+	assert.Equal(t, DefaultFakeUUID, versionA.UUID)
+	assert.Equal(t, DefaultFakeUUID, versionA.PipelineId)
+
+	clientManager.UpdateUUID(util.NewFakeUUIDGeneratorOrFatal(NonDefaultFakeUUID, nil))
+	resourceManager = resource.NewResourceManager(clientManager, &resource.ResourceManagerOptions{CollectMetrics: false})
+	pipelineServer = createPipelineServer(resourceManager, httpServer.Client())
+
+	pipelineB, err := pipelineServer.CreatePipelineAndVersion(context.Background(), &apiv2.CreatePipelineAndVersionRequest{
+		Pipeline: &apiv2.Pipeline{
+			DisplayName: "pipeline-b",
+			Description: "second pipeline",
+		},
+		PipelineVersion: &apiv2.PipelineVersion{
+			PackageUrl: &apiv2.Url{
+				PipelineUrl: httpServer.URL + "/arguments-parameters.yaml",
+			},
+		},
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, pipelineB)
+	assert.Equal(t, NonDefaultFakeUUID, pipelineB.GetPipelineId())
+
+	_, err = pipelineServer.GetPipelineVersion(context.Background(), &apiv2.GetPipelineVersionRequest{
+		PipelineId:        NonDefaultFakeUUID,
+		PipelineVersionId: versionA.UUID,
+	})
+	if !assert.NotNil(t, err, "GetPipelineVersion should reject a version that belongs to a different pipeline") {
+		return
+	}
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+}
+
 func TestRecoverClearTagsIntent(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/backend/test/v2/api/pipeline_api_test.go
+++ b/backend/test/v2/api/pipeline_api_test.go
@@ -1623,7 +1623,7 @@ var _ = Describe("Get Pipeline Version API Tests >", Label(constants.POSITIVE, c
 			Expect(retrievedVersion.Tags).To(Equal(versionTags), "Tags should match what was set during creation")
 		})
 
-		It("Returns version even when pipeline ID in URL does not match the version's pipeline", func() {
+		It("Rejects request when pipeline ID in URL does not match the version's pipeline", func() {
 			pipelineDir := "valid"
 			pipelineSpecFilePath := filepath.Join(pipelineFilesRootDir, pipelineDir, helloWorldPipelineFileName)
 
@@ -1640,14 +1640,11 @@ var _ = Describe("Get Pipeline Version API Tests >", Label(constants.POSITIVE, c
 			Expect(err).NotTo(HaveOccurred(), "Failed to list pipeline versions for pipeline1")
 			Expect(versionsList).Should(HaveLen(1))
 
-			// NOTE: The server does not validate that the version belongs to the specified pipeline.
-			retrievedVersion, err := pipelineClient.GetPipelineVersion(&pipeline_params.PipelineServiceGetPipelineVersionParams{
+			_, err = pipelineClient.GetPipelineVersion(&pipeline_params.PipelineServiceGetPipelineVersionParams{
 				PipelineID:        pipeline2.PipelineID,
 				PipelineVersionID: versionsList[0].PipelineVersionID,
 			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(retrievedVersion.PipelineID).To(Equal(pipeline1.PipelineID))
-			_ = pipeline2
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
@@ -2052,8 +2049,26 @@ var _ = Describe("Verify Pipeline Negative Tests >", Label("Negative", constants
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("By valid version ID but with the pipeline ID that does not contain this version should ideally fail", func() {
-			Skip("Server does not currently validate pipeline ownership for GetPipelineVersion")
+		It("By valid version ID but with the pipeline ID that does not contain this version", func() {
+			pipelineDir := "valid"
+			pipelineSpecFilePath := filepath.Join(pipelineFilesRootDir, pipelineDir, helloWorldPipelineFileName)
+
+			name1 := testContext.Pipeline.PipelineGeneratedName + "-1"
+			pipeline1 := uploadPipelineAndVerify(pipelineSpecFilePath, &name1, nil)
+			name2 := testContext.Pipeline.PipelineGeneratedName + "-2"
+			pipeline2 := uploadPipelineAndVerify(pipelineSpecFilePath, &name2, nil)
+
+			versionsList, _, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+				PipelineID: pipeline1.PipelineID,
+			})
+			Expect(err).NotTo(HaveOccurred(), "Failed to list pipeline versions for pipeline1")
+			Expect(versionsList).Should(HaveLen(1))
+
+			_, err = pipelineClient.GetPipelineVersion(&pipeline_params.PipelineServiceGetPipelineVersionParams{
+				PipelineID:        pipeline2.PipelineID,
+				PipelineVersionID: versionsList[0].PipelineVersionID,
+			})
+			Expect(err).To(HaveOccurred())
 		})
 
 		if *config.KubeflowMode {

--- a/backend/test/v2/integration/run_api_test.go
+++ b/backend/test/v2/integration/run_api_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -335,16 +336,25 @@ func (s *RunAPITestSuite) TestRunAPIs() {
 	}}
 	longRunningRun, err := s.runClient.Create(createLongRunningRunRequest)
 	assert.Nil(t, err)
+	longRunningRunID := longRunningRun.RunID
 
 	/* ---------- Terminate the long-running run ------------*/
 	err = s.runClient.Terminate(&run_params.RunServiceTerminateRunParams{
-		RunID: longRunningRun.RunID,
+		RunID: longRunningRunID,
 	})
 	assert.Nil(t, err)
 
 	/* ---------- Get long-running run ---------- */
-	longRunningRun, err = s.runClient.Get(&run_params.RunServiceGetRunParams{RunID: longRunningRun.RunID})
-	assert.Nil(t, err)
+	var getRunErr error
+	require.Eventually(t, func() bool {
+		longRunningRun, getRunErr = s.runClient.Get(&run_params.RunServiceGetRunParams{RunID: longRunningRunID})
+		if getRunErr != nil || longRunningRun == nil || longRunningRun.State == nil {
+			return false
+		}
+		return *longRunningRun.State == run_model.V2beta1RuntimeStateCANCELING ||
+			*longRunningRun.State == run_model.V2beta1RuntimeStateCANCELED
+	}, time.Minute, time.Second, "terminated run should become CANCELING or CANCELED")
+	require.NoError(t, getRunErr)
 	s.checkTerminatedRunDetail(t, longRunningRun, helloWorldExperiment.ExperimentID, longRunningPipelineVersion.PipelineID, longRunningPipelineVersion.PipelineVersionID)
 }
 


### PR DESCRIPTION
Reject requests when the pipeline_id in the URL does not match the version's owning pipeline.

**Description of your changes:**

`GetPipelineVersion` looked up a pipeline version by version id only and ignored the `pipeline_id` in the URL path. A client could pass another pipeline's id and still get the version back.

This change compares the fetched version's `PipelineId` with the `pipeline_id` from the request. If they do not match, the handler returns an invalid argument error, using the same message pattern as run creation in `resource_manager.go`.

Added `TestGetPipelineVersion_RejectsMismatchedPipelineID` to cover the mismatch case.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

Fixes #13808
