### PR TITLE
fix(backend): deduplicate MLMD executions on retry in GetExecutionsInDAG. Fixes #13591

### DIFF
--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -1052,15 +1052,14 @@ func (c *Client) GetExecutionsInDAG(ctx context.Context, dag *DAG, pipeline *Pip
 
 			existing, ok := executionsMap[taskName]
 			if ok {
-				// TODO: The failure to handle this results in a specific edge
-				// case which has yet to be solved for. If you have three nested
-				// pipelines: A, which calls B, which calls C, and B and C share
-				// a task that A does not have but depends on in a producer
-				// subtask, when GetExecutionsInDAG is called, it will raise
-				// this error.
-
-				// TODO(Bobgy): to support retry, we need to handle multiple tasks with the same task name.
-				return nil, fmt.Errorf("two tasks have the same task name %q, id1=%v id2=%v", taskName, existing.GetID(), execution.GetID())
+				// When Argo retries a failed child task, a new MLMD execution
+				// record is created with the same task name. Keep the newer
+				// execution (higher create_time_since_epoch) so that
+				// UpdateDAGExecutionsState sees the post-retry state.
+				if e.GetCreateTimeSinceEpoch() > existing.GetExecution().GetCreateTimeSinceEpoch() {
+					executionsMap[taskName] = execution
+				}
+				continue
 			}
 			executionsMap[taskName] = execution
 		}

