### PR TITLE
fix(components): relax protobuf pin in GCPC docs extra. Fixes #12647

### DIFF
--- a/components/google-cloud/RELEASE.md
+++ b/components/google-cloud/RELEASE.md
@@ -1,6 +1,7 @@
 ## Upcoming release
 
 * Remove deprecated Wide and Deep Tabular Workflow pipeline.
+* Fix `docs` extra's `protobuf` pin so it no longer conflicts with the `protobuf` range required by `kfp`.
 
 ## Release 2.22.0
 

--- a/components/google-cloud/setup.py
+++ b/components/google-cloud/setup.py
@@ -65,7 +65,11 @@ setuptools.setup(
         # second list of deps are true dependencies for building the site
         "docs": (
             [
-                "protobuf>=4.21.1,<5",
+                # Must stay aligned with the protobuf range kfp itself requires
+                # (see sdk/python/requirements.in), otherwise `pip install
+                # .[docs]` cannot resolve a protobuf version that satisfies
+                # both this package and the pinned `kfp` dependency below.
+                "protobuf>=6.31.1,<7.0",
                 "grpcio-status<=1.47.0",
             ]
             + [


### PR DESCRIPTION
## Description of your changes

The `docs` extra for `google-cloud-pipeline-components` pins `protobuf>=4.21.1,<5`. This was added when `kfp` still allowed older protobuf versions, but current `kfp` releases require `protobuf>=6.31.1,<7.0` (see `sdk/python/requirements.in`, and confirmed against the published `kfp==2.17.0` metadata on PyPI).

Because the `docs` extra's `protobuf<5` pin and current `kfp`'s `protobuf>=6.31.1` requirement don't overlap, `pip`'s resolver can't satisfy both with the latest `kfp`. Verified with `pip install "google-cloud-pipeline-components[docs]" --dry-run` against the released 2.22.0 package: instead of failing outright, pip silently backtracks and installs `kfp==2.13.0` (the last `kfp` release still compatible with `protobuf<5`) rather than the current `kfp==2.17.0` — so anyone building docs via this extra silently gets an `kfp` that's several minor versions behind, with no warning.

This updates the `docs` extra's protobuf range to match what `kfp` itself declares, consistent with `protobuf==6.33.5` already used across the rest of the repo (backend, SDK, kfp-pipeline-spec, kubernetes_platform), so installing `.[docs]` no longer forces a silent `kfp` downgrade.

Fixes #12647

## Checklist

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).