### PR TITLE
fix(sdk): raise clean error instead of crashing when pipeline input is returned as output

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -5136,6 +5136,16 @@ class TestCannotReturnFromWithinControlFlowGroup(unittest.TestCase):
                 with dsl.ExitHandler(print_and_return(text='exit task')):
                     return print_and_return(text=string).output
 
+    def test_pipeline_input_param_as_output_raises_clean_error(self):
+        """Returning a pipeline input parameter as an output should raise
+        InvalidTopologyException, not crash with AttributeError."""
+        with self.assertRaises(compiler_utils.InvalidTopologyException):
+
+            @dsl.pipeline
+            def my_pipeline(x: str) -> str:
+                task = print_and_return(text='hello')
+                return x
+
 
 class TestConditionLogic(unittest.TestCase):
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -16,8 +16,7 @@
 import copy
 import json
 import typing
-from typing import (Any, DefaultDict, Dict, List, Mapping, Optional, Tuple,
-                    Union)
+from typing import Any, DefaultDict, Dict, List, Mapping, Optional, Tuple, Union
 import warnings
 
 from google.protobuf import json_format
@@ -2033,6 +2032,10 @@ def validate_pipeline_outputs_dict(
                 )
 
         elif isinstance(channel, pipeline_channel.PipelineChannel):
+            if channel.task is None:
+                raise compiler_utils.InvalidTopologyException(
+                    'Pipeline outputs must be the output of a task, not a pipeline input parameter.'
+                )
             if channel.task.parent_task_group.group_type != tasks_group.TasksGroupType.PIPELINE:
                 raise compiler_utils.InvalidTopologyException(
                     f'Pipeline outputs may only be returned from the top level of the pipeline function scope. Got pipeline output from within the control flow group dsl.{channel.task.parent_task_group.__class__.__name__}.'


### PR DESCRIPTION
**Description of your changes:**

Fixes one half of the TODO at `pipeline_spec_builder.py:2079`.

When a pipeline input parameter is returned alongside a task output,
`channel.task` is `None` because pipeline inputs have no `task_name`.
The existing code called `.parent_task_group` on `None`, causing an
`AttributeError` crash instead of a useful error message.

This PR adds an explicit `InvalidTopologyException` check when
`channel.task` is `None`, with a clear message that pipeline outputs
must come from a task, not a pipeline input parameter.

Also added `test_pipeline_input_param_as_output_raises_clean_error`
to `TestCannotReturnFromWithinControlFlowGroup`.

**Checklist:**
- [x] You have signed off your commits
- [x] The title for your pull request (PR) should follow our title convention.

Part of #13817