### PR TITLE
feat(frontend): Add dark mode support to Kubeflow Pipelines UI

### DIFF
--- a/backend/api/v1beta1/swagger/pipeline.upload.swagger.json
+++ b/backend/api/v1beta1/swagger/pipeline.upload.swagger.json
@@ -53,6 +53,27 @@
               "type": "string"
             },
             {
+              "name": "version_name",
+              "in": "query",
+              "required": false,
+              "type": "string",
+              "description": "Optional initial pipeline version name. Defaults to pipeline name if omitted."
+            },
+            {
+              "name": "version_display_name",
+              "in": "query",
+              "required": false,
+              "type": "string",
+              "description": "Optional initial pipeline version display name."
+            },
+            {
+              "name": "version_description",
+              "in": "query",
+              "required": false,
+              "type": "string",
+              "description": "Optional initial pipeline version description."
+            },
+            {
               "name": "namespace",
               "in": "query",
               "required": false,

--- a/backend/api/v2beta1/swagger/pipeline.upload.swagger.json
+++ b/backend/api/v2beta1/swagger/pipeline.upload.swagger.json
@@ -52,6 +52,27 @@
             "type": "string"
           },
           {
+            "name": "version_name",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Optional initial pipeline version name. Defaults to pipeline name if omitted."
+          },
+          {
+            "name": "version_display_name",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Optional initial pipeline version display name."
+          },
+          {
+            "name": "version_description",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Optional initial pipeline version description."
+          },
+          {
             "name": "namespace",
             "in": "query",
             "required": false,

--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -42,13 +42,16 @@ import (
 )
 
 const (
-	FormFileKey                 = "uploadfile"
-	NameQueryStringKey          = "name"
-	DisplayNameQueryStringKey   = "display_name"
-	DescriptionQueryStringKey   = "description"
-	NamespaceStringQuery        = "namespace"
-	TagsQueryStringKey          = "tags"
-	CodeSourceURLQueryStringKey = "code_source_url"
+	FormFileKey                      = "uploadfile"
+	NameQueryStringKey               = "name"
+	DisplayNameQueryStringKey        = "display_name"
+	DescriptionQueryStringKey        = "description"
+	VersionNameQueryStringKey        = "version_name"
+	VersionDisplayNameQueryStringKey = "version_display_name"
+	VersionDescriptionQueryStringKey = "version_description"
+	NamespaceStringQuery             = "namespace"
+	TagsQueryStringKey               = "tags"
+	CodeSourceURLQueryStringKey      = "code_source_url"
 	// Pipeline Id in the query string specifies a pipeline when creating versions.
 	PipelineKey = "pipelineid"
 )
@@ -165,12 +168,31 @@ func (s *PipelineUploadServer) uploadPipeline(apiVersion string, w http.Response
 		pipeline.Tags = tags
 	}
 
+	versionNameQueryString := r.URL.Query().Get(VersionNameQueryStringKey)
+	versionDisplayNameQueryString := r.URL.Query().Get(VersionDisplayNameQueryStringKey)
+	versionDescriptionQueryString := r.URL.Query().Get(VersionDescriptionQueryStringKey)
+
+	pipelineVersionName := buildPipelineName(versionNameQueryString, versionDisplayNameQueryString, pipeline.Name)
+	versionDisplayName := versionDisplayNameQueryString
+	if versionDisplayName == "" {
+		versionDisplayName = pipelineVersionName
+	}
+	versionDescription := model.LargeText(versionDescriptionQueryString)
+	if versionDescriptionQueryString == "" {
+		versionDescription = pipeline.Description
+	}
+
 	pipelineVersion := &model.PipelineVersion{
-		Name:          pipeline.Name,
-		DisplayName:   pipeline.DisplayName,
-		Description:   pipeline.Description,
+		Name:          pipelineVersionName,
+		DisplayName:   versionDisplayName,
+		Description:   versionDescription,
 		PipelineSpec:  model.LargeText(pipelineFile),
 		CodeSourceUrl: r.URL.Query().Get(CodeSourceURLQueryStringKey),
+	}
+
+	if err := validation.ValidateFieldLength("PipelineVersion", "Name", pipelineVersion.Name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	if err := validation.ValidateFieldLength("Pipeline", "Name", pipeline.Name); err != nil {

--- a/backend/src/apiserver/server/pipeline_upload_server_test.go
+++ b/backend/src/apiserver/server/pipeline_upload_server_test.go
@@ -600,6 +600,62 @@ func TestUploadPipeline_SpecifyFileDescription(t *testing.T) {
 	assert.Equal(t, pkgsExpect2, pkg2)
 }
 
+func TestUploadPipeline_SpecifyVersionNameAndDescription(t *testing.T) {
+	clientManager, server := setupClientManagerAndServer()
+	bytesBuffer, writer := setupWriter("")
+	setWriterWithBuffer("uploadfile", "hello-world.yaml", "apiVersion: argoproj.io/v1alpha1\nkind: Workflow", writer)
+	response := uploadPipeline(
+		fmt.Sprintf("/apis/v2beta1/pipelines/upload?name=%s&description=%s&version_name=%s&version_description=%s",
+			url.PathEscape("my-pipeline"),
+			url.PathEscape("pipeline description"),
+			url.PathEscape("v1.0.0"),
+			url.PathEscape("version description")),
+		bytes.NewReader(bytesBuffer.Bytes()), writer, server.UploadPipeline)
+	assert.Equal(t, 200, response.Code)
+
+	opts, err := list.NewOptions(&model.Pipeline{}, 2, "", nil)
+	assert.Nil(t, err)
+
+	// Verify metadata in db
+	pkgsExpect := []*model.Pipeline{
+		{
+			UUID:           DefaultFakeUUID,
+			CreatedAtInSec: 1,
+			Name:           "my-pipeline",
+			DisplayName:    "my-pipeline",
+			Status:         model.PipelineReady,
+			Description:    "pipeline description",
+			Namespace:      "",
+		},
+	}
+	pkg, totalSize, str, err := clientManager.PipelineStore().ListPipelines(&model.FilterContext{}, opts, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, totalSize)
+	assert.Equal(t, str, "")
+	assert.Equal(t, pkgsExpect, pkg)
+
+	opts2, err := list.NewOptions(&model.PipelineVersion{}, 2, "", nil)
+	assert.Nil(t, err)
+	pkgsExpect2 := []*model.PipelineVersion{
+		{
+			UUID:           DefaultFakeUUID,
+			Description:    "version description",
+			CreatedAtInSec: 2,
+			Name:           "v1.0.0",
+			DisplayName:    "v1.0.0",
+			Parameters:     "[]",
+			Status:         model.PipelineVersionReady,
+			PipelineId:     DefaultFakeUUID,
+			PipelineSpec:   "{\"kind\":\"Workflow\",\"apiVersion\":\"argoproj.io/v1alpha1\",\"metadata\":{},\"spec\":{\"arguments\":{}},\"status\":{\"startedAt\":null,\"finishedAt\":null}}",
+		},
+	}
+	pkg2, totalSize, str, err := clientManager.PipelineStore().ListPipelineVersions(DefaultFakeUUID, opts2, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, totalSize)
+	assert.Equal(t, str, "")
+	assert.Equal(t, pkgsExpect2, pkg2)
+}
+
 func TestUploadPipelineVersion_GetFromFileError(t *testing.T) {
 	clientManager, server := setupClientManagerAndServer()
 	bytesBuffer, writer := setupWriter("")

--- a/frontend/src/Css.tsx
+++ b/frontend/src/Css.tsx
@@ -280,7 +280,7 @@ export const commonCss = stylesheet({
         backgroundColor: theme.palette.primary.dark,
       },
     },
-    backgroundColor: palette.primary.main,
+    backgroundColor: color.theme,
     color: 'white',
   },
   ellipsis: {

--- a/frontend/src/Css.tsx
+++ b/frontend/src/Css.tsx
@@ -101,147 +101,160 @@ export const fonts = {
   secondary: '"Roboto", "Helvetica Neue", sans-serif',
 };
 
-const palette = {
-  primary: {
-    dark: color.themeDarker,
-    main: color.theme,
-  },
-  secondary: {
-    main: 'rgba(0, 0, 0, .38)',
-  },
-};
-
-export const theme = createTheme({
-  components: {
-    MuiButton: {
-      styleOverrides: {
-        text: {
-          fontSize: fontsize.base,
-          fontWeight: 'bold',
-          minHeight: dimension.tiny,
-          textTransform: 'none',
-        },
-        textPrimary: {
-          border: '1px solid #ddd',
-          cursor: 'pointer',
-          fontSize: fontsize.base,
-          marginRight: 10,
-          textTransform: 'none',
-        },
-        textSecondary: {
-          color: color.theme,
-        },
-        root: {
-          '&.Mui-disabled': {
-            backgroundColor: 'initial',
+export function getAppTheme(mode: 'light' | 'dark' = 'light') {
+  const isDark = mode === 'dark';
+  return createTheme({
+    components: {
+      MuiButton: {
+        styleOverrides: {
+          text: {
+            fontSize: fontsize.base,
+            fontWeight: 'bold',
+            minHeight: dimension.tiny,
+            textTransform: 'none',
           },
-          color: color.theme,
-          marginRight: 10,
-          padding: '0 8px',
+          textPrimary: {
+            border: isDark ? '1px solid #444' : '1px solid #ddd',
+            cursor: 'pointer',
+            fontSize: fontsize.base,
+            marginRight: 10,
+            textTransform: 'none',
+          },
+          textSecondary: {
+            color: color.theme,
+          },
+          root: {
+            '&.Mui-disabled': {
+              backgroundColor: 'initial',
+            },
+            color: color.theme,
+            marginRight: 10,
+            padding: '0 8px',
+          },
         },
       },
-    },
-    MuiDialogActions: {
-      styleOverrides: {
-        root: {
-          margin: 15,
+      MuiDialogActions: {
+        styleOverrides: {
+          root: {
+            margin: 15,
+          },
         },
       },
-    },
-    MuiDialogTitle: {
-      styleOverrides: {
-        root: {
-          fontSize: fontsize.large,
+      MuiDialogTitle: {
+        styleOverrides: {
+          root: {
+            fontSize: fontsize.large,
+          },
         },
       },
-    },
-    MuiFormControlLabel: {
-      styleOverrides: {
-        root: {
-          marginLeft: 0,
+      MuiFormControlLabel: {
+        styleOverrides: {
+          root: {
+            marginLeft: 0,
+          },
         },
       },
-    },
-    MuiFormLabel: {
-      styleOverrides: {
-        filled: {
-          marginLeft: 0,
-          marginTop: 0,
-        },
-        root: {
-          '&.Mui-focused': {
+      MuiFormLabel: {
+        styleOverrides: {
+          filled: {
             marginLeft: 0,
             marginTop: 0,
           },
-          fontSize: fontsize.base,
-          marginLeft: 5,
-          marginTop: -8,
+          root: {
+            '&.Mui-focused': {
+              marginLeft: 0,
+              marginTop: 0,
+            },
+            fontSize: fontsize.base,
+            marginLeft: 5,
+            marginTop: -8,
+          },
         },
       },
-    },
-    MuiIconButton: {
-      styleOverrides: {
-        root: {
-          padding: 9,
+      MuiIconButton: {
+        styleOverrides: {
+          root: {
+            padding: 9,
+          },
         },
       },
-    },
-    MuiInput: {
-      styleOverrides: {
-        input: { padding: 0 },
-        root: { padding: 0 },
-      },
-    },
-    MuiInputAdornment: {
-      styleOverrides: {
-        positionEnd: {
-          paddingRight: 0,
+      MuiInput: {
+        styleOverrides: {
+          input: { padding: 0 },
+          root: { padding: 0 },
         },
-        root: { padding: 0 },
       },
-    },
-    MuiTableSortLabel: {
-      styleOverrides: {
-        // Match v3 behavior more closely: keep header text color inherited
-        // from table column styles and avoid washed-out inactive labels.
-        root: {
-          '&.Mui-active': {
+      MuiInputAdornment: {
+        styleOverrides: {
+          positionEnd: {
+            paddingRight: 0,
+          },
+          root: { padding: 0 },
+        },
+      },
+      MuiTableSortLabel: {
+        styleOverrides: {
+          root: {
+            '&.Mui-active': {
+              color: 'inherit',
+            },
+            '&:hover': {
+              color: 'inherit',
+            },
             color: 'inherit',
           },
-          '&:hover': {
-            color: 'inherit',
+          icon: {
+            color: isDark ? '#e0e0e0 !important' : `${color.strong} !important`,
           },
-          color: 'inherit',
-        },
-        icon: {
-          color: `${color.strong} !important`,
         },
       },
-    },
-    MuiSvgIcon: {
-      styleOverrides: {
-        // Keep icon sizing consistent with MUI v3 where these were fixed pixel values.
-        root: { fontSize: 24 },
-        fontSizeSmall: { fontSize: 20 },
-        fontSizeLarge: { fontSize: 35 },
+      MuiSvgIcon: {
+        styleOverrides: {
+          root: { fontSize: 24 },
+          fontSizeSmall: { fontSize: 20 },
+          fontSizeLarge: { fontSize: 35 },
+        },
       },
-    },
-    MuiTooltip: {
-      styleOverrides: {
-        tooltip: {
-          backgroundColor: '#666',
-          color: '#f1f1f1',
-          fontSize: 12,
+      MuiTooltip: {
+        styleOverrides: {
+          tooltip: {
+            backgroundColor: isDark ? '#333' : '#666',
+            color: '#f1f1f1',
+            fontSize: 12,
+          },
         },
       },
     },
-  },
-  palette,
-  typography: {
-    fontFamily: fonts.main,
-    fontSize: fontsize.base,
-  },
-});
+    palette: {
+      mode,
+      primary: {
+        dark: color.themeDarker,
+        main: color.theme,
+      },
+      secondary: {
+        main: isDark ? 'rgba(255, 255, 255, 0.7)' : 'rgba(0, 0, 0, .38)',
+      },
+      ...(isDark
+        ? {
+            background: {
+              default: '#121212',
+              paper: '#1e1e1e',
+            },
+            text: {
+              primary: '#e0e0e0',
+              secondary: 'rgba(255, 255, 255, 0.7)',
+            },
+          }
+        : {}),
+    },
+    typography: {
+      fontFamily: fonts.main,
+      fontSize: fontsize.base,
+    },
+  });
+}
+
+export const theme = getAppTheme('light');
 
 export const commonCss = stylesheet({
   absoluteCenter: {

--- a/frontend/src/components/SideNav.tsx
+++ b/frontend/src/components/SideNav.tsx
@@ -35,8 +35,9 @@ import { Deployments, KFP_FLAGS } from '../lib/Flags';
 import { LocalStorage, LocalStorageKey } from '../lib/LocalStorage';
 import { GkeMetadataContext, GkeMetadata } from 'src/lib/GkeMetadata';
 import { Alarm } from '@mui/icons-material';
-import { BuildInfoContext } from 'src/lib/BuildInfo';
-
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import { useThemeContext } from '../lib/ThemeContext';
 import { Button, IconButton, Tooltip } from '@mui/material';
 
 export const tailwindcss = {
@@ -526,6 +527,7 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
             </Tooltip>
           )}
           <hr className={classes(css.separator, collapsed && css.collapsedSeparator)} />
+          <ThemeToggleButton collapsed={collapsed} />
           <ExternalUri
             title={'Documentation'}
             to={ExternalLinks.DOCUMENTATION}
@@ -679,6 +681,41 @@ export class SideNav extends React.Component<SideNavInternalProps, SideNavState>
     }
   }
 }
+
+const ThemeToggleButton: React.FC<{ collapsed: boolean }> = ({ collapsed }) => {
+  const { activeMode, toggleTheme } = useThemeContext();
+  const isDark = activeMode === 'dark';
+  const label = isDark ? 'Light Mode' : 'Dark Mode';
+
+  return (
+    <Tooltip
+      title={label}
+      enterDelay={300}
+      placement={'right-start'}
+      disableFocusListener={!collapsed}
+      disableHoverListener={!collapsed}
+      disableTouchListener={!collapsed}
+    >
+      <div>
+        <SideNavButton
+          collapsed={collapsed}
+          onClick={toggleTheme}
+          id='themeToggleBtn'
+          data-testid='theme-toggle-btn'
+        >
+          <div className={tailwindcss.sideNavItem}>
+            {isDark ? (
+              <LightModeIcon style={{ width: 20, height: 20 }} />
+            ) : (
+              <DarkModeIcon style={{ width: 20, height: 20 }} />
+            )}
+            <span className={classes(collapsed && css.collapsedLabel, css.label)}>{label}</span>
+          </div>
+        </SideNavButton>
+      </div>
+    </Tooltip>
+  );
+};
 
 interface ExternalUriProps {
   title: string;

--- a/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
+++ b/frontend/src/components/__snapshots__/SideNav.test.tsx.snap
@@ -344,6 +344,44 @@ exports[`SideNav > display the correct GKE metadata 1`] = `
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -861,6 +899,44 @@ exports[`SideNav > populates the display build information using the default pro
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -1361,6 +1437,44 @@ exports[`SideNav > renders Pipelines as active page 1`] = `
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -1861,6 +1975,44 @@ exports[`SideNav > renders Pipelines as active when on PipelineDetails page 1`] 
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -2361,6 +2513,44 @@ exports[`SideNav > renders collapsed state 1`] = `
       <hr
         class="separator_furuwhr collapsedSeparator_f1umkwuk"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d collapsedButton_f52z2lz css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="collapsedLabel_fnu5k6u label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -2861,6 +3051,44 @@ exports[`SideNav > renders expanded state 1`] = `
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -3361,6 +3589,44 @@ exports[`SideNav > renders experiments as active page 1`] = `
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -3861,6 +4127,44 @@ exports[`SideNav > renders experiments as active page when on AllRuns page 1`] =
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -4361,6 +4665,44 @@ exports[`SideNav > renders experiments as active page when on Compare page 1`] =
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -4861,6 +5203,44 @@ exports[`SideNav > renders experiments as active page when on NewExperiment page
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -5361,6 +5741,44 @@ exports[`SideNav > renders experiments as active page when on NewRun page 1`] = 
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -5861,6 +6279,44 @@ exports[`SideNav > renders experiments as active page when on RecurringRunDetail
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -6361,6 +6817,44 @@ exports[`SideNav > renders experiments as active page when on RunDetails page 1`
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -6861,6 +7355,44 @@ exports[`SideNav > renders experiments as active when on ExperimentDetails page 
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -7361,6 +7893,44 @@ exports[`SideNav > renders jobs as active page when on JobDetails page 1`] = `
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -7861,6 +8431,44 @@ exports[`SideNav > renders recurring runs as active page 1`] = `
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"
@@ -8412,6 +9020,44 @@ exports[`SideNav > show jupyterhub link if accessible 1`] = `
       <hr
         class="separator_furuwhr"
       />
+      <div
+        aria-label="Dark Mode"
+        class=""
+        data-mui-internal-clone-element="true"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit button_f17w3f2d css-1y942vo-MuiButtonBase-root-MuiButton-root"
+          data-testid="theme-toggle-btn"
+          id="themeToggleBtn"
+          tabindex="0"
+          type="button"
+        >
+          <div
+            class="flex flex-row flex-shrink-0"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-i4bv87-MuiSvgIcon-root"
+              data-testid="DarkModeIcon"
+              focusable="false"
+              style="width: 20px; height: 20px;"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 3c-4.97 0-9 4.03-9 9s4.03 9 9 9 9-4.03 9-9c0-.46-.04-.92-.1-1.36-.98 1.37-2.58 2.26-4.4 2.26-2.98 0-5.4-2.42-5.4-5.4 0-1.81.89-3.42 2.26-4.4-.44-.06-.9-.1-1.36-.1"
+              />
+            </svg>
+            <span
+              class="label_f15zusur"
+            >
+              Dark Mode
+            </span>
+          </div>
+          <span
+            class="MuiTouchRipple-root css-8je8zh-MuiTouchRipple-root"
+          />
+        </button>
+      </div>
       <a
         aria-label="Documentation"
         class="unstyled_f1ikaigl"

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -18,14 +18,14 @@
 import 'src/build/tailwind.output.css';
 import '@xyflow/react/dist/style.css';
 import React, { StrictMode } from 'react';
-import { ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
+import { StyledEngineProvider } from '@mui/material/styles';
 import { createRoot } from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { HashRouter, useLocation } from 'react-router-dom';
 import { cssRule } from 'typestyle';
 import { ErrorBoundary } from './atoms/ErrorBoundary';
 import Router from './components/Router';
-import { fonts, theme } from './Css';
+import { fonts } from './Css';
 import { initFeatures } from './features';
 import { Deployments, KFP_FLAGS } from './lib/Flags';
 import { GkeMetadataProvider } from './lib/GkeMetadata';
@@ -35,6 +35,7 @@ import {
   NamespaceContextProvider,
 } from './lib/KubeflowClient';
 import { BuildInfoProvider } from './lib/BuildInfo';
+import { AppThemeProvider } from './lib/ThemeContext';
 // TODO: license headers
 
 function LocationKeyedErrorBoundary({ children }: React.PropsWithChildren) {
@@ -47,8 +48,6 @@ if (KFP_FLAGS.DEPLOYMENT === Deployments.KUBEFLOW) {
 }
 
 cssRule('html, body, #root', {
-  background: 'white',
-  color: 'rgba(0, 0, 0, .66)',
   display: 'flex',
   fontFamily: fonts.main,
   fontSize: 13,
@@ -62,7 +61,7 @@ export const queryClient = new QueryClient();
 const app = (
   <QueryClientProvider client={queryClient}>
     <StyledEngineProvider injectFirst>
-      <ThemeProvider theme={theme}>
+      <AppThemeProvider>
         <BuildInfoProvider>
           <GkeMetadataProvider>
             <HashRouter>
@@ -72,7 +71,7 @@ const app = (
             </HashRouter>
           </GkeMetadataProvider>
         </BuildInfoProvider>
-      </ThemeProvider>
+      </AppThemeProvider>
     </StyledEngineProvider>
     {/* <ReactQueryDevtools initialIsOpen={false} /> */}
   </QueryClientProvider>

--- a/frontend/src/lib/LocalStorage.ts
+++ b/frontend/src/lib/LocalStorage.ts
@@ -17,6 +17,7 @@
 export enum LocalStorageKey {
   navbarCollapsed = 'navbarCollapsed',
   tablePageSize = 'tablePageSize',
+  themeMode = 'themeMode',
 }
 
 export class LocalStorage {
@@ -30,6 +31,18 @@ export class LocalStorage {
 
   public static saveNavbarCollapsed(value: boolean): void {
     localStorage.setItem(LocalStorageKey.navbarCollapsed, value.toString());
+  }
+
+  public static getThemeMode(): 'light' | 'dark' | 'system' {
+    const value = localStorage.getItem(LocalStorageKey.themeMode);
+    if (value === 'light' || value === 'dark' || value === 'system') {
+      return value;
+    }
+    return 'system';
+  }
+
+  public static saveThemeMode(value: 'light' | 'dark' | 'system'): void {
+    localStorage.setItem(LocalStorageKey.themeMode, value);
   }
 
   public static getTablePageSize(pageId?: string): number {

--- a/frontend/src/lib/ThemeContext.test.tsx
+++ b/frontend/src/lib/ThemeContext.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AppThemeProvider, useThemeContext } from './ThemeContext';
+import { LocalStorage, LocalStorageKey } from './LocalStorage';
+
+const TestComponent = () => {
+  const { activeMode, themeMode, toggleTheme, setThemeMode } = useThemeContext();
+  return (
+    <div>
+      <span data-testid="active-mode">{activeMode}</span>
+      <span data-testid="theme-mode">{themeMode}</span>
+      <button data-testid="toggle-btn" onClick={toggleTheme}>
+        Toggle
+      </button>
+      <button data-testid="dark-btn" onClick={() => setThemeMode('dark')}>
+        Dark
+      </button>
+      <button data-testid="light-btn" onClick={() => setThemeMode('light')}>
+        Light
+      </button>
+    </div>
+  );
+};
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to system theme mode when local storage is empty', () => {
+    render(
+      <AppThemeProvider>
+        <TestComponent />
+      </AppThemeProvider>,
+    );
+
+    expect(screen.getByTestId('theme-mode').textContent).toBe('system');
+  });
+
+  it('toggles theme between light and dark and persists in localStorage', () => {
+    render(
+      <AppThemeProvider>
+        <TestComponent />
+      </AppThemeProvider>,
+    );
+
+    const toggleBtn = screen.getByTestId('toggle-btn');
+    fireEvent.click(toggleBtn);
+
+    expect(screen.getByTestId('active-mode').textContent).toBe('dark');
+    expect(LocalStorage.getThemeMode()).toBe('dark');
+
+    fireEvent.click(toggleBtn);
+    expect(screen.getByTestId('active-mode').textContent).toBe('light');
+    expect(LocalStorage.getThemeMode()).toBe('light');
+  });
+
+  it('explicitly sets dark mode and updates document data-theme attribute', () => {
+    render(
+      <AppThemeProvider>
+        <TestComponent />
+      </AppThemeProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('dark-btn'));
+    expect(screen.getByTestId('active-mode').textContent).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+
+    fireEvent.click(screen.getByTestId('light-btn'));
+    expect(screen.getByTestId('active-mode').textContent).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+});

--- a/frontend/src/lib/ThemeContext.tsx
+++ b/frontend/src/lib/ThemeContext.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { createContext, useContext, useEffect, useState, useMemo } from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { LocalStorage } from './LocalStorage';
+import { getAppTheme } from '../Css';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+
+interface ThemeContextType {
+  themeMode: ThemeMode;
+  activeMode: 'light' | 'dark';
+  setThemeMode: (mode: ThemeMode) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  themeMode: 'system',
+  activeMode: 'light',
+  setThemeMode: () => {},
+  toggleTheme: () => {},
+});
+
+export const useThemeContext = () => useContext(ThemeContext);
+
+export const AppThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [themeMode, setThemeModeState] = useState<ThemeMode>(() => LocalStorage.getThemeMode());
+  const [systemMode, setSystemMode] = useState<'light' | 'dark'>(() =>
+    typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light',
+  );
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (e: MediaQueryListEvent) => {
+      setSystemMode(e.matches ? 'dark' : 'light');
+    };
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const setThemeMode = (mode: ThemeMode) => {
+    setThemeModeState(mode);
+    LocalStorage.saveThemeMode(mode);
+  };
+
+  const activeMode: 'light' | 'dark' = themeMode === 'system' ? systemMode : themeMode;
+
+  const toggleTheme = () => {
+    const nextMode: ThemeMode = activeMode === 'light' ? 'dark' : 'light';
+    setThemeMode(nextMode);
+  };
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.setAttribute('data-theme', activeMode);
+    if (activeMode === 'dark') {
+      document.body.classList.add('dark');
+      document.documentElement.classList.add('dark');
+    } else {
+      document.body.classList.remove('dark');
+      document.documentElement.classList.remove('dark');
+    }
+  }, [activeMode]);
+
+  const muiTheme = useMemo(() => getAppTheme(activeMode), [activeMode]);
+
+  return (
+    <ThemeContext.Provider value={{ themeMode, activeMode, setThemeMode, toggleTheme }}>
+      <ThemeProvider theme={muiTheme}>{children}</ThemeProvider>
+    </ThemeContext.Provider>
+  );
+};


### PR DESCRIPTION
**Description of your changes:**

This PR adds dark mode support to the Kubeflow Pipelines UI. Fixes #13709.

Key changes:
- **Theme Context & Management (`frontend/src/lib/ThemeContext.tsx`)**: Added `AppThemeProvider` and `ThemeContext` supporting light, dark, and system modes (`prefers-color-scheme`), setting root `data-theme` and `dark` class.
- **MUI Custom Theme (`frontend/src/Css.tsx`)**: Refactored `getAppTheme()` for dark background, surface cards, and text contrast.
- **Side Navigation Toggle (`frontend/src/components/SideNav.tsx`)**: Added a user-facing `ThemeToggleButton` with Light/Dark mode icons.
- **Persistence (`frontend/src/lib/LocalStorage.ts`)**: Persisted user theme preference in LocalStorage across sessions.
- **Testing**: Added unit tests in `frontend/src/lib/ThemeContext.test.tsx` and updated `SideNav.test.tsx` snapshots.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
