### PR TITLE
fix(backend): use pipeline version references for pinned recurring runs. Fixes #13933

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1348,11 +1348,21 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 	var manifest string
 	var scheduledWorkflow *scheduledworkflow.ScheduledWorkflow
 	var tmpl template.Template
+	// Only jobs that embed a compiled workflow into the ScheduledWorkflow persist their
+	// manifest in the recurring run; reference-based jobs are resolved from the stored
+	// pipeline version by the ScheduledWorkflow controller through the CreateRun API at
+	// trigger time.
+	embedManifest := false
 
 	// If the pipeline version or pipeline spec is provided, this means the user wants to pin to a specific pipeline.
 	// Otherwise, always let the ScheduledWorkflow controller pick the latest.
 	if job.PipelineVersionId != "" || job.PipelineSpecManifest != "" || job.WorkflowSpecManifest != "" {
 		var err error
+		// A raw manifest means a legacy/freeform submission that must keep embedding the
+		// compiled workflow. Capture this before fetchTemplateFromPipelineSpec, which
+		// back-fills pipeline reference fields on job.PipelineSpec.
+		hasRawManifest := job.PipelineSpecManifest != "" || job.WorkflowSpecManifest != ""
+
 		// Create a template based on the manifest of an existing pipeline version or used-provided manifest.
 		// Update the job.PipelineSpec if an existing pipeline version is used.
 		tmpl, manifest, err = r.fetchTemplateFromPipelineSpec(&job.PipelineSpec)
@@ -1360,19 +1370,34 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			return nil, util.NewInternalServerError(err, "Failed to create a recurring run with an invalid pipeline spec manifest")
 		}
 
-		// When plugins are enabled, the SWF controller must call the CreateRun API
-		// so that per-run plugin logic executes.
-		if r.pluginDispatcher.PluginsRegistered() {
-			// Plugin-enabled: create a lightweight SWF without inline workflow spec
-			// so the SWF controller calls the CreateRun API for per-run plugin logic.
-			scheduledWorkflow, err = template.NewGenericScheduledWorkflow(job)
+		if v2Tmpl, ok := tmpl.(*template.V2Spec); ok && !hasRawManifest {
+			// Pinned to a specific V2 pipeline version by reference: validate the inputs
+			// up front, then store only the pipeline (version) reference in the
+			// ScheduledWorkflow so the controller creates runs through the CreateRun API
+			// at trigger time, compiling the stored pipeline version fresh on each run.
+			if err := v2Tmpl.ValidateJobInputs(job); err != nil {
+				return nil, util.Wrap(err, "Failed to validate the input parameters on the pinned pipeline version")
+			}
+			scheduledWorkflow, err = referenceScheduledWorkflow(job)
+			if err != nil {
+				return nil, err
+			}
 		} else {
-			// TODO(gkcalat): consider changing the flow. Other resource UUIDs are assigned by their respective stores (DB).
-			// Convert modelJob into scheduledWorkflow.
-			scheduledWorkflow, err = tmpl.ScheduledWorkflow(job)
-		}
-		if err != nil {
-			return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
+			embedManifest = true
+			// When plugins are enabled, the SWF controller must call the CreateRun API
+			// so that per-run plugin logic executes.
+			if r.pluginDispatcher.PluginsRegistered() {
+				// Plugin-enabled: create a lightweight SWF without inline workflow spec
+				// so the SWF controller calls the CreateRun API for per-run plugin logic.
+				scheduledWorkflow, err = template.NewGenericScheduledWorkflow(job)
+			} else {
+				// TODO(gkcalat): consider changing the flow. Other resource UUIDs are assigned by their respective stores (DB).
+				// Convert modelJob into scheduledWorkflow.
+				scheduledWorkflow, err = tmpl.ScheduledWorkflow(job)
+			}
+			if err != nil {
+				return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
+			}
 		}
 	} else if job.PipelineId == "" {
 		return nil, errors.New("Cannot create a job with an empty pipeline ID")
@@ -1408,18 +1433,9 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			return nil, util.Wrap(err, "Failed to validate the input parameters on the latest pipeline version")
 		}
 
-		scheduledWorkflow, err = template.NewGenericScheduledWorkflow(job)
+		scheduledWorkflow, err = referenceScheduledWorkflow(job)
 		if err != nil {
-			return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
-		}
-
-		parameters, err := template.StringMapToCRDParameters(string(job.RuntimeConfig.Parameters))
-		if err != nil {
-			return nil, util.Wrap(err, "Converting runtime config's parameters to CDR parameters failed")
-		}
-
-		scheduledWorkflow.Spec.Workflow = &scheduledworkflow.WorkflowResource{
-			Parameters: parameters, PipelineRoot: string(job.PipelineRoot),
+			return nil, err
 		}
 	}
 
@@ -1443,7 +1459,10 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 		modelRef.ResourceUUID = string(swf.UID)
 	}
 
-	if tmpl == nil {
+	if !embedManifest {
+		// Reference-based recurring run: the manifest is resolved from the pipeline
+		// version by the ScheduledWorkflow controller at trigger time, so it is not
+		// persisted in the recurring run.
 		return r.jobStore.CreateJob(job)
 	}
 
@@ -1463,6 +1482,26 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 		job.PipelineSpecManifest = model.LargeText(manifest)
 	}
 	return r.jobStore.CreateJob(job)
+}
+
+// referenceScheduledWorkflow builds a ScheduledWorkflow that references a pipeline
+// (version) instead of embedding a compiled workflow. The ScheduledWorkflow controller
+// resolves the referenced pipeline through the CreateRun API at trigger time.
+func referenceScheduledWorkflow(job *model.Job) (*scheduledworkflow.ScheduledWorkflow, error) {
+	scheduledWorkflow, err := template.NewGenericScheduledWorkflow(job)
+	if err != nil {
+		return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
+	}
+
+	parameters, err := template.StringMapToCRDParameters(string(job.RuntimeConfig.Parameters))
+	if err != nil {
+		return nil, util.Wrap(err, "Converting runtime config's parameters to CDR parameters failed")
+	}
+
+	scheduledWorkflow.Spec.Workflow = &scheduledworkflow.WorkflowResource{
+		Parameters: parameters, PipelineRoot: string(job.PipelineRoot),
+	}
+	return scheduledWorkflow, nil
 }
 
 // Enables or disables a recurring run with given id.

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -796,20 +796,28 @@ func (r *ResourceManager) ReconcileSwfCrs(ctx context.Context) error {
 		default:
 		}
 
