### PR TITLE
feat(backend): add error counters and latency histograms to API servers. Fixes #13133

### DIFF
--- a/backend/src/apiserver/server/experiment_server.go
+++ b/backend/src/apiserver/server/experiment_server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"time"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -65,8 +66,6 @@ var (
 		Help: "The total number of UnarchiveExperiment requests",
 	})
 
-	// TODO(jingzhang36): error count and success count.
-
 	experimentCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "experiment_server_run_count",
 		Help: "The current number of experiments in Kubeflow Pipelines instance",
@@ -113,17 +112,26 @@ func (s *BaseExperimentServer) createExperiment(ctx context.Context, experiment 
 func (s *ExperimentServerV1) CreateExperimentV1(ctx context.Context, request *apiv1beta1.CreateExperimentRequest) (
 	*apiv1beta1.Experiment, error,
 ) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		createExperimentRequests.Inc()
 	}
 
 	modelExperiment, err := toModelExperiment(request.GetExperiment())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "CreateExperimentV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "CreateExperimentV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "[ExperimentServer]: Failed to create a v1beta1 experiment due to conversion error")
 	}
 
 	newExperiment, err := s.createExperiment(ctx, modelExperiment)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "CreateExperimentV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "CreateExperimentV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a v1beta1 experiment")
 	}
 
@@ -133,7 +141,15 @@ func (s *ExperimentServerV1) CreateExperimentV1(ctx context.Context, request *ap
 
 	apiExperiment := toApiExperimentV1(newExperiment)
 	if apiExperiment == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "CreateExperimentV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "CreateExperimentV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(errors.New("Failed to convert internal experiment representation to its API counterpart"), "Failed to create v1beta1 experiment")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("experiment", "CreateExperimentV1", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "CreateExperimentV1").Observe(time.Since(startTime).Seconds())
 	}
 	return apiExperiment, nil
 }
@@ -141,17 +157,26 @@ func (s *ExperimentServerV1) CreateExperimentV1(ctx context.Context, request *ap
 func (s *ExperimentServer) CreateExperiment(ctx context.Context, request *apiv2beta1.CreateExperimentRequest) (
 	*apiv2beta1.Experiment, error,
 ) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		createExperimentRequests.Inc()
 	}
 
 	modelExperiment, err := toModelExperiment(request.GetExperiment())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "CreateExperiment", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "CreateExperiment").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "[ExperimentServer]: Failed to create a experiment due to conversion error")
 	}
 
 	newExperiment, err := s.createExperiment(ctx, modelExperiment)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "CreateExperiment", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "CreateExperiment").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a experiment")
 	}
 
@@ -161,7 +186,15 @@ func (s *ExperimentServer) CreateExperiment(ctx context.Context, request *apiv2b
 
 	apiExperiment := toApiExperiment(newExperiment)
 	if apiExperiment == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "CreateExperiment", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "CreateExperiment").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(errors.New("Failed to convert internal experiment representation to its API counterpart"), "Failed to create experiment")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("experiment", "CreateExperiment", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "CreateExperiment").Observe(time.Since(startTime).Seconds())
 	}
 	return apiExperiment, nil
 }
@@ -177,18 +210,31 @@ func (s *BaseExperimentServer) getExperiment(ctx context.Context, experimentId s
 func (s *ExperimentServerV1) GetExperimentV1(ctx context.Context, request *apiv1beta1.GetExperimentRequest) (
 	*apiv1beta1.Experiment, error,
 ) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		getExperimentRequests.Inc()
 	}
 
 	experiment, err := s.getExperiment(ctx, request.GetId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "GetExperimentV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "GetExperimentV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to fetch v1beta1 experiment")
 	}
 
 	apiExperiment := toApiExperimentV1(experiment)
 	if apiExperiment == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "GetExperimentV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "GetExperimentV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(errors.New("Failed to convert internal experiment representation to its v1beta1 API counterpart"), "Failed to fetch v1beta1 experiment")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("experiment", "GetExperimentV1", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "GetExperimentV1").Observe(time.Since(startTime).Seconds())
 	}
 	return apiExperiment, nil
 }
@@ -196,18 +242,31 @@ func (s *ExperimentServerV1) GetExperimentV1(ctx context.Context, request *apiv1
 func (s *ExperimentServer) GetExperiment(ctx context.Context, request *apiv2beta1.GetExperimentRequest) (
 	*apiv2beta1.Experiment, error,
 ) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		getExperimentRequests.Inc()
 	}
 
 	experiment, err := s.getExperiment(ctx, request.GetExperimentId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "GetExperiment", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "GetExperiment").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to fetch experiment")
 	}
 
 	apiExperiment := toApiExperiment(experiment)
 	if apiExperiment == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "GetExperiment", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "GetExperiment").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(errors.New("Failed to convert internal experiment representation to its API counterpart"), "Failed to fetch experiment")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("experiment", "GetExperiment", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "GetExperiment").Observe(time.Since(startTime).Seconds())
 	}
 	return apiExperiment, nil
 }
@@ -236,12 +295,17 @@ func (s *BaseExperimentServer) listExperiments(ctx context.Context, pageToken st
 func (s *ExperimentServerV1) ListExperimentsV1(ctx context.Context, request *apiv1beta1.ListExperimentsRequest) (
 	*apiv1beta1.ListExperimentsResponse, error,
 ) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		listExperimentsV1Requests.Inc()
 	}
 
 	filterContext, err := validateFilterV1(request.ResourceReferenceKey)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "ListExperimentsV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "ListExperimentsV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Validating v1beta1 filter failed")
 	}
 	namespace := ""
@@ -249,12 +313,20 @@ func (s *ExperimentServerV1) ListExperimentsV1(ctx context.Context, request *api
 		if filterContext.ReferenceKey.Type == model.NamespaceResourceType {
 			namespace = filterContext.ReferenceKey.ID
 		} else {
+			if s.options.CollectMetrics {
+				requestCounter.WithLabelValues("experiment", "ListExperimentsV1", "error").Inc()
+				requestLatency.WithLabelValues("experiment", "ListExperimentsV1").Observe(time.Since(startTime).Seconds())
+			}
 			return nil, util.NewInvalidInputError("Failed to list v1beta1 experiment due to invalid resource reference key. It must be of type 'Namespace' and contain an existing or empty namespace, but you provided %v of type %v", filterContext.ReferenceKey.ID, filterContext.ReferenceKey.Type)
 		}
 	}
 
 	opts, err := validatedListOptions(&model.Experiment{}, request.GetPageToken(), int(request.GetPageSize()), request.GetSortBy(), request.GetFilter(), "v1beta1")
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "ListExperimentsV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "ListExperimentsV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create list options")
 	}
 
@@ -267,7 +339,15 @@ func (s *ExperimentServerV1) ListExperimentsV1(ctx context.Context, request *api
 		namespace,
 	)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "ListExperimentsV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "ListExperimentsV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "List v1beta1 experiments failed")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("experiment", "ListExperimentsV1", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "ListExperimentsV1").Observe(time.Since(startTime).Seconds())
 	}
 	return &apiv1beta1.ListExperimentsResponse{
 		Experiments:   toApiExperimentsV1(experiments),
@@ -279,18 +359,31 @@ func (s *ExperimentServerV1) ListExperimentsV1(ctx context.Context, request *api
 func (s *ExperimentServer) ListExperiments(ctx context.Context, request *apiv2beta1.ListExperimentsRequest) (
 	*apiv2beta1.ListExperimentsResponse, error,
 ) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		listExperimentsV1Requests.Inc()
 	}
 
 	opts, err := validatedListOptions(&model.Experiment{}, request.GetPageToken(), int(request.GetPageSize()), request.GetSortBy(), request.GetFilter(), "v2beta1")
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "ListExperiments", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "ListExperiments").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create list options")
 	}
 
 	experiments, totalSize, nextPageToken, err := s.listExperiments(ctx, request.GetPageToken(), request.GetPageSize(), request.GetSortBy(), opts, request.GetNamespace())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "ListExperiments", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "ListExperiments").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "List experiments failed")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("experiment", "ListExperiments", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "ListExperiments").Observe(time.Since(startTime).Seconds())
 	}
 	return &apiv2beta1.ListExperimentsResponse{
 		Experiments:   toApiExperiments(experiments),
@@ -308,31 +401,45 @@ func (s *BaseExperimentServer) deleteExperiment(ctx context.Context, experimentI
 }
 
 func (s *ExperimentServerV1) DeleteExperimentV1(ctx context.Context, request *apiv1beta1.DeleteExperimentRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		deleteExperimentRequests.Inc()
 	}
 
 	if err := s.deleteExperiment(ctx, request.GetId()); err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "DeleteExperimentV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "DeleteExperimentV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to delete v1beta1 experiment")
 	}
 
 	if s.options.CollectMetrics {
 		experimentCount.Dec()
+		requestCounter.WithLabelValues("experiment", "DeleteExperimentV1", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "DeleteExperimentV1").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *ExperimentServer) DeleteExperiment(ctx context.Context, request *apiv2beta1.DeleteExperimentRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		deleteExperimentRequests.Inc()
 	}
 
 	if err := s.deleteExperiment(ctx, request.GetExperimentId()); err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "DeleteExperiment", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "DeleteExperiment").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to delete experiment")
 	}
 
 	if s.options.CollectMetrics {
 		experimentCount.Dec()
+		requestCounter.WithLabelValues("experiment", "DeleteExperiment", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "DeleteExperiment").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -376,22 +483,40 @@ func (s *BaseExperimentServer) archiveExperiment(ctx context.Context, experiment
 }
 
 func (s *ExperimentServerV1) ArchiveExperimentV1(ctx context.Context, request *apiv1beta1.ArchiveExperimentRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		archiveExperimentRequests.Inc()
 	}
 	if err := s.archiveExperiment(ctx, request.GetId()); err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "ArchiveExperimentV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "ArchiveExperimentV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to archive v1beta1 experiment")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("experiment", "ArchiveExperimentV1", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "ArchiveExperimentV1").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *ExperimentServer) ArchiveExperiment(ctx context.Context, request *apiv2beta1.ArchiveExperimentRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		archiveExperimentRequests.Inc()
 	}
 
 	if err := s.archiveExperiment(ctx, request.GetExperimentId()); err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "ArchiveExperiment", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "ArchiveExperiment").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to archive experiment")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("experiment", "ArchiveExperiment", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "ArchiveExperiment").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -405,23 +530,41 @@ func (s *BaseExperimentServer) unarchiveExperiment(ctx context.Context, experime
 }
 
 func (s *ExperimentServerV1) UnarchiveExperimentV1(ctx context.Context, request *apiv1beta1.UnarchiveExperimentRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		unarchiveExperimentRequests.Inc()
 	}
 
 	if err := s.unarchiveExperiment(ctx, request.GetId()); err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "UnarchiveExperimentV1", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "UnarchiveExperimentV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to unarchive v1beta1 experiment")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("experiment", "UnarchiveExperimentV1", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "UnarchiveExperimentV1").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *ExperimentServer) UnarchiveExperiment(ctx context.Context, request *apiv2beta1.UnarchiveExperimentRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		unarchiveExperimentRequests.Inc()
 	}
 
 	if err := s.unarchiveExperiment(ctx, request.GetExperimentId()); err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("experiment", "UnarchiveExperiment", "error").Inc()
