### PR TITLE
fix(backend): populate task runtime state in TaskStore scanRows. Fixes #13975

### DIFF
--- a/backend/src/apiserver/storage/task_store.go
+++ b/backend/src/apiserver/storage/task_store.go
@@ -199,6 +199,7 @@ func (s *TaskStore) scanRows(rows *sql.Rows) ([]*model.Task, error) {
 			Fingerprint:       fingerprint,
 			Name:              name.String,
 			ParentTaskId:      parentTaskId.String,
+			State:             model.RuntimeState(state.String),
 			StateHistory:      stateHistoryNew,
 			MLMDInputs:        model.LargeText(inputs.String),
 			MLMDOutputs:       model.LargeText(outputs.String),

--- a/backend/src/apiserver/storage/task_store_test.go
+++ b/backend/src/apiserver/storage/task_store_test.go
@@ -143,6 +143,7 @@ func initializeTaskStore() (*DB, *TaskStore) {
 		StartedTimestamp:  5,
 		FinishedTimestamp: 6,
 		Fingerprint:       "1",
+		State:             model.RuntimeStateRunning,
 	}
 	taskStore.CreateTask(task4)
 
@@ -178,8 +179,10 @@ func TestListTasks(t *testing.T) {
 			CreatedTimestamp:  5,
 			FinishedTimestamp: 6,
 			Fingerprint:       "1",
+			State:             model.RuntimeStateRunning,
 		},
 	}
+
 	expectedSecondPageTasks := []*model.Task{
 		{
 			UUID:              defaultFakeTaskIdFive,
@@ -192,6 +195,7 @@ func TestListTasks(t *testing.T) {
 			StartedTimestamp:  7,
 			FinishedTimestamp: 8,
 			Fingerprint:       "10",
+			State:             model.RuntimeStateUnspecified,
 		},
 	}
 
@@ -230,7 +234,9 @@ func TestTaskStore_GetTask(t *testing.T) {
 		StartedTimestamp:  5,
 		FinishedTimestamp: 6,
 		Fingerprint:       "1",
+		State:             model.RuntimeStateRunning,
 	}
+
 	task2 := &model.Task{
 		UUID:              defaultFakeTaskIdFive,
 		Namespace:         "ns2",
@@ -242,8 +248,8 @@ func TestTaskStore_GetTask(t *testing.T) {
 		StartedTimestamp:  7,
 		FinishedTimestamp: 8,
 		Fingerprint:       "10",
+		State:             model.RuntimeStateUnspecified,
 	}
-
 	tests := []struct {
 		name    string
 		id      string
@@ -326,7 +332,7 @@ func TestTaskStore_patchWithExistingTasks(t *testing.T) {
 					StartedTimestamp:  5,
 					FinishedTimestamp: 6,
 					Fingerprint:       "1",
-					State:             model.RuntimeStateUnspecified,
+					State:             model.RuntimeStateRunning,
 				},
 			},
 			false,
@@ -455,7 +461,7 @@ func TestTaskStore_patchWithExistingTasks(t *testing.T) {
 					PipelineName:      "namespace/ns2/pipeline/pipeline2",
 					RunID:             defaultFakeRunIdTwo,
 					MLMDExecutionID:   "4",
-					State:             model.RuntimeStateUnspecified,
+					State:             model.RuntimeStateRunning,
 					StartedTimestamp:  5,
 					FinishedTimestamp: 6,
 					Fingerprint:       "1",
@@ -465,7 +471,7 @@ func TestTaskStore_patchWithExistingTasks(t *testing.T) {
 					CreatedTimestamp:  5,
 					PodName:           "pod4",
 					Namespace:         "ns2",
-					State:             model.RuntimeStateUnspecified,
+					State:             model.RuntimeStateRunning,
 					PipelineName:      "namespace/ns2/pipeline/pipeline2",
 					RunID:             defaultFakeRunIdTwo,
 					MLMDExecutionID:   "4",
@@ -566,8 +572,8 @@ func TestTaskStore_UpdateOrCreateTasks(t *testing.T) {
 		StartedTimestamp:  5,
 		FinishedTimestamp: 6,
 		Fingerprint:       "1",
-		State:             model.RuntimeStateUnspecified,
-		StateHistory:      []*model.RuntimeStatus{{UpdateTimeInSec: 1, State: model.RuntimeStateUnspecified}},
+		State:             model.RuntimeStateRunning,
+		StateHistory:      []*model.RuntimeStatus{{UpdateTimeInSec: 1, State: model.RuntimeStateRunning}},
 	}
 	want2 := &model.Task{
 		UUID:              defaultFakeTaskIdFive,


### PR DESCRIPTION
Fixes #13975

## Description

This PR fixes `TaskStore.scanRows()` to correctly populate the `Task.State` field when reading task records from the database.

Previously, the `State` column was selected from the database but was not scanned into the `Task` model. As a result, tasks returned by `ListTasks`, `GetTask`, and `patchWithExistingTasks` always had an empty runtime state, even when a persisted state existed in the database.

### Changes

- Scan the `State` column in `TaskStore.scanRows()`.
- Populate `Task.State` from the scanned database value.
- Update storage tests to reflect the expected persisted runtime state.

## Testing

```
go test ./backend/src/apiserver/storage/...
```

## Checklist

- [x] You have signed off your commits.
- [x] The title for your pull request (PR) follows the repository title convention.