-		// If the pipeline isn't pinned, skip it. The runs API is used directly by the ScheduledWorkflow controller
-		// in this case with just the pipeline ID and optionally the pipeline version ID.
-		if jobs[i].PipelineSpec.PipelineSpecManifest == "" && jobs[i].PipelineSpec.WorkflowSpecManifest == "" {
-			continue
-		}
+		// Mirror the ScheduledWorkflow shape CreateJob would produce for this job today:
+		// jobs without a persisted manifest are reference-based (pinned version or
+		// "always latest") and jobs created while plugins are registered go through the
+		// CreateRun API, so both carry only the pipeline reference plus runtime inputs;
+		// only manifest-backed jobs re-embed a freshly compiled workflow.
+		var newScheduledWorkflow *scheduledworkflow.ScheduledWorkflow
+		if (jobs[i].PipelineSpec.PipelineSpecManifest == "" && jobs[i].PipelineSpec.WorkflowSpecManifest == "") ||
+			r.pluginDispatcher.PluginsRegistered() {
+			newScheduledWorkflow, err = template.NewReferenceScheduledWorkflow(jobs[i])
+			if err != nil {
+				return failedToReconcileSwfCrsError(err)
+			}
+		} else {
+			tmpl, _, err := r.fetchTemplateFromPipelineSpec(&jobs[i].PipelineSpec)
+			if err != nil {
+				return failedToReconcileSwfCrsError(err)
+			}
 
-		tmpl, _, err := r.fetchTemplateFromPipelineSpec(&jobs[i].PipelineSpec)
-		if err != nil {
-			return failedToReconcileSwfCrsError(err)
-		}
-
-		newScheduledWorkflow, err := tmpl.ScheduledWorkflow(jobs[i])
-		if err != nil {
-			return failedToReconcileSwfCrsError(err)
+			newScheduledWorkflow, err = tmpl.ScheduledWorkflow(jobs[i])
+			if err != nil {
+				return failedToReconcileSwfCrsError(err)
+			}
 		}
 
 		for {
@@ -1378,7 +1386,13 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			if err := v2Tmpl.ValidateJobInputs(job); err != nil {
 				return nil, util.Wrap(err, "Failed to validate the input parameters on the pinned pipeline version")
 			}
-			scheduledWorkflow, err = referenceScheduledWorkflow(job)
+			// The pinned version never changes, so a compilation failure would repeat on
+			// every trigger. Compile once here to surface such errors at creation time;
+			// the compiled workflow itself is intentionally discarded.
+			if _, err := v2Tmpl.ScheduledWorkflow(job); err != nil {
+				return nil, util.Wrap(err, "Failed to compile the pinned pipeline version")
+			}
+			scheduledWorkflow, err = template.NewReferenceScheduledWorkflow(job)
 			if err != nil {
 				return nil, err
 			}
@@ -1387,9 +1401,11 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			// When plugins are enabled, the SWF controller must call the CreateRun API
 			// so that per-run plugin logic executes.
 			if r.pluginDispatcher.PluginsRegistered() {
-				// Plugin-enabled: create a lightweight SWF without inline workflow spec
-				// so the SWF controller calls the CreateRun API for per-run plugin logic.
-				scheduledWorkflow, err = template.NewGenericScheduledWorkflow(job)
+				// Plugin-enabled: create a SWF without inline workflow spec so the SWF
+				// controller calls the CreateRun API for per-run plugin logic. The
+				// reference SWF still carries the runtime parameters and pipeline root
+				// so they reach the CreateRun request.
+				scheduledWorkflow, err = template.NewReferenceScheduledWorkflow(job)
 			} else {
 				// TODO(gkcalat): consider changing the flow. Other resource UUIDs are assigned by their respective stores (DB).
 				// Convert modelJob into scheduledWorkflow.
@@ -1433,7 +1449,7 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			return nil, util.Wrap(err, "Failed to validate the input parameters on the latest pipeline version")
 		}
 
-		scheduledWorkflow, err = referenceScheduledWorkflow(job)
+		scheduledWorkflow, err = template.NewReferenceScheduledWorkflow(job)
 		if err != nil {
 			return nil, err
 		}
@@ -1482,26 +1498,6 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 		job.PipelineSpecManifest = model.LargeText(manifest)
 	}
 	return r.jobStore.CreateJob(job)
-}
-
-// referenceScheduledWorkflow builds a ScheduledWorkflow that references a pipeline
-// (version) instead of embedding a compiled workflow. The ScheduledWorkflow controller
-// resolves the referenced pipeline through the CreateRun API at trigger time.
-func referenceScheduledWorkflow(job *model.Job) (*scheduledworkflow.ScheduledWorkflow, error) {
-	scheduledWorkflow, err := template.NewGenericScheduledWorkflow(job)
-	if err != nil {
-		return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
-	}
-
-	parameters, err := template.StringMapToCRDParameters(string(job.RuntimeConfig.Parameters))
-	if err != nil {
-		return nil, util.Wrap(err, "Converting runtime config's parameters to CDR parameters failed")
-	}
-
-	scheduledWorkflow.Spec.Workflow = &scheduledworkflow.WorkflowResource{
-		Parameters: parameters, PipelineRoot: string(job.PipelineRoot),
-	}
-	return scheduledWorkflow, nil
 }
 
 // Enables or disables a recurring run with given id.

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3697,6 +3697,113 @@ func TestCreateJob_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 	assert.Equal(t, expectedJob.ToV1(), newJob.ToV1())
 }
 