+			requestLatency.WithLabelValues("experiment", "UnarchiveExperiment").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to unarchive experiment")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("experiment", "UnarchiveExperiment", "success").Inc()
+		requestLatency.WithLabelValues("experiment", "UnarchiveExperiment").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }

--- a/backend/src/apiserver/server/job_server.go
+++ b/backend/src/apiserver/server/job_server.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"time"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -63,8 +64,6 @@ var (
 		Name: "job_server_enable_requests",
 		Help: "The total number of EnableJob requests",
 	})
-
-	// TODO(jingzhang36): error count and success count.
 
 	jobCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "job_server_job_count",
@@ -121,12 +120,17 @@ func (s *BaseJobServer) createJob(ctx context.Context, job *model.Job) (*model.J
 }
 
 func (s *JobServerV1) CreateJob(ctx context.Context, request *apiv1beta1.CreateJobRequest) (*apiv1beta1.Job, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		createJobRequests.Inc()
 	}
 
 	modelJob, err := toModelJob(request.GetJob())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "CreateJob", "error").Inc()
+			requestLatency.WithLabelValues("job", "CreateJob").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a recurring run due to conversion error")
 	}
 
@@ -136,6 +140,10 @@ func (s *JobServerV1) CreateJob(ctx context.Context, request *apiv1beta1.CreateJ
 	if modelJob.PipelineId != "" && modelJob.WorkflowSpecManifest == "" && modelJob.PipelineSpecManifest == "" && modelJob.PipelineVersionId == "" {
 		pipelineVersion, err := s.resourceManager.GetLatestPipelineVersion(modelJob.PipelineId)
 		if err != nil {
+			if s.options.CollectMetrics {
+				requestCounter.WithLabelValues("job", "CreateJob", "error").Inc()
+				requestLatency.WithLabelValues("job", "CreateJob").Observe(time.Since(startTime).Seconds())
+			}
 			return nil, util.Wrapf(err, "Failed to fetch a pipeline version from pipeline %v", modelJob.PipelineId)
 		}
 
@@ -144,11 +152,17 @@ func (s *JobServerV1) CreateJob(ctx context.Context, request *apiv1beta1.CreateJ
 
 	newJob, err := s.createJob(ctx, modelJob)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "CreateJob", "error").Inc()
+			requestLatency.WithLabelValues("job", "CreateJob").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a recurring run")
 	}
 
 	if s.options.CollectMetrics {
 		jobCount.Inc()
+		requestCounter.WithLabelValues("job", "CreateJob", "success").Inc()
+		requestLatency.WithLabelValues("job", "CreateJob").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiJobV1(newJob), nil
 }
@@ -162,18 +176,31 @@ func (s *BaseJobServer) getJob(ctx context.Context, jobId string) (*model.Job, e
 }
 
 func (s *JobServerV1) GetJob(ctx context.Context, request *apiv1beta1.GetJobRequest) (*apiv1beta1.Job, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		getJobRequests.Inc()
 	}
 
 	recurringRun, err := s.getJob(ctx, request.GetId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "GetJob", "error").Inc()
+			requestLatency.WithLabelValues("job", "GetJob").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to fetch a v1beta1 recurring run")
 	}
 
 	apiJob := toApiJobV1(recurringRun)
 	if apiJob == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "GetJob", "error").Inc()
+			requestLatency.WithLabelValues("job", "GetJob").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(util.NewInvalidInputError("Failed to convert internal recurring run representation to its v1beta1 API counterpart"), "Failed to fetch a v1beta1 recurring run")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("job", "GetJob", "success").Inc()
+		requestLatency.WithLabelValues("job", "GetJob").Observe(time.Since(startTime).Seconds())
 	}
 	return apiJob, nil
 }
@@ -215,12 +242,17 @@ func (s *BaseJobServer) listJobs(ctx context.Context, pageToken string, pageSize
 }
 
 func (s *JobServerV1) ListJobs(ctx context.Context, r *apiv1beta1.ListJobsRequest) (*apiv1beta1.ListJobsResponse, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		listJobRequests.Inc()
 	}
 
 	filterContext, err := validateFilterV1(r.GetResourceReferenceKey())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "ListJobs", "error").Inc()
+			requestLatency.WithLabelValues("job", "ListJobs").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to list v1beta1 runs: validating filter failed")
 	}
 	namespace := ""
@@ -237,16 +269,32 @@ func (s *JobServerV1) ListJobs(ctx context.Context, r *apiv1beta1.ListJobsReques
 
 	opts, err := validatedListOptions(&model.Job{}, r.GetPageToken(), int(r.GetPageSize()), r.GetSortBy(), r.GetFilter(), "v1beta1")
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "ListJobs", "error").Inc()
+			requestLatency.WithLabelValues("job", "ListJobs").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to list jobs due to error parsing the listing options")
 	}
 
 	jobs, total_size, nextPageToken, err := s.listJobs(ctx, r.GetPageToken(), int(r.GetPageSize()), r.GetSortBy(), opts, namespace, experimentId)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "ListJobs", "error").Inc()
+			requestLatency.WithLabelValues("job", "ListJobs").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to list jobs")
 	}
 	apiJobs := toApiJobsV1(jobs)
 	if apiJobs == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "ListJobs", "error").Inc()
+			requestLatency.WithLabelValues("job", "ListJobs").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(util.NewInvalidInputError("Failed to convert internal recurring run representations to their v1beta1 API counterparts"), "Failed to list v1beta1 recurring runs")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("job", "ListJobs", "success").Inc()
+		requestLatency.WithLabelValues("job", "ListJobs").Observe(time.Since(startTime).Seconds())
 	}
 	return &apiv1beta1.ListJobsResponse{
 		Jobs:          apiJobs,
@@ -256,12 +304,21 @@ func (s *JobServerV1) ListJobs(ctx context.Context, r *apiv1beta1.ListJobsReques
 }
 
 func (s *JobServerV1) EnableJob(ctx context.Context, request *apiv1beta1.EnableJobRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		enableJobRequests.Inc()
 	}
 	err := s.enableJob(ctx, request.GetId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "EnableJob", "error").Inc()
+			requestLatency.WithLabelValues("job", "EnableJob").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to enable a v1beta1 recurring run")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("job", "EnableJob", "success").Inc()
+		requestLatency.WithLabelValues("job", "EnableJob").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -275,13 +332,22 @@ func (s *BaseJobServer) disableJob(ctx context.Context, jobId string) error {
 }
 
 func (s *JobServerV1) DisableJob(ctx context.Context, request *apiv1beta1.DisableJobRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		disableJobRequests.Inc()
 	}
 
 	err := s.disableJob(ctx, request.GetId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "DisableJob", "error").Inc()
+			requestLatency.WithLabelValues("job", "DisableJob").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to disable a v1beta1 recurring run")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("job", "DisableJob", "success").Inc()
+		requestLatency.WithLabelValues("job", "DisableJob").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -296,15 +362,22 @@ func (s *BaseJobServer) deleteJob(ctx context.Context, jobID string, propagation
 }
 
 func (s *JobServerV1) DeleteJob(ctx context.Context, request *apiv1beta1.DeleteJobRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		deleteJobRequests.Inc()
 	}
 	err := s.deleteJob(ctx, request.GetId(), apiv2beta1.DeletePropagationPolicy_DELETE_PROPAGATION_POLICY_UNSPECIFIED)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "DeleteJob", "error").Inc()
