### PR TITLE
fix(backend): close MLflow nested runs at task-level instead of a single apiserver-side sweep

### DIFF
--- a/backend/src/apiserver/plugins/mlflow/handler_test.go
+++ b/backend/src/apiserver/plugins/mlflow/handler_test.go
@@ -811,20 +811,20 @@ func TestBuildRunURL(t *testing.T) {
 
 func TestShouldSyncNestedRun(t *testing.T) {
 	t.Run("terminal mode syncs non-terminal statuses", func(t *testing.T) {
-		assert.True(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeTerminal, "RUNNING"))
-		assert.True(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeTerminal, "SCHEDULED"))
-		assert.True(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeTerminal, "PENDING"))
-		assert.True(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeTerminal, ""))
-		assert.False(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeTerminal, "FINISHED"))
-		assert.False(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeTerminal, "FAILED"))
-		assert.False(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeTerminal, "KILLED"))
+		assert.True(t, commonmlflow.IsOpenRunStatus("RUNNING"))
+		assert.True(t, commonmlflow.IsOpenRunStatus("SCHEDULED"))
+		assert.True(t, commonmlflow.IsOpenRunStatus("PENDING"))
+		assert.True(t, commonmlflow.IsOpenRunStatus(""))
+		assert.False(t, commonmlflow.IsOpenRunStatus("FINISHED"))
+		assert.False(t, commonmlflow.IsOpenRunStatus("FAILED"))
+		assert.False(t, commonmlflow.IsOpenRunStatus("KILLED"))
 	})
 
 	t.Run("retry mode syncs only failed and killed", func(t *testing.T) {
-		assert.True(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeRetry, "FAILED"))
-		assert.True(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeRetry, "KILLED"))
-		assert.False(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeRetry, "RUNNING"))
-		assert.False(t, shouldSyncNestedRun(apiserverPlugins.RunSyncModeRetry, "FINISHED"))
+		assert.True(t, shouldReopenNestedRun("FAILED"))
+		assert.True(t, shouldReopenNestedRun("KILLED"))
+		assert.False(t, shouldReopenNestedRun("RUNNING"))
+		assert.False(t, shouldReopenNestedRun("FINISHED"))
 	})
 }
 

--- a/backend/src/apiserver/plugins/mlflow/util.go
+++ b/backend/src/apiserver/plugins/mlflow/util.go
@@ -175,11 +175,11 @@ func FailedPluginOutput(experimentID, experimentName, runID, runURL, stateMessag
 	return buildPluginOutput(experimentID, experimentName, runID, runURL, apiv2beta1.PluginState_PLUGIN_FAILED, stateMessage)
 }
 
-// maxSearchPages caps SearchRuns pagination to prevent infinite loops.
-const maxSearchPages = 100
+// maxSearchPages caps SearchRuns pagination in reopenNestedRuns (retry path).
+const maxSearchPages = 10
 
 // maxNestingDepth caps recursive nested run traversal.