+func TestCreateJob_ThroughPipelineVersionV2(t *testing.T) {
+	// Create experiment, pipeline and a V2 pipeline version.
+	store, manager, experiment, pipeline, _ := initWithExperimentAndPipeline(t)
+	defer store.Close()
+	pipelineStore, ok := store.pipelineStore.(*storage.PipelineStore)
+	assert.True(t, ok)
+	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(FakeUUIDOne, nil))
+	pv := createPipelineVersion(
+		pipeline.UUID,
+		"version_for_job",
+		"",
+		"",
+		v2SpecHelloWorld,
+		"",
+		"",
+	)
+	version, err := manager.CreatePipelineVersion(pv)
+	assert.Nil(t, err)
+
+	job := &model.Job{
+		DisplayName:  "j1",
+		Enabled:      true,
+		ExperimentId: experiment.UUID,
+		PipelineSpec: model.PipelineSpec{
+			PipelineVersionId: version.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters:   "{\"text\":\"world\"}",
+				PipelineRoot: "job-1-root",
+			},
+		},
+	}
+	newJob, err := manager.CreateJob(context.Background(), job)
+	assert.Nil(t, err)
+	expectedJob := &model.Job{
+		UUID:        "123e4567-e89b-12d3-a456-426655440000",
+		DisplayName: "j1",
+		K8SName:     "job-",
+		Namespace:   "ns1",
+		// The compiled workflow is not embedded for a pinned V2 pipeline version, so the
+		// API server selects the service account when compiling the run at trigger time.
+		ServiceAccount: "",
+		Enabled:        true,
+		CreatedAtInSec: 5,
+		UpdatedAtInSec: 5,
+		Conditions:     "STATUS_UNSPECIFIED",
+		ExperimentId:   experiment.UUID,
+		PipelineSpec: model.PipelineSpec{
+			PipelineId:        version.PipelineId,
+			PipelineName:      version.Name,
+			PipelineVersionId: version.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters:   "{\"text\":\"world\"}",
+				PipelineRoot: "job-1-root",
+			},
+		},
+	}
+	assert.Equal(t, expectedJob.ToV1(), newJob.ToV1())
+
+	// The ScheduledWorkflow references the pinned pipeline version instead of embedding
+	// the compiled workflow, so the controller creates runs through the CreateRun API.
+	swf, err := store.SwfClient().ScheduledWorkflow("ns1").Get(context.Background(), "job-", v1.GetOptions{})
+	require.Nil(t, err)
+	assert.Equal(t, version.PipelineId, swf.Spec.PipelineId)
+	assert.Equal(t, version.UUID, swf.Spec.PipelineVersionId)
+	require.NotNil(t, swf.Spec.Workflow)
+	assert.Nil(t, swf.Spec.Workflow.Spec)
+	require.Len(t, swf.Spec.Workflow.Parameters, 1)
+	assert.Equal(t, "text", swf.Spec.Workflow.Parameters[0].Name)
+	assert.Equal(t, "\"world\"", swf.Spec.Workflow.Parameters[0].Value)
+	assert.Equal(t, "job-1-root", swf.Spec.Workflow.PipelineRoot)
+}
+
+func TestCreateJob_ThroughPipelineVersionV2_InvalidParams(t *testing.T) {
+	// Create experiment, pipeline and a V2 pipeline version.
+	store, manager, experiment, pipeline, _ := initWithExperimentAndPipeline(t)
+	defer store.Close()
+	pipelineStore, ok := store.pipelineStore.(*storage.PipelineStore)
+	assert.True(t, ok)
+	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(FakeUUIDOne, nil))
+	pv := createPipelineVersion(
+		pipeline.UUID,
+		"version_for_job",
+		"",
+		"",
+		v2SpecHelloWorld,
+		"",
+		"",
+	)
+	version, err := manager.CreatePipelineVersion(pv)
+	assert.Nil(t, err)
+
+	job := &model.Job{
+		DisplayName:  "j1",
+		Enabled:      true,
+		ExperimentId: experiment.UUID,
+		PipelineSpec: model.PipelineSpec{
+			PipelineVersionId: version.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters: "{\"text\":\"world\",\"param2\":\"extra\"}",
+			},
+		},
+	}
+	_, err = manager.CreateJob(context.Background(), job)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "parameter(s) provided are not required by pipeline: param2")
+}
+
 func TestCreateJob_EmptyPipelineSpec(t *testing.T) {
 	initEnvVars()
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3655,6 +3655,113 @@ func TestCreateJob_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 	assert.Equal(t, expectedJob.ToV1(), newJob.ToV1())
 }
 