+			requestLatency.WithLabelValues("job", "DeleteJob").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to disable a recurring run")
 	}
 	if s.options.CollectMetrics {
 		jobCount.Dec()
+		requestCounter.WithLabelValues("job", "DeleteJob", "success").Inc()
+		requestLatency.WithLabelValues("job", "DeleteJob").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -318,16 +391,25 @@ func (s *BaseJobServer) enableJob(ctx context.Context, jobId string) error {
 }
 
 func (s *JobServer) CreateRecurringRun(ctx context.Context, request *apiv2beta1.CreateRecurringRunRequest) (*apiv2beta1.RecurringRun, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		createJobRequests.Inc()
 	}
 
 	modelJob, err := toModelJob(request.GetRecurringRun())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "CreateRecurringRun", "error").Inc()
+			requestLatency.WithLabelValues("job", "CreateRecurringRun").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a recurring run due to conversion error")
 	}
 	newRecurringRun, err := s.createJob(ctx, modelJob)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "CreateRecurringRun", "error").Inc()
+			requestLatency.WithLabelValues("job", "CreateRecurringRun").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a recurring run")
 	}
 
@@ -336,46 +418,84 @@ func (s *JobServer) CreateRecurringRun(ctx context.Context, request *apiv2beta1.
 	}
 	apiRecurringRun := toApiRecurringRun(newRecurringRun)
 	if apiRecurringRun == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "CreateRecurringRun", "error").Inc()
+			requestLatency.WithLabelValues("job", "CreateRecurringRun").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(util.NewInvalidInputError("Failed to convert internal recurring run representation to its API counterpart"), "Failed to create a recurring run")
 	}
 
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("job", "CreateRecurringRun", "success").Inc()
+		requestLatency.WithLabelValues("job", "CreateRecurringRun").Observe(time.Since(startTime).Seconds())
+	}
 	return apiRecurringRun, nil
 }
 
 func (s *JobServer) GetRecurringRun(ctx context.Context, request *apiv2beta1.GetRecurringRunRequest) (*apiv2beta1.RecurringRun, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		getJobRequests.Inc()
 	}
 	recurringRun, err := s.getJob(ctx, request.GetRecurringRunId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "GetRecurringRun", "error").Inc()
+			requestLatency.WithLabelValues("job", "GetRecurringRun").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to fetch a recurring run")
 	}
 
 	apiRecurringRun := toApiRecurringRun(recurringRun)
 	if apiRecurringRun == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "GetRecurringRun", "error").Inc()
+			requestLatency.WithLabelValues("job", "GetRecurringRun").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(util.NewInvalidInputError("Failed to convert internal recurring run representation to its API counterpart"), "Failed to fetch a recurring run")
 	}
 
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("job", "GetRecurringRun", "success").Inc()
+		requestLatency.WithLabelValues("job", "GetRecurringRun").Observe(time.Since(startTime).Seconds())
+	}
 	return apiRecurringRun, nil
 }
 
 func (s *JobServer) ListRecurringRuns(ctx context.Context, r *apiv2beta1.ListRecurringRunsRequest) (*apiv2beta1.ListRecurringRunsResponse, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		listJobRequests.Inc()
 	}
 
 	opts, err := validatedListOptions(&model.Job{}, r.GetPageToken(), int(r.GetPageSize()), r.GetSortBy(), r.GetFilter(), "v2beta1")
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "ListRecurringRuns", "error").Inc()
+			requestLatency.WithLabelValues("job", "ListRecurringRuns").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to list recurring runs due to error parsing the listing options")
 	}
 
 	jobs, total_size, nextPageToken, err := s.listJobs(ctx, r.GetPageToken(), int(r.GetPageSize()), r.GetSortBy(), opts, r.GetNamespace(), r.GetExperimentId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "ListRecurringRuns", "error").Inc()
+			requestLatency.WithLabelValues("job", "ListRecurringRuns").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to list jobs")
 	}
 	apiRecurringRuns := toApiRecurringRuns(jobs)
 	if apiRecurringRuns == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "ListRecurringRuns", "error").Inc()
+			requestLatency.WithLabelValues("job", "ListRecurringRuns").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(util.NewInvalidInputError("Failed to convert internal recurring run representations to their API counterparts"), "Failed to list recurring runs")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("job", "ListRecurringRuns", "success").Inc()
+		requestLatency.WithLabelValues("job", "ListRecurringRuns").Observe(time.Since(startTime).Seconds())
 	}
 	return &apiv2beta1.ListRecurringRunsResponse{
 		RecurringRuns: apiRecurringRuns,
@@ -385,38 +505,63 @@ func (s *JobServer) ListRecurringRuns(ctx context.Context, r *apiv2beta1.ListRec
 }
 
 func (s *JobServer) EnableRecurringRun(ctx context.Context, request *apiv2beta1.EnableRecurringRunRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		enableJobRequests.Inc()
 	}
 	err := s.enableJob(ctx, request.GetRecurringRunId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "EnableRecurringRun", "error").Inc()
+			requestLatency.WithLabelValues("job", "EnableRecurringRun").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to enable a recurring run")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("job", "EnableRecurringRun", "success").Inc()
+		requestLatency.WithLabelValues("job", "EnableRecurringRun").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *JobServer) DisableRecurringRun(ctx context.Context, request *apiv2beta1.DisableRecurringRunRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		disableJobRequests.Inc()
 	}
 
 	err := s.disableJob(ctx, request.GetRecurringRunId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "DisableRecurringRun", "error").Inc()
+			requestLatency.WithLabelValues("job", "DisableRecurringRun").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to disable a recurring run")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("job", "DisableRecurringRun", "success").Inc()
+		requestLatency.WithLabelValues("job", "DisableRecurringRun").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
 
 func (s *JobServer) DeleteRecurringRun(ctx context.Context, request *apiv2beta1.DeleteRecurringRunRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		deleteJobRequests.Inc()
 	}
 	err := s.deleteJob(ctx, request.GetRecurringRunId(), request.GetPropagationPolicy())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("job", "DeleteRecurringRun", "error").Inc()
+			requestLatency.WithLabelValues("job", "DeleteRecurringRun").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to delete a recurring run")
 	}
 	if s.options.CollectMetrics {
 		jobCount.Dec()
+		requestCounter.WithLabelValues("job", "DeleteRecurringRun", "success").Inc()
+		requestLatency.WithLabelValues("job", "DeleteRecurringRun").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }

--- a/backend/src/apiserver/server/metrics.go
+++ b/backend/src/apiserver/server/metrics.go
@@ -1,0 +1,33 @@
+// Copyright 2018 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	requestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "api_server_request_count",
+		Help: "Total API requests by server, method, and status",
+	}, []string{"server", "method", "status"})
+
+	requestLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "api_server_request_latency_seconds",
+		Help:    "API request latency in seconds by server and method",
+		Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+	}, []string{"server", "method"})
+)

--- a/backend/src/apiserver/server/pipeline_server.go
+++ b/backend/src/apiserver/server/pipeline_server.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"google.golang.org/grpc/metadata"
@@ -83,7 +84,6 @@ var (
 		Help: "The total number of DeletePipelineVersion requests",
 	})
 
-	// TODO(jingzhang36): error count and success count.
 	pipelineCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "pipeline_server_pipeline_count",
 		Help: "The current number of pipelines in Kubeflow Pipelines instance",
