### PR TITLE
fix(sdk): preserve explicit backoff_factor=0.0 in RetryPolicy.to_proto(). Fixes #13804

### DIFF
--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -377,7 +377,7 @@ class RetryPolicy:
         # include defaults so that IR is more reflective of runtime behavior
         max_retry_count = self.max_retry_count or 0
         backoff_duration = self.backoff_duration or '0s'
-        backoff_factor = self.backoff_factor or 2.0
+        backoff_factor = self.backoff_factor if self.backoff_factor is not None else 2.0
         backoff_max_duration = self.backoff_max_duration or '3600s'
 
         backoff_duration_seconds = f'{convert_duration_to_seconds(backoff_duration)}s'

--- a/sdk/python/kfp/dsl/structures_test.py
+++ b/sdk/python/kfp/dsl/structures_test.py
@@ -915,6 +915,26 @@ class TestRetryPolicy(unittest.TestCase):
         self.assertEqual(retry_policy_proto.backoff_max_duration.seconds,
                          1209600)
 
+    def test_to_proto_backoff_factor_zero(self):
+        """backoff_factor=0.0 must not be silently replaced by the default 2.0."""
+        retry_policy_struct = structures.RetryPolicy(
+            max_retry_count=3,
+            backoff_duration='30s',
+            backoff_factor=0.0,
+            backoff_max_duration='120s',
+        )
+        retry_policy_proto = retry_policy_struct.to_proto()
+        self.assertEqual(retry_policy_proto.backoff_factor, 0.0)
+
+    def test_to_proto_defaults(self):
+        """Omitted fields should use documented defaults."""
+        retry_policy_struct = structures.RetryPolicy()
+        retry_policy_proto = retry_policy_struct.to_proto()
+        self.assertEqual(retry_policy_proto.max_retry_count, 0)
+        self.assertEqual(retry_policy_proto.backoff_duration.seconds, 0)
+        self.assertEqual(retry_policy_proto.backoff_factor, 2.0)
+        self.assertEqual(retry_policy_proto.backoff_max_duration.seconds, 3600)
+
 
 class TestDeserializeV1ComponentYamlDefaults(unittest.TestCase):
 


### PR DESCRIPTION
## Description

`RetryPolicy.to_proto()` uses `self.backoff_factor or 2.0` to apply a default value. In Python, `0.0` is falsy, so an explicit `backoff_factor=0.0` is silently replaced with the default `2.0` — no error, no warning.

This changes the compiled pipeline YAML, causing unexpected exponential backoff when the user intended linear (no growth) retries.

### Root cause

```python
# sdk/python/kfp/dsl/structures.py:380
backoff_factor = self.backoff_factor or 2.0  # BUG: 0.0 is falsy
```

### Fix

```python
backoff_factor = self.backoff_factor if self.backoff_factor is not None else 2.0
```

### Reproducer (no cluster required)

```python
from kfp import dsl, compiler

@dsl.component
def my_op() -> str:
    return "hello"

@dsl.pipeline(name="retry-backoff-factor-bug")
def my_pipeline():
    my_op().set_retry(
        num_retries=3,
        backoff_duration="30s",
        backoff_factor=0.0,   # explicit: no exponential growth
        backoff_max_duration="120s",
    )

compiler.Compiler().compile(my_pipeline, "/tmp/pipeline.yaml")
# Before fix: backoffFactor is 2.0 in output YAML
# After fix:  backoffFactor is 0.0
```

### Changes

- `sdk/python/kfp/dsl/structures.py:380` — fix truthiness check to `is not None`
- `sdk/python/kfp/dsl/structures_test.py` — add `test_to_proto_backoff_factor_zero` and `test_to_proto_defaults`

## Checklist

- [x] I have signed off my commits with `git commit -s`
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
