### PR TITLE
fix(sdk): detect cyclic dependencies in local topological_sort. Fixes #12675

### DIFF
--- a/sdk/python/kfp/local/graph_utils.py
+++ b/sdk/python/kfp/local/graph_utils.py
@@ -62,22 +62,30 @@ def topological_sort(dependency_map: Dict[str, List[str]]) -> List[str]:
         A totally ordered stack of tasks. Tasks should be executed in the order they are popped off the right side of the stack.
     """
 
+    visiting: Set[str] = set()
+    visited: Set[str] = set()
+    result = []
+
     def dfs(node: str) -> None:
-        visited.add(node)
+        if node in visiting:
+            raise ValueError(
+                f'Cyclic task dependency detected involving task {node!r}.')
+        if node in visited:
+            return
+        visiting.add(node)
         for neighbor in dependency_map[node]:
             if neighbor not in dependency_map:
                 # Neighbor is outside the subset being sorted (e.g., an exit
                 # task filtered from the body pass). Skip it here — the caller
                 # is responsible for sequencing cross-subset dependencies.
                 continue
-            if neighbor not in visited:
-                dfs(neighbor)
+            dfs(neighbor)
+        visiting.remove(node)
+        visited.add(node)
         result.append(node)
 
     # sort lists to force deterministic result
     dependency_map = {k: sorted(v) for k, v in dependency_map.items()}
-    visited: Set[str] = set()
-    result = []
     for node in dependency_map:
         if node not in visited:
             dfs(node)

--- a/sdk/python/kfp/local/graph_utils_test.py
+++ b/sdk/python/kfp/local/graph_utils_test.py
@@ -70,6 +70,22 @@ class TestTopologicalSort(unittest.TestCase):
         expected = ['A', 'C', 'B', 'D']
         self.assertEqual(actual, expected)
 
+    def test_cyclic_dependency_raises(self):
+        graph = {'A': ['B'], 'B': ['A']}
+        with self.assertRaisesRegex(
+                ValueError,
+                "Cyclic task dependency detected involving task 'A'",
+        ):
+            graph_utils.topological_sort(graph)
+
+    def test_self_cycle_raises(self):
+        graph = {'A': ['A']}
+        with self.assertRaisesRegex(
+                ValueError,
+                "Cyclic task dependency detected involving task 'A'",
+        ):
+            graph_utils.topological_sort(graph)
+
 
 class TestTopologicalSortTasks(unittest.TestCase):
 


### PR DESCRIPTION
**Description of your changes:**

- Detect cycles during DFS in `graph_utils.topological_sort` and raise `ValueError` with a clear message
- Add unit tests for two-node and self cycles

Previously, cyclic dependency graphs such as `{'A': ['B'], 'B': ['A']}` returned a misleading ordering instead of failing fast during local pipeline execution.

Fixes #12675

**Local testing:**

```bash
yapf --in-place sdk/python/kfp/local/graph_utils.py sdk/python/kfp/local/graph_utils_test.py
isort sdk/python/kfp/local/graph_utils.py sdk/python/kfp/local/graph_utils_test.py
pytest sdk/python/kfp/local/graph_utils_test.py -v
```

Results:
- `sdk/python/kfp/local/graph_utils_test.py`: 10 passed

**Local runner E2E testing:**

- Ran a pipeline with cyclic task dependencies (`task_a.after(task_b)` and `task_b.after(task_a)`) via `SubprocessRunner`
- Local execution failed fast with:
  `ValueError: Cyclic task dependency detected involving task 'task-b'.`

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).