### PR TITLE
fix(backend): record pod failure details in MLMD on launcher failure

### DIFF
--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -196,6 +196,10 @@ func (l *LauncherV2) Execute(ctx context.Context) (err error) {
 			return
 		}
 
+		if status == pb.Execution_FAILED && err != nil {
+			l.attachFailureToExecution(ctx, execution, err)
+		}
+
 		if perr := l.publish(ctx, execution, executorOutput, outputArtifacts, status); perr != nil {
 			if err != nil {
 				err = fmt.Errorf("failed to publish execution with error %s after execution failed: %s", perr.Error(), err.Error())

--- a/backend/src/v2/component/pod_failure.go
+++ b/backend/src/v2/component/pod_failure.go
@@ -1,0 +1,175 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/kubeflow/pipelines/backend/src/v2/metadata"
+	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
+	"google.golang.org/protobuf/types/known/structpb"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const executionErrorCustomPropertyKey = "error"
+
+// attachFailureToExecution adds best-effort, structured failure details to the
+// MLMD execution custom properties. This is intended to help users debug pod-
+// and container-level failures (e.g., OOMKilled, ImagePullBackOff) without
+// requiring kubectl access.
+func (l *LauncherV2) attachFailureToExecution(ctx context.Context, execution *metadata.Execution, originalErr error) {
+	e := execution.GetExecution()
+	if e == nil {
+		return
+	}
+	if e.CustomProperties == nil {
+		e.CustomProperties = make(map[string]*pb.Value)
+	}
+
+	fields := make(map[string]*structpb.Value)
+	fields["message"] = structpb.NewStringValue(originalErr.Error())
+
+	if exitCode, ok := exitCodeFromError(originalErr); ok {
+		fields["exitCode"] = structpb.NewNumberValue(float64(exitCode))
+	}
+
+	if l.options.Namespace != "" && l.options.PodName != "" && l.clientManager != nil && l.clientManager.K8sClient() != nil {
+		pod, perr := l.clientManager.K8sClient().CoreV1().Pods(l.options.Namespace).Get(ctx, l.options.PodName, metav1.GetOptions{})
+		if perr == nil && pod != nil {
+			if podFields := podFailureFields(pod); len(podFields) > 0 {
+				for k, v := range podFields {
+					fields[k] = v
+				}
+				if reason := fields["reason"]; reason != nil && reason.GetStringValue() != "" {
+					fields["message"] = structpb.NewStringValue(fmt.Sprintf("%s (kubernetes reason=%s)", originalErr.Error(), reason.GetStringValue()))
+				}
+			}
+		}
+	}
+
+	e.CustomProperties[executionErrorCustomPropertyKey] = &pb.Value{
+		Value: &pb.Value_StructValue{
+			StructValue: &structpb.Struct{Fields: fields},
+		},
+	}
+}
+
+func exitCodeFromError(err error) (int, bool) {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ProcessState != nil {
+		code := exitErr.ProcessState.ExitCode()
+		if code >= 0 {
+			return code, true
+		}
+	}
+	return 0, false
+}
+
+// podFailureFields returns a best-effort set of structured fields describing a
+// pod/container failure. It intentionally returns a small, stable set of keys
+// to keep downstream consumers simple.
+func podFailureFields(pod *corev1.Pod) map[string]*structpb.Value {
+	if pod == nil {
+		return nil
+	}
+
+	best := bestContainerFailure(pod)
+
+	fields := map[string]*structpb.Value{
+		"podName":   structpb.NewStringValue(pod.GetName()),
+		"namespace": structpb.NewStringValue(pod.GetNamespace()),
+	}
+
+	if best.reason == "" && pod.Status.Reason != "" {
+		best.reason = pod.Status.Reason
+	}
+	if best.message == "" && pod.Status.Message != "" {
+		best.message = pod.Status.Message
+	}
+
+	if best.containerName != "" {
+		fields["containerName"] = structpb.NewStringValue(best.containerName)
+	}
+	if best.reason != "" {
+		fields["reason"] = structpb.NewStringValue(best.reason)
+	}
+	if best.message != "" {
+		fields["kubernetesMessage"] = structpb.NewStringValue(best.message)
+	}
+	if best.exitCode != nil {
+		fields["containerExitCode"] = structpb.NewNumberValue(float64(*best.exitCode))
+	}
+
+	if len(fields) <= 2 {
+		return nil
+	}
+	return fields
+}
+
+type containerFailure struct {
+	containerName string
+	reason        string
+	message       string
+	exitCode      *int32
+}
+
+// bestContainerFailure finds the most relevant failure from a pod's container
+// statuses, prioritizing waiting reasons (ImagePullBackOff, CrashLoopBackOff)
+// and terminated reasons (OOMKilled, Error) over generic pod status.
+func bestContainerFailure(pod *corev1.Pod) containerFailure {
+	consider := func(name string, state corev1.ContainerState) containerFailure {
+		if state.Waiting != nil {
+			return containerFailure{
+				containerName: name,
+				reason:        state.Waiting.Reason,
+				message:       state.Waiting.Message,
+			}
+		}
+		if state.Terminated != nil {
+			exitCode := state.Terminated.ExitCode
+			return containerFailure{
+				containerName: name,
+				reason:        state.Terminated.Reason,
+				message:       state.Terminated.Message,
+				exitCode:      &exitCode,
+			}
+		}
+		return containerFailure{}
+	}
+
+	for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+		c := consider(cs.Name, cs.State)
+		if c.reason != "" && cs.State.Waiting != nil {
+			return c
+		}
+	}
+
+	for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+		c := consider(cs.Name, cs.State)
+		if c.reason != "" && cs.State.Terminated != nil {
+			return c
+		}
+		c = consider(cs.Name, cs.LastTerminationState)
+		if c.reason != "" {
+			return c
+		}
+	}
+
+	return containerFailure{}
+}

