### PR TITLE
fix(sdk): load v1 component I/O names that YAML 1.1 resolves as booleans. Fixes #13756

### DIFF
--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -8,6 +8,8 @@
 
 ## Bug fixes and other changes
 
+* Load v1 component input and output names that YAML 1.1 resolves as booleans (`on`, `off`, `yes`, `no`) as strings instead of failing with a `TypeError`. Fixes #13756
+
 # 2.15.2
 
 ## Bug fixes and other changes

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -1084,9 +1084,71 @@ def load_documents_from_yaml(component_yaml: str) -> Tuple[dict, dict]:
     return pipeline_spec_dict, platform_spec_dict
 
 
+class _V1ComponentYamlLoader(yaml.SafeLoader):
+    """YAML loader that resolves booleans per the YAML 1.2 core schema.
+
+    PyYAML implements YAML 1.1, which resolves the unquoted scalars
+    ``on``, ``off``, ``yes`` and ``no`` to booleans. v1 component YAML
+    uses these words as ordinary strings, most commonly as input and
+    output names.
+    """
+
+
+def _drop_yaml_1_1_bool_resolvers() -> Dict[str, List[tuple]]:
+    """Builds implicit resolvers that only treat t/T/f/F scalars as bools.
+
+    This restricts implicit booleans to
+    true/True/TRUE/false/False/FALSE.
+    """
+    resolvers_by_first_char = {}
+    for first_char, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items(
+    ):
+        resolvers_by_first_char[first_char] = [
+            (tag, regexp)
+            for tag, regexp in resolvers
+            if tag != 'tag:yaml.org,2002:bool' or first_char in 'tTfF'
+        ]
+    return resolvers_by_first_char
+
+
+_V1ComponentYamlLoader.yaml_implicit_resolvers = _drop_yaml_1_1_bool_resolvers()
+
+_YAML_1_1_BOOL_STRINGS = {
+    'yes': True,
+    'no': False,
+    'on': True,
+    'off': False,
+}
+
+
+def _normalize_v1_io_specs(component_dict: Dict[str, Any]) -> None:
+    """Validates v1 I/O names and restores boolean ``optional`` values.
+
+    ``_V1ComponentYamlLoader`` keeps ``on``/``off``/``yes``/``no`` as
+    strings so that they can be used as I/O names. ``optional`` is
+    declared as a boolean, so the boolean meaning is restored for that
+    field only.
+    """
+    for field_name, io_kind in (('inputs', 'input'), ('outputs', 'output')):
+        for spec in component_dict.get(field_name) or []:
+            if not isinstance(spec, dict):
+                continue
+            name = spec.get('name')
+            if not isinstance(name, str):
+                raise ValueError(
+                    f'Invalid {io_kind} name {name!r} in the component YAML. Component {io_kind} names must be strings. Quote the name to keep it a string, such as name: "{name}".'
+                )
+            optional = spec.get('optional')
+            if isinstance(optional, str):
+                normalized = _YAML_1_1_BOOL_STRINGS.get(optional.lower())
+                if normalized is not None:
+                    spec['optional'] = normalized
+
+
 def _load_component_spec_from_component_text(
         text) -> v1_structures.ComponentSpec:
-    component_dict = yaml.safe_load(text)
+    component_dict = yaml.load(text, Loader=_V1ComponentYamlLoader)
+    _normalize_v1_io_specs(component_dict)
     component_spec = v1_structures.ComponentSpec.from_dict(component_dict)
 
     # Calculating hash digest for the component

--- a/sdk/python/kfp/dsl/structures_test.py
+++ b/sdk/python/kfp/dsl/structures_test.py
@@ -1113,6 +1113,112 @@ implementation:
         self.assertEqual(outputs['output4'].type, 'Dict')
 
 
