### PR TITLE
feat(backend): add kubeflow-pipelines tag to the S3 user agent

### DIFF
--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awsv2middleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	awsv2cfg "github.com/aws/aws-sdk-go-v2/config"
 	awsv2creds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -79,6 +80,9 @@ const (
 
 	clientQPS   = "ClientQPS"
 	clientBurst = "ClientBurst"
+
+	tagName      = "TAG_NAME"
+	userAgentKey = "kubeflow-pipelines"
 )
 
 var scheme *runtime.Scheme
@@ -1028,6 +1032,9 @@ func newS3BucketClient(ctx context.Context, config *blobStorageConfig) (*s3.Clie
 	s3Client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
 		o.BaseEndpoint = awsv2.String(endpointWithProtocol)
 		o.UsePathStyle = true
+		// Append to the SDK user agent so object store operators can attribute requests.
+		o.APIOptions = append(o.APIOptions, awsv2middleware.AddUserAgentKeyValue(
+			userAgentKey, common.GetStringConfigWithDefault(tagName, "unknown")))
 	})
 
 	return s3Client, nil

--- a/backend/src/apiserver/client_manager/client_manager_test.go
+++ b/backend/src/apiserver/client_manager/client_manager_test.go
@@ -302,10 +302,11 @@ func TestBuildCreateBucketInput_DefaultRegion(t *testing.T) {
 }
 
 type fakeS3HTTPServer struct {
-	t       *testing.T
-	server  *httptest.Server
-	buckets map[string]bool
-	log     []string
+	t          *testing.T
+	server     *httptest.Server
+	buckets    map[string]bool
+	log        []string
+	userAgents []string
 }
 
 func newFakeS3HTTPServer(t *testing.T) *fakeS3HTTPServer {
@@ -323,6 +324,7 @@ func (f *fakeS3HTTPServer) endpoint() string {
 }
 
 func (f *fakeS3HTTPServer) handle(w http.ResponseWriter, r *http.Request) {
+	f.userAgents = append(f.userAgents, r.Header.Get("User-Agent"))
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/"), "/")
 	if len(parts) == 0 || parts[0] == "" {
 		http.Error(w, "missing bucket", http.StatusBadRequest)
@@ -358,6 +360,10 @@ func (f *fakeS3HTTPServer) setBucket(name string) {
 
 func (f *fakeS3HTTPServer) requestLog() []string {
 	return f.log
+}
+
+func (f *fakeS3HTTPServer) requestUserAgents() []string {
+	return f.userAgents
 }
 
 func TestEnsureBucketExists_IntegrationCreatesBucket(t *testing.T) {
@@ -399,6 +405,28 @@ func TestEnsureBucketExists_IntegrationBucketAlreadyExists(t *testing.T) {
 	log := server.requestLog()
 	require.Len(t, log, 1)
 	assert.Equal(t, "HEAD:existing-bucket", log[0])
+}
+
+func TestNewS3BucketClient_AppendsUserAgent(t *testing.T) {
+	server := newFakeS3HTTPServer(t)
+	server.setBucket("user-agent-bucket")
+
+	cfg := &blobStorageConfig{
+		bucketName: "user-agent-bucket",
+		endpoint:   server.endpoint(),
+		region:     "us-east-1",
+		secure:     false,
+		accessKey:  "key",
+		secretKey:  "secret",
+	}
+
+	err := ensureBucketExists(context.Background(), cfg)
+	require.NoError(t, err)
+
+	userAgents := server.requestUserAgents()
+	require.Len(t, userAgents, 1)
+	assert.Contains(t, userAgents[0], "aws-sdk-go-v2/")
+	assert.Contains(t, userAgents[0], userAgentKey+"/unknown")
 }
 
 func TestLoadAWSConfig_EmptyCredentials(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**

Fixes #13941

The API server reaches its object store through an AWS SDK for Go v2 S3 client built in `newS3BucketClient` (`backend/src/apiserver/client_manager/client_manager.go`), so every request it sends carries only the SDK's default user agent, for example `aws-sdk-go-v2/1.43.1 os/macos lang/go#1.26.5 ...`. That endpoint is configurable through `OBJECTSTORECONFIG_HOST` and `OBJECTSTORECONFIG_PORT`, so the store behind it can be Amazon S3 or any S3-compatible implementation (Backblaze B2, Cloudflare R2, MinIO, SeaweedFS). Operators of those stores currently cannot separate KFP traffic from any other Go SDK client hitting the same bucket, which makes it awkward to attribute load, scope a rate limit, or line up an error spike with a KFP rollout.

This appends one key/value to the existing user agent instead of replacing it, so the outgoing header becomes `aws-sdk-go-v2/1.43.1 ... kubeflow-pipelines/2.17.0`.

The version comes from the `TAG_NAME` config that `backend/Dockerfile` already sets and that `/healthz` already reports, read through `common.GetStringConfigWithDefault` so an unset value degrades to `kubeflow-pipelines/unknown` rather than failing client construction. No new dependency is needed: `aws/middleware` ships inside `github.com/aws/aws-sdk-go-v2`, which is already a direct requirement in `go.mod`.

**Deliberately not changed:** the driver and launcher client in `backend/src/v2/objectstore`. Those images do not receive `TAG_NAME` today, so the tag would always read `unknown` there. Wiring a version into the driver and launcher images is a separate change and belongs in its own PR.

**Tests**

`TestNewS3BucketClient_AppendsUserAgent` drives a real request through the existing `fakeS3HTTPServer` and asserts the outgoing `User-Agent` still contains `aws-sdk-go-v2/`, proving nothing was replaced, and now also contains the `kubeflow-pipelines/` tag. The fake gained a `userAgents` recorder next to its existing request log.

```
$ go test ./backend/src/apiserver/client_manager/...
ok  	github.com/kubeflow/pipelines/backend/src/apiserver/client_manager	0.867s

$ golangci-lint run --new --new-from-rev=origin/master ./backend/src/apiserver/client_manager/...
0 issues.
```

Formatting verified with `gofmt -l` and `goimports -l` on the changed package, both clean.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).