### PR TITLE
fix(frontend): prevent experiment change from clearing create run form fields. Fixes #11856

### DIFF
--- a/frontend/src/pages/NewRunSwitcher.tsx
+++ b/frontend/src/pages/NewRunSwitcher.tsx
@@ -160,7 +160,6 @@ function NewRunSwitcher(props: PageProps) {
   const v1TemplateStr = v1Template || '';
 
   const {
-    isFetching: experimentIsFetching,
     isError: experimentIsError,
     error: experimentError,
     data: experiment,
@@ -213,8 +212,7 @@ function NewRunSwitcher(props: PageProps) {
     recurringRunIsFetching ||
     pipelineIsFetching ||
     pipelineVersionIsFetching ||
-    (!isTemplateV2(templateString) && v1TemplateStrIsFetching) ||
-    experimentIsFetching
+    (!isTemplateV2(templateString) && v1TemplateStrIsFetching)
   ) {
     return (
       <div style={{ textAlign: 'center', paddingTop: 40 }}>


### PR DESCRIPTION
**Description of your changes:**

When a user changes the experiment or pipeline version selection in the Create Run form, the entire NewRunV2 component was unmounted and remounted, destroying all local state (run name, description, parameters, service account).

**Root causes:**
1. **NewRunSwitcher.tsx** — experimentIsFetching was included in the loading spinner condition. When the experiment changed, the URL query params were updated, triggering a re-fetch. During the fetch, the loading spinner appeared, unmounting the entire NewRunV2 form component and clearing all user-entered fields.
2. **NewRunV2.tsx** — A redundant key={parameterStateKey} prop on NewRunParametersV2 caused the component to forcibly remount when the pipeline template changed, clearing all parameter values.

**Fix:**
- Remove experimentIsFetching from the loading condition in NewRunSwitcher.tsx — the experiment data is managed locally in NewRunV2 and doesn't need to block rendering.
- Remove the key={parameterStateKey} prop from NewRunParametersV2 in NewRunV2.tsx — the useKeyedState hook inside NewRunV2 already handles key-based state resets; the React key was redundant and harmful.

**Checklist:**
- [X] You have signed off your commits
- [X] The title for your pull request (PR) should follow our title convention