@@ -240,6 +240,7 @@ func (s *BasePipelineServer) createPipelineAndPipelineVersion(ctx context.Contex
 // Creates a pipeline and a pipeline version in a single transaction.
 // Supports v1beta1 behavior.
 func (s *PipelineServerV1) CreatePipelineV1(ctx context.Context, request *apiv1beta1.CreatePipelineRequest) (*apiv1beta1.Pipeline, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		createPipelineRequests.Inc()
 		createPipelineVersionRequests.Inc()
@@ -248,18 +249,28 @@ func (s *PipelineServerV1) CreatePipelineV1(ctx context.Context, request *apiv1b
 	// Convert the input request
 	pipeline, err := toModelPipeline(request.GetPipeline())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline (v1beta1) due to pipeline conversion error")
 	}
 
 	// Create both pipeline and pipeline version is a single transaction
 	newPipeline, newPipelineVersion, err := s.createPipelineAndPipelineVersion(ctx, pipeline, request.GetPipeline().GetUrl().GetPipelineUrl(), nil)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline (v1beta1)")
 	}
 
 	if s.options.CollectMetrics {
 		pipelineCount.Inc()
 		pipelineVersionCount.Inc()
+		requestCounter.WithLabelValues("pipeline", "CreatePipelineV1", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "CreatePipelineV1").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiPipelineV1(newPipeline, newPipelineVersion), nil
 }
@@ -267,6 +278,7 @@ func (s *PipelineServerV1) CreatePipelineV1(ctx context.Context, request *apiv1b
 // Creates a pipeline, but does not create a pipeline version.
 // Supports v2beta1 behavior.
 func (s *PipelineServer) CreatePipeline(ctx context.Context, request *apiv2beta1.CreatePipelineRequest) (*apiv2beta1.Pipeline, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		createPipelineRequests.Inc()
 	}
@@ -274,17 +286,27 @@ func (s *PipelineServer) CreatePipeline(ctx context.Context, request *apiv2beta1
 	// Convert the input request. Fail fast if pipeline is corrupted.
 	pipeline, err := toModelPipeline(request.GetPipeline())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline as pipeline conversion failed")
 	}
 
 	// Create pipeline
 	createdPipeline, err := s.createPipeline(ctx, pipeline)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline due to server error")
 	}
 
 	if s.options.CollectMetrics {
 		pipelineCount.Inc()
+		requestCounter.WithLabelValues("pipeline", "CreatePipeline", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "CreatePipeline").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiPipeline(createdPipeline), nil
 }
@@ -293,6 +315,7 @@ func (s *PipelineServer) CreatePipeline(ctx context.Context, request *apiv2beta1
 // Updates default pipeline version for a given pipeline.
 // Supports v1beta1 behavior.
 func (s *PipelineServerV1) UpdatePipelineDefaultVersionV1(ctx context.Context, request *apiv1beta1.UpdatePipelineDefaultVersionRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		updatePipelineDefaultVersionRequests.Inc()
 	}
@@ -301,11 +324,23 @@ func (s *PipelineServerV1) UpdatePipelineDefaultVersionV1(ctx context.Context, r
 	}
 	err := s.canAccessPipeline(ctx, request.GetPipelineId(), resourceAttributes)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "UpdatePipelineDefaultVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "UpdatePipelineDefaultVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to update (v1beta1) default pipeline version to %s for pipeline %s due to authorization error", request.GetVersionId(), request.GetPipelineId())
 	}
 	err = s.resourceManager.UpdatePipelineDefaultVersion(request.GetPipelineId(), request.GetVersionId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "UpdatePipelineDefaultVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "UpdatePipelineDefaultVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to update (v1beta1) default pipeline version to %s for pipeline %s. Check error stack", request.GetVersionId(), request.GetPipelineId())
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "UpdatePipelineDefaultVersionV1", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "UpdatePipelineDefaultVersionV1").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -331,33 +366,55 @@ func (s *BasePipelineServer) getPipeline(ctx context.Context, pipelineId string)
 // Note, the default pipeline version will be set to be the latest pipeline version.
 // Supports v1beta behavior.
 func (s *PipelineServerV1) GetPipelineV1(ctx context.Context, request *apiv1beta1.GetPipelineRequest) (*apiv1beta1.Pipeline, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		getPipelineRequests.Inc()
 	}
 	pipelineId := request.GetId()
 	pipeline, err := s.getPipeline(ctx, pipelineId)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetPipelineV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetPipelineV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get a pipeline (v1beta1) %s. Check error stack", pipelineId)
 	}
 
 	pipelineVersion, err := s.getLatestPipelineVersion(ctx, pipelineId)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetPipelineV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetPipelineV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get a pipeline (v1beta1) %s due to error fetching the latest pipeline version", pipelineId)
 	}
 
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "GetPipelineV1", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "GetPipelineV1").Observe(time.Since(startTime).Seconds())
+	}
 	return toApiPipelineV1(pipeline, pipelineVersion), nil
 }
 
 // Returns a pipeline.
 // Supports v2beta behavior.
 func (s *PipelineServer) GetPipeline(ctx context.Context, request *apiv2beta1.GetPipelineRequest) (*apiv2beta1.Pipeline, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		getPipelineRequests.Inc()
 	}
 	pipelineId := request.GetPipelineId()
 	pipeline, err := s.getPipeline(ctx, pipelineId)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get a pipeline %s. Check error stack", pipelineId)
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "GetPipeline", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "GetPipeline").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiPipeline(pipeline), nil
 }
@@ -394,6 +451,7 @@ func (s *BasePipelineServer) getPipelineByName(ctx context.Context, name string,
 // Returns a pipeline with the default (latest) pipeline version given a name and a namespace.
 // Supports v1beta behavior.
 func (s *PipelineServerV1) GetPipelineByNameV1(ctx context.Context, request *apiv1beta1.GetPipelineByNameRequest) (*apiv1beta1.Pipeline, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		getPipelineRequests.Inc()
 	}
@@ -403,7 +461,15 @@ func (s *PipelineServerV1) GetPipelineByNameV1(ctx context.Context, request *api
 
 	pipeline, pipelineVersion, err := s.getPipelineByName(ctx, name, namespace, "v1beta1")
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetPipelineByNameV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetPipelineByNameV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get a pipeline (v1beta1) with name %s and namespace %s. Check error stack.", name, namespace)
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "GetPipelineByNameV1", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "GetPipelineByNameV1").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiPipelineV1(pipeline, pipelineVersion), nil
 }
@@ -411,6 +477,7 @@ func (s *PipelineServerV1) GetPipelineByNameV1(ctx context.Context, request *api
 // Returns a pipeline given name and namespace.
 // Supports v2beta behavior.
 func (s *PipelineServer) GetPipelineByName(ctx context.Context, request *apiv2beta1.GetPipelineByNameRequest) (*apiv2beta1.Pipeline, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		getPipelineRequests.Inc()
 	}
@@ -420,7 +487,15 @@ func (s *PipelineServer) GetPipelineByName(ctx context.Context, request *apiv2be
 
 	pipeline, _, err := s.getPipelineByName(ctx, name, namespace, "v2beta1")
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetPipelineByName", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetPipelineByName").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get a pipeline with name %s and namespace %s. Check error stack.", name, namespace)
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "GetPipelineByName", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "GetPipelineByName").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiPipeline(pipeline), nil
 }
@@ -462,6 +537,7 @@ func (s *BasePipelineServer) listPipelines(ctx context.Context, namespace string
 // Returns pipelines with default pipeline versions for a given query.
 // Supports v1beta behavior.
 func (s *PipelineServerV1) ListPipelinesV1(ctx context.Context, request *apiv1beta1.ListPipelinesRequest) (*apiv1beta1.ListPipelinesResponse, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		listPipelineRequests.Inc()
 	}
@@ -475,10 +551,18 @@ func (s *PipelineServerV1) ListPipelinesV1(ctx context.Context, request *apiv1be
 	namespace := ""
 	filterContext, err := validateFilterV1(request.GetResourceReferenceKey())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelinesV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelinesV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to list pipelines (v1beta1) due to filter validation error")
 	}
 	refKey := filterContext.ReferenceKey
 	if refKey != nil && refKey.Type != model.NamespaceResourceType {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelinesV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelinesV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to list pipelines (v1beta1) due to invalid resource references for pipelines: %v", refKey)
 	}
 	if refKey != nil && refKey.Type == model.NamespaceResourceType {
@@ -493,14 +577,26 @@ func (s *PipelineServerV1) ListPipelinesV1(ctx context.Context, request *apiv1be
 	// Validate list options
 	opts, err := validatedListOptions(&model.Pipeline{}, pageToken, int(pageSize), sortBy, filter, "v1beta1")
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelinesV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelinesV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipelines due invalid list options: pageToken: %v, pageSize: %v, sortBy: %v, filter: %v", pageToken, int(pageSize), sortBy, filter)
 	}
 
 	pipelines, pipelineVersions, totalSize, nextPageToken, err := s.listPipelines(ctx, namespace, pageToken, pageSize, sortBy, opts, "v1beta1", nil)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelinesV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelinesV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipelines (v1beta1) in namespace %s. Check error stack", namespace)
 	}
 
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "ListPipelinesV1", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "ListPipelinesV1").Observe(time.Since(startTime).Seconds())
+	}
 	apiPipelines := toApiPipelinesV1(pipelines, pipelineVersions)
 	return &apiv1beta1.ListPipelinesResponse{Pipelines: apiPipelines, TotalSize: int32(totalSize), NextPageToken: nextPageToken}, nil
 }
