### PR TITLE
Fix configuration errors in the platform-agnostic-postgresql overlay

### DIFF
--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -41,5 +41,8 @@ Standalone mode is single-user and unauthenticated. Multi-user deployments requi
 | `FRONTEND_SERVER_NAMESPACE` | Namespace used by a local frontend server |
 | `MINIO_ENDPOINT_REWRITE` | Rewrites object-store endpoints in local proxy mode |
 | `MAX_METRICS_FILE_BYTES` | Maximum uncompressed metrics JSON size; defaults to 1 MiB |
+| `DBDRIVERNAME` | API-server database driver: `mysql` or `pgx` |
 
 `TENSORBOARD_PROXY_SIGNING_SECRET` is optional; it defaults to `MINIO_SECRET_KEY`.
+
+`initConfig()` in `backend/src/apiserver/main.go` binds config keys through `viper.AutomaticEnv()` with a `.` → `_` replacer, so the `DBDriverName` key reads from `DBDRIVERNAME`. A variable named `DB_DRIVER_NAME` does not bind, leaving the `mysql` default in `backend/src/apiserver/config/config.json` in force. The PostgreSQL overlay sets `DBDRIVERNAME` from the `dbType` key of the `pipeline-install-config` ConfigMap.

--- a/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
+++ b/manifests/kustomize/base/installs/generic/postgres/pipeline-install-config.yaml
@@ -12,8 +12,8 @@ data:
     namespace: `kubectl rollout restart deployment -n <your-namespace>`.
   appName: pipeline
   appVersion: 2.0.0
-  dbType: postgres
-  postgresHost: postgres
+  dbType: pgx
+  postgresHost: postgres-service
   postgresPort: "5432"
   mlmdDb: metadb
   cacheDb: cachedb

--- a/manifests/kustomize/base/postgresql/pipeline/ml-pipeline-apiserver-deployment-patch.yaml
+++ b/manifests/kustomize/base/postgresql/pipeline/ml-pipeline-apiserver-deployment-patch.yaml
@@ -8,7 +8,6 @@ spec:
       initContainers:
       - name: wait-for-database
         env:
-        - $patch: replace
         - name: WAIT_HOST
           valueFrom:
             configMapKeyRef:
@@ -21,64 +20,46 @@ spec:
               key: postgresPort
       containers:
       - name: ml-pipeline-api-server
+        # This list merges into the base env list by `name` rather than replacing
+        # it, so everything the base owns - V2_DRIVER_IMAGE / V2_LAUNCHER_IMAGE,
+        # OBJECTSTORECONFIG_HOST / OBJECTSTORECONFIG_PORT, the security context
+        # defaults, DRIVER_POD_LABELS / DRIVER_POD_ANNOTATIONS - keeps reaching
+        # the API server on a PostgreSQL install and stays in sync automatically.
         env:
-        - $patch: replace
-        - name: AUTO_UPDATE_PIPELINE_DEFAULT_VERSION
-          valueFrom:
-            configMapKeyRef:
-              name: pipeline-install-config
-              key: autoUpdatePipelineDefaultVersion
-              optional: true
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: OBJECTSTORECONFIG_SECURE
-          value: "false"
-        - name: OBJECTSTORECONFIG_BUCKETNAME
-          valueFrom:
-            configMapKeyRef:
-              name: pipeline-install-config
-              key: bucketName
-              optional: true
-        - name: DBCONFIG_CONMAXLIFETIME
-          valueFrom:
-            configMapKeyRef:
-              name: pipeline-install-config
-              key: ConMaxLifeTime
-              optional: true
+        # Remove the MySQL-specific env vars from the base (references to
+        # mysql-secret and to the mysqlHost/mysqlPort keys, neither of which
+        # exists in a PostgreSQL deployment, would block Pod startup).
+        - name: DBCONFIG_USER
+          $patch: delete
+        - name: DBCONFIG_PASSWORD
+          $patch: delete
+        - name: DBCONFIG_DBNAME
+          $patch: delete
+        - name: DBCONFIG_HOST
+          $patch: delete
+        - name: DBCONFIG_PORT
+          $patch: delete
         - name: DB_DRIVER_NAME
