### PR TITLE
fix(backend): allow cluster default StorageClass in createPVC driver

### DIFF
--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -973,14 +973,8 @@ func createPVC(
 	}
 
 	// Optional input: storage_class_name
-	// When not provided, use default value `standard`
-	storageClassNameInput, ok := inputs.ParameterValues["storage_class_name"]
-	var storageClassName string
-	if !ok {
-		storageClassName = "standard"
-	} else {
-		storageClassName = storageClassNameInput.GetStringValue()
-	}
+	// When not provided or null, leave pointer nil to use cluster default StorageClass.
+	storageClassName := resolveStorageClassName(inputs)
 
 	// Optional input: annotations
 	pvcAnnotations := make(map[string]string)
@@ -1067,7 +1061,7 @@ func createPVC(
 					k8score.ResourceStorage: k8sres.MustParse(volumeSizeInput.GetStringValue()),
 				},
 			},
-			StorageClassName: &storageClassName,
+			StorageClassName: storageClassName,
 			VolumeName:       volumeName,
 			DataSource:       dataSource,
 		},
@@ -1111,6 +1105,21 @@ func buildPVCDataSource(pvcDataSourceInput *structpb.Value) (*k8score.TypedLocal
 	}
 
 	return &dataSource, nil
+}
+
+// resolveStorageClassName resolves storage_class_name parameter value to a *string pointer.
+// If unprovided, nil, or null, it returns nil so Kubernetes uses the cluster's default StorageClass.
+func resolveStorageClassName(inputs *pipelinespec.ExecutorInput_Inputs) *string {
+	if inputs == nil || inputs.ParameterValues == nil {
+		return nil
+	}
+	if storageClassNameInput, ok := inputs.ParameterValues["storage_class_name"]; ok && storageClassNameInput != nil {
+		if _, isNull := storageClassNameInput.GetKind().(*structpb.Value_NullValue); !isNull {
+			val := storageClassNameInput.GetStringValue()
+			return &val
+		}
+	}
+	return nil
 }
 
 func deletePVC(

--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -3970,3 +3970,62 @@ func Test_extendPodSpecPatch_InitContainers_AdminSecurityDefaults(t *testing.T) 
 	assert.NotNil(t, got.HostUsers)
 	assert.False(t, *got.HostUsers)
 }
+
+func Test_resolveStorageClassName(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name     string
+		inputs   *pipelinespec.ExecutorInput_Inputs
+		wantName *string
+	}{
+		{
+			name:     "nil inputs returns nil",
+			inputs:   nil,
+			wantName: nil,
+		},
+		{
+			name: "storage_class_name parameter omitted returns nil for cluster default",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"size": structpb.NewStringValue("5Gi"),
+				},
+			},
+			wantName: nil,
+		},
+		{
+			name: "storage_class_name parameter null returns nil for cluster default",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"storage_class_name": structpb.NewNullValue(),
+				},
+			},
+			wantName: nil,
+		},
+		{
+			name: "storage_class_name parameter specified returns pointer to string",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"storage_class_name": structpb.NewStringValue("fast-sc"),
+				},
+			},
+			wantName: strPtr("fast-sc"),
+		},
+		{
+			name: "storage_class_name parameter empty string returns pointer to empty string for static binding",
+			inputs: &pipelinespec.ExecutorInput_Inputs{
+				ParameterValues: map[string]*structpb.Value{
+					"storage_class_name": structpb.NewStringValue(""),
+				},
+			},
+			wantName: strPtr(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveStorageClassName(tt.inputs)
+			assert.Equal(t, tt.wantName, got)
+		})
+	}
+}


### PR DESCRIPTION
**Description of your changes:**

Fixes #13873

### Context & Problem
In the KFP Kubernetes platform extension (`CreatePVC`), `storage_class_name` is optional. The Python SDK docstring documents that leaving it as `None` or omitted should allow Kubernetes to provision using the cluster's default `StorageClass`. 

However, in the Go backend driver (`createPVC` in `backend/src/v2/driver/k8s.go`), unprovided or null `storage_class_name` inputs were previously hardcoded to `"standard"`. Passing `&"standard"` as a non-nil pointer in `PersistentVolumeClaimSpec.StorageClassName` forces Kubernetes to look for a `StorageClass` named `"standard"`, causing PVC creation to fail with `storageclasses.storage.k8s.io "standard" not found` on any cluster where the default `StorageClass` carries a different name (such as `gp2`/`gp3` on EKS, `standard-rwd` on GKE, `managed-csi` on AKS, or `local-path` on Kind/k3s).

### Changes
1. Added helper function `resolveStorageClassName(inputs *pipelinespec.ExecutorInput_Inputs) *string` in `backend/src/v2/driver/k8s.go`.
2. Updated `createPVC` to call `resolveStorageClassName`, which returns `nil` when `storage_class_name` is unprovided or `null`, allowing Kubernetes to fall back to the cluster default `StorageClass`. If an explicit string or `""` (for static PV binding) is provided, it returns a pointer to that string.
3. Added unit tests `Test_resolveStorageClassName` in `backend/src/v2/driver/k8s_test.go` verifying omitted, null, custom, and empty string parameter inputs.

### Verification
- Ran Go unit tests for the driver package:
  ```bash
  go test -v ./backend/src/v2/driver/ -run Test_resolveStorageClassName