@@ -508,6 +604,7 @@ func (s *PipelineServerV1) ListPipelinesV1(ctx context.Context, request *apiv1be
 // Returns pipelines for a given query.
 // Supports v2beta1 behavior.
 func (s *PipelineServer) ListPipelines(ctx context.Context, request *apiv2beta1.ListPipelinesRequest) (*apiv2beta1.ListPipelinesResponse, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		listPipelineRequests.Inc()
 	}
@@ -523,18 +620,34 @@ func (s *PipelineServer) ListPipelines(ctx context.Context, request *apiv2beta1.
 	// the standard filter/list options which map keys to DB columns.
 	cleanedFilterSpec, tagFilters, err := extractTagFiltersFromFilterSpec(filterSpec)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelines", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelines").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipelines due to invalid tag filter in filter spec")
 	}
 
 	// Validate list options with the cleaned filter (tag predicates removed)
 	opts, err := validatedListOptions(&model.Pipeline{}, pageToken, int(pageSize), sortBy, cleanedFilterSpec, "v2beta1")
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelines", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelines").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipelines due invalid list options: pageToken: %v, pageSize: %v, sortBy: %v, filter: %v", pageToken, int(pageSize), sortBy, cleanedFilterSpec)
 	}
 
 	pipelines, _, totalSize, nextPageToken, err := s.listPipelines(ctx, namespace, pageToken, pageSize, sortBy, opts, "v2beta1", tagFilters)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelines", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelines").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipelines in namespace %s. Check error stack", namespace)
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "ListPipelines", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "ListPipelines").Observe(time.Since(startTime).Seconds())
 	}
 	return &apiv2beta1.ListPipelinesResponse{Pipelines: toApiPipelines(pipelines), TotalSize: int32(totalSize), NextPageToken: nextPageToken}, nil
 }
@@ -622,16 +735,23 @@ func (s *BasePipelineServer) deletePipeline(ctx context.Context, pipelineId stri
 // Deletes a pipeline.
 // Supports v1beta1 behavior.
 func (s *PipelineServerV1) DeletePipelineV1(ctx context.Context, request *apiv1beta1.DeletePipelineRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		deletePipelineRequests.Inc()
 	}
 
 	if err := s.deletePipeline(ctx, request.GetId(), false); err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "DeletePipelineV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "DeletePipelineV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to delete pipeline (v1beta1) %s. Check error stack", request.GetId())
 	}
 
 	if s.options.CollectMetrics {
 		pipelineCount.Dec()
+		requestCounter.WithLabelValues("pipeline", "DeletePipelineV1", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "DeletePipelineV1").Observe(time.Since(startTime).Seconds())
 	}
 
 	return &emptypb.Empty{}, nil
@@ -640,16 +760,23 @@ func (s *PipelineServerV1) DeletePipelineV1(ctx context.Context, request *apiv1b
 // Deletes a pipeline.
 // Supports v2beta1 behavior.
 func (s *PipelineServer) DeletePipeline(ctx context.Context, request *apiv2beta1.DeletePipelineRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		deletePipelineRequests.Inc()
 	}
 
 	if err := s.deletePipeline(ctx, request.GetPipelineId(), request.GetCascade()); err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "DeletePipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "DeletePipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to delete pipeline %s. Check error stack", request.GetPipelineId())
 	}
 
 	if s.options.CollectMetrics {
 		pipelineCount.Dec()
+		requestCounter.WithLabelValues("pipeline", "DeletePipeline", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "DeletePipeline").Observe(time.Since(startTime).Seconds())
 	}
 
 	return &emptypb.Empty{}, nil
@@ -658,8 +785,13 @@ func (s *PipelineServer) DeletePipeline(ctx context.Context, request *apiv2beta1
 // Returns the default (latest) pipeline template for a given pipeline id.
 // Supports v1beta1 behavior.
 func (s *PipelineServerV1) GetTemplate(ctx context.Context, request *apiv1beta1.GetTemplateRequest) (*apiv1beta1.GetTemplateResponse, error) {
+	startTime := time.Now()
 	pipelineId := request.GetId()
 	if pipelineId == "" {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetTemplate", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetTemplate").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to get the default pipeline template (v1beta1). Pipeline id cannot be empty")
 	}
 	// Check authorization
@@ -668,11 +800,23 @@ func (s *PipelineServerV1) GetTemplate(ctx context.Context, request *apiv1beta1.
 	}
 	err := s.canAccessPipeline(ctx, pipelineId, resourceAttributes)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetTemplate", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetTemplate").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get the default template (v1beta1) due to authorization error. Verify that you have access to pipeline id %s", pipelineId)
 	}
 	template, err := s.resourceManager.GetPipelineLatestTemplate(pipelineId)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetTemplate", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetTemplate").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get the default template (v1beta1) for pipeline %s. Check error stack", pipelineId)
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "GetTemplate", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "GetTemplate").Observe(time.Since(startTime).Seconds())
 	}
 	return &apiv1beta1.GetTemplateResponse{Template: string(template)}, nil
 }
@@ -738,6 +882,7 @@ func NewPipelineServerV1(resourceManager *resource.ResourceManager, options *Pip
 // Creates a pipeline and a pipeline version in a single transaction.
 // Supports v2beta1 behavior.
 func (s *PipelineServer) CreatePipelineAndVersion(ctx context.Context, request *apiv2beta1.CreatePipelineAndVersionRequest) (*apiv2beta1.Pipeline, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		createPipelineRequests.Inc()
 		createPipelineVersionRequests.Inc()
@@ -746,18 +891,28 @@ func (s *PipelineServer) CreatePipelineAndVersion(ctx context.Context, request *
 	// Convert the input request
 	pipeline, err := toModelPipeline(request.GetPipeline())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineAndVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineAndVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline due to pipeline conversion error")
 	}
 
 	// Create both pipeline and pipeline version in a single transaction
 	newPipeline, _, err := s.createPipelineAndPipelineVersion(ctx, pipeline, request.GetPipelineVersion().GetPackageUrl().GetPipelineUrl(), request.GetPipelineVersion().GetTags())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineAndVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineAndVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline")
 	}
 
 	if s.options.CollectMetrics {
 		pipelineCount.Inc()
 		pipelineVersionCount.Inc()
+		requestCounter.WithLabelValues("pipeline", "CreatePipelineAndVersion", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "CreatePipelineAndVersion").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiPipeline(newPipeline), nil
 }
@@ -834,6 +989,7 @@ func (s *BasePipelineServer) createPipelineVersion(ctx context.Context, pv *mode
 // Creates a pipeline version.
 // Supports v1beta behavior.
 func (s *PipelineServerV1) CreatePipelineVersionV1(ctx context.Context, request *apiv1beta1.CreatePipelineVersionRequest) (*apiv1beta1.PipelineVersion, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		createPipelineVersionRequests.Inc()
 	}
@@ -841,12 +997,20 @@ func (s *PipelineServerV1) CreatePipelineVersionV1(ctx context.Context, request 
 	// Fail fast
 	if request.Version == nil || request.Version.PackageUrl == nil ||
 		len(request.Version.PackageUrl.PipelineUrl) == 0 {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to create a pipeline version (v1beta1). Pipeline version is nil or pipeline's URL is empty")
 	}
 
 	// Convert to pipeline
 	pv, err := toModelPipelineVersion(request.GetVersion())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline version (v1beta1) due to conversion error")
 	}
 
@@ -858,6 +1022,10 @@ func (s *PipelineServerV1) CreatePipelineVersionV1(ctx context.Context, request 
 		}
 	}
 	if len(pipelineId) == 0 {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline version (v1beta1) due to missing pipeline id")
 	}
 	pv.PipelineId = pipelineId
@@ -865,6 +1033,10 @@ func (s *PipelineServerV1) CreatePipelineVersionV1(ctx context.Context, request 
 	// Create a pipeline version
 	newpv, err := s.createPipelineVersion(ctx, pv)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline version (v1beta1) due to internal server error")
 	}
 	if s.options.CollectMetrics {
@@ -875,7 +1047,15 @@ func (s *PipelineServerV1) CreatePipelineVersionV1(ctx context.Context, request 
 	// Note, v1beta1 PipelineVersion does not have error message. Errors in converting to API will result in error.
 	result := toApiPipelineVersionV1(newpv)
 	if result == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(util.NewInvalidInputError("Failed to convert internal pipeline version representation to its v1beta1 API counterpart"), "Failed to create a pipeline version (v1beta1) due to error converting back to API")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "CreatePipelineVersionV1", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "CreatePipelineVersionV1").Observe(time.Since(startTime).Seconds())
 	}
 	return result, nil
 }
@@ -883,24 +1063,45 @@ func (s *PipelineServerV1) CreatePipelineVersionV1(ctx context.Context, request 
 // Creates a pipeline version.
 // Supports v2beta1 behavior.
 func (s *PipelineServer) CreatePipelineVersion(ctx context.Context, request *apiv2beta1.CreatePipelineVersionRequest) (*apiv2beta1.PipelineVersion, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		createPipelineVersionRequests.Inc()
 	}
 
 	// Fail fast
 	if request.GetPipelineVersion() == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to create a pipeline version. Pipeline version is nil")
 	} else if request.GetPipelineVersion().GetPackageUrl() == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to create a pipeline version. Package URL is nil")
 	} else if request.GetPipelineVersion().GetPackageUrl().GetPipelineUrl() == "" {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to create a pipeline version. Package URL is empty")
 	} else if request.GetPipelineId() == "" || request.GetPipelineVersion().GetPipelineId() == "" {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to create a pipeline version. Parent pipeline id is empty")
 	}
 
 	// Convert to pipeline
 	pv, err := toModelPipelineVersion(request.GetPipelineVersion())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline version due to conversion error")
 	}
 
