### PR TITLE
fix(frontend): remove unused experimentIsFetching variable in NewRunSwitcher

### DIFF
--- a/frontend/src/pages/NewRunSwitcher.tsx
+++ b/frontend/src/pages/NewRunSwitcher.tsx
@@ -213,8 +213,7 @@ function NewRunSwitcher(props: PageProps) {
     recurringRunIsFetching ||
     pipelineIsFetching ||
     pipelineVersionIsFetching ||
-    (!isTemplateV2(templateString) && v1TemplateStrIsFetching) ||
-    experimentIsFetching
+    (!isTemplateV2(templateString) && v1TemplateStrIsFetching)
   ) {
     return (
       <div style={{ textAlign: 'center', paddingTop: 40 }}>

--- a/frontend/src/pages/NewRunSwitcher.tsx
+++ b/frontend/src/pages/NewRunSwitcher.tsx
@@ -160,7 +160,6 @@ function NewRunSwitcher(props: PageProps) {
   const v1TemplateStr = v1Template || '';
 
   const {
-    isFetching: experimentIsFetching,
     isError: experimentIsError,
     error: experimentError,
     data: experiment,

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -720,7 +720,6 @@ function NewRunV2(props: NewRunV2Props) {
 
         {/* PipelineRoot and Run Parameters */}
         <NewRunParametersV2
-          key={parameterStateKey}
           pipelineRoot={pipelineRoot}
           initialParameterState={initialParameterState}
           handlePipelineRootChange={handlePipelineRootChange}


### PR DESCRIPTION
## Description

PR #13853 removed `experimentIsFetching` from the loading condition in `NewRunSwitcher.tsx` but left the variable destructured from the experiment query. The unused variable trips `@typescript-eslint/no-unused-vars`, which fails the `npm run build` step in the frontend Docker build. Since every PR triggers a frontend image build, this breaks CI for all new PRs (the frontend image build, and downstream E2E/API tests that depend on it).

### Root cause

```ts
// frontend/src/pages/NewRunSwitcher.tsx
const {
  isFetching: experimentIsFetching, // BUG: unused after #13853
  isError: experimentIsError,
  ...
} = useQuery<V2beta1Experiment, Error>({...});
```

### Fix

Remove the unused `isFetching: experimentIsFetching` destructuring.

### Files changed

- `frontend/src/pages/NewRunSwitcher.tsx` — remove unused `experimentIsFetching`

## Checklist

- [x] I have signed off my commits with `git commit -s`