--- a/backend/src/v2/metadata/client_update_dag_state_test.go
+++ b/backend/src/v2/metadata/client_update_dag_state_test.go
@@ -544,3 +544,178 @@ func TestUpdateDAGExecutionsState_ErrorPropagation(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateDAGExecutionsState_RetryDuplicateTaskName(t *testing.T) {
+	// When Argo retries a failed child task, a new MLMD execution record is
+	// created with the same task_name. GetExecutionsInDAG must deduplicate
+	// by keeping the newer execution so UpdateDAGExecutionsState sees the
+	// post-retry state.
+	failedExecution := &pb.Execution{
+		Id:             int64Ptr(11),
+		LastKnownState: pb.Execution_FAILED.Enum(),
+		CustomProperties: map[string]*pb.Value{
+			keyTaskName:    StringValue("search-videos"),
+			keyParentDagID: intValue(10),
+		},
+		CreateTimeSinceEpoch: int64Ptr(1000),
+	}
+	retriedExecution := &pb.Execution{
+		Id:             int64Ptr(12),
+		LastKnownState: pb.Execution_COMPLETE.Enum(),
+		CustomProperties: map[string]*pb.Value{
+			keyTaskName:    StringValue("search-videos"),
+			keyParentDagID: intValue(10),
+		},
+		CreateTimeSinceEpoch: int64Ptr(2000),
+	}
+
+	dagExecution := makeExecution(10, pb.Execution_RUNNING, map[string]*pb.Value{
+		keyTotalDagTasks: intValue(1),
+	})
+
+	store := map[int64]*pb.Execution{
+		10: dagExecution,
+		11: failedExecution,
+		12: retriedExecution,
+	}
+
+	runCtxID := int64(500)
+	pipeline := &Pipeline{pipelineRunCtx: &pb.Context{Id: &runCtxID}}
+	dag := makeDAG(dagExecution)
+
+	mock := buildMock(
+		store,
+		map[int64][]*pb.Context{10: {}},
+		map[int64][]*pb.Execution{runCtxID: {failedExecution, retriedExecution}},
+		defaultPutExecution(store),
+	)
+	client := newTestClient(mock)
+
+	err := client.UpdateDAGExecutionsState(context.Background(), dag, pipeline)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dagExecution.GetLastKnownState() != pb.Execution_COMPLETE {
+		t.Errorf("expected DAG state COMPLETE after retry, got %v", dagExecution.GetLastKnownState())
+	}
+}
+
+func TestUpdateDAGExecutionsState_RetryKeepsNewerExecution(t *testing.T) {
+	// Verify that when two executions share the same task name, the one with
+	// the higher create_time_since_epoch is kept (the retried one).
+	olderExecution := &pb.Execution{
+		Id:             int64Ptr(20),
+		LastKnownState: pb.Execution_FAILED.Enum(),
+		CustomProperties: map[string]*pb.Value{
+			keyTaskName:    StringValue("task-a"),
+			keyParentDagID: intValue(10),
+		},
+		CreateTimeSinceEpoch: int64Ptr(100),
+	}
+	newerExecution := &pb.Execution{
+		Id:             int64Ptr(21),
+		LastKnownState: pb.Execution_FAILED.Enum(),
+		CustomProperties: map[string]*pb.Value{
+			keyTaskName:    StringValue("task-a"),
+			keyParentDagID: intValue(10),
+		},
+		CreateTimeSinceEpoch: int64Ptr(200),
+	}
+
+	dagExecution := makeExecution(10, pb.Execution_RUNNING, map[string]*pb.Value{
+		keyTotalDagTasks: intValue(1),
+	})
+
+	store := map[int64]*pb.Execution{
+		10: dagExecution,
+		20: olderExecution,
+		21: newerExecution,
+	}
+
+	runCtxID := int64(500)
+	pipeline := &Pipeline{pipelineRunCtx: &pb.Context{Id: &runCtxID}}
+	dag := makeDAG(dagExecution)
+
+	var putState pb.Execution_State
+	mock := buildMock(
+		store,
+		map[int64][]*pb.Context{10: {}},
+		map[int64][]*pb.Execution{runCtxID: {olderExecution, newerExecution}},
+		func(_ context.Context, req *pb.PutExecutionRequest, _ ...grpc.CallOption) (*pb.PutExecutionResponse, error) {
+			putState = req.GetExecution().GetLastKnownState()
+			if stored, ok := store[req.GetExecution().GetId()]; ok {
+				stored.LastKnownState = req.GetExecution().LastKnownState
+			}
+			return &pb.PutExecutionResponse{}, nil
+		},
+	)
+	client := newTestClient(mock)
+
+	err := client.UpdateDAGExecutionsState(context.Background(), dag, pipeline)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The newer execution is FAILED, so the DAG should be FAILED.
+	if putState != pb.Execution_FAILED {
+		t.Errorf("expected DAG state FAILED (from newer execution), got %v", putState)
+	}
+}
+
+func TestUpdateDAGExecutionsState_RetryMixedStates(t *testing.T) {
+	// Two tasks in a DAG: one has a failed+retried execution pair, the other
+	// is a single completed execution. After deduplication the DAG should
+	// transition to COMPLETE.
+	searchFailed := &pb.Execution{
+		Id:             int64Ptr(11),
+		LastKnownState: pb.Execution_FAILED.Enum(),
+		CustomProperties: map[string]*pb.Value{
+			keyTaskName:    StringValue("search-videos"),
+			keyParentDagID: intValue(10),
+		},
+		CreateTimeSinceEpoch: int64Ptr(1000),
+	}
+	searchRetried := &pb.Execution{
+		Id:             int64Ptr(12),
+		LastKnownState: pb.Execution_COMPLETE.Enum(),
+		CustomProperties: map[string]*pb.Value{
+			keyTaskName:    StringValue("search-videos"),
+			keyParentDagID: intValue(10),
+		},
+		CreateTimeSinceEpoch: int64Ptr(2000),
+	}
+	saveVideos := makeExecution(13, pb.Execution_COMPLETE, map[string]*pb.Value{
+		keyTaskName:    StringValue("save-videos"),
+		keyParentDagID: intValue(10),
+	})
+
+	dagExecution := makeExecution(10, pb.Execution_RUNNING, map[string]*pb.Value{
+		keyTotalDagTasks: intValue(2),
+	})
+
+	store := map[int64]*pb.Execution{
+		10: dagExecution,
+		11: searchFailed,
+		12: searchRetried,
+		13: saveVideos,
+	}
+
+	runCtxID := int64(500)
+	pipeline := &Pipeline{pipelineRunCtx: &pb.Context{Id: &runCtxID}}
+	dag := makeDAG(dagExecution)
+
+	mock := buildMock(
+		store,
+		map[int64][]*pb.Context{10: {}},
+		map[int64][]*pb.Execution{runCtxID: {searchFailed, searchRetried, saveVideos}},
+		defaultPutExecution(store),
+	)
+	client := newTestClient(mock)
+
+	err := client.UpdateDAGExecutionsState(context.Background(), dag, pipeline)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dagExecution.GetLastKnownState() != pb.Execution_COMPLETE {
+		t.Errorf("expected DAG state COMPLETE after retry, got %v", dagExecution.GetLastKnownState())
+	}
+}


### PR DESCRIPTION
## Problem

When Argo retries a failed child task, a new MLMD execution record is created with the same `task_name`. `GetExecutionsInDAG` errors on this duplicate, causing the entire `UpdateDAGExecutionsState` call to fail silently — the parent DAG execution stays FAILED in MLMD even though Argo reports the retried node as Succeeded.

The root cause is at `client.go:1062`:
```go
return nil, fmt.Errorf("two tasks have the same task name %q, id1=%v id2=%v", ...)
```

## Fix

In `GetExecutionsInDAG`, when two executions share the same `task_name`, keep the one with the higher `create_time_since_epoch` (the retried execution) instead of returning an error. This allows `UpdateDAGExecutionsState` to correctly evaluate child states after retry and propagate the terminal state upward.

## Changes

- `backend/src/v2/metadata/client.go`: Replace the error-on-duplicate logic with deduplication by creation time
- `backend/src/v2/metadata/client_update_dag_state_test.go`: Add 3 tests covering retry scenarios

## Test verification

- All 19 tests in the metadata package pass
- gofmt clean
- 3 new retry-specific tests: `TestUpdateDAGExecutionsState_RetryDuplicateTaskName`, `TestUpdateDAGExecutionsState_RetryKeepsNewerExecution`, `TestUpdateDAGExecutionsState_RetryMixedStates`

Fixes #13591
