### PR TITLE
fix: replace bare except with ValueError in metadata_helpers.py

### DIFF
--- a/backend/metadata_writer/src/metadata_helpers.py
+++ b/backend/metadata_writer/src/metadata_helpers.py
@@ -83,7 +83,7 @@ def get_or_create_artifact_type(store, type_name, properties: dict = None) -> me
     try:
         artifact_type = store.get_artifact_type(type_name=type_name)
         return artifact_type
-    except:
+    except ValueError:
         artifact_type = metadata_store_pb2.ArtifactType(
             name=type_name,
             properties=properties,
@@ -96,7 +96,7 @@ def get_or_create_execution_type(store, type_name, properties: dict = None) -> m
     try:
         execution_type = store.get_execution_type(type_name=type_name)
         return execution_type
-    except:
+    except ValueError:
         execution_type = metadata_store_pb2.ExecutionType(
             name=type_name,
             properties=properties,
@@ -109,7 +109,7 @@ def get_or_create_context_type(store, type_name, properties: dict = None) -> met
     try:
         context_type = store.get_context_type(type_name=type_name)
         return context_type
-    except:
+    except ValueError:
         context_type = metadata_store_pb2.ContextType(
             name=type_name,
             properties=properties,
@@ -208,7 +208,7 @@ def get_or_create_context_with_type(
 ) -> metadata_store_pb2.Context:
     try:
         context = get_context_by_name(store, context_name)
-    except:
+    except ValueError:
         context = create_context_with_type(
             store=store,
             context_name=context_name,

--- a/backend/metadata_writer/src/test_metadata_helpers.py
+++ b/backend/metadata_writer/src/test_metadata_helpers.py
@@ -1,0 +1,183 @@
+import unittest
+from unittest import mock
+
+from ml_metadata.proto import metadata_store_pb2
+
+from metadata_helpers import (
+    get_or_create_artifact_type,
+    get_or_create_execution_type,
+    get_or_create_context_type,
+    get_or_create_context_with_type,
+)
+
+
+class TestGetOrCreateArtifactType(unittest.TestCase):
+    def setUp(self):
+        self.store = mock.MagicMock()
+
+    def test_get_path_returns_existing(self):
+        existing = metadata_store_pb2.ArtifactType(name="test-type")
+        self.store.get_artifact_type.return_value = existing
+
+        result = get_or_create_artifact_type(self.store, "test-type")
+
+        self.store.get_artifact_type.assert_called_once_with(type_name="test-type")
+        self.store.put_artifact_type.assert_not_called()
+        self.assertEqual(result, existing)
+
+    def test_create_path_puts_new_type(self):
+        self.store.get_artifact_type.side_effect = ValueError("not found")
+        self.store.put_artifact_type.return_value = 42
+
+        result = get_or_create_artifact_type(self.store, "test-type")
+
+        self.store.get_artifact_type.assert_called_once_with(type_name="test-type")
+        self.store.put_artifact_type.assert_called_once()
+        self.assertEqual(result.id, 42)
+        self.assertEqual(result.name, "test-type")
+
+    def test_unrelated_exception_propagates(self):
+        self.store.get_artifact_type.side_effect = RuntimeError("something else")
+
+        with self.assertRaises(RuntimeError):
+            get_or_create_artifact_type(self.store, "test-type")
+
+        self.store.put_artifact_type.assert_not_called()
+
+
+class TestGetOrCreateExecutionType(unittest.TestCase):
+    def setUp(self):
+        self.store = mock.MagicMock()
+
+    def test_get_path_returns_existing(self):
+        existing = metadata_store_pb2.ExecutionType(name="test-type")
+        self.store.get_execution_type.return_value = existing
+
+        result = get_or_create_execution_type(self.store, "test-type")
+
+        self.store.get_execution_type.assert_called_once_with(type_name="test-type")
+        self.store.put_execution_type.assert_not_called()
+        self.assertEqual(result, existing)
+
+    def test_create_path_puts_new_type(self):
+        self.store.get_execution_type.side_effect = ValueError("not found")
+        self.store.put_execution_type.return_value = 42
+
+        result = get_or_create_execution_type(self.store, "test-type")
+
+        self.store.get_execution_type.assert_called_once_with(type_name="test-type")
+        self.store.put_execution_type.assert_called_once()
+        self.assertEqual(result.id, 42)
+        self.assertEqual(result.name, "test-type")
+
+    def test_unrelated_exception_propagates(self):
+        self.store.get_execution_type.side_effect = RuntimeError("something else")
+
+        with self.assertRaises(RuntimeError):
+            get_or_create_execution_type(self.store, "test-type")
+
+        self.store.put_execution_type.assert_not_called()
+
+
+class TestGetOrCreateContextType(unittest.TestCase):
+    def setUp(self):
+        self.store = mock.MagicMock()
+
+    def test_get_path_returns_existing(self):
+        existing = metadata_store_pb2.ContextType(name="test-type")
+        self.store.get_context_type.return_value = existing
+
+        result = get_or_create_context_type(self.store, "test-type")
+
+        self.store.get_context_type.assert_called_once_with(type_name="test-type")
+        self.store.put_context_type.assert_not_called()
+        self.assertEqual(result, existing)
+
+    def test_create_path_puts_new_type(self):
+        self.store.get_context_type.side_effect = ValueError("not found")
+        self.store.put_context_type.return_value = 42
+
+        result = get_or_create_context_type(self.store, "test-type")
+
+        self.store.get_context_type.assert_called_once_with(type_name="test-type")
+        self.store.put_context_type.assert_called_once()
+        self.assertEqual(result.id, 42)
+        self.assertEqual(result.name, "test-type")
+
+    def test_unrelated_exception_propagates(self):
+        self.store.get_context_type.side_effect = RuntimeError("something else")
+
+        with self.assertRaises(RuntimeError):
+            get_or_create_context_type(self.store, "test-type")
+
+        self.store.put_context_type.assert_not_called()
+
+
+class TestGetOrCreateContextWithType(unittest.TestCase):
+    def setUp(self):
+        self.store = mock.MagicMock()
+
+    @mock.patch("metadata_helpers.get_context_by_name")
+    def test_get_path_returns_existing_and_verifies_type(self, mock_get_context):
+        existing_context = metadata_store_pb2.Context(name="test-context", type_id=1)
+        mock_get_context.return_value = existing_context
+        existing_context_type = metadata_store_pb2.ContextType(
+            name="test-type-name"
+        )
+        self.store.get_context_types_by_id.return_value = [existing_context_type]
+
+        result = get_or_create_context_with_type(
+            self.store,
+            context_name="test-context",
+            type_name="test-type-name",
+        )
+
+        mock_get_context.assert_called_once_with(self.store, "test-context")
+        self.store.get_context_types_by_id.assert_called_once_with([1])
+        self.assertEqual(result, existing_context)
+
+    @mock.patch("metadata_helpers.create_context_with_type")
+    @mock.patch("metadata_helpers.get_context_by_name")
+    def test_create_path_calls_create_and_returns_new_context(
+        self, mock_get_context, mock_create_context
+    ):
+        mock_get_context.side_effect = ValueError("not found")
+        new_context = metadata_store_pb2.Context(name="test-context", type_id=1)
+        mock_create_context.return_value = new_context
+
+        result = get_or_create_context_with_type(
+            self.store,
+            context_name="test-context",
+            type_name="test-type",
+            properties={"key": "value"},
+            type_properties={"tkey": "tval"},
+            custom_properties={"ckey": "cval"},
+        )
+
+        mock_get_context.assert_called_once_with(self.store, "test-context")
+        mock_create_context.assert_called_once_with(
+            store=self.store,
+            context_name="test-context",
+            type_name="test-type",
+            properties={"key": "value"},
+            type_properties={"tkey": "tval"},
+            custom_properties={"ckey": "cval"},
+        )
+        self.assertEqual(result, new_context)
+
+    @mock.patch("metadata_helpers.create_context_with_type")
+    @mock.patch("metadata_helpers.get_context_by_name")
+    def test_unrelated_exception_propagates(
+        self, mock_get_context, mock_create_context
+    ):
+        mock_get_context.side_effect = RuntimeError("something else")
+
+        with self.assertRaises(RuntimeError):
+            get_or_create_context_with_type(
+                self.store,
+                context_name="test-context",
+                type_name="test-type",
+            )
+
+        mock_get_context.assert_called_once_with(self.store, "test-context")
+        mock_create_context.assert_not_called()


### PR DESCRIPTION
# Description

The `get_or_create_*` functions and `get_or_create_context_with_type` in `metadata_helpers.py` used bare `except:` clauses to catch "not found" errors from the ML Metadata store. The ml-metadata library raises `ValueError` when a type or context is not found, but bare `except:` catches everything — including `TypeError`, `KeyError`, network errors, memory errors — and silently falls through to the create path. This risks creating duplicate or invalid MLMD entities when unrelated errors occur.

# Change type

/kind bug

# Changelog

```release-note
fix: Replaced bare except: with except ValueError: in metadata_helpers.py get_or_create_* and get_or_create_context_with_type functions to prevent swallowing unrelated errors
```