### PR TITLE
test(e2e): add Kind GPU scheduling check with Fake GPU Operator

### DIFF
--- a/.github/actions/install-fgo-fake/action.yml
+++ b/.github/actions/install-fgo-fake/action.yml
@@ -1,0 +1,66 @@
+name: "Install Fake GPU Operator (fake backend)"
+description: >
+  Install Run:ai Fake GPU Operator with the default fake backend on Kind,
+  label nodes into the simulated GPU pool, and wait until nvidia.com/gpu is allocatable.
+
+inputs:
+  chart_version:
+    description: "fake-gpu-operator Helm chart version to pin"
+    required: false
+    default: "0.0.59"
+  namespace:
+    description: "Namespace for the Fake GPU Operator release"
+    required: false
+    default: "gpu-operator"
+  node_pool:
+    description: "Value for run.ai/simulated-gpu-node-pool node label"
+    required: false
+    default: "default"
+  gpu_count:
+    description: "Fake GPU count advertised per pool node"
+    required: false
+    default: "2"
+  helm_timeout:
+    description: "Helm --wait timeout"
+    required: false
+    default: "5m"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Helm
+      uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 
+      with:
+        version: v3.17.3
+
+    # Kind already removes control-plane NoSchedule on single-node clusters
+    # (create-cluster uses default one-node Kind), so no untaint step here.
+
+    - name: Label nodes for Fake GPU Operator pool
+      shell: bash
+      env:
+        NODE_POOL: ${{ inputs.node_pool }}
+      run: |
+        kubectl label node --all \
+          "run.ai/simulated-gpu-node-pool=${NODE_POOL}" \
+          --overwrite
+
+    - name: Install Fake GPU Operator (fake backend)
+      shell: bash
+      env:
+        CHART_VERSION: ${{ inputs.chart_version }}
+        NAMESPACE: ${{ inputs.namespace }}
+        NODE_POOL: ${{ inputs.node_pool }}
+        GPU_COUNT: ${{ inputs.gpu_count }}
+        HELM_TIMEOUT: ${{ inputs.helm_timeout }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        "${ACTION_PATH}/install-fgo-fake.sh"
+
+    - name: Wait for allocatable nvidia.com/gpu
+      shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        "${ACTION_PATH}/wait-for-allocatable-gpu.sh"

--- a/.github/actions/install-fgo-fake/install-fgo-fake.sh
+++ b/.github/actions/install-fgo-fake/install-fgo-fake.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Install Fake GPU Operator (fake backend) via Helm.
+# Env: CHART_VERSION, NAMESPACE, NODE_POOL, GPU_COUNT, HELM_TIMEOUT
+
+set -euo pipefail
+
+helm repo add fake-gpu-operator \
+  https://runai.jfrog.io/artifactory/api/helm/fake-gpu-operator-charts-prod \
+  --force-update
+helm repo update fake-gpu-operator
+
+helm upgrade -i fake-gpu-operator fake-gpu-operator/fake-gpu-operator \
+  --version "${CHART_VERSION}" \
+  --namespace "${NAMESPACE}" \
+  --create-namespace \
+  --set "topology.nodePools.${NODE_POOL}.gpuCount=${GPU_COUNT}" \
+  --wait \
+  --timeout "${HELM_TIMEOUT}"

--- a/.github/actions/install-fgo-fake/wait-for-allocatable-gpu.sh
+++ b/.github/actions/install-fgo-fake/wait-for-allocatable-gpu.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Wait until a node advertises allocatable nvidia.com/gpu.
+# Env: NAMESPACE (FGO namespace, for diagnostics)
+
+set -euo pipefail
+
+# print output on success; warn on failure without aborting.
+run_diagnostic() {
+  local label=$1
+  shift
+  local out
+  if ! out=$("$@" 2>&1); then
+    echo "WARNING: ${label} failed: ${out}" >&2
+  else
+    printf '%s\n' "${out}"
+  fi
+}
+
+echo "Waiting for nodes to advertise nvidia.com/gpu..."
+deadline=$((SECONDS + 300))
+while (( SECONDS < deadline )); do
+  gpu_lines=()
+  if ! out=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"="}{.status.allocatable.nvidia\.com/gpu}{"\n"}{end}' 2>&1); then
+    echo "WARNING: kubectl get nodes (GPU poll) failed: ${out}" >&2
+  else
+    mapfile -t gpu_lines <<< "${out}"
+  fi
+  printf '%s\n' "${gpu_lines[@]}"
+  for line in "${gpu_lines[@]}"; do
+    gpu_qty="${line#*=}"
+    if [[ -n "${gpu_qty}" && "${gpu_qty}" != "0" && "${gpu_qty}" != "<none>" ]]; then
+      echo "Allocatable nvidia.com/gpu is ready (${line})."
+      run_diagnostic "kubectl get nodes" \
+        kubectl get nodes -o custom-columns='NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu,POOL:.metadata.labels.run\.ai/simulated-gpu-node-pool'
+      run_diagnostic "kubectl get pods" \
+        kubectl get pods -n "${NAMESPACE}" -o wide
+      exit 0
+    fi
+  done
+  sleep 5
+done
+
+echo "Timed out waiting for nvidia.com/gpu allocatable."
+run_diagnostic "kubectl get nodes" kubectl get nodes -o yaml
+run_diagnostic "kubectl get pods" kubectl get pods -n "${NAMESPACE}" -o wide
+run_diagnostic "kubectl describe nodes" kubectl describe nodes
+exit 1

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -23,6 +23,7 @@ on:
       - '.github/workflows/image-builds.yml'
       - '.github/actions/create-cluster/**'
       - '.github/actions/deploy/**'
