### PR TITLE
fix(backend): use cluster default StorageClass for CreatePVC. Fixes #11396

### DIFF
--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -972,15 +972,7 @@ func createPVC(
 		return "", createdExecution, pb.Execution_FAILED, fmt.Errorf("failed to create pvc: parameter volumeSize not provided")
 	}
 
-	// Optional input: storage_class_name
-	// When not provided, use default value `standard`
-	storageClassNameInput, ok := inputs.ParameterValues["storage_class_name"]
-	var storageClassName string
-	if !ok {
-		storageClassName = "standard"
-	} else {
-		storageClassName = storageClassNameInput.GetStringValue()
-	}
+	storageClassName := pvcStorageClassNameFromInputs(inputs)
 
 	// Optional input: annotations
 	pvcAnnotations := make(map[string]string)
@@ -1067,7 +1059,7 @@ func createPVC(
 					k8score.ResourceStorage: k8sres.MustParse(volumeSizeInput.GetStringValue()),
 				},
 			},
-			StorageClassName: &storageClassName,
+			StorageClassName: storageClassName,
 			VolumeName:       volumeName,
 			DataSource:       dataSource,
 		},
@@ -1089,6 +1081,17 @@ func createPVC(
 	}
 
 	return createdPVC.ObjectMeta.Name, createdExecution, pb.Execution_COMPLETE, nil
+}
+
+// pvcStorageClassNameFromInputs returns the StorageClassName for a PVC based on
+// executor inputs. When storage_class_name is omitted, returns nil so
+// Kubernetes applies the cluster default StorageClass.
+func pvcStorageClassNameFromInputs(inputs *pipelinespec.ExecutorInput_Inputs) *string {
+	if storageClassNameInput, ok := inputs.ParameterValues["storage_class_name"]; ok {
+		sc := storageClassNameInput.GetStringValue()
+		return &sc
+	}
+	return nil
 }
 
 // buildPVCDataSource converts a protobuf Value representing a PVC data source

--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -3356,6 +3356,56 @@ func Test_extendPodSpecPatch_PvcMounts_Passthrough_AppliedToPod(t *testing.T) {
 	assert.NotEmpty(t, taskCfg.VolumeMounts)
 }
 
+func Test_pvcStorageClassNameFromInputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputs   *pipelinespec.ExecutorInput_Inputs
+		wantNil  bool
+		wantName string
+	}{
+		{
+			name: "storage_class_name not provided uses cluster default",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"size": structpb.NewStringValue("5Gi"),
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "explicit storage_class_name is preserved",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"storage_class_name": structpb.NewStringValue("gp2"),
+				},
+			},
+			wantName: "gp2",
+		},
+		{
+			name: "empty storage_class_name is preserved for static PVCs",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"storage_class_name": structpb.NewStringValue(""),
+				},
+			},
+			wantName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pvcStorageClassNameFromInputs(tt.inputs)
+			if tt.wantNil {
+				assert.Nil(t, got)
+				return
+			}
+			if assert.NotNil(t, got) {
+				assert.Equal(t, tt.wantName, *got)
+			}
+		})
+	}
+}
+
 func Test_buildPVCDataSource(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
**Description of your changes:**

When `kfp.kubernetes.CreatePVC` is called without `storage_class_name`, the compiled pipeline does not pass that parameter to the driver. The v2 driver previously defaulted missing `storage_class_name` to the hardcoded value `"standard"`, which breaks clusters whose default StorageClass is not named `standard`.

This change omits `PersistentVolumeClaim.spec.storageClassName` when `storage_class_name` is absent from executor inputs, allowing Kubernetes to apply the cluster default StorageClass. Explicit values (including empty string for static PVCs) are preserved.

**Root cause:** `createPVC` in `backend/src/v2/driver/k8s.go` used `storageClassName = "standard"` when the `storage_class_name` parameter was missing.

**Regression test:** `Test_pvcStorageClassNameFromInputs` covers missing, explicit, and empty-string `storage_class_name` inputs.

**Tests run:**
```bash
cd backend/src/v2/driver && go test -run 'Test_pvcStorageClassNameFromInputs|Test_buildPVCDataSource' -count=1
# PASS (3 subtests in Test_pvcStorageClassNameFromInputs)
```

Cluster E2E was not run; this is a driver input-to-PVC-spec mapping fix covered by unit tests.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention.