### PR TITLE
fix(backend): remove duplicate --publish_logs argument in launcher command

### DIFF
--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -351,9 +351,6 @@ func initPodSpecPatch(
 		// Add log level to user code launcher if not default (set to 1)
 		launcherCmd = append(launcherCmd, "--log_level", pipelineLogLevel)
 	}
-	if publishLogs == "true" {
-		launcherCmd = append(launcherCmd, "--publish_logs", publishLogs)
-	}
 	launcherCmd = append(launcherCmd, "--") // separater before user command and args
 	res := k8score.ResourceRequirements{
 		Limits:   map[k8score.ResourceName]k8sres.Quantity{},

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -646,6 +646,7 @@ func Test_initPodSpecPatch_modelcarDoesNotInheritMLflowCredentialEnvVars(t *test
 // Validate that setting publishLogs to true propagates to the driver container
 // commands in the podSpec.
 func Test_initPodSpecPatch_publishLogs(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
 	podSpec, err := initPodSpecPatch(
 		&pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{},
 		&pipelinespec.ComponentSpec{},
@@ -671,12 +672,14 @@ func Test_initPodSpecPatch_publishLogs(t *testing.T) {
 	assert.Nil(t, err)
 	cmd := podSpec.Containers[0].Command
 	assert.Contains(t, cmd, "--publish_logs")
-	// TODO: There may be a simpler way to check this.
+	publishLogsCount := 0
 	for idx, val := range cmd {
 		if val == "--publish_logs" {
+			publishLogsCount++
 			assert.Equal(t, cmd[idx+1], "true")
 		}
 	}
+	assert.Equal(t, 1, publishLogsCount, "expected --publish_logs flag to occur exactly once")
 }
 
 func Test_initPodSpecPatch_resourceRequests(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**

When log publishing is enabled (`publishLogs == "true"`), `initPodSpecPatch` in `backend/src/v2/driver/driver.go` generates a container command array containing duplicate `--publish_logs` flags.

**Fix:**
- Removed the redundant conditional append block in `driver.go` so `--publish_logs <value>` is emitted exactly once.
- Updated `Test_initPodSpecPatch_publishLogs` in `driver_test.go` to initialize test proxy configuration (`proxy.InitializeConfigWithEmptyForTests()`) and assert that `--publish_logs` occurs exactly once in the generated command slice.

Fixes #13911

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