-const maxNestingDepth = 4
+const maxNestingDepth = 6
 
 func SyncParentAndNestedRuns(ctx context.Context, requestCtx *commonmlflow.RequestContext, parentRunID, experimentID string, mode apiserverPlugins.RunSyncMode, terminalStatus string, endTimeMs *int64) []string {
 	if requestCtx == nil || requestCtx.Client == nil {
@@ -212,19 +212,33 @@ func SyncParentAndNestedRuns(ctx context.Context, requestCtx *commonmlflow.Reque
 	return syncErrors
 }
 
-// syncNestedRuns searches for MLflow runs tagged with the given parentRunID and
-// updates their status. It recurses into each found run to handle deeper nesting
-// (e.g., parent → loop nested run → iteration nested run).
+// syncNestedRuns enforces the recursion depth budget, then dispatches to
+// closeNestedRuns (terminal) or reopenNestedRuns (retry).
 func syncNestedRuns(ctx context.Context, requestCtx *commonmlflow.RequestContext, parentRunID, experimentID string, mode apiserverPlugins.RunSyncMode, targetStatus string, endTimeMs *int64, depth int) []string {
 	if depth >= maxNestingDepth {
 		return []string{fmt.Sprintf("max nesting depth (%d) reached when syncing children of run %s", maxNestingDepth, parentRunID)}
 	}
-	action := "close nested run"
 	if mode == apiserverPlugins.RunSyncModeRetry {
-		action = "reopen nested run"
+		return reopenNestedRuns(ctx, requestCtx, parentRunID, experimentID, targetStatus, endTimeMs, depth)
 	}
+	return closeNestedRuns(ctx, requestCtx, parentRunID, experimentID, targetStatus, endTimeMs, depth)
+}
+
+// closeNestedRuns closes open direct children of parentRunID and their descendants, bottom-up.
+func closeNestedRuns(ctx context.Context, requestCtx *commonmlflow.RequestContext, parentRunID, experimentID, targetStatus string, endTimeMs *int64, depth int) []string {
 	var syncErrors []string
-	filter := fmt.Sprintf(`tags.%q = '%s'`, commonmlflow.TagNestedRunParentRunID, parentRunID)
+	childCloseErrors := commonmlflow.CloseOpenChildRuns(ctx, requestCtx.Client, experimentID, parentRunID, targetStatus, endTimeMs, func(childRunID string) {
+		syncErrors = append(syncErrors, syncNestedRuns(ctx, requestCtx, childRunID, experimentID, apiserverPlugins.RunSyncModeTerminal, targetStatus, endTimeMs, depth+1)...)
+	})
+	syncErrors = append(syncErrors, childCloseErrors...)
+	return syncErrors
+}
+
+// reopenNestedRuns reopens FAILED/KILLED nested runs of parentRunID on KFP
+// run retry.
+func reopenNestedRuns(ctx context.Context, requestCtx *commonmlflow.RequestContext, parentRunID, experimentID, targetStatus string, endTimeMs *int64, depth int) []string {
+	var syncErrors []string
+	filter := fmt.Sprintf(`tags.%q = '%s'`, commonmlflow.ParentRunTagKey, parentRunID)
 	pageToken := ""
 	for page := 0; page < maxSearchPages; page++ {
 		searchResp, err := requestCtx.Client.SearchRuns(ctx, []string{experimentID}, filter, 1000, pageToken)
@@ -242,16 +256,22 @@ func syncNestedRuns(ctx context.Context, requestCtx *commonmlflow.RequestContext
 			if nestedRunID == "" {
 				nestedRunID = mlflowRun.Info.RunUUID
 			}
-			if nestedRunID == "" || nestedRunID == parentRunID || !shouldSyncNestedRun(mode, mlflowRun.Info.Status) {
+			if nestedRunID == "" || nestedRunID == parentRunID || !shouldReopenNestedRun(mlflowRun.Info.Status) {
 				continue
 			}
-			childErrors := syncNestedRuns(ctx, requestCtx, nestedRunID, experimentID, mode, targetStatus, endTimeMs, depth+1)
+			childErrors := syncNestedRuns(ctx, requestCtx, nestedRunID, experimentID, apiserverPlugins.RunSyncModeRetry, targetStatus, endTimeMs, depth+1)
 			syncErrors = append(syncErrors, childErrors...)
 			if err := requestCtx.Client.UpdateRun(ctx, nestedRunID, targetStatus, endTimeMs); err != nil {
-				syncErrors = append(syncErrors, fmt.Sprintf("failed to %s %s: %v", action, nestedRunID, err))
+				syncErrors = append(syncErrors, fmt.Sprintf("failed to reopen nested run %s: %v", nestedRunID, err))
 			}
 		}
 		if searchResp.NextPageToken == "" {
+			break
+		}
+		if page == maxSearchPages-1 {
+			syncErrors = append(syncErrors, fmt.Sprintf(
+				"pagination limit (%d pages) reached while reopening nested runs of %s; some runs may have been skipped",
+				maxSearchPages, parentRunID))
 			break
 		}
 		pageToken = searchResp.NextPageToken
@@ -283,16 +303,11 @@ func buildPluginOutput(experimentID, experimentName, runID, runURL string, state
 	}
 }
 
-func shouldSyncNestedRun(mode apiserverPlugins.RunSyncMode, status string) bool {
+// shouldReopenNestedRun reports whether a nested run is eligible to be
+// reopened on retry, i.e. it previously ended in a failed/killed state.
+func shouldReopenNestedRun(status string) bool {
 	upperStatus := strings.ToUpper(status)
-	switch mode {
-	case apiserverPlugins.RunSyncModeTerminal:
-		return upperStatus != "FINISHED" && upperStatus != "FAILED" && upperStatus != "KILLED"
-	case apiserverPlugins.RunSyncModeRetry:
-		return upperStatus == "FAILED" || upperStatus == "KILLED"
-	default:
-		return false
-	}
+	return upperStatus == "FAILED" || upperStatus == "KILLED"
 }
 
 type searchRunPayload struct {

--- a/backend/src/apiserver/plugins/mlflow/util_test.go
+++ b/backend/src/apiserver/plugins/mlflow/util_test.go
@@ -383,6 +383,74 @@ func TestSyncParentAndNestedRuns_RetryMode(t *testing.T) {
 	assert.Equal(t, "parent-2:RUNNING", updateCalls[0])
 }
 
+func TestReopenNestedRuns_PaginationLimitReached(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/2.0/mlflow/runs/update":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/2.0/mlflow/runs/search":
+			page++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[],"next_page_token":"more"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	requestCtx := newTestMLflowRequestContext(t, server.URL)
+	errors := SyncParentAndNestedRuns(context.Background(), requestCtx, "parent-run", "exp-1", apiserverPlugins.RunSyncModeRetry, "FAILED", nil)
+	require.Len(t, errors, 1)
+	assert.Contains(t, errors[0], "pagination limit (10 pages) reached while reopening nested runs of parent-run")
+	assert.Equal(t, maxSearchPages, page)
+}
+
+func TestSyncParentAndNestedRuns_MaxNestingDepthReached(t *testing.T) {
+	var updateCalls []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/2.0/mlflow/runs/update":
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]interface{}
+			_ = json.Unmarshal(body, &req)
+			updateCalls = append(updateCalls, fmt.Sprintf("%s:%s", req["run_id"], req["status"]))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/2.0/mlflow/runs/search":
+			// Every run has exactly one open child, one level deeper
+			// (run-0 -> run-1 -> run-2 -> ...), forming a chain deeper than
+			// maxNestingDepth so the recursion must stop on its own.
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]interface{}
+			_ = json.Unmarshal(body, &req)
+			filter := req["filter"].(string)
+			var parentDepth int
+			_, err := fmt.Sscanf(filter, `tags."mlflow.parentRunId" = 'run-%d'`, &parentDepth)
+			require.NoError(t, err)
+			childRunID := fmt.Sprintf("run-%d", parentDepth+1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"runs":[{"info":{"run_id":%q,"status":"RUNNING"}}]}`, childRunID)
+		}
+	}))
+	defer server.Close()
+
+	requestCtx := newTestMLflowRequestContext(t, server.URL)
+	errors := SyncParentAndNestedRuns(context.Background(), requestCtx, "run-0", "exp-1", apiserverPlugins.RunSyncModeTerminal, "FAILED", nil)
+
+	require.Len(t, errors, 1)
+	assert.Contains(t, errors[0], fmt.Sprintf("max nesting depth (%d) reached when syncing children of run run-%d", maxNestingDepth, maxNestingDepth))
+
+	// run-0 through run-<maxNestingDepth> are all closed by their respective
+	// parent's sweep; only the search past run-<maxNestingDepth> is skipped.
+	wantUpdated := make([]string, 0, maxNestingDepth+1)
+	for i := 0; i <= maxNestingDepth; i++ {
+		wantUpdated = append(wantUpdated, fmt.Sprintf("run-%d:FAILED", i))
+	}
+	assert.ElementsMatch(t, wantUpdated, updateCalls)
+}
+
 func TestSyncParentAndNestedRuns_WithNestedRuns(t *testing.T) {
 	var updateCalls []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -418,30 +486,83 @@ func TestSyncParentAndNestedRuns_WithNestedRuns(t *testing.T) {
 	assert.Contains(t, updateCalls, "nested-1:FAILED")
 }
 
-func TestShouldSyncNestedRun_TerminalMode(t *testing.T) {
-	tests := []struct {
-		status string
-		want   bool
-	}{
-		{"RUNNING", true},
-		{"SCHEDULED", true},
-		{"FINISHED", false},
-		{"FAILED", false},
-		{"KILLED", false},
-		{"finished", false},
-		{"failed", false},
-		{"killed", false},
-	}
+func TestSyncParentAndNestedRuns_SkipsAlreadyTerminalChildren(t *testing.T) {
+	var updateCalls []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/2.0/mlflow/runs/update":
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]interface{}
+			_ = json.Unmarshal(body, &req)
+			updateCalls = append(updateCalls, fmt.Sprintf("%s:%s", req["run_id"], req["status"]))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/2.0/mlflow/runs/search":
+			body, _ := io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			if strings.Contains(string(body), "nested-finished") || strings.Contains(string(body), "nested-running") {
+				_, _ = w.Write([]byte(`{"runs":[]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"runs":[
+				{"info":{"run_id":"nested-finished","status":"FINISHED"}},
+				{"info":{"run_id":"nested-running","status":"RUNNING"}}
+			]}`))
+		}
+	}))
+	defer server.Close()
 
-	for _, tt := range tests {
-		t.Run(tt.status, func(t *testing.T) {
-			got := shouldSyncNestedRun(apiserverPlugins.RunSyncModeTerminal, tt.status)
-			assert.Equal(t, tt.want, got)
-		})
-	}
+	requestCtx := newTestMLflowRequestContext(t, server.URL)
+	errors := SyncParentAndNestedRuns(context.Background(), requestCtx, "parent-1", "exp-1", apiserverPlugins.RunSyncModeTerminal, "FAILED", nil)
+	assert.Empty(t, errors)
+
+	// Only the parent and the still-open child are closed; the already
+	// terminal "nested-finished" child gets zero update calls.
+	require.Len(t, updateCalls, 2)
+	assert.Contains(t, updateCalls, "parent-1:FAILED")
+	assert.Contains(t, updateCalls, "nested-running:FAILED")
+	assert.NotContains(t, updateCalls, "nested-finished:FAILED")
 }
 
-func TestShouldSyncNestedRun_RetryMode(t *testing.T) {
+func TestSyncParentAndNestedRuns_ClosesOrphansUnderTerminalChild(t *testing.T) {
+	var updateCalls []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/2.0/mlflow/runs/update":
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]interface{}
+			_ = json.Unmarshal(body, &req)
+			updateCalls = append(updateCalls, fmt.Sprintf("%s:%s", req["run_id"], req["status"]))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/2.0/mlflow/runs/search":
+			body, _ := io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			if strings.Contains(string(body), "orphan-grandchild") {
+				_, _ = w.Write([]byte(`{"runs":[]}`))
+				return
+			}
+			if strings.Contains(string(body), "nested-finished") {
+				_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"orphan-grandchild","status":"RUNNING"}}]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"nested-finished","status":"FINISHED"}}]}`))
+		}
+	}))
+	defer server.Close()
+
+	requestCtx := newTestMLflowRequestContext(t, server.URL)
+	errors := SyncParentAndNestedRuns(context.Background(), requestCtx, "parent-1", "exp-1", apiserverPlugins.RunSyncModeTerminal, "FAILED", nil)
+	assert.Empty(t, errors)
+
+	// Parent and orphaned grandchild close; the already-terminal intermediate child is not updated.
+	require.Len(t, updateCalls, 2)
+	assert.Contains(t, updateCalls, "parent-1:FAILED")
+	assert.Contains(t, updateCalls, "orphan-grandchild:FAILED")
+	assert.NotContains(t, updateCalls, "nested-finished:FAILED")
+}
+
+func TestShouldReopenNestedRun(t *testing.T) {
 	tests := []struct {
 		status string
 		want   bool
@@ -457,15 +578,10 @@ func TestShouldSyncNestedRun_RetryMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.status, func(t *testing.T) {
-			got := shouldSyncNestedRun(apiserverPlugins.RunSyncModeRetry, tt.status)
+			got := shouldReopenNestedRun(tt.status)
 			assert.Equal(t, tt.want, got)
 		})
 	}
