### PR TITLE
fix(cache): avoid admission-webhook panic on malformed ARGO_TEMPLATE

### DIFF
--- a/backend/src/cache/server/mutation.go
+++ b/backend/src/cache/server/mutation.go
@@ -242,7 +242,15 @@ func intersectStructureWithSkeleton(src map[string]interface{}, skeleton map[str
 			if skeletonValue == nil {
 				result[key] = value
 			} else {
-				result[key] = intersectStructureWithSkeleton(value.(map[string]interface{}), skeletonValue.(map[string]interface{}))
+				valueMap, valueIsMap := value.(map[string]interface{})
+				skeletonMap, skeletonIsMap := skeletonValue.(map[string]interface{})
+				if !valueIsMap || !skeletonIsMap {
+					// The template value does not match the expected object shape
+					// (e.g. a user-supplied ARGO_TEMPLATE whose "container" is not a
+					// JSON object); skip the key instead of panicking the webhook.
+					continue
+				}
+				result[key] = intersectStructureWithSkeleton(valueMap, skeletonMap)
 			}
 		}
 	}

--- a/backend/src/cache/server/mutation_test.go
+++ b/backend/src/cache/server/mutation_test.go
@@ -270,3 +270,23 @@ func TestMutatePodIfCachedWithTeamplateCleanup(t *testing.T) {
 	require.Equal(t, patchOperation[1].Op, OperationTypeAdd)
 	require.Equal(t, patchOperation[2].Op, OperationTypeAdd)
 }
+
+func TestGenerateCacheKeyFromTemplateMalformedContainer(t *testing.T) {
+	// A user-controlled ARGO_TEMPLATE whose "container" is not a JSON object still
+	// reaches intersectStructureWithSkeleton, which recurses into the "container"
+	// key. Such input must not panic the mutating webhook.
+	malformed := []string{
+		`{"container": "not-an-object"}`,
+		`{"container": 123}`,
+		`{"container": ["a", "b"]}`,
+		`{"container": null}`,
+		`{"container": true}`,
+	}
+	for _, tmpl := range malformed {
+		t.Run(tmpl, func(t *testing.T) {
+			key, err := generateCacheKeyFromTemplate(tmpl)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, key)
+		})
+	}
+}


### PR DESCRIPTION
## Description

`intersectStructureWithSkeleton` blindly asserted `value.(map[string]interface{})` when recursing into a non-nil skeleton key (e.g. `container`). That template comes from the user-controlled `ARGO_TEMPLATE` pod env via the `/mutate` cache webhook, so a pod whose `container` is not a JSON object (string / number / array / bool / null) panics the admission handler. With `failurePolicy: Ignore` the pod is still admitted but unmutated, so caching silently breaks for that step, plus stack-trace log spam on retries.

This type-checks before recursing and skips malformed keys instead of panicking.

## Testing

Added `TestGenerateCacheKeyFromTemplateMalformedContainer`, a table-driven test over the malformed `container` shapes (string / number / array / null / bool). Each previously panicked and now returns a valid cache key. `go build` and `go vet` are clean on `backend/src/cache/server/`.

## Documentation

None; this is an internal defensive fix with no user-facing surface change.