### PR TITLE
fix(deps): update visualization Pillow pin

### DIFF
--- a/backend/src/apiserver/visualization/requirements.txt
+++ b/backend/src/apiserver/visualization/requirements.txt
@@ -248,7 +248,7 @@ pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-pillow==12.2.0
+pillow==12.3.0
     # via bokeh
 platformdirs==4.4.0
     # via jupyter-core


### PR DESCRIPTION
## Summary

- update the visualization lockfile from Pillow 12.2.0 to 12.3.0
- preserve the dependency resolutions that have since landed on `master`

## Why

This replaces #13815, whose Dependabot branch conflicts after other visualization lockfile updates merged. Pillow has no additional transitive dependencies here, so the current-master replacement is a single pin change.

## Verification

- confirmed the diff contains one file with one insertion and one deletion
- `git diff --check origin/master...HEAD`
- verified the commit includes the required DCO sign-off
