### PR TITLE
fix(backend): reject runAsUser=0 at API level instead of deferring to kubelet

### DIFF
--- a/backend/src/common/security_context/security_context.go
+++ b/backend/src/common/security_context/security_context.go
@@ -1,0 +1,15 @@
+// Package securitycontext provides shared security-context helpers for the backend.
+package securitycontext
+
+// IsRunAsNonRootEffective returns whether runAsNonRoot is effectively
+// true given admin and component settings. Admin takes precedence;
+// component value is used only when admin is nil.
+func IsRunAsNonRootEffective(admin, component *bool) bool {
+	if admin != nil {
+		return *admin
+	}
+	if component != nil {
+		return *component
+	}
+	return false
+}

--- a/backend/src/common/security_context/security_context_test.go
+++ b/backend/src/common/security_context/security_context_test.go
@@ -1,0 +1,34 @@
+package securitycontext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRunAsNonRootEffective(t *testing.T) {
+	tr := true
+	fa := false
+
+	tests := []struct {
+		name      string
+		admin     *bool
+		component *bool
+		want      bool
+	}{
+		{"both nil", nil, nil, false},
+		{"admin true", &tr, nil, true},
+		{"admin false", &fa, nil, false},
+		{"component true", nil, &tr, true},
+		{"component false", nil, &fa, false},
+		{"admin true overrides component false", &tr, &fa, true},
+		{"admin false overrides component true", &fa, &tr, false},
+		{"both true", &tr, &tr, true},
+		{"both false", &fa, &fa, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsRunAsNonRootEffective(tt.admin, tt.component))
+		})
+	}
+}