--- a/backend/src/v2/component/pod_failure_test.go
+++ b/backend/src/v2/component/pod_failure_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_podFailureFields_waitingReason_ImagePullBackOff(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "ImagePullBackOff",
+							Message: "Back-off pulling image",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fields := podFailureFields(pod)
+	require.NotNil(t, fields)
+	require.Equal(t, "p", fields["podName"].GetStringValue())
+	require.Equal(t, "ns", fields["namespace"].GetStringValue())
+	require.Equal(t, "main", fields["containerName"].GetStringValue())
+	require.Equal(t, "ImagePullBackOff", fields["reason"].GetStringValue())
+	require.Equal(t, "Back-off pulling image", fields["kubernetesMessage"].GetStringValue())
+}
+
+func Test_podFailureFields_terminatedReason_OOMKilled(t *testing.T) {
+	exitCode := int32(137)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   "OOMKilled",
+							Message:  "Container killed due to memory",
+							ExitCode: exitCode,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fields := podFailureFields(pod)
+	require.NotNil(t, fields)
+	require.Equal(t, "main", fields["containerName"].GetStringValue())
+	require.Equal(t, "OOMKilled", fields["reason"].GetStringValue())
+	require.Equal(t, float64(137), fields["containerExitCode"].GetNumberValue())
+	require.Equal(t, "Container killed due to memory", fields["kubernetesMessage"].GetStringValue())
+}
+
+func Test_podFailureFields_crashLoopBackOff(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-123", Namespace: "kubeflow"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "CrashLoopBackOff",
+							Message: "back-off 5m0s restarting failed container",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fields := podFailureFields(pod)
+	require.NotNil(t, fields)
+	require.Equal(t, "pod-123", fields["podName"].GetStringValue())
+	require.Equal(t, "kubeflow", fields["namespace"].GetStringValue())
+	require.Equal(t, "CrashLoopBackOff", fields["reason"].GetStringValue())
+}
+
+func Test_podFailureFields_initContainer(t *testing.T) {
+	exitCode := int32(1)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "init",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   "Error",
+							ExitCode: exitCode,
+						},
+					},
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "main",
+					State: corev1.ContainerState{},
+				},
+			},
+		},
+	}
+
+	fields := podFailureFields(pod)
+	require.NotNil(t, fields)
+	require.Equal(t, "init", fields["containerName"].GetStringValue())
+	require.Equal(t, "Error", fields["reason"].GetStringValue())
+	require.Equal(t, float64(1), fields["containerExitCode"].GetNumberValue())
+}
+
+func Test_podFailureFields_nilPod(t *testing.T) {
+	fields := podFailureFields(nil)
+	require.Nil(t, fields)
+}
+
+func Test_podFailureFields_noFailure(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  "main",
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+				},
+			},
+		},
+	}
+
+	fields := podFailureFields(pod)
+	require.Nil(t, fields)
+}
+
+func Test_bestContainerFailure_waitingPriorityOverTerminated(t *testing.T) {
+	exitCode := int32(137)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   "OOMKilled",
+							ExitCode: exitCode,
+						},
+					},
+				},
+				{
+					Name: "sidecar",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "ImagePullBackOff",
+							Message: "image not found",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	best := bestContainerFailure(pod)
+	require.Equal(t, "sidecar", best.containerName)
+	require.Equal(t, "ImagePullBackOff", best.reason)
+}
+
+func Test_bestContainerFailure_lastTerminationState(t *testing.T) {
+	exitCode := int32(137)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "main",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "CrashLoopBackOff",
+							Message: "restart",
+						},
+					},
+					LastTerminationState: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							Reason:   "OOMKilled",
+							ExitCode: exitCode,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	best := bestContainerFailure(pod)
+	require.Equal(t, "CrashLoopBackOff", best.reason)
+	require.Nil(t, best.exitCode)
+}
+
+func Test_exitCodeFromError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantOk   bool
+	}{
+		{
+			name:   "non-ExitError",
+			err:    fmt.Errorf("some error"),
+			wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, ok := exitCodeFromError(tt.err)
+			require.Equal(t, tt.wantCode, code)
+			require.Equal(t, tt.wantOk, ok)
+		})
+	}
+}


