### PR TITLE
fix(sdk): use short in-cluster service DNS name for KFP client. Fixes #13337

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -128,7 +128,7 @@ class Client:
     """
 
     # in-cluster DNS name of the pipeline service
-    _IN_CLUSTER_DNS_NAME = 'ml-pipeline.{}.svc.cluster.local:8888'
+    _IN_CLUSTER_DNS_NAME = 'ml-pipeline.{}.svc:8888'
     _KUBE_PROXY_PATH = 'api/v1/namespaces/{}/services/ml-pipeline:http/proxy/'
 
     # Auto populated path in pods

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -548,5 +548,30 @@ class TestClient(parameterized.TestCase):
             self.assertEqual(result, expected_result)
 
 
+class TestInClusterDnsName(unittest.TestCase):
+
+    @patch.object(client.Client, '_get_config_with_default_credentials')
+    @patch('kubernetes.config.load_incluster_config')
+    def test_load_config_uses_short_cluster_dns_name(self, mock_incluster,
+                                                     mock_get_creds):
+        mock_get_creds.side_effect = lambda cfg: cfg
+        kfp_client = client.Client.__new__(client.Client)
+        config = kfp_client._load_config(
+            host=None,
+            client_id=None,
+            namespace='kubeflow',
+            other_client_id=None,
+            other_client_secret=None,
+            existing_token=None,
+            proxy=None,
+            ssl_ca_cert=None,
+            kube_context=None,
+            credentials=None,
+            verify_ssl=None,
+        )
+        self.assertEqual(config.host, 'ml-pipeline.kubeflow.svc:8888')
+        mock_incluster.assert_called_once()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of your changes:**

- Change `Client._IN_CLUSTER_DNS_NAME` from `ml-pipeline.{}.svc.cluster.local:8888` to `ml-pipeline.{}.svc:8888`
- Add `TestInClusterDnsName` unit test verifying in-cluster config loading uses the short DNS form

When running inside a Kubernetes cluster, the KFP Python client auto-detects in-cluster mode and connects via the pipeline service DNS name. Using the hardcoded `cluster.local` suffix breaks on clusters with a custom cluster domain. The shorter `svc` form is resolved correctly via Kubernetes DNS search paths.

Fixes #13337

**Local testing:**

```bash
yapf --in-place sdk/python/kfp/client/client.py sdk/python/kfp/client/client_test.py
isort sdk/python/kfp/client/client.py sdk/python/kfp/client/client_test.py
pytest sdk/python/kfp/client/client_test.py::TestInClusterDnsName -v
pytest sdk/python/kfp/client/ -q
```

Results:
- `TestInClusterDnsName`: 1 passed
- `sdk/python/kfp/client/`: 64 passed

**Cluster E2E testing (Kind / `dev-pipelines-api`):**

- In-cluster pod curled `http://ml-pipeline.kubeflow.svc:8888/apis/v2beta1/healthz` successfully
- In-cluster pod installed this branch and verified:
  - `Client._IN_CLUSTER_DNS_NAME == 'ml-pipeline.{}.svc:8888'`
  - `_load_config()` selects `ml-pipeline.kubeflow.svc:8888`
  - Live healthz call via short DNS name succeeded

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).