--- a/backend/src/v2/compiler/argocompiler/argo.go
+++ b/backend/src/v2/compiler/argocompiler/argo.go
@@ -27,6 +27,7 @@ import (
 	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/v2/compiler"
+	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -208,13 +209,14 @@ func Compile(jobArg *pipelinespec.PipelineJob, kubernetesSpecArg *pipelinespec.S
 		wf:        wf,
 		templates: make(map[string]*wfapi.Template),
 		// TODO(chensun): release process and update the images.
-		launcherImage:   GetLauncherImage(),
-		launcherCommand: GetLauncherCommand(),
-		driverImage:     GetDriverImage(),
-		driverCommand:   GetDriverCommand(),
-		job:             job,
-		spec:            spec,
-		executors:       deploy.GetExecutors(),
+		launcherImage:     GetLauncherImage(),
+		launcherCommand:   GetLauncherCommand(),
+		driverImage:       GetDriverImage(),
+		driverCommand:     GetDriverCommand(),
+		job:               job,
+		spec:              spec,
+		executors:         deploy.GetExecutors(),
+		kubernetesConfigs: make(map[string]*kubernetesplatform.KubernetesExecutorConfig),
 	}
 	if opts != nil {
 		c.cacheDisabled = opts.CacheDisabled
@@ -332,6 +334,7 @@ type workflowCompiler struct {
 	defaultRunAsNonRoot  *bool
 	defaultHostUsers     *bool
 	driverPodConfig      *common.DriverPodConfig
+	kubernetesConfigs    map[string]*kubernetesplatform.KubernetesExecutorConfig
 }
 
 // applyDriverPodConfig applies driver pod labels and annotations to a workflow

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/kubeflow/pipelines/backend/src/v2/config"
 	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -322,13 +321,9 @@ func (c *workflowCompiler) containerExecutorTask(name string, inputs containerEx
 		return nil, fmt.Errorf("component reference is nil")
 	}
 
-	// Retrieve pod metadata defined in the Kubernetes Spec, if any
-	kubernetesConfigParam := c.wf.Spec.Arguments.GetParameterByName(argumentsKubernetesSpec + refName)
-	k8sExecCfg := &kubernetesplatform.KubernetesExecutorConfig{}
-	if kubernetesConfigParam != nil && kubernetesConfigParam.Value != nil {
-		if err := protojson.Unmarshal([]byte((*kubernetesConfigParam.Value)), k8sExecCfg); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal kubernetes config: %v", err)
-		}
+	k8sExecCfg := c.kubernetesConfigs[refName]
+	if k8sExecCfg == nil {
+		k8sExecCfg = &kubernetesplatform.KubernetesExecutorConfig{}
 	}
 	dagTask := &wfapi.DAGTask{
 		Name:     name,

--- a/backend/src/v2/compiler/argocompiler/spec_patch.go
+++ b/backend/src/v2/compiler/argocompiler/spec_patch.go
@@ -19,15 +19,55 @@ import (
 	"fmt"
 
 	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 
 func (c *workflowCompiler) AddKubernetesSpec(name string, kubernetesSpec *structpb.Struct) error {
-	err := c.saveKubernetesSpec(name, kubernetesSpec)
+	k8sExecConfig, err := unmarshalKubernetesExecutorConfig(name, kubernetesSpec)
 	if err != nil {
 		return err
+	}
+	if err := c.validateKubernetesSecurityContext(name, k8sExecConfig); err != nil {
+		return err
+	}
+	c.kubernetesConfigs[name] = k8sExecConfig
+	return c.saveKubernetesSpec(name, kubernetesSpec)
+}
+
+func unmarshalKubernetesExecutorConfig(name string, kubernetesSpec *structpb.Struct) (*kubernetesplatform.KubernetesExecutorConfig, error) {
+	if kubernetesSpec == nil {
+		return &kubernetesplatform.KubernetesExecutorConfig{}, nil
+	}
+	jsonBytes, err := kubernetesSpec.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal kubernetes spec for component %q: %w", name, err)
+	}
+	config := &kubernetesplatform.KubernetesExecutorConfig{}
+	if err := protojson.Unmarshal(jsonBytes, config); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal kubernetes spec for component %q: %w", name, err)
+	}
+	return config, nil
+}
+
+func (c *workflowCompiler) validateKubernetesSecurityContext(name string, config *kubernetesplatform.KubernetesExecutorConfig) error {
+	securityContext := config.GetSecurityContext()
+	if securityContext == nil {
+		return nil
+	}
+	if c.defaultRunAsUser != nil {
+		return nil
+	}
+	if securityContext.RunAsUser != nil && *securityContext.RunAsUser == 0 {
+		return fmt.Errorf(
+			"runAsUser=0 (root) is not allowed for component %q: "+
+				"the container security context enforces non-root execution "+
+				"(allowPrivilegeEscalation=false); use a non-root UID instead",
+			name,
+		)
 	}
 	return nil
 }

--- a/backend/src/v2/compiler/argocompiler/spec_patch.go
+++ b/backend/src/v2/compiler/argocompiler/spec_patch.go
@@ -61,11 +61,12 @@ func (c *workflowCompiler) validateKubernetesSecurityContext(name string, config
 	if c.defaultRunAsUser != nil {
 		return nil
 	}
-	if securityContext.RunAsUser != nil && *securityContext.RunAsUser == 0 {
+	if c.defaultRunAsNonRoot != nil && *c.defaultRunAsNonRoot &&
+		securityContext.RunAsUser != nil && *securityContext.RunAsUser == 0 {
 		return fmt.Errorf(
 			"runAsUser=0 (root) is not allowed for component %q: "+
-				"the container security context enforces non-root execution "+
-				"(allowPrivilegeEscalation=false); use a non-root UID instead",
+				"the admin security policy enforces non-root execution "+
+				"(runAsNonRoot=true); use a non-root UID instead",
 			name,
 		)
 	}

--- a/backend/src/v2/compiler/argocompiler/spec_patch.go
+++ b/backend/src/v2/compiler/argocompiler/spec_patch.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	securitycontext "github.com/kubeflow/pipelines/backend/src/common/security_context"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -61,12 +62,11 @@ func (c *workflowCompiler) validateKubernetesSecurityContext(name string, config
 	if c.defaultRunAsUser != nil {
 		return nil
 	}
-	if c.defaultRunAsNonRoot != nil && *c.defaultRunAsNonRoot &&
+	if securitycontext.IsRunAsNonRootEffective(c.defaultRunAsNonRoot, securityContext.RunAsNonRoot) &&
 		securityContext.RunAsUser != nil && *securityContext.RunAsUser == 0 {
 		return fmt.Errorf(
 			"runAsUser=0 (root) is not allowed for component %q: "+
-				"the admin security policy enforces non-root execution "+
-				"(runAsNonRoot=true); use a non-root UID instead",
+				"runAsNonRoot is true; use a non-root UID instead",
 			name,
 		)
 	}

--- a/backend/src/v2/compiler/argocompiler/spec_patch_test.go
+++ b/backend/src/v2/compiler/argocompiler/spec_patch_test.go
@@ -18,7 +18,11 @@ import (
 	"testing"
 
 	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -253,4 +257,173 @@ func TestApplyWorkflowSpecPatch_ComplexPatch(t *testing.T) {
 	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, wf.Spec.SecurityContext.SeccompProfile.Type)
 	assert.Equal(t, false, *wf.Spec.HostNetwork)
 	assert.Equal(t, corev1.DNSClusterFirst, *wf.Spec.DNSPolicy)
+}
+
+func kubernetesExecutorConfigToStruct(t *testing.T, config *kubernetesplatform.KubernetesExecutorConfig) *structpb.Struct {
+	t.Helper()
+	jsonBytes, err := protojson.Marshal(config)
+	require.NoError(t, err)
+	s := &structpb.Struct{}
+	require.NoError(t, protojson.Unmarshal(jsonBytes, s))
+	return s
+}
+
+func TestKubernetesExecutorConfigRoundTrip(t *testing.T) {
+	original := &kubernetesplatform.KubernetesExecutorConfig{
+		SecurityContext: &kubernetesplatform.SecurityContext{
+			RunAsUser:  int64Ptr(1000),
+			RunAsGroup: int64Ptr(2000),
+		},
+	}
+
+	s := kubernetesExecutorConfigToStruct(t, original)
+	result, err := unmarshalKubernetesExecutorConfig("comp-test", s)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(1000), *result.GetSecurityContext().RunAsUser)
+	assert.Equal(t, int64(2000), *result.GetSecurityContext().RunAsGroup)
+}
+
+func TestAddKubernetesSpec_RejectsRootRunAsUser(t *testing.T) {
+	tests := []struct {
+		name                string
+		componentName       string
+		defaultRunAsUser    *int64
+		defaultRunAsNonRoot *bool
+		config              *kubernetesplatform.KubernetesExecutorConfig
+		expectError         bool
+		errorContains       string
+	}{
+		{
+			name:          "runAsUser=0 rejected",
+			componentName: "comp-train",
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: int64Ptr(0),
+				},
+			},
+			expectError:   true,
+			errorContains: "runAsUser=0 (root) is not allowed",
+		},
+		{
+			name:                "runAsUser=0 rejected with admin runAsNonRoot",
+			componentName:       "comp-train",
+			defaultRunAsNonRoot: new(true),
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: int64Ptr(0),
+				},
+			},
+			expectError:   true,
+			errorContains: "runAsUser=0 (root) is not allowed",
+		},
+		{
+			name:             "runAsUser=0 allowed when admin sets defaultRunAsUser",
+			componentName:    "comp-train",
+			defaultRunAsUser: int64Ptr(1000),
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: int64Ptr(0),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "non-root runAsUser=1000 allowed",
+			componentName: "comp-train",
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: int64Ptr(1000),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:                "non-root allowed with admin runAsNonRoot",
+			componentName:       "comp-train",
+			defaultRunAsNonRoot: new(true),
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: int64Ptr(1000),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "no security context",
+			componentName: "comp-train",
+			config:        &kubernetesplatform.KubernetesExecutorConfig{},
+			expectError:   false,
+		},
+		{
+			name:          "security context without runAsUser",
+			componentName: "comp-train",
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsGroup: int64Ptr(1000),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:             "runAsUser=0 allowed when admin defaultRunAsUser is zero",
+			componentName:    "comp-train",
+			defaultRunAsUser: int64Ptr(0),
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: int64Ptr(0),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:          "nil kubernetes spec",
+			componentName: "comp-train",
+			config:        nil,
+			expectError:   false,
+		},
+		{
+			name:          "error includes component name",
+			componentName: "my-custom-component",
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: int64Ptr(0),
+				},
+			},
+			expectError:   true,
+			errorContains: "my-custom-component",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			compiler := &workflowCompiler{
+				wf: &wfapi.Workflow{
+					Spec: wfapi.WorkflowSpec{
+						Arguments: wfapi.Arguments{
+							Parameters: []wfapi.Parameter{},
+						},
+					},
+				},
+				kubernetesConfigs:   make(map[string]*kubernetesplatform.KubernetesExecutorConfig),
+				defaultRunAsUser:    tt.defaultRunAsUser,
+				defaultRunAsNonRoot: tt.defaultRunAsNonRoot,
+			}
+
+			var kubernetesSpec *structpb.Struct
+			if tt.config != nil {
+				kubernetesSpec = kubernetesExecutorConfigToStruct(t, tt.config)
+			}
+			err := compiler.AddKubernetesSpec(tt.componentName, kubernetesSpec)
+
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				assert.Empty(t, compiler.kubernetesConfigs, "rejected config must not be cached")
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, compiler.kubernetesConfigs[tt.componentName])
+			}
+		})
+	}
 }