+          $patch: delete
+        - name: DBCONFIG_MYSQLCONFIG_USER
+          $patch: delete
+        - name: DBCONFIG_MYSQLCONFIG_PASSWORD
+          $patch: delete
+        - name: DBCONFIG_MYSQLCONFIG_DBNAME
+          $patch: delete
+        - name: DBCONFIG_MYSQLCONFIG_HOST
+          $patch: delete
+        - name: DBCONFIG_MYSQLCONFIG_PORT
+          $patch: delete
+        # initConfig() calls viper.AutomaticEnv() with a "." -> "_" replacer, so
+        # the config key DBDriverName is read from the env var DBDRIVERNAME.
+        # DB_DRIVER_NAME, deleted above, never bound and left the config.json
+        # default ("mysql") in force on a PostgreSQL install.
+        - name: DBDRIVERNAME
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
               key: dbType
-              optional: true
-        - name: BLOCK_V1_PIPELINES
-          valueFrom:
-            configMapKeyRef:
-              name: pipeline-install-config
-              key: BLOCK_V1_PIPELINES
-              optional: true
-        - name: V1_ALLOWED_NAMESPACES
-          valueFrom:
-            configMapKeyRef:
-              name: pipeline-install-config
-              key: V1_ALLOWED_NAMESPACES
-              optional: true
-        # Driver pod labels and annotations. This patch replaces the container env list,
-        # so these must be repeated here to reach the API server on PostgreSQL installs.
-        - name: DRIVER_POD_LABELS
-          valueFrom:
-            configMapKeyRef:
-              name: pipeline-install-config
-              key: DRIVER_POD_LABELS
-              optional: true
-        - name: DRIVER_POD_ANNOTATIONS
-          valueFrom:
-            configMapKeyRef:
-              name: pipeline-install-config
-              key: DRIVER_POD_ANNOTATIONS
-              optional: true
         # PostgreSQL Config
         - name: DBCONFIG_POSTGRESQLCONFIG_USER
           valueFrom:
@@ -95,27 +76,14 @@ spec:
             configMapKeyRef:
               name: pipeline-install-config
               key: pipelineDb
-              optional: true
         - name: DBCONFIG_POSTGRESQLCONFIG_HOST
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
               key: postgresHost
-              optional: true
         - name: DBCONFIG_POSTGRESQLCONFIG_PORT
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
               key: postgresPort
-              optional: true
         # end of PostgreSQL variables
-        - name: OBJECTSTORECONFIG_ACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: mlpipeline-minio-artifact
-              key: accesskey
-        - name: OBJECTSTORECONFIG_SECRETACCESSKEY
-          valueFrom:
-            secretKeyRef:
-              name: mlpipeline-minio-artifact
-              key: secretkey

--- a/manifests/kustomize/third-party/postgresql/base/pg-secret.yaml
+++ b/manifests/kustomize/third-party/postgresql/base/pg-secret.yaml
@@ -3,5 +3,5 @@ kind: Secret
 metadata:
   name: postgres-secret
 type: Opaque
-data:
+stringData:
   root_password: password


### PR DESCRIPTION
Fixes the manifest half of #13956 — the configuration bugs in the `platform-agnostic-postgresql` overlay.

**This does not make the overlay work on its own.** The two storage-layer problems in #13956 (the postgres `StatementBuilder` being defined but never used, and the 106 CamelCase `gorm:"column:…"` tags) still block `ml-pipeline` from reaching Ready. Those need code changes and a design decision that is not mine to make. What this PR does is remove the configuration errors that sit *in front* of them, so anyone working on the storage layer is not also fighting four unrelated bugs.

None of these are architecture-specific. I found them on arm64, but every one applies identically on x86_64.

## 1. `pg-secret.yaml` uses `data:` with a plaintext value

`third-party/postgresql/base/pg-secret.yaml` supplies the literal string `password` under `data:`, which requires base64. Kubernetes therefore base64-*decodes* `password` — which happens to be valid base64 — producing six non-UTF-8 bytes:

```
$ printf 'password' | base64 -d | xxd
00000000: a5ab 2cc2 8add                           ..,...
```

That is byte-for-byte what ends up in the cluster. containerd cannot marshal it into a container spec, so the postgres pod never starts, with an error that gives no hint of the cause:

```
CreateContainerError: grpc: error while marshaling: string field contains invalid UTF-8
```

