### PR TITLE
fix(sdk): normalize artifact URIs, fix artifact list serialization, and recover from corrupt entries in local cache. Fixes #13983

### DIFF
--- a/sdk/python/kfp/local/cache.py
+++ b/sdk/python/kfp/local/cache.py
@@ -49,11 +49,14 @@ class LocalCache:
         """Serializes a Python value to a JSON-friendly form for key
         computation."""
         if isinstance(value, dsl.Artifact):
+            uri = value.uri
+            if uri and not _is_remote_uri(uri):
+                uri = os.path.basename(uri)
             return {
                 _ARTIFACT_MARKER: True,
                 'schema_title': type(value).schema_title,
                 'name': value.name,
-                'uri': value.uri,
+                'uri': uri,
                 'metadata': value.metadata,
             }
         if isinstance(value, list):
@@ -135,6 +138,11 @@ class LocalCache:
                 f'Cache entry for key {key} references missing artifact '
                 f'{e.uri}. Treating as cache miss.')
             return None
+        except (KeyError, TypeError, ValueError, AttributeError) as e:
+            logging.warning(
+                f'Failed to deserialize cache entry for key {key}: {e}. '
+                'Treating as cache miss.')
+            return None
 
     def put(self, key: str, outputs: Dict[str, Any]) -> None:
         """Persists `outputs` under `key`, atomically."""
@@ -148,6 +156,12 @@ class LocalCache:
                 with os.fdopen(fd, 'w') as f:
                     json.dump(serialized, f)
                 os.replace(tmp_path, entry_path)
+            except PermissionError as e:
+                logging.warning(
+                    f'Permission error when updating cache entry {entry_path}: {e}.'
+                )
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
             except Exception:
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)
@@ -163,11 +177,14 @@ class LocalCache:
     def _serialize_output(value: Any) -> Any:
         if isinstance(value, dsl.Artifact):
             return LocalCache._serialize_artifact(value)
-        if isinstance(value, list) and value and isinstance(
-                value[0], dsl.Artifact):
+        if isinstance(value, list) and any(
+                isinstance(x, dsl.Artifact) for x in value):
             return {
                 _ARTIFACT_LIST_MARKER: True,
-                'artifacts': [LocalCache._serialize_artifact(a) for a in value],
+                'artifacts': [
+                    LocalCache._serialize_artifact(a)
+                    if isinstance(a, dsl.Artifact) else a for a in value
+                ],
             }
         return value
 
@@ -195,6 +212,7 @@ class LocalCache:
         if isinstance(value, dict) and value.get(_ARTIFACT_LIST_MARKER):
             return [
                 LocalCache._deserialize_artifact(a)
+                if isinstance(a, dict) and a.get(_ARTIFACT_MARKER) else a
                 for a in value.get('artifacts', [])
             ]
         return value

--- a/sdk/python/kfp/local/cache_test.py
+++ b/sdk/python/kfp/local/cache_test.py
@@ -150,6 +150,23 @@ class LocalCacheKeyTest(unittest.TestCase):
         )
         self.assertNotEqual(k1, k2)
 
+    def test_artifact_argument_same_filename_different_temp_dir(self):
+        a1 = dsl.Artifact(name='a', uri='/tmp/dir1/art.txt')
+        a2 = dsl.Artifact(name='a', uri='/tmp/dir2/art.txt')
+        k1 = self.cache.compute_key(
+            component_name='c',
+            image='img',
+            full_command=[],
+            arguments={'art': a1},
+        )
+        k2 = self.cache.compute_key(
+            component_name='c',
+            image='img',
+            full_command=[],
+            arguments={'art': a2},
+        )
+        self.assertEqual(k1, k2)
+
 
 class LocalCachePutGetTest(unittest.TestCase):
 
@@ -203,6 +220,25 @@ class LocalCachePutGetTest(unittest.TestCase):
         got = self.cache.get('k')
         self.assertIsNotNone(got)
         self.assertEqual(got['out_art'].uri, 'gs://bucket/a')
+
+    def test_heterogeneous_artifact_list_roundtrip(self):
+        artifact_path = os.path.join(self.tmpdir, 'art.txt')
+        with open(artifact_path, 'w') as f:
+            f.write('hi')
+        art = dsl.Artifact(name='a', uri=artifact_path)
+        outputs = {'out_list': [None, art, 42]}
+        self.cache.put('k_mixed', outputs)
+        got = self.cache.get('k_mixed')
+        self.assertIsNotNone(got)
+        self.assertIsNone(got['out_list'][0])
+        self.assertIsInstance(got['out_list'][1], dsl.Artifact)
+        self.assertEqual(got['out_list'][2], 42)
+
+    def test_corrupt_cache_file_treated_as_miss(self):
+        entry_path = os.path.join(self.tmpdir, 'corrupt_key.json')
+        with open(entry_path, 'w') as f:
+            f.write('{"out_art": {"__kfp_artifact__": true, "uri": "/non/existent/corrupt/path.txt"}}')
+        self.assertIsNone(self.cache.get('corrupt_key'))
 
     def test_atomic_write_no_partial(self):
         # Concurrent writers should not corrupt entries.


### PR DESCRIPTION
**Description of your changes:**

### Problem
In `sdk/python/kfp/local/cache.py`, the file-backed `LocalCache` engine handles task output caching for local execution (`kfp.local.init(...)`). Analysis of the local caching subsystem revealed 4 closely related defects:
1. **Absolute Local Artifact URIs in Cache Keys**: `LocalCache._serialize_value_for_key` incorporated `value.uri` (the absolute local path on disk). When running pipelines under different temporary directory roots, identical artifact inputs produced different cache keys (`hashlib.sha256`), causing cache misses across local execution sessions.
2. **Fragile Heterogeneous Artifact List Serialization**: `_serialize_output` checked `isinstance(value[0], dsl.Artifact)` to detect artifact lists. If a list contained leading `None` values or non-artifact elements before an artifact, the `__kfp_artifact_list__` marker was omitted, leaving outputs deserialized as raw dictionaries instead of `dsl.Artifact` objects.
3. **Unhandled Deserialization Exceptions**: `LocalCache.get(key)` invoked `_deserialize_outputs(serialized)` outside error handling. If a cache entry file was corrupted or malformed, `_deserialize_outputs` raised `KeyError` / `TypeError` / `ValueError` unhandled, crashing local task execution instead of treating it as a cache miss.
4. **File Replace Permission Contention**: `LocalCache.put(key, outputs)` raised unhandled `PermissionError` during atomic `os.replace` when concurrent reader threads/processes held file locks on Windows environments.

### Solution
1. **URI Normalization in Key Hashing**: Updated `_serialize_value_for_key` to normalize local artifact URIs (`os.path.basename(uri)`) so identical artifact content hashes consistently regardless of absolute pipeline root variations.
2. **Robust Heterogeneous Artifact List Serialization**: Updated `_serialize_output` to check `any(isinstance(x, dsl.Artifact) for x in value)` and serialize/deserialize all artifact elements within lists regardless of element order or leading `None` values.
3. **Graceful Cache Recovery**: Added exception handling in `LocalCache.get` for `(KeyError, TypeError, ValueError, AttributeError)` to log warnings and safely return `None` (cache miss) on corrupt cache entries.
4. **Permission Error Resilience**: Added `PermissionError` handling in `LocalCache.put` during atomic rename.
5. **Unit Tests**: Added 3 unit tests in `sdk/python/kfp/local/cache_test.py` covering local URI normalization, mixed artifact list roundtripping, and corrupted file recovery.

Fixes #13983

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
