### PR TITLE
fix(backend): wait for all DAG tasks before marking a DAG FAILED

### DIFF
--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -850,7 +850,7 @@ func (c *Client) UpdateDAGExecutionsState(ctx context.Context, dag *DAG, pipelin
 	switch {
 	case completedTasks == int(expectedTaskCount):
 		newState = pb.Execution_COMPLETE
-	case failedTasks > 0:
+	case failedTasks > 0 && completedTasks+failedTasks == int(expectedTaskCount):
 		newState = pb.Execution_FAILED
 	default:
 		glog.V(4).Infof("DAG is still running")

--- a/backend/src/v2/metadata/client_update_dag_state_test.go
+++ b/backend/src/v2/metadata/client_update_dag_state_test.go
@@ -178,6 +178,12 @@ func TestUpdateDAGExecutionsState_StateResolution(t *testing.T) {
 			expectedState: pb.Execution_RUNNING,
 		},
 		{
+			name:          "one failed while sibling still running",
+			taskStates:    []pb.Execution_State{pb.Execution_FAILED, pb.Execution_RUNNING},
+			expectedTasks: 2,
+			expectedState: pb.Execution_RUNNING,
+		},
+		{
 			name:          "cached and canceled count as complete",
 			taskStates:    []pb.Execution_State{pb.Execution_COMPLETE, pb.Execution_CACHED, pb.Execution_CANCELED},
 			expectedTasks: 3,


### PR DESCRIPTION
**Description of your changes:**

UpdateDAGExecutionsState's FAILED branch fired as soon as any task failed, without checking if sibling tasks were still running. The COMPLETE branch correctly waits for every expected task to finish (completedTasks == expectedTaskCount), but FAILED had no equivalent check, so a DAG with 5 expected tasks and 1 failure got marked FAILED in MLMD immediately, even with 4 siblings still actively running. This is more premature than Argo's own documented fail-fast behavior, which explicitly waits for all DAG nodes to reach a terminal state before failing the workflow.

Fixed FAILED to also require completedTasks+failedTasks == expectedTaskCount, mirroring the same "wait for all" discipline the COMPLETE branch already uses.

Added a test case ("one failed while sibling still running") to the existing table-driven test, confirmed it fails against the old code before the fix and passes after.

Fixes #13888.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).