### PR TITLE
fix(backend): propagate ctx instead of using context.TODO/Background in PVC operations

### DIFF
--- a/backend/src/v2/driver/k8s.go
+++ b/backend/src/v2/driver/k8s.go
@@ -1074,7 +1074,7 @@ func createPVC(
 	}
 
 	// Create the PVC in the cluster
-	createdPVC, err := k8sClient.CoreV1().PersistentVolumeClaims(opts.Namespace).Create(context.Background(), pvc, metav1.CreateOptions{})
+	createdPVC, err := k8sClient.CoreV1().PersistentVolumeClaims(opts.Namespace).Create(ctx, pvc, metav1.CreateOptions{})
 	if err != nil {
 		return "", createdExecution, pb.Execution_FAILED, fmt.Errorf("failed to create pvc: %w", err)
 	}
@@ -1194,13 +1194,13 @@ func deletePVC(
 	}
 
 	// Get the PVC you want to delete, verify that it exists.
-	_, err = k8sClient.CoreV1().PersistentVolumeClaims(opts.Namespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
+	_, err = k8sClient.CoreV1().PersistentVolumeClaims(opts.Namespace).Get(ctx, pvcName, metav1.GetOptions{})
 	if err != nil {
 		return createdExecution, pb.Execution_FAILED, fmt.Errorf("failed to delete pvc %s: cannot find pvc: %v", pvcName, err)
 	}
 
 	// Delete the PVC.
-	err = k8sClient.CoreV1().PersistentVolumeClaims(opts.Namespace).Delete(context.TODO(), pvcName, metav1.DeleteOptions{})
+	err = k8sClient.CoreV1().PersistentVolumeClaims(opts.Namespace).Delete(ctx, pvcName, metav1.DeleteOptions{})
 	if err != nil {
 		return createdExecution, pb.Execution_FAILED, fmt.Errorf("failed to delete pvc %s: %v", pvcName, err)
 	}
@@ -1305,7 +1305,7 @@ func publishDriverExecution(
 		return fmt.Errorf("error getting pod name: %w", err)
 	}
 
-	pod, err := k8sClient.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	pod, err := k8sClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error retrieving info for pod %s: %w", podName, err)
 	}


### PR DESCRIPTION
## Description

`createPVC`, `deletePVC`, and `publishDriverExecution` in the v2 driver use `context.Background()` / `context.TODO()` for Kubernetes API calls instead of propagating the `ctx` parameter already available in their function signatures. This means PVC create/delete operations and driver pod metadata lookups do not respect the caller's context cancellation or deadline.

### Root cause

Three Kubernetes API calls in `backend/src/v2/driver/k8s.go` ignore the passed context:

| Function | Line | Before (bug) | After (fix) |
|----------|------|---------------|-------------|
| `createPVC` | 1077 | `context.Background()` | `ctx` |
| `deletePVC` | 1197 | `context.TODO()` | `ctx` |
| `deletePVC` | 1203 | `context.TODO()` | `ctx` |
| `publishDriverExecution` | 1308 | `context.TODO()` | `ctx` |

### Fix

Replace each `context.Background()` and `context.TODO()` call with the existing `ctx` parameter that is already passed to the enclosing function.

### Changes

- `backend/src/v2/driver/k8s.go` — 4 lines changed

## Checklist

- [x] I have signed off my commits with `git commit -s`
- [x] All existing tests pass locally