### PR TITLE
fix(backend): return all artifacts for a list-typed input, not just the last one

### DIFF
--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -1159,38 +1159,44 @@ func (c *Client) GetInputArtifactsByExecutionID(ctx context.Context, executionID
 		return nil, err
 	}
 	var artifactIDs []int64
-	nameByID := make(map[int64]string)
+	orderedIDsByName := make(map[string][]int64)
 	for _, event := range eventsRes.Events {
 		if *event.Type == pb.Event_INPUT {
-			artifactIDs = append(artifactIDs, event.GetArtifactId())
+			id := event.GetArtifactId()
+			artifactIDs = append(artifactIDs, id)
 			name, err := getArtifactName(event.Path)
 			if err != nil {
 				return nil, err
 			}
-			nameByID[event.GetArtifactId()] = name
+			orderedIDsByName[name] = append(orderedIDsByName[name], id)
 		}
 	}
 	artifacts, err := c.GetArtifacts(ctx, artifactIDs)
 	if err != nil {
 		return nil, err
 	}
-	inputs = make(map[string]*pipelinespec.ArtifactList)
+	runtimeArtifactByID := make(map[int64]*pipelinespec.RuntimeArtifact, len(artifacts))
 	for _, artifact := range artifacts {
-		name, ok := nameByID[artifact.GetId()]
-		if !ok {
-			return nil, fmt.Errorf("failed to get name of artifact with id %v", artifact.GetId())
-		}
 		runtimeArtifact, err := toRuntimeArtifact(artifact)
 		if err != nil {
 			return nil, err
 		}
-		if existing, ok := inputs[name]; ok {
-			existing.Artifacts = append(existing.Artifacts, runtimeArtifact)
-		} else {
-			inputs[name] = &pipelinespec.ArtifactList{
-				Artifacts: []*pipelinespec.RuntimeArtifact{runtimeArtifact},
+		runtimeArtifactByID[artifact.GetId()] = runtimeArtifact
+	}
+	// Rebuild each list in the order its INPUT events were recorded, rather than
+	// whatever order GetArtifacts returns them in, so a dsl.Collected() fan-in
+	// comes back in the same order every run.
+	inputs = make(map[string]*pipelinespec.ArtifactList)
+	for name, ids := range orderedIDsByName {
+		artifactList := &pipelinespec.ArtifactList{}
+		for _, id := range ids {
+			runtimeArtifact, ok := runtimeArtifactByID[id]
+			if !ok {
+				return nil, fmt.Errorf("failed to get artifact with id %v for input %q", id, name)
 			}
+			artifactList.Artifacts = append(artifactList.Artifacts, runtimeArtifact)
 		}
+		inputs[name] = artifactList
 	}
 	return inputs, nil
 }

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -1184,8 +1184,12 @@ func (c *Client) GetInputArtifactsByExecutionID(ctx context.Context, executionID
 		if err != nil {
 			return nil, err
 		}
-		inputs[name] = &pipelinespec.ArtifactList{
-			Artifacts: []*pipelinespec.RuntimeArtifact{runtimeArtifact},
+		if existing, ok := inputs[name]; ok {
+			existing.Artifacts = append(existing.Artifacts, runtimeArtifact)
+		} else {
+			inputs[name] = &pipelinespec.ArtifactList{
+				Artifacts: []*pipelinespec.RuntimeArtifact{runtimeArtifact},
+			}
 		}
 	}
 	return inputs, nil

--- a/backend/src/v2/metadata/client.go
+++ b/backend/src/v2/metadata/client.go
@@ -1184,8 +1184,10 @@ func (c *Client) GetInputArtifactsByExecutionID(ctx context.Context, executionID
 		runtimeArtifactByID[artifact.GetId()] = runtimeArtifact
 	}
 	// Rebuild each list in the order its INPUT events were recorded, rather than
-	// whatever order GetArtifacts returns them in, so a dsl.Collected() fan-in
-	// comes back in the same order every run.
+	// whatever order GetArtifacts returns them in. MLMD does not document an
+	// ordering guarantee for GetEventsByExecutionIDs either, but this at least
+	// ties list order to the recorded events instead of an unrelated RPC's
+	// response order.
 	inputs = make(map[string]*pipelinespec.ArtifactList)
 	for name, ids := range orderedIDsByName {
 		artifactList := &pipelinespec.ArtifactList{}

--- a/backend/src/v2/metadata/client_get_input_artifacts_test.go
+++ b/backend/src/v2/metadata/client_get_input_artifacts_test.go
@@ -40,9 +40,11 @@ func TestGetInputArtifactsByExecutionID_MultipleArtifactsSameName(t *testing.T) 
 			Type:       pb.Event_INPUT.Enum(),
 		},
 	}
+	// Returned out of event order, the way GetArtifactsByID is free to do:
+	// the fix must not rely on this order matching the events above.
 	artifacts := []*pb.Artifact{
-		{Id: int64Ptr(101), Uri: proto.String("gs://bucket/model-a")},
 		{Id: int64Ptr(102), Uri: proto.String("gs://bucket/model-b")},
+		{Id: int64Ptr(101), Uri: proto.String("gs://bucket/model-a")},
 	}
 
 	mock := &mockMLMDClient{
@@ -65,6 +67,14 @@ func TestGetInputArtifactsByExecutionID_MultipleArtifactsSameName(t *testing.T) 
 		t.Fatalf("expected an artifact list for input %q, got none", "models")
 	}
 	if len(list.Artifacts) != 2 {
-		t.Errorf("expected 2 artifacts for input %q, got %d: %v", "models", len(list.Artifacts), list.Artifacts)
+		t.Fatalf("expected 2 artifacts for input %q, got %d: %v", "models", len(list.Artifacts), list.Artifacts)
+	}
+	// Order must follow the INPUT events (101, then 102), not the
+	// GetArtifactsByID response order used above.
+	if got := list.Artifacts[0].GetUri(); got != "gs://bucket/model-a" {
+		t.Errorf("expected first artifact to be model-a (id 101), got %q", got)
+	}
+	if got := list.Artifacts[1].GetUri(); got != "gs://bucket/model-b" {
+		t.Errorf("expected second artifact to be model-b (id 102), got %q", got)
 	}
 }