--- a/backend/src/v2/compiler/argocompiler/spec_patch_test.go
+++ b/backend/src/v2/compiler/argocompiler/spec_patch_test.go
@@ -295,15 +295,14 @@ func TestAddKubernetesSpec_RejectsRootRunAsUser(t *testing.T) {
 		errorContains       string
 	}{
 		{
-			name:          "runAsUser=0 rejected",
+			name:          "runAsUser=0 allowed without runAsNonRoot enforcement",
 			componentName: "comp-train",
 			config: &kubernetesplatform.KubernetesExecutorConfig{
 				SecurityContext: &kubernetesplatform.SecurityContext{
 					RunAsUser: int64Ptr(0),
 				},
 			},
-			expectError:   true,
-			errorContains: "runAsUser=0 (root) is not allowed",
+			expectError: false,
 		},
 		{
 			name:                "runAsUser=0 rejected with admin runAsNonRoot",
@@ -377,14 +376,26 @@ func TestAddKubernetesSpec_RejectsRootRunAsUser(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:                "runAsUser=0 allowed when admin defaultRunAsNonRoot is false",
+			componentName:       "comp-train",
+			defaultRunAsNonRoot: new(false),
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: int64Ptr(0),
+				},
+			},
+			expectError: false,
+		},
+		{
 			name:          "nil kubernetes spec",
 			componentName: "comp-train",
 			config:        nil,
 			expectError:   false,
 		},
 		{
-			name:          "error includes component name",
-			componentName: "my-custom-component",
+			name:                "error includes component name",
+			componentName:       "my-custom-component",
+			defaultRunAsNonRoot: new(true),
 			config: &kubernetesplatform.KubernetesExecutorConfig{
 				SecurityContext: &kubernetesplatform.SecurityContext{
 					RunAsUser: int64Ptr(0),

--- a/backend/src/v2/compiler/argocompiler/spec_patch_test.go
+++ b/backend/src/v2/compiler/argocompiler/spec_patch_test.go
@@ -376,6 +376,18 @@ func TestAddKubernetesSpec_RejectsRootRunAsUser(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:                "admin defaultRunAsNonRoot=false overrides component runAsNonRoot=true",
+			componentName:       "comp-train",
+			defaultRunAsNonRoot: new(false),
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser:    int64Ptr(0),
+					RunAsNonRoot: new(true),
+				},
+			},
+			expectError: false,
+		},
+		{
 			name:                "runAsUser=0 allowed when admin defaultRunAsNonRoot is false",
 			componentName:       "comp-train",
 			defaultRunAsNonRoot: new(false),
@@ -403,6 +415,41 @@ func TestAddKubernetesSpec_RejectsRootRunAsUser(t *testing.T) {
 			},
 			expectError:   true,
 			errorContains: "my-custom-component",
+		},
+		{
+			name:          "runAsUser=0 rejected with component runAsNonRoot=true",
+			componentName: "comp-train",
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser:    int64Ptr(0),
+					RunAsNonRoot: new(true),
+				},
+			},
+			expectError:   true,
+			errorContains: "runAsUser=0 (root) is not allowed",
+		},
+		{
+			name:          "runAsUser=0 allowed with component runAsNonRoot=false",
+			componentName: "comp-train",
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser:    int64Ptr(0),
+					RunAsNonRoot: new(false),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:             "component runAsNonRoot=true overridden by admin defaultRunAsUser",
+			componentName:    "comp-train",
+			defaultRunAsUser: int64Ptr(1000),
+			config: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser:    int64Ptr(0),
+					RunAsNonRoot: new(true),
+				},
+			},
+			expectError: false,
 		},
 	}
 