+func TestCreateJob_ThroughPipelineVersionV2(t *testing.T) {
+	// Create experiment, pipeline and a V2 pipeline version.
+	store, manager, experiment, pipeline, _ := initWithExperimentAndPipeline(t)
+	defer store.Close()
+	pipelineStore, ok := store.pipelineStore.(*storage.PipelineStore)
+	assert.True(t, ok)
+	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(FakeUUIDOne, nil))
+	pv := createPipelineVersion(
+		pipeline.UUID,
+		"version_for_job",
+		"",
+		"",
+		v2SpecHelloWorld,
+		"",
+		"",
+	)
+	version, err := manager.CreatePipelineVersion(pv)
+	assert.Nil(t, err)
+
+	job := &model.Job{
+		DisplayName:  "j1",
+		Enabled:      true,
+		ExperimentId: experiment.UUID,
+		PipelineSpec: model.PipelineSpec{
+			PipelineVersionId: version.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters:   "{\"text\":\"world\"}",
+				PipelineRoot: "job-1-root",
+			},
+		},
+	}
+	newJob, err := manager.CreateJob(context.Background(), job)
+	assert.Nil(t, err)
+	expectedJob := &model.Job{
+		UUID:        "123e4567-e89b-12d3-a456-426655440000",
+		DisplayName: "j1",
+		K8SName:     "job-",
+		Namespace:   "ns1",
+		// The compiled workflow is not embedded for a pinned V2 pipeline version, so the
+		// API server selects the service account when compiling the run at trigger time.
+		ServiceAccount: "",
+		Enabled:        true,
+		CreatedAtInSec: 5,
+		UpdatedAtInSec: 5,
+		Conditions:     "STATUS_UNSPECIFIED",
+		ExperimentId:   experiment.UUID,
+		PipelineSpec: model.PipelineSpec{
+			PipelineId:        version.PipelineId,
+			PipelineName:      version.Name,
+			PipelineVersionId: version.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters:   "{\"text\":\"world\"}",
+				PipelineRoot: "job-1-root",
+			},
+		},
+	}
+	assert.Equal(t, expectedJob.ToV1(), newJob.ToV1())
+
+	// The ScheduledWorkflow references the pinned pipeline version instead of embedding
+	// the compiled workflow, so the controller creates runs through the CreateRun API.
+	swf, err := store.SwfClient().ScheduledWorkflow("ns1").Get(context.Background(), "job-", v1.GetOptions{})
+	require.Nil(t, err)
+	assert.Equal(t, version.PipelineId, swf.Spec.PipelineId)
+	assert.Equal(t, version.UUID, swf.Spec.PipelineVersionId)
+	require.NotNil(t, swf.Spec.Workflow)
+	assert.Nil(t, swf.Spec.Workflow.Spec)
+	require.Len(t, swf.Spec.Workflow.Parameters, 1)
+	assert.Equal(t, "text", swf.Spec.Workflow.Parameters[0].Name)
+	assert.Equal(t, "\"world\"", swf.Spec.Workflow.Parameters[0].Value)
+	assert.Equal(t, "job-1-root", swf.Spec.Workflow.PipelineRoot)
+}
+
+func TestCreateJob_ThroughPipelineVersionV2_InvalidParams(t *testing.T) {
+	// Create experiment, pipeline and a V2 pipeline version.
+	store, manager, experiment, pipeline, _ := initWithExperimentAndPipeline(t)
+	defer store.Close()
+	pipelineStore, ok := store.pipelineStore.(*storage.PipelineStore)
+	assert.True(t, ok)
+	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(FakeUUIDOne, nil))
+	pv := createPipelineVersion(
+		pipeline.UUID,
+		"version_for_job",
+		"",
+		"",
+		v2SpecHelloWorld,
+		"",
+		"",
+	)
+	version, err := manager.CreatePipelineVersion(pv)
+	assert.Nil(t, err)
+
+	job := &model.Job{
+		DisplayName:  "j1",
+		Enabled:      true,
+		ExperimentId: experiment.UUID,
+		PipelineSpec: model.PipelineSpec{
+			PipelineVersionId: version.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters: "{\"text\":\"world\",\"param2\":\"extra\"}",
+			},
+		},
+	}
+	_, err = manager.CreateJob(context.Background(), job)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "parameter(s) provided are not required by pipeline: param2")
+}
+
 func TestCreateJob_EmptyPipelineSpec(t *testing.T) {
 	initEnvVars()
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -4738,6 +4738,69 @@ func TestReconcileSwfCrs(t *testing.T) {
 	require.NotNil(t, swf.Spec.Workflow.Spec)
 }
 
+func TestReconcileSwfCrs_PinnedPipelineVersionReference(t *testing.T) {
+	// Create experiment, pipeline and a V2 pipeline version.
+	store, manager, experiment, pipeline, _ := initWithExperimentAndPipeline(t)
+	defer store.Close()
+	pipelineStore, ok := store.pipelineStore.(*storage.PipelineStore)
+	assert.True(t, ok)
+	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(FakeUUIDOne, nil))
+	pv := createPipelineVersion(
+		pipeline.UUID,
+		"version_for_job",
+		"",
+		"",
+		v2SpecHelloWorld,
+		"",
+		"",
+	)
+	version, err := manager.CreatePipelineVersion(pv)
+	require.Nil(t, err)
+
+	job := &model.Job{
+		DisplayName:  "j1",
+		Enabled:      true,
+		ExperimentId: experiment.UUID,
+		PipelineSpec: model.PipelineSpec{
+			PipelineVersionId: version.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters:   "{\"text\":\"world\"}",
+				PipelineRoot: "job-1-root",
+			},
+		},
+	}
+	_, err = manager.CreateJob(context.Background(), job)
+	require.Nil(t, err)
+
+	swfClient := store.SwfClient().ScheduledWorkflow("ns1")
+	ctx := context.Background()
+
+	swf, err := swfClient.Get(ctx, "job-", v1.GetOptions{})
+	require.Nil(t, err)
+
+	// Emulate CR drift, e.g. after a database restore or a manual edit of the CR.
+	swf.Spec.PipelineVersionId = "some-other-version"
+	swf.Spec.Workflow = nil
+	_, err = swfClient.Update(ctx, swf)
+	require.Nil(t, err)
+
+	err = manager.ReconcileSwfCrs(ctx)
+	require.Nil(t, err)
+
+	// The reference-based ScheduledWorkflow is rebuilt from the stored recurring run:
+	// the pinned pipeline version reference and runtime inputs are restored, and no
+	// compiled workflow is embedded.
+	swf, err = swfClient.Get(ctx, "job-", v1.GetOptions{})
+	require.Nil(t, err)
+	assert.Equal(t, version.UUID, swf.Spec.PipelineVersionId)
+	require.NotNil(t, swf.Spec.Workflow)
+	assert.Nil(t, swf.Spec.Workflow.Spec)
+	require.Len(t, swf.Spec.Workflow.Parameters, 1)
+	assert.Equal(t, "text", swf.Spec.Workflow.Parameters[0].Name)
+	assert.Equal(t, "\"world\"", swf.Spec.Workflow.Parameters[0].Value)
+	assert.Equal(t, "job-1-root", swf.Spec.Workflow.PipelineRoot)
+}
+
 func TestReportScheduledWorkflowResource_Error(t *testing.T) {
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	defer store.Close()

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -4780,6 +4780,69 @@ func TestReconcileSwfCrs(t *testing.T) {
 	require.NotNil(t, swf.Spec.Workflow.Spec)
 }
 
+func TestReconcileSwfCrs_PinnedPipelineVersionReference(t *testing.T) {
+	// Create experiment, pipeline and a V2 pipeline version.
+	store, manager, experiment, pipeline, _ := initWithExperimentAndPipeline(t)
+	defer store.Close()
+	pipelineStore, ok := store.pipelineStore.(*storage.PipelineStore)
+	assert.True(t, ok)
+	pipelineStore.SetUUIDGenerator(util.NewFakeUUIDGeneratorOrFatal(FakeUUIDOne, nil))
+	pv := createPipelineVersion(
+		pipeline.UUID,
+		"version_for_job",
+		"",
+		"",
+		v2SpecHelloWorld,
+		"",
+		"",
+	)
+	version, err := manager.CreatePipelineVersion(pv)
+	require.Nil(t, err)
+
+	job := &model.Job{
+		DisplayName:  "j1",
+		Enabled:      true,
+		ExperimentId: experiment.UUID,
+		PipelineSpec: model.PipelineSpec{
+			PipelineVersionId: version.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters:   "{\"text\":\"world\"}",
+				PipelineRoot: "job-1-root",
+			},
+		},
+	}
+	_, err = manager.CreateJob(context.Background(), job)
+	require.Nil(t, err)
+
+	swfClient := store.SwfClient().ScheduledWorkflow("ns1")
+	ctx := context.Background()
+
+	swf, err := swfClient.Get(ctx, "job-", v1.GetOptions{})
+	require.Nil(t, err)
+
+	// Emulate CR drift, e.g. after a database restore or a manual edit of the CR.
+	swf.Spec.PipelineVersionId = "some-other-version"
+	swf.Spec.Workflow = nil
+	_, err = swfClient.Update(ctx, swf)
+	require.Nil(t, err)
+
+	err = manager.ReconcileSwfCrs(ctx)
+	require.Nil(t, err)
+
+	// The reference-based ScheduledWorkflow is rebuilt from the stored recurring run:
+	// the pinned pipeline version reference and runtime inputs are restored, and no
+	// compiled workflow is embedded.
+	swf, err = swfClient.Get(ctx, "job-", v1.GetOptions{})
+	require.Nil(t, err)
+	assert.Equal(t, version.UUID, swf.Spec.PipelineVersionId)
+	require.NotNil(t, swf.Spec.Workflow)
+	assert.Nil(t, swf.Spec.Workflow.Spec)
+	require.Len(t, swf.Spec.Workflow.Parameters, 1)
+	assert.Equal(t, "text", swf.Spec.Workflow.Parameters[0].Name)
+	assert.Equal(t, "\"world\"", swf.Spec.Workflow.Parameters[0].Value)
+	assert.Equal(t, "job-1-root", swf.Spec.Workflow.PipelineRoot)
+}
+
 func TestReportScheduledWorkflowResource_Error(t *testing.T) {
 	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
 	defer store.Close()

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -205,6 +206,10 @@ func StringMapToCRDParameters(modelParams string) ([]scheduledworkflow.Parameter
 		}
 		swParams = append(swParams, swParam)
 	}
