### PR TITLE
fix(backend): prevent terminated run state regressions

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1547,6 +1547,25 @@ func (r *ResourceManager) CreateOrUpdateTasks(t []*model.Task, runID string) ([]
 	return tasks, nil
 }
 
+func shouldPreserveTerminatedRunState(currentState, reportedState model.RuntimeState) bool {
+	currentState = currentState.ToV2()
+	reportedState = reportedState.ToV2()
+
+	if currentState == model.RuntimeStateCanceled {
+		return reportedState != model.RuntimeStateCanceled
+	}
+	if currentState != model.RuntimeStateCancelling {
+		return false
+	}
+
+	switch reportedState {
+	case model.RuntimeStateCancelling, model.RuntimeStateSucceeded, model.RuntimeStateFailed, model.RuntimeStateCanceled:
+		return false
+	default:
+		return true
+	}
+}
+
 // Reports a workflow CR.
 // This is called to update runs.
 func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec util.ExecutionSpec) (util.ExecutionSpec, error) {
@@ -1602,11 +1621,42 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 	// If run already exists, simply update it
 	run, updateError := r.GetRun(runId)
 	if updateError == nil {
-		run.State = state
-		run.Conditions = string(state.ToV1())
-		run.FinishedAtInSec = execStatus.FinishedAt()
-		run.WorkflowRuntimeManifest = model.LargeText(execSpec.ToStringForStore())
-		if updateError = r.runStore.UpdateRun(run); updateError != nil {
+		const maxStateUpdateAttempts = 3
+		updated := false
+		for attempt := 0; attempt < maxStateUpdateAttempts; attempt++ {
+			expectedState := run.State
+			if shouldPreserveTerminatedRunState(run.State, state) {
+				glog.Infof(
+					"Preserving run %q state %q instead of applying stale workflow state %q",
+					runId,
+					run.State,
+					state,
+				)
+			} else {
+				run.State = state
+				run.Conditions = string(state.ToV1())
+				run.FinishedAtInSec = execStatus.FinishedAt()
+			}
+			run.WorkflowRuntimeManifest = model.LargeText(execSpec.ToStringForStore())
+
+			updated, updateError = r.runStore.UpdateRunWithExpectedState(run, expectedState)
+			if updateError != nil || updated {
+				break
+			}
+
+			run, updateError = r.GetRun(runId)
+			if updateError != nil {
+				break
+			}
+		}
+		if updateError == nil && !updated {
+			updateError = util.NewUnavailableServerError(
+				fmt.Errorf("run state changed during %d update attempts", maxStateUpdateAttempts),
+				"Failed to report workflow for run %s due to concurrent state updates",
+				runId,
+			)
+		}
+		if updateError != nil {
 			return nil, util.Wrapf(updateError, "Failed to report a workflow for existing run %s during updating the run. Check if the run entry is corrupted", runId)
 		}
 	}

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3973,6 +3973,110 @@ func TestReportWorkflowResource_ScheduledWorkflowIDEmpty_Success(t *testing.T) {
 	assert.Equal(t, expectedRun.ToV1(), run.ToV1())
 }
 
+type runStoreWithBeforeFirstConditionalUpdateHook struct {
+	storage.RunStoreInterface
+	beforeFirstUpdate func()
+	updateCalls       int
+}
+
+func (s *runStoreWithBeforeFirstConditionalUpdateHook) UpdateRunWithExpectedState(run *model.Run, expectedState model.RuntimeState) (bool, error) {
+	s.updateCalls++
+	if s.updateCalls == 1 {
+		s.beforeFirstUpdate()
+	}
+	return s.RunStoreInterface.UpdateRunWithExpectedState(run, expectedState)
+}
+
+func TestReportWorkflowResource_RetriesConcurrentTerminationWithoutRegressingState(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+
+	runStore := manager.runStore.(*storage.RunStore)
+	hookedRunStore := &runStoreWithBeforeFirstConditionalUpdateHook{
+		RunStoreInterface: runStore,
+		beforeFirstUpdate: func() {
+			require.NoError(t, runStore.TerminateRun(run.UUID))
+		},
+	}
+	manager.runStore = hookedRunStore
+
+	staleWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: "ns1",
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+	})
+	_, err := manager.ReportWorkflowResource(context.Background(), staleWorkflow)
+	require.NoError(t, err)
+
+	updatedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateCancelling, updatedRun.State)
+	assert.Equal(t, string(model.RuntimeStateCancelling.ToV1()), updatedRun.Conditions)
+	assert.Equal(t, model.LargeText(staleWorkflow.ToStringForStore()), updatedRun.WorkflowRuntimeManifest)
+	assert.Equal(t, 2, hookedRunStore.updateCalls)
+}
+
+func TestShouldPreserveTerminatedRunState(t *testing.T) {
+	testCases := []struct {
+		name          string
+		currentState  model.RuntimeState
+		reportedState model.RuntimeState
+		want          bool
+	}{
+		{
+			name:          "canceling rejects unspecified",
+			currentState:  model.RuntimeStateCancelling,
+			reportedState: model.RuntimeStateUnspecified,
+			want:          true,
+		},
+		{
+			name:          "canceling rejects running",
+			currentState:  model.RuntimeStateCancelling,
+			reportedState: model.RuntimeStateRunning,
+			want:          true,
+		},
+		{
+			name:          "canceling accepts canceled",
+			currentState:  model.RuntimeStateCancelling,
+			reportedState: model.RuntimeStateCanceled,
+			want:          false,
+		},
+		{
+			name:          "canceling rejects skipped",
+			currentState:  model.RuntimeStateCancelling,
+			reportedState: model.RuntimeStateSkipped,
+			want:          true,
+		},
+		{
+			name:          "canceled rejects failed",
+			currentState:  model.RuntimeStateCanceled,
+			reportedState: model.RuntimeStateFailed,
+			want:          true,
+		},
+		{
+			name:          "canceled accepts canceled",
+			currentState:  model.RuntimeStateCanceled,
+			reportedState: model.RuntimeStateCanceled,
+			want:          false,
+		},
+		{
+			name:          "running accepts succeeded",
+			currentState:  model.RuntimeStateRunning,
+			reportedState: model.RuntimeStateSucceeded,
+			want:          false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.want, shouldPreserveTerminatedRunState(testCase.currentState, testCase.reportedState))
+		})
+	}
+}
+
 func TestReportWorkflowResource_ScheduledWorkflowIDNotEmpty_Success(t *testing.T) {
 	store, manager, job := initWithJob(t)
 	defer store.Close()

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -83,6 +83,10 @@ type RunStoreInterface interface {
 	// Note: only state, runtime manifest can be updated. Does not update dependent tasks.
 	UpdateRun(run *model.Run) (err error)
 
+	// Updates a run only when its persisted state still matches expectedState.
+	// Returns false without updating when another writer changed the state.
+	UpdateRunWithExpectedState(run *model.Run, expectedState model.RuntimeState) (bool, error)
+
 	// Updates only the PluginsOutput column for a run. Use this when plugin
 	// handlers need to persist output without touching core run fields (State,
 	// Conditions, etc.) to avoid redundant writes and potential clobbering.
@@ -611,9 +615,18 @@ func (s *RunStore) GetRunByRecurringRunIDAndDisplayName(recurringRunID, displayN
 }
 
 func (s *RunStore) UpdateRun(run *model.Run) error {
+	_, err := s.updateRun(run, nil)
+	return err
+}
+
+func (s *RunStore) UpdateRunWithExpectedState(run *model.Run, expectedState model.RuntimeState) (bool, error) {
+	return s.updateRun(run, &expectedState)
+}
+
+func (s *RunStore) updateRun(run *model.Run, expectedState *model.RuntimeState) (bool, error) {
 	tx, err := s.db.DB.Begin()
 	if err != nil {
-		return util.NewInternalServerError(err, "transaction creation failed")
+		return false, util.NewInternalServerError(err, "transaction creation failed")
 	}
 	if len(run.RunDetails.StateHistory) == 0 || run.RunDetails.StateHistory[len(run.RunDetails.StateHistory)-1].State != run.RunDetails.State {
 		run.RunDetails.StateHistory = append(run.RunDetails.StateHistory, &model.RuntimeStatus{
@@ -640,40 +653,53 @@ func (s *RunStore) UpdateRun(run *model.Run) error {
 	if run.PluginsOutputString != nil {
 		updateFields["PluginsOutput"] = largeTextToNullableSQL(run.PluginsOutputString)
 	}
-	sql, args, err := sq.
+	updateQuery := sq.
 		Update("run_details").
 		SetMap(updateFields).
-		Where(sq.Eq{"UUID": run.UUID}).
-		ToSql()
+		Where(sq.Eq{"UUID": run.UUID})
+	if expectedState != nil {
+		updateQuery = updateQuery.Where(sq.Eq{"State": expectedState.ToString()})
+	}
+	sql, args, err := updateQuery.ToSql()
 	if err != nil {
 		tx.Rollback()
-		return util.NewInternalServerError(err,
+		return false, util.NewInternalServerError(err,
 			"Failed to create query to update run %s", run.UUID)
 	}
 	result, err := tx.Exec(sql, args...)
 	if err != nil {
 		tx.Rollback()
-		return util.NewInternalServerError(err,
+		return false, util.NewInternalServerError(err,
 			"Failed to update run %s", run.UUID)
 	}
 	r, err := result.RowsAffected()
 	if err != nil {
 		tx.Rollback()
-		return util.NewInternalServerError(err,
+		return false, util.NewInternalServerError(err,
 			"Failed to update run %s", run.UUID)
 	}
 	if r > 1 {
 		tx.Rollback()
-		return util.NewInternalServerError(errors.New("Failed to update run"), "Failed to update run %s. More than 1 rows affected", run.UUID)
+		return false, util.NewInternalServerError(errors.New("Failed to update run"), "Failed to update run %s. More than 1 rows affected", run.UUID)
 	} else if r == 0 {
 		tx.Rollback()
-		return util.Wrap(util.NewResourceNotFoundError("Run", run.UUID), "Failed to update run")
+		if expectedState != nil {
+			currentRun, getErr := s.GetRun(run.UUID)
+			if getErr != nil {
+				return false, getErr
+			}
+			if currentRun.State.ToV2() == expectedState.ToV2() {
+				return true, nil
+			}
+			return false, nil
+		}
+		return false, util.Wrap(util.NewResourceNotFoundError("Run", run.UUID), "Failed to update run")
 	}
 
 	if err := tx.Commit(); err != nil {
-		return util.NewInternalServerError(err, "failed to commit transaction for run %s", run.UUID)
+		return false, util.NewInternalServerError(err, "failed to commit transaction for run %s", run.UUID)
 	}
-	return nil
+	return true, nil
 }
 
 // UpdateRunPluginsOutput updates only the PluginsOutput column for the given

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -865,6 +865,29 @@ func TestCreateAndUpdateRun_UpdateSuccess(t *testing.T) {
 	assert.Equal(t, expectedRun.ToV1(), runDetail.ToV1())
 }
 
+func TestUpdateRunWithExpectedState_DetectsConcurrentStateChange(t *testing.T) {
+	db, runStore := initializeRunStore()
+	defer db.Close()
+
+	staleRun, err := runStore.GetRun("1")
+	require.NoError(t, err)
+	require.Equal(t, model.RuntimeStateRunning, staleRun.State)
+
+	require.NoError(t, runStore.TerminateRun(staleRun.UUID))
+
+	staleRun.State = model.RuntimeStateUnspecified
+	staleRun.Conditions = string(model.RuntimeStateUnspecified.ToV1())
+	staleRun.WorkflowRuntimeManifest = "stale-workflow"
+	updated, err := runStore.UpdateRunWithExpectedState(staleRun, model.RuntimeStateRunning)
+	require.NoError(t, err)
+	assert.False(t, updated)
+
+	currentRun, err := runStore.GetRun(staleRun.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateCancelling, currentRun.State)
+	assert.Equal(t, "workflow1", string(currentRun.WorkflowRuntimeManifest))
+}
+
 func TestCreateAndUpdateRun_CreateSuccess(t *testing.T) {
 	db, runStore := initializeRunStore()
 	defer db.Close()


### PR DESCRIPTION
## Summary

- prevent stale workflow reports from moving runs backward from `CANCELING` or `CANCELED`
- make workflow-driven run updates compare the persisted state atomically and retry after concurrent changes
- preserve workflow metadata updates while retaining the authoritative termination state

## Why

PR #13876 exposed a race in the legacy v2 Run API integration test: `TerminateRun` persisted `CANCELING`, but an older workflow observation could overwrite it with `RUNTIME_STATE_UNSPECIFIED`. The zero-valued protobuf enum was then omitted from JSON, so the client observed a nil `State`.

The storage compare-and-swap closes the read/update race; an in-memory transition check alone would still allow termination to commit between those operations.

## Testing

- `go test ./backend/src/apiserver/resource -count=1`
- `go test ./backend/src/apiserver/storage -count=1`
- deterministic regression coverage injects termination between the workflow report read and its first conditional update

Related to #13876.