### PR TITLE
fix(sdk): validate pipeline input returned as pipeline output. Fixes #13817

### DIFF
--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -5136,6 +5136,22 @@ class TestCannotReturnFromWithinControlFlowGroup(unittest.TestCase):
                 with dsl.ExitHandler(print_and_return(text='exit task')):
                     return print_and_return(text=string).output
 
+    def test_pipeline_input_parameter_raises(self):
+
+        with self.assertRaisesRegex(
+                compiler_utils.InvalidTopologyException,
+                'Pipeline outputs must be produced by a task, not a pipeline input parameter.'
+        ):
+
+            @dsl.component
+            def identity(x: str) -> str:
+                return x
+
+            @dsl.pipeline
+            def my_pipeline(x: str) -> str:
+                identity(x='hello')
+                return x
+
 
 class TestConditionLogic(unittest.TestCase):
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -16,8 +16,7 @@
 import copy
 import json
 import typing
-from typing import (Any, DefaultDict, Dict, List, Mapping, Optional, Tuple,
-                    Union)
+from typing import Any, DefaultDict, Dict, List, Mapping, Optional, Tuple, Union
 import warnings
 
 from google.protobuf import json_format
@@ -2033,6 +2032,10 @@ def validate_pipeline_outputs_dict(
                 )
 
         elif isinstance(channel, pipeline_channel.PipelineChannel):
+            if channel.task is None:
+                raise compiler_utils.InvalidTopologyException(
+                    'Pipeline outputs must be produced by a task, not a pipeline input parameter.'
+                )
             if channel.task.parent_task_group.group_type != tasks_group.TasksGroupType.PIPELINE:
                 raise compiler_utils.InvalidTopologyException(
                     f'Pipeline outputs may only be returned from the top level of the pipeline function scope. Got pipeline output from within the control flow group dsl.{channel.task.parent_task_group.__class__.__name__}.'


### PR DESCRIPTION
**Description of your changes:**

- Raise `InvalidTopologyException` when a pipeline input parameter is returned as a pipeline output
- Add compiler unit test for the regression

Previously, returning a pipeline input parameter from a pipeline function crashed during compilation with `AttributeError: 'NoneType' object has no attribute 'parent_task_group'` because `channel.task` is `None` for pipeline inputs.

Fixes #13817

**Local testing:**

```bash
yapf --in-place sdk/python/kfp/compiler/pipeline_spec_builder.py sdk/python/kfp/compiler/compiler_test.py
isort sdk/python/kfp/compiler/pipeline_spec_builder.py sdk/python/kfp/compiler/compiler_test.py
pytest sdk/python/kfp/compiler/compiler_test.py::TestCannotReturnFromWithinControlFlowGroup::test_pipeline_input_parameter_raises -v
pytest sdk/python/kfp/compiler/compiler_test.py::TestCannotReturnFromWithinControlFlowGroup -q
```

Results:
- `test_pipeline_input_parameter_raises`: 1 passed
- `TestCannotReturnFromWithinControlFlowGroup`: 4 passed

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).