### PR TITLE
fix(backend): extract failed node error messages in workflow status logging

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1812,7 +1812,24 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 			if execStatus.Condition() == exec.ExecutionSucceeded {
 				workflowSuccessCounter.WithLabelValues(execNamespace, execName).Inc()
 			} else {
-				glog.Errorf("pipeline '%s' finished with an error", execName)
+				errorMsg := execStatus.Message()
+				// If workflow-level message is empty, try to get error from failed nodes
+				if errorMsg == "" {
+					if wf, ok := execSpec.(*util.Workflow); ok {
+						for nodeID, node := range wf.Status.Nodes {
+							if node.Phase == "Failed" || node.Phase == "Error" {
+								if node.Message != "" {
+									errorMsg = fmt.Sprintf("Node '%s' failed: %s", nodeID, node.Message)
+									break
+								}
+							}
+						}
+					}
+				}
+				if errorMsg == "" {
+					errorMsg = "(no error message available)"
+				}
+				glog.Errorf("pipeline '%s' finished with an error: %s", execName, errorMsg)
 
 				// also collects counts regarding retries
 				workflowFailedCounter.WithLabelValues(execNamespace, execName).Inc()


### PR DESCRIPTION
## Summary

When a pipeline workflow fails, the current error log only prints the pipeline name without any error details. This change enhances `ReportWorkflowResource` to extract meaningful error messages:

1. First tries `execStatus.Message()` for the workflow-level error
2. If empty, iterates over failed/errored nodes to find a node-level error message
3. Falls back to `"(no error message available)"` if neither source has a message

This makes it much easier to diagnose pipeline failures from API server logs without having to inspect the Argo Workflow object directly.

**Split from #7512 (postgres integration PR) — this change is independent of the database backend.**

## Test plan

- [x] `go build ./backend/...` passes
- [x] Verified the change is limited to logging behavior in `ReportWorkflowResource`; no functional impact on run execution or status reporting
- [x] Integration tests require a cluster environment; manual verification deferred to CI