--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -753,13 +753,14 @@ func extendPodSpecPatch(
 		}
 		existingSecurityContext := podSpec.Containers[0].SecurityContext
 		isCompilerHardened := existingSecurityContext.AllowPrivilegeEscalation != nil && !*existingSecurityContext.AllowPrivilegeEscalation
+		runAsNonRootEnforced := existingSecurityContext.RunAsNonRoot != nil && *existingSecurityContext.RunAsNonRoot
 		if userSecurityContext.RunAsUser != nil {
 			if existingSecurityContext.RunAsUser != nil {
 				glog.Warningf("Ignoring user-specified runAsUser (%d): security context already set by admin (runAsUser=%d)",
 					*userSecurityContext.RunAsUser, *existingSecurityContext.RunAsUser)
 			} else {
-				if isCompilerHardened && *userSecurityContext.RunAsUser == 0 {
-					glog.Warningf("Setting runAsUser=0 (root) on a container with hardened security context; consider using a non-root UID")
+				if *userSecurityContext.RunAsUser == 0 && (isCompilerHardened || runAsNonRootEnforced) {
+					return fmt.Errorf("runAsUser=0 (root) is not allowed: the container security context enforces non-root execution (runAsNonRoot=true or allowPrivilegeEscalation=false); use a non-root UID instead")
 				}
 				podSpec.Containers[0].SecurityContext.RunAsUser = userSecurityContext.RunAsUser
 			}

--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	securitycontext "github.com/kubeflow/pipelines/backend/src/common/security_context"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/v2/cacheutils"
 	"github.com/kubeflow/pipelines/backend/src/v2/common/plugins"
@@ -752,14 +753,14 @@ func extendPodSpecPatch(
 			podSpec.Containers[0].SecurityContext = &k8score.SecurityContext{}
 		}
 		existingSecurityContext := podSpec.Containers[0].SecurityContext
-		runAsNonRootEnforced := existingSecurityContext.RunAsNonRoot != nil && *existingSecurityContext.RunAsNonRoot
+		runAsNonRootEnforced := securitycontext.IsRunAsNonRootEffective(existingSecurityContext.RunAsNonRoot, userSecurityContext.RunAsNonRoot)
 		if userSecurityContext.RunAsUser != nil {
 			if existingSecurityContext.RunAsUser != nil {
 				glog.Warningf("Ignoring user-specified runAsUser (%d): security context already set by admin (runAsUser=%d)",
 					*userSecurityContext.RunAsUser, *existingSecurityContext.RunAsUser)
 			} else {
 				if *userSecurityContext.RunAsUser == 0 && runAsNonRootEnforced {
-					return fmt.Errorf("runAsUser=0 (root) is not allowed: the admin security policy enforces non-root execution (runAsNonRoot=true); use a non-root UID instead")
+					return fmt.Errorf("runAsUser=0 (root) is not allowed: runAsNonRoot is true; use a non-root UID instead")
 				}
 				podSpec.Containers[0].SecurityContext.RunAsUser = userSecurityContext.RunAsUser
 			}

--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -752,15 +752,14 @@ func extendPodSpecPatch(
 			podSpec.Containers[0].SecurityContext = &k8score.SecurityContext{}
 		}
 		existingSecurityContext := podSpec.Containers[0].SecurityContext
-		isCompilerHardened := existingSecurityContext.AllowPrivilegeEscalation != nil && !*existingSecurityContext.AllowPrivilegeEscalation
 		runAsNonRootEnforced := existingSecurityContext.RunAsNonRoot != nil && *existingSecurityContext.RunAsNonRoot
 		if userSecurityContext.RunAsUser != nil {
 			if existingSecurityContext.RunAsUser != nil {
 				glog.Warningf("Ignoring user-specified runAsUser (%d): security context already set by admin (runAsUser=%d)",
 					*userSecurityContext.RunAsUser, *existingSecurityContext.RunAsUser)
 			} else {
-				if *userSecurityContext.RunAsUser == 0 && (isCompilerHardened || runAsNonRootEnforced) {
-					return fmt.Errorf("runAsUser=0 (root) is not allowed: the container security context enforces non-root execution (runAsNonRoot=true or allowPrivilegeEscalation=false); use a non-root UID instead")
+				if *userSecurityContext.RunAsUser == 0 && runAsNonRootEnforced {
+					return fmt.Errorf("runAsUser=0 (root) is not allowed: the admin security policy enforces non-root execution (runAsNonRoot=true); use a non-root UID instead")
 				}
 				podSpec.Containers[0].SecurityContext.RunAsUser = userSecurityContext.RunAsUser
 			}

--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 	k8score "k8s.io/api/core/v1"
 	k8sres "k8s.io/apimachinery/pkg/api/resource"
@@ -2396,24 +2397,10 @@ func Test_extendPodSpecPatch_SecurityContext_RootOnHardenedContainer(t *testing.
 		map[string]*structpb.Value{},
 		nil,
 	)
-	assert.Nil(t, err)
-	assert.NotNil(t, got)
-	// runAsUser=0 is applied but the container is flagged as hardened
-	// (allowPrivilegeEscalation=false), so a warning is logged.
-	assert.Equal(t, &k8score.PodSpec{
-		Containers: []k8score.Container{
-			{
-				Name: "main",
-				SecurityContext: &k8score.SecurityContext{
-					RunAsUser:                &rootUID,
-					AllowPrivilegeEscalation: &allowPrivEsc,
-					Capabilities: &k8score.Capabilities{
-						Drop: []k8score.Capability{"ALL"},
-					},
-				},
-			},
-		},
-	}, got)
+	// runAsUser=0 on a hardened container (allowPrivilegeEscalation=false)
+	// must be rejected with an immediate error instead of deferring to kubelet.
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "runAsUser=0 (root) is not allowed")
 }
 
 func Test_extendPodSpecPatch_SecurityContext_AdminRunAsNonRoot(t *testing.T) {
@@ -2491,6 +2478,88 @@ func Test_extendPodSpecPatch_SecurityContext_UserRunAsNonRootNoAdmin(t *testing.
 	assert.Nil(t, err)
 	// User-specified runAsNonRoot is applied when no admin default is set.
 	assert.True(t, *got.Containers[0].SecurityContext.RunAsNonRoot)
+}
+
+func Test_extendPodSpecPatch_SecurityContext_RootRejectedWhenRunAsNonRootEnforced(t *testing.T) {
+	adminRunAsNonRoot := true
+	rootUID := int64(0)
+
+	got := &k8score.PodSpec{Containers: []k8score.Container{
+		{Name: "main"},
+	}}
+	err := extendPodSpecPatch(
+		context.Background(),
+		got,
+		Options{
+			DefaultRunAsNonRoot: &adminRunAsNonRoot,
+			KubernetesExecutorConfig: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: &rootUID,
+				},
+			},
+		},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	// runAsUser=0 must be rejected when admin enforces runAsNonRoot=true.
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "runAsUser=0 (root) is not allowed")
+}
+
+func Test_extendPodSpecPatch_SecurityContext_NonRootAllowedWhenRunAsNonRootEnforced(t *testing.T) {
+	adminRunAsNonRoot := true
+	nonRootUID := int64(1000)
+
+	got := &k8score.PodSpec{Containers: []k8score.Container{
+		{Name: "main"},
+	}}
+	err := extendPodSpecPatch(
+		context.Background(),
+		got,
+		Options{
+			DefaultRunAsNonRoot: &adminRunAsNonRoot,
+			KubernetesExecutorConfig: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser: &nonRootUID,
+				},
+			},
+		},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	require.Nil(t, err)
+	require.Equal(t, nonRootUID, *got.Containers[0].SecurityContext.RunAsUser)
+}
+
+func Test_extendPodSpecPatch_SecurityContext_NonRootAllowedOnHardenedContainer(t *testing.T) {
+	nonRootUID := int64(1000)
+	allowPrivEsc := false
+
+	got := &k8score.PodSpec{Containers: []k8score.Container{
+		{
+			Name: "main",
+			SecurityContext: &k8score.SecurityContext{
+				AllowPrivilegeEscalation: &allowPrivEsc,
+			},
+		},
+	}}
+	err := extendPodSpecPatch(
+		context.Background(),
+		got,
+		Options{KubernetesExecutorConfig: &kubernetesplatform.KubernetesExecutorConfig{
+			SecurityContext: &kubernetesplatform.SecurityContext{
+				RunAsUser: &nonRootUID,
+			},
+		}},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	// Non-root UID is allowed even on hardened containers.
+	require.Nil(t, err)
+	require.Equal(t, nonRootUID, *got.Containers[0].SecurityContext.RunAsUser)
 }
 
 func Test_extendPodSpecPatch_ImagePullPolicy(t *testing.T) {

--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -2564,6 +2564,88 @@ func Test_extendPodSpecPatch_SecurityContext_NonRootAllowedOnHardenedContainer(t
 	require.Equal(t, nonRootUID, *got.Containers[0].SecurityContext.RunAsUser)
 }
 
+func Test_extendPodSpecPatch_SecurityContext_RootRejectedWithUserRunAsNonRoot(t *testing.T) {
+	rootUID := int64(0)
+	userRunAsNonRoot := true
+
+	got := &k8score.PodSpec{Containers: []k8score.Container{
+		{Name: "main"},
+	}}
+	err := extendPodSpecPatch(
+		context.Background(),
+		got,
+		Options{KubernetesExecutorConfig: &kubernetesplatform.KubernetesExecutorConfig{
+			SecurityContext: &kubernetesplatform.SecurityContext{
+				RunAsUser:    &rootUID,
+				RunAsNonRoot: &userRunAsNonRoot,
+			},
+		}},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	// Component sets runAsNonRoot=true and runAsUser=0 — contradiction must be rejected.
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "runAsUser=0 (root) is not allowed")
+}
+
+func Test_extendPodSpecPatch_SecurityContext_RootAllowedWhenAdminRunAsNonRootFalseOverridesUser(t *testing.T) {
+	adminRunAsNonRoot := false
+	rootUID := int64(0)
+	userRunAsNonRoot := true
+
+	got := &k8score.PodSpec{Containers: []k8score.Container{
+		{Name: "main"},
+	}}
+	err := extendPodSpecPatch(
+		context.Background(),
+		got,
+		Options{
+			DefaultRunAsNonRoot: &adminRunAsNonRoot,
+			KubernetesExecutorConfig: &kubernetesplatform.KubernetesExecutorConfig{
+				SecurityContext: &kubernetesplatform.SecurityContext{
+					RunAsUser:    &rootUID,
+					RunAsNonRoot: &userRunAsNonRoot,
+				},
+			},
+		},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	// Admin explicitly allows root (runAsNonRoot=false) — user's runAsNonRoot=true
+	// is ignored (with warning) and runAsUser=0 must be allowed.
+	require.Nil(t, err)
+	require.Equal(t, rootUID, *got.Containers[0].SecurityContext.RunAsUser)
+	require.False(t, *got.Containers[0].SecurityContext.RunAsNonRoot)
+}
+
+func Test_extendPodSpecPatch_SecurityContext_RootAllowedWithUserRunAsNonRootFalse(t *testing.T) {
+	rootUID := int64(0)
+	userRunAsNonRoot := false
+
+	got := &k8score.PodSpec{Containers: []k8score.Container{
+		{Name: "main"},
+	}}
+	err := extendPodSpecPatch(
+		context.Background(),
+		got,
+		Options{KubernetesExecutorConfig: &kubernetesplatform.KubernetesExecutorConfig{
+			SecurityContext: &kubernetesplatform.SecurityContext{
+				RunAsUser:    &rootUID,
+				RunAsNonRoot: &userRunAsNonRoot,
+			},
+		}},
+		nil, nil, nil,
+		map[string]*structpb.Value{},
+		nil,
+	)
+	// Component explicitly sets runAsNonRoot=false — root is allowed.
+	require.Nil(t, err)
+	require.Equal(t, rootUID, *got.Containers[0].SecurityContext.RunAsUser)
+	require.Equal(t, userRunAsNonRoot, *got.Containers[0].SecurityContext.RunAsNonRoot)
+}
+
 func Test_extendPodSpecPatch_ImagePullPolicy(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/backend/src/v2/driver/k8s_test.go
+++ b/backend/src/v2/driver/k8s_test.go
@@ -2397,10 +2397,12 @@ func Test_extendPodSpecPatch_SecurityContext_RootOnHardenedContainer(t *testing.
 		map[string]*structpb.Value{},
 		nil,
 	)
-	// runAsUser=0 on a hardened container (allowPrivilegeEscalation=false)
-	// must be rejected with an immediate error instead of deferring to kubelet.
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "runAsUser=0 (root) is not allowed")
+	// allowPrivilegeEscalation=false does not prevent root — it only blocks
+	// privilege escalation. runAsUser=0 is allowed here.
+	require.Nil(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, rootUID, *got.Containers[0].SecurityContext.RunAsUser)
+	require.Equal(t, allowPrivEsc, *got.Containers[0].SecurityContext.AllowPrivilegeEscalation)
 }
 
 func Test_extendPodSpecPatch_SecurityContext_AdminRunAsNonRoot(t *testing.T) {


### PR DESCRIPTION
## Description

When a pipeline component sets `runAsUser: 0` and `runAsNonRoot` is effectively true — either from admin `defaultRunAsNonRoot=true` or the component's own `runAsNonRoot: true` — the compiler and driver now return an immediate error instead of letting the pod fail at kubelet level.

This provides clear, early feedback to pipeline authors instead of a confusing late CrashLoopBackOff. The change is safe because any pipeline setting `runAsUser=0` alongside `runAsNonRoot=true` was already broken (the kubelet would refuse the pod); this only changes *when* and *how* the failure is reported.

### Validation layers

1. **Compiler** (`validateKubernetesSecurityContext`): rejects `runAsUser=0` at compile time when effective `runAsNonRoot` is true.
2. **Driver** (`extendPodSpecPatch`): rejects `runAsUser=0` at runtime when effective `runAsNonRoot` is true (defense-in-depth for pipelines compiled before the compiler check existed).

### Precedence

Effective `runAsNonRoot` is computed via `common.IsRunAsNonRootEffective(admin, component)`:
- Admin `defaultRunAsNonRoot` takes precedence when set (even if `false`)
- Component-level `runAsNonRoot` is used only when admin value is nil
- Admin `defaultRunAsUser` bypasses the check entirely (admin explicitly controls identity)

### What is NOT rejected

- `runAsUser=0` without any `runAsNonRoot` enforcement (no admin default, no component setting)
- `runAsUser=0` with `allowPrivilegeEscalation=false` alone — this only prevents privilege escalation (setuid), not root execution
- `runAsUser=0` when admin sets `defaultRunAsNonRoot=false` (admin explicitly allows root)
- `runAsUser=0` when admin sets `defaultRunAsUser` (admin controls identity)

## Changes

### New shared utility
- `backend/src/v2/common/security_context.go`: `IsRunAsNonRootEffective(admin, component *bool) bool` — resolves admin-overrides-component precedence for `runAsNonRoot`

### Compiler (`backend/src/v2/compiler/argocompiler/`)
- `spec_patch.go`: `AddKubernetesSpec` now unmarshals and caches `KubernetesExecutorConfig`, then validates security context before saving
- `spec_patch.go`: `validateKubernetesSecurityContext` uses `IsRunAsNonRootEffective` to check both admin and component-level `runAsNonRoot`
- `container.go`: `containerExecutorTask` reads from the cache instead of re-unmarshalling from workflow parameters
- `argo.go`: `kubernetesConfigs` map added to `workflowCompiler` struct

### Driver (`backend/src/v2/driver/`)
- `k8s.go`: `extendPodSpecPatch` computes `runAsNonRootEnforced` via `IsRunAsNonRootEffective` instead of only checking the admin-set value

### Tests
- `common/security_context_test.go`: 9 subtests covering all precedence combinations
- `spec_patch_test.go`: 16 subtests including component-level `runAsNonRoot` scenarios and admin-overrides-component
- `k8s_test.go`: 15 security context tests including component-level `runAsNonRoot`, admin-false-overrides-user-true, and user-false-allows-root

## Checklist

- [x] You have signed off your commits
- [x] The title for your pull request follows the convention