@@ -909,16 +1110,26 @@ func (s *PipelineServer) CreatePipelineVersion(ctx context.Context, request *api
 		pv.PipelineId = request.GetPipelineId()
 	}
 	if pv.PipelineId == "" {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline version due to missing pipeline id")
 	}
 
 	newPipelineVersion, err := s.createPipelineVersion(ctx, pv)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "CreatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "CreatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrap(err, "Failed to create a pipeline version. Check error stack")
 	}
 
 	if s.options.CollectMetrics {
 		pipelineVersionCount.Inc()
+		requestCounter.WithLabelValues("pipeline", "CreatePipelineVersion", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "CreatePipelineVersion").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiPipelineVersion(newPipelineVersion), nil
 }
@@ -940,17 +1151,30 @@ func (s *BasePipelineServer) getPipelineVersion(ctx context.Context, pipelineVer
 // Returns a pipeline version.
 // Supports v1beta behavior.
 func (s *PipelineServerV1) GetPipelineVersionV1(ctx context.Context, request *apiv1beta1.GetPipelineVersionRequest) (*apiv1beta1.PipelineVersion, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		getPipelineVersionRequests.Inc()
 	}
 
 	pipelineVersion, err := s.getPipelineVersion(ctx, request.GetVersionId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetPipelineVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetPipelineVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get a pipeline version (v1beta1) %s", request.GetVersionId())
 	}
 	apiPipelineVersion := toApiPipelineVersionV1(pipelineVersion)
 	if apiPipelineVersion == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetPipelineVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetPipelineVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInternalServerError(util.NewInvalidInputError("Pipeline version cannot be converted to v1beta1 API"), "Failed to get a pipeline version (v1beta1) due to error converting to API counterpart")
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "GetPipelineVersionV1", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "GetPipelineVersionV1").Observe(time.Since(startTime).Seconds())
 	}
 	return apiPipelineVersion, nil
 }
@@ -958,13 +1182,22 @@ func (s *PipelineServerV1) GetPipelineVersionV1(ctx context.Context, request *ap
 // Returns a pipeline version.
 // Supports v2beta1 behavior.
 func (s *PipelineServer) GetPipelineVersion(ctx context.Context, request *apiv2beta1.GetPipelineVersionRequest) (*apiv2beta1.PipelineVersion, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		getPipelineVersionRequests.Inc()
 	}
 
 	pipelineVersion, err := s.getPipelineVersion(ctx, request.GetPipelineVersionId())
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get a pipeline version %s", request.GetPipelineVersionId())
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "GetPipelineVersion", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "GetPipelineVersion").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiPipelineVersion(pipelineVersion), nil
 }
@@ -997,12 +1230,17 @@ func (s *BasePipelineServer) listPipelineVersions(ctx context.Context, pipelineI
 // Returns an array of pipeline versions for a given query.
 // Supports v1beta1 behavior.
 func (s *PipelineServerV1) ListPipelineVersionsV1(ctx context.Context, request *apiv1beta1.ListPipelineVersionsRequest) (*apiv1beta1.ListPipelineVersionsResponse, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		listPipelineVersionRequests.Inc()
 	}
 
 	// Check if parent pipeline id is present in the request
 	if request.ResourceKey == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelineVersionsV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelineVersionsV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to list pipeline versions (v1beta1) due to missing pipeline id")
 	}
 	pipelineId := request.GetResourceKey().GetId()
@@ -1014,16 +1252,32 @@ func (s *PipelineServerV1) ListPipelineVersionsV1(ctx context.Context, request *
 	// Validate query parameters
 	opts, err := validatedListOptions(&model.PipelineVersion{}, pageToken, int(pageSize), sortBy, filter, "v1beta1")
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelineVersionsV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelineVersionsV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipeline versions due invalid list options: pageToken: %v, pageSize: %v, sortBy: %v, filter: %v", pageToken, int(pageSize), sortBy, filter)
 	}
 
 	pipelineVersions, totalSize, nextPageToken, err := s.listPipelineVersions(ctx, pipelineId, opts, nil)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelineVersionsV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelineVersionsV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipeline versions (v1beta1) with pipeline id %s. Check error stack", pipelineId)
 	}
 	apiPipelineVersions := toApiPipelineVersionsV1(pipelineVersions)
 	if apiPipelineVersions == nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelineVersionsV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelineVersionsV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipeline versions (v1beta1) with pipeline id %s due to conversion error", pipelineId)
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "ListPipelineVersionsV1", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "ListPipelineVersionsV1").Observe(time.Since(startTime).Seconds())
 	}
 	return &apiv1beta1.ListPipelineVersionsResponse{
 		Versions:      apiPipelineVersions,
@@ -1035,6 +1289,7 @@ func (s *PipelineServerV1) ListPipelineVersionsV1(ctx context.Context, request *
 // Returns an array of pipeline versions for a given query.
 // Supports v2beta1 behavior.
 func (s *PipelineServer) ListPipelineVersions(ctx context.Context, request *apiv2beta1.ListPipelineVersionsRequest) (*apiv2beta1.ListPipelineVersionsResponse, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		listPipelineVersionRequests.Inc()
 	}
@@ -1050,18 +1305,34 @@ func (s *PipelineServer) ListPipelineVersions(ctx context.Context, request *apiv
 	// the standard filter/list options which map keys to DB columns.
 	cleanedFilterSpec, tagFilters, err := extractTagFiltersFromFilterSpec(filterSpec)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelineVersions", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelineVersions").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipeline versions due to invalid tag filter in filter spec")
 	}
 
 	// Validate query parameters with the cleaned filter (tag predicates removed)
 	opts, err := validatedListOptions(&model.PipelineVersion{}, pageToken, int(pageSize), sortBy, cleanedFilterSpec, "v2beta1")
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelineVersions", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelineVersions").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipeline versions due invalid list options: pageToken: %v, pageSize: %v, sortBy: %v, filter: %v", pageToken, int(pageSize), sortBy, cleanedFilterSpec)
 	}
 
 	pipelineVersions, totalSize, nextPageToken, err := s.listPipelineVersions(ctx, pipelineId, opts, tagFilters)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "ListPipelineVersions", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "ListPipelineVersions").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to list pipeline versions for pipeline %s", pipelineId)
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "ListPipelineVersions", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "ListPipelineVersions").Observe(time.Since(startTime).Seconds())
 	}
 	return &apiv2beta1.ListPipelineVersionsResponse{
 		PipelineVersions: toApiPipelineVersions(pipelineVersions),
@@ -1096,17 +1367,26 @@ func (s *BasePipelineServer) deletePipelineVersion(ctx context.Context, pipeline
 // Deletes a pipeline version.
 // Supports v1beta1 behavior.
 func (s *PipelineServerV1) DeletePipelineVersionV1(ctx context.Context, request *apiv1beta1.DeletePipelineVersionRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		deletePipelineVersionRequests.Inc()
 	}
 
 	pipelineVersionId := request.GetVersionId()
 	if pipelineVersionId == "" {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "DeletePipelineVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "DeletePipelineVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to delete a pipeline version (v1beta1) due missing pipeline version id")
 	}
 
 	pipelineVersion, err := s.resourceManager.GetPipelineVersion(pipelineVersionId)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "DeletePipelineVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "DeletePipelineVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to delete a pipeline version (v1beta1) %s due error fetching a pipeline id", pipelineVersionId)
 	}
 
@@ -1114,11 +1394,17 @@ func (s *PipelineServerV1) DeletePipelineVersionV1(ctx context.Context, request 
 
 	err = s.deletePipelineVersion(ctx, pipelineId, pipelineVersionId)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "DeletePipelineVersionV1", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "DeletePipelineVersionV1").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to delete a pipeline version (v1beta1) %v under pipeline %v. Check error stack", pipelineVersionId, pipelineId)
 	}
 
 	if s.options.CollectMetrics {
 		pipelineVersionCount.Dec()
+		requestCounter.WithLabelValues("pipeline", "DeletePipelineVersionV1", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "DeletePipelineVersionV1").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -1126,27 +1412,42 @@ func (s *PipelineServerV1) DeletePipelineVersionV1(ctx context.Context, request 
 // Deletes a pipeline version.
 // Supports v2beta1 behavior.
 func (s *PipelineServer) DeletePipelineVersion(ctx context.Context, request *apiv2beta1.DeletePipelineVersionRequest) (*emptypb.Empty, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		deletePipelineVersionRequests.Inc()
 	}
 
 	pipelineVersionId := request.GetPipelineVersionId()
 	if pipelineVersionId == "" {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "DeletePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "DeletePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to delete a pipeline version due missing pipeline version id")
 	}
 
 	pipelineId := request.GetPipelineId()
 	if pipelineId == "" {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "DeletePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "DeletePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to delete a pipeline version %s due missing pipeline id", pipelineVersionId)
 	}
 
 	err := s.deletePipelineVersion(ctx, pipelineId, pipelineVersionId)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "DeletePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "DeletePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to delete a pipeline version id %v under pipeline id %v. Check error stack", pipelineVersionId, pipelineId)
 	}
 
 	if s.options.CollectMetrics {
 		pipelineVersionCount.Dec()
+		requestCounter.WithLabelValues("pipeline", "DeletePipelineVersion", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "DeletePipelineVersion").Observe(time.Since(startTime).Seconds())
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -1172,6 +1473,7 @@ func recoverClearTagsIntent(ctx context.Context, tags map[string]string) map[str
 // UpdatePipeline updates a pipeline's mutable fields (display_name, tags).
 // Supports v2beta1 behavior.
 func (s *PipelineServer) UpdatePipeline(ctx context.Context, request *apiv2beta1.UpdatePipelineRequest) (*apiv2beta1.Pipeline, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		updatePipelineRequests.Inc()
 	}
@@ -1179,6 +1481,10 @@ func (s *PipelineServer) UpdatePipeline(ctx context.Context, request *apiv2beta1
 	pipeline := request.GetPipeline()
 	pipelineID := pipeline.GetPipelineId()
 	if pipelineID == "" {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "UpdatePipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "UpdatePipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to update a pipeline. Pipeline id cannot be empty")
 	}
 
@@ -1187,13 +1493,25 @@ func (s *PipelineServer) UpdatePipeline(ctx context.Context, request *apiv2beta1
 		Verb: common.RbacResourceVerbUpdate,
 	}
 	if err := s.canAccessPipeline(ctx, pipelineID, resourceAttributes); err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "UpdatePipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "UpdatePipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to update pipeline %v due to authorization error", pipelineID)
 	}
 
 	tags := recoverClearTagsIntent(ctx, pipeline.GetTags())
 	updatedPipeline, err := s.resourceManager.UpdatePipeline(pipelineID, pipeline.GetDisplayName(), tags)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "UpdatePipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "UpdatePipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to update pipeline %v. Check error stack", pipelineID)
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "UpdatePipeline", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "UpdatePipeline").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiPipeline(updatedPipeline), nil
 }
@@ -1201,6 +1519,7 @@ func (s *PipelineServer) UpdatePipeline(ctx context.Context, request *apiv2beta1
 // UpdatePipelineVersion updates a pipeline version's mutable fields (display_name, tags).
 // Supports v2beta1 behavior.
 func (s *PipelineServer) UpdatePipelineVersion(ctx context.Context, request *apiv2beta1.UpdatePipelineVersionRequest) (*apiv2beta1.PipelineVersion, error) {
+	startTime := time.Now()
 	if s.options.CollectMetrics {
 		updatePipelineVersionRequests.Inc()
 	}
@@ -1208,11 +1527,19 @@ func (s *PipelineServer) UpdatePipelineVersion(ctx context.Context, request *api
 	pipelineVersion := request.GetPipelineVersion()
 	pipelineVersionID := pipelineVersion.GetPipelineVersionId()
 	if pipelineVersionID == "" {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "UpdatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "UpdatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to update a pipeline version. Pipeline version id cannot be empty")
 	}
 
 	pipelineID := pipelineVersion.GetPipelineId()
 	if pipelineID == "" {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "UpdatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "UpdatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.NewInvalidInputError("Failed to update pipeline version %v. Pipeline id cannot be empty", pipelineVersionID)
 	}
 
@@ -1221,13 +1548,25 @@ func (s *PipelineServer) UpdatePipelineVersion(ctx context.Context, request *api
 		Verb: common.RbacResourceVerbUpdate,
 	}
 	if err := s.canAccessPipelineVersion(ctx, pipelineVersionID, resourceAttributes); err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "UpdatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "UpdatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to update pipeline version %v due to authorization error", pipelineVersionID)
 	}
 
 	tags := recoverClearTagsIntent(ctx, pipelineVersion.GetTags())
 	updatedVersion, err := s.resourceManager.UpdatePipelineVersion(pipelineVersionID, pipelineVersion.GetDisplayName(), tags)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "UpdatePipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "UpdatePipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to update pipeline version %v. Check error stack", pipelineVersionID)
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "UpdatePipelineVersion", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "UpdatePipelineVersion").Observe(time.Since(startTime).Seconds())
 	}
 	return toApiPipelineVersion(updatedVersion), nil
 }
