### PR TITLE
test(backend): stabilize pipeline version filter check

### DIFF
--- a/backend/test/v2/api/pipeline_api_test.go
+++ b/backend/test/v2/api/pipeline_api_test.go
@@ -1278,14 +1278,13 @@ var _ = Describe("List Pipelines Versions API Tests >", Label(constants.POSITIVE
 
 			// Filter by both tag and name
 			filter := fmt.Sprintf(`{"predicates":[{"key":"tags.env","operation":"EQUALS","string_value":"combined-test"},{"key":"name","operation":"EQUALS","string_value":"%s"}]}`, vName)
-			versions, totalSize, _, err := pipelineClient.ListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
+			result, pollVersions := eventuallyListPipelineVersions(&pipeline_params.PipelineServiceListPipelineVersionsParams{
 				PipelineID: createdPipeline.PipelineID,
 				Filter:     &filter,
 			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(totalSize).To(Equal(1))
-			Expect(versions[0].Name).To(Equal(vName))
-			Expect(versions[0].Tags).To(HaveKeyWithValue("env", "combined-test"))
+			Eventually(pollVersions, informerSyncTimeout, informerSyncInterval).Should(Equal(1), "Expected the version matching both tag and name filters to appear")
+			Expect(result.Versions[0].Name).To(Equal(vName))
+			Expect(result.Versions[0].Tags).To(HaveKeyWithValue("env", "combined-test"))
 		})
 	})
 })


### PR DESCRIPTION
## Description

Stabilize the API integration test that filters pipeline versions by both tag and name.

The Kubernetes-native pipeline store lists versions through an informer cache, so an uploaded version may not be visible to an immediate list request. The neighboring tag-filter tests already account for this by polling with `eventuallyListPipelineVersions`, but the combined tag-and-name case still used a one-shot assertion. This caused the intermittent failure observed while validating #13761.

This change uses the existing informer-aware polling helper and retains the original assertions for the returned version name and tags.

## Verification

- `gofmt -d backend/test/v2/api/pipeline_api_test.go`
- `git diff --check`
- `go test -vet=off -p=1 ./backend/test/v2/api -run '^$'`

The full API integration case requires a deployed KFP cluster and will run in CI.
