### PR TITLE
fix(backend): detect circular component references and enforce reserved keywords in visitor.go. Fixes #13966

### DIFF
--- a/backend/src/v2/compiler/visitor.go
+++ b/backend/src/v2/compiler/visitor.go
@@ -22,7 +22,6 @@
 package compiler
 
 import (
-	"bytes"
 	"fmt"
 	"sort"
 
@@ -58,10 +57,12 @@ func Accept(job *pipelinespec.PipelineJob, kubernetesSpec *pipelinespec.SinglePl
 	if job == nil {
 		return nil
 	}
-	// TODO(Bobgy): reserve root as a keyword that cannot be user component names
 	spec, err := GetPipelineSpec(job)
 	if err != nil {
 		return err
+	}
+	if _, exists := spec.GetComponents()[RootComponentName]; exists {
+		return fmt.Errorf("reserved component name %q cannot be used as a user component name", RootComponentName)
 	}
 	deploy, err := GetDeploymentConfig(spec)
 	if err != nil {
@@ -73,6 +74,7 @@ func Accept(job *pipelinespec.PipelineJob, kubernetesSpec *pipelinespec.SinglePl
 		kubernetesSpec: kubernetesSpec,
 		visitor:        v,
 		visited:        make(map[string]bool),
+		inStack:        make(map[string]bool),
 	}
 	return state.dfs(RootComponentName, spec.GetRoot(), nil)
 }
@@ -84,22 +86,33 @@ type pipelineDFS struct {
 	visitor        Visitor
 	// Records which DAG components are visited, map key is component name.
 	visited map[string]bool
+	// Records components currently in the active DFS recursion stack for cycle detection.
+	inStack map[string]bool
 }
 
 func (state *pipelineDFS) dfs(name string, component *pipelinespec.ComponentSpec, componentTask *pipelinespec.PipelineTaskSpec) error {
-	// each component is only visited once
-	// TODO(Bobgy): return an error when circular reference detected
+	if state == nil {
+		return fmt.Errorf("dfs: unexpected value state=nil")
+	}
+	if state.inStack[name] {
+		return fmt.Errorf("circular reference detected in component graph: %s", name)
+	}
 	if state.visited[name] {
 		return nil
 	}
 	state.visited[name] = true
+	state.inStack[name] = true
+	defer func() {
+		delete(state.inStack, name)
+	}()
+
 	if component == nil {
 		return nil
 	}
-	if state == nil {
-		return fmt.Errorf("dfs: unexpected value state=nil")
-	}
 	componentError := func(err error) error {
+		if componentTask != nil && componentTask.GetTaskInfo() != nil && componentTask.GetTaskInfo().GetName() != "" {
+			return fmt.Errorf("error processing task %q (component name=%q): %w", componentTask.GetTaskInfo().GetName(), name, err)
+		}
 		return fmt.Errorf("error processing component name=%q: %w", name, err)
 	}
 	executorLabel := component.GetExecutorLabel()
@@ -174,32 +187,35 @@ func (state *pipelineDFS) dfs(name string, component *pipelinespec.ComponentSpec
 }
 
 func GetDeploymentConfig(spec *pipelinespec.PipelineSpec) (*pipelinespec.PipelineDeploymentConfig, error) {
+	if spec == nil || spec.GetDeploymentSpec() == nil {
+		return &pipelinespec.PipelineDeploymentConfig{}, nil
+	}
 	jsonBytes, err := protojson.Marshal(spec.GetDeploymentSpec())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal deployment spec: %w", err)
 	}
-	buffer := bytes.NewBuffer(jsonBytes)
 	deploymentConfig := &pipelinespec.PipelineDeploymentConfig{}
 	// Allow unknown '@type' field in the json message.
 	unmarshaler := protojson.UnmarshalOptions{
 		DiscardUnknown: true,
 	}
-	if err := unmarshaler.Unmarshal(buffer.Bytes(), deploymentConfig); err != nil {
-		return nil, err
+	if err := unmarshaler.Unmarshal(jsonBytes, deploymentConfig); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal deployment config: %w", err)
 	}
 	return deploymentConfig, nil
 }
 
 func GetPipelineSpec(job *pipelinespec.PipelineJob) (*pipelinespec.PipelineSpec, error) {
-	// TODO(Bobgy): can we avoid this marshal to string step?
+	if job == nil || job.GetPipelineSpec() == nil {
+		return nil, fmt.Errorf("pipeline spec is nil in pipeline job")
+	}
 	marshaler := &protojson.MarshalOptions{}
 	jsonBytes, err := marshaler.Marshal(job.GetPipelineSpec())
 	if err != nil {
 		return nil, fmt.Errorf("failed marshal pipeline spec to json: %w", err)
 	}
-	jsonStr := string(jsonBytes)
 	spec := &pipelinespec.PipelineSpec{}
-	if err := protojson.Unmarshal([]byte(jsonStr), spec); err != nil {
+	if err := protojson.Unmarshal(jsonBytes, spec); err != nil {
 		return nil, fmt.Errorf("failed to parse pipeline spec: %v", err)
 	}
 	return spec, nil

--- a/backend/src/v2/compiler/visitor_test.go
+++ b/backend/src/v2/compiler/visitor_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compiler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type dummyVisitor struct {
+	visitedContainers []string
+	visitedDAGs       []string
+}
+
+func (v *dummyVisitor) Container(name string, component *pipelinespec.ComponentSpec, container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec) error {
+	v.visitedContainers = append(v.visitedContainers, name)
+	return nil
+}
+
+func (v *dummyVisitor) Importer(name string, component *pipelinespec.ComponentSpec, importer *pipelinespec.PipelineDeploymentConfig_ImporterSpec) error {
+	return nil
+}
+
+func (v *dummyVisitor) Resolver(name string, component *pipelinespec.ComponentSpec, resolver *pipelinespec.PipelineDeploymentConfig_ResolverSpec) error {
+	return nil
+}
+
+func (v *dummyVisitor) DAG(name string, component *pipelinespec.ComponentSpec, dag *pipelinespec.DagSpec) error {
+	v.visitedDAGs = append(v.visitedDAGs, name)
+	return nil
+}
+
+func (v *dummyVisitor) AddKubernetesSpec(name string, kubernetesSpec *structpb.Struct) error {
+	return nil
+}
+
+func TestAccept_NilJob(t *testing.T) {
+	v := &dummyVisitor{}
+	err := Accept(nil, nil, v)
+	assert.NoError(t, err)
+}
+
+func TestAccept_ReservedRootComponentName(t *testing.T) {
+	spec := &pipelinespec.PipelineSpec{
+		Components: map[string]*pipelinespec.ComponentSpec{
+			"root": {
+				Implementation: &pipelinespec.ComponentSpec_ExecutorLabel{
+					ExecutorLabel: "exec-1",
+				},
+			},
+		},
+	}
+	specStruct, err := structpb.NewStruct(protoStructToMap(t, spec))
+	assert.NoError(t, err)
+
+	job := &pipelinespec.PipelineJob{
+		PipelineSpec: specStruct,
+	}
+
+	v := &dummyVisitor{}
+	err = Accept(job, nil, v)
+	assert.ErrorContains(t, err, `reserved component name "root" cannot be used as a user component name`)
+}
+
+func TestAccept_CircularComponentReference(t *testing.T) {
+	spec := &pipelinespec.PipelineSpec{
+		Root: &pipelinespec.ComponentSpec{
+			Implementation: &pipelinespec.ComponentSpec_Dag{
+				Dag: &pipelinespec.DagSpec{
+					Tasks: map[string]*pipelinespec.PipelineTaskSpec{
+						"task-a": {
+							TaskInfo: &pipelinespec.PipelineTaskInfo{Name: "task-a"},
+							ComponentRef: &pipelinespec.ComponentRef{
+								Name: "comp-a",
+							},
+						},
+					},
+				},
+			},
+		},
+		Components: map[string]*pipelinespec.ComponentSpec{
+			"comp-a": {
+				Implementation: &pipelinespec.ComponentSpec_Dag{
+					Dag: &pipelinespec.DagSpec{
+						Tasks: map[string]*pipelinespec.PipelineTaskSpec{
+							"task-b": {
+								TaskInfo: &pipelinespec.PipelineTaskInfo{Name: "task-b"},
+								ComponentRef: &pipelinespec.ComponentRef{
+									Name: "comp-b",
+								},
+							},
+						},
+					},
+				},
+			},
+			"comp-b": {
+				Implementation: &pipelinespec.ComponentSpec_Dag{
+					Dag: &pipelinespec.DagSpec{
+						Tasks: map[string]*pipelinespec.PipelineTaskSpec{
+							"task-cycle": {
+								TaskInfo: &pipelinespec.PipelineTaskInfo{Name: "task-cycle"},
+								ComponentRef: &pipelinespec.ComponentRef{
+									Name: "comp-a", // Creates cycle comp-a -> comp-b -> comp-a
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	specStruct, err := structpb.NewStruct(protoStructToMap(t, spec))
+	assert.NoError(t, err)
+
+	job := &pipelinespec.PipelineJob{
+		PipelineSpec: specStruct,
+	}
+
+	v := &dummyVisitor{}
+	err = Accept(job, nil, v)
+	assert.ErrorContains(t, err, "circular reference detected in component graph: comp-a")
+}
+
+func TestAccept_EnrichedErrorContextForMissingExecutor(t *testing.T) {
+	spec := &pipelinespec.PipelineSpec{
+		Root: &pipelinespec.ComponentSpec{
+			Implementation: &pipelinespec.ComponentSpec_Dag{
+				Dag: &pipelinespec.DagSpec{
+					Tasks: map[string]*pipelinespec.PipelineTaskSpec{
+						"missing-exec-task": {
+							TaskInfo: &pipelinespec.PipelineTaskInfo{Name: "missing-exec-task"},
+							ComponentRef: &pipelinespec.ComponentRef{
+								Name: "comp-missing",
+							},
+						},
+					},
+				},
+			},
+		},
+		Components: map[string]*pipelinespec.ComponentSpec{
+			"comp-missing": {
+				Implementation: &pipelinespec.ComponentSpec_ExecutorLabel{
+					ExecutorLabel: "non-existent-executor",
+				},
+			},
+		},
+	}
+
+	specStruct, err := structpb.NewStruct(protoStructToMap(t, spec))
+	assert.NoError(t, err)
+
+	job := &pipelinespec.PipelineJob{
+		PipelineSpec: specStruct,
+	}
+
+	v := &dummyVisitor{}
+	err = Accept(job, nil, v)
+	assert.ErrorContains(t, err, `error processing task "missing-exec-task" (component name="comp-missing")`)
+}
+
+func protoStructToMap(t *testing.T, msg proto.Message) map[string]interface{} {
+	jsonBytes, err := protojson.Marshal(msg)
+	assert.NoError(t, err)
+	var result map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &result)
+	assert.NoError(t, err)
+	return result
+}


### PR DESCRIPTION
**Description of your changes:**

### Problem
In `backend/src/v2/compiler/visitor.go`, component dependency graphs are traversed using a depth-first search (`pipelineDFS.dfs`). Analysis of the compiler visitor pattern revealed multiple related defects:
1. **Uncaught Circular Component References**: `pipelineDFS` used a single flat `visited map[string]bool` map. When a sub-DAG component referenced an ancestor component (circular dependency), `if state.visited[name] { return nil }` returned `nil` silently. This allowed invalid cyclic pipeline specs to bypass API server validation and generate incomplete/corrupted Argo Workflow specs that failed with cryptic errors in Argo.
2. **Unenforced Reserved `root` Component Name**: `RootComponentName` ("root") was not validated against user component names, allowing user components named `"root"` to collide with root DAG traversal state.
3. **Opaque Error Context**: Error messages for missing component refs or executors omitted task name and parent DAG component context.
4. **Redundant Proto Serialization Passes**: `GetPipelineSpec` and `GetDeploymentConfig` performed double JSON round-tripping (`protojson.Marshal` -> string -> `protojson.Unmarshal`), adding memory allocations during large pipeline compilation.

### Solution
1. **Active Call-Stack Cycle Detection**: Added `inStack map[string]bool` to `pipelineDFS` to track active DFS recursion. If `inStack[name]` is true, `dfs` returns a clear cycle error (`circular reference detected in component graph: <name>`).
2. **Reserved Keyword Enforcement**: Rejects user components named `RootComponentName` ("root") in `Accept`.
3. **Enriched Error Context**: Included task name (`task.GetTaskInfo().GetName()`) and parent component name in `componentError`.
4. **Proto Unmarshaling Optimization**: Direct unmarshaling from `jsonBytes` eliminating intermediate `string` conversions and buffer allocations.
5. **Unit Tests**: Added `visitor_test.go` covering cycle detection, reserved keyword checks, and error message context.

Fixes #13966

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