+class TestLoadV1ComponentWithYamlBooleanNames(parameterized.TestCase):
+
+    @parameterized.parameters(['on', 'off', 'yes', 'no', 'On', 'OFF'])
+    def test_unquoted_boolean_like_input_name(self, name: str):
+        comp_text = textwrap.dedent(f"""\
+            name: test
+            inputs:
+            - {{name: {name}, type: String}}
+            implementation:
+              container:
+                image: alpine
+                command: [echo, {{inputValue: {name}}}]
+            """)
+
+        comp = components.load_component_from_text(comp_text)
+
+        sanitized_name = name.lower()
+        self.assertEqual(
+            list(comp.component_spec.inputs.keys()), [sanitized_name])
+        self.assertEqual(comp.component_spec.inputs[sanitized_name].type,
+                         'String')
+        self.assertEqual(comp.component_spec.implementation.container.command, [
+            'echo',
+            placeholders.InputValuePlaceholder(input_name=sanitized_name),
+        ])
+
+    @parameterized.parameters(['on', 'off', 'yes', 'no'])
+    def test_unquoted_boolean_like_output_name(self, name: str):
+        comp_text = textwrap.dedent(f"""\
+            name: test
+            outputs:
+            - {{name: {name}}}
+            implementation:
+              container:
+                image: alpine
+                command: [echo, {{outputPath: {name}}}]
+            """)
+
+        comp = components.load_component_from_text(comp_text)
+
+        self.assertEqual(list(comp.component_spec.outputs.keys()), [name])
+
+    def test_block_style_unquoted_boolean_like_input_name(self):
+        comp_text = textwrap.dedent("""\
+            name: test
+            inputs:
+            - name: off
+              type: String
+            implementation:
+              container:
+                image: alpine
+                command: [echo]
+            """)
+
+        comp = components.load_component_from_text(comp_text)
+
+        self.assertEqual(list(comp.component_spec.inputs.keys()), ['off'])
+
+    def test_unquoted_boolean_like_default_still_casts_to_bool(self):
+        comp_text = textwrap.dedent("""\
+            name: test
+            inputs:
+            - {name: val, type: Boolean, default: yes}
+            implementation:
+              container:
+                image: alpine
+                command: [echo, {inputValue: val}]
+            """)
+
+        comp = components.load_component_from_text(comp_text)
+
+        self.assertIs(comp.component_spec.inputs['val'].default, True)
+
+    def test_unquoted_boolean_like_optional_still_casts_to_bool(self):
+        comp_text = textwrap.dedent("""\
+            name: test
+            inputs:
+            - {name: val, type: String, optional: yes}
+            implementation:
+              container:
+                image: alpine
+                command: [echo, {inputValue: val}]
+            """)
+
+        comp = components.load_component_from_text(comp_text)
+
+        self.assertTrue(comp.component_spec.inputs['val'].optional)
+
+    def test_non_string_input_name_raises_clear_error(self):
+        comp_text = textwrap.dedent("""\
+            name: test
+            inputs:
+            - {name: 5, type: String}
+            implementation:
+              container:
+                image: alpine
+                command: [echo]
+            """)
+
+        with self.assertRaisesRegex(
+                ValueError,
+                r'Invalid input name 5 in the component YAML\. Component input names must be strings\.'
+        ):
+            components.load_component_from_text(comp_text)
+
+
 class TestLoadDocumentsFromYAML(unittest.TestCase):
 
     def test_no_documents(self):


### PR DESCRIPTION
**Description of your changes:**

`load_component_from_text` and `load_component_from_file` failed on v1 component YAML whose input or output name is one of the YAML 1.1 boolean words `on`, `off`, `yes` or `no`, in both flow style and block style:

```yaml
name: test
inputs:
- {name: off, type: String}
implementation:
  container:
    image: alpine
    command: [echo]
```

PyYAML implements YAML 1.1, so `yaml.safe_load` resolved those unquoted scalars to Python booleans before `v1_structures.ComponentSpec.from_dict` ran, producing a nested `TypeError`:

```
TypeError: Error: InputSpec.from_dict(struct={'name': False, 'type': 'String'}) failed with exception:
Error: Structure "False" is incompatible with type "<class 'str'>". ...
```

The same coercion also affects placeholders: `{inputValue: off}` became `{'inputValue': False}`, which then fails in `utils.sanitize_input_name` with `AttributeError: 'bool' object has no attribute 'lower'`. Repairing only the `name` fields would therefore not be enough, and `bool -> str` cannot recover the original spelling (`on`, `On`, `ON`, ...).

Changes, all scoped to `_load_component_spec_from_component_text`, the single entry point for v1 component text:

* `_V1ComponentYamlLoader` is a `yaml.SafeLoader` subclass whose implicit resolvers keep the boolean tag only for scalars starting with `t`/`T`/`f`/`F`. This matches the YAML 1.2 core schema: `true`/`false` still resolve to booleans, `null`/`~` still resolve to null, and `on`/`off`/`yes`/`no` stay strings.
* `_normalize_v1_io_specs` restores the boolean meaning of the `optional` field when it is written as `yes`/`no`/`on`/`off`, so component YAML that loads today keeps loading. `optional` is the only strictly boolean-typed field in `v1_structures`.
* The same pass raises a `ValueError` naming the offending input or output when a name is not a string, replacing the nested `TypeError` from `InputSpec.from_dict`.

Boolean-typed defaults are unaffected: `default: yes` now reaches `type_utils.deserialize_v1_component_yaml_default` as the string `'yes'`, and `bool_cast_fn`/`strtobool` already map `yes`/`no`/`on`/`off` to booleans, so the resulting default is still `True`. A `String`-typed input with `default: yes` changes from `'True'` to `'yes'`, which is the value the YAML actually spells.

`load_documents_from_yaml` and the v2 IR path are deliberately unchanged. Compiled IR YAML is emitted by PyYAML, whose emitter quotes scalars that would otherwise resolve to a non-string type, so IR round-trips correctly today.

Fixes #13756

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
