### PR TITLE
fix(ci): resume Trivy vulnerability scanning

### DIFF
--- a/.github/resources/scripts/trivy_workflow_test.py
+++ b/.github/resources/scripts/trivy_workflow_test.py
@@ -43,15 +43,18 @@ class TrivyWorkflowTest(unittest.TestCase):
         self.assertNotIn('TRIVY_SKIP_DB_UPDATE', self.workflow)
         self.assertNotIn('TRIVY_SKIP_JAVA_DB_UPDATE', self.workflow)
 
-    def test_scan_uses_reviewed_pins_and_vulnerability_scope(self):
+    def test_scan_uses_reviewed_pins_and_reports_all_vulnerabilities(self):
         self.assertIn(
             'aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25',
             self.workflow,
         )
         self.assertIn("version: 'v0.73.0'", self.workflow)
         self.assertIn("scanners: 'vuln'", self.workflow)
-        self.assertIn("severity: 'CRITICAL,HIGH'", self.workflow)
-        self.assertIn('limit-severities-for-sarif: true', self.workflow)
+        self.assertIn(
+            "severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'", self.workflow
+        )
+        self.assertNotIn('ignore-unfixed:', self.workflow)
+        self.assertNotIn('limit-severities-for-sarif:', self.workflow)
 
     def test_scan_has_least_privilege_and_manual_recovery(self):
         self.assertIn('  workflow_dispatch:', self.workflow)

--- a/.github/resources/scripts/trivy_workflow_test.py
+++ b/.github/resources/scripts/trivy_workflow_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_PATH = ROOT / '.github/workflows/trivy.yml'
+CI_SCRIPTS_WORKFLOW_PATH = ROOT / '.github/workflows/ci-scripts-tests.yml'
+
+
+class TrivyWorkflowTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = WORKFLOW_PATH.read_text(encoding='utf-8')
+        cls.ci_scripts_workflow = CI_SCRIPTS_WORKFLOW_PATH.read_text(
+            encoding='utf-8'
+        )
+
+    def test_scan_can_bootstrap_current_databases(self):
+        self.assertIn(
+            'TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2',
+            self.workflow,
+        )
+        self.assertIn(
+            'TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1',
+            self.workflow,
+        )
+        self.assertNotIn('TRIVY_SKIP_DB_UPDATE', self.workflow)
+        self.assertNotIn('TRIVY_SKIP_JAVA_DB_UPDATE', self.workflow)
+
+    def test_scan_uses_reviewed_pins_and_vulnerability_scope(self):
+        self.assertIn(
+            'aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25',
+            self.workflow,
+        )
+        self.assertIn("version: 'v0.73.0'", self.workflow)
+        self.assertIn("scanners: 'vuln'", self.workflow)
+        self.assertIn("severity: 'CRITICAL,HIGH'", self.workflow)
+        self.assertIn('limit-severities-for-sarif: true', self.workflow)
+
+    def test_scan_has_least_privilege_and_manual_recovery(self):
+        self.assertIn('  workflow_dispatch:', self.workflow)
+        self.assertIn('      contents: read', self.workflow)
+        self.assertIn('      security-events: write', self.workflow)
+        self.assertIn('          persist-credentials: false', self.workflow)
+
+    def test_ci_scripts_tests_run_for_trivy_workflow_changes(self):
+        self.assertIn(
+            "      - '.github/workflows/trivy.yml'", self.ci_scripts_workflow
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/workflows/ci-scripts-tests.yml
+++ b/.github/workflows/ci-scripts-tests.yml
@@ -24,6 +24,7 @@ on:
       - '.github/workflows/create-manifest.yml'
       - '.github/workflows/e2e-test.yml'
       - '.github/workflows/image-builds.yml'
+      - '.github/workflows/trivy.yml'
       - '.github/workflows/ci-scripts-tests.yml'
       - '.github/workflows/gh-workflow-approve.yml'
       - 'manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -25,11 +25,9 @@ jobs:
           version: 'v0.73.0'
           scan-type: 'fs'
           scanners: 'vuln'
-          ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          limit-severities-for-sarif: true
+          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
           exit-code: '0'
           skip-dirs: 'components'
         env:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -4,30 +4,38 @@ on:
   schedule:
     # Every Friday at 19:39
     - cron: '39 19 * * 5'
+  workflow_dispatch:
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
+          version: 'v0.73.0'
           scan-type: 'fs'
+          scanners: 'vuln'
           ignore-unfixed: true
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          limit-severities-for-sarif: true
+          exit-code: '0'
           skip-dirs: 'components'
         env:
           # Use ECR instead of GitHub Container Registry to avoid rate limiting.
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
-          TRIVY_SKIP_DB_UPDATE: true
-          TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@256d634097be96e792d6764f9edaefc4320557b1 # v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -546,7 +546,8 @@ When changing an effect-heavy frontend component, add or run the smallest releva
 - Frontend workflow (`frontend.yml`) verifies generated API clients are up to date by running `npm run apis:all` and failing on diff.
 - The weekly Trivy filesystem scan (`trivy.yml`) can also be dispatched manually. It runs with explicit read-only
   repository access plus `security-events: write`, downloads current vulnerability databases from the configured
-  ECR mirrors, and uploads only fixable Critical/High vulnerability findings to code scanning.
+  ECR mirrors, and uploads vulnerability findings at every severity to code scanning, including findings without
+  an available fix.
 
 ### Test matrices and variants (Kubernetes, stores, proxy, cache)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ### Document metadata
 
-- Last updated: 2026-07-29
+- Last updated: 2026-08-04
 - Scope: KFP master branch (v2 engine), backend (Go), SDK (Python), frontend (React 19)
 
 ### Maintenance (agents and contributors)
@@ -544,6 +544,9 @@ When changing an effect-heavy frontend component, add or run the smallest releva
   `backend/api/Dockerfile` and reuses that local image for v1beta1 and v2beta1 generation,
   so generator upgrades and their checked-in outputs can be validated atomically.
 - Frontend workflow (`frontend.yml`) verifies generated API clients are up to date by running `npm run apis:all` and failing on diff.
+- The weekly Trivy filesystem scan (`trivy.yml`) can also be dispatched manually. It runs with explicit read-only
+  repository access plus `security-events: write`, downloads current vulnerability databases from the configured
+  ECR mirrors, and uploads only fixable Critical/High vulnerability findings to code scanning.
 
 ### Test matrices and variants (Kubernetes, stores, proxy, cache)
 


### PR DESCRIPTION
## Summary

- allow the scheduled filesystem scan to download current Trivy vulnerability databases from the configured ECR mirrors
- pin reviewed Trivy action and binary releases, explicitly scope the scan to vulnerabilities, and report every severity including findings without an available fix
- add least-privilege permissions, manual dispatch, and regression coverage for the workflow's security and database-update invariants

## Root cause

PR #12563 moved database updates into a separate daily cache workflow and configured the scanner with `TRIVY_SKIP_DB_UPDATE` and `TRIVY_SKIP_JAVA_DB_UPDATE`. PR #12612 removed that cache workflow on January 6, 2026, but left both skip flags in the scanner. The January 9 scan could still use the remaining cache; after it expired, fresh runners failed because Trivy was forbidden from downloading its initial databases.

## Verification

- `python3 -m unittest -v trivy_workflow_test.py`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.9 .github/workflows/trivy.yml .github/workflows/ci-scripts-tests.yml`
- `git diff --check`
