### PR TITLE
feat(backend): add ClassifyPodFailure taxonomy for pod lifecycle failures

### DIFF
--- a/backend/src/common/util/pod_failure_classifier.go
+++ b/backend/src/common/util/pod_failure_classifier.go
@@ -36,6 +36,34 @@ const (
 	PodFailureCategoryNone PodFailureCategory = ""
 )
 
+// PodFailureSignalSource identifies where a PodFailureSignal's Reason came
+// from.
+//
+// ImagePullBackOff, CrashLoopBackOff, OOMKilled and the other reasons below
+// are all readable from the pod's own status (containerStatuses[].state).
+// Unschedulable is not: there is no container yet, so Argo leaves the pod
+// Pending with no message, and the only signal is a FailedScheduling Event
+// recorded against the pod. Carrying Source alongside Reason means a future
+// caller that watches pod Events can classify through this same function
+// without another signature change (see #12843).
+type PodFailureSignalSource string
+
+const (
+	// PodFailureSignalSourcePodStatus means Reason was read from the pod's
+	// own status (e.g. a container waiting/terminated reason).
+	PodFailureSignalSourcePodStatus PodFailureSignalSource = "PodStatus"
+	// PodFailureSignalSourcePodEvent means Reason was read from a
+	// Kubernetes Event recorded against the pod (e.g. FailedScheduling).
+	PodFailureSignalSourcePodEvent PodFailureSignalSource = "PodEvent"
+)
+
+// PodFailureSignal is the input to ClassifyPodFailure: a raw failure reason
+// or status message, and where it was read from.
+type PodFailureSignal struct {
+	Reason string
+	Source PodFailureSignalSource
+}
+
 type podFailurePattern struct {
 	substring string
 	category  PodFailureCategory
@@ -60,16 +88,22 @@ var podFailurePatterns = []podFailurePattern{
 	{"Evicted", PodFailureCategoryNode},
 }
 
-// ClassifyPodFailure inspects a raw Kubernetes/Argo failure reason or status
-// message and classifies it into a PodFailureCategory, along with the
-// specific substring that matched. It returns PodFailureCategoryNone and an
-// empty reason if the message does not match any known pattern.
-func ClassifyPodFailure(message string) (category PodFailureCategory, matchedReason string) {
-	if message == "" {
+// ClassifyPodFailure inspects a pod lifecycle failure signal and classifies
+// it into a PodFailureCategory, along with the specific substring that
+// matched. It returns PodFailureCategoryNone and an empty reason if the
+// signal does not match any known pattern.
+//
+// Matching is currently substring-based against signal.Reason regardless of
+// signal.Source; no pattern here is sourced from a pod Event yet, since
+// nothing in this codebase watches pod Events today. Source is carried so
+// that whoever adds that watch (see #12843) can pass a PodEvent-sourced
+// signal, such as a FailedScheduling reason, through this same function.
+func ClassifyPodFailure(signal PodFailureSignal) (category PodFailureCategory, matchedReason string) {
+	if signal.Reason == "" {
 		return PodFailureCategoryNone, ""
 	}
 	for _, pattern := range podFailurePatterns {
-		if strings.Contains(message, pattern.substring) {
+		if strings.Contains(signal.Reason, pattern.substring) {
 			return pattern.category, pattern.substring
 		}
 	}

--- a/backend/src/common/util/pod_failure_classifier.go
+++ b/backend/src/common/util/pod_failure_classifier.go
@@ -52,6 +52,12 @@ var podFailurePatterns = []podFailurePattern{
 	{"ErrImagePull", PodFailureCategoryProvisioning},
 	{"ErrImageNeverPull", PodFailureCategoryProvisioning},
 	{"InvalidImageName", PodFailureCategoryProvisioning},
+	// Checked before the generic "Unschedulable" entry below, since a GPU-insufficient message
+	// contains both substrings and the more specific one should win. nvidia.com/gpu is the
+	// resource name the NVIDIA device plugin registers, the standard way GPUs are scheduled in
+	// Kubernetes; the scheduler's own message format is "0/N nodes are available: N Insufficient
+	// nvidia.com/gpu".
+	{"Insufficient nvidia.com/gpu", PodFailureCategoryProvisioning},
 	{"Unschedulable", PodFailureCategoryProvisioning},
 	{"CrashLoopBackOff", PodFailureCategoryRuntime},
 	{"OOMKilled", PodFailureCategoryRuntime},

--- a/backend/src/common/util/pod_failure_classifier.go
+++ b/backend/src/common/util/pod_failure_classifier.go
@@ -36,34 +36,6 @@ const (
 	PodFailureCategoryNone PodFailureCategory = ""
 )
 
-// PodFailureSignalSource identifies where a PodFailureSignal's Reason came
-// from.
-//
-// ImagePullBackOff, CrashLoopBackOff, OOMKilled and the other reasons below
-// are all readable from the pod's own status (containerStatuses[].state).
-// Unschedulable is not: there is no container yet, so Argo leaves the pod
-// Pending with no message, and the only signal is a FailedScheduling Event
-// recorded against the pod. Carrying Source alongside Reason means a future
-// caller that watches pod Events can classify through this same function
-// without another signature change (see #12843).
-type PodFailureSignalSource string
-
-const (
-	// PodFailureSignalSourcePodStatus means Reason was read from the pod's
-	// own status (e.g. a container waiting/terminated reason).
-	PodFailureSignalSourcePodStatus PodFailureSignalSource = "PodStatus"
-	// PodFailureSignalSourcePodEvent means Reason was read from a
-	// Kubernetes Event recorded against the pod (e.g. FailedScheduling).
-	PodFailureSignalSourcePodEvent PodFailureSignalSource = "PodEvent"
-)
-
-// PodFailureSignal is the input to ClassifyPodFailure: a raw failure reason
-// or status message, and where it was read from.
-type PodFailureSignal struct {
-	Reason string
-	Source PodFailureSignalSource
-}
-
 type podFailurePattern struct {
 	substring string
 	category  PodFailureCategory
@@ -88,22 +60,22 @@ var podFailurePatterns = []podFailurePattern{
 	{"Evicted", PodFailureCategoryNode},
 }
 
-// ClassifyPodFailure inspects a pod lifecycle failure signal and classifies
-// it into a PodFailureCategory, along with the specific substring that
-// matched. It returns PodFailureCategoryNone and an empty reason if the
-// signal does not match any known pattern.
+// ClassifyPodFailure inspects a raw Kubernetes/Argo failure reason or status
+// message and classifies it into a PodFailureCategory, along with the
+// specific substring that matched. It returns PodFailureCategoryNone and an
+// empty reason if the message does not match any known pattern.
 //
-// Matching is currently substring-based against signal.Reason regardless of
-// signal.Source; no pattern here is sourced from a pod Event yet, since
-// nothing in this codebase watches pod Events today. Source is carried so
-// that whoever adds that watch (see #12843) can pass a PodEvent-sourced
-// signal, such as a FailedScheduling reason, through this same function.
-func ClassifyPodFailure(signal PodFailureSignal) (category PodFailureCategory, matchedReason string) {
-	if signal.Reason == "" {
+// All three categories, including Unschedulable (via the pod's PodScheduled
+// condition) and Node-caused failures like preemption and eviction (via the
+// pod's DisruptionTarget condition), are readable from the pod object
+// itself, so callers do not need a separate Kubernetes Event watch to
+// populate this.
+func ClassifyPodFailure(reason string) (category PodFailureCategory, matchedReason string) {
+	if reason == "" {
 		return PodFailureCategoryNone, ""
 	}
 	for _, pattern := range podFailurePatterns {
-		if strings.Contains(signal.Reason, pattern.substring) {
+		if strings.Contains(reason, pattern.substring) {
 			return pattern.category, pattern.substring
 		}
 	}

--- a/backend/src/common/util/pod_failure_classifier.go
+++ b/backend/src/common/util/pod_failure_classifier.go
@@ -58,6 +58,14 @@ var podFailurePatterns = []podFailurePattern{
 	// Kubernetes; the scheduler's own message format is "0/N nodes are available: N Insufficient
 	// nvidia.com/gpu".
 	{"Insufficient nvidia.com/gpu", PodFailureCategoryProvisioning},
+	// A scheduling predicate failure, not a resource-capacity failure: the pod references a PVC
+	// (for example through kfp-kubernetes' mount_pvc) that has not been bound yet. Kubernetes'
+	// stable scheduler message is "pod has unbound immediate PersistentVolumeClaims". Checked
+	// before the generic "Unschedulable" entry both for specificity and because this predicate
+	// message does not reliably also contain the word "Unschedulable" the way a resource-capacity
+	// failure's rendered message does, so without this entry such a message could fall through
+	// unclassified rather than just being classified generically.
+	{"unbound immediate PersistentVolumeClaims", PodFailureCategoryProvisioning},
 	{"Unschedulable", PodFailureCategoryProvisioning},
 	{"CrashLoopBackOff", PodFailureCategoryRuntime},
 	{"OOMKilled", PodFailureCategoryRuntime},

--- a/backend/src/common/util/pod_failure_classifier.go
+++ b/backend/src/common/util/pod_failure_classifier.go
@@ -41,7 +41,12 @@ type podFailurePattern struct {
 	category  PodFailureCategory
 }
 
-// podFailurePatterns is ordered; the first matching substring wins.
+// podFailurePatterns is ordered; the first matching substring wins. Entries match one of two
+// input shapes: a raw Kubernetes condition/status Reason value (e.g. PodReasonUnschedulable,
+// PodReasonPreemptionByScheduler, PodReasonTerminationByKubelet, or pod.Status.Reason's
+// "Evicted"), or Argo's rendered node message, which uses its own prose wording. Both need an
+// entry for a given failure since callers pass either shape: code reading the pod object
+// directly gets the former, code classifying an Argo node's message gets the latter.
 var podFailurePatterns = []podFailurePattern{
 	{"ImagePullBackOff", PodFailureCategoryProvisioning},
 	{"ErrImagePull", PodFailureCategoryProvisioning},
@@ -57,7 +62,9 @@ var podFailurePatterns = []podFailurePattern{
 	{"RunContainerError", PodFailureCategoryRuntime},
 	{"NodeLost", PodFailureCategoryNode},
 	{"Preempted", PodFailureCategoryNode},
+	{"PreemptionByScheduler", PodFailureCategoryNode},
 	{"Evicted", PodFailureCategoryNode},
+	{"TerminationByKubelet", PodFailureCategoryNode},
 }
 
 // ClassifyPodFailure inspects a raw Kubernetes/Argo failure reason or status
@@ -65,11 +72,12 @@ var podFailurePatterns = []podFailurePattern{
 // specific substring that matched. It returns PodFailureCategoryNone and an
 // empty reason if the message does not match any known pattern.
 //
-// All three categories, including Unschedulable (via the pod's PodScheduled
-// condition) and Node-caused failures like preemption and eviction (via the
-// pod's DisruptionTarget condition), are readable from the pod object
-// itself, so callers do not need a separate Kubernetes Event watch to
-// populate this.
+// Unschedulable is readable directly off the pod's PodScheduled condition
+// Reason, an exact match against PodReasonUnschedulable. Node-caused
+// failures need both a condition-reason pattern (PreemptionByScheduler,
+// TerminationByKubelet, from the pod's DisruptionTarget condition) and a
+// prose pattern (Preempted, Evicted), since the frontend's mirrored table
+// classifies Argo's rendered node message instead of a raw condition Reason.
 func ClassifyPodFailure(reason string) (category PodFailureCategory, matchedReason string) {
 	if reason == "" {
 		return PodFailureCategoryNone, ""

--- a/backend/src/common/util/pod_failure_classifier.go
+++ b/backend/src/common/util/pod_failure_classifier.go
@@ -1,0 +1,77 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "strings"
+
+// PodFailureCategory classifies a pod lifecycle failure into one of the
+// buckets described in https://github.com/kubeflow/pipelines/issues/12843,
+// so that timeout enforcement and UI classification share a single source
+// of truth instead of maintaining independent, potentially drifting logic.
+type PodFailureCategory string
+
+const (
+	// PodFailureCategoryProvisioning covers failures where the pod cannot
+	// be scheduled or its container image cannot be pulled.
+	PodFailureCategoryProvisioning PodFailureCategory = "Provisioning"
+	// PodFailureCategoryRuntime covers failures where the pod starts but
+	// fails during execution.
+	PodFailureCategoryRuntime PodFailureCategory = "Runtime"
+	// PodFailureCategoryNode covers failures caused by the underlying node.
+	PodFailureCategoryNode PodFailureCategory = "Node"
+	// PodFailureCategoryNone means the message did not match any known pod
+	// lifecycle failure pattern (e.g. an ordinary user pipeline-code error).
+	PodFailureCategoryNone PodFailureCategory = ""
+)
+
+type podFailurePattern struct {
+	substring string
+	category  PodFailureCategory
+}
+
+// podFailurePatterns is ordered; the first matching substring wins.
+var podFailurePatterns = []podFailurePattern{
+	{"ImagePullBackOff", PodFailureCategoryProvisioning},
+	{"ErrImagePull", PodFailureCategoryProvisioning},
+	{"ErrImageNeverPull", PodFailureCategoryProvisioning},
+	{"InvalidImageName", PodFailureCategoryProvisioning},
+	{"Unschedulable", PodFailureCategoryProvisioning},
+	{"CrashLoopBackOff", PodFailureCategoryRuntime},
+	{"OOMKilled", PodFailureCategoryRuntime},
+	{"DeadlineExceeded", PodFailureCategoryRuntime},
+	{"ContainerCannotRun", PodFailureCategoryRuntime},
+	{"CreateContainerConfigError", PodFailureCategoryRuntime},
+	{"CreateContainerError", PodFailureCategoryRuntime},
+	{"RunContainerError", PodFailureCategoryRuntime},
+	{"NodeLost", PodFailureCategoryNode},
+	{"Preempted", PodFailureCategoryNode},
+	{"Evicted", PodFailureCategoryNode},
+}
+
+// ClassifyPodFailure inspects a raw Kubernetes/Argo failure reason or status
+// message and classifies it into a PodFailureCategory, along with the
+// specific substring that matched. It returns PodFailureCategoryNone and an
+// empty reason if the message does not match any known pattern.
+func ClassifyPodFailure(message string) (category PodFailureCategory, matchedReason string) {
+	if message == "" {
+		return PodFailureCategoryNone, ""
+	}
+	for _, pattern := range podFailurePatterns {
+		if strings.Contains(message, pattern.substring) {
+			return pattern.category, pattern.substring
+		}
+	}
+	return PodFailureCategoryNone, ""
+}

--- a/backend/src/common/util/pod_failure_classifier_test.go
+++ b/backend/src/common/util/pod_failure_classifier_test.go
@@ -82,6 +82,18 @@ func TestClassifyPodFailure(t *testing.T) {
 			expectReason:   "Evicted",
 		},
 		{
+			name:           "PreemptionByScheduler condition reason is Node",
+			reason:         "PreemptionByScheduler",
+			expectCategory: PodFailureCategoryNode,
+			expectReason:   "PreemptionByScheduler",
+		},
+		{
+			name:           "TerminationByKubelet condition reason is Node",
+			reason:         "TerminationByKubelet",
+			expectCategory: PodFailureCategoryNode,
+			expectReason:   "TerminationByKubelet",
+		},
+		{
 			name:           "first matching pattern wins when message contains multiple substrings",
 			reason:         "ImagePullBackOff eventually led to OOMKilled during retry",
 			expectCategory: PodFailureCategoryProvisioning,

--- a/backend/src/common/util/pod_failure_classifier_test.go
+++ b/backend/src/common/util/pod_failure_classifier_test.go
@@ -23,75 +23,110 @@ import (
 func TestClassifyPodFailure(t *testing.T) {
 	testCases := []struct {
 		name           string
-		message        string
+		reason         string
+		source         PodFailureSignalSource
 		expectCategory PodFailureCategory
 		expectReason   string
 	}{
 		{
 			name:           "empty message",
-			message:        "",
+			reason:         "",
+			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryNone,
 			expectReason:   "",
 		},
 		{
 			name:           "ordinary user pipeline error is not classified",
-			message:        "exit status 1: division by zero in user script",
+			reason:         "exit status 1: division by zero in user script",
+			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryNone,
 			expectReason:   "",
 		},
 		{
 			name:           "ImagePullBackOff is Provisioning",
-			message:        `Failed to pull image "bad-tag:latest": ImagePullBackOff`,
+			reason:         `Failed to pull image "bad-tag:latest": ImagePullBackOff`,
+			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryProvisioning,
 			expectReason:   "ImagePullBackOff",
 		},
 		{
 			name:           "Unschedulable is Provisioning",
-			message:        "0/1 nodes are available: 1 Insufficient cpu. Unschedulable",
+			reason:         "0/1 nodes are available: 1 Insufficient cpu. Unschedulable",
+			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryProvisioning,
 			expectReason:   "Unschedulable",
 		},
 		{
 			name:           "OOMKilled is Runtime",
-			message:        "container terminated with reason OOMKilled, exit code 137",
+			reason:         "container terminated with reason OOMKilled, exit code 137",
+			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryRuntime,
 			expectReason:   "OOMKilled",
 		},
 		{
 			name:           "CrashLoopBackOff is Runtime",
-			message:        "back-off restarting failed container: CrashLoopBackOff",
+			reason:         "back-off restarting failed container: CrashLoopBackOff",
+			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryRuntime,
 			expectReason:   "CrashLoopBackOff",
 		},
 		{
 			name:           "NodeLost is Node",
-			message:        "node has been marked NodeLost by the controller",
+			reason:         "node has been marked NodeLost by the controller",
+			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryNode,
 			expectReason:   "NodeLost",
 		},
 		{
 			name:           "Preempted is Node",
-			message:        "pod was Preempted to make room for a higher priority pod",
+			reason:         "pod was Preempted to make room for a higher priority pod",
+			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryNode,
 			expectReason:   "Preempted",
 		},
 		{
 			name:           "Evicted is Node",
-			message:        "pod Evicted due to node memory pressure",
+			reason:         "pod Evicted due to node memory pressure",
+			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryNode,
 			expectReason:   "Evicted",
 		},
 		{
 			name:           "first matching pattern wins when message contains multiple substrings",
-			message:        "ImagePullBackOff eventually led to OOMKilled during retry",
+			reason:         "ImagePullBackOff eventually led to OOMKilled during retry",
+			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryProvisioning,
 			expectReason:   "ImagePullBackOff",
+		},
+		{
+			// Documents the current, known gap: nothing watches pod Events yet,
+			// so a FailedScheduling reason doesn't match any pattern even when
+			// explicitly sourced from a PodEvent. See #12843 and #13401.
+			name:           "FailedScheduling from a pod event is not yet classified",
+			reason:         "0/3 nodes are available: 3 Insufficient cpu.",
+			source:         PodFailureSignalSourcePodEvent,
+			expectCategory: PodFailureCategoryNone,
+			expectReason:   "",
+		},
+		{
+			// Source doesn't change matching today, only Reason does; a
+			// PodEvent-sourced reason that happens to contain a known
+			// substring still classifies the same way a PodStatus-sourced
+			// one would.
+			name:           "matching is independent of source",
+			reason:         "CrashLoopBackOff",
+			source:         PodFailureSignalSourcePodEvent,
+			expectCategory: PodFailureCategoryRuntime,
+			expectReason:   "CrashLoopBackOff",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			category, reason := ClassifyPodFailure(testCase.message)
+			category, reason := ClassifyPodFailure(PodFailureSignal{
+				Reason: testCase.reason,
+				Source: testCase.source,
+			})
 			assert.Equal(t, testCase.expectCategory, category)
 			assert.Equal(t, testCase.expectReason, reason)
 		})

--- a/backend/src/common/util/pod_failure_classifier_test.go
+++ b/backend/src/common/util/pod_failure_classifier_test.go
@@ -58,6 +58,18 @@ func TestClassifyPodFailure(t *testing.T) {
 			expectReason:   "Insufficient nvidia.com/gpu",
 		},
 		{
+			name:           "unbound PVC message alone, with no Unschedulable substring, is still classified",
+			reason:         "pod has unbound immediate PersistentVolumeClaims",
+			expectCategory: PodFailureCategoryProvisioning,
+			expectReason:   "unbound immediate PersistentVolumeClaims",
+		},
+		{
+			name:           "unbound PVC message matches the specific pattern even when Unschedulable is also present",
+			reason:         "0/3 nodes are available: pod has unbound immediate PersistentVolumeClaims. Unschedulable",
+			expectCategory: PodFailureCategoryProvisioning,
+			expectReason:   "unbound immediate PersistentVolumeClaims",
+		},
+		{
 			name:           "regression guard: plain CPU/memory Unschedulable still matches the generic pattern",
 			reason:         "0/3 nodes are available: 3 Insufficient memory. Unschedulable",
 			expectCategory: PodFailureCategoryProvisioning,

--- a/backend/src/common/util/pod_failure_classifier_test.go
+++ b/backend/src/common/util/pod_failure_classifier_test.go
@@ -24,109 +24,74 @@ func TestClassifyPodFailure(t *testing.T) {
 	testCases := []struct {
 		name           string
 		reason         string
-		source         PodFailureSignalSource
 		expectCategory PodFailureCategory
 		expectReason   string
 	}{
 		{
 			name:           "empty message",
 			reason:         "",
-			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryNone,
 			expectReason:   "",
 		},
 		{
 			name:           "ordinary user pipeline error is not classified",
 			reason:         "exit status 1: division by zero in user script",
-			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryNone,
 			expectReason:   "",
 		},
 		{
 			name:           "ImagePullBackOff is Provisioning",
 			reason:         `Failed to pull image "bad-tag:latest": ImagePullBackOff`,
-			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryProvisioning,
 			expectReason:   "ImagePullBackOff",
 		},
 		{
 			name:           "Unschedulable is Provisioning",
 			reason:         "0/1 nodes are available: 1 Insufficient cpu. Unschedulable",
-			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryProvisioning,
 			expectReason:   "Unschedulable",
 		},
 		{
 			name:           "OOMKilled is Runtime",
 			reason:         "container terminated with reason OOMKilled, exit code 137",
-			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryRuntime,
 			expectReason:   "OOMKilled",
 		},
 		{
 			name:           "CrashLoopBackOff is Runtime",
 			reason:         "back-off restarting failed container: CrashLoopBackOff",
-			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryRuntime,
 			expectReason:   "CrashLoopBackOff",
 		},
 		{
 			name:           "NodeLost is Node",
 			reason:         "node has been marked NodeLost by the controller",
-			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryNode,
 			expectReason:   "NodeLost",
 		},
 		{
 			name:           "Preempted is Node",
 			reason:         "pod was Preempted to make room for a higher priority pod",
-			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryNode,
 			expectReason:   "Preempted",
 		},
 		{
 			name:           "Evicted is Node",
 			reason:         "pod Evicted due to node memory pressure",
-			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryNode,
 			expectReason:   "Evicted",
 		},
 		{
 			name:           "first matching pattern wins when message contains multiple substrings",
 			reason:         "ImagePullBackOff eventually led to OOMKilled during retry",
-			source:         PodFailureSignalSourcePodStatus,
 			expectCategory: PodFailureCategoryProvisioning,
 			expectReason:   "ImagePullBackOff",
-		},
-		{
-			// Documents the current, known gap: nothing watches pod Events yet,
-			// so a FailedScheduling reason doesn't match any pattern even when
-			// explicitly sourced from a PodEvent. See #12843 and #13401.
-			name:           "FailedScheduling from a pod event is not yet classified",
-			reason:         "0/3 nodes are available: 3 Insufficient cpu.",
-			source:         PodFailureSignalSourcePodEvent,
-			expectCategory: PodFailureCategoryNone,
-			expectReason:   "",
-		},
-		{
-			// Source doesn't change matching today, only Reason does; a
-			// PodEvent-sourced reason that happens to contain a known
-			// substring still classifies the same way a PodStatus-sourced
-			// one would.
-			name:           "matching is independent of source",
-			reason:         "CrashLoopBackOff",
-			source:         PodFailureSignalSourcePodEvent,
-			expectCategory: PodFailureCategoryRuntime,
-			expectReason:   "CrashLoopBackOff",
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			category, reason := ClassifyPodFailure(PodFailureSignal{
-				Reason: testCase.reason,
-				Source: testCase.source,
-			})
+			category, reason := ClassifyPodFailure(testCase.reason)
 			assert.Equal(t, testCase.expectCategory, category)
 			assert.Equal(t, testCase.expectReason, reason)
 		})

--- a/backend/src/common/util/pod_failure_classifier_test.go
+++ b/backend/src/common/util/pod_failure_classifier_test.go
@@ -52,6 +52,18 @@ func TestClassifyPodFailure(t *testing.T) {
 			expectReason:   "Unschedulable",
 		},
 		{
+			name:           "GPU-insufficient scheduling failure matches the specific GPU pattern, not generic Unschedulable",
+			reason:         "0/5 nodes are available: 5 Insufficient nvidia.com/gpu. Unschedulable",
+			expectCategory: PodFailureCategoryProvisioning,
+			expectReason:   "Insufficient nvidia.com/gpu",
+		},
+		{
+			name:           "regression guard: plain CPU/memory Unschedulable still matches the generic pattern",
+			reason:         "0/3 nodes are available: 3 Insufficient memory. Unschedulable",
+			expectCategory: PodFailureCategoryProvisioning,
+			expectReason:   "Unschedulable",
+		},
+		{
 			name:           "OOMKilled is Runtime",
 			reason:         "container terminated with reason OOMKilled, exit code 137",
 			expectCategory: PodFailureCategoryRuntime,

--- a/backend/src/common/util/pod_failure_classifier_test.go
+++ b/backend/src/common/util/pod_failure_classifier_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyPodFailure(t *testing.T) {
+	testCases := []struct {
+		name           string
+		message        string
+		expectCategory PodFailureCategory
+		expectReason   string
+	}{
+		{
+			name:           "empty message",
+			message:        "",
+			expectCategory: PodFailureCategoryNone,
+			expectReason:   "",
+		},
+		{
+			name:           "ordinary user pipeline error is not classified",
+			message:        "exit status 1: division by zero in user script",
+			expectCategory: PodFailureCategoryNone,
+			expectReason:   "",
+		},
+		{
+			name:           "ImagePullBackOff is Provisioning",
+			message:        `Failed to pull image "bad-tag:latest": ImagePullBackOff`,
+			expectCategory: PodFailureCategoryProvisioning,
+			expectReason:   "ImagePullBackOff",
+		},
+		{
+			name:           "Unschedulable is Provisioning",
+			message:        "0/1 nodes are available: 1 Insufficient cpu. Unschedulable",
+			expectCategory: PodFailureCategoryProvisioning,
+			expectReason:   "Unschedulable",
+		},
+		{
+			name:           "OOMKilled is Runtime",
+			message:        "container terminated with reason OOMKilled, exit code 137",
+			expectCategory: PodFailureCategoryRuntime,
+			expectReason:   "OOMKilled",
+		},
+		{
+			name:           "CrashLoopBackOff is Runtime",
+			message:        "back-off restarting failed container: CrashLoopBackOff",
+			expectCategory: PodFailureCategoryRuntime,
+			expectReason:   "CrashLoopBackOff",
+		},
+		{
+			name:           "NodeLost is Node",
+			message:        "node has been marked NodeLost by the controller",
+			expectCategory: PodFailureCategoryNode,
+			expectReason:   "NodeLost",
+		},
+		{
+			name:           "Preempted is Node",
+			message:        "pod was Preempted to make room for a higher priority pod",
+			expectCategory: PodFailureCategoryNode,
+			expectReason:   "Preempted",
+		},
+		{
+			name:           "Evicted is Node",
+			message:        "pod Evicted due to node memory pressure",
+			expectCategory: PodFailureCategoryNode,
+			expectReason:   "Evicted",
+		},
+		{
+			name:           "first matching pattern wins when message contains multiple substrings",
+			message:        "ImagePullBackOff eventually led to OOMKilled during retry",
+			expectCategory: PodFailureCategoryProvisioning,
+			expectReason:   "ImagePullBackOff",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			category, reason := ClassifyPodFailure(testCase.message)
+			assert.Equal(t, testCase.expectCategory, category)
+			assert.Equal(t, testCase.expectReason, reason)
+		})
+	}
+}

--- a/backend/src/common/util/pod_lifecycle_message_resolver.go
+++ b/backend/src/common/util/pod_lifecycle_message_resolver.go
@@ -14,7 +14,27 @@
 
 package util
 
-import workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+import (
+	"strings"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+)
+
+// driverTaskNameSuffix is the fixed suffix the compiler appends to a task's own name to name its
+// paired driver DAGTask. See containerDriverTask's caller in
+// backend/src/v2/compiler/argocompiler/dag.go: `driverTaskName := name + "-driver"`.
+const driverTaskNameSuffix = "-driver"
+
+// lastNameSegment returns the final dot-separated segment of an Argo node's hierarchical Name
+// (e.g. "my-wf(0).root(0).heavy-task-driver" -> "heavy-task-driver"), which is the DAGTask's own
+// name within its parent DAG, independent of the workflow's name or how deeply the task is
+// nested. Confirmed against a live workflow's actual node names, not just compiler source.
+func lastNameSegment(name string) string {
+	if idx := strings.LastIndex(name, "."); idx != -1 {
+		return name[idx+1:]
+	}
+	return name
+}
 
 // nonFailureNodePhases are terminal/benign Argo node phases that never represent a pod lifecycle
 // failure, even when the node has a leftover message (e.g. a Skipped node's skip-reason, or a
@@ -113,4 +133,59 @@ func resolveNodeLifecycleMessage(
 
 	resolved[nodeID] = ""
 	return ""
+}
+
+// ResolveMissingTaskDriverFailure checks whether taskName's own executor node was never created
+// because its paired driver task failed first, and if so, returns the driver's own resolved
+// failure message.
+//
+// KFP's compiler emits two separate DAGTasks per component task, in the same parent DAG: the
+// driver ("<name>-driver", resolves inputs, builds the pod spec, and handles Kubernetes-specific
+// config such as PVC/Secret mounts referenced via kfp-kubernetes) and the executor ("<name>",
+// the node the UI renders) -- and the executor Depends on the driver
+// (backend/src/v2/compiler/argocompiler/dag.go, containerDriverTask/executor.Depends). That is a
+// sibling relationship via a scheduling dependency, not parent/child containment, so
+// ResolveNodeLifecycleMessage's tree walk never reaches it: it only walks Children.
+//
+// If the driver fails, Argo never creates the executor node at all, since its dependency never
+// resolved. There is then no Pod-type node anywhere in the tree for ResolveNodeLifecycleMessage
+// to find -- the task simply never appears to have started, and the real failure (for example, a
+// kubernetes.mount_pvc() reference to a PVC that doesn't exist) is entirely invisible to it.
+//
+// parentNodeID must be a node already known to exist -- the enclosing DAG node is always
+// instantiated before either of a task's driver/executor children are, so it is always a safe
+// starting point even when the task itself has no node yet. taskName is the plain DAGTask name
+// as written in the compiled template, not the hierarchical Argo node Name.
+func ResolveMissingTaskDriverFailure(
+	nodes map[string]workflowapi.NodeStatus,
+	parentNodeID string,
+	taskName string,
+) string {
+	parent, ok := nodes[parentNodeID]
+	if !ok {
+		return ""
+	}
+
+	var driverChildID string
+	for _, childID := range parent.Children {
+		child, ok := nodes[childID]
+		if !ok {
+			continue
+		}
+		switch lastNameSegment(child.Name) {
+		case taskName:
+			// The executor already has its own node; whatever happened to it is
+			// ResolveNodeLifecycleMessage's job, not this function's.
+			return ""
+		case taskName + driverTaskNameSuffix:
+			driverChildID = childID
+		}
+	}
+
+	if driverChildID == "" {
+		// No driver child for taskName under this parent at all -- taskName doesn't belong here.
+		return ""
+	}
+
+	return ResolveNodeLifecycleMessage(nodes, driverChildID)
 }

--- a/backend/src/common/util/pod_lifecycle_message_resolver.go
+++ b/backend/src/common/util/pod_lifecycle_message_resolver.go
@@ -45,6 +45,17 @@ var nonFailureNodePhases = map[workflowapi.NodePhase]bool{
 	workflowapi.NodeOmitted:   true,
 }
 
+// nonPodFailurePhases are Pod-node phases whose message is never a genuine pod lifecycle
+// failure, even though the node is Pod-type and has a non-empty message. NodeError specifically
+// means Argo's own controller failed to manage the pod, for example a Kubernetes API error
+// while creating it, which is distinct from the pod itself failing. Confirmed against Argo's own
+// NodePhase constants (workflow_types.go), which define NodeFailed and NodeError as separate
+// values, and against Argo's own retryStrategy.retryPolicy evaluation, which treats them as
+// different trigger conditions rather than one combined failure state.
+var nonPodFailurePhases = map[workflowapi.NodePhase]bool{
+	workflowapi.NodeError: true,
+}
+
 // ResolveNodeLifecycleMessage returns the pod lifecycle failure message that should be
 // attributed to nodeID, or an empty string if none applies. Feed the result into
 // ClassifyPodFailure to get a category.
@@ -68,6 +79,11 @@ var nonFailureNodePhases = map[workflowapi.NodePhase]bool{
 //     the first non-empty message -- in either direction -- can resurface a stale failure from
 //     an earlier attempt even while the latest attempt is currently healthy and running. Only
 //     the latest attempt reflects what is happening right now.
+//  3. A Pod-type node's message is only trusted when the node's own phase is not NodeError.
+//     NodeFailed means the container itself failed, a real pod lifecycle failure. NodeError
+//     means Argo's own controller failed to manage the pod, not the pod itself, so its message
+//     is an Argo/Kubernetes-API-level string, not a pod failure reason, and must not be
+//     classified as one.
 func ResolveNodeLifecycleMessage(nodes map[string]workflowapi.NodeStatus, nodeID string) string {
 	resolved := make(map[string]string, len(nodes))
 	visiting := make(map[string]bool, len(nodes))
@@ -102,8 +118,10 @@ func resolveNodeLifecycleMessage(
 
 	// Only a Pod-type node's own message is a candidate pod lifecycle failure. Control-flow
 	// nodes (Retry, DAG, StepGroup, ...) have their own message semantics and are never treated
-	// as a pod failure here, even when non-empty.
-	if node.Type == workflowapi.NodeTypePod && node.Message != "" {
+	// as a pod failure here, even when non-empty. A NodeError phase is also excluded even on a
+	// Pod-type node, since that means Argo's own controller failed to manage the pod rather than
+	// the pod itself failing.
+	if node.Type == workflowapi.NodeTypePod && node.Message != "" && !nonPodFailurePhases[node.Phase] {
 		resolved[nodeID] = node.Message
 		return node.Message
 	}

--- a/backend/src/common/util/pod_lifecycle_message_resolver.go
+++ b/backend/src/common/util/pod_lifecycle_message_resolver.go
@@ -1,0 +1,116 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+
+// nonFailureNodePhases are terminal/benign Argo node phases that never represent a pod lifecycle
+// failure, even when the node has a leftover message (e.g. a Skipped node's skip-reason, or a
+// Succeeded node that previously failed and later completed on retry).
+var nonFailureNodePhases = map[workflowapi.NodePhase]bool{
+	workflowapi.NodeSucceeded: true,
+	workflowapi.NodeSkipped:   true,
+	workflowapi.NodeOmitted:   true,
+}
+
+// ResolveNodeLifecycleMessage returns the pod lifecycle failure message that should be
+// attributed to nodeID, or an empty string if none applies. Feed the result into
+// ClassifyPodFailure to get a category.
+//
+// Two correctness properties are enforced here, neither handled by the raw-message approach in
+// the KEP under review on kubeflow/pipelines#12843 (persisting Argo's node.Message as-is for UI
+// display):
+//
+//  1. Only a Pod-type node's own message is ever treated as a pod lifecycle failure. Argo's
+//     control-flow nodes (Retry, DAG, StepGroup) carry their own orchestration messages -- e.g.
+//     "No more retries left" on a Retry node once all attempts are exhausted, or "Max duration
+//     limit exceeded" -- which are not pod failures and must not be classified as one. A rule of
+//     "any non-empty message on any non-terminal node" mislabels a task's own exhausted retry
+//     policy as an infrastructure failure, and can actively hide the real underlying reason (a
+//     Retry node's own "No more retries left" message takes precedence over its last attempt's
+//     real "OOMKilled" message under a naive own-message-wins rule).
+//  2. For a Retry-type node, only the most recent attempt's message is ever consulted, and it is
+//     authoritative even when empty. Argo appends retry attempt children oldest-first (confirmed
+//     against argo-workflows' workflow/controller/operator.go, which always does
+//     `node.Children = append(node.Children, childID)`), so a lookup that searches children for
+//     the first non-empty message -- in either direction -- can resurface a stale failure from
+//     an earlier attempt even while the latest attempt is currently healthy and running. Only
+//     the latest attempt reflects what is happening right now.
+func ResolveNodeLifecycleMessage(nodes map[string]workflowapi.NodeStatus, nodeID string) string {
+	resolved := make(map[string]string, len(nodes))
+	visiting := make(map[string]bool, len(nodes))
+	return resolveNodeLifecycleMessage(nodes, nodeID, resolved, visiting)
+}
+
+func resolveNodeLifecycleMessage(
+	nodes map[string]workflowapi.NodeStatus,
+	nodeID string,
+	resolved map[string]string,
+	visiting map[string]bool,
+) string {
+	if message, ok := resolved[nodeID]; ok {
+		return message
+	}
+	node, ok := nodes[nodeID]
+	if !ok {
+		return ""
+	}
+	if visiting[nodeID] {
+		// Cycle guard: the Argo node graph is not expected to contain cycles, but don't hang if
+		// one somehow exists.
+		return ""
+	}
+	visiting[nodeID] = true
+	defer delete(visiting, nodeID)
+
+	if nonFailureNodePhases[node.Phase] {
+		resolved[nodeID] = ""
+		return ""
+	}
+
+	// Only a Pod-type node's own message is a candidate pod lifecycle failure. Control-flow
+	// nodes (Retry, DAG, StepGroup, ...) have their own message semantics and are never treated
+	// as a pod failure here, even when non-empty.
+	if node.Type == workflowapi.NodeTypePod && node.Message != "" {
+		resolved[nodeID] = node.Message
+		return node.Message
+	}
+
+	if node.Type == workflowapi.NodeTypeRetry && len(node.Children) > 0 {
+		// The Argo controller appends retry attempt children oldest-first (confirmed against
+		// argo-workflows' operator.go), so the last child is the most recent attempt. That
+		// attempt is authoritative: if it produced no message, the retry group currently has no
+		// pod-level failure to report, even if an earlier attempt failed. Do NOT fall through to
+		// earlier children here -- doing so would resurface a stale failure from an attempt that
+		// has already been superseded by a healthy one.
+		latest := node.Children[len(node.Children)-1]
+		message := resolveNodeLifecycleMessage(nodes, latest, resolved, visiting)
+		resolved[nodeID] = message
+		return message
+	}
+
+	// For non-Retry parents (DAG, StepGroup, ...), children represent genuinely different
+	// things, not sequential attempts of the same thing, so search all of them for the first
+	// non-empty message.
+	for _, childID := range node.Children {
+		if message := resolveNodeLifecycleMessage(nodes, childID, resolved, visiting); message != "" {
+			resolved[nodeID] = message
+			return message
+		}
+	}
+
+	resolved[nodeID] = ""
+	return ""
+}

--- a/backend/src/common/util/pod_lifecycle_message_resolver_test.go
+++ b/backend/src/common/util/pod_lifecycle_message_resolver_test.go
@@ -127,6 +127,27 @@ func TestResolveNodeLifecycleMessage(t *testing.T) {
 			want:   "",
 		},
 		{
+			name: "a NodeError on a Pod node is Argo's own error, not a pod failure",
+			nodes: map[string]workflowapi.NodeStatus{
+				"pod": {
+					Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeError,
+					Message: "pods \"my-task\" is forbidden: error looking up service account",
+				},
+			},
+			nodeID:  "pod",
+			want:    "",
+			comment: "NodeError means the controller failed to manage the pod, not the pod itself",
+		},
+		{
+			name: "a NodeFailed Pod message still surfaces normally",
+			nodes: map[string]workflowapi.NodeStatus{
+				"pod": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed, Message: "OOMKilled"},
+			},
+			nodeID:  "pod",
+			want:    "OOMKilled",
+			comment: "regression guard: NodeFailed must still work after the NodeError exclusion",
+		},
+		{
 			name: "cyclic children do not cause infinite recursion",
 			nodes: map[string]workflowapi.NodeStatus{
 				"a": {Type: workflowapi.NodeTypeDAG, Phase: workflowapi.NodeFailed, Children: []string{"b"}},

--- a/backend/src/common/util/pod_lifecycle_message_resolver_test.go
+++ b/backend/src/common/util/pod_lifecycle_message_resolver_test.go
@@ -167,3 +167,158 @@ func TestResolveNodeLifecycleMessage_IntegratesWithClassifyPodFailure(t *testing
 	assert.Equal(t, PodFailureCategoryRuntime, category)
 	assert.Equal(t, "OOMKilled", reason)
 }
+
+func TestLastNameSegment(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"my-wf(0).root(0).heavy-task-driver", "heavy-task-driver"},
+		{"my-wf(0).root(0).heavy-task-driver(0)", "heavy-task-driver(0)"},
+		{"my-wf(0).root(0).heavy-task", "heavy-task"},
+		{"my-wf", "my-wf"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, lastNameSegment(tt.name))
+		})
+	}
+}
+
+// Node shapes below are modeled directly on a real workflow's live status.nodes, captured with
+// `kubectl get wf -o json` against a KFP v2 pipeline with a single component task named
+// "heavy-task", not reconstructed from compiler source alone:
+//
+//	id=...-2792668430 name=wf(0).root(0).heavy-task-driver         type=Retry  phase=Succeeded
+//	id=...-297853757  name=wf(0).root(0).heavy-task-driver(0)      type=Pod    phase=Succeeded
+//	id=...-435981245  name=wf(0).root(0).heavy-task                type=Retry  phase=Running
+//
+// The driver is itself Retry-wrapped, not a bare Pod node directly -- both the "-driver" group
+// node and its "(0)" attempt child exist, same as any other retried task.
+func TestResolveMissingTaskDriverFailure(t *testing.T) {
+	// realDagChildren mirrors "root(0)"'s actual Children from the same captured workflow: the
+	// driver group node's ID, and (only once the driver succeeds) the executor group node's ID.
+	t.Run("driver failed: no executor node exists yet, driver's message surfaces", func(t *testing.T) {
+		nodes := map[string]workflowapi.NodeStatus{
+			"root": {
+				Type: workflowapi.NodeTypeDAG, Phase: workflowapi.NodeRunning,
+				// Only the driver child exists -- the executor was never created, since it
+				// Depends on the driver and the driver never succeeded.
+				Children: []string{"driver-group"},
+			},
+			"driver-group": {
+				Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeFailed,
+				Name:     "wf(0).root(0).heavy-task-driver",
+				Children: []string{"driver-attempt-0"},
+			},
+			"driver-attempt-0": {
+				Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed,
+				Name: "wf(0).root(0).heavy-task-driver(0)",
+				Message: "failed to create PVC \"typo-name\": " +
+					"persistentvolumeclaims \"typo-name\" not found",
+			},
+		}
+		got := ResolveMissingTaskDriverFailure(nodes, "root", "heavy-task")
+		assert.Contains(t, got, "persistentvolumeclaims \"typo-name\" not found")
+	})
+
+	t.Run("driver succeeded and executor already exists: defers, returns empty", func(t *testing.T) {
+		nodes := map[string]workflowapi.NodeStatus{
+			"root": {
+				Type:     workflowapi.NodeTypeDAG,
+				Phase:    workflowapi.NodeRunning,
+				Children: []string{"driver-group", "executor-group"},
+			},
+			"driver-group": {
+				Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeSucceeded,
+				Name:     "wf(0).root(0).heavy-task-driver",
+				Children: []string{"driver-attempt-0"},
+			},
+			"driver-attempt-0": {
+				Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeSucceeded,
+				Name: "wf(0).root(0).heavy-task-driver(0)",
+			},
+			"executor-group": {
+				Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeRunning,
+				Name: "wf(0).root(0).heavy-task",
+			},
+		}
+		got := ResolveMissingTaskDriverFailure(nodes, "root", "heavy-task")
+		assert.Equal(t, "", got,
+			"the executor node exists, so ResolveNodeLifecycleMessage owns this, not the driver check")
+	})
+
+	t.Run("driver still running, executor doesn't exist yet: not a failure, returns empty", func(t *testing.T) {
+		nodes := map[string]workflowapi.NodeStatus{
+			"root": {
+				Type: workflowapi.NodeTypeDAG, Phase: workflowapi.NodeRunning,
+				Children: []string{"driver-group"},
+			},
+			"driver-group": {
+				Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeRunning,
+				Name:     "wf(0).root(0).heavy-task-driver",
+				Children: []string{"driver-attempt-0"},
+			},
+			"driver-attempt-0": {
+				Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeRunning,
+				Name: "wf(0).root(0).heavy-task-driver(0)",
+			},
+		}
+		got := ResolveMissingTaskDriverFailure(nodes, "root", "heavy-task")
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("unrelated task name under the same parent: no match, returns empty", func(t *testing.T) {
+		nodes := map[string]workflowapi.NodeStatus{
+			"root": {
+				Type: workflowapi.NodeTypeDAG, Phase: workflowapi.NodeRunning,
+				Children: []string{"driver-group"},
+			},
+			"driver-group": {
+				Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeFailed,
+				Name:     "wf(0).root(0).heavy-task-driver",
+				Children: []string{"driver-attempt-0"},
+			},
+			"driver-attempt-0": {
+				Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed,
+				Name: "wf(0).root(0).heavy-task-driver(0)", Message: "some driver failure",
+			},
+		}
+		got := ResolveMissingTaskDriverFailure(nodes, "root", "some-other-task")
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("unknown parent node: returns empty rather than panicking", func(t *testing.T) {
+		got := ResolveMissingTaskDriverFailure(map[string]workflowapi.NodeStatus{}, "does-not-exist", "heavy-task")
+		assert.Equal(t, "", got)
+	})
+
+	t.Run("two tasks sharing a parent are not confused with each other", func(t *testing.T) {
+		nodes := map[string]workflowapi.NodeStatus{
+			"root": {
+				Type: workflowapi.NodeTypeDAG, Phase: workflowapi.NodeRunning,
+				Children: []string{"a-driver-group", "b-driver-group", "b-executor-group"},
+			},
+			"a-driver-group": {
+				Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeFailed,
+				Name:     "wf(0).root(0).task-a-driver",
+				Children: []string{"a-driver-attempt-0"},
+			},
+			"a-driver-attempt-0": {
+				Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed,
+				Name: "wf(0).root(0).task-a-driver(0)", Message: "task A's driver failed",
+			},
+			"b-driver-group": {
+				Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeSucceeded,
+				Name: "wf(0).root(0).task-b-driver",
+			},
+			"b-executor-group": {
+				Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeRunning,
+				Name: "wf(0).root(0).task-b",
+			},
+		}
+		assert.Contains(t, ResolveMissingTaskDriverFailure(nodes, "root", "task-a"), "task A's driver failed")
+		assert.Equal(t, "", ResolveMissingTaskDriverFailure(nodes, "root", "task-b"))
+	})
+}

--- a/backend/src/common/util/pod_lifecycle_message_resolver_test.go
+++ b/backend/src/common/util/pod_lifecycle_message_resolver_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveNodeLifecycleMessage(t *testing.T) {
+	tests := []struct {
+		name    string
+		nodes   map[string]workflowapi.NodeStatus
+		nodeID  string
+		want    string
+		comment string
+	}{
+		{
+			name: "pod node keeps its own message",
+			nodes: map[string]workflowapi.NodeStatus{
+				"pod": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed, Message: "OOMKilled"},
+			},
+			nodeID: "pod",
+			want:   "OOMKilled",
+		},
+		{
+			name: "task node bubbles up its pod child's message",
+			nodes: map[string]workflowapi.NodeStatus{
+				"task": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodePending, Children: []string{"executor"}},
+				"executor": {
+					Type: workflowapi.NodeTypePod, Phase: workflowapi.NodePending,
+					Message: "Back-off pulling image \"does-not-exist:v1\"",
+				},
+			},
+			nodeID: "task",
+			want:   "Back-off pulling image \"does-not-exist:v1\"",
+		},
+		{
+			name: "retry node's own exhausted-retries message does not shadow the real failure",
+			nodes: map[string]workflowapi.NodeStatus{
+				"retry": {
+					Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeFailed,
+					Message: "No more retries left", Children: []string{"retry(0)"},
+				},
+				"retry(0)": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed, Message: "OOMKilled"},
+			},
+			nodeID:  "retry",
+			want:    "OOMKilled",
+			comment: "a Retry node's own message is control-flow prose, never a pod failure",
+		},
+		{
+			name: "max-duration message on a DAG node is not a pod failure",
+			nodes: map[string]workflowapi.NodeStatus{
+				"dag": {Type: workflowapi.NodeTypeDAG, Phase: workflowapi.NodeFailed, Message: "Max duration limit exceeded"},
+			},
+			nodeID: "dag",
+			want:   "",
+		},
+		{
+			name: "running parent shows the latest attempt, not a stale earlier failure",
+			nodes: map[string]workflowapi.NodeStatus{
+				"task": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeRunning, Children: []string{"retry"}},
+				"retry": {
+					Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeRunning,
+					// Argo appends retry children oldest-first: retry(0) is the failed first
+					// attempt, retry(1) is the current, healthy attempt.
+					Children: []string{"retry(0)", "retry(1)"},
+				},
+				"retry(0)": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed, Message: "OOMKilled"},
+				"retry(1)": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeRunning, Message: ""},
+			},
+			nodeID:  "task",
+			want:    "",
+			comment: "must not show attempt 0's stale OOMKilled while attempt 1 is live and healthy",
+		},
+		{
+			name: "a later failed attempt is preferred over an earlier failed attempt",
+			nodes: map[string]workflowapi.NodeStatus{
+				"retry": {
+					Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeFailed,
+					Children: []string{"retry(0)", "retry(1)"},
+				},
+				"retry(0)": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed, Message: "OOMKilled"},
+				"retry(1)": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed, Message: "ImagePullBackOff"},
+			},
+			nodeID: "retry",
+			want:   "ImagePullBackOff",
+		},
+		{
+			name: "succeeded node does not inherit a failed descendant's message",
+			nodes: map[string]workflowapi.NodeStatus{
+				"task":     {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeSucceeded, Children: []string{"executor"}},
+				"executor": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed, Message: "OOMKilled"},
+			},
+			nodeID: "task",
+			want:   "",
+		},
+		{
+			name: "skipped node's skip-reason is not a failure",
+			nodes: map[string]workflowapi.NodeStatus{
+				"skipped": {
+					Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeSkipped,
+					Message: "when 'true != true' evaluated false",
+				},
+			},
+			nodeID: "skipped",
+			want:   "",
+		},
+		{
+			name:   "missing node returns empty",
+			nodes:  map[string]workflowapi.NodeStatus{},
+			nodeID: "does-not-exist",
+			want:   "",
+		},
+		{
+			name: "cyclic children do not cause infinite recursion",
+			nodes: map[string]workflowapi.NodeStatus{
+				"a": {Type: workflowapi.NodeTypeDAG, Phase: workflowapi.NodeFailed, Children: []string{"b"}},
+				"b": {Type: workflowapi.NodeTypeDAG, Phase: workflowapi.NodeFailed, Children: []string{"a"}},
+			},
+			nodeID: "a",
+			want:   "",
+		},
+		{
+			name: "three-level nesting (DAG -> Retry -> Pod) bubbles up correctly",
+			nodes: map[string]workflowapi.NodeStatus{
+				"stepgroup": {Type: workflowapi.NodeTypeStepGroup, Phase: workflowapi.NodeFailed, Children: []string{"retry"}},
+				"retry":     {Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeFailed, Children: []string{"retry(0)"}},
+				"retry(0)":  {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed, Message: "Unschedulable"},
+			},
+			nodeID: "stepgroup",
+			want:   "Unschedulable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveNodeLifecycleMessage(tt.nodes, tt.nodeID)
+			assert.Equal(t, tt.want, got, tt.comment)
+		})
+	}
+}
+
+func TestResolveNodeLifecycleMessage_IntegratesWithClassifyPodFailure(t *testing.T) {
+	nodes := map[string]workflowapi.NodeStatus{
+		"retry": {
+			Type: workflowapi.NodeTypeRetry, Phase: workflowapi.NodeFailed,
+			Message: "No more retries left", Children: []string{"retry(0)"},
+		},
+		"retry(0)": {Type: workflowapi.NodeTypePod, Phase: workflowapi.NodeFailed, Message: "OOMKilled"},
+	}
+	message := ResolveNodeLifecycleMessage(nodes, "retry")
+	category, reason := ClassifyPodFailure(message)
+	assert.Equal(t, PodFailureCategoryRuntime, category)
+	assert.Equal(t, "OOMKilled", reason)
+}


### PR DESCRIPTION
**Description of your changes:**

Adds ClassifyPodFailure(message string) (category, matchedReason string) in backend/src/common/util, mapping raw Kubernetes/Argo failure strings (ImagePullBackOff, OOMKilled, CrashLoopBackOff, NodeLost, etc.) into the Provisioning/Runtime/Node categories described in #12843.

Going through the existing PRs on that issue, #12989 and #13102 each independently defined their own timeout category constants (different names, different types, for the same three categories), and #13097's failure detection is a flat boolean with no category info at all. This is meant to be a single shared place both the timeout logic and the UI-facing code can use instead of drifting apart. It's a pure, standalone function with no dependency on NodeStatus or any of those PRs, so it doesn't block on any of them merging first.

More detail in #13835.

Also adds two functions that build on ClassifyPodFailure to resolve which message should actually be classified, since the raw Argo node.Message is not always safe to use as is.

ResolveNodeLifecycleMessage walks a task's Argo node tree with three rules a plain read of node.Message misses.

Only a Pod-type node's own message counts as a pod lifecycle failure. Control-flow nodes such as Retry or DAG carry their own orchestration messages, for example "No more retries left" once a retry group is exhausted, and that message is not a pod failure. Treating any non-empty message as a failure can hide the real reason, since a Retry node's own message would take priority over its last attempt's actual OOMKilled message.

```mermaid
flowchart LR
    subgraph before ["Before, raw node.Message read as is"]
        direction TB
        B1["Retry node<br/>Message: No more retries left"] --> BR["Shown to user:<br/>No more retries left"]
    end
    subgraph after ["After, ResolveNodeLifecycleMessage"]
        direction TB
        A1["Retry node<br/>Message: No more retries left, ignored, not Pod type"] --> A2["attempt(0), Pod<br/>Message: OOMKilled"]
        A2 --> AR["Shown to user:<br/>OOMKilled"]
    end
    style BR fill:#fce8e6,stroke:#c5221f
    style AR fill:#e6f4ea,stroke:#188038
```

For a retried task, the most recent attempt is also authoritative, not the first non-empty one found. Argo appends retry attempts oldest first, so a naive lookup can show a stale failure from an early attempt while a later attempt is already healthy and running.

```mermaid
flowchart LR
    subgraph before ["Before, first non-empty child wins"]
        direction TB
        B1["attempt(0), Failed, OOMKilled"] --> BR["Shown to user:<br/>OOMKilled, stale"]
    end
    subgraph after ["After, latest attempt is authoritative"]
        direction TB
        A1["attempt(1), Running, no message"] --> AR["Shown to user:<br/>nothing, correct"]
    end
    style BR fill:#fce8e6,stroke:#c5221f
    style AR fill:#e6f4ea,stroke:#188038
```

A Pod-type node's message is only trusted when its own phase is not NodeError. NodeFailed means the container itself failed, a real pod lifecycle failure. NodeError means Argo's own controller failed to manage the pod, for example a Kubernetes API error while creating it, not the pod itself failing, so its message should not be classified as a pod failure reason.

ResolveMissingTaskDriverFailure covers a case none of the current approaches on this issue handle. KFP's compiler emits two separate DAG tasks per component, a driver task that resolves inputs and builds the pod spec, and the executor task that runs the user's container, with the executor depending on the driver. If the driver itself fails, for example a kubernetes.mount_pvc() reference to a PVC that does not exist, Argo never creates the executor node, so there is no Pod-type node anywhere in the tree for anything to point a diagnostic at.

```mermaid
flowchart LR
    subgraph before ["Before, no fix"]
        direction TB
        B1["Executor node does not exist"] --> BR["Shown to user:<br/>nothing, task just sits"]
    end
    subgraph after ["After, ResolveMissingTaskDriverFailure"]
        direction TB
        A1["Driver Pod, Failed<br/>PVC typo-name not found"] --> AR["Shown to user:<br/>the driver's real message"]
    end
    style BR fill:#fce8e6,stroke:#c5221f
    style AR fill:#e6f4ea,stroke:#188038
```

Both functions are covered by table-driven tests, including a regression test for the retry-staleness case above and a case confirming two sibling tasks under the same parent are not confused with each other. Node shapes in the tests are modeled on a real workflow's live status.nodes, not just reconstructed from compiler source.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
