### PR TITLE
fix(backend): fix database transaction and SQL rows leak in JobStore and RunStore

### DIFF
--- a/backend/src/apiserver/storage/job_store.go
+++ b/backend/src/apiserver/storage/job_store.go
@@ -112,9 +112,12 @@ func (s *JobStore) ListJobs(
 
 	rows, err := tx.Query(rowsSql, rowsArgs...)
 	if err != nil {
+		tx.Rollback()
 		return errorF(err)
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
+		tx.Rollback()
 		return errorF(err)
 	}
 	jobs, err := s.scanRows(rows)
@@ -122,13 +125,13 @@ func (s *JobStore) ListJobs(
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -138,7 +141,6 @@ func (s *JobStore) ListJobs(
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -143,9 +143,12 @@ func (s *RunStore) ListRuns(
 
 	rows, err := tx.Query(rowsSql, rowsArgs...)
 	if err != nil {
+		tx.Rollback()
 		return errorF(err)
 	}
+	defer rows.Close()
 	if err := rows.Err(); err != nil {
+		tx.Rollback()
 		return errorF(err)
 	}
 	runs, err := s.scanRowsToRuns(rows)
@@ -153,13 +156,13 @@ func (s *RunStore) ListRuns(
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer rows.Close()
 
 	sizeRow, err := tx.Query(sizeSql, sizeArgs...)
 	if err != nil {
 		tx.Rollback()
 		return errorF(err)
 	}
+	defer sizeRow.Close()
 	if err := sizeRow.Err(); err != nil {
 		tx.Rollback()
 		return errorF(err)
@@ -169,7 +172,6 @@ func (s *RunStore) ListRuns(
 		tx.Rollback()
 		return errorF(err)
 	}
-	defer sizeRow.Close()
 
 	err = tx.Commit()
 	if err != nil {


### PR DESCRIPTION
**Description of your changes:**

Fixes #13954

In `JobStore.ListJobs` (`backend/src/apiserver/storage/job_store.go`) and `RunStore.ListRuns` (`backend/src/apiserver/storage/run_store.go`), errors returned during initial query execution (`tx.Query(...)`) or result set checking (`rows.Err()`) failed to call `tx.Rollback()`, leaving database transactions open and dangling in the connection pool.

Additionally, `defer rows.Close()` and `defer sizeRow.Close()` were registered *after* scanning methods (`s.scanRows(...)` and `list.ScanRowToTotalSize(...)`). If scanning encountered an error, the function returned before `defer` was evaluated, leaking SQL row cursors.

This PR:
- Adds explicit `tx.Rollback()` calls when `tx.Query` or `rows.Err()` encounters an error in both `JobStore.ListJobs` and `RunStore.ListRuns`.
- Moves `defer rows.Close()` and `defer sizeRow.Close()` to execute immediately after `tx.Query` completes without error, ensuring SQL cursors are cleaned up reliably on all exit paths.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
