### PR TITLE
fix(frontend): update canceling run status icon color

### DIFF
--- a/frontend/src/pages/StatusV2.tsx
+++ b/frontend/src/pages/StatusV2.tsx
@@ -60,7 +60,7 @@ export function statusToIcon(
       break;
     case V2beta1RuntimeState.CANCELING:
       IconComponent = RunningIcon;
-      iconColor = color.blue;
+      iconColor = color.alert;
       title = 'Run is canceling';
       break;
     case V2beta1RuntimeState.PAUSED:

--- a/frontend/src/pages/__snapshots__/StatusV2.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/StatusV2.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`Status > statusToIcon > handles CANCELING state 1`] = `
       width="18"
     >
       <g
-        fill="#4285f4"
+        fill="#f9ab00"
         fill-rule="nonzero"
         transform="translate(-450, -307)"
       >
@@ -395,7 +395,7 @@ exports[`Status > statusToIcon > renders an icon with tooltip for phase: CANCELI
       width="18"
     >
       <g
-        fill="#4285f4"
+        fill="#f9ab00"
         fill-rule="nonzero"
         transform="translate(-450, -307)"
       >


### PR DESCRIPTION
**Description of your changes:**

Updates the UI status icon for the `CANCELING` runtime state to distinguish it from the `RUNNING` state.

Previously, both `RUNNING` and `CANCELING` used the same blue running icon, making it difficult to visually identify unless hovered on the status. This change updates the `CANCELING` state to use the **alert color**  while retaining the existing running icon.


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
