### PR TITLE
fix(ci): constrain fastjsonschema on Python 3.9

### DIFF
--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -661,7 +661,11 @@ def create_notebook_component_from_func(
     # Resolve default packages for notebooks when not specified
     if packages_to_install is None:
         packages_to_install = [
-            'nbclient>=0.10,<1', 'ipykernel>=6,<7', 'jupyter_client>=7,<9'
+            'nbclient>=0.10,<1',
+            'ipykernel>=6,<7',
+            'jupyter_client>=7,<9',
+            # 2.22.0 uses Python 3.10 union syntax but permits Python 3.9.
+            'fastjsonschema<2.22; python_version < "3.10"',
         ]
 
     # Validate notebook path and determine relpath

--- a/sdk/python/kfp/dsl/notebook_component_decorator.py
+++ b/sdk/python/kfp/dsl/notebook_component_decorator.py
@@ -36,7 +36,8 @@ def notebook_component(
         base_image: Base container image for the component.
         packages_to_install: Runtime-only packages to install inside the
             component container. When None, defaults to
-            ["nbclient>=0.10,<1", "ipykernel>=6,<7", "jupyter_client>=7,<9"]
+            ["nbclient>=0.10,<1", "ipykernel>=6,<7", "jupyter_client>=7,<9",
+            "fastjsonschema<2.22; python_version < '3.10'"]
             to ensure the notebook can execute with a Python kernel and client.
             When [], installs nothing. When non-empty, installs the exact list.
         output_component_file: Optional path to write the component YAML.

--- a/sdk/python/kfp/dsl/notebook_component_decorator_test.py
+++ b/sdk/python/kfp/dsl/notebook_component_decorator_test.py
@@ -58,6 +58,7 @@ class TestNotebookComponentDecorator(unittest.TestCase):
         self.assertIn('nbclient>=0.10,<1', command)
         self.assertIn('ipykernel>=6,<7', command)
         self.assertIn('jupyter_client>=7,<9', command)
+        self.assertIn('fastjsonschema<2.22; python_version < "3.10"', command)
 
     def test_notebook_component_no_extra_packages_when_empty_list(self):
         nb_path = self._make_temp_notebook('pass\n')
@@ -71,6 +72,7 @@ class TestNotebookComponentDecorator(unittest.TestCase):
         self.assertNotIn('nbclient>=0.10,<1', command)
         self.assertNotIn('ipykernel>=6,<7', command)
         self.assertNotIn('jupyter_client>=7,<9', command)
+        self.assertNotIn('fastjsonschema<2.22', command)
 
 
 class TestNotebookExecutorTemplate(unittest.TestCase):

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -4,6 +4,9 @@ docker==7.1.0
 isort==5.10.1
 mypy==0.941
 nbformat==5.10.4
+# fastjsonschema 2.22.0 uses Python 3.10 union syntax despite advertising
+# Python 3.9 support. Remove this bound once upstream restores compatibility.
+fastjsonschema<2.22; python_version < "3.10"
 pip-tools==6.0.0
 pre-commit==2.19.0
 pycln==2.1.1

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -57,7 +57,13 @@ def read_readme() -> str:
 _version = find_version('kfp', 'version.py')
 docker = ['docker']
 kubernetes = [f'kfp-kubernetes=={_version}']
-notebooks = ["nbclient>=0.10,<1", "ipykernel>=6,<7", "jupyter_client>=7,<9"]
+notebooks = [
+    "nbclient>=0.10,<1",
+    "ipykernel>=6,<7",
+    "jupyter_client>=7,<9",
+    # 2.22.0 uses Python 3.10 union syntax but permits Python 3.9.
+    'fastjsonschema<2.22; python_version < "3.10"',
+]
 
 setuptools.setup(
     name='kfp',


### PR DESCRIPTION
## Summary

- constrain `fastjsonschema` to releases before 2.22 on Python 3.9
- apply the constraint to SDK development, default notebook component runtimes,
  and the published `kfp[notebooks]` extra
- leave dependency resolution unchanged on Python 3.10 and newer
- preserve explicit `packages_to_install` behavior

## Root cause

`nbformat==5.10.4` allows `fastjsonschema>=2.15`. Version 2.22.0 contains
Python 3.10 union syntax while its package metadata still permits Python 3.9.

The initial development-requirements constraint fixed the CI job environment,
but notebook components create an isolated runtime environment from their
default package list. Both Python 3.9 jobs therefore still installed the
unconstrained release inside notebook execution and failed while importing
`nbformat`.

Upstream has merged a minimum-Python metadata fix, but no corrected release has
been published and 2.22.0 has not yet been yanked. The conditional bound can be
removed after upstream resolution is reliable.

## Verification

- Python 3.9 notebook component decorator suite: 8 passed
- Python 3.9
  `TestRunLocalPipeline::test_notebook_component_local_exec`: passed
- Python 3.9
  `TestSubProcessRunner::test_execution[Notebook Component Simple]`: passed
- `kfp[notebooks]` dry-run resolves `fastjsonschema==2.21.2` on Python 3.9
- YAPF check on all changed Python files
- `git diff --check`