@@ -1235,18 +1574,31 @@ func (s *PipelineServer) UpdatePipelineVersion(ctx context.Context, request *api
 // Returns pipeline template.
 // Supports v1beta1 behavior.
 func (s *PipelineServerV1) GetPipelineVersionTemplate(ctx context.Context, request *apiv1beta1.GetPipelineVersionTemplateRequest) (*apiv1beta1.GetTemplateResponse, error) {
+	startTime := time.Now()
 	resourceAttributes := &authorizationv1.ResourceAttributes{
 		Verb: common.RbacResourceVerbGet,
 	}
 	err := s.canAccessPipelineVersion(ctx, request.GetVersionId(), resourceAttributes)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetPipelineVersionTemplate", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetPipelineVersionTemplate").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get a pipeline template due to authorization error. Verify that you have access to pipeline version %s", request.GetVersionId())
 	}
 	template, err := s.resourceManager.GetPipelineVersionTemplate(request.VersionId)
 	if err != nil {
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline", "GetPipelineVersionTemplate", "error").Inc()
+			requestLatency.WithLabelValues("pipeline", "GetPipelineVersionTemplate").Observe(time.Since(startTime).Seconds())
+		}
 		return nil, util.Wrapf(err, "Failed to get a pipeline template for pipeline version %s", request.GetVersionId())
 	}
 
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline", "GetPipelineVersionTemplate", "success").Inc()
+		requestLatency.WithLabelValues("pipeline", "GetPipelineVersionTemplate").Observe(time.Since(startTime).Seconds())
+	}
 	return &apiv1beta1.GetTemplateResponse{Template: string(template)}, nil
 }
 

--- a/backend/src/apiserver/server/pipeline_upload_server.go
+++ b/backend/src/apiserver/server/pipeline_upload_server.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -63,8 +64,6 @@ var (
 		Name: "pipeline_version_upload_requests",
 		Help: "The number of pipeline version upload requests",
 	})
