### PR TITLE
fix(sdk): raise a clear error for v1 component outputs with an empty type. Fixes #13745

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -8,6 +8,8 @@
 
 ## Bug fixes and other changes
 
+* Raise a clear error instead of an `IndexError` when a v1 component output declares an empty `{}` type and is referenced by an `{outputPath: ...}` placeholder. Fixes #13745
+
 # 2.15.2
 
 ## Bug fixes and other changes

--- a/sdk/python/kfp/dsl/placeholders.py
+++ b/sdk/python/kfp/dsl/placeholders.py
@@ -374,6 +374,10 @@ def maybe_convert_v1_yaml_placeholder_to_v2_placeholder(
         for output in outputs:
             if output['name'] == first_value:
                 type_ = output.get('type')
+                if isinstance(type_, dict) and not type_:
+                    raise ValueError(
+                        f'Invalid empty type {{}} for output {first_value!r}. Specify a type name, such as type: String, or remove the type field.'
+                    )
                 is_parameter = type_utils.is_parameter_type(type_)
                 if is_parameter:
                     return OutputParameterPlaceholder(

--- a/sdk/python/kfp/dsl/structures_test.py
+++ b/sdk/python/kfp/dsl/structures_test.py
@@ -859,6 +859,24 @@ sdkVersion: kfp-2.0.0-alpha.2""")
             outputs=None)
         self.assertEqual(loaded_component_spec, component_spec)
 
+    def test_v1_output_with_empty_type_and_output_path_placeholder(self):
+        component_yaml_v1 = textwrap.dedent("""\
+            name: bad-comp
+            outputs:
+            - {name: out, type: {}}
+            implementation:
+              container:
+                image: python:3.11
+                command: [sh, -c]
+                args: [cp, {outputPath: out}, /tmp/x]
+            """)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Invalid empty type \{\} for output 'out'\. Specify a type name"
+        ):
+            structures.ComponentSpec.from_yaml_documents(component_yaml_v1)
+
 
 class TestNormalizeTimeString(parameterized.TestCase):
 

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -183,6 +183,8 @@ def is_parameter_type(type_name: Optional[Union[str, dict]]) -> bool:
     if isinstance(type_name, str):
         type_name = type_annotations.get_short_type_name(type_name)
     elif isinstance(type_name, dict):
+        if not type_name:
+            return False
         type_name = list(type_name.keys())[0]
     else:
         return False
@@ -208,7 +210,7 @@ def bundled_artifact_to_artifact_proto(
 
 def get_parameter_type(
     param_type: Optional[Union[Type, str, dict]]
-) -> 'pipeline_spec_pb2.ParameterType':
+) -> Optional['pipeline_spec_pb2.ParameterType']:
     """Get the IR I/O parameter type for the given ComponentSpec I/O type.
 
     Args:
@@ -216,7 +218,8 @@ def get_parameter_type(
         builtin type or a type name.
 
     Returns:
-      The enum value of the mapped IR I/O primitive type.
+      The enum value of the mapped IR I/O primitive type, or None if the type
+      does not map to a parameter type.
 
     Raises:
       AttributeError: if type_name is not a string type.
@@ -227,6 +230,8 @@ def get_parameter_type(
     if type(param_type) == type:
         type_name = param_type.__name__
     elif isinstance(param_type, dict):
+        if not param_type:
+            return None
         type_name = list(param_type.keys())[0]
     else:
         type_name = type_annotations.get_short_type_name(str(param_type))

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -91,6 +91,9 @@ class TypeUtilsTest(parameterized.TestCase):
         self.assertEqual(expected_result,
                          type_utils.is_parameter_type(type_name))
 
+    def test_is_parameter_type_empty_dict(self):
+        self.assertFalse(type_utils.is_parameter_type({}))
+
     @parameterized.parameters(
         {
             'given_type': 'Int',
@@ -180,6 +183,9 @@ class TypeUtilsTest(parameterized.TestCase):
     def test_get_parameter_type_invalid(self):
         with self.assertRaises(AttributeError):
             type_utils.get_parameter_type_schema(None)
+
+    def test_get_parameter_type_empty_dict(self):
+        self.assertIsNone(type_utils.get_parameter_type({}))
 
     @parameterized.parameters(
         {


### PR DESCRIPTION
**Description of your changes:**

Loading a v1 component YAML whose output declares an empty type (`type: {}`) and is referenced by an `{outputPath: ...}` placeholder crashed with an unhandled `IndexError: list index out of range`:

```yaml
name: bad-comp
outputs:
- {name: out, type: {}}
implementation:
  container:
    image: python:3.11
    command: [sh, -c]
    args: [cp, {outputPath: out}, /tmp/x]
```

`type_utils.is_parameter_type()` and `type_utils.get_parameter_type()` both assume a dict type has at least one key and index `list(...keys())[0]` unconditionally. `placeholders.maybe_convert_v1_yaml_placeholder_to_v2_placeholder()` reaches that code while deciding whether an `outputPath` placeholder maps to an output parameter or an output artifact.

Changes:

* `is_parameter_type({})` now returns `False` and `get_parameter_type({})` now returns `None`. Both stay total functions, so none of their other callers in the compiler, `pipeline_channel`, `pipeline_task` or `type_annotations` can start raising. `get_parameter_type_name()` already turns a `None` result into a descriptive `ValueError`, and `type_annotations.construct_type_for_inputpath_or_outputpath` already treats a falsy result as "not a parameter type".
* When an `outputPath` placeholder resolves to an output with an empty type, the loader raises a `ValueError` naming the output and stating how to fix the YAML. That call site is the only place where the output name is in scope, and it is the only code path whose behavior changes, so component YAML that loads today is unaffected.

The empty type is rejected rather than silently treated as an artifact because `type: {}` is usually a truncated dict type such as `{JsonObject: {...}}`, which is a parameter type. Degrading it to `system.Artifact` would quietly change the generated placeholder from `OutputParameterPlaceholder` to `OutputPathPlaceholder`.

Tests cover the empty-dict input to both `type_utils` helpers and an end-to-end load of the YAML from the issue.

Fixes #13745

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