+      - '.github/actions/install-fgo-fake/**'
       - '.github/actions/test-and-report/**'
       - '.github/resources/**'
       - 'api/**'
@@ -96,6 +97,13 @@ jobs:
             cache_enabled: "true"
             pod_to_pod_tls_enabled: "true"
             test_label: "E2ECritical"
+          # Schedule-only NVIDIA GPU lane (Kind + Fake GPU Operator fake backend).
+          - k8s_version: "v1.36.1"
+            cache_enabled: "true"
+            argo_version: "v3.7.17"
+            proxy: "false"
+            test_label: "gpu-scheduling-check"
+            pod_to_pod_tls_enabled: "false"
       fail-fast: false
     name: End to End ${{ matrix.test_label}} Tests - K8s ${{ matrix.k8s_version }} cacheEnabled=${{ matrix.cache_enabled }} argoVersion=${{ matrix.argo_version}} proxy=${{ matrix.proxy}} pod_to_pod_tls_enabled=${{ matrix.pod_to_pod_tls_enabled }}
     steps:
@@ -122,6 +130,11 @@ jobs:
           image_tag: latest
           image_registry: kind-registry:5000
 
+      - name: Install Fake GPU Operator (fake backend)
+        uses: ./.github/actions/install-fgo-fake
+        id: install-fgo-fake
+        if: ${{ matrix.test_label == 'gpu-scheduling-check' && steps.deploy.outcome == 'success' }}
+
       - name: Configure Cluster CA Cert for TLS-Enabled Tests
         shell: bash
         if: ${{ matrix.pod_to_pod_tls_enabled == 'true'}}
@@ -131,7 +144,7 @@ jobs:
       - name: Configure Input Variables
         shell: bash
         id: configure
-        if: ${{ steps.deploy.outcome == 'success' }}
+        if: ${{ steps.deploy.outcome == 'success' && steps.install-fgo-fake.outcome != 'failure' }}
         env:
           DISPATCH_NUMBER_OF_NODES: ${{ inputs.number_of_parallel_tests }}
           DISPATCH_TEST_LABEL: ${{ inputs.test_label }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-27
+- Last updated: 2026-07-29
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -244,10 +244,13 @@ ginkgo -v --label-filter="Smoke" ./backend/test/v2/api
 ginkgo -v ./backend/test/end2end -- -namespace=kubeflow -isDebugMode=true
 ```
 
+Without `--label-filter`, `gpu-scheduling-check`-labeled E2E tests also run (they request `nvidia.com/gpu`) and may pend or fail on CPU-only clusters; pass `--label-filter` to limit what runs (for example `Smoke`, or `gpu-scheduling-check` on clusters with `nvidia.com/gpu` from real GPUs or Fake GPU Operator fake backend).
+
 Test data is centralized under:
 
 - `test_data/pipeline_files/valid/` (inputs) with a `valid/critical/` subset for smoke lanes
 - `test_data/compiled-workflows/` (expected compiled Argo Workflows)
+- `test_data/sdk_compiled_pipelines/valid/gpu-scheduling/` (schedule-only NVIDIA GPU fixture for Kind + FGO fake; label `gpu-scheduling-check`; no CUDA/torch asserts)
 
 ## Local execution
 
@@ -552,6 +555,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 - Argo Workflows version matrix for compatibility (where relevant): `e2e-test.yml` exercises `v3.7.17` and `v4.0.8` across the standard cache/test-label matrix, while `api-server-tests.yml` covers standalone and Kubernetes-native Argo compatibility across the standard matrices (with standalone low-Kubernetes spot lanes per supported Argo version).
 - Focused Argo runtime compatibility API tests run only in the canonical standalone `v4.0.8` / Kubernetes `v1.36.1` job via `ARGO_COMPATIBILITY_TESTS`; this covers recurring-run creation, run retry, task metadata/artifacts, and archived logs without adding another E2E lane.
 - Proxy / cache toggles: dedicated jobs run with HTTP proxy enabled and with execution cache disabled to validate those modes.
+- GPU scheduling (Kind): `e2e-test.yml` includes a `gpu-scheduling-check` matrix lane that installs Fake GPU Operator **fake** backend via `.github/actions/install-fgo-fake` (JFrog Helm chart), then runs schedule-only E2E fixtures under `test_data/sdk_compiled_pipelines/valid/gpu-scheduling/`. This does not cover CUDA/`torch.cuda`.
 - Kind concurrency caps: automatic critical, essential, and multi-user E2E lanes use the historical ten Ginkgo nodes, E2EFailure uses two, and nested-pipeline E2E uses three because each spec fans out into child pipelines. Manual workflow dispatches retain their requested concurrency.
 - Standard automatic and multi-user E2E Critical lanes split the 33 pipeline specs into duration-balanced shard A/B jobs on independent Kind runners; low-Kubernetes, TLS, and manual-dispatch compatibility lanes stay unsharded. The cache-enabled multi-user shards exercise the artifact-proxy compatibility path. Pipeline-level Ginkgo labels define the partition, and new Critical pipelines default to shard B so coverage is preserved.
 - Artifacts: failing logs and test outputs are uploaded as workflow artifacts for debugging.
@@ -560,6 +564,7 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 
 - Kind-based clusters are provisioned via the `kfp-cluster` composite action, parameterized by `k8s_version`, `pipeline_store`, `proxy`, `cache_enabled`, and optional `argo_version`.
 - The `create-cluster` and `deploy` actions are used by newer suites; `kfp-k8s` installs SDK components from source inside jobs that execute Python-based tests.
+- The `install-fgo-fake` composite action labels Kind nodes into the FGO simulated pool and waits for allocatable `nvidia.com/gpu` (single-node Kind already clears the control-plane taint).
 - Kind's `kindnet` DaemonSet keeps its 100m CPU request but has no CPU limit in CI, allowing the NFQUEUE packet-forwarding path to drain bursts instead of being held to a 100m quota.
 - Runner disk cleanup is conditional: `create-cluster` skips the expensive toolchain/package/container cleanup when at least 60 GiB is already free, but retains the cleanup as a fallback on constrained hosted runners.
 - The `deploy` action downloads and loads CI-built images before deploying optional Tinyproxy support, imports control-plane archives two at a time, preloads runtime base images used by test pods and init containers, and waits for Tinyproxy readiness/endpoints in proxy lanes. Artifact downloads use the `download-artifact-with-retry` composite action, which retries one failed download after 20 seconds while preserving name, pattern, merge, and cross-run inputs.
@@ -713,7 +718,7 @@ docformatter --check --recursive sdk/python/ --exclude "compiler_test.py"
 - Run backend unit tests: `go test -v $(go list ./backend/... | grep -v backend/test/)`
 - Run compiler tests: `ginkgo -v ./backend/test/compiler`
 - Run API tests: `ginkgo -v --label-filter="Smoke" ./backend/test/v2/api`
-- Run E2E tests: `ginkgo -v ./backend/test/end2end -- -namespace=kubeflow`
+- Run E2E tests: `ginkgo -v ./backend/test/end2end -- -namespace=kubeflow` (CPU-only: add `--label-filter`, e.g. `Smoke`, to avoid `gpu-scheduling-check` tests)
 - Check formatting:
   `yapf --recursive --diff sdk/python/ && pycln --check sdk/python && isort --check --profile google sdk/python`
 - Frontend dev server: `cd frontend && npm start`

--- a/backend/test/constants/test_features.go
+++ b/backend/test/constants/test_features.go
@@ -35,6 +35,9 @@ const (
 	E2eParallelNested string = "E2EParallelNested"
 	// E2eProxy - For pipeline that runs with a proxy
 	E2eProxy string = "E2EProxy"
+	// E2eGpuSchedulingCheck - Schedule-only NVIDIA GPU checks (e.g. Kind + FGO fake);
+	// does not require CUDA / torch.cuda.
+	E2eGpuSchedulingCheck string = "gpu-scheduling-check"
 
 	WorkflowCompiler       string = "WorkflowCompiler"
 	WorkflowCompilerVisits string = "WorkflowCompilerVisits"

--- a/backend/test/end2end/pipeline_e2e_test.go
+++ b/backend/test/end2end/pipeline_e2e_test.go
@@ -235,6 +235,19 @@ var _ = Describe("Upload and Verify Pipeline Run >", Label(FullRegression), func
 			})
 		}
 	})
+
+	// Schedule-only NVIDIA GPU check (Kind + FGO fake). Does not assert CUDA/torch.
+	// Filter with --label-filter=gpu-scheduling-check. Without a filter this also
+	// runs and needs a cluster that advertises nvidia.com/gpu (real or FGO fake).
+	Context("GPU scheduling check >", Label(E2eGpuSchedulingCheck), func() {
+		var pipelineDir = "valid/gpu-scheduling"
+		pipelineFiles := testutil.GetListOfFilesInADir(filepath.Join(testutil.GetPipelineFilesDir(), pipelineDir))
+		for _, pipelineFile := range pipelineFiles {
+			It(fmt.Sprintf("Upload %s pipeline", pipelineFile), FlakeAttempts(2), func() {
+				validatePipelineRunSuccess(pipelineFile, pipelineDir, testContext)
+			})
+		}
+	})
 })
 
 func validatePipelineRunSuccess(pipelineFile string, pipelineDir string, testContext *apitests.TestContext) {

--- a/test_data/compiled-workflows/nvidia_gpu_scheduling_check.yaml
+++ b/test_data/compiled-workflows/nvidia_gpu_scheduling_check.yaml
@@ -1,0 +1,410 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: nvidia-gpu-scheduling-check-
+spec:
+  arguments:
+    parameters:
+    - name: kubernetes-comp-verify-gpu-scheduled
+      value: '{"tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}]}'
+    - name: components-22deaaeaf18e6b8634b6ebaa8a34b86426def1687134b6fd3d21779bc7942cf6
+      value: '{"executorLabel":"exec-verify-gpu-scheduled"}'
+    - name: implementations-22deaaeaf18e6b8634b6ebaa8a34b86426def1687134b6fd3d21779bc7942cf6
+      value: '{"args":["echo \"GPU scheduling check: PASS\""],"command":["sh","-c"],"image":"python:3.11","resources":{"accelerator":{"count":"1","resourceCount":"1","resourceType":"nvidia.com/gpu","type":"nvidia.com/gpu"}}}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"verify-gpu-scheduled":{"cachingOptions":{},"componentRef":{"name":"comp-verify-gpu-scheduled"},"taskInfo":{"name":"verify-gpu-scheduled"}}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - nvidia-gpu-scheduling-check
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      command:
+      - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: task-name
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: driver
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+        name: executor
+        template: system-container-impl
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+    metadata: {}
+    name: system-container-executor
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher:latest
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: launcher
+    name: system-container-impl
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-22deaaeaf18e6b8634b6ebaa8a34b86426def1687134b6fd3d21779bc7942cf6}}'
+          - name: task
+            value: '{"cachingOptions":{},"componentRef":{"name":"comp-verify-gpu-scheduled"},"taskInfo":{"name":"verify-gpu-scheduled"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-22deaaeaf18e6b8634b6ebaa8a34b86426def1687134b6fd3d21779bc7942cf6}}'
+          - name: task-name
+            value: verify-gpu-scheduled
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+          - name: kubernetes-config
+            value: '{{workflow.parameters.kubernetes-comp-verify-gpu-scheduled}}'
+        name: verify-gpu-scheduled-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.verify-gpu-scheduled-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.verify-gpu-scheduled-driver.outputs.parameters.cached-decision}}'
+        depends: verify-gpu-scheduled-driver.Succeeded
+        name: verify-gpu-scheduled
+        template: system-container-executor
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - nvidia-gpu-scheduling-check
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: ""
+        name: task-name
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: driver
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/test_data/sdk_compiled_pipelines/valid/gpu-scheduling/nvidia_gpu_scheduling_check.py
+++ b/test_data/sdk_compiled_pipelines/valid/gpu-scheduling/nvidia_gpu_scheduling_check.py
@@ -1,0 +1,63 @@
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Schedule-only NVIDIA GPU check for Kind + Fake GPU Operator (fake backend).
+
+Requests nvidia.com/gpu and a NoSchedule toleration. Succeeds when the task
+schedules and runs; does not assert torch.cuda / CUDA compute.
+"""
+
+from kfp import compiler, dsl, kubernetes
+from kfp.dsl import PipelineTask
+
+
+def add_gpu_toleration(task: PipelineTask, accelerator_type: str,
+                       accelerator_limit: int):
+    task.set_accelerator_type(accelerator=accelerator_type)
+    task.set_accelerator_limit(accelerator_limit)
+    kubernetes.add_toleration(
+        task,
+        key=accelerator_type,
+        operator="Exists",
+        effect="NoSchedule",
+    )
+
+
+@dsl.container_component
+def verify_gpu_scheduled():
+    """Lightweight success marker once the GPU-requesting pod runs."""
+    return dsl.ContainerSpec(
+        image='python:3.11',
+        command=['sh', '-c'],
+        args=['echo "GPU scheduling check: PASS"'],
+    )
+
+
+@dsl.pipeline(
+    name="nvidia-gpu-scheduling-check",
+    description=(
+        "Verifies a task requesting nvidia.com/gpu with a matching toleration "
+        "can schedule and complete (no CUDA/torch assertions)."
+    ),
+)
+def nvidia_gpu_scheduling_check():
+    task = verify_gpu_scheduled().set_caching_options(False)
+    add_gpu_toleration(task, "nvidia.com/gpu", 1)
+
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(
+        nvidia_gpu_scheduling_check,
+        package_path=__file__.replace(".py", ".yaml"),
+    )

--- a/test_data/sdk_compiled_pipelines/valid/gpu-scheduling/nvidia_gpu_scheduling_check.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/gpu-scheduling/nvidia_gpu_scheduling_check.yaml
@@ -1,0 +1,47 @@
+# PIPELINE DEFINITION
+# Name: nvidia-gpu-scheduling-check
+# Description: Verifies a task requesting nvidia.com/gpu with a matching toleration can schedule and complete (no CUDA/torch assertions).
+components:
+  comp-verify-gpu-scheduled:
+    executorLabel: exec-verify-gpu-scheduled
+deploymentSpec:
+  executors:
+    exec-verify-gpu-scheduled:
+      container:
+        args:
+        - 'echo "GPU scheduling check: PASS"'
+        command:
+        - sh
+        - -c
+        image: python:3.11
+        resources:
+          accelerator:
+            count: '1'
+            resourceCount: '1'
+            resourceType: nvidia.com/gpu
+            type: nvidia.com/gpu
+pipelineInfo:
+  description: Verifies a task requesting nvidia.com/gpu with a matching toleration
+    can schedule and complete (no CUDA/torch assertions).
+  name: nvidia-gpu-scheduling-check
+root:
+  dag:
+    tasks:
+      verify-gpu-scheduled:
+        cachingOptions: {}
+        componentRef:
+          name: comp-verify-gpu-scheduled
+        taskInfo:
+          name: verify-gpu-scheduled
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.15.2
+---
+platforms:
+  kubernetes:
+    deploymentSpec:
+      executors:
+        exec-verify-gpu-scheduled:
+          tolerations:
+          - effect: NoSchedule
+            key: nvidia.com/gpu
+            operator: Exists


### PR DESCRIPTION
## Summary
- Adds a schedule-only E2E label/fixture (`gpu-scheduling-check`) that requests `nvidia.com/gpu` and verifies the run succeeds (no CUDA/`torch.cuda`).
- Adds `.github/actions/install-fgo-fake` to install Fake GPU Operator **fake** backend on Kind and wait for allocatable `nvidia.com/gpu`.
- Wires a dedicated `e2e-test.yml` matrix lane that installs FGO after deploy, then runs the new label.

## Test plan
- [x] Local Kind + FGO fake: `ginkgo -v --label-filter=gpu-scheduling-check ./backend/test/end2end -- -namespace=kubeflow -apiUrl=http://localhost:8888` → **PASSED**
- [x] CI: confirm the new `gpu-scheduling-check` E2E job installs FGO and passes
- [x] Confirm other E2E lanes are unchanged / still green

