### PR TITLE
fix(deps): patch pyasn1 Python locks

### DIFF
--- a/backend/src/apiserver/visualization/requirements.txt
+++ b/backend/src/apiserver/visualization/requirements.txt
@@ -222,7 +222,7 @@ pure-eval==0.2.3
     # via stack-data
 pyarrow==14.0.1
     # via -r requirements.in
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   pyasn1-modules
     #   rsa

--- a/kubernetes_platform/python/requirements.txt
+++ b/kubernetes_platform/python/requirements.txt
@@ -63,7 +63,7 @@ protobuf==6.33.5
     #   kfp
     #   kfp-pipeline-spec
     #   proto-plus
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   pyasn1-modules
     #   rsa

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -60,7 +60,7 @@ protobuf==6.33.5
     #   googleapis-common-protos
     #   kfp-pipeline-spec
     #   proto-plus
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   pyasn1-modules
     #   rsa


### PR DESCRIPTION
## Summary

- update `pyasn1` from 0.6.3 to 0.6.4 in the SDK, `kfp-kubernetes`, and visualization lockfiles
- preserve the Python 3.9-specific `requests` and `urllib3` dependency branches
- leave all other resolved dependencies unchanged

This replaces #13776, whose generated lockfile diff removed the supported
Python 3.9 branches. The backend and metadata-writer lockfiles are covered
separately by #13778.

## Verification

- confirmed the diff is exactly three pin changes: 3 insertions and 3 deletions
- confirmed the Python 3.9 `requests` and `urllib3` entries remain unchanged
- `git diff --check origin/master...HEAD`
