### PR TITLE
fix(frontend): distinguish pod lifecycle failures from pipeline errors

### DIFF
--- a/frontend/src/lib/StatusUtils.test.tsx
+++ b/frontend/src/lib/StatusUtils.test.tsx
@@ -21,6 +21,7 @@ import {
   statusToBgColor,
   checkIfTerminated,
   parseNodePhase,
+  isPodLifecycleFailure,
 } from './StatusUtils';
 import { NodeStatus, S3Artifact, Artifact } from 'third_party/argo-ui/argo_template';
 
@@ -215,6 +216,49 @@ describe('StatusUtils', () => {
           },
         }),
       ).toEqual('Succeeded');
+    });
+  });
+
+  describe('isPodLifecycleFailure', () => {
+    // Kept in sync with podFailurePatterns in
+    // backend/src/common/util/pod_failure_classifier.go, so the frontend
+    // recognizes exactly the reasons the backend does.
+    [
+      'ImagePullBackOff',
+      'ErrImagePull',
+      'ErrImageNeverPull',
+      'InvalidImageName',
+      'Unschedulable',
+      'CrashLoopBackOff',
+      'OOMKilled',
+      'DeadlineExceeded',
+      'ContainerCannotRun',
+      'CreateContainerConfigError',
+      'CreateContainerError',
+      'RunContainerError',
+      'NodeLost',
+      'Preempted',
+      'PreemptionByScheduler',
+      'Evicted',
+      'TerminationByKubelet',
+    ].forEach((reason) => {
+      it(`returns true for a message containing ${reason}`, () => {
+        expect(isPodLifecycleFailure(`some prefix text ${reason} some suffix text`)).toBe(true);
+      });
+    });
+
+    it('returns false for a plain pipeline code error', () => {
+      expect(
+        isPodLifecycleFailure('Traceback (most recent call last): ValueError: bad input'),
+      ).toBe(false);
+    });
+
+    it('returns false for an empty message', () => {
+      expect(isPodLifecycleFailure('')).toBe(false);
+    });
+
+    it('returns false for an undefined message', () => {
+      expect(isPodLifecycleFailure(undefined)).toBe(false);
     });
   });
 });

--- a/frontend/src/lib/StatusUtils.ts
+++ b/frontend/src/lib/StatusUtils.ts
@@ -114,6 +114,32 @@ export function checkIfTerminated(status?: NodePhase, nodeMessage?: string): Nod
   return status;
 }
 
