### PR TITLE
fix(backend): select the storage dialect by driver instead of always MySQL

### DIFF
--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -376,7 +376,24 @@ func InitDBClient(initConnectionTimeout time.Duration) *storage.DB {
 	if err != nil {
 		glog.Fatalf("Failed to retrieve *sql.DB from gorm.DB. Error: %v", err)
 	}
-	return storage.NewDB(newdb, storage.NewMySQLDialect())
+	return storage.NewDB(newdb, newStorageDialect(driverName))
+}
+
+// newStorageDialect returns the storage-layer dialect matching driverName. The
+// storage dialect is distinct from the SQLDialect used by the migration flow
+// above: it covers the query-building differences the stores rely on
+// (GROUP_CONCAT vs STRING_AGG, ON DUPLICATE KEY vs ON CONFLICT, UPDATE JOIN vs
+// UPDATE FROM, and driver-specific duplicate-key detection).
+func newStorageDialect(driverName string) storage.SQLDialect {
+	switch driverName {
+	case "mysql":
+		return storage.NewMySQLDialect()
+	case "pgx":
+		return storage.NewPostgreSQLDialect()
+	default:
+		glog.Fatalf("Driver %v is not supported, use \"mysql\" for MySQL, or \"pgx\" for PostgreSQL", driverName)
+		return nil
+	}
 }
 
 // Initializes Database driver. Use `driverName` to indicate which type of DB to use:

--- a/backend/src/apiserver/storage/db.go
+++ b/backend/src/apiserver/storage/db.go
@@ -17,13 +17,19 @@ package storage
 import (
 	"bytes"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/VividCortex/mysqlerr"
 	"github.com/go-sql-driver/mysql"
+	"github.com/jackc/pgx/v5/pgconn"
 	sqlite3 "github.com/mattn/go-sqlite3"
 )
+
+// pgUniqueViolation is the PostgreSQL SQLSTATE for a unique constraint
+// violation. See https://www.postgresql.org/docs/current/errcodes-appendix.html
+const pgUniqueViolation = "23505"
 
 // DB a struct wrapping plain sql library with SQL dialect, to solve any feature
 // difference between MySQL, which is used in production, and Sqlite, which is used
@@ -142,6 +148,55 @@ func (d SQLiteDialect) UpdateWithJointOrFrom(targetTable, joinTable, setClause, 
 	return fmt.Sprintf("UPDATE %s SET %s FROM %s WHERE %s AND %s", targetTable, setClause, joinTable, joinClause, whereClause)
 }
 
+// PostgreSQLDialect implements SQLDialect with PostgreSQL dialect implementation.
+type PostgreSQLDialect struct{}
+
+// GroupConcat uses STRING_AGG, PostgreSQL's equivalent of GROUP_CONCAT. Unlike
+// MySQL, the separator is a required argument, so an empty separator falls back
+// to the comma MySQL's GROUP_CONCAT defaults to. The expression is cast to text
+// because STRING_AGG has no implicit conversion from other types.
+func (d PostgreSQLDialect) GroupConcat(expr string, separator string) string {
+	if separator == "" {
+		separator = ","
+	}
+	return fmt.Sprintf("STRING_AGG(%s::text, '%s')", expr, separator)
+}
+
+// Concat uses the SQL-standard CONCAT function, which PostgreSQL supports.
+// Separators are single-quoted, since PostgreSQL reads double quotes as an
+// identifier rather than a string literal.
+func (d PostgreSQLDialect) Concat(exprs []string, separator string) string {
+	separatorSQL := ","
+	if separator != "" {
+		separatorSQL = fmt.Sprintf(`,'%s',`, separator)
+	}
+	return fmt.Sprintf("CONCAT(%s)", strings.Join(exprs, separatorSQL))
+}
+
+// IsDuplicateError reports whether err is a PostgreSQL unique-violation
+// (SQLSTATE 23505). errors.As is used because the pgx stdlib driver wraps
+// *pgconn.PgError before returning it through database/sql.
+func (d PostgreSQLDialect) IsDuplicateError(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation
+}
+
+func (d PostgreSQLDialect) SelectForUpdate(query string) string {
+	return query + " FOR UPDATE"
+}
+
+// Upsert uses INSERT ... ON CONFLICT DO UPDATE, which PostgreSQL shares with
+// SQLite, rather than MySQL's ON DUPLICATE KEY UPDATE.
+func (d PostgreSQLDialect) Upsert(query string, key string, overwrite bool, columns ...string) string {
+	return fmt.Sprintf("%v ON CONFLICT(%v) DO UPDATE SET %v", query, key, prepareUpdateSuffixPostgreSQL(columns, overwrite))
+}
+
+// UpdateWithJointOrFrom uses UPDATE ... FROM, which PostgreSQL shares with
+// SQLite, rather than MySQL's UPDATE ... INNER JOIN.
+func (d PostgreSQLDialect) UpdateWithJointOrFrom(targetTable, joinTable, setClause, joinClause, whereClause string) string {
+	return fmt.Sprintf("UPDATE %s SET %s FROM %s WHERE %s AND %s", targetTable, setClause, joinTable, joinClause, whereClause)
+}
+
 func NewMySQLDialect() MySQLDialect {
 	return MySQLDialect{}
 }
