### PR TITLE
feat(sdk,backend): support ephemeral storage requests and limits. Fixes #11137

### DIFF
--- a/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
+++ b/api/v2alpha1/go/pipelinespec/pipeline_spec.pb.go
@@ -5106,10 +5106,18 @@ type PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec struct {
 	// The memory request in GB. This container execution
 	// needs at least resource_memory_request RAM to run. Handles static
 	// values and placeholders.
-	ResourceMemoryRequest string                                                                         `protobuf:"bytes,10,opt,name=resource_memory_request,json=resourceMemoryRequest,proto3" json:"resource_memory_request,omitempty"`
-	Accelerator           *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig `protobuf:"bytes,3,opt,name=accelerator,proto3" json:"accelerator,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	ResourceMemoryRequest string `protobuf:"bytes,10,opt,name=resource_memory_request,json=resourceMemoryRequest,proto3" json:"resource_memory_request,omitempty"`
+	// The ephemeral storage limit in GB. This container execution needs
+	// at most resource_ephemeral_storage_limit ephemeral storage to run.
+	// Handles static values and placeholders.
+	ResourceEphemeralStorageLimit string `protobuf:"bytes,11,opt,name=resource_ephemeral_storage_limit,json=resourceEphemeralStorageLimit,proto3" json:"resource_ephemeral_storage_limit,omitempty"`
+	// The ephemeral storage request in GB. This container execution needs
+	// at least resource_ephemeral_storage_request ephemeral storage to run.
+	// Handles static values and placeholders.
+	ResourceEphemeralStorageRequest string                                                                         `protobuf:"bytes,12,opt,name=resource_ephemeral_storage_request,json=resourceEphemeralStorageRequest,proto3" json:"resource_ephemeral_storage_request,omitempty"`
+	Accelerator                     *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig `protobuf:"bytes,3,opt,name=accelerator,proto3" json:"accelerator,omitempty"`
+	unknownFields                   protoimpl.UnknownFields
+	sizeCache                       protoimpl.SizeCache
 }
 
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) Reset() {
@@ -5198,6 +5206,20 @@ func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) GetResourc
 func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) GetResourceMemoryRequest() string {
 	if x != nil {
 		return x.ResourceMemoryRequest
+	}
+	return ""
+}
+
+func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) GetResourceEphemeralStorageLimit() string {
+	if x != nil {
+		return x.ResourceEphemeralStorageLimit
+	}
+	return ""
+}
+
+func (x *PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec) GetResourceEphemeralStorageRequest() string {
+	if x != nil {
+		return x.ResourceEphemeralStorageRequest
 	}
 	return ""
 }
@@ -5963,9 +5985,9 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\x0econstant_value\x18\x01 \x01(\v2\x13.ml_pipelines.ValueB\x02\x18\x01H\x00R\rconstantValue\x12-\n" +
 	"\x11runtime_parameter\x18\x02 \x01(\tH\x00R\x10runtimeParameter\x124\n" +
 	"\bconstant\x18\x03 \x01(\v2\x16.google.protobuf.ValueH\x00R\bconstantB\a\n" +
-	"\x05value\"\x83\x18\n" +
+	"\x05value\"\x99\x19\n" +
 	"\x18PipelineDeploymentConfig\x12S\n" +
-	"\texecutors\x18\x01 \x03(\v25.ml_pipelines.PipelineDeploymentConfig.ExecutorsEntryR\texecutors\x1a\xfc\t\n" +
+	"\texecutors\x18\x01 \x03(\v25.ml_pipelines.PipelineDeploymentConfig.ExecutorsEntryR\texecutors\x1a\x92\v\n" +
 	"\x15PipelineContainerSpec\x12\x14\n" +
 	"\x05image\x18\x01 \x01(\tR\x05image\x12\x18\n" +
 	"\acommand\x18\x02 \x03(\tR\acommand\x12\x12\n" +
@@ -5977,7 +5999,7 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\x0fpre_cache_check\x18\x01 \x01(\v2K.ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.Lifecycle.ExecR\rpreCacheCheck\x1a4\n" +
 	"\x04Exec\x12\x18\n" +
 	"\acommand\x18\x02 \x03(\tR\acommand\x12\x12\n" +
-	"\x04args\x18\x03 \x03(\tR\x04args\x1a\x8b\x05\n" +
+	"\x04args\x18\x03 \x03(\tR\x04args\x1a\xa1\x06\n" +
 	"\fResourceSpec\x12\x1f\n" +
 	"\tcpu_limit\x18\x01 \x01(\x01B\x02\x18\x01R\bcpuLimit\x12%\n" +
 	"\fmemory_limit\x18\x02 \x01(\x01B\x02\x18\x01R\vmemoryLimit\x12#\n" +
@@ -5988,7 +6010,9 @@ const file_pipeline_spec_proto_rawDesc = "" +
 	"\x15resource_memory_limit\x18\b \x01(\tR\x13resourceMemoryLimit\x120\n" +
 	"\x14resource_cpu_request\x18\t \x01(\tR\x12resourceCpuRequest\x126\n" +
 	"\x17resource_memory_request\x18\n" +
-	" \x01(\tR\x15resourceMemoryRequest\x12}\n" +
+	" \x01(\tR\x15resourceMemoryRequest\x12G\n" +
+	" resource_ephemeral_storage_limit\x18\v \x01(\tR\x1dresourceEphemeralStorageLimit\x12K\n" +
+	"\"resource_ephemeral_storage_request\x18\f \x01(\tR\x1fresourceEphemeralStorageRequest\x12}\n" +
 	"\vaccelerator\x18\x03 \x01(\v2[.ml_pipelines.PipelineDeploymentConfig.PipelineContainerSpec.ResourceSpec.AcceleratorConfigR\vaccelerator\x1a\x91\x01\n" +
 	"\x11AcceleratorConfig\x12\x16\n" +
 	"\x04type\x18\x01 \x01(\tB\x02\x18\x01R\x04type\x12\x18\n" +

--- a/api/v2alpha1/pipeline_spec.proto
+++ b/api/v2alpha1/pipeline_spec.proto
@@ -811,6 +811,16 @@ message PipelineDeploymentConfig {
       // values and placeholders.
       string resource_memory_request = 10;
 
+      // The ephemeral storage limit in GB. This container execution needs
+      // at most resource_ephemeral_storage_limit ephemeral storage to run.
+      // Handles static values and placeholders.
+      string resource_ephemeral_storage_limit = 11;
+
+      // The ephemeral storage request in GB. This container execution needs
+      // at least resource_ephemeral_storage_request ephemeral storage to run.
+      // Handles static values and placeholders.
+      string resource_ephemeral_storage_request = 12;
+
       // The specification on the accelerators being attached to this container.
       message AcceleratorConfig {
         // The type of accelerators.

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -412,6 +412,32 @@ func initPodSpecPatch(
 		res.Requests[k8score.ResourceCPU] = *cpuRequest
 	}
 
+	ephemeralStorageLimit, err := getPodResource(
+		container.GetResources().GetResourceEphemeralStorageLimit(),
+		0,
+		executorInput,
+		"%v",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
+	}
+	if ephemeralStorageLimit != nil {
+		res.Limits[k8score.ResourceEphemeralStorage] = *ephemeralStorageLimit
+	}
+
+	ephemeralStorageRequest, err := getPodResource(
+		container.GetResources().GetResourceEphemeralStorageRequest(),
+		0,
+		executorInput,
+		"%v",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to init podSpecPatch: %w", err)
+	}
+	if ephemeralStorageRequest != nil {
+		res.Requests[k8score.ResourceEphemeralStorage] = *ephemeralStorageRequest
+	}
+
 	accelerator := container.GetResources().GetAccelerator()
 	if accelerator != nil {
 		var acceleratorType string

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -310,10 +310,12 @@ func Test_initPodSpecPatch_resource_placeholders(t *testing.T) {
 		Args:    []string{"--function_to_execute", "add"},
 		Command: []string{"sh", "-ec", "python3 -m kfp.components.executor_main"},
 		Resources: &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec{
-			ResourceCpuRequest:    "{{$.inputs.parameters['pipelinechannel--cpu_request']}}",
-			ResourceCpuLimit:      "{{$.inputs.parameters['pipelinechannel--cpu_limit']}}",
-			ResourceMemoryRequest: "{{$.inputs.parameters['pipelinechannel--memory_request']}}",
-			ResourceMemoryLimit:   "{{$.inputs.parameters['pipelinechannel--memory_limit']}}",
+			ResourceCpuRequest:              "{{$.inputs.parameters['pipelinechannel--cpu_request']}}",
+			ResourceCpuLimit:                "{{$.inputs.parameters['pipelinechannel--cpu_limit']}}",
+			ResourceMemoryRequest:           "{{$.inputs.parameters['pipelinechannel--memory_request']}}",
+			ResourceMemoryLimit:             "{{$.inputs.parameters['pipelinechannel--memory_limit']}}",
+			ResourceEphemeralStorageRequest: "{{$.inputs.parameters['pipelinechannel--ephemeral_storage_request']}}",
+			ResourceEphemeralStorageLimit:   "{{$.inputs.parameters['pipelinechannel--ephemeral_storage_limit']}}",
 			Accelerator: &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec_AcceleratorConfig{
 				ResourceType:  "{{$.inputs.parameters['pipelinechannel--accelerator_type']}}",
 				ResourceCount: "{{$.inputs.parameters['pipelinechannel--accelerator_count']}}",
@@ -362,6 +364,26 @@ func Test_initPodSpecPatch_resource_placeholders(t *testing.T) {
 				"pipelinechannel--memory_limit": {
 					Kind: &structpb.Value_StringValue{
 						StringValue: "500Mi",
+					},
+				},
+				"ephemeral_storage_request": {
+					Kind: &structpb.Value_StringValue{
+						StringValue: "{{$.inputs.parameters['pipelinechannel--ephemeral_storage_request']}}",
+					},
+				},
+				"pipelinechannel--ephemeral_storage_request": {
+					Kind: &structpb.Value_StringValue{
+						StringValue: "1G",
+					},
+				},
+				"ephemeral_storage_limit": {
+					Kind: &structpb.Value_StringValue{
+						StringValue: "{{$.inputs.parameters['pipelinechannel--ephemeral_storage_limit']}}",
+					},
+				},
+				"pipelinechannel--ephemeral_storage_limit": {
+					Kind: &structpb.Value_StringValue{
+						StringValue: "2Gi",
 					},
 				},
 				"accelerator_type": {
@@ -419,6 +441,8 @@ func Test_initPodSpecPatch_resource_placeholders(t *testing.T) {
 	assert.Equal(t, k8sres.MustParse("400m"), res.Limits[k8score.ResourceCPU])
 	assert.Equal(t, k8sres.MustParse("100Mi"), res.Requests[k8score.ResourceMemory])
 	assert.Equal(t, k8sres.MustParse("500Mi"), res.Limits[k8score.ResourceMemory])
+	assert.Equal(t, k8sres.MustParse("1G"), res.Requests[k8score.ResourceEphemeralStorage])
+	assert.Equal(t, k8sres.MustParse("2Gi"), res.Limits[k8score.ResourceEphemeralStorage])
 	assert.Equal(t, k8sres.MustParse("1"), res.Limits[k8score.ResourceName("nvidia.com/gpu")])
 
 	assert.Empty(t, taskConfig.Resources.Limits)
@@ -773,6 +797,42 @@ func Test_initPodSpecPatch_resourceRequests(t *testing.T) {
 			},
 			`"resources":{"limits":{"cpu":"2","memory":"1500M"}}`,
 			`"requests"`,
+		},
+		{
+			"Valid - with ephemeral storage",
+			args{
+				&pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{
+					Image:   "python:3.11",
+					Args:    []string{"--function_to_execute", "add"},
+					Command: []string{"sh", "-ec", "python3 -m kfp.components.executor_main"},
+					Resources: &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec_ResourceSpec{
+						ResourceEphemeralStorageLimit:   "1G",
+						ResourceEphemeralStorageRequest: "500M",
+					},
+				},
+				&pipelinespec.ComponentSpec{
+					Implementation: &pipelinespec.ComponentSpec_ExecutorLabel{ExecutorLabel: "addition"},
+					InputDefinitions: &pipelinespec.ComponentInputsSpec{
+						Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+							"a": {Type: pipelinespec.PrimitiveType_DOUBLE},
+							"b": {Type: pipelinespec.PrimitiveType_DOUBLE},
+						},
+					},
+					OutputDefinitions: &pipelinespec.ComponentOutputsSpec{
+						Parameters: map[string]*pipelinespec.ComponentOutputsSpec_ParameterSpec{
+							"Output": {Type: pipelinespec.PrimitiveType_DOUBLE},
+						},
+					},
+				},
+				nil,
+				1,
+				"MyPipeline",
+				"a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6",
+				"1",
+				"false",
+			},
+			`"resources":{"limits":{"ephemeral-storage":"1G"},"requests":{"ephemeral-storage":"500M"}}`,
+			"",
 		},
 	}
 	for _, tt := range tests {

--- a/sdk/python/kfp/compiler/compiler_test.py
+++ b/sdk/python/kfp/compiler/compiler_test.py
@@ -3989,6 +3989,36 @@ class TestResourceConfig(unittest.TestCase):
         self.assertIn('resourceCount', resources['accelerator'])
         self.assertNotIn('count', resources['accelerator'])
 
+    def test_ephemeral_storage(self):
+
+        @dsl.pipeline
+        def simple_pipeline():
+            return_1().set_ephemeral_storage_request('2G').set_ephemeral_storage_limit(
+                '5G')
+
+        dict_format = json_format.MessageToDict(simple_pipeline.pipeline_spec)
+        resources = dict_format['deploymentSpec']['executors']['exec-return-1'][
+            'container']['resources']
+
+        self.assertEqual('2G', resources['resourceEphemeralStorageRequest'])
+        self.assertEqual('5G', resources['resourceEphemeralStorageLimit'])
+
+    def test_ephemeral_storage_input_parameter(self):
+
+        @dsl.pipeline
+        def simple_pipeline(ephemeral_storage_request: str,
+                            ephemeral_storage_limit: str):
+            return_1().set_ephemeral_storage_request(
+                ephemeral_storage_request).set_ephemeral_storage_limit(
+                    ephemeral_storage_limit)
+
+        dict_format = json_format.MessageToDict(simple_pipeline.pipeline_spec)
+        resources = dict_format['deploymentSpec']['executors']['exec-return-1'][
+            'container']['resources']
+
+        self.assertIn('resourceEphemeralStorageRequest', resources)
+        self.assertIn('resourceEphemeralStorageLimit', resources)
+
 
 class TestPlatformConfig(unittest.TestCase):
 

--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -788,6 +788,12 @@ def build_container_spec_for_task(
             if task.container_spec.resources.memory_limit == placeholder:
                 container_spec.resources.memory_limit = compiler_utils._memory_to_float(
                     task.container_spec.resources.memory_limit)
+        if task.container_spec.resources.ephemeral_storage_request is not None:
+            container_spec.resources.resource_ephemeral_storage_request = convert_to_placeholder(
+                task.container_spec.resources.ephemeral_storage_request)
+        if task.container_spec.resources.ephemeral_storage_limit is not None:
+            container_spec.resources.resource_ephemeral_storage_limit = convert_to_placeholder(
+                task.container_spec.resources.ephemeral_storage_limit)
         if task.container_spec.resources.accelerator_count is not None:
             ac_type = None
             ac_type_placholder = convert_to_placeholder(

--- a/sdk/python/kfp/dsl/pipeline_task.py
+++ b/sdk/python/kfp/dsl/pipeline_task.py
@@ -545,16 +545,36 @@ class PipelineTask:
         Returns:
             The numeric string value of the memory request/limit.
         """
-        if isinstance(memory, pipeline_channel.PipelineChannel):
-            memory = str(memory)
+        return self._validate_resource_amount_request_limit(memory, 'memory')
+
+    def _validate_resource_amount_request_limit(self, resource_amount: str,
+                                                resource_type: str) -> str:
+        """Validates a resource amount (memory/ephemeral storage) request or
+        limit string and returns it unchanged.
+
+        Args:
+            resource_amount: The resource amount request or limit. This string
+                should be a number or a number followed by one of "E", "Ei",
+                "P", "Pi", "T", "Ti", "G", "Gi", "M", "Mi", "K", or "Ki".
+            resource_type: The type of the resource, used in the error message.
+                Should be either 'memory' or 'ephemeral storage'.
+
+        Raises:
+            ValueError if the resource amount string value is invalid.
+
+        Returns:
+            The numeric string value of the resource amount.
+        """
+        if isinstance(resource_amount, pipeline_channel.PipelineChannel):
+            resource_amount = str(resource_amount)
         else:
             if re.match(r'^[0-9]+(E|Ei|P|Pi|T|Ti|G|Gi|M|Mi|K|Ki){0,1}$',
-                        memory) is None:
+                        resource_amount) is None:
                 raise ValueError(
-                    'Invalid memory string. Should be a number or a number '
-                    'followed by one of "E", "Ei", "P", "Pi", "T", "Ti", "G", '
-                    '"Gi", "M", "Mi", "K", "Ki".')
-        return memory
+                    f'Invalid {resource_type} string. Should be a number or a '
+                    'number followed by one of "E", "Ei", "P", "Pi", "T", "Ti", '
+                    '"G", "Gi", "M", "Mi", "K", "Ki".')
+        return resource_amount
 
     @warn_if_final()
     def set_memory_request(
@@ -607,6 +627,62 @@ class PipelineTask:
         else:
             self.container_spec.resources = structures.ResourceSpec(
                 memory_limit=memory)
+
+        return self
+
+    @warn_if_final()
+    def set_ephemeral_storage_request(
+        self, ephemeral_storage: Union[str, pipeline_channel.PipelineChannel]
+    ) -> 'PipelineTask':
+        """Sets ephemeral storage request (minimum) for the task.
+
+        Args:
+            ephemeral_storage: The minimum ephemeral storage requests required.
+                This string should be a number or a number followed by one of
+                "E", "Ei", "P", "Pi", "T", "Ti", "G", "Gi", "M", "Mi", "K", or
+                "Ki".
+
+        Returns:
+            Self return to allow chained setting calls.
+        """
+        self._ensure_container_spec_exists()
+
+        ephemeral_storage = self._validate_resource_amount_request_limit(
+            ephemeral_storage, 'ephemeral storage')
+
+        if self.container_spec.resources is not None:
+            self.container_spec.resources.ephemeral_storage_request = ephemeral_storage
+        else:
+            self.container_spec.resources = structures.ResourceSpec(
+                ephemeral_storage_request=ephemeral_storage)
+
+        return self
+
+    @warn_if_final()
+    def set_ephemeral_storage_limit(
+        self, ephemeral_storage: Union[str, pipeline_channel.PipelineChannel]
+    ) -> 'PipelineTask':
+        """Sets ephemeral storage limit (maximum) for the task.
+
+        Args:
+            ephemeral_storage: The maximum ephemeral storage requests allowed.
+                This string should be a number or a number followed by one of
+                "E", "Ei", "P", "Pi", "T", "Ti", "G", "Gi", "M", "Mi", "K", or
+                "Ki".
+
+        Returns:
+            Self return to allow chained setting calls.
+        """
+        self._ensure_container_spec_exists()
+
+        ephemeral_storage = self._validate_resource_amount_request_limit(
+            ephemeral_storage, 'ephemeral storage')
+
+        if self.container_spec.resources is not None:
+            self.container_spec.resources.ephemeral_storage_limit = ephemeral_storage
+        else:
+            self.container_spec.resources = structures.ResourceSpec(
+                ephemeral_storage_limit=ephemeral_storage)
 
         return self
 

--- a/sdk/python/kfp/dsl/pipeline_task_test.py
+++ b/sdk/python/kfp/dsl/pipeline_task_test.py
@@ -349,6 +349,106 @@ class PipelineTaskTest(parameterized.TestCase):
         self.assertEqual(expected_memory,
                          task.container_spec.resources.memory_limit)
 
+    @parameterized.parameters(
+        {
+            'ephemeral_storage': '1E',
+            'expected_ephemeral_storage': '1E',
+        },
+        {
+            'ephemeral_storage': '15Ei',
+            'expected_ephemeral_storage': '15Ei',
+        },
+        {
+            'ephemeral_storage': '2P',
+            'expected_ephemeral_storage': '2P',
+        },
+        {
+            'ephemeral_storage': '25Pi',
+            'expected_ephemeral_storage': '25Pi',
+        },
+        {
+            'ephemeral_storage': '3T',
+            'expected_ephemeral_storage': '3T',
+        },
+        {
+            'ephemeral_storage': '35Ti',
+            'expected_ephemeral_storage': '35Ti',
+        },
+        {
+            'ephemeral_storage': '4G',
+            'expected_ephemeral_storage': '4G',
+        },
+        {
+            'ephemeral_storage': '45Gi',
+            'expected_ephemeral_storage': '45Gi',
+        },
+        {
+            'ephemeral_storage': '5M',
+            'expected_ephemeral_storage': '5M',
+        },
+        {
+            'ephemeral_storage': '55Mi',
+            'expected_ephemeral_storage': '55Mi',
+        },
+        {
+            'ephemeral_storage': '6K',
+            'expected_ephemeral_storage': '6K',
+        },
+        {
+            'ephemeral_storage': '65Ki',
+            'expected_ephemeral_storage': '65Ki',
+        },
+        {
+            'ephemeral_storage': '7000',
+            'expected_ephemeral_storage': '7000',
+        },
+    )
+    def test_set_ephemeral_storage_limit(self, ephemeral_storage: str,
+                                         expected_ephemeral_storage: str):
+        task = pipeline_task.PipelineTask(
+            component_spec=structures.ComponentSpec.from_yaml_documents(
+                V2_YAML),
+            args={'input1': 'value'},
+        )
+        task.set_ephemeral_storage_request(ephemeral_storage)
+        self.assertEqual(
+            expected_ephemeral_storage,
+            task.container_spec.resources.ephemeral_storage_request)
+        task.set_ephemeral_storage_limit(ephemeral_storage)
+        self.assertEqual(
+            expected_ephemeral_storage,
+            task.container_spec.resources.ephemeral_storage_limit)
+
+    @parameterized.parameters(
+        {
+            'ephemeral_storage': 'abc',
+        },
+        {
+            'ephemeral_storage': '1.5',
+        },
+        {
+            'ephemeral_storage': '-1',
+        },
+    )
+    def test_set_ephemeral_storage_invalid(self, ephemeral_storage: str):
+        task = pipeline_task.PipelineTask(
+            component_spec=structures.ComponentSpec.from_yaml_documents(
+                V2_YAML),
+            args={'input1': 'value'},
+        )
+        with self.assertRaisesRegex(
+                ValueError,
+                'Invalid ephemeral storage string. Should be a number or a '
+                'number followed by one of "E", "Ei", "P", "Pi", "T", "Ti", '
+                '"G", "Gi", "M", "Mi", "K", "Ki".'):
+            task.set_ephemeral_storage_request(ephemeral_storage)
+        with self.assertRaisesRegex(
+                ValueError,
+                'Invalid ephemeral storage string. Should be a number or a '
+                'number followed by one of "E", "Ei", "P", "Pi", "T", "Ti", '
+                '"G", "Gi", "M", "Mi", "K", "Ki".'):
+            task.set_ephemeral_storage_limit(ephemeral_storage)
+
     def test_set_accelerator_type_with_type_only(self):
         task = pipeline_task.PipelineTask(
             component_spec=structures.ComponentSpec.from_yaml_documents(

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -239,6 +239,8 @@ class ResourceSpec:
         cpu_limit (optional): the limit of the number of vCPU cores.
         memory_request (optional): the memory requirement in GB.
         memory_limit (optional): the memory limit in GB.
+        ephemeral_storage_request (optional): the ephemeral storage requirement in GB.
+        ephemeral_storage_limit (optional): the ephemeral storage limit in GB.
         accelerator_type (optional): the type of accelerators attached to the
             container.
         accelerator_count (optional): the number of accelerators attached.
@@ -247,6 +249,8 @@ class ResourceSpec:
     cpu_limit: Optional[str] = None
     memory_request: Optional[str] = None
     memory_limit: Optional[str] = None
+    ephemeral_storage_request: Optional[str] = None
+    ephemeral_storage_limit: Optional[str] = None
     accelerator_type: Optional[str] = None
     accelerator_count: Optional[str] = None
 


### PR DESCRIPTION
**Description of your changes:**
Add support for setting ephemeral storage resource requests and limits for pipeline tasks in KFP v2.

This was supported in KFP v1 but was dropped in v2. Without it, pods may get evicted when they exceed their ephemeral storage request (currently always zero), and the Kubernetes scheduler cannot schedule pods based on their ephemeral storage needs.

Changes:
- **Proto** (`api/v2alpha1/pipeline_spec.proto`): add `resource_ephemeral_storage_limit` and `resource_ephemeral_storage_request` string fields to `ResourceSpec` (following the existing `resource_*` pattern that supports pipeline input parameters / placeholders), and regenerate the Go protos.
- **SDK** (`dsl/structures.py`): add `ephemeral_storage_request` and `ephemeral_storage_limit` fields to the `ResourceSpec` dataclass.
- **SDK** (`dsl/pipeline_task.py`): add `set_ephemeral_storage_request` and `set_ephemeral_storage_limit` task setters, reusing the memory validation logic (shared via `_validate_resource_amount_request_limit`).
- **SDK** (`compiler/pipeline_spec_builder.py`): wire ephemeral storage values into the compiled pipeline spec with placeholder support.
- **Backend** (`backend/src/v2/driver/driver.go`): resolve ephemeral storage requests/limits (including placeholders) and set them on the pod spec via `k8s.io/api/core/v1.ResourceEphemeralStorage`.
- **Tests**: add driver tests (static and placeholder ephemeral storage resources), SDK setter tests, and compiler tests.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
