### PR TITLE
fix(frontend): keep the reason pod logs could not be read

### DIFF
--- a/frontend/server/handlers/pod-logs.ts
+++ b/frontend/server/handlers/pod-logs.ts
@@ -133,6 +133,11 @@ export function getPodLogsHandler(
       stream.on('end', () => res.end());
       stream.pipe(res);
     } catch (err) {
+      // Every log source failed. Logging the error prints the chain of causes
+      // built up by composePodLogsStreamHandler, which is the only place the
+      // earlier failures - notably why the pod itself could not be read - are
+      // still recorded. The response keeps reporting the last error alone.
+      console.error(`Could not get main container logs for pod, ${podName}.`, err);
       res.status(500).send('Could not get main container logs: ' + err);
     }
   };

--- a/frontend/server/workflow-helper.test.ts
+++ b/frontend/server/workflow-helper.test.ts
@@ -93,6 +93,91 @@ describe('workflow-helper', () => {
         ),
       ).rejects.toEqual('unknown error for fallback');
     });
+
+    it('records the default handler error as the cause when both fail.', async () => {
+      const defaultError = new Error('pods "podName" not found');
+      const fallbackError = new Error('Unable to find pod log archive information');
+      const defaultHandler = vi.fn((_podName: string, _createdAt: string, _namespace?: string) =>
+        Promise.reject(defaultError),
+      );
+      const fallbackHandler = vi.fn((_podName: string, _createdAt: string, _namespace?: string) =>
+        Promise.reject(fallbackError),
+      );
+
+      const thrown = await composePodLogsStreamHandler(defaultHandler, fallbackHandler)(
+        'podName',
+        '2024-08-13',
+        'namespace',
+      ).catch((err) => err);
+
+      // The thrown value is unchanged, so callers matching on its message still work.
+      expect(thrown).toBe(fallbackError);
+      expect(thrown.message).toBe('Unable to find pod log archive information');
+      // The reason the pod itself could not be read is no longer discarded.
+      expect(thrown.cause).toBe(defaultError);
+    });
+
+    it('keeps the Kubernetes error reachable when all three log sources fail.', async () => {
+      // getPodLogsHandler nests the handlers when log archiving is on:
+      // compose(fromK8s, compose(fromWorkflow, fromArchive)).
+      const k8sError = new Error('pods "podName" not found');
+      const workflowError = new Error('Unable to find pod log archive information in workflow');
+      const archiveError = new Error('Unable to find pod log archive information');
+      const reject = (err: Error) => vi.fn(() => Promise.reject(err));
+
+      const thrown = await composePodLogsStreamHandler(
+        reject(k8sError),
+        composePodLogsStreamHandler(reject(workflowError), reject(archiveError)),
+      )('podName', '2024-08-13', 'namespace').catch((err) => err);
+
+      const causes = [];
+      for (let err = thrown; err instanceof Error && err.cause; err = err.cause) {
+        causes.push(err.cause);
+      }
+      expect(thrown).toBe(archiveError);
+      expect(causes).toEqual([workflowError, k8sError]);
+    });
+
+    it('does not overwrite a cause the fallback error already carries.', async () => {
+      const existingCause = new Error('original cause');
+      const fallbackError = new Error('fallback failed', { cause: existingCause });
+      const defaultHandler = vi.fn((_podName: string, _createdAt: string, _namespace?: string) =>
+        Promise.reject(new Error('default failed')),
+      );
+      const fallbackHandler = vi.fn((_podName: string, _createdAt: string, _namespace?: string) =>
+        Promise.reject(fallbackError),
+      );
+
+      const thrown = await composePodLogsStreamHandler(defaultHandler, fallbackHandler)(
+        'podName',
+        '2024-08-13',
+        'namespace',
+      ).catch((err) => err);
+
+      expect(thrown.cause).toBe(existingCause);
+    });
+
+    it('logs why the default handler failed before falling back.', async () => {
+      const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+      const defaultError = new Error('pods "podName" not found');
+      const fallbackStream = new PassThrough();
+      const defaultHandler = vi.fn((_podName: string, _createdAt: string, _namespace?: string) =>
+        Promise.reject(defaultError),
+      );
+      const fallbackHandler = vi.fn((_podName: string, _createdAt: string, _namespace?: string) =>
+        Promise.resolve(fallbackStream),
+      );
+
+      const stream = await composePodLogsStreamHandler(defaultHandler, fallbackHandler)(
+        'podName',
+        '2024-08-13',
+        'namespace',
+      );
+
+      expect(stream).toBe(fallbackStream);
+      expect(debug).toHaveBeenCalledWith(expect.stringContaining('podName'), defaultError);
+      debug.mockRestore();
+    });
   });
 
   describe('getPodLogsStreamFromK8s', () => {

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -72,6 +72,35 @@ export interface SecretSelector {
   name: string;
 }
 
+// Log sources are composed at most three deep (Kubernetes API, workflow status,
+// archive), so this bounds the walk below well above what can legitimately occur.
+const MAX_CAUSE_DEPTH = 8;
+
+/**
+ * Records why an earlier log source failed at the end of the cause chain of the
+ * error thrown by the next one, so every source that was tried stays inspectable.
+ *
+ * Appending rather than overwriting matters because these handlers nest: the
+ * archive error already carries the workflow error by the time the outer handler
+ * attaches the Kubernetes one. The error is returned as-is when it cannot carry a
+ * cause, since handlers here may reject with a plain string. Its own message and
+ * identity are never touched, so callers matching on them still work.
+ */
+function withCause(error: unknown, cause: unknown): unknown {
+  let end = error;
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth++) {
+    if (!(end instanceof Error)) {
+      return error;
+    }
+    if (end.cause === undefined) {
+      end.cause = cause;
+      return error;
+    }
+    end = end.cause;
+  }
+  return error;
+}
+
 /**
  * Compose a pod logs stream handler - i.e. a stream handler returns a stream
  * containing the pod logs.
@@ -88,7 +117,15 @@ export function composePodLogsStreamHandler<T = Stream>(
       return await handler(podName, createdAt, namespace);
     } catch (err) {
       if (fallback) {
-        return await fallback(podName, createdAt, namespace);
+        // Debug rather than warn: once a pod is garbage collected the Kubernetes
+        // API cannot serve its logs, so falling through to the archive is the
+        // expected path for any completed run, not a problem worth reporting.
+        console.debug(`Failed to get logs for pod, ${podName}, trying the next log source.`, err);
+        try {
+          return await fallback(podName, createdAt, namespace);
+        } catch (fallbackErr) {
+          throw withCause(fallbackErr, err);
+        }
       }
       console.warn(err);
       throw err;


### PR DESCRIPTION
## Description of your changes

`composePodLogsStreamHandler` tries the log sources in order — Kubernetes API, then the Argo workflow status, then the archive bucket. When a source failed, its error was discarded and the next one was tried silently.

That loses the diagnostic in exactly the case the fallbacks exist for. Once a pod is gone, the Kubernetes API is the only source that can say *why* — evicted, OOMKilled, image pull failure, or a namespace the caller cannot read. The archive lookup then fails too, and `getPodLogsHandler` answers with the last error alone:

```
Could not get main container logs: Error: Unable to find pod log archive information
```

The reason reaches neither the response nor the server log.

The `console.warn` already in the `catch` block does not cover this: it runs only when no fallback was supplied, and `getPodLogsHandler` always supplies one ([`pod-logs.ts#L69-L79`](https://github.com/kubeflow/pipelines/blob/master/frontend/server/handlers/pod-logs.ts#L69-L79)), so on the deployed path it never runs at all.

**What this changes**

- Each failure is recorded as a `cause` of the error that is finally thrown.
- Causes are appended at the **end** of the chain rather than written to the first free slot. The handlers nest when log archiving is enabled — `compose(fromK8s, compose(fromWorkflow, fromArchive))` — so the archive error already carries the workflow error by the time the outer handler attaches the Kubernetes one. Writing to the first free slot would silently drop the Kubernetes error on precisely that configuration. The walk is depth capped.
- `getPodLogsHandler` logs the error it catches, which prints the chain.
- Falling back is logged at `debug`, not `warn` — a completed run's pod is garbage collected, so failing over to the archive is the ordinary path for it and not worth reporting on every request.

**What this deliberately does not change**

- The thrown value's identity and message are untouched, so the `Unable to find pod log archive information` check in `getPodLogsHandler` and any other caller matching on the message keep working. The existing test asserting `rejects.toEqual('unknown error for fallback')` passes unmodified.
- The response body still reports only the last error. Widening what is returned to the browser is a separate call, given it is attacker-visible.
- A cause chain that is already complete is left alone, and rejections that are plain strings rather than `Error`s pass through unchanged.

## Checklist

- [x] The title for your pull request (PR) should follow our title convention.
- [x] Do you want this pull request (PR) cherry-picked into the current release branch? — No
- [x] Unit tests added.

**Tests**

Five cases added to `workflow-helper.test.ts`, covering the flat two-source shape, the nested three-source shape, the already-set cause, and the debug log. `npx vitest run workflow-helper.test.ts` → 15 passed.

Two of the new tests fail against `master` without the source change, and the nested-shape test fails against a first-free-slot implementation, which is what motivated the chain walk.

The `integration-tests/mock-backend-*` suites fail in my local checkout both with and without this change (54 failures either way); they are untouched by this PR.