### PR TITLE
fix(frontend): remove React Compiler manual-memoization suppressions …

### DIFF
--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -30,7 +30,11 @@ import { useMutation } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { V2beta1Experiment, V2beta1ExperimentStorageState } from 'src/apisv2beta1/experiment';
 import { V2beta1Pipeline, V2beta1PipelineVersion } from 'src/apisv2beta1/pipeline';
-import { V2beta1PipelineVersionReference, V2beta1Run } from 'src/apisv2beta1/run';
+import {
+  V2beta1PipelineVersionReference,
+  V2beta1Run,
+  type V2beta1RuntimeConfig,
+} from 'src/apisv2beta1/run';
 import { V2beta1Filter, V2beta1PredicateOperation } from 'src/apisv2beta1/filter';
 import BusyButton from 'src/atoms/BusyButton';
 import { ExternalLink } from 'src/atoms/ExternalLink';
@@ -308,16 +312,27 @@ function NewRunV2(props: NewRunV2Props) {
   );
   const runName = customRunName ?? defaultRunName;
 
-  const clonedRuntimeConfig = cloneOrigin.isRecurring
-    ? cloneOrigin.recurringRun?.runtime_config
-    : cloneOrigin.run?.runtime_config;
+  // Serialize the mutable generated-API runtime config to a primitive string
+  // during render.  Primitives are inherently immutable, so this value is a
+  // safe memoization dependency that React Compiler can reason about without
+  // requiring manual-memoization suppressions.
+  const clonedRuntimeConfigKey = JSON.stringify(
+    (cloneOrigin.isRecurring
+      ? cloneOrigin.recurringRun?.runtime_config
+      : cloneOrigin.run?.runtime_config) ?? null,
+  );
+  // Reconstruct a local value from the serialized form.  The sole dependency
+  // is the primitive key above, so the compiler can prove this memoization is
+  // safe and all downstream hooks that depend on `clonedRuntimeConfig` are
+  // transitively safe as well.
+  const clonedRuntimeConfig = useMemo(
+    (): V2beta1RuntimeConfig | undefined =>
+      JSON.parse(clonedRuntimeConfigKey) ?? undefined,
+    [clonedRuntimeConfigKey],
+  );
   const { defaultPipelineRoot, specParameters } = useMemo(
     () => getTemplateData(templateString),
     [templateString],
-  );
-  const clonedRuntimeConfigKey = useMemo(
-    () => JSON.stringify(clonedRuntimeConfig ?? null),
-    [clonedRuntimeConfig],
   );
   const parameterStateKey = useMemo(
     () =>


### PR DESCRIPTION
Here's the PR description:

---

**Description of your changes:**

## Summary

Removes the `react-hooks/preserve-manual-memoization` suppression block from `NewRunV2` by normalizing the mutable generated-API runtime config at the component boundary.

## Problem

PR #13833 enables React Hooks 7 correctness rules and adds a `preserve-manual-memoization` warning. Three `useMemo` calls in `NewRunV2` depend on `clonedRuntimeConfig`, which is a direct reference to a mutable generated API object (`V2beta1RuntimeConfig`). React Compiler cannot prove these memoizations are safe, requiring suppression comments.

## Approach

Serialize the mutable API value to a primitive JSON string eagerly during render, then reconstruct a local-only value via `useMemo` keyed on that string. Since primitives are inherently immutable, the compiler can prove the memoization is safe, and all downstream hooks that depend on `clonedRuntimeConfig` are transitively safe as well.

No behavioral change — the JSON roundtrip is lossless for `V2beta1RuntimeConfig` (only `{ [key: string]: object }` and `string` fields).

## Which issue(s) this PR fixes:

Fixes https://github.com/kubeflow/pipelines/issues/13948

## Verification

- `npm run typecheck` — passes
- `npm run lint` — passes (zero warnings)
- `npx vitest run src/pages/NewRunV2.test.tsx` — 38/38 tests pass

## Dependencies

Follow-up to #13833. Both PRs modify the same lines; whichever merges second will need a straightforward rebase.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