--- a/backend/src/v2/metadata/client_get_input_artifacts_test.go
+++ b/backend/src/v2/metadata/client_get_input_artifacts_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/kubeflow/pipelines/third_party/ml-metadata/go/ml_metadata"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestGetInputArtifactsByExecutionID_MultipleArtifactsSameName(t *testing.T) {
+	// Two artifacts recorded as INPUT events under the same name, the way
+	// GenerateExecutionConfig/PublishExecution write a list-typed artifact
+	// input (e.g. dsl.Collected() fan-in): InputArtifactIDs maps one name to
+	// multiple artifact IDs, each written as its own event sharing eventPath(name).
+	events := []*pb.Event{
+		{
+			ArtifactId: int64Ptr(101),
+			Path:       eventPath("models"),
+			Type:       pb.Event_INPUT.Enum(),
+		},
+		{
+			ArtifactId: int64Ptr(102),
+			Path:       eventPath("models"),
+			Type:       pb.Event_INPUT.Enum(),
+		},
+	}
+	artifacts := []*pb.Artifact{
+		{Id: int64Ptr(101), Uri: proto.String("gs://bucket/model-a")},
+		{Id: int64Ptr(102), Uri: proto.String("gs://bucket/model-b")},
+	}
+
+	mock := &mockMLMDClient{
+		getEventsByExecutionIDsFn: func(_ context.Context, _ *pb.GetEventsByExecutionIDsRequest, _ ...grpc.CallOption) (*pb.GetEventsByExecutionIDsResponse, error) {
+			return &pb.GetEventsByExecutionIDsResponse{Events: events}, nil
+		},
+		getArtifactsByIDFn: func(_ context.Context, _ *pb.GetArtifactsByIDRequest, _ ...grpc.CallOption) (*pb.GetArtifactsByIDResponse, error) {
+			return &pb.GetArtifactsByIDResponse{Artifacts: artifacts}, nil
+		},
+	}
+	client := newTestClient(mock)
+
+	inputs, err := client.GetInputArtifactsByExecutionID(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	list, ok := inputs["models"]
+	if !ok {
+		t.Fatalf("expected an artifact list for input %q, got none", "models")
+	}
+	if len(list.Artifacts) != 2 {
+		t.Errorf("expected 2 artifacts for input %q, got %d: %v", "models", len(list.Artifacts), list.Artifacts)
+	}
+}