### PR DESCRIPTION
## Description of the changes

When a component task fails due to a pod-level reason (OOMKilled, ImagePullBackOff, CrashLoopBackOff, etc.), the launcher now enriches the MLMD execution `error` custom property with structured details including:

- The failure reason (e.g., `OOMKilled`, `ImagePullBackOff`)
- The container exit code where available (e.g., 137 for OOMKilled)
- The Kubernetes message for additional context
- Pod name and namespace for traceability

This allows the backend to propagate meaningful failure reasons to the UI and gives users actionable information without requiring access to kubectl.

### Implementation

- **New file: `backend/src/v2/component/pod_failure.go`** — Contains `attachFailureToExecution()` which reads the pod status via the Kubernetes API and extracts structured failure fields. Includes `bestContainerFailure()` which prioritizes waiting reasons (ImagePullBackOff, CrashLoopBackOff) over terminated reasons (OOMKilled, Error).
- **Modified: `backend/src/v2/component/launcher_v2.go`** — Integrates into the launcher's `Execute()` deferred publish path so failure details are captured before MLMD publication.
- **New file: `backend/src/v2/component/pod_failure_test.go`** — Comprehensive unit tests covering all failure scenarios (ImagePullBackOff, OOMKilled, CrashLoopBackOff, init containers, nil pod, no failure).

### How it works

When execution fails (`status == pb.Execution_FAILED`), the launcher calls `attachFailureToExecution()` which:

1. Reads the current error from the execution
2. Extracts the process exit code if available
3. Fetches the pod from the Kubernetes API
4. Identifies the most relevant container failure using `bestContainerFailure()`
5. Writes all structured details to the MLMD execution `error` custom property

The structured `error` property contains fields like:
```json
{
  "message": "component failed (kubernetes reason=OOMKilled)",
  "exitCode": 137,
  "podName": "my-pipeline-task-abc123",
  "namespace": "kubeflow",
  "containerName": "main",
  "reason": "OOMKilled",
  "kubernetesMessage": "Container killed due to memory",
  "containerExitCode": 137
}
```

**Fixes:** #13192

## Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our [title convention](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention)