### PR TITLE
fix(proxy): install Python dependencies in virtualenv

### DIFF
--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -16,11 +16,15 @@
 FROM gcr.io/inverting-proxy/agent@sha256:432f609b1e98793723807f62a0a5b900deec491322a73330a9c844210fe70385
 
 # We need --allow-releaseinfo-change, because of https://github.com/kubeflow/pipelines/issues/6311#issuecomment-899224137.
-RUN apt update --allow-releaseinfo-change && apt-get install -y curl jq python3-pip
+RUN apt update --allow-releaseinfo-change && apt-get install -y curl jq python3-venv
+ENV VIRTUAL_ENV=/opt/proxy-venv
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 COPY requirements.txt .
-RUN python3 -m pip install -r \
+RUN python3 -m venv "${VIRTUAL_ENV}" \
+    && "${VIRTUAL_ENV}/bin/python3" -m pip install -r \
     requirements.txt --quiet --no-cache-dir \
-    && rm -f requirements.txt
+    && rm -f requirements.txt \
+    && "${VIRTUAL_ENV}/bin/python3" -c "import requests"
 
 # Install gcloud SDK (pinned)
 ARG GCLOUD_VERSION=557.0.0


### PR DESCRIPTION
## Summary

- install the inverse-proxy Python dependency in a dedicated virtual environment
- put that environment first on `PATH` for the runtime `python3` caller
- verify during the image build that `requests` is importable

## Root cause

The inverse-proxy base image update in #13847 moved the image onto a Debian environment that enforces PEP 668. The Dockerfile continued installing `requests` into the system Python environment, so every subsequent master image build failed with `externally-managed-environment`.

Using a virtual environment preserves the base image's managed Python installation and keeps the existing `attempt-register-vm-on-proxy.sh` runtime contract unchanged.

## Validation

- `git diff --check`
- `docker build --platform linux/amd64 --progress=plain -t kfp-inverse-proxy-agent:pep668-fix-amd64 -f proxy/Dockerfile proxy`
- ran `python3 -m unittest -v get_proxy_url_test.py` inside the built image; all four tests passed