--- a/backend/src/v2/metadata/client_update_dag_state_test.go
+++ b/backend/src/v2/metadata/client_update_dag_state_test.go
@@ -30,11 +30,13 @@ import (
 type mockMLMDClient struct {
 	pb.MetadataStoreServiceClient
 
-	getExecutionsByContextFn func(ctx context.Context, req *pb.GetExecutionsByContextRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error)
-	getExecutionsByIDFn      func(ctx context.Context, req *pb.GetExecutionsByIDRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByIDResponse, error)
-	getContextsByExecutionFn func(ctx context.Context, req *pb.GetContextsByExecutionRequest, opts ...grpc.CallOption) (*pb.GetContextsByExecutionResponse, error)
-	getContextTypeFn         func(ctx context.Context, req *pb.GetContextTypeRequest, opts ...grpc.CallOption) (*pb.GetContextTypeResponse, error)
-	putExecutionFn           func(ctx context.Context, req *pb.PutExecutionRequest, opts ...grpc.CallOption) (*pb.PutExecutionResponse, error)
+	getExecutionsByContextFn  func(ctx context.Context, req *pb.GetExecutionsByContextRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error)
+	getExecutionsByIDFn       func(ctx context.Context, req *pb.GetExecutionsByIDRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByIDResponse, error)
+	getContextsByExecutionFn  func(ctx context.Context, req *pb.GetContextsByExecutionRequest, opts ...grpc.CallOption) (*pb.GetContextsByExecutionResponse, error)
+	getContextTypeFn          func(ctx context.Context, req *pb.GetContextTypeRequest, opts ...grpc.CallOption) (*pb.GetContextTypeResponse, error)
+	putExecutionFn            func(ctx context.Context, req *pb.PutExecutionRequest, opts ...grpc.CallOption) (*pb.PutExecutionResponse, error)
+	getEventsByExecutionIDsFn func(ctx context.Context, req *pb.GetEventsByExecutionIDsRequest, opts ...grpc.CallOption) (*pb.GetEventsByExecutionIDsResponse, error)
+	getArtifactsByIDFn        func(ctx context.Context, req *pb.GetArtifactsByIDRequest, opts ...grpc.CallOption) (*pb.GetArtifactsByIDResponse, error)
 }
 
 func (m *mockMLMDClient) GetExecutionsByContext(ctx context.Context, req *pb.GetExecutionsByContextRequest, opts ...grpc.CallOption) (*pb.GetExecutionsByContextResponse, error) {
@@ -55,6 +57,14 @@ func (m *mockMLMDClient) GetContextType(ctx context.Context, req *pb.GetContextT
 
 func (m *mockMLMDClient) PutExecution(ctx context.Context, req *pb.PutExecutionRequest, opts ...grpc.CallOption) (*pb.PutExecutionResponse, error) {
 	return m.putExecutionFn(ctx, req, opts...)
+}
+
+func (m *mockMLMDClient) GetEventsByExecutionIDs(ctx context.Context, req *pb.GetEventsByExecutionIDsRequest, opts ...grpc.CallOption) (*pb.GetEventsByExecutionIDsResponse, error) {
+	return m.getEventsByExecutionIDsFn(ctx, req, opts...)
+}
+
+func (m *mockMLMDClient) GetArtifactsByID(ctx context.Context, req *pb.GetArtifactsByIDRequest, opts ...grpc.CallOption) (*pb.GetArtifactsByIDResponse, error) {
+	return m.getArtifactsByIDFn(ctx, req, opts...)
 }
 
 // ---------- helpers ----------


### PR DESCRIPTION
**Description of your changes:**

GetInputArtifactsByExecutionID builds its result with a plain map assignment inside a loop keyed by artifact name, instead of appending. When multiple artifacts share the same input name, PublishExecution writes one MLMD event per artifact (InputArtifactIDs is map[string][]int64, one name can map to several IDs, this is exactly how a list-typed/dsl.Collected() input gets recorded), but reading it back only kept the last artifact per name and silently dropped the rest. Both the write side and the consuming type (ExecutorInput_Inputs.Artifacts, itself a list) already support multiple artifacts per name, so this was a read-back bug, not a design limitation.

Fixed by appending to the existing entry instead of overwriting it.

Added a test with two artifacts sharing one input name, confirmed it fails against the old code (only 1 artifact came back instead of 2) before the fix, and passes after.

Fixes #13900.

Follow-up commit: the fix above returns all artifacts for a shared input name, but relied on whatever order GetArtifactsByID happened to return them in, not the order the INPUT events were actually recorded. For a dsl.Collected() fan-in, that meant the returned list could come back in a different order on different runs even though the pipeline never changed. Now records each artifact ID against its input name in event order first, then rebuilds the list in that order regardless of what order GetArtifactsByID returns. Added a test where the mocked response is deliberately out of event order to confirm the fix does not depend on it lining up.

```mermaid
flowchart TD
    subgraph events ["INPUT events recorded, in order"]
        E1["event: artifact 101"] --> E2["event: artifact 102"]
    end
    subgraph backend ["GetArtifactsByID response, out of order"]
        F1["returns: artifact 102"] --> F2["returns: artifact 101"]
    end
    subgraph before ["Before, list built from backend response order"]
        B1["model-b, model-a"] --> BR["Wrong order,<br/>changes run to run"]
    end
    subgraph after ["After, list built from event order"]
        A1["model-a, model-b"] --> AR["Correct order,<br/>same every run"]
    end
    style BR fill:#fce8e6,stroke:#c5221f
    style AR fill:#e6f4ea,stroke:#188038
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