-
-	// TODO(jingzhang36): error count and success count.
 )
 
 type PipelineUploadServerOptions struct {
@@ -98,12 +97,17 @@ func (s *PipelineUploadServer) uploadPipeline(apiVersion string, w http.Response
 		uploadPipelineRequests.Inc()
 		uploadPipelineVersionRequests.Inc()
 	}
+	startTime := time.Now()
 
 	glog.Infof("Upload pipeline called")
 	file, header, err := r.FormFile(FormFileKey)
 	if err != nil {
 		glog.Errorf("Failed to read pipeline from file: %v", err)
 		s.writeErrorToResponse(w, http.StatusBadRequest, errors.New("Failed to read pipeline from file"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 	defer file.Close()
@@ -112,18 +116,30 @@ func (s *PipelineUploadServer) uploadPipeline(apiVersion string, w http.Response
 	if err != nil {
 		glog.Errorf("Failed to read a pipeline spec file: %v", err)
 		s.writeErrorToResponse(w, http.StatusBadRequest, errors.New("Failed to read a pipeline spec file"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
 	pipelineNamespace := r.URL.Query().Get(NamespaceStringQuery)
 	if err := validation.ValidateFieldLength("Pipeline", "Namespace", pipelineNamespace); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 	pipelineNamespace = s.resourceManager.ReplaceNamespace(pipelineNamespace)
 	err = validation.ValidateNamespaceRequired(pipelineNamespace)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 	resourceAttributes := &authorizationv1.ResourceAttributes{
@@ -134,6 +150,10 @@ func (s *PipelineUploadServer) uploadPipeline(apiVersion string, w http.Response
 	if err != nil {
 		glog.Errorf("Failed to create a pipeline due to authorization error: %v", err)
 		s.writeErrorToResponse(w, http.StatusBadRequest, errors.New("Failed to create a pipeline"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
@@ -159,6 +179,10 @@ func (s *PipelineUploadServer) uploadPipeline(apiVersion string, w http.Response
 		if err := json.Unmarshal([]byte(tagsParam), &tags); err != nil {
 			glog.Errorf("Failed to parse tags query parameter: %v", err)
 			s.writeErrorToResponse(w, http.StatusBadRequest, errors.New("Failed to parse tags query parameter. Expected JSON object with string keys and values"))
+			if s.options.CollectMetrics {
+				requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+				requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+			}
 			return
 		}
 		pipeline.Tags = tags
@@ -173,6 +197,10 @@ func (s *PipelineUploadServer) uploadPipeline(apiVersion string, w http.Response
 
 	if err := validation.ValidateFieldLength("Pipeline", "Name", pipeline.Name); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
@@ -183,15 +211,27 @@ func (s *PipelineUploadServer) uploadPipeline(apiVersion string, w http.Response
 		if util.IsUserErrorCodeMatch(err, codes.AlreadyExists) {
 			glog.Errorf("Failed to create a pipeline and a pipeline version. The pipeline already exists: %v", err)
 			s.writeErrorToResponse(w, http.StatusConflict, errors.New("Failed to create a pipeline and a pipeline version"))
+			if s.options.CollectMetrics {
+				requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+				requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+			}
 			return
 		}
 		if util.IsUserErrorCodeMatch(err, codes.InvalidArgument) {
 			glog.Errorf("Failed to create a pipeline and a pipeline version: %v", err)
 			s.writeErrorToResponse(w, http.StatusBadRequest, errors.New(err.(*util.UserError).ExternalMessage()))
+			if s.options.CollectMetrics {
+				requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+				requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+			}
 			return
 		}
 		glog.Errorf("Failed to create a pipeline and a pipeline version: %v", err)
 		s.writeErrorToResponse(w, http.StatusInternalServerError, errors.New("Failed to create a pipeline and a pipeline version"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
@@ -208,6 +248,10 @@ func (s *PipelineUploadServer) uploadPipeline(apiVersion string, w http.Response
 	default:
 		glog.Errorf("Failed to create a pipeline. Invalid API version: %v", apiVersion)
 		s.writeErrorToResponse(w, http.StatusInternalServerError, errors.New("Failed to create a pipeline"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
@@ -220,13 +264,25 @@ func (s *PipelineUploadServer) uploadPipeline(apiVersion string, w http.Response
 	if err != nil {
 		glog.Errorf("Failed to create a pipeline. Marshaling error: %v", err)
 		s.writeErrorToResponse(w, http.StatusInternalServerError, errors.New("Failed to create a pipeline"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 	_, err = w.Write(data)
 	if err != nil {
 		glog.Errorf("Failed to create a pipeline. Write error: %v", err)
 		s.writeErrorToResponse(w, http.StatusInternalServerError, errors.New("Failed to create a pipeline"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
+		}
 		return
+	}
+	if s.options.CollectMetrics {
+		requestCounter.WithLabelValues("pipeline_upload", "UploadPipeline", "success").Inc()
+		requestLatency.WithLabelValues("pipeline_upload", "UploadPipeline").Observe(time.Since(startTime).Seconds())
 	}
 }
 
@@ -249,12 +305,17 @@ func (s *PipelineUploadServer) uploadPipelineVersion(apiVersion string, w http.R
 	if s.options.CollectMetrics {
 		uploadPipelineVersionRequests.Inc()
 	}
+	startTime := time.Now()
 
 	glog.Infof("Upload pipeline version called")
 	file, header, err := r.FormFile(FormFileKey)
 	if err != nil {
 		glog.Errorf("Failed to create a pipeline version. Error parsing pipeline spec filename: %v", err)
 		s.writeErrorToResponse(w, http.StatusBadRequest, errors.New("Failed to create a pipeline version"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 	defer file.Close()
@@ -263,12 +324,20 @@ func (s *PipelineUploadServer) uploadPipelineVersion(apiVersion string, w http.R
 	if err != nil {
 		glog.Errorf("Failed to create a pipeline version. Error reading pipeline spec file: %v", err)
 		s.writeErrorToResponse(w, http.StatusBadRequest, errors.New("Failed to create a pipeline version"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 	pipelineID := r.URL.Query().Get(PipelineKey)
 	if pipelineID == "" {
 		glog.Errorf("Failed to create a pipeline version. Error reading pipeline id")
 		s.writeErrorToResponse(w, http.StatusBadRequest, errors.New("Failed to create a pipeline version"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
@@ -284,6 +353,10 @@ func (s *PipelineUploadServer) uploadPipelineVersion(apiVersion string, w http.R
 	// Validate PipelineVersion name length
 	if err := validation.ValidateFieldLength("PipelineVersion", "Name", pipelineVersionName); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
@@ -291,12 +364,20 @@ func (s *PipelineUploadServer) uploadPipelineVersion(apiVersion string, w http.R
 	if err != nil {
 		glog.Errorf("Failed to create a pipeline version. Error reading namespace: %v", err)
 		s.writeErrorToResponse(w, http.StatusBadRequest, errors.New("Failed to create a pipeline version"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
 	err = validation.ValidateNamespaceRequired(namespace)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
@@ -308,6 +389,10 @@ func (s *PipelineUploadServer) uploadPipelineVersion(apiVersion string, w http.R
 	if err != nil {
 		glog.Errorf("Failed to create a pipeline version. Authorization error: %v", err)
 		s.writeErrorToResponse(w, http.StatusBadRequest, errors.New("Failed to create a pipeline version"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
@@ -318,6 +403,10 @@ func (s *PipelineUploadServer) uploadPipelineVersion(apiVersion string, w http.R
 		if err := json.Unmarshal([]byte(tagsParam), &versionTags); err != nil {
 			glog.Errorf("Failed to parse tags query parameter: %v", err)
 			s.writeErrorToResponse(w, http.StatusBadRequest, errors.New("Failed to parse tags query parameter. Expected JSON object with string keys and values"))
+			if s.options.CollectMetrics {
+				requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+				requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+			}
 			return
 		}
 	}
@@ -338,15 +427,27 @@ func (s *PipelineUploadServer) uploadPipelineVersion(apiVersion string, w http.R
 		if util.IsUserErrorCodeMatch(err, codes.AlreadyExists) {
 			glog.Errorf("Failed to create a pipeline version. The pipeline already exists: %v", err)
 			s.writeErrorToResponse(w, http.StatusConflict, errors.New("Failed to create a pipeline version"))
+			if s.options.CollectMetrics {
+				requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+				requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+			}
 			return
 		}
 		if util.IsUserErrorCodeMatch(err, codes.InvalidArgument) {
 			glog.Errorf("Failed to create a pipeline version: %v", err)
 			s.writeErrorToResponse(w, http.StatusBadRequest, errors.New(err.(*util.UserError).ExternalMessage()))
+			if s.options.CollectMetrics {
+				requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+				requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+			}
 			return
 		}
 		glog.Errorf("Failed to create a pipeline version: %v", err)
 		s.writeErrorToResponse(w, http.StatusInternalServerError, errors.New("Failed to create a pipeline version"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
@@ -359,6 +460,10 @@ func (s *PipelineUploadServer) uploadPipelineVersion(apiVersion string, w http.R
 	default:
 		glog.Errorf("Failed to create a pipeline version. Invalid API version: %v", apiVersion)
 		s.writeErrorToResponse(w, http.StatusInternalServerError, errors.New("Failed to create a pipeline version"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 	// Marshal the message to bytes
@@ -370,17 +475,27 @@ func (s *PipelineUploadServer) uploadPipelineVersion(apiVersion string, w http.R
 	if err != nil {
 		glog.Errorf("Failed to create a pipeline version. Marshaling error: %v", err)
 		s.writeErrorToResponse(w, http.StatusInternalServerError, errors.New("Failed to create a pipeline version"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 	_, err = w.Write(data)
 	if err != nil {
 		glog.Errorf("Failed to create a pipeline version. Write error: %v", err)
 		s.writeErrorToResponse(w, http.StatusInternalServerError, errors.New("Failed to create a pipeline version"))
+		if s.options.CollectMetrics {
+			requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "error").Inc()
+			requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
+		}
 		return
 	}
 
 	if s.options.CollectMetrics {
 		pipelineVersionCount.Inc()
+		requestCounter.WithLabelValues("pipeline_upload", "UploadPipelineVersion", "success").Inc()
+		requestLatency.WithLabelValues("pipeline_upload", "UploadPipelineVersion").Observe(time.Since(startTime).Seconds())
 	}
 }
 


### PR DESCRIPTION
## Description

Adds per-handler error counters and latency histograms to the four API server files that had TODO comments requesting this functionality (issue #13133).

## Changes

### New file
- `backend/src/apiserver/server/metrics.go` — shared CounterVec and HistogramVec definitions:
  - `api_server_request_count` (labels: server, method, status)
  - `api_server_request_latency_seconds` (labels: server, method; buckets: 10ms–60s)

### Modified files
- **experiment_server.go** — 12 handler methods instrumented (Create/Get/List/Delete/Archive/Unarchive x v1beta1/v2beta1)
- **job_server.go** — 12 handler methods instrumented (Create/Get/List/Enable/Disable/Delete x v1beta1/v2beta1)
- **pipeline_server.go** — 24 handler methods instrumented (all pipeline and pipeline version CRUD operations)
- **pipeline_upload_server.go** — 2 HTTP handler methods instrumented (UploadPipeline, UploadPipelineVersion)

### What was removed
- The `TODO(jingzhang36): error count and success count.` comments in all four files

## How it works

Each public handler method now:
1. Records `startTime := time.Now()` on entry
2. Increments error counter and observes latency on every error return path
3. Increments success counter and observes latency on the successful return path

All metrics are gated behind the existing `CollectMetrics` option (same pattern as the existing per-method counters).

## Testing

- `go build ./backend/src/apiserver/server/...` — passes
- `go test ./backend/src/apiserver/server/...` — all tests pass
- `gofmt` — no formatting issues

## Fixes

Fixes #13133
