### PR TITLE
fix(backend): return permanent error when token refresh fails in ReportRunMetrics

### DIFF
--- a/backend/src/agent/persistence/client/pipeline_client.go
+++ b/backend/src/agent/persistence/client/pipeline_client.go
@@ -209,7 +209,10 @@ func (p *PipelineClient) ReportRunMetrics(request *api.ReportRunMetricsRequest) 
 		statusCode, _ := status.FromError(err)
 		if statusCode.Code() == codes.Unauthenticated && strings.Contains(err.Error(), "service account token has expired") {
 			// If unauthenticated because SA token is expired, re-read/refresh the token and try again
-			p.tokenRefresher.RefreshToken()
+			if refreshErr := p.tokenRefresher.RefreshToken(); refreshErr != nil {
+				return nil, util.NewCustomError(refreshErr, util.CUSTOM_CODE_PERMANENT,
+					"Failed to refresh token: %v", refreshErr.Error())
+			}
 			return nil, util.NewCustomError(err, util.CUSTOM_CODE_TRANSIENT,
 				"Error while reporting workflow resource (code: %v, message: %v): %v",
 				statusCode.Code(),


### PR DESCRIPTION
## Summary

`ReportRunMetrics` discards the return value of `p.tokenRefresher.RefreshToken()`:

```go
if statusCode.Code() == codes.Unauthenticated && strings.Contains(err.Error(), "service account token has expired") {
    // If unauthenticated because SA token is expired, re-read/refresh the token and try again
    p.tokenRefresher.RefreshToken()
    return nil, util.NewCustomError(err, util.CUSTOM_CODE_TRANSIENT, ...)
}
```

Its two sibling methods in the same file, `ReportWorkflow` and `ReportScheduledWorkflow`, both check the refresh error and return `CUSTOM_CODE_PERMANENT` if it fails, since a broken token refresh (e.g. missing/unreadable service account token file) isn't something retrying will ever fix:

```go
if refreshErr := p.tokenRefresher.RefreshToken(); refreshErr != nil {
    return util.NewCustomError(refreshErr, util.CUSTOM_CODE_PERMANENT, "Failed to refresh token: %v", refreshErr.Error())
}
```

`ReportRunMetrics` is the odd one out: it always returns `CUSTOM_CODE_TRANSIENT` regardless of whether the refresh itself succeeded, so a persistently broken token refresh makes the persistence worker retry this call forever with backoff instead of giving up.

## Fix

Mirror the existing pattern from `ReportWorkflow`/`ReportScheduledWorkflow`.

## Test plan

- `go build ./backend/src/agent/persistence/...` passes.
- `go test ./backend/src/agent/persistence/...` passes.
- No test file exists for `pipeline_client.go` currently (`ReportWorkflow`/`ReportScheduledWorkflow`/`ReportRunMetrics` have no direct unit tests today), so no new test was added; this change mirrors already-established, untested sibling logic in the same file.