### PR TITLE
fix(backend): stabilize integration test cleanup ordering and timeout handling

### DIFF
--- a/backend/test/v2/integration/cache_test.go
+++ b/backend/test/v2/integration/cache_test.go
@@ -47,7 +47,7 @@ func TestCache(t *testing.T) {
 
 func (s *CacheTestSuite) SetupSuite() {
 	var err error
-	s.mlmdClient, err = testutils.NewTestMlmdClient("127.0.0.1", metadata.GetMetadataConfig().Port, *config.TLSEnabled, *config.CaCertPath)
+	s.mlmdClient, err = testutils.NewTestMlmdClient("localhost", metadata.GetMetadataConfig().Port, *config.TLSEnabled, *config.CaCertPath)
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), s.mlmdClient)
 }
@@ -129,6 +129,8 @@ func (s *CacheTestSuite) SetupTest() {
 		glog.Exitf("Failed to get recurring run client. Error: %s", err.Error())
 	}
 
+	// Clean up before each test to ensure test isolation.
+	// See comments on s.cleanUp() in run_api_test.go
 	s.cleanUp()
 }
 
@@ -169,18 +171,30 @@ func (s *CacheTestSuite) TestCacheRecurringRun() {
 		}
 
 		if len(allRuns) >= 2 {
-			for _, run := range allRuns {
+			// Only check the first 2 runs, not all runs (recurring run keeps creating new ones)
+			firstTwoSucceeded := true
+			for i := 0; i < 2 && i < len(allRuns); i++ {
+				run := allRuns[i]
 				if *run.State != *run_model.V2beta1RuntimeStateSUCCEEDED.Pointer() {
-					return false
+					firstTwoSucceeded = false
 				}
 			}
-			return true
+			if firstTwoSucceeded {
+				return true
+			}
 		}
 
 		return false
 	}, 4*time.Minute, 5*time.Second)
 
+	// Wait a bit more to ensure the first run's launcher has finished writing cache to database
+	// The run state becomes SUCCEEDED when the user container finishes, but launcher still needs
+	// time to publish results and create cache entry in the database
+	time.Sleep(15 * time.Second)
+
 	state := s.getContainerExecutionState(t, allRuns[1].RunID)
+
+	// The second run should use cache from the first run
 	if *cacheEnabled {
 		require.Equal(t, pb.Execution_CACHED, state)
 	} else {
@@ -387,8 +401,8 @@ func (s *CacheTestSuite) TearDownSuite() {
 }
 
 func (s *CacheTestSuite) cleanUp() {
-	test.DeleteAllRuns(s.runClient, s.resourceNamespace, s.T())
 	test.DeleteAllRecurringRuns(s.recurringRunClient, s.resourceNamespace, s.T())
+	test.DeleteAllRuns(s.runClient, s.resourceNamespace, s.T())
 	test.DeleteAllPipelines(s.pipelineClient, s.T())
 }
 
@@ -416,6 +430,6 @@ func (s *CacheTestSuite) getContainerExecutionState(t *testing.T, runID string) 
 			return execution.GetLastKnownState()
 		}
 	}
-	t.Fatalf("no container execution found for run %s", runID)
+	require.FailNowf(t, "no container execution found for run %s", runID)
 	return pb.Execution_UNKNOWN
 }

--- a/backend/test/v2/integration/experiment_api_test.go
+++ b/backend/test/v2/integration/experiment_api_test.go
@@ -392,8 +392,8 @@ func (s *ExperimentApiTest) TearDownSuite() {
 }
 
 func (s *ExperimentApiTest) cleanUp() {
-	test.DeleteAllRuns(s.runClient, s.resourceNamespace, s.T())
 	test.DeleteAllRecurringRuns(s.recurringRunClient, s.resourceNamespace, s.T())
+	test.DeleteAllRuns(s.runClient, s.resourceNamespace, s.T())
 	test.DeleteAllPipelines(s.pipelineClient, s.T())
 	test.DeleteAllExperiments(s.experimentClient, s.resourceNamespace, s.T())
 }

--- a/backend/test/v2/integration/recurring_run_api_test.go
+++ b/backend/test/v2/integration/recurring_run_api_test.go
@@ -153,7 +153,10 @@ func (s *RecurringRunApiTestSuite) SetupTest() {
 	}
 	s.swfClient = client.NewScheduledWorkflowClientOrFatal(time.Second*30, util.ClientParameters{QPS: 5, Burst: 10})
 
+	// Clean up before each test to ensure test isolation.
+	// See comments on s.cleanUp() in run_api_test.go
 	s.cleanUp()
+
 }
 
 func (s *RecurringRunApiTestSuite) TestRecurringRunApis() {
@@ -741,8 +744,8 @@ func (s *RecurringRunApiTestSuite) TearDownSuite() {
 /** ======== the following are util functions ========= **/
 
 func (s *RecurringRunApiTestSuite) cleanUp() {
-	test.DeleteAllRuns(s.runClient, s.resourceNamespace, s.T())
 	test.DeleteAllRecurringRuns(s.recurringRunClient, s.resourceNamespace, s.T())
+	test.DeleteAllRuns(s.runClient, s.resourceNamespace, s.T())
 	test.DeleteAllPipelines(s.pipelineClient, s.T())
 	test.DeleteAllExperiments(s.experimentClient, s.resourceNamespace, s.T())
 }


### PR DESCRIPTION
## Summary

Fixes test flakiness in integration test cleanup by addressing two root causes:

**Cleanup ordering**: All test suites now delete recurring runs *before* runs. Previously, deleting runs first could race with recurring runs spawning new child runs during cleanup, causing leftover resources and cascading test failures.

**Deletion verification**: `DeleteAllRuns` and `DeleteAllRecurringRuns` in `test_utils.go` now poll until resources are confirmed deleted (up to 60s timeout), instead of fire-and-forget deletes. "Not found" errors are tolerated for races with other tests.

**Cache test fixes** (`cache_test.go`):
- Only checks the first 2 runs in `TestCacheRecurringRun` (recurring runs keep spawning new ones)
- Adds 15s sleep after run success to allow the launcher to write cache entries to the database
- Changes MLMD client host from `127.0.0.1` to `localhost`

**Split from #7512 (postgres integration PR) — these changes are independent of the database backend.**

## Test plan

- [x] `go build ./backend/...` passes
- [x] These are integration test changes requiring a cluster environment; verification deferred to CI
- [x] Changes affect only test cleanup utilities and test assertions, no production code modified