-}
-
-func TestShouldSyncNestedRun_UnsupportedMode(t *testing.T) {
-	got := shouldSyncNestedRun("unsupported", "RUNNING")
-	assert.False(t, got)
 }
 
 func TestCreateRunWithKFPTags(t *testing.T) {

--- a/backend/src/common/plugins/mlflow/config.go
+++ b/backend/src/common/plugins/mlflow/config.go
@@ -43,9 +43,6 @@ const (
 // CredentialSecretName is the fixed Kubernetes Secret name for secret-based MLflow auth.
 const CredentialSecretName = "kfp-mlflow-credentials"
 
-// TagNestedRunParentRunID is the MLflow tag used for nested run parent linkage.
-const TagNestedRunParentRunID = "mlflow.parentRunId"
-
 // MLflowRuntimeConfig is the JSON payload marshaled into KFP_MLFLOW_CONFIG.
 type MLflowRuntimeConfig struct {
 	Endpoint            string                             `json:"endpoint"`

--- a/backend/src/common/plugins/mlflow/util.go
+++ b/backend/src/common/plugins/mlflow/util.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mlflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// maxChildSearchPages bounds SearchRuns pagination in CloseOpenChildRuns.
+const maxChildSearchPages = 10
+
+type searchRunPayload struct {
+	Info struct {
+		RunID   string `json:"run_id"`
+		RunUUID string `json:"run_uuid"`
+		Status  string `json:"status"`
+	} `json:"info"`
+}
+
+// IsOpenRunStatus reports whether a run status is non-terminal.
+func IsOpenRunStatus(status string) bool {
+	switch strings.ToUpper(status) {
+	case "FINISHED", "FAILED", "KILLED":
+		return false
+	default:
+		return true
+	}
+}
+
+// CloseOpenChildRuns closes open direct children of parentRunID. beforeClose
+// runs for every valid child (including terminal ones) to reach orphaned
+// descendants; UpdateRun is called only for still-open children.
+func CloseOpenChildRuns(ctx context.Context, client *Client, experimentID, parentRunID, targetStatus string, endTimeMs *int64, beforeClose func(childRunID string)) []string {
+	if client == nil {
+		return []string{"MLflow client is required"}
+	}
+	if experimentID == "" || parentRunID == "" {
+		return []string{"experimentID and parentRunID are required to close child MLflow runs"}
+	}
+
+	var errs []string
+	filter := fmt.Sprintf(`tags.%q = '%s'`, ParentRunTagKey, parentRunID)
+	pageToken := ""
+	for page := 0; page < maxChildSearchPages; page++ {
+		searchResp, err := client.SearchRuns(ctx, []string{experimentID}, filter, 1000, pageToken)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("failed to search child runs of %s: %v", parentRunID, err))
+			break
+		}
+		for _, runPayload := range searchResp.Runs {
+			var run searchRunPayload
+			if err := json.Unmarshal(runPayload, &run); err != nil {
+				errs = append(errs, fmt.Sprintf("failed to decode child run payload: %v", err))
+				continue
+			}
+			childRunID := run.Info.RunID
+			if childRunID == "" {
+				childRunID = run.Info.RunUUID
+			}
+			if childRunID == "" || childRunID == parentRunID {
+				continue
+			}
+			if beforeClose != nil {
+				beforeClose(childRunID)
+			}
+			if !IsOpenRunStatus(run.Info.Status) {
+				continue
+			}
+			if err := client.UpdateRun(ctx, childRunID, targetStatus, endTimeMs); err != nil {
+				errs = append(errs, fmt.Sprintf("failed to close child run %s: %v", childRunID, err))
+			}
+		}
+		if searchResp.NextPageToken == "" {
+			break
+		}
+		if page == maxChildSearchPages-1 {
+			errs = append(errs, fmt.Sprintf(
+				"pagination limit (%d pages) reached while closing child runs of %s; some runs may have been skipped",
+				maxChildSearchPages, parentRunID))
+			break
+		}
+		pageToken = searchResp.NextPageToken
+	}
+	return errs
+}

--- a/backend/src/common/plugins/mlflow/util_test.go
+++ b/backend/src/common/plugins/mlflow/util_test.go
@@ -1,0 +1,333 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mlflow
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsOpenRunStatus(t *testing.T) {
+	assert.False(t, IsOpenRunStatus("FINISHED"))
+	assert.False(t, IsOpenRunStatus("FAILED"))
+	assert.False(t, IsOpenRunStatus("KILLED"))
+	assert.False(t, IsOpenRunStatus("finished"))
+	assert.True(t, IsOpenRunStatus("RUNNING"))
+	assert.True(t, IsOpenRunStatus("SCHEDULED"))
+	assert.True(t, IsOpenRunStatus(""))
+}
+
+func TestCloseOpenChildRuns_NilClient(t *testing.T) {
+	errs := CloseOpenChildRuns(context.Background(), nil, "exp-1", "parent-run", "FAILED", nil, nil)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "MLflow client is required")
+}
+
+func TestCloseOpenChildRuns_MissingIDs(t *testing.T) {
+	c := newTestClient(t, "http://mlflow.example.com")
+
+	errs := CloseOpenChildRuns(context.Background(), c, "", "parent-run", "FAILED", nil, nil)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "experimentID and parentRunID are required")
+
+	errs = CloseOpenChildRuns(context.Background(), c, "exp-1", "", "FAILED", nil, nil)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "experimentID and parentRunID are required")
+}
+
+func TestCloseOpenChildRuns_ClosesOnlyOpenDirectChildren(t *testing.T) {
+	var updatedRunIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRunsSearch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[
+				{"info":{"run_id":"child-running","status":"RUNNING"}},
+				{"info":{"run_id":"child-finished","status":"FINISHED"}},
+				{"info":{"run_uuid":"child-scheduled-uuid","status":"SCHEDULED"}}
+			]}`))
+		case pathRunsUpdate:
+			body := decodeUpdateRunBody(t, r)
+			updatedRunIDs = append(updatedRunIDs, body["run_id"].(string))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, nil)
+	require.Empty(t, errs)
+	assert.ElementsMatch(t, []string{"child-running", "child-scheduled-uuid"}, updatedRunIDs)
+}
+
+func TestCloseOpenChildRuns_NoOpenChildren_NoUpdates(t *testing.T) {
+	updateCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRunsSearch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"child-finished","status":"FINISHED"}}]}`))
+		case pathRunsUpdate:
+			updateCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, nil)
+	require.Empty(t, errs)
+	assert.False(t, updateCalled)
+}
+
+func TestCloseOpenChildRuns_SkipsSelfReferencingRun(t *testing.T) {
+	updateCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRunsSearch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"parent-run","status":"RUNNING"}}]}`))
+		case pathRunsUpdate:
+			updateCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, nil)
+	require.Empty(t, errs)
+	assert.False(t, updateCalled)
+}
+
+func TestCloseOpenChildRuns_PaginatesAcrossMultiplePages(t *testing.T) {
+	var updatedRunIDs []string
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRunsSearch:
+			page++
+			w.WriteHeader(http.StatusOK)
+			if page == 1 {
+				_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"child-1","status":"RUNNING"}}],"next_page_token":"page-2"}`))
+			} else {
+				_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"child-2","status":"RUNNING"}}]}`))
+			}
+		case pathRunsUpdate:
+			body := decodeUpdateRunBody(t, r)
+			updatedRunIDs = append(updatedRunIDs, body["run_id"].(string))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, nil)
+	require.Empty(t, errs)
+	assert.Equal(t, 2, page)
+	assert.ElementsMatch(t, []string{"child-1", "child-2"}, updatedRunIDs)
+}
+
+func TestCloseOpenChildRuns_SearchError_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error_code":"INTERNAL_ERROR","message":"boom"}`))
+	}))
+	defer server.Close()
+
+	c := newTestClientWithFastRetry(t, server.URL)
+	errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, nil)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "failed to search child runs")
+}
+
+func TestCloseOpenChildRuns_UpdateError_ReportedButOthersStillClosed(t *testing.T) {
+	var updatedRunIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRunsSearch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[
+				{"info":{"run_id":"child-bad","status":"RUNNING"}},
+				{"info":{"run_id":"child-good","status":"RUNNING"}}
+			]}`))
+		case pathRunsUpdate:
+			body := decodeUpdateRunBody(t, r)
+			runID := body["run_id"].(string)
+			if runID == "child-bad" {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error_code":"INTERNAL_ERROR","message":"boom"}`))
+				return
+			}
+			updatedRunIDs = append(updatedRunIDs, runID)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClientWithFastRetry(t, server.URL)
+	errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, nil)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "failed to close child run child-bad")
+	assert.Equal(t, []string{"child-good"}, updatedRunIDs)
+}
+
+func TestCloseOpenChildRuns_DecodeError_ReportedButOthersStillClosed(t *testing.T) {
+	var updatedRunIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRunsSearch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":["not-an-object",{"info":{"run_id":"child-good","status":"RUNNING"}}]}`))
+		case pathRunsUpdate:
+			body := decodeUpdateRunBody(t, r)
+			updatedRunIDs = append(updatedRunIDs, body["run_id"].(string))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, nil)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "failed to decode child run payload")
+	assert.Equal(t, []string{"child-good"}, updatedRunIDs)
+}
+
+func TestCloseOpenChildRuns_BeforeCloseCalledBeforeUpdate(t *testing.T) {
+	var events []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRunsSearch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[
+				{"info":{"run_id":"child-1","status":"RUNNING"}},
+				{"info":{"run_id":"child-finished","status":"FINISHED"}}
+			]}`))
+		case pathRunsUpdate:
+			body := decodeUpdateRunBody(t, r)
+			events = append(events, "update:"+body["run_id"].(string))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, func(childRunID string) {
+		events = append(events, "beforeClose:"+childRunID)
+	})
+	require.Empty(t, errs)
+	// beforeClose runs for every valid direct child; UpdateRun only for open ones.
+	assert.Equal(t, []string{"beforeClose:child-1", "update:child-1", "beforeClose:child-finished"}, events)
+}
+
+func TestCloseOpenChildRuns_BeforeCloseTraversesTerminalChildren(t *testing.T) {
+	var updatedRunIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRunsSearch:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			w.WriteHeader(http.StatusOK)
+			if strings.Contains(string(body), "terminal-child") {
+				_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"orphan-grandchild","status":"RUNNING"}}]}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"terminal-child","status":"FINISHED"}}]}`))
+		case pathRunsUpdate:
+			body := decodeUpdateRunBody(t, r)
+			updatedRunIDs = append(updatedRunIDs, body["run_id"].(string))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, func(childRunID string) {
+		if childRunID != "terminal-child" {
+			return
+		}
+		subErrs := CloseOpenChildRuns(context.Background(), c, "exp-1", childRunID, "FAILED", nil, nil)
+		require.Empty(t, subErrs)
+	})
+	require.Empty(t, errs)
+	assert.Equal(t, []string{"orphan-grandchild"}, updatedRunIDs)
+}
+
+func TestCloseOpenChildRuns_PaginationLimitReached(t *testing.T) {
+	page := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == pathRunsSearch {
+			page++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[],"next_page_token":"more"}`))
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, nil)
+	require.Len(t, errs, 1)
+	assert.Contains(t, errs[0], "pagination limit (10 pages) reached while closing child runs of parent-run")
+	assert.Equal(t, maxChildSearchPages, page)
+}
+
+func TestCloseOpenChildRuns_NilBeforeClose_NoPanic(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathRunsSearch:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[{"info":{"run_id":"child-1","status":"RUNNING"}}]}`))
+		case pathRunsUpdate:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClient(t, server.URL)
+	require.NotPanics(t, func() {
+		errs := CloseOpenChildRuns(context.Background(), c, "exp-1", "parent-run", "FAILED", nil, nil)
+		require.Empty(t, errs)
+	})
+}
+
+// decodeUpdateRunBody decodes a /runs/update request body for assertions.
+func decodeUpdateRunBody(t *testing.T, r *http.Request) map[string]interface{} {
+	t.Helper()
+	rawBody, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(rawBody, &body))
+	return body
+}

