### PR TITLE
feat(sdk): recognize pydantic BaseModel as a STRUCT parameter type

### DIFF
--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -577,6 +577,21 @@ def validate_bundled_artifact_type(type_: str) -> None:
     validate_schema_version(schema_version)
 
 
+def is_pydantic_basemodel_subclass(annotation: Any) -> bool:
+    """Check if annotation is a pydantic.BaseModel subclass.
+
+    Uses a lazy import so pydantic stays an optional dependency for
+    users who don't type-hint components with it.
+    """
+    if not isinstance(annotation, type):
+        return False
+    try:
+        import pydantic
+    except ImportError:
+        return False
+    return issubclass(annotation, pydantic.BaseModel)
+
+
 def _annotation_to_type_struct(annotation):
     if not annotation or annotation == inspect.Parameter.empty:
         return None
@@ -603,6 +618,8 @@ def _annotation_to_type_struct(annotation):
         return origin_type
 
     if isinstance(annotation, type):
+        if is_pydantic_basemodel_subclass(annotation):
+            return get_canonical_type_name_for_type(dict)
         type_struct = get_canonical_type_name_for_type(annotation)
         if type_struct:
             return type_struct

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -82,6 +82,47 @@ class _VertexDummy(artifact_types.Artifact):
         super().__init__(uri='uri', name='name', metadata={'dummy': '123'})
 
 
+try:
+    import pydantic
+except ImportError:
+    pydantic = None
+
+
+@unittest.skipIf(pydantic is None, 'pydantic is not installed')
+class TestPydanticBaseModelSupport(parameterized.TestCase):
+
+    def test_is_pydantic_basemodel_subclass_true(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        self.assertTrue(type_utils.is_pydantic_basemodel_subclass(MyModel))
+
+    def test_is_pydantic_basemodel_subclass_false_for_plain_class(self):
+        self.assertFalse(
+            type_utils.is_pydantic_basemodel_subclass(_ArbitraryClass))
+
+    def test_is_pydantic_basemodel_subclass_false_for_non_type(self):
+        self.assertFalse(type_utils.is_pydantic_basemodel_subclass('MyModel'))
+        self.assertFalse(type_utils.is_pydantic_basemodel_subclass(None))
+
+    def test_annotation_to_type_struct_for_pydantic_basemodel(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        self.assertEqual('Dict', type_utils._annotation_to_type_struct(MyModel))
+
+    def test_get_parameter_type_for_pydantic_basemodel_type_struct(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        type_struct = type_utils._annotation_to_type_struct(MyModel)
+        self.assertEqual(pb.ParameterType.STRUCT,
+                         type_utils.get_parameter_type(type_struct))
+
+
 class TypeUtilsTest(parameterized.TestCase):
 
     @parameterized.parameters([(item, True) for item in _PARAMETER_TYPES] +


### PR DESCRIPTION
**Description of your changes:**

First slice toward #10690. Component type hints that are a `pydantic.BaseModel` subclass are now recognized by the compiler and treated as a STRUCT parameter (the same bucket a plain `Dict` already goes into), instead of falling through to being misclassified as an artifact type. This is compile-time detection only, via a new `type_utils.is_pydantic_basemodel_subclass()` helper (lazy-imports pydantic so it stays an optional dependency) used in `_annotation_to_type_struct()`. Runtime validation/serialization in the executor is a separate follow-up PR. Covered by new unit tests, and the full `sdk/python/kfp/dsl` and `sdk/python/kfp/compiler` suites pass locally (902 passed).

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).