### PR TITLE
fix(backend): close SQL rows on all early return paths in storage layer

### DIFF
--- a/backend/src/apiserver/storage/default_experiment_store.go
+++ b/backend/src/apiserver/storage/default_experiment_store.go
@@ -46,12 +46,12 @@ func (s *DefaultExperimentStore) initializeDefaultExperimentTable() error {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to get default experiment")
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		tx.Rollback()
 		return util.NewInternalServerError(err, "Failed to get default experiment")
 	}
 	next := rows.Next()
-	defer rows.Close()
 
 	// If the table is not initialized, then set the default value.
 	if !next {

--- a/backend/src/apiserver/storage/experiment_store.go
+++ b/backend/src/apiserver/storage/experiment_store.go
@@ -96,6 +96,7 @@ func (s *ExperimentStore) ListExperiments(filterContext *model.FilterContext, op
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -105,13 +106,13 @@ func (s *ExperimentStore) ListExperiments(filterContext *model.FilterContext, op
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -121,7 +122,6 @@ func (s *ExperimentStore) ListExperiments(filterContext *model.FilterContext, op
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {

--- a/backend/src/apiserver/storage/job_store.go
+++ b/backend/src/apiserver/storage/job_store.go
@@ -114,6 +114,7 @@ func (s *JobStore) ListJobs(
 	if err != nil {
 		return errorF(err)
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		return errorF(err)
 	}
@@ -122,13 +123,13 @@ func (s *JobStore) ListJobs(
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -138,7 +139,6 @@ func (s *JobStore) ListJobs(
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {

--- a/backend/src/apiserver/storage/pipeline_store.go
+++ b/backend/src/apiserver/storage/pipeline_store.go
@@ -268,6 +268,7 @@ func (s *PipelineStore) ListPipelinesV1(filterContext *model.FilterContext, opts
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to execute SQL for listing pipelines")
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to execute SQL for listing pipelines")
@@ -277,7 +278,6 @@ func (s *PipelineStore) ListPipelinesV1(filterContext *model.FilterContext, opts
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to parse results of listing pipelines")
 	}
-	defer rows.Close()
 
 	// Count pipelines
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
@@ -285,6 +285,7 @@ func (s *PipelineStore) ListPipelinesV1(filterContext *model.FilterContext, opts
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to count pipelines")
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to count pipelines")
@@ -294,7 +295,6 @@ func (s *PipelineStore) ListPipelinesV1(filterContext *model.FilterContext, opts
 		tx.Rollback()
 		return nil, nil, 0, "", util.NewInternalServerError(err, "Failed to parse results of counting pipelines")
 	}
-	defer sizeRow.Close()
 
 	// Commit transaction
 	err = tx.Commit()

--- a/backend/src/apiserver/storage/task_store.go
+++ b/backend/src/apiserver/storage/task_store.go
@@ -257,6 +257,7 @@ func (s *TaskStore) ListTasks(filterContext *model.FilterContext, opts *list.Opt
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -266,13 +267,13 @@ func (s *TaskStore) ListTasks(filterContext *model.FilterContext, opts *list.Opt
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -282,7 +283,6 @@ func (s *TaskStore) ListTasks(filterContext *model.FilterContext, opts *list.Opt
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {


### PR DESCRIPTION
## Description

In the API server storage layer, `defer rows.Close()` is placed after the `scanRows` (or equivalent) call, not immediately after the `Query` succeeds. If `rows.Err()` or `scanRows` returns an error before the `defer` is reached, the result set leaks — the database connection is never returned to the pool. The same pattern affects `sizeRow` result sets.

Over time, accumulated leaked connections can exhaust the connection pool, causing the API server to become unavailable.

### Root cause

All five files follow the same pattern:

```go
rows, err := tx.Query(...)
if err != nil { ... }
if err := rows.Err(); err != nil { return ... }  // LEAK: rows not closed
result, err := s.scanRows(rows)
if err != nil { return ... }                      // LEAK: rows not closed
defer rows.Close()                                 // too late — early returns above skip this
```

### Fix

Move `defer rows.Close()` (and `defer sizeRow.Close()`) right after the error check for `Query`, before any early return path.

### Files changed

- `backend/src/apiserver/storage/experiment_store.go`
- `backend/src/apiserver/storage/task_store.go`
- `backend/src/apiserver/storage/pipeline_store.go`
- `backend/src/apiserver/storage/job_store.go`
- `backend/src/apiserver/storage/default_experiment_store.go`

## Checklist

- [x] I have signed off my commits with `git commit -s`