### PR TITLE
fix(backend): prevent DB connection leaks by deferring rows.Close() immediately

### DIFF
--- a/backend/src/apiserver/storage/db_status_store.go
+++ b/backend/src/apiserver/storage/db_status_store.go
@@ -48,12 +48,12 @@ func (s *DBStatusStore) InitializeDBStatusTable() error {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to load database status")
 	}
+	defer rows.Close() // "rows" shouldn't be used after this point.
 	if err := rows.Err(); err != nil {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to load database status")
 	}
 	next := rows.Next()
-	defer rows.Close() // "rows" shouldn't be used after this point.
 
 	// The table is not initialized
 	if !next {
@@ -91,10 +91,10 @@ func (s *DBStatusStore) HaveSamplesLoaded() (bool, error) {
 	if err != nil {
 		return false, util.NewInternalServerError(err, "Error when getting load sample status")
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		return false, util.NewInternalServerError(err, "Error when getting load sample status")
 	}
-	defer rows.Close()
 	if rows.Next() {
 		err = rows.Scan(&haveSamplesLoaded)
 		if err != nil {

--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -46,12 +46,12 @@ func (s *DefaultExperimentStore) initializeDefaultExperimentTable() error {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to get default experiment")
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to get default experiment")
 	}
 	next := rows.Next()
-	defer rows.Close()
 
 	// If the table is not initialized, then set the default value.
 	if !next {
@@ -106,10 +106,10 @@ func (s *DefaultExperimentStore) GetDefaultExperimentId() (string, error) {
 	if err != nil {
 		return "", util.NewInternalServerError(err, "Error when getting default experiment ID")
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		return "", util.NewInternalServerError(err, "Error when getting default experiment ID")
 	}
-	defer rows.Close()
 
 	if rows.Next() {
 		err = rows.Scan(&defaultExperimentId)

--- a/backend/src/apiserver/storage/experiment_store.go
+++ b/backend/src/apiserver/storage/experiment_store.go
@@ -96,6 +96,7 @@ func (s *ExperimentStore) ListExperiments(filterContext *model.FilterContext, op
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -105,13 +106,13 @@ func (s *ExperimentStore) ListExperiments(filterContext *model.FilterContext, op
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -121,7 +122,6 @@ func (s *ExperimentStore) ListExperiments(filterContext *model.FilterContext, op
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {

--- a/backend/src/apiserver/storage/job_store.go
+++ b/backend/src/apiserver/storage/job_store.go
@@ -114,6 +114,7 @@ func (s *JobStore) ListJobs(
 	if err != nil {
 		return errorF(err)
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		return errorF(err)
 	}
@@ -122,13 +123,13 @@ func (s *JobStore) ListJobs(
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -138,7 +139,6 @@ func (s *JobStore) ListJobs(
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {

--- a/backend/src/apiserver/storage/pipeline_store.go
+++ b/backend/src/apiserver/storage/pipeline_store.go
@@ -268,6 +268,7 @@ func (s *PipelineStore) ListPipelinesV1(filterContext *model.FilterContext, opts
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to execute SQL for listing pipelines")
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to execute SQL for listing pipelines")
@@ -277,7 +278,6 @@ func (s *PipelineStore) ListPipelinesV1(filterContext *model.FilterContext, opts
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to parse results of listing pipelines")
 	}
-	defer rows.Close()
 
 	// Count pipelines
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
@@ -285,6 +285,7 @@ func (s *PipelineStore) ListPipelinesV1(filterContext *model.FilterContext, opts
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to count pipelines")
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to count pipelines")
@@ -294,7 +295,6 @@ func (s *PipelineStore) ListPipelinesV1(filterContext *model.FilterContext, opts
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to parse results of counting pipelines")
 	}
-	defer sizeRow.Close()
 
 	// Commit transaction
 	err = tx.Commit()

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -145,6 +145,7 @@ func (s *RunStore) ListRuns(
 	if err != nil {
 		return errorF(err)
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		return errorF(err)
 	}
@@ -153,13 +154,13 @@ func (s *RunStore) ListRuns(
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -169,7 +170,6 @@ func (s *RunStore) ListRuns(
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {

--- a/backend/src/apiserver/storage/task_store.go
+++ b/backend/src/apiserver/storage/task_store.go
@@ -257,6 +257,7 @@ func (s *TaskStore) ListTasks(filterContext *model.FilterContext, opts *list.Opt
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -266,13 +267,13 @@ func (s *TaskStore) ListTasks(filterContext *model.FilterContext, opts *list.Opt
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -282,7 +283,6 @@ func (s *TaskStore) ListTasks(filterContext *model.FilterContext, opts *list.Opt
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {


### PR DESCRIPTION

### What this PR does / why we need it:
This PR fixes database connection leaks across the `apiserver/storage` layer. In Go's `database/sql`, if `*sql.Rows` is not explicitly closed, the underlying database connection remains held. 

Previously, `defer rows.Close()` and `defer sizeRow.Close()` were registered *after* error-handling logic (like checking `rows.Err()` and scanning rows). If an error occurred in those intermediate steps, the function would return early without registering the defer, leaking the database connection. 

This PR moves all such `defer rows.Close()` and `defer sizeRow.Close()` statements immediately after their respective `tx.Query` / `db.Query` error checks, ensuring connections are always returned to the pool.

Fixes #13916

### Special notes for your reviewer:
Modified files to fix the late `defer rows.Close()` / `defer sizeRow.Close()` anti-pattern:
- `pipeline_store.go`
- `experiment_store.go`
- `default_experiment_store.go`
- `run_store.go`
- `task_store.go`
- `job_store.go`
- `db_status_store.go`

All unit tests in `backend/src/apiserver/storage` were run and pass locally.

### Checklists
- [x] Tested the changes locally.
- [x] Formatted the code correctly (`go fmt` / `go vet`).
