### PR TITLE
fix(kubernetes_platform): check generated protobuf under PKG_DIR

### DIFF
--- a/kubernetes_platform/python/generate_proto.py
+++ b/kubernetes_platform/python/generate_proto.py
@@ -66,7 +66,11 @@ def generate_proto(source: str) -> None:
     Args:
       source: The source proto file that needs to be compiled.
     """
-    output = source.replace('.proto', '_pb2.py')
+    # protoc writes into PKG_DIR (--python_out), not next to the .proto source.
+    output = os.path.join(
+        PKG_DIR,
+        os.path.basename(source).replace('.proto', '_pb2.py'),
+    )
 
     if not os.path.exists(output) or (
             os.path.exists(source) and


### PR DESCRIPTION
## Summary
- Fix `kubernetes_platform/python/generate_proto.py` so the up-to-date check uses the real `protoc` output under `PKG_DIR`.
- Same class of bug as #13712 (which targets `api/v2alpha1/python/generate_proto.py`); this PR covers the kubernetes_platform copy only to avoid conflicting with #13719.

## Problem
The script used `source.replace(".proto", "_pb2.py")`, which looks next to the `.proto` under `proto/`. `protoc` is invoked with `--python_out=PKG_DIR`, so the real file is `python/kfp/kubernetes/kubernetes_executor_config_pb2.py`. The wrong path made the mtime optimization unreliable.

## Test plan
- [ ] Inspect `generate_proto.py` path logic
- [ ] Optional: with `protoc` available, run `python kubernetes_platform/python/generate_proto.py` twice and confirm the second run skips generation when output is newer

Related: #13712