### PR TITLE
fix(backend): use request context instead of context.TODO() in driver k8s calls

### DIFF
--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -1084,13 +1084,13 @@ func deletePVC(
 	}
 
 	// Get the PVC you want to delete, verify that it exists.
-	_, err = k8sClient.CoreV1().PersistentVolumeClaims(opts.Namespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
+	_, err = k8sClient.CoreV1().PersistentVolumeClaims(opts.Namespace).Get(ctx, pvcName, metav1.GetOptions{})
 	if err != nil {
 		return createdExecution, pb.Execution_FAILED, fmt.Errorf("failed to delete pvc %s: cannot find pvc: %v", pvcName, err)
 	}
 
 	// Delete the PVC.
-	err = k8sClient.CoreV1().PersistentVolumeClaims(opts.Namespace).Delete(context.TODO(), pvcName, metav1.DeleteOptions{})
+	err = k8sClient.CoreV1().PersistentVolumeClaims(opts.Namespace).Delete(ctx, pvcName, metav1.DeleteOptions{})
 	if err != nil {
 		return createdExecution, pb.Execution_FAILED, fmt.Errorf("failed to delete pvc %s: %v", pvcName, err)
 	}
@@ -1195,7 +1195,7 @@ func publishDriverExecution(
 		return fmt.Errorf("error getting pod name: %w", err)
 	}
 
-	pod, err := k8sClient.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	pod, err := k8sClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error retrieving info for pod %s: %w", podName, err)
 	}


### PR DESCRIPTION
**Description of your changes:**

deletePVC and publishDriverExecution both already receive ctx as a parameter and use it elsewhere in the same function, but their PVC Get/Delete and Pod Get calls used context.TODO() instead, so those specific calls could never be canceled or bounded by a timeout along with the rest of the request. Replaced context.TODO() with the already-available ctx at all three call sites.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).