### PR TITLE
fix(sdk): compile container components with parameterized image. Fixes #10657

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -2105,6 +2105,36 @@ class TestBooleanInputCompiledCorrectly(unittest.TestCase):
             pipeline_spec.root.input_definitions.parameters['boolean']
             .default_value.bool_value, True)
 
+    def test_container_component_with_parameter_image(self):
+
+        @dsl.container_component
+        def say_hello(image_uri: str):
+            return dsl.ContainerSpec(
+                image=image_uri,
+                command=['echo'],
+                args=['Hello'],
+            )
+
+        @dsl.pipeline
+        def hello_pipeline(image_uri: str):
+            say_hello(image_uri=image_uri)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pipeline_spec_path = os.path.join(tmpdir, 'output.yaml')
+            compiler.Compiler().compile(
+                pipeline_func=hello_pipeline,
+                package_path=pipeline_spec_path,
+            )
+            with open(pipeline_spec_path, 'r') as f:
+                pipeline_spec = yaml.safe_load(f)
+
+        executor = next(
+            iter(pipeline_spec['deploymentSpec']['executors'].values()))
+        self.assertEqual(
+            executor['container']['image'],
+            "{{$.inputs.parameters['image_uri']}}",
+        )
+
     def test_pipeline_no_input(self):
 
         @dsl.component

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -331,6 +331,9 @@ class PipelineTask:
             raise ValueError(
                 '_extract_container_spec_and_convert_placeholders used incorrectly. ComponentSpec.implementation.container is None.'
             )
+        container_spec.image = (
+            placeholders.convert_command_line_element_to_string(
+                container_spec.image))
         container_spec.command = [
             placeholders.convert_command_line_element_to_string(e)
             for e in container_spec.command or []


### PR DESCRIPTION
**Description of your changes:**

- Convert `container_spec.image` placeholders to strings in `PipelineTask._extract_container_spec_and_convert_placeholders`, consistent with how `command` and `args` are already handled
- Add `test_container_component_with_parameter_image` compiler unit test for `@container_component` pipelines that pass a parameter as the container image

When a `@container_component` uses a parameterized image (e.g. `image=image_uri`), the image field remained an `InputValuePlaceholder` object at compile time. Protobuf serialization then failed with `TypeError: bad argument type for built-in operation`.

Fixes #10657

**Local testing:**

```bash
yapf --in-place sdk/python/kfp/dsl/pipeline_task.py sdk/python/kfp/compiler/compiler_test.py
isort sdk/python/kfp/dsl/pipeline_task.py sdk/python/kfp/compiler/compiler_test.py
pytest sdk/python/kfp/compiler/compiler_test.py::TestBooleanInputCompiledCorrectly::test_container_component_with_parameter_image -v
pytest sdk/python/kfp/dsl/pipeline_task_test.py -q
pytest sdk/python/kfp/compiler/ -q
```

Results:
- `test_container_component_with_parameter_image`: 1 passed
- `sdk/python/kfp/dsl/pipeline_task_test.py`: 55 passed
- `sdk/python/kfp/compiler/`: 292 passed

**Cluster E2E testing (Kind / `dev-pipelines-api`):**

- Compiled pipeline with parameterized `image_uri` using this branch
- Submitted run `e2e-parameterized-image-run` to live KFP API (`image_uri=alpine:3.20`)
- Compiled spec contained `image: "{{$.inputs.parameters['image_uri']}}"`
- Run `3c43b347-37b2-4652-a917-5d88d882305e` reached **`SUCCEEDED`**

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).