### PR TITLE
chore(deps): enable repository-wide Docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 # Dependabot configuration for scheduled version updates.
 #
-# Scope: Go modules (`gomod`) only. This makes Go dependency bumps explicit and
-# deterministic across every Go module in the repo, rather than relying on the
-# implicit/security-only behavior that previously left some advisories (e.g.
-# golang.org/x/net) unactioned.
+# Scope: Go modules (`gomod`) and repository-wide container image references.
+# This makes dependency bumps explicit and deterministic across every Go module,
+# Dockerfile/Containerfile, and Kubernetes manifest in the repo, rather than
+# relying on implicit/security-only behavior.
 #
 # Note: Dependabot security updates are enabled separately (in repo settings),
 # not by this file. This file does not turn them on or off, though they still
@@ -39,3 +39,19 @@ updates:
         update-types:
           - "minor"
           - "patch"
+  - package-ecosystem: docker
+    # Dependabot's Docker ecosystem also updates image references in Kubernetes
+    # manifests. The recursive glob covers the repository root and every nested
+    # directory, including custom-named Dockerfiles.
+    directories:
+      - "**/*"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Update the same image in one PR when it is referenced from multiple
+      # Dockerfiles or Kubernetes manifests.
+      docker-images:
+        group-by: dependency-name

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-23
+- Last updated: 2026-07-24
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -530,6 +530,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 ## CI/CD (GitHub Actions)
 
 - Workflows: `.github/workflows/` (build, test, lint, release)
+- `.github/dependabot.yml` schedules weekly Go module updates and repository-wide Docker ecosystem updates. Docker coverage recursively includes Dockerfiles, Containerfiles, and Kubernetes manifest image references, grouping each image's updates across directories.
 - `ci-health-report.yml` runs daily (and on dispatch): aggregates master-branch lane failure rates and per-test flake counts from `junit-xml - *` artifacts, publishing to the job summary and a tracking issue labeled `ci-health`.
 - `ci-scripts-tests.yml` runs the stdlib unit tests for CI tooling, diagnostics, and meta-workflow concurrency on PRs touching `.github/resources/scripts/*.py`, `.github/resources/scripts/*.sh`, `ci-checks.yml`, `gh-workflow-approve.yml`, the create-cluster action, the scoped curl retry configuration, or the test workflow itself (run locally with `cd .github/resources/scripts && python3 -m unittest discover -v -p '*_test.py'`).
 - The `CI Check` and `Approve Workflow Runs` meta-workflows filter unrelated label events before entering per-PR job concurrency. Only `synchronize` events cancel an active run, so Dependabot/Prow label bursts do not leave cancelled checks on the current head SHA.


### PR DESCRIPTION
## Summary

- enable weekly Dependabot updates for Docker image references in every repository directory
- include Dockerfiles, Containerfiles, and Kubernetes manifests through the Docker ecosystem
- group each image's updates across directories into a single pull request
- document the repository-wide dependency update coverage

## Why

The existing Dependabot configuration only schedules Go module updates. A root-only Docker configuration would not discover nested manifests, so this uses the supported recursive `**/*` directory glob. Grouping by dependency name keeps repeated image references synchronized without opening a separate pull request for every directory.

Related to #13449 and #13490.

## Verification

- parsed `.github/dependabot.yml` with Ruby's YAML parser
- asserted the Docker ecosystem uses `directories: ["**/*"]`
- asserted cross-directory grouping uses `group-by: dependency-name`
- confirmed the repository contains 24 Dockerfile/Containerfile-style files
- ran `git diff --check`