@@ -150,11 +205,32 @@ func NewSQLiteDialect() SQLiteDialect {
 	return SQLiteDialect{}
 }
 
+func NewPostgreSQLDialect() PostgreSQLDialect {
+	return PostgreSQLDialect{}
+}
+
 func prepareUpdateSuffixMySQL(columns []string, overwrite bool) string {
 	columnsExtended := make([]string, 0)
 	if overwrite {
 		for _, c := range columns {
 			columnsExtended = append(columnsExtended, fmt.Sprintf("%[1]v=VALUES(%[1]v)", c))
+		}
+	} else {
+		for _, c := range columns {
+			columnsExtended = append(columnsExtended, fmt.Sprintf("%[1]v=%[1]v", c))
+		}
+	}
+	return strings.Join(columnsExtended, ",")
+}
+
+// prepareUpdateSuffixPostgreSQL builds the SET clause of an ON CONFLICT DO
+// UPDATE. PostgreSQL spells the pseudo-table EXCLUDED, matching SQLite's
+// excluded, rather than MySQL's VALUES().
+func prepareUpdateSuffixPostgreSQL(columns []string, overwrite bool) string {
+	columnsExtended := make([]string, 0)
+	if overwrite {
+		for _, c := range columns {
+			columnsExtended = append(columnsExtended, fmt.Sprintf("%[1]v=EXCLUDED.%[1]v", c))
 		}
 	} else {
 		for _, c := range columns {

--- a/backend/src/apiserver/storage/db_test.go
+++ b/backend/src/apiserver/storage/db_test.go
@@ -15,8 +15,11 @@
 package storage
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -134,4 +137,106 @@ func TestSQLiteDialect_UpdateWithJointOrFrom(t *testing.T) {
 		"target_table.status = ?")
 	expectedQuery := `UPDATE target_table SET State = ? FROM other_table WHERE target_table.Name = other_table.Name AND target_table.status = ?`
 	assert.Equal(t, expectedQuery, actualQuery)
+}
+
+func TestPostgreSQLDialect_GroupConcat_WithSeparator(t *testing.T) {
+	postgresDialect := NewPostgreSQLDialect()
+
+	actualQuery := postgresDialect.GroupConcat("col1", ";")
+
+	expectedQuery := `STRING_AGG(col1::text, ';')`
+	assert.Equal(t, expectedQuery, actualQuery)
+}
+
+// PostgreSQL requires an explicit separator, so an empty one must fall back to
+// the comma that MySQL's GROUP_CONCAT uses by default rather than emitting a
+// single-argument STRING_AGG, which does not parse.
+func TestPostgreSQLDialect_GroupConcat_WithoutSeparator(t *testing.T) {
+	postgresDialect := NewPostgreSQLDialect()
+
+	actualQuery := postgresDialect.GroupConcat("col1", "")
+
+	expectedQuery := `STRING_AGG(col1::text, ',')`
+	assert.Equal(t, expectedQuery, actualQuery)
+}
+
+// Separators must be single-quoted: PostgreSQL reads a double-quoted token as
+// an identifier, not a string literal.
+func TestPostgreSQLDialect_Concat_WithSeparator(t *testing.T) {
+	postgresDialect := NewPostgreSQLDialect()
+
+	actualQuery := postgresDialect.Concat([]string{"col1", "col2"}, "-")
+
+	expectedQuery := `CONCAT(col1,'-',col2)`
+	assert.Equal(t, expectedQuery, actualQuery)
+}
+
+func TestPostgreSQLDialect_Concat_WithoutSeparator(t *testing.T) {
+	postgresDialect := NewPostgreSQLDialect()
+
+	actualQuery := postgresDialect.Concat([]string{"col1", "col2"}, "")
+
+	expectedQuery := `CONCAT(col1,col2)`
+	assert.Equal(t, expectedQuery, actualQuery)
+}
+
+func TestPostgreSQLDialect_Upsert_Overwrite(t *testing.T) {
+	postgresDialect := NewPostgreSQLDialect()
+
+	actualQuery := postgresDialect.Upsert("INSERT INTO tbl VALUES (?)", "UUID", true, "Name", "State")
+
+	expectedQuery := `INSERT INTO tbl VALUES (?) ON CONFLICT(UUID) DO UPDATE SET Name=EXCLUDED.Name,State=EXCLUDED.State`
+	assert.Equal(t, expectedQuery, actualQuery)
+}
+
+func TestPostgreSQLDialect_Upsert_NoOverwrite(t *testing.T) {
+	postgresDialect := NewPostgreSQLDialect()
+
+	actualQuery := postgresDialect.Upsert("INSERT INTO tbl VALUES (?)", "UUID", false, "Name")
+
+	expectedQuery := `INSERT INTO tbl VALUES (?) ON CONFLICT(UUID) DO UPDATE SET Name=Name`
+	assert.Equal(t, expectedQuery, actualQuery)
+}
+
+func TestPostgreSQLDialect_SelectForUpdate(t *testing.T) {
+	postgresDialect := NewPostgreSQLDialect()
+
+	assert.Equal(t, "SELECT * FROM tbl FOR UPDATE", postgresDialect.SelectForUpdate("SELECT * FROM tbl"))
+}
+
+// PostgreSQL uses UPDATE ... FROM, like SQLite, rather than MySQL's
+// UPDATE ... INNER JOIN.
+func TestPostgreSQLDialect_UpdateWithJointOrFrom(t *testing.T) {
+	postgresDialect := NewPostgreSQLDialect()
+	actualQuery := postgresDialect.UpdateWithJointOrFrom(
+		"target_table",
+		"other_table",
+		"State = ?",
+		"target_table.Name = other_table.Name",
+		"target_table.status = ?")
+	expectedQuery := `UPDATE target_table SET State = ? FROM other_table WHERE target_table.Name = other_table.Name AND target_table.status = ?`
+	assert.Equal(t, expectedQuery, actualQuery)
+}
+
+func TestPostgreSQLDialect_IsDuplicateError(t *testing.T) {
+	postgresDialect := NewPostgreSQLDialect()
+
+	assert.True(t, postgresDialect.IsDuplicateError(&pgconn.PgError{Code: pgUniqueViolation}))
+	// A wrapped error must still be recognised: the pgx stdlib driver wraps
+	// *pgconn.PgError before it surfaces through database/sql.
+	assert.True(t, postgresDialect.IsDuplicateError(fmt.Errorf("insert failed: %w", &pgconn.PgError{Code: pgUniqueViolation})))
+
+	// A different SQLSTATE is not a duplicate-key error.
+	assert.False(t, postgresDialect.IsDuplicateError(&pgconn.PgError{Code: "23503"}))
+	assert.False(t, postgresDialect.IsDuplicateError(errors.New("some other failure")))
+	assert.False(t, postgresDialect.IsDuplicateError(nil))
+}
+
+// The MySQL dialect must not treat a PostgreSQL unique violation as a
+// duplicate-key error, which is what happened while every install used
+// MySQLDialect regardless of driver.
+func TestMySQLDialect_IsDuplicateError_IgnoresPostgresError(t *testing.T) {
+	mysqlDialect := NewMySQLDialect()
+
+	assert.False(t, mysqlDialect.IsDuplicateError(&pgconn.PgError{Code: pgUniqueViolation}))
 }


### PR DESCRIPTION
Part of #13956. This is a bug I found while scoping items 1 and 2 that the issue does not mention.

`initDBClient` ends with:

```go
return storage.NewDB(newdb, storage.NewMySQLDialect())
```

The dialect is hardcoded, so **every install gets `MySQLDialect` regardless of `driverName`** — including PostgreSQL installs, which reach this line through the `pgx` branch a few lines above.

## What that breaks

`storage.SQLDialect` exists specifically to paper over engine differences, and only `MySQLDialect` and `SQLiteDialect` implement it — there is no PostgreSQL implementation at all. So on a PostgreSQL install the stores emit MySQL-only SQL:

| Method | Emitted (MySQL) | PostgreSQL needs |
| --- | --- | --- |
| `GroupConcat` | `GROUP_CONCAT(x SEPARATOR "y")` | `STRING_AGG(x::text, 'y')` |
| `Concat` | `CONCAT(a,"y",b)` | `CONCAT(a,'y',b)` — double quotes are an identifier in PG |
| `Upsert` | `ON DUPLICATE KEY UPDATE c=VALUES(c)` | `ON CONFLICT(k) DO UPDATE SET c=EXCLUDED.c` |
| `UpdateWithJointOrFrom` | `UPDATE t INNER JOIN u ...` | `UPDATE t SET ... FROM u ...` |
| `IsDuplicateError` | asserts `*mysql.MySQLError` | `*pgconn.PgError`, SQLSTATE `23505` |

`IsDuplicateError` is the quiet one. A pgx error can never satisfy `err.(*mysql.MySQLError)`, so it returns `false` for every conflict and callers take the "not a duplicate" branch — no error, just wrong behaviour.

## Change

- Add `PostgreSQLDialect` implementing `SQLDialect`, plus `NewPostgreSQLDialect()`.
- Replace the hardcoded call with `newStorageDialect(driverName)`, which rejects unknown drivers with the same message `initDBDriver` already uses rather than silently defaulting to one engine.

Implementation notes:

- `STRING_AGG` requires an explicit separator, unlike `GROUP_CONCAT` which defaults to `,`. An empty separator falls back to `,` so the SQL keeps parsing and keeps MySQL's behaviour. A single-argument `STRING_AGG` does not parse; there is a test for this.
- Separators are single-quoted, since PostgreSQL reads a double-quoted token as an identifier rather than a string literal.
- `IsDuplicateError` uses `errors.As` because the pgx stdlib driver wraps `*pgconn.PgError` before it surfaces through `database/sql`. Tested with wrapped, bare, unrelated-SQLSTATE, non-PG, and nil errors.
- The SQLSTATE is a local `pgUniqueViolation` constant rather than adding a dependency on `jackc/pgerrcode` for one value.

## What this does *not* fix

This does not make the PostgreSQL overlay work, and it is not intended to. Still outstanding from #13956:

- **Item 1** — the storage call sites still build with squirrel's default `?` placeholders instead of the `$1` form the dialect in `client_manager/dialect.go` already defines.
- **Item 2** — identifier casing.
- The `Concat` call sites in `job_store.go:220` and `run_store.go:270,283,298` pass double-quoted SQL string literals (`` `"["` ``, `` `"]"` ``) which PostgreSQL reads as identifiers. That is caller-side and left alone here deliberately, rather than writing MySQL-only syntax into a new PostgreSQL dialect.

Those need the design decision discussed in https://github.com/kubeflow/pipelines/issues/13956#issuecomment-5223303540. This PR removes one independent layer: the stores now receive a dialect matching the engine they are talking to.

## Testing

10 new tests in `db_test.go` covering every `PostgreSQLDialect` method, both separator branches, both `Upsert` overwrite branches, and five `IsDuplicateError` cases. Plus a regression test asserting `MySQLDialect.IsDuplicateError` returns `false` for a PostgreSQL error, which is the bug being fixed.

```
ok  github.com/kubeflow/pipelines/backend/src/apiserver/storage         4.360s
ok  github.com/kubeflow/pipelines/backend/src/apiserver/client_manager  4.804s
```

Note for reproducing locally: the `storage` package needs `CGO_ENABLED=1`, since `SQLiteDialect.IsDuplicateError` uses `mattn/go-sqlite3`, which only exposes `sqlite3.Error` and `sqlite3.ErrConstraint` under cgo.

I have not run this against a live PostgreSQL instance — the remaining items above still prevent `ml-pipeline` from reaching Ready, so there is nothing end-to-end to verify against yet.