--- a/backend/src/v2/common/plugins/mlflow/handler.go
+++ b/backend/src/v2/common/plugins/mlflow/handler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	commonplugins "github.com/kubeflow/pipelines/backend/src/common/plugins"
@@ -121,6 +122,12 @@ func (h *MLflowHandler) OnTaskEnd(ctx context.Context, info *plugins.TaskInfo) e
 	err = requestCtx.Client.UpdateRun(ctx, resolvedRunID, resolvedStatus, &runEndTime)
 	if err != nil {
 		return fmt.Errorf("failed to update MLflow run: %v", err)
+	}
+
+	// close still-open direct child runs whose own OnTaskEnd
+	// didn't get to run (e.g. a crashed pod).
+	if childCloseErrs := commonmlflow.CloseOpenChildRuns(ctx, requestCtx.Client, h.runtimeCfg.ExperimentID, resolvedRunID, resolvedStatus, &runEndTime, nil); len(childCloseErrs) > 0 {
+		glog.Warningf("failed to close some MLflow child runs of %s: %s", resolvedRunID, strings.Join(childCloseErrs, "; "))
 	}
 
 	return nil

--- a/backend/src/v2/common/plugins/mlflow/handler_test.go
+++ b/backend/src/v2/common/plugins/mlflow/handler_test.go
@@ -106,6 +106,9 @@ func defaultMLflowHandlerFunc(t *testing.T) http.Handler {
 		case "/api/2.0/mlflow/runs/log-batch":
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{}`))
+		case "/api/2.0/mlflow/runs/search":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[]}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
@@ -262,6 +265,9 @@ func TestOnTaskEnd_NestedRunIDFromApplyCustomProperties_Success(t *testing.T) {
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedLogBatchBody))
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{}`))
+		case "/api/2.0/mlflow/runs/search":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[]}`))
 		default:
 			t.Fatalf("unexpected path: %s", r.URL.Path)
 		}
@@ -427,6 +433,89 @@ func TestOnTaskEnd_Success(t *testing.T) {
 	}
 	handler, _ := NewMLflowTaskHandler(runtimeCfg)
 	handler.nestedRunID = "test-run-id"
+	err := handler.OnTaskEnd(context.Background(), taskInfoEnd)
+	require.NoError(t, err)
+}
+
+func TestOnTaskEnd_ClosesOpenDirectChildRuns(t *testing.T) {
+	cleanup := setupSAToken(t)
+	defer cleanup()
+
+	var updatedRunIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/2.0/mlflow/runs/update":
+			var body map[string]interface{}
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			updatedRunIDs = append(updatedRunIDs, body["run_id"].(string))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"run":{"info":{"run_id":"test-run-id"}}}`))
+		case "/api/2.0/mlflow/runs/log-batch":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/2.0/mlflow/runs/search":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"runs":[
+				{"info":{"run_id":"child-open","status":"RUNNING"}},
+				{"info":{"run_id":"child-finished","status":"FINISHED"}}
+			]}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	runtimeCfg := &commonmlflow.MLflowRuntimeConfig{
+		Endpoint:     server.URL,
+		ParentRunID:  "test-parent-run-id",
+		ExperimentID: "test-exp",
+		AuthType:     "kubernetes",
+		Timeout:      "10s",
+	}
+	handler, _ := NewMLflowTaskHandler(runtimeCfg)
+	handler.nestedRunID = "test-run-id"
+
+	err := handler.OnTaskEnd(context.Background(), taskInfoEnd)
+
+	require.NoError(t, err)
+	// Own run closes first, then the still-open direct child; the
+	// already-finished child is left untouched.
+	assert.Equal(t, []string{"test-run-id", "child-open"}, updatedRunIDs)
+}
+
+func TestOnTaskEnd_ChildCloseFailure_DoesNotFailOwnUpdate(t *testing.T) {
+	cleanup := setupSAToken(t)
+	defer cleanup()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/2.0/mlflow/runs/update":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"run":{"info":{"run_id":"test-run-id"}}}`))
+		case "/api/2.0/mlflow/runs/log-batch":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		case "/api/2.0/mlflow/runs/search":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error_code":"INTERNAL_ERROR","message":"boom"}`))
+		default:
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	runtimeCfg := &commonmlflow.MLflowRuntimeConfig{
+		Endpoint:     server.URL,
+		ParentRunID:  "test-parent-run-id",
+		ExperimentID: "test-exp",
+		AuthType:     "kubernetes",
+		Timeout:      "10s",
+	}
+	handler, _ := NewMLflowTaskHandler(runtimeCfg)
+	handler.nestedRunID = "test-run-id"
+
+	// The task's own status update succeeds; the child-closing safety net
+	// failing must not surface as an OnTaskEnd error (best-effort).
 	err := handler.OnTaskEnd(context.Background(), taskInfoEnd)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
**Description of your changes:**

Moves MLflow nested-run cleanup from a single recursive apiserver-side sweep at run-end to a distributed model: each task now closes its own open direct children in `OnTaskEnd`, while the apiserver keeps a bounded recursive sweep only as a safety net for orphaned runs.

**Changes:**

- Add `CloseOpenChildRuns` to `backend/src/common/plugins/mlflow`, a shared,  single-level "find and force-close direct open children of a run"  primitive usable by both the apiserver and the v2 driver/launcher.
- v2 driver/launcher (`OnTaskEnd`): after closing its own MLflow run, a task now also closes any of its own open direct children via `CloseOpenChildRuns`.
- Apiserver (`syncNestedRuns`): split into `closeNestedRuns` (terminal mode, now a thin recursive safety net built on the shared helper) and  `reopenNestedRuns` (retry mode, unchanged retry-specific logic for reopening FAILED/KILLED runs).

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
