### PR TITLE
fix(backend): Propagate retry strategy for tasks in dsl.ParallelFor

### DIFF
--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -456,6 +456,16 @@ func (c *workflowCompiler) iterationItemTask(name string, task *pipelinespec.Pip
 			Tasks: iterationTasks,
 		},
 	}
+
+	taskRetrySpec := task.GetRetryPolicy()
+	if taskRetrySpec != nil {
+		iterationsTmpl.Inputs.Parameters = append(iterationsTmpl.Inputs.Parameters, c.addParameterDefault(c.getTaskRetryParameters(task), "0")...)
+		iterationsTmpl.RetryStrategy = c.getTaskRetryStrategyFromInput(inputParameter(paramRetryMaxCount),
+			inputParameter(paramRetryBackOffDuration),
+			inputParameter(paramRetryBackOffFactor),
+			inputParameter(paramRetryBackOffMaxDuration))
+	}
+
 	iterationsTmplName, err := c.addTemplate(iterationsTmpl, componentName+"-"+name)
 	if err != nil {
 		return nil, err
@@ -484,6 +494,11 @@ func (c *workflowCompiler) iterationItemTask(name string, task *pipelinespec.Pip
 			WithSequence: &wfapi.Sequence{Count: &iterationCount},
 		},
 	}
+
+	if taskRetrySpec != nil {
+		iteratorTasks[1].Arguments.Parameters = append(iteratorTasks[1].Arguments.Parameters, c.getTaskRetryParametersWithValues(task)...)
+	}
+
 	return iteratorTasks, nil
 }
 


### PR DESCRIPTION
**Description:**
### What does this PR do?
Fixes an issue where `.set_retry()` configuration on tasks inside a `dsl.ParallelFor` context is ignored by the backend compiler.

### Why is this needed?
Currently, if an iteration inside a parallel loop fails due to a transient error, the entire loop branch fails without any retries, regardless of whether `.set_retry()` was called on the inner task. This makes data-parallel ML jobs extremely brittle.

The Python SDK correctly attaches the `RetryPolicy` to the inner task's `PipelineTaskSpec`, but the Go backend Argo compiler (`dag.go`) was leaving the iteration template's `RetryStrategy` nil at compile time.

### How does this PR fix it?
In `backend/src/v2/compiler/argocompiler/dag.go` inside `iterationItemTask`:
1. We now check `task.GetRetryPolicy()`.
2. If present, we append the necessary retry parameter defaults to the `iterationsTmpl` inputs.
3. We set the `RetryStrategy` on the `iterationsTmpl` using the extracted parameters.
4. We propagate the retry parameter values through the `Arguments` of the DAGTask calling the template (`iteratorTasks`).

### Testing
- [x] Verified Go backend compilation.
- [x] Tested with `compiler_test.go` golden updates.

### Fixes Issue
Fixes #13897 
