### PR TITLE
fix(backend): propagate error when scanRowsToRuns fails

### DIFF
--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -352,7 +352,7 @@ func (s *RunStore) scanRowsToRuns(rows *sql.Rows) ([]*model.Run, error) {
 		)
 		if err != nil {
 			glog.Errorf("Failed to scan row into a run: %v", err)
-			return runs, nil
+			return runs, err
 		}
 		metrics, err := parseMetrics(metricsInString)
 		if err != nil {

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -352,7 +352,7 @@ func (s *RunStore) scanRowsToRuns(rows *sql.Rows) ([]*model.Run, error) {
 		)
 		if err != nil {
 			glog.Errorf("Failed to scan row into a run: %v", err)
-			return runs, err
+			return nil, err
 		}
 		metrics, err := parseMetrics(metricsInString)
 		if err != nil {


### PR DESCRIPTION
**Description of your changes:**
Currently, if `rows.Scan` fails while iterating over run records, the error is logged but the function returns `runs, nil`. This silently swallows the error, causing partial or empty result sets to be returned to the API layer as a success, masking potential schema mismatches or database errors.

This PR ensures the error is correctly propagated to the caller, preventing silent data truncation during `ListRuns` and `GetRun` API calls. Matches the error handling pattern already used correctly in other storage packages like `task_store.go`.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).