### PR TITLE
fix(frontend): prefix each route in getRegisterHandler with basePath

### DIFF
--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -618,9 +618,45 @@ describe('UIServer apis', () => {
         );
     });
 
+    it('rejects reportMetrics under the base path', async () => {
+      const runId = 'a-random-run-id';
+      await request
+        .post(`/pipeline/apis/v1beta1/runs/${runId}:reportMetrics`)
+        .expect(
+          403,
+          '/pipeline/apis/v1beta1/runs/a-random-run-id:reportMetrics endpoint is not meant for external usage.',
+        );
+    });
+
+    it('rejects reportWorkflow under the base path', async () => {
+      const workflowId = 'a-random-workflow-id';
+      await request
+        .post(`/pipeline/apis/v1beta1/workflows/${workflowId}`)
+        .expect(
+          403,
+          '/pipeline/apis/v1beta1/workflows/a-random-workflow-id endpoint is not meant for external usage.',
+        );
+    });
+
+    it('rejects reportScheduledWorkflow under the base path', async () => {
+      const swf = 'a-random-swf-id';
+      await request
+        .post(`/pipeline/apis/v2beta1/scheduledworkflows/${swf}`)
+        .expect(
+          403,
+          '/pipeline/apis/v2beta1/scheduledworkflows/a-random-swf-id endpoint is not meant for external usage.',
+        );
+    });
+
     it('does not reject similar apis', async () => {
       await request // use reportMetrics as runId to see if it can confuse route parsing
         .post(`/apis/v1beta1/runs/xxx-reportMetrics:archive`)
+        .expect(200, 'KFP API is working');
+    });
+
+    it('proxies other run apis under the base path', async () => {
+      await request
+        .post(`/pipeline/apis/v1beta1/runs/a-random-run-id:archive`)
         .expect(200, 'KFP API is working');
     });
 

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -46,7 +46,13 @@ function getRegisterHandler(app: Application, basePath: string) {
     handler: express.Handler,
   ) => {
     func.call(app, route, handler);
-    return func.call(app, `${basePath}${route}`, handler);
+    // Prefix each route on its own. Interpolating an array collapses it into a
+    // single comma-joined path that matches no request, which would leave the
+    // base path copy of a multi-route registration effectively unregistered.
+    const basePathRoute = Array.isArray(route)
+      ? route.map((singleRoute) => `${basePath}${singleRoute}`)
+      : `${basePath}${route}`;
+    return func.call(app, basePathRoute, handler);
   };
 }
 


### PR DESCRIPTION
**Description of your changes:**

Repro: `POST /pipeline/apis/v1beta1/workflows/<id>` reaches the API server and returns 200, while the unprefixed `/apis/v1beta1/workflows/<id>` returns 403 the way it should.

Cause: `getRegisterHandler` builds the second registration as `` `${basePath}${route}` ``, which stringifies an array into one comma-joined path that never matches a request. The 403 deny list for the internal report endpoints is the only call site that passes an array, so under `/pipeline` those requests fall through to the catch-all proxy that strips the prefix and forwards to `ml-pipeline`, exposing ReportWorkflow, ReportScheduledWorkflow and ReportRunMetrics.

Fix: map the prefix over each element when the route is an array, so a multi-route registration gets a base path copy of every route rather than one unmatchable path.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