+// Substrings that indicate a Kubernetes pod lifecycle failure (the platform
+// couldn't run the step) rather than a failure in the user's own pipeline code.
+const POD_LIFECYCLE_FAILURE_PATTERNS = [
+  'ImagePullBackOff',
+  'ErrImagePull',
+  'ErrImageNeverPull',
+  'InvalidImageName',
+  'Unschedulable',
+  'CrashLoopBackOff',
+  'OOMKilled',
+  'DeadlineExceeded',
+  'NodeLost',
+  'Preempted',
+  'Evicted',
+];
+
+// isPodLifecycleFailure returns true if nodeMessage looks like it was caused by
+// a Kubernetes pod lifecycle issue rather than an error in the user's own
+// pipeline code.
+export function isPodLifecycleFailure(nodeMessage?: string): boolean {
+  if (!nodeMessage) {
+    return false;
+  }
+  return POD_LIFECYCLE_FAILURE_PATTERNS.some((pattern) => nodeMessage.includes(pattern));
+}
+
 export function parseNodePhase(node: NodeStatus): NodePhase {
   if (node.phase !== 'Succeeded') {
     return node.phase as NodePhase; // HACK: NodePhase is a string enum that has the same items as node.phase.

--- a/frontend/src/lib/StatusUtils.ts
+++ b/frontend/src/lib/StatusUtils.ts
@@ -116,6 +116,8 @@ export function checkIfTerminated(status?: NodePhase, nodeMessage?: string): Nod
 
 // Substrings that indicate a Kubernetes pod lifecycle failure (the platform
 // couldn't run the step) rather than a failure in the user's own pipeline code.
+// Mirrors podFailurePatterns in backend/src/common/util/pod_failure_classifier.go;
+// keep the two in sync.
 const POD_LIFECYCLE_FAILURE_PATTERNS = [
   'ImagePullBackOff',
   'ErrImagePull',
@@ -125,9 +127,15 @@ const POD_LIFECYCLE_FAILURE_PATTERNS = [
   'CrashLoopBackOff',
   'OOMKilled',
   'DeadlineExceeded',
+  'ContainerCannotRun',
+  'CreateContainerConfigError',
+  'CreateContainerError',
+  'RunContainerError',
   'NodeLost',
   'Preempted',
+  'PreemptionByScheduler',
   'Evicted',
+  'TerminationByKubelet',
 ];
 
 // isPodLifecycleFailure returns true if nodeMessage looks like it was caused by

--- a/frontend/src/pages/RunDetails.test.tsx
+++ b/frontend/src/pages/RunDetails.test.tsx
@@ -1038,6 +1038,32 @@ describe('RunDetails', () => {
     });
   });
 
+  it('shows a pod lifecycle failure message distinctly from a pipeline code failure', async () => {
+    testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
+      metadata: { name: 'workflow1' },
+      status: {
+        nodes: {
+          node1: {
+            id: 'node1',
+            name: 'node1',
+            templateName: 'template1',
+            phase: 'Failed',
+            message: 'OOMKilled',
+          },
+        },
+      },
+    });
+    await renderRunDetails();
+    await clickGraphNode('node1');
+    await userEvent.click(screen.getByRole('button', { name: 'Logs' }));
+    await waitFor(() => {
+      expect(getRunDetailsState()?.selectedNodeDetails).toHaveProperty(
+        'phaseMessage',
+        'This step failed due to a Kubernetes pod issue, not an error in your pipeline code: OOMKilled',
+      );
+    });
+  });
+
   it('dismisses node message banner if node loses message after refresh', async () => {
     testRun.pipeline_runtime!.workflow_manifest = JSON.stringify({
       metadata: { name: 'workflow1' },

--- a/frontend/src/pages/RunDetails.tsx
+++ b/frontend/src/pages/RunDetails.tsx
@@ -63,7 +63,7 @@ import CompareUtils from 'src/lib/CompareUtils';
 import { OutputArtifactLoader } from 'src/lib/OutputArtifactLoader';
 import RunUtils from 'src/lib/RunUtils';
 import { compareGraphEdges, KeyValue, transitiveReduction } from 'src/lib/StaticGraphParser';
-import { hasFinished, NodePhase } from 'src/lib/StatusUtils';
+import { hasFinished, isPodLifecycleFailure, NodePhase } from 'src/lib/StatusUtils';
 import {
   decodeCompressedNodes,
   errorToMessage,
@@ -1042,13 +1042,14 @@ class RunDetails extends Page<RunDetailsInternalProps, RunDetailsState> {
       if (node) {
         selectedNodeDetails.phaseMessage =
           node && node.message
-            ? `This step is in ${node.phase} state with this message: ` + node.message
+            ? (isPodLifecycleFailure(node.message)
+                ? 'This step failed due to a Kubernetes pod issue, not an error in your pipeline code: '
+                : `This step is in ${node.phase} state with this message: `) + node.message
             : undefined;
 
         selectedNodeDetails.phase = node.phase;
 
         switch (node.phase) {
-          // TODO: make distinction between system and pipelines error clear
           case NodePhase.ERROR:
           case NodePhase.FAILED:
             sidepanelBannerMode = 'error';


### PR DESCRIPTION
**Description of your changes:**

The run detail side panel (RunDetails.tsx) showed the same generic message for a step that failed due to a Kubernetes pod lifecycle issue (OOMKilled, ImagePullBackOff, etc.) and a step that failed due to a bug in the user's own pipeline code, with a TODO acknowledging the gap.

Added isPodLifecycleFailure(nodeMessage) to StatusUtils.ts, next to the existing checkIfTerminated (same message-inspection pattern), and used it in RunDetails.tsx to show a distinct message for pod lifecycle failures instead of the generic "This step is in X state" text. Kept the banner color/Mode and the NodePhase enum untouched since both are used broadly elsewhere, so this stays scoped to the message text.

Added a test asserting an OOMKilled message produces the distinct message, alongside the existing tests for the generic case.

The pattern list here had drifted from the backend ClassifyPodFailure list in #13863, missing ContainerCannotRun, CreateContainerConfigError, CreateContainerError, RunContainerError, PreemptionByScheduler, and TerminationByKubelet. A task failing with one of those would be classified as a pod lifecycle failure on the backend but shown as an ordinary pipeline error here. Brought the two lists back in sync and added a dedicated test file for isPodLifecycleFailure covering all seventeen patterns, since it previously only had one integration test through the full RunDetails component.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