+	// Sort by name so the resulting spec is deterministic: ScheduledWorkflow
+	// reconciliation compares specs with DeepEqual, and map iteration order would
+	// otherwise produce spurious diffs.
+	sort.Slice(swParams, func(i, j int) bool { return swParams[i].Name < swParams[j].Name })
 	return swParams, nil
 }
 

--- a/backend/src/apiserver/template/template.go
+++ b/backend/src/apiserver/template/template.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -213,6 +214,10 @@ func StringMapToCRDParameters(modelParams string) ([]scheduledworkflow.Parameter
 		}
 		swParams = append(swParams, swParam)
 	}
+	// Sort by name so the resulting spec is deterministic: ScheduledWorkflow
+	// reconciliation compares specs with DeepEqual, and map iteration order would
+	// otherwise produce spurious diffs.
+	sort.Slice(swParams, func(i, j int) bool { return swParams[i].Name < swParams[j].Name })
 	return swParams, nil
 }
 

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -1022,6 +1022,35 @@ func TestNewGenericScheduledWorkflow(t *testing.T) {
 	assert.Equal(t, int64(120), swf.Spec.PeriodicSchedule.IntervalSecond)
 }
 
+func TestNewReferenceScheduledWorkflow(t *testing.T) {
+	modelJob := &model.Job{
+		K8SName:      "my-job",
+		Enabled:      true,
+		ExperimentId: "exp-1",
+		PipelineSpec: model.PipelineSpec{
+			PipelineId:        "pipe-1",
+			PipelineVersionId: "version-1",
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters:   `{"b_param":"world","a_param":"hello","c_param":42}`,
+				PipelineRoot: "gs://my-bucket/root",
+			},
+		},
+	}
+	swf, err := NewReferenceScheduledWorkflow(modelJob)
+	assert.Nil(t, err)
+	assert.Equal(t, "pipe-1", swf.Spec.PipelineId)
+	assert.Equal(t, "version-1", swf.Spec.PipelineVersionId)
+	require.NotNil(t, swf.Spec.Workflow)
+	// No compiled workflow is embedded; only the runtime inputs are carried.
+	assert.Nil(t, swf.Spec.Workflow.Spec)
+	assert.Equal(t, "gs://my-bucket/root", swf.Spec.Workflow.PipelineRoot)
+	// Parameters are sorted by name so the spec is deterministic for reconciliation.
+	require.Len(t, swf.Spec.Workflow.Parameters, 3)
+	assert.Equal(t, scheduledworkflow.Parameter{Name: "a_param", Value: `"hello"`}, swf.Spec.Workflow.Parameters[0])
+	assert.Equal(t, scheduledworkflow.Parameter{Name: "b_param", Value: `"world"`}, swf.Spec.Workflow.Parameters[1])
+	assert.Equal(t, scheduledworkflow.Parameter{Name: "c_param", Value: `42`}, swf.Spec.Workflow.Parameters[2])
+}
+
 func TestValidateJobInputs(t *testing.T) {
 	proxy.InitializeConfigWithEmptyForTests()
 	v2SpecHelloWorldYAML := loadYaml(t, "testdata/hello_world.yaml")

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -1066,6 +1066,35 @@ func TestNewGenericScheduledWorkflow(t *testing.T) {
 	assert.Equal(t, int64(120), swf.Spec.PeriodicSchedule.IntervalSecond)
 }
 
+func TestNewReferenceScheduledWorkflow(t *testing.T) {
+	modelJob := &model.Job{
+		K8SName:      "my-job",
+		Enabled:      true,
+		ExperimentId: "exp-1",
+		PipelineSpec: model.PipelineSpec{
+			PipelineId:        "pipe-1",
+			PipelineVersionId: "version-1",
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters:   `{"b_param":"world","a_param":"hello","c_param":42}`,
+				PipelineRoot: "gs://my-bucket/root",
+			},
+		},
+	}
+	swf, err := NewReferenceScheduledWorkflow(modelJob)
+	assert.Nil(t, err)
+	assert.Equal(t, "pipe-1", swf.Spec.PipelineId)
+	assert.Equal(t, "version-1", swf.Spec.PipelineVersionId)
+	require.NotNil(t, swf.Spec.Workflow)
+	// No compiled workflow is embedded; only the runtime inputs are carried.
+	assert.Nil(t, swf.Spec.Workflow.Spec)
+	assert.Equal(t, "gs://my-bucket/root", swf.Spec.Workflow.PipelineRoot)
+	// Parameters are sorted by name so the spec is deterministic for reconciliation.
+	require.Len(t, swf.Spec.Workflow.Parameters, 3)
+	assert.Equal(t, scheduledworkflow.Parameter{Name: "a_param", Value: `"hello"`}, swf.Spec.Workflow.Parameters[0])
+	assert.Equal(t, scheduledworkflow.Parameter{Name: "b_param", Value: `"world"`}, swf.Spec.Workflow.Parameters[1])
+	assert.Equal(t, scheduledworkflow.Parameter{Name: "c_param", Value: `42`}, swf.Spec.Workflow.Parameters[2])
+}
+
 func TestValidateJobInputs(t *testing.T) {
 	proxy.InitializeConfigWithEmptyForTests()
 	v2SpecHelloWorldYAML := loadYaml(t, "testdata/hello_world.yaml")

--- a/backend/src/apiserver/template/v2_template.go
+++ b/backend/src/apiserver/template/v2_template.go
@@ -85,6 +85,26 @@ func NewGenericScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.Schedu
 	}, nil
 }
 