It also explains why `postgres-secret.root_password` and `postgres-secret-extended.password` never agree: the latter correctly uses `stringData:`, so its value really is the string `password`, while postgres is seeded with the six garbage bytes.

Changed to `stringData:`, matching `postgres-secret-extended.yaml`.

## 2. `postgresHost` names a Service that does not exist

`base/installs/generic/postgres/pipeline-install-config.yaml` sets `postgresHost: postgres`, but the Service created by `third-party/postgresql/base/pg-service.yaml` is named `postgres-service`. The name never resolves:

```
$ kubectl get svc -n kubeflow postgres
Error from server (NotFound): services "postgres" not found

psql: error: could not translate host name "postgres" to address: Try again
```

Changed to `postgres-service`. `dbHost` is updated for consistency, though it is marked in-file as a relic.

## 3. `dbType: postgres` is not a value the server accepts

`initDBDriver` (`backend/src/apiserver/client_manager/client_manager.go:401`) accepts only `mysql` or `pgx`, and `glog.Fatalf`s on anything else. Changed to `pgx`.

## 4. `DB_DRIVER_NAME` never binds

`base/postgresql/pipeline/ml-pipeline-apiserver-deployment-patch.yaml` sets env `DB_DRIVER_NAME`, but `initConfig()` in `backend/src/apiserver/main.go` uses:

```go
viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
viper.AutomaticEnv()
```

so `common.GetStringConfig("DBDriverName")` resolves to env **`DBDRIVERNAME`**. `DB_DRIVER_NAME` is silently ignored and `config.json`'s `"DBDriverName": "mysql"` default wins — the api-server attempts MySQL on a PostgreSQL install. The visible symptom is:

```
config.go:75] Config DBConfig.MySQLConfig.ExtraParams not specified, skipping
```

on an install with no MySQL anywhere.

Renamed the env var to `DBDRIVERNAME`. (Renaming is the smaller change; `viper.BindEnv("DBDriverName", "DB_DRIVER_NAME")` in `initConfig` would be the alternative if you would rather keep the existing env var name as the public interface.)

## 5. `$patch: replace` drops the object-store and runtime-image configuration

`base/postgresql/pipeline/ml-pipeline-apiserver-deployment-patch.yaml` begins its env list with:

```yaml
        env:
        - $patch: replace
```

That discards the base list rather than merging it by `name`, so `OBJECTSTORECONFIG_HOST` and `OBJECTSTORECONFIG_PORT` — set in `base/pipeline/ml-pipeline-apiserver-deployment.yaml:50` — never reach the rendered deployment:

```
F main.go:160] failed to initialize object store:
  failed to build config from environment variables: ObjectStoreConfig.Host is required
```

It also discards the release-pinned `V2_DRIVER_IMAGE` and `V2_LAUNCHER_IMAGE`, so the compiler falls back to `ghcr.io/kubeflow/kfp-{driver,launcher}:latest` and a released PostgreSQL install can run mismatched runtime images, along with `PUBLISH_LOGS`, `CLUSTER_DOMAIN`, `COMPILED_PIPELINE_SPEC_PATCH` and the `DEFAULT_SECURITY_CONTEXT_*` set.

Removed `$patch: replace` from both the init container and the api-server container, and instead `$patch: delete` only the MySQL-specific entries — the `mysql-secret` and `mysqlHost`/`mysqlPort` references that cannot resolve on a PostgreSQL install and would block Pod startup. Everything else merges from the base and stays in sync automatically. This is the same approach #12379 takes for this deployment.

## Verification

Applied these values to a live `platform-agnostic-postgresql` install and confirmed each one clears its failure:

- postgres pod starts instead of `CreateContainerError`
- `postgres-service` resolves, and TCP password auth succeeds from another pod
- the api-server stops reading MySQL config and initialises the postgres client:
  ```
  I client_manager.go:570] Running AutoMigrate.
  I client_manager.go:279] DB client initialized successfully
  ```

It then fails on the storage-layer issues in #13956, as expected — which is why this PR is explicitly only half the fix.

`kustomize build` of `env/platform-agnostic-postgresql` and `env/dev/postgresql` confirms the rendered api-server keeps the base env list, carries the pinned V2 images, and no longer references `mysql-secret` or `DB_DRIVER_NAME`.

I have not run the conformance or integration suites.
