### PR TITLE
fix(deps): update brace-expansion to 5.0.9

### DIFF
--- a/test/frontend-integration-test/package-lock.json
+++ b/test/frontend-integration-test/package-lock.json
@@ -1816,9 +1816,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"

--- a/test/frontend-integration-test/package.json
+++ b/test/frontend-integration-test/package.json
@@ -24,7 +24,7 @@
     "node": ">=20.0.0"
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
+    "brace-expansion": "5.0.9",
     "mocha": {
       "serialize-javascript": "7.0.5"
     }

--- a/test/frontend-integration-test/patches/brace-expansion+5.0.9.patch
+++ b/test/frontend-integration-test/patches/brace-expansion+5.0.9.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/brace-expansion/dist/commonjs/index.js b/node_modules/brace-expansion/dist/commonjs/index.js
-index be9df86..849931e 100644
+index 869a6be..407241f 100644
 --- a/node_modules/brace-expansion/dist/commonjs/index.js
 +++ b/node_modules/brace-expansion/dist/commonjs/index.js
-@@ -260,4 +260,7 @@ function expand_(str, max, maxLength, isTop) {
+@@ -286,4 +286,7 @@ function expand_(str, max, maxLength, isTop) {
      }
      return acc;
  }


### PR DESCRIPTION
## Summary

- update the frontend integration test's `brace-expansion` override from 5.0.8 to 5.0.9
- refresh the lockfile to the first patched 5.x release for GHSA-rgw5-rvv9-x895 / CVE-2026-69152
- regenerate the existing CommonJS compatibility patch for the secured release

## Why

Dependabot alert 3757 reports that `brace-expansion` versions before 5.0.9 are vulnerable to denial of service through unbounded intermediate arrays. The integration-test dependency tree deliberately overrides legacy minimatch consumers to the 5.x package, so the compatibility patch must move with the version bump.

## Verification

- `npm ci`
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)
- compatibility smoke test covering brace-expansion's callable and named CommonJS APIs plus minimatch 3.x, 5.x, and 9.x consumers
- `git diff --check`