+// NewReferenceScheduledWorkflow builds a ScheduledWorkflow that references a pipeline
+// (version) instead of embedding a compiled workflow. The ScheduledWorkflow controller
+// resolves the referenced pipeline through the CreateRun API at trigger time.
+func NewReferenceScheduledWorkflow(modelJob *model.Job) (*scheduledworkflow.ScheduledWorkflow, error) {
+	scheduledWorkflow, err := NewGenericScheduledWorkflow(modelJob)
+	if err != nil {
+		return nil, util.Wrap(err, "Failed to create a recurring run during scheduled workflow creation")
+	}
+
+	parameters, err := StringMapToCRDParameters(string(modelJob.RuntimeConfig.Parameters))
+	if err != nil {
+		return nil, util.Wrap(err, "Converting runtime config's parameters to CDR parameters failed")
+	}
+
+	scheduledWorkflow.Spec.Workflow = &scheduledworkflow.WorkflowResource{
+		Parameters: parameters, PipelineRoot: string(modelJob.PipelineRoot),
+	}
+	return scheduledWorkflow, nil
+}
+
 func (t *V2Spec) PipelineSpec() *pipelinespec.PipelineSpec {
 	return t.spec
 }

--- a/backend/src/crd/controller/scheduledworkflow/controller.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller.go
@@ -39,6 +39,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -665,12 +666,22 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 			PipelineRoot: swf.Spec.Workflow.PipelineRoot,
 		}
 
+		// Expand recurring-run macros such as [[ScheduledTime]], [[Index]] and
+		// [[CurrentTime]] with the trigger's epochs and index, matching the
+		// substitution the embedded-workflow path performs in NewWorkflow. The run
+		// UUID is not known yet, so [[RunUUID]] is left for the API server to expand.
+		formatter := commonutil.NewSWFParameterFormatter("", nextScheduledEpoch, nowEpoch, swf.NextIndex())
+
 		for _, param := range swf.Spec.Workflow.Parameters {
 			val := &structpb.Value{}
 
 			err := val.UnmarshalJSON([]byte(param.Value))
 			if err != nil {
 				return false, "", err
+			}
+
+			if stringValue, ok := val.GetKind().(*structpb.Value_StringValue); ok {
+				val = structpb.NewStringValue(formatter.Format(stringValue.StringValue))
 			}
 
 			runtimeConfig.Parameters[param.Name] = val
@@ -695,6 +706,10 @@ func (c *Controller) submitNewWorkflowIfNotAlreadySubmitted(
 			RecurringRunId: string(swf.UID),
 			RuntimeConfig:  runtimeConfig,
 			PluginsInput:   pluginsInput,
+			// Record the trigger's scheduled time on the run so the stored run reflects
+			// the schedule (rather than the creation time) and server-side macro
+			// expansion of [[ScheduledTime]] uses the correct epoch.
+			ScheduledAt: timestamppb.New(time.Unix(nextScheduledEpoch, 0)),
 			PipelineSource: &api.Run_PipelineVersionReference{
 				PipelineVersionReference: &api.PipelineVersionReference{
 					PipelineId: swf.Spec.PipelineId,

--- a/backend/src/crd/controller/scheduledworkflow/controller_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"testing"
 
+	api "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/client"
 	util "github.com/kubeflow/pipelines/backend/src/crd/controller/scheduledworkflow/util"
@@ -31,6 +32,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // v1AllowedNamespaces mirrors the unexported constant in backend/src/common/util/v1_support.go.
@@ -299,6 +303,109 @@ func TestSubmitNewWorkflowIfNotAlreadySubmitted_BlockV1AllowsV2(t *testing.T) {
 		})
 	}
 }
+
+func TestSubmitNewWorkflowIfNotAlreadySubmitted_PipelineVersionReference(t *testing.T) {
+	executionClient := &fakeExecutionClient{}
+	runClient := &fakeRunClient{}
+	controller := &Controller{
+		workflowClient: client.NewWorkflowClient(executionClient, &fakeExecutionInformer{}),
+		runClient:      runClient,
+	}
+	swf := util.NewScheduledWorkflow(&swfapi.ScheduledWorkflow{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "kubeflow.org/v2beta1",
+			Kind:       "ScheduledWorkflow",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scheduled-workflow",
+			Namespace: "ns1",
+			UID:       "scheduled-workflow-uid",
+		},
+		Spec: swfapi.ScheduledWorkflowSpec{
+			ExperimentId:      "experiment-id",
+			PipelineId:        "pipeline-id",
+			PipelineVersionId: "pipeline-version-id",
+			ServiceAccount:    "service-account",
+			// A pinned pipeline (version) reference: runtime inputs are present, but no
+			// compiled workflow is embedded.
+			Workflow: &swfapi.WorkflowResource{
+				Parameters: []swfapi.Parameter{
+					{Name: "text", Value: `"world"`},
+				},
+				PipelineRoot: "gs://my-bucket/root",
+			},
+		},
+	})
+
+	submitted, workflowName, err := controller.submitNewWorkflowIfNotAlreadySubmitted(
+		context.Background(), swf, 100, 200)
+
+	require.NoError(t, err)
+	assert.True(t, submitted)
+	// No Argo workflow may be created directly; the run must go through the CreateRun API
+	// so the pinned pipeline version is compiled fresh at trigger time.
+	assert.Nil(t, executionClient.createdWorkflow)
+	require.NotNil(t, runClient.createRunRequest)
+	request := runClient.createRunRequest
+	assert.Equal(t, "experiment-id", request.ExperimentId)
+	assert.Equal(t, string(swf.UID), request.Run.RecurringRunId)
+	assert.Equal(t, workflowName, request.Run.DisplayName)
+	assert.Equal(t, "service-account", request.Run.ServiceAccount)
+	reference := request.Run.GetPipelineVersionReference()
+	require.NotNil(t, reference)
+	assert.Equal(t, "pipeline-id", reference.PipelineId)
+	assert.Equal(t, "pipeline-version-id", reference.PipelineVersionId)
+	require.NotNil(t, request.Run.RuntimeConfig)
+	assert.Equal(t, "gs://my-bucket/root", request.Run.RuntimeConfig.PipelineRoot)
+	assert.Equal(t, "world", request.Run.RuntimeConfig.Parameters["text"].GetStringValue())
+}
+
+type fakeRunClient struct {
+	createRunRequest *api.CreateRunRequest
+}
+
+func (f *fakeRunClient) CreateRun(ctx context.Context, in *api.CreateRunRequest,
+	opts ...grpc.CallOption) (*api.Run, error) {
+	f.createRunRequest = in
+	return &api.Run{DisplayName: in.GetRun().GetDisplayName()}, nil
+}
+
+func (f *fakeRunClient) GetRun(ctx context.Context, in *api.GetRunRequest,
+	opts ...grpc.CallOption) (*api.Run, error) {
+	return nil, nil
+}
+
+func (f *fakeRunClient) ListRuns(ctx context.Context, in *api.ListRunsRequest,
+	opts ...grpc.CallOption) (*api.ListRunsResponse, error) {
+	return nil, nil
+}
+
+func (f *fakeRunClient) ArchiveRun(ctx context.Context, in *api.ArchiveRunRequest,
+	opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+
+func (f *fakeRunClient) UnarchiveRun(ctx context.Context, in *api.UnarchiveRunRequest,
+	opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+
+func (f *fakeRunClient) DeleteRun(ctx context.Context, in *api.DeleteRunRequest,
+	opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+
+func (f *fakeRunClient) TerminateRun(ctx context.Context, in *api.TerminateRunRequest,
+	opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+
+func (f *fakeRunClient) RetryRun(ctx context.Context, in *api.RetryRunRequest,
+	opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return nil, nil
+}
+
+var _ api.RunServiceClient = &fakeRunClient{}
 
 type fakeExecutionClient struct {
 	createdWorkflow commonutil.ExecutionSpec

--- a/backend/src/crd/controller/scheduledworkflow/controller_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_test.go
@@ -331,6 +331,8 @@ func TestSubmitNewWorkflowIfNotAlreadySubmitted_PipelineVersionReference(t *test
 			Workflow: &swfapi.WorkflowResource{
 				Parameters: []swfapi.Parameter{
 					{Name: "text", Value: `"world"`},
+					{Name: "macros", Value: `"run-[[Index]]-scheduled-[[ScheduledTime]]-now-[[CurrentTime]]-uuid-[[RunUUID]]"`},
+					{Name: "number", Value: `42`},
 				},
 				PipelineRoot: "gs://my-bucket/root",
 			},
@@ -358,6 +360,17 @@ func TestSubmitNewWorkflowIfNotAlreadySubmitted_PipelineVersionReference(t *test
 	require.NotNil(t, request.Run.RuntimeConfig)
 	assert.Equal(t, "gs://my-bucket/root", request.Run.RuntimeConfig.PipelineRoot)
 	assert.Equal(t, "world", request.Run.RuntimeConfig.Parameters["text"].GetStringValue())
+	// Recurring-run macros are expanded with the trigger's scheduled epoch (100), the
+	// current epoch (200) and the next index (1), matching the embedded-workflow path.
+	// [[RunUUID]] is left intact for the API server, which knows the run ID.
+	assert.Equal(t,
+		"run-1-scheduled-19700101000140-now-19700101000320-uuid-[[RunUUID]]",
+		request.Run.RuntimeConfig.Parameters["macros"].GetStringValue())
+	// Non-string parameters pass through unchanged.
+	assert.Equal(t, float64(42), request.Run.RuntimeConfig.Parameters["number"].GetNumberValue())
+	// The trigger's scheduled time is recorded on the run.
+	require.NotNil(t, request.Run.ScheduledAt)
+	assert.Equal(t, int64(100), request.Run.ScheduledAt.GetSeconds())
 }
 
 type fakeRunClient struct {

--- a/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow.go
+++ b/backend/src/crd/controller/scheduledworkflow/util/scheduled_workflow.go
@@ -112,6 +112,11 @@ func (s *ScheduledWorkflow) nextIndex() int64 {
 	return s.lastIndex() + 1
 }
 
+// NextIndex returns the one-based index of the next run of this schedule.
+func (s *ScheduledWorkflow) NextIndex() int64 {
+	return s.nextIndex()
+}
+
 // MinIndex returns the minimum index of the workflow to retrieve as part of the workflow
 // history.
 func (s *ScheduledWorkflow) MinIndex() int64 {


### PR DESCRIPTION
## Description of your changes

Fixes #13933.

When a recurring run is pinned to a specific pipeline version (the normal UI flow of selecting a version), `CreateJob` resolved the template at creation time and embedded the compiled Argo workflow into the `ScheduledWorkflow` CR (`spec.workflow.spec`) and the stored recurring run (`PipelineSpecManifest`/`WorkflowSpecManifest`). This duplicated the durably stored pipeline version and baked in whatever launcher/driver image references were current at creation time — platform upgrades (e.g. patching a CVE in the launcher image) never reached already-created recurring runs.

This PR routes pinned **V2** pipeline versions onto the reference-based path that already exists for the "always use latest" case (#13440):

- `CreateJob` now stores only `pipelineId`/`pipelineVersionId` on the `ScheduledWorkflow` (plus runtime parameters and pipeline root) and persists the recurring run without a manifest. Job inputs are still validated up front via `ValidateJobInputs`.
- At trigger time, the ScheduledWorkflow controller's existing reference branch calls `RunService.CreateRun` with a `PipelineVersionReference` carrying the pinned `PipelineVersionId`, so the run is compiled fresh from the stored pipeline version with the platform's current images. No controller changes were needed — this branch already forwards a non-empty pinned version id.
- The duplicated reference-SWF construction is extracted into a `referenceScheduledWorkflow` helper shared with the "latest" branch, and the manifest-persistence gate is now an explicit `embedManifest` flag instead of relying on `tmpl` nil-ness.

Behavior preserved:

- **Raw manifest submissions** (`PipelineSpecManifest`/`WorkflowSpecManifest` supplied) keep embedding, as before.
- **V1 (Argo) templates** keep embedding, including the v1beta1 API's pin-latest-at-creation shim.
- **Existing recurring runs** are unaffected: they keep their persisted manifests and continue to be reconciled by `ReconcileSwfCrs`; new pinned jobs are skipped by its existing empty-manifest check, same as latest-path jobs.
- Like the latest path, the recurring run's service account is no longer defaulted from the compiled spec at creation time; the default is applied when the run is compiled at trigger time.

Per-trigger compilation cost matches what the "latest" path already incurs today.

## Testing

- New `TestCreateJob_ThroughPipelineVersionV2`: pinned V2 version → stored job has no manifest, SWF carries `pipelineVersionId` with `spec.workflow.spec` absent and runtime parameters present.
- New `TestCreateJob_ThroughPipelineVersionV2_InvalidParams`: extra runtime parameter is rejected at creation time.
- New `TestSubmitNewWorkflowIfNotAlreadySubmitted_PipelineVersionReference`: closes an existing coverage gap on the controller's reference branch — asserts no Argo workflow is created directly and the `CreateRunRequest` carries the pinned `PipelineVersionReference`, recurring run id, and translated runtime config.
- Existing pinned-V1 and raw-manifest tests (`TestCreateJob_ThroughPipelineVersion`, `TestCreateJob_ThroughPipelineIdAndPipelineVersion`, `TestCreateJob_ThroughWorkflowSpec*`, `TestReconcileSwfCrs`, v1 `job_server` tests) pass unmodified.
- Full backend unit sweep (per repo guide, excluding integration/compiler/E2E suites) passes.

## Checklist

- [x] The title of your PR is conformant to the [contribution guidelines](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention)

## Test Evidence

**Before**: ScheduledWorkflow spec with argo workflow baked in:

<img width="1059" height="721" alt="Screenshot 2026-08-20 at 9 22 07 AM" src="https://github.com/user-attachments/assets/12f99d04-706b-4ac9-b0bf-2e31cae4610c" />

**After**: Now works the same as "always run latest" except it contains a pinned pipeline version like above:

<img width="1049" height="732" alt="Screenshot 2026-08-20 at 2 56 59 PM" src="https://github.com/user-attachments/assets/5a89fdca-296f-4102-b5a1-b939297dfe1e" />

Successful scheduled run:

<img width="1413" height="713" alt="Screenshot 2026-08-20 at 2 57 14 PM" src="https://github.com/user-attachments/assets/4f96ec17-7616-4af0-ab5e-be9175c0062f" />
