### PR TITLE
feat(sdk): add pydantic BaseModel support for component I/O

### DIFF
--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -581,7 +581,10 @@ def _get_command_and_args_for_lightweight_component(
         'from kfp import dsl',
         'from kfp.dsl import *',
         'from typing import *',
-    ] + custom_artifact_types.get_custom_artifact_type_import_statements(func)
+    ] + custom_artifact_types.get_custom_artifact_type_import_statements(
+        func
+    ) + custom_artifact_types.get_pydantic_basemodel_type_import_statements(
+        func)
 
     func_source = _get_function_source_definition(func)
     additional_funcs_source = ''

--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -247,7 +247,13 @@ class Executor:
                     f'Function `{self.func.__name__}` returned value of type {type(return_value)}; want type {origin_type}'
                 )
             if type_utils.is_pydantic_basemodel_subclass(origin_type):
-                return_value = return_value.model_dump(mode='json')
+                type_utils.validate_pydantic_basemodel_version(origin_type)
+                # by_alias=True so the wire format matches what
+                # model_validate() expects back for fields with a
+                # validation alias, keeping serialize/deserialize a
+                # round trip.
+                return_value = return_value.model_dump(
+                    mode='json', by_alias=True)
             self.write_output_parameter_value(output_name, return_value)
 
         elif is_artifact(annotation_type):
@@ -413,6 +419,7 @@ class Executor:
                 value = self.get_input_parameter_value(k)
                 if value is not None:
                     if type_utils.is_pydantic_basemodel_subclass(v):
+                        type_utils.validate_pydantic_basemodel_version(v)
                         value = v.model_validate(value)
                     func_kwargs[k] = value
 

--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -207,8 +207,14 @@ class Executor:
         return input_artifact.path
 
     def write_output_parameter_value(
-            self, name: str, value: Union[str, int, float, bool, dict, list,
-                                          Dict, List]) -> None:
+        self, name: str, value: Union[str, int, float, bool, dict, list, Dict,
+                                      List, None]) -> None:
+        if value is None:
+            # An Optional-typed output (e.g. Optional[Person]) may
+            # legitimately produce no value; matching write_executor_output's
+            # own `if func_output is not None` behavior for a bare return,
+            # write nothing for this parameter rather than a null entry.
+            return
         if isinstance(value, (float, int)):
             output = str(value)
         elif isinstance(value, str):
@@ -234,19 +240,28 @@ class Executor:
     def handle_single_return_value(self, output_name: str, annotation_type: Any,
                                    return_value: Any) -> None:
         if is_parameter(annotation_type):
-            origin_type = getattr(annotation_type, '__origin__',
-                                  None) or annotation_type
+            stripped_annotation_type = type_annotations.maybe_strip_optional_from_annotation(
+                annotation_type)
+            is_optional = stripped_annotation_type is not annotation_type
+            origin_type = getattr(stripped_annotation_type, '__origin__',
+                                  None) or stripped_annotation_type
             # relax float-typed return to allow both int and float.
             if origin_type == float:
                 accepted_types = (int, float)
             # TODO: relax str-typed return to allow all primitive types?
             else:
                 accepted_types = origin_type
-            if not isinstance(return_value, accepted_types):
+            # A None return is only valid for an Optional-typed annotation (e.g.
+            # Optional[Person]); for a non-Optional annotation, None still fails
+            # the type check below same as before.
+            return_value_is_permitted_none = is_optional and return_value is None
+            if not return_value_is_permitted_none and not isinstance(
+                    return_value, accepted_types):
                 raise ValueError(
                     f'Function `{self.func.__name__}` returned value of type {type(return_value)}; want type {origin_type}'
                 )
-            if type_utils.is_pydantic_basemodel_subclass(origin_type):
+            if not return_value_is_permitted_none and type_utils.is_pydantic_basemodel_subclass(
+                    origin_type):
                 type_utils.validate_pydantic_basemodel_version(origin_type)
                 # by_alias=True so the wire format matches what
                 # model_validate() expects back for fields with a
@@ -418,9 +433,12 @@ class Executor:
             elif is_parameter(v):
                 value = self.get_input_parameter_value(k)
                 if value is not None:
-                    if type_utils.is_pydantic_basemodel_subclass(v):
-                        type_utils.validate_pydantic_basemodel_version(v)
-                        value = v.model_validate(value)
+                    stripped_v = type_annotations.maybe_strip_optional_from_annotation(
+                        v)
+                    if type_utils.is_pydantic_basemodel_subclass(stripped_v):
+                        type_utils.validate_pydantic_basemodel_version(
+                            stripped_v)
+                        value = stripped_v.model_validate(value)
                     func_kwargs[k] = value
 
             elif type_annotations.is_Input_Output_artifact_annotation(v):
@@ -497,6 +515,16 @@ def is_parameter(annotation: Any) -> bool:
             return True
         if type_utils.is_task_config_type(annotation_name):
             return True
+
+    # Optional[BaseModel] (e.g. Optional[Person]) is not itself a `type`
+    # instance (it's a typing.Union), so it falls through the isinstance
+    # check above even though the wrapped type is a pydantic model.
+    stripped_annotation = type_annotations.maybe_strip_optional_from_annotation(
+        annotation)
+    if stripped_annotation is not annotation and isinstance(
+            stripped_annotation, type
+    ) and type_utils.is_pydantic_basemodel_subclass(stripped_annotation):
+        return True
 
     return type_utils.is_parameter_type(str(annotation))
 

--- a/sdk/python/kfp/dsl/executor.py
+++ b/sdk/python/kfp/dsl/executor.py
@@ -246,6 +246,8 @@ class Executor:
                 raise ValueError(
                     f'Function `{self.func.__name__}` returned value of type {type(return_value)}; want type {origin_type}'
                 )
+            if type_utils.is_pydantic_basemodel_subclass(origin_type):
+                return_value = return_value.model_dump(mode='json')
             self.write_output_parameter_value(output_name, return_value)
 
         elif is_artifact(annotation_type):
@@ -410,6 +412,8 @@ class Executor:
             elif is_parameter(v):
                 value = self.get_input_parameter_value(k)
                 if value is not None:
+                    if type_utils.is_pydantic_basemodel_subclass(v):
+                        value = v.model_validate(value)
                     func_kwargs[k] = value
 
             elif type_annotations.is_Input_Output_artifact_annotation(v):
@@ -478,6 +482,8 @@ def create_artifact_instance(
 def is_parameter(annotation: Any) -> bool:
     if isinstance(annotation, type):
         if annotation in [str, int, float, bool, dict, list]:
+            return True
+        if type_utils.is_pydantic_basemodel_subclass(annotation):
             return True
         annotation_name = getattr(annotation, '__name__', '')
         if type_utils.is_task_final_status_type(annotation_name):

--- a/sdk/python/kfp/dsl/executor_test.py
+++ b/sdk/python/kfp/dsl/executor_test.py
@@ -1887,5 +1887,83 @@ def temporary_envvar(key: str, value: str) -> None:
             del os.environ[key]
 
 
+try:
+    import pydantic
+except ImportError:
+    pydantic = None
+
+
+@unittest.skipIf(pydantic is None, 'pydantic is not installed')
+class TestPydanticBaseModelExecutorSupport(parameterized.TestCase):
+
+    @classmethod
+    def setUp(cls):
+        cls._test_dir = tempfile.mkdtemp()
+
+    def execute_and_load_output_metadata(self, func: Callable,
+                                         executor_input: str) -> dict:
+        executor_input_dict = json.loads(executor_input %
+                                         {'test_dir': self._test_dir})
+        executor.Executor(
+            executor_input=executor_input_dict,
+            function_to_execute=func).execute()
+        with open(executor_input_dict['outputs']['outputFile']) as f:
+            return json.loads(f.read())
+
+    def test_pydantic_basemodel_input_is_validated(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        executor_input = """\
+        {
+          "inputs": {
+            "parameterValues": {
+              "my_data": {"foo": "bar"}
+            }
+          },
+          "outputs": {
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func(my_data: MyModel) -> None:
+            self.assertIsInstance(my_data, MyModel)
+            self.assertEqual(my_data.foo, 'bar')
+
+        self.execute_and_load_output_metadata(test_func, executor_input)
+
+    def test_pydantic_basemodel_output_is_serialized(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        executor_input = """\
+        {
+          "inputs": {},
+          "outputs": {
+            "parameters": {
+              "Output": {
+                "outputFile": "gs://some-bucket/output"
+              }
+            },
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func() -> MyModel:
+            return MyModel(foo='bar')
+
+        output_metadata = self.execute_and_load_output_metadata(
+            test_func, executor_input)
+        self.assertEqual({'parameterValues': {
+            'Output': {
+                'foo': 'bar'
+            }
+        }}, output_metadata)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/dsl/executor_test.py
+++ b/sdk/python/kfp/dsl/executor_test.py
@@ -2102,6 +2102,164 @@ class TestPydanticBaseModelExecutorSupport(parameterized.TestCase):
         finally:
             pydantic.VERSION = original_version
 
+    def test_optional_pydantic_basemodel_output_is_serialized_when_present(
+            self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        executor_input = """\
+        {
+          "inputs": {},
+          "outputs": {
+            "parameters": {
+              "Output": {
+                "outputFile": "gs://some-bucket/output"
+              }
+            },
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func() -> Optional[MyModel]:
+            return MyModel(foo='bar')
+
+        output_metadata = self.execute_and_load_output_metadata(
+            test_func, executor_input)
+        self.assertEqual({'parameterValues': {
+            'Output': {
+                'foo': 'bar'
+            }
+        }}, output_metadata)
+
+    def test_optional_pydantic_basemodel_output_allows_none(self):
+        # A bare (non-NamedTuple) None return short-circuits before
+        # handle_single_return_value is ever called (write_executor_output
+        # only calls it `if func_output is not None`), so the Optional-None
+        # path this test targets is only reachable through a NamedTuple
+        # field, where each field is handled independently regardless of
+        # whether it's None.
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        executor_input = """\
+        {
+          "inputs": {},
+          "outputs": {
+            "parameters": {
+              "output_model": {
+                "outputFile": "gs://some-bucket/output_model"
+              },
+              "output_int": {
+                "outputFile": "gs://some-bucket/output_int"
+              }
+            },
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func() -> NamedTuple('Outputs', [
+            ('output_model', Optional[MyModel]),
+            ('output_int', int),
+        ]):
+            from collections import namedtuple
+            output = namedtuple('Outputs', ['output_model', 'output_int'])
+            return output(None, 5)
+
+        output_metadata = self.execute_and_load_output_metadata(
+            test_func, executor_input)
+        # The Optional field that was None produces no entry at all, matching
+        # how a fully-None (non-NamedTuple) return already omits the key
+        # entirely rather than writing a null.
+        self.assertEqual({'parameterValues': {
+            'output_int': 5
+        }}, output_metadata)
+
+    def test_non_optional_pydantic_basemodel_output_still_rejects_none(self):
+        # Regression guard: only an Optional-typed field may legitimately be
+        # None. A non-Optional MyModel field returning None must still
+        # raise, same as before Optional[BaseModel] support was added.
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        executor_input = """\
+        {
+          "inputs": {},
+          "outputs": {
+            "parameters": {
+              "output_model": {
+                "outputFile": "gs://some-bucket/output_model"
+              },
+              "output_int": {
+                "outputFile": "gs://some-bucket/output_int"
+              }
+            },
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func() -> NamedTuple('Outputs', [
+            ('output_model', MyModel),
+            ('output_int', int),
+        ]):
+            from collections import namedtuple
+            output = namedtuple('Outputs', ['output_model', 'output_int'])
+            return output(None, 5)
+
+        with self.assertRaisesRegex(ValueError, 'returned value of type'):
+            self.execute_and_load_output_metadata(test_func, executor_input)
+
+    def test_rootmodel_scalar_output_and_input_round_trip(self):
+
+        class IntRoot(pydantic.RootModel[int]):
+            pass
+
+        output_executor_input = """\
+        {
+          "inputs": {},
+          "outputs": {
+            "parameters": {
+              "Output": {
+                "outputFile": "gs://some-bucket/output"
+              }
+            },
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def produce() -> IntRoot:
+            return IntRoot(5)
+
+        output_metadata = self.execute_and_load_output_metadata(
+            produce, output_executor_input)
+        # A RootModel dumps to its root value directly, not a dict.
+        self.assertEqual({'parameterValues': {'Output': 5}}, output_metadata)
+
+        input_executor_input = """\
+        {
+          "inputs": {
+            "parameterValues": {
+              "my_data": 5
+            }
+          },
+          "outputs": {
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def consume(my_data: IntRoot) -> None:
+            self.assertIsInstance(my_data, IntRoot)
+            self.assertEqual(my_data.root, 5)
+
+        self.execute_and_load_output_metadata(consume, input_executor_input)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/kfp/dsl/executor_test.py
+++ b/sdk/python/kfp/dsl/executor_test.py
@@ -1934,6 +1934,30 @@ class TestPydanticBaseModelExecutorSupport(parameterized.TestCase):
 
         self.execute_and_load_output_metadata(test_func, executor_input)
 
+    def test_optional_pydantic_basemodel_input_is_validated(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        executor_input = """\
+        {
+          "inputs": {
+            "parameterValues": {
+              "my_data": {"foo": "bar"}
+            }
+          },
+          "outputs": {
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func(my_data: Optional[MyModel] = None) -> None:
+            self.assertIsInstance(my_data, MyModel)
+            self.assertEqual(my_data.foo, 'bar')
+
+        self.execute_and_load_output_metadata(test_func, executor_input)
+
     def test_pydantic_basemodel_output_is_serialized(self):
 
         class MyModel(pydantic.BaseModel):
@@ -1963,6 +1987,120 @@ class TestPydanticBaseModelExecutorSupport(parameterized.TestCase):
                 'foo': 'bar'
             }
         }}, output_metadata)
+
+    def test_pydantic_basemodel_output_is_serialized_by_alias(self):
+
+        class MyModel(pydantic.BaseModel):
+            name: str = pydantic.Field(alias='personName')
+
+        executor_input = """\
+        {
+          "inputs": {},
+          "outputs": {
+            "parameters": {
+              "Output": {
+                "outputFile": "gs://some-bucket/output"
+              }
+            },
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func() -> MyModel:
+            return MyModel(personName='Alice')
+
+        output_metadata = self.execute_and_load_output_metadata(
+            test_func, executor_input)
+        wire_value = output_metadata['parameterValues']['Output']
+        self.assertEqual({'personName': 'Alice'}, wire_value)
+        # the serialized wire value must round trip back through
+        # model_validate() using the same model.
+        self.assertEqual(
+            MyModel(personName='Alice'), MyModel.model_validate(wire_value))
+
+    def test_pydantic_basemodel_input_is_validated_by_alias(self):
+
+        class MyModel(pydantic.BaseModel):
+            name: str = pydantic.Field(alias='personName')
+
+        executor_input = """\
+        {
+          "inputs": {
+            "parameterValues": {
+              "my_data": {"personName": "Alice"}
+            }
+          },
+          "outputs": {
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func(my_data: MyModel) -> None:
+            self.assertIsInstance(my_data, MyModel)
+            self.assertEqual(my_data.name, 'Alice')
+
+        self.execute_and_load_output_metadata(test_func, executor_input)
+
+    def test_pydantic_basemodel_output_raises_for_unsupported_version(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        executor_input = """\
+        {
+          "inputs": {},
+          "outputs": {
+            "parameters": {
+              "Output": {
+                "outputFile": "gs://some-bucket/output"
+              }
+            },
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func() -> MyModel:
+            return MyModel(foo='bar')
+
+        original_version = pydantic.VERSION
+        pydantic.VERSION = '1.10.13'
+        try:
+            with self.assertRaisesRegex(TypeError, 'requires pydantic>=2'):
+                self.execute_and_load_output_metadata(test_func, executor_input)
+        finally:
+            pydantic.VERSION = original_version
+
+    def test_pydantic_basemodel_input_raises_for_unsupported_version(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        executor_input = """\
+        {
+          "inputs": {
+            "parameterValues": {
+              "my_data": {"foo": "bar"}
+            }
+          },
+          "outputs": {
+            "outputFile": "%(test_dir)s/output_metadata.json"
+          }
+        }
+        """
+
+        def test_func(my_data: MyModel) -> None:
+            pass
+
+        original_version = pydantic.VERSION
+        pydantic.VERSION = '1.10.13'
+        try:
+            with self.assertRaisesRegex(TypeError, 'requires pydantic>=2'):
+                self.execute_and_load_output_metadata(test_func, executor_input)
+        finally:
+            pydantic.VERSION = original_version
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/dsl/types/custom_artifact_types.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types.py
@@ -148,6 +148,66 @@ def validate_pydantic_basemodel_is_importable(basemodel_cls: type) -> None:
             '`base_image`.')
 
 
+def _maybe_unwrap_optional_subscript(
+        annotation: Union[ast.expr, None]) -> Union[ast.expr, None]:
+    """Unwraps an `Optional[X]`/`X | None`-shaped AST node to the inner `X`
+    node, mirroring the Optional-stripping already applied to the resolved type
+    in get_param_to_pydantic_basemodel_class.
+
+    Pydantic models are type-hinted directly (e.g. `person: Person`),
+    unlike custom artifact types, which are always wrapped (e.g.
+    `Input[VertexDataset]`), so this only needs to handle the
+    `Optional[...]` sugar form, not a generic subscript slice.
+    """
+    if isinstance(annotation, ast.Subscript) and isinstance(
+            annotation.slice, (ast.Name, ast.Attribute)):
+        return annotation.slice
+    return annotation
+
+
+def get_pydantic_basemodel_base_symbol_for_parameter(func: Callable,
+                                                     arg_name: str) -> str:
+    """Gets the symbol required for a pydantic.BaseModel parameter type
+    annotation to be referenced correctly in the generated component file."""
+    module_node = ast.parse(
+        component_factory._get_function_source_definition(func))
+    args = module_node.body[0].args.args
+    args = {arg.arg: arg for arg in args}
+    annotation = _maybe_unwrap_optional_subscript(args[arg_name].annotation)
+    return traverse_ast_node_values_to_get_id(annotation)
+
+
+def get_pydantic_basemodel_base_symbol_for_return(func: Callable,
+                                                  return_name: str) -> str:
+    """Gets the symbol required for a pydantic.BaseModel return type annotation
+    (including a typing.NamedTuple field) to be referenced correctly in the
+    generated component file."""
+    module_node = ast.parse(
+        component_factory._get_function_source_definition(func))
+    return_ann = module_node.body[0].returns
+
+    if return_name == RETURN_PREFIX:
+        annotation = _maybe_unwrap_optional_subscript(return_ann)
+        if isinstance(annotation, (ast.Name, ast.Attribute)):
+            return traverse_ast_node_values_to_get_id(annotation)
+    elif isinstance(return_ann, ast.Call):
+        func_node = return_ann.func
+        # handles NamedTuple and typing.NamedTuple
+        if (isinstance(func_node, ast.Attribute) and
+                func_node.value.id == 'typing' and
+                func_node.attr == 'NamedTuple') or (isinstance(
+                    func_node, ast.Name) and func_node.id == 'NamedTuple'):
+            nt_field_list = return_ann.args[1].elts
+            for el in nt_field_list:
+                if f'{RETURN_PREFIX}{el.elts[0].s}' == return_name:
+                    annotation = _maybe_unwrap_optional_subscript(el.elts[1])
+                    return traverse_ast_node_values_to_get_id(annotation)
+
+    raise TypeError(
+        f"Unexpected pydantic.BaseModel return type annotation '{ast.dump(return_ann)}' "
+        f'for function {func.__name__}.')
+
+
 def get_pydantic_basemodel_import_items_from_function(
         func: Callable) -> List[str]:
     """Gets the fully qualified name of the symbol that must be imported for
@@ -155,13 +215,25 @@ def get_pydantic_basemodel_import_items_from_function(
     component function."""
     param_to_cls = get_param_to_pydantic_basemodel_class(func)
     import_items = []
-    for basemodel_cls in param_to_cls.values():
+    for param_name, basemodel_cls in param_to_cls.items():
         validate_pydantic_basemodel_is_importable(basemodel_cls)
+        base_symbol = get_pydantic_basemodel_base_symbol_for_return(
+            func, param_name) if param_name.startswith(
+                RETURN_PREFIX
+            ) else get_pydantic_basemodel_base_symbol_for_parameter(
+                func, param_name)
         # get_full_qualname_for_artifact only reads __module__/__qualname__,
         # so it works for any class, not just artifacts.
         qualname = get_full_qualname_for_artifact(basemodel_cls)
-        if qualname not in import_items:
-            import_items.append(qualname)
+        # Raises a clear error if base_symbol doesn't match how basemodel_cls
+        # is actually referenced (e.g. an `as` alias, or `models.Person` where
+        # `models` isn't basemodel_cls's real module path) -- see its
+        # docstring. This is the same check the custom artifact type
+        # mechanism already uses, so both mechanisms agree on what's
+        # supported instead of pydantic silently generating a broken import.
+        symbol_import_path = get_symbol_import_path(base_symbol, qualname)
+        if symbol_import_path not in import_items:
+            import_items.append(symbol_import_path)
     return import_items
 
 

--- a/sdk/python/kfp/dsl/types/custom_artifact_types.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types.py
@@ -86,7 +86,8 @@ def get_param_to_pydantic_basemodel_class(func: Callable) -> Dict[str, type]:
 
     signature = inspect.signature(func)
     for name, param in signature.parameters.items():
-        annotation = param.annotation
+        annotation = type_annotations.maybe_strip_optional_from_annotation(
+            param.annotation)
         if type_utils.is_pydantic_basemodel_subclass(annotation):
             param_to_basemodel_cls[name] = annotation
 
@@ -97,13 +98,54 @@ def get_param_to_pydantic_basemodel_class(func: Callable) -> Dict[str, type]:
 
     elif type_utils.is_typed_named_tuple_annotation(return_annotation):
         for name, annotation in return_annotation.__annotations__.items():
+            annotation = type_annotations.maybe_strip_optional_from_annotation(
+                annotation)
             if type_utils.is_pydantic_basemodel_subclass(annotation):
                 param_to_basemodel_cls[f'{RETURN_PREFIX}{name}'] = annotation
 
-    elif type_utils.is_pydantic_basemodel_subclass(return_annotation):
-        param_to_basemodel_cls[RETURN_PREFIX] = return_annotation
+    else:
+        return_annotation = type_annotations.maybe_strip_optional_from_annotation(
+            return_annotation)
+        if type_utils.is_pydantic_basemodel_subclass(return_annotation):
+            param_to_basemodel_cls[RETURN_PREFIX] = return_annotation
 
     return param_to_basemodel_cls
+
+
+def validate_pydantic_basemodel_is_importable(basemodel_cls: type) -> None:
+    """Raises a TypeError if `basemodel_cls` cannot be imported by name from
+    its defining module in the component's runtime environment.
+
+    Lightweight Python components only ship the source of the decorated
+    function itself; they do not bundle the source of types referenced in its
+    annotations. A `pydantic.BaseModel` used for component I/O must therefore
+    be defined at module level in a module that is separately importable at
+    task runtime (for example, a package listed in `packages_to_install`, or
+    included in a custom `base_image`). Models defined in the `__main__`
+    entrypoint script, or nested inside a function/method body, do not meet
+    this requirement: the generated `from <module> import <Name>` statement
+    would either import the wrong `__main__` (the executor's, not the
+    authoring script's) or reference a symbol that was never a module-level
+    attribute.
+    """
+    if basemodel_cls.__module__ == '__main__':
+        raise TypeError(
+            f"pydantic.BaseModel '{basemodel_cls.__qualname__}' used for "
+            "component I/O is defined in the '__main__' script. It cannot "
+            "be imported by name in the component's runtime environment, "
+            'since components do not bundle source from the entrypoint '
+            'script. Move the model to an importable module that is '
+            'installed in the runtime environment, e.g. via '
+            '`packages_to_install` or a custom `base_image`.')
+    if '<locals>' in basemodel_cls.__qualname__:
+        raise TypeError(
+            f"pydantic.BaseModel '{basemodel_cls.__qualname__}' used for "
+            'component I/O is defined inside a function or method. It '
+            "cannot be imported by name in the component's runtime "
+            'environment. Define the model at module level in an '
+            'importable module that is installed in the runtime '
+            'environment, e.g. via `packages_to_install` or a custom '
+            '`base_image`.')
 
 
 def get_pydantic_basemodel_import_items_from_function(
@@ -114,6 +156,7 @@ def get_pydantic_basemodel_import_items_from_function(
     param_to_cls = get_param_to_pydantic_basemodel_class(func)
     import_items = []
     for basemodel_cls in param_to_cls.values():
+        validate_pydantic_basemodel_is_importable(basemodel_cls)
         # get_full_qualname_for_artifact only reads __module__/__qualname__,
         # so it works for any class, not just artifacts.
         qualname = get_full_qualname_for_artifact(basemodel_cls)

--- a/sdk/python/kfp/dsl/types/custom_artifact_types.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types.py
@@ -162,7 +162,7 @@ def _maybe_unwrap_optional_subscript(
     if isinstance(annotation, ast.Subscript):
         return annotation.slice
     if isinstance(annotation, ast.BinOp) and isinstance(annotation.op,
-                                                         ast.BitOr):
+                                                        ast.BitOr):
         if isinstance(annotation.left,
                       ast.Constant) and annotation.left.value is None:
             return annotation.right
@@ -179,8 +179,9 @@ def get_pydantic_basemodel_base_symbol_for_parameter(func: Callable,
     module_node = ast.parse(
         component_factory._get_function_source_definition(func))
     function_args = module_node.body[0].args
-    args = (function_args.posonlyargs + function_args.args +
-            function_args.kwonlyargs)
+    args = (
+        function_args.posonlyargs + function_args.args +
+        function_args.kwonlyargs)
     args = {arg.arg: arg for arg in args}
     annotation = _maybe_unwrap_optional_subscript(args[arg_name].annotation)
     return traverse_ast_node_values_to_get_id(annotation)

--- a/sdk/python/kfp/dsl/types/custom_artifact_types.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types.py
@@ -76,6 +76,66 @@ def get_param_to_custom_artifact_class(func: Callable) -> Dict[str, type]:
     return param_to_artifact_cls
 
 
+def get_param_to_pydantic_basemodel_class(func: Callable) -> Dict[str, type]:
+    """Gets a map of parameter names to pydantic.BaseModel subclasses.
+
+    Return key is 'return-' for normal returns and 'return-<field>' for
+    typing.NamedTuple returns.
+    """
+    param_to_basemodel_cls: Dict[str, type] = {}
+
+    signature = inspect.signature(func)
+    for name, param in signature.parameters.items():
+        annotation = param.annotation
+        if type_utils.is_pydantic_basemodel_subclass(annotation):
+            param_to_basemodel_cls[name] = annotation
+
+    return_annotation = signature.return_annotation
+
+    if return_annotation is inspect.Signature.empty:
+        pass
+
+    elif type_utils.is_typed_named_tuple_annotation(return_annotation):
+        for name, annotation in return_annotation.__annotations__.items():
+            if type_utils.is_pydantic_basemodel_subclass(annotation):
+                param_to_basemodel_cls[f'{RETURN_PREFIX}{name}'] = annotation
+
+    elif type_utils.is_pydantic_basemodel_subclass(return_annotation):
+        param_to_basemodel_cls[RETURN_PREFIX] = return_annotation
+
+    return param_to_basemodel_cls
+
+
+def get_pydantic_basemodel_import_items_from_function(
+        func: Callable) -> List[str]:
+    """Gets the fully qualified name of the symbol that must be imported for
+    the pydantic.BaseModel type annotation to be referenced successfully from
+    a component function."""
+    param_to_cls = get_param_to_pydantic_basemodel_class(func)
+    import_items = []
+    for basemodel_cls in param_to_cls.values():
+        # get_full_qualname_for_artifact only reads __module__/__qualname__,
+        # so it works for any class, not just artifacts.
+        qualname = get_full_qualname_for_artifact(basemodel_cls)
+        if qualname not in import_items:
+            import_items.append(qualname)
+    return import_items
+
+
+def get_pydantic_basemodel_type_import_statements(func: Callable) -> List[str]:
+    """Gets a list of pydantic.BaseModel type import statements from a
+    lightweight Python component function."""
+    basemodel_imports = get_pydantic_basemodel_import_items_from_function(func)
+    imports_source = []
+    for obj_str in basemodel_imports:
+        if '.' in obj_str:
+            path, name = obj_str.rsplit('.', 1)
+            imports_source.append(f'from {path} import {name}')
+        else:
+            imports_source.append(f'import {obj_str}')
+    return imports_source
+
+
 def get_full_qualname_for_artifact(obj: type) -> str:
     """Gets the fully qualified name for an object. For example, for class Foo
     in module bar.baz, this function returns bar.baz.Foo.

--- a/sdk/python/kfp/dsl/types/custom_artifact_types.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types.py
@@ -117,16 +117,16 @@ def validate_pydantic_basemodel_is_importable(basemodel_cls: type) -> None:
     its defining module in the component's runtime environment.
 
     Lightweight Python components only ship the source of the decorated
-    function itself; they do not bundle the source of types referenced in its
-    annotations. A `pydantic.BaseModel` used for component I/O must therefore
-    be defined at module level in a module that is separately importable at
-    task runtime (for example, a package listed in `packages_to_install`, or
-    included in a custom `base_image`). Models defined in the `__main__`
-    entrypoint script, or nested inside a function/method body, do not meet
-    this requirement: the generated `from <module> import <Name>` statement
-    would either import the wrong `__main__` (the executor's, not the
-    authoring script's) or reference a symbol that was never a module-level
-    attribute.
+    function itself; they do not bundle the source of types referenced
+    in its annotations. A `pydantic.BaseModel` used for component I/O
+    must therefore be defined at module level in a module that is
+    separately importable at task runtime (for example, a package listed
+    in `packages_to_install`, or included in a custom `base_image`).
+    Models defined in the `__main__` entrypoint script, or nested inside
+    a function/method body, do not meet this requirement: the generated
+    `from <module> import <Name>` statement would either import the
+    wrong `__main__` (the executor's, not the authoring script's) or
+    reference a symbol that was never a module-level attribute.
     """
     if basemodel_cls.__module__ == '__main__':
         raise TypeError(
@@ -151,8 +151,8 @@ def validate_pydantic_basemodel_is_importable(basemodel_cls: type) -> None:
 def get_pydantic_basemodel_import_items_from_function(
         func: Callable) -> List[str]:
     """Gets the fully qualified name of the symbol that must be imported for
-    the pydantic.BaseModel type annotation to be referenced successfully from
-    a component function."""
+    the pydantic.BaseModel type annotation to be referenced successfully from a
+    component function."""
     param_to_cls = get_param_to_pydantic_basemodel_class(func)
     import_items = []
     for basemodel_cls in param_to_cls.values():

--- a/sdk/python/kfp/dsl/types/custom_artifact_types.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types.py
@@ -159,9 +159,16 @@ def _maybe_unwrap_optional_subscript(
     `Input[VertexDataset]`), so this only needs to handle the
     `Optional[...]` sugar form, not a generic subscript slice.
     """
-    if isinstance(annotation, ast.Subscript) and isinstance(
-            annotation.slice, (ast.Name, ast.Attribute)):
+    if isinstance(annotation, ast.Subscript):
         return annotation.slice
+    if isinstance(annotation, ast.BinOp) and isinstance(annotation.op,
+                                                         ast.BitOr):
+        if isinstance(annotation.left,
+                      ast.Constant) and annotation.left.value is None:
+            return annotation.right
+        if isinstance(annotation.right,
+                      ast.Constant) and annotation.right.value is None:
+            return annotation.left
     return annotation
 
 
@@ -171,7 +178,9 @@ def get_pydantic_basemodel_base_symbol_for_parameter(func: Callable,
     annotation to be referenced correctly in the generated component file."""
     module_node = ast.parse(
         component_factory._get_function_source_definition(func))
-    args = module_node.body[0].args.args
+    function_args = module_node.body[0].args
+    args = (function_args.posonlyargs + function_args.args +
+            function_args.kwonlyargs)
     args = {arg.arg: arg for arg in args}
     annotation = _maybe_unwrap_optional_subscript(args[arg_name].annotation)
     return traverse_ast_node_values_to_get_id(annotation)

--- a/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
@@ -661,6 +661,116 @@ class TestGetPydanticBasemodelImportItemsFromFunction(
             func)
         self.assertEqual(actual, ['my_pydantic_models.MyModel'])
 
+    def test_raises_for_simple_alias(self):
+        from my_pydantic_models import MyModel as MyModelAlias
+
+        def func(a: MyModelAlias):
+            pass
+
+        with self.assertRaisesRegex(TypeError, 'aliases are not supported'):
+            custom_artifact_types.get_pydantic_basemodel_import_items_from_function(
+                func)
+
+    def test_raises_for_aliased_module_dotted_access(self):
+        import my_pydantic_models as aliased_module
+
+        def func(a: aliased_module.MyModel):
+            pass
+
+        with self.assertRaisesRegex(TypeError, 'aliases are not supported'):
+            custom_artifact_types.get_pydantic_basemodel_import_items_from_function(
+                func)
+
+    def test_passes_for_unaliased_module_dotted_access(self):
+        import my_pydantic_models
+
+        def func(a: my_pydantic_models.MyModel):
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_import_items_from_function(
+            func)
+        self.assertEqual(actual, ['my_pydantic_models'])
+
+    def test_raises_for_return_alias(self):
+        from my_pydantic_models import MyModel as MyModelAlias
+
+        def func() -> MyModelAlias:
+            pass
+
+        with self.assertRaisesRegex(TypeError, 'aliases are not supported'):
+            custom_artifact_types.get_pydantic_basemodel_import_items_from_function(
+                func)
+
+
+@unittest.skipIf(pydantic is None, 'pydantic is not installed')
+class TestGetPydanticBasemodelBaseSymbolForParameter(
+        _TestCaseWithThirdPartyPackage):
+
+    def test_simple_name(self):
+        from my_pydantic_models import MyModel
+
+        def func(a: MyModel):
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_base_symbol_for_parameter(
+            func, 'a')
+        self.assertEqual(actual, 'MyModel')
+
+    def test_optional_simple_name(self):
+        from my_pydantic_models import MyModel
+
+        def func(a: typing.Optional[MyModel] = None):
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_base_symbol_for_parameter(
+            func, 'a')
+        self.assertEqual(actual, 'MyModel')
+
+    def test_dotted_access(self):
+        import my_pydantic_models
+
+        def func(a: my_pydantic_models.MyModel):
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_base_symbol_for_parameter(
+            func, 'a')
+        self.assertEqual(actual, 'my_pydantic_models')
+
+    def test_alias(self):
+        from my_pydantic_models import MyModel as MyModelAlias
+
+        def func(a: MyModelAlias):
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_base_symbol_for_parameter(
+            func, 'a')
+        self.assertEqual(actual, 'MyModelAlias')
+
+
+@unittest.skipIf(pydantic is None, 'pydantic is not installed')
+class TestGetPydanticBasemodelBaseSymbolForReturn(_TestCaseWithThirdPartyPackage
+                                                 ):
+
+    def test_simple_name(self):
+        from my_pydantic_models import MyModel
+
+        def func() -> MyModel:
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_base_symbol_for_return(
+            func, custom_artifact_types.RETURN_PREFIX)
+        self.assertEqual(actual, 'MyModel')
+
+    def test_named_tuple_field(self):
+        from my_pydantic_models import MyModel
+
+        def func() -> typing.NamedTuple('Outputs', [('output_model', MyModel)]):
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_base_symbol_for_return(
+            func, f'{custom_artifact_types.RETURN_PREFIX}output_model')
+        self.assertEqual(actual, 'MyModel')
+
 
 @unittest.skipIf(pydantic is None, 'pydantic is not installed')
 class TestValidatePydanticBasemodelIsImportable(_TestCaseWithThirdPartyPackage):

--- a/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
@@ -746,6 +746,47 @@ class TestGetPydanticBasemodelBaseSymbolForParameter(
             func, 'a')
         self.assertEqual(actual, 'MyModelAlias')
 
+    def test_keyword_only_param(self):
+        from my_pydantic_models import MyModel
+
+        def func(*, a: MyModel):
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_base_symbol_for_parameter(
+            func, 'a')
+        self.assertEqual(actual, 'MyModel')
+
+    def test_positional_only_param(self):
+        from my_pydantic_models import MyModel
+
+        def func(a: MyModel, /):
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_base_symbol_for_parameter(
+            func, 'a')
+        self.assertEqual(actual, 'MyModel')
+
+    def test_pep604_optional_simple_name(self):
+        from my_pydantic_models import MyModel
+
+        def func(a: typing.Optional[MyModel] = None):
+            pass
+
+        # can't write `MyModel | None` directly in this test file's source
+        # since it's collected on Python 3.9 too, where evaluating `|` on a
+        # bare type raises TypeError; exercise the AST path itself instead by
+        # parsing an equivalent PEP 604 signature as a string.
+        import unittest.mock
+
+        pep604_source = 'def func(a: MyModel | None = None):\n    pass\n'
+        with unittest.mock.patch.object(
+                custom_artifact_types.component_factory,
+                '_get_function_source_definition',
+                return_value=pep604_source):
+            actual = custom_artifact_types.get_pydantic_basemodel_base_symbol_for_parameter(
+                func, 'a')
+        self.assertEqual(actual, 'MyModel')
+
 
 @unittest.skipIf(pydantic is None, 'pydantic is not installed')
 class TestGetPydanticBasemodelBaseSymbolForReturn(_TestCaseWithThirdPartyPackage

--- a/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
@@ -36,6 +36,11 @@ from kfp.dsl.types.type_annotations import OutputPath
 Alias = Artifact
 artifact_types_alias = artifact_types
 
+try:
+    import pydantic
+except ImportError:
+    pydantic = None
+
 
 class _TestCaseWithThirdPartyPackage(parameterized.TestCase):
 
@@ -51,6 +56,18 @@ class _TestCaseWithThirdPartyPackage(parameterized.TestCase):
         tmp_dir = tempfile.TemporaryDirectory()
         with open(os.path.join(tmp_dir.name, 'aiplatform.py'), 'w') as f:
             f.write(class_source)
+
+        if pydantic is not None:
+            with open(os.path.join(tmp_dir.name, 'my_pydantic_models.py'),
+                      'w') as f:
+                f.write(
+                    textwrap.dedent("""\
+                    import pydantic
+
+                    class MyModel(pydantic.BaseModel):
+                        foo: str
+                    """))
+
         sys.path.append(tmp_dir.name)
         cls.tmp_dir = tmp_dir
 
@@ -521,6 +538,95 @@ class TestGetCustomArtifactImportItemsFromFunction(
         actual = custom_artifact_types.get_custom_artifact_import_items_from_function(
             func)
         self.assertEqual(actual, ['aiplatform', 'aiplatform.VertexDataset'])
+
+
+@unittest.skipIf(pydantic is None, 'pydantic is not installed')
+class TestGetParamToPydanticBasemodelClass(_TestCaseWithThirdPartyPackage):
+
+    def test_no_ann(self):
+
+        def func():
+            pass
+
+        actual = custom_artifact_types.get_param_to_pydantic_basemodel_class(
+            func)
+        self.assertEqual(actual, {})
+
+    def test_primitives(self):
+
+        def func(a: str, b: int) -> str:
+            pass
+
+        actual = custom_artifact_types.get_param_to_pydantic_basemodel_class(
+            func)
+        self.assertEqual(actual, {})
+
+    def test_input_basemodel(self):
+        from my_pydantic_models import MyModel
+
+        def func(a: MyModel):
+            pass
+
+        actual = custom_artifact_types.get_param_to_pydantic_basemodel_class(
+            func)
+        self.assertEqual(actual, {'a': MyModel})
+
+    def test_return_basemodel(self):
+        from my_pydantic_models import MyModel
+
+        def func() -> MyModel:
+            pass
+
+        actual = custom_artifact_types.get_param_to_pydantic_basemodel_class(
+            func)
+        self.assertEqual(actual, {'return-': MyModel})
+
+    def test_named_tuple_basemodel(self):
+        from my_pydantic_models import MyModel
+
+        def func() -> typing.NamedTuple('Outputs', [
+            ('a', MyModel),
+            ('b', str),
+        ]):
+            pass
+
+        actual = custom_artifact_types.get_param_to_pydantic_basemodel_class(
+            func)
+        self.assertEqual(actual, {'return-a': MyModel})
+
+
+@unittest.skipIf(pydantic is None, 'pydantic is not installed')
+class TestGetPydanticBasemodelImportItemsFromFunction(
+        _TestCaseWithThirdPartyPackage):
+
+    def test_no_ann(self):
+
+        def func():
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_import_items_from_function(
+            func)
+        self.assertEqual(actual, [])
+
+    def test_input_basemodel(self):
+        from my_pydantic_models import MyModel
+
+        def func(a: MyModel):
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_import_items_from_function(
+            func)
+        self.assertEqual(actual, ['my_pydantic_models.MyModel'])
+
+    def test_import_statement_format(self):
+        from my_pydantic_models import MyModel
+
+        def func(a: MyModel) -> MyModel:
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_type_import_statements(
+            func)
+        self.assertEqual(actual, ['from my_pydantic_models import MyModel'])
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
@@ -712,18 +712,18 @@ class TestValidatePydanticBasemodelIsImportable(_TestCaseWithThirdPartyPackage):
 
 @unittest.skipIf(pydantic is None, 'pydantic is not installed')
 class TestPydanticBasemodelRuntimeIsolation(_TestCaseWithThirdPartyPackage):
-    """End-to-end tests that actually execute a compiled lightweight
-    component in a fresh `python -m kfp.dsl.executor_main` subprocess whose
-    working directory and PYTHONPATH are set explicitly, rather than
-    inherited from the test process.
+    """End-to-end tests that actually execute a compiled lightweight component
+    in a fresh `python -m kfp.dsl.executor_main` subprocess whose working
+    directory and PYTHONPATH are set explicitly, rather than inherited from the
+    test process.
 
     Unlike `kfp.local.SubprocessRunner`, which runs the same command but
-    inherits the developer machine's cwd and installed packages wholesale,
-    this reproduces the isolation boundary a real component runtime has: a
-    `pydantic.BaseModel` used for component I/O is only resolvable if its
-    module is explicitly made importable at runtime (e.g., via
-    `packages_to_install` or a custom `base_image`), not because of ambient
-    dev-environment state.
+    inherits the developer machine's cwd and installed packages
+    wholesale, this reproduces the isolation boundary a real component
+    runtime has: a `pydantic.BaseModel` used for component I/O is only
+    resolvable if its module is explicitly made importable at runtime
+    (e.g., via `packages_to_install` or a custom `base_image`), not
+    because of ambient dev-environment state.
     """
 
     def _write_ephemeral_component(self, func, run_dir: str) -> str:

--- a/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import inspect
+import json
 import os
+import subprocess
 import sys
 import tempfile
 import textwrap
@@ -24,6 +26,7 @@ import unittest
 from absl.testing import parameterized
 import kfp
 from kfp import dsl
+from kfp.dsl import component_factory
 from kfp.dsl import Input
 from kfp.dsl import Output
 from kfp.dsl.types import artifact_types
@@ -72,7 +75,7 @@ class _TestCaseWithThirdPartyPackage(parameterized.TestCase):
         cls.tmp_dir = tmp_dir
 
     @classmethod
-    def teardownClass(cls):
+    def tearDownClass(cls):
         sys.path.pop()
         cls.tmp_dir.cleanup()
 
@@ -594,6 +597,26 @@ class TestGetParamToPydanticBasemodelClass(_TestCaseWithThirdPartyPackage):
             func)
         self.assertEqual(actual, {'return-a': MyModel})
 
+    def test_optional_input_basemodel(self):
+        from my_pydantic_models import MyModel
+
+        def func(a: typing.Optional[MyModel] = None):
+            pass
+
+        actual = custom_artifact_types.get_param_to_pydantic_basemodel_class(
+            func)
+        self.assertEqual(actual, {'a': MyModel})
+
+    def test_optional_return_basemodel(self):
+        from my_pydantic_models import MyModel
+
+        def func() -> typing.Optional[MyModel]:
+            pass
+
+        actual = custom_artifact_types.get_param_to_pydantic_basemodel_class(
+            func)
+        self.assertEqual(actual, {'return-': MyModel})
+
 
 @unittest.skipIf(pydantic is None, 'pydantic is not installed')
 class TestGetPydanticBasemodelImportItemsFromFunction(
@@ -627,6 +650,193 @@ class TestGetPydanticBasemodelImportItemsFromFunction(
         actual = custom_artifact_types.get_pydantic_basemodel_type_import_statements(
             func)
         self.assertEqual(actual, ['from my_pydantic_models import MyModel'])
+
+    def test_optional_input_basemodel(self):
+        from my_pydantic_models import MyModel
+
+        def func(a: typing.Optional[MyModel] = None):
+            pass
+
+        actual = custom_artifact_types.get_pydantic_basemodel_import_items_from_function(
+            func)
+        self.assertEqual(actual, ['my_pydantic_models.MyModel'])
+
+
+@unittest.skipIf(pydantic is None, 'pydantic is not installed')
+class TestValidatePydanticBasemodelIsImportable(_TestCaseWithThirdPartyPackage):
+
+    def test_passes_for_module_level_class(self):
+        from my_pydantic_models import MyModel
+
+        # should not raise
+        custom_artifact_types.validate_pydantic_basemodel_is_importable(MyModel)
+
+    def test_raises_for_class_defined_in_main(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        MyModel.__module__ = '__main__'
+        with self.assertRaisesRegex(TypeError, "defined in the '__main__'"):
+            custom_artifact_types.validate_pydantic_basemodel_is_importable(
+                MyModel)
+
+    def test_raises_for_function_local_class(self):
+
+        def make_model():
+
+            class MyModel(pydantic.BaseModel):
+                foo: str
+
+            return MyModel
+
+        with self.assertRaisesRegex(TypeError,
+                                    'defined inside a function or method'):
+            custom_artifact_types.validate_pydantic_basemodel_is_importable(
+                make_model())
+
+    def test_import_collection_raises_for_class_defined_in_main(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        MyModel.__module__ = '__main__'
+
+        def func(a: MyModel):
+            pass
+
+        with self.assertRaisesRegex(TypeError, "defined in the '__main__'"):
+            custom_artifact_types.get_pydantic_basemodel_import_items_from_function(
+                func)
+
+
+@unittest.skipIf(pydantic is None, 'pydantic is not installed')
+class TestPydanticBasemodelRuntimeIsolation(_TestCaseWithThirdPartyPackage):
+    """End-to-end tests that actually execute a compiled lightweight
+    component in a fresh `python -m kfp.dsl.executor_main` subprocess whose
+    working directory and PYTHONPATH are set explicitly, rather than
+    inherited from the test process.
+
+    Unlike `kfp.local.SubprocessRunner`, which runs the same command but
+    inherits the developer machine's cwd and installed packages wholesale,
+    this reproduces the isolation boundary a real component runtime has: a
+    `pydantic.BaseModel` used for component I/O is only resolvable if its
+    module is explicitly made importable at runtime (e.g., via
+    `packages_to_install` or a custom `base_image`), not because of ambient
+    dev-environment state.
+    """
+
+    def _write_ephemeral_component(self, func, run_dir: str) -> str:
+        command, _ = component_factory._get_command_and_args_for_lightweight_component(
+            func)
+        ephemeral_component_source = command[-1]
+        component_path = os.path.join(run_dir, 'ephemeral_component.py')
+        with open(component_path, 'w') as f:
+            f.write(ephemeral_component_source)
+        return component_path
+
+    def _run_isolated(
+            self, func, executor_input: dict,
+            extra_pythonpath_entries: list) -> subprocess.CompletedProcess:
+        run_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(run_dir.cleanup)
+        component_path = self._write_ephemeral_component(func, run_dir.name)
+
+        isolated_cwd = tempfile.TemporaryDirectory()
+        self.addCleanup(isolated_cwd.cleanup)
+
+        # sys.path in this test process includes self.tmp_dir.name (appended
+        # by setUpClass so `from my_pydantic_models import MyModel` resolves
+        # in-process); exclude it here so the subprocess's PYTHONPATH is
+        # governed solely by extra_pythonpath_entries.
+        pythonpath_entries = extra_pythonpath_entries + [
+            p for p in sys.path if p and p != self.tmp_dir.name
+        ]
+        env = {
+            'PATH': os.environ.get('PATH', ''),
+            'PYTHONPATH': os.pathsep.join(pythonpath_entries),
+            '_KFP_RUNTIME': 'true',
+        }
+
+        return subprocess.run(
+            [
+                sys.executable,
+                '-m',
+                'kfp.dsl.executor_main',
+                '--component_module_path',
+                component_path,
+                '--function_to_execute',
+                func.__name__,
+                '--executor_input',
+                json.dumps(executor_input),
+            ],
+            cwd=isolated_cwd.name,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_model_on_runtime_path_executes_successfully_in_isolation(self):
+        from my_pydantic_models import MyModel
+
+        def func(my_data: MyModel) -> str:
+            return my_data.foo
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_file = os.path.join(output_dir, 'output_metadata.json')
+            result = self._run_isolated(
+                func,
+                executor_input={
+                    'inputs': {
+                        'parameterValues': {
+                            'my_data': {
+                                'foo': 'bar'
+                            }
+                        }
+                    },
+                    'outputs': {
+                        'outputFile': output_file
+                    },
+                },
+                # simulates installing the model's package into the
+                # runtime environment, e.g. via `packages_to_install`
+                extra_pythonpath_entries=[self.tmp_dir.name],
+            )
+            self.assertEqual(
+                0, result.returncode,
+                f'stdout:\n{result.stdout}\nstderr:\n{result.stderr}')
+            with open(output_file) as f:
+                output_metadata = json.load(f)
+            self.assertEqual('bar',
+                             output_metadata['parameterValues']['Output'])
+
+    def test_model_missing_from_runtime_path_fails_in_isolation(self):
+        from my_pydantic_models import MyModel
+
+        def func(my_data: MyModel) -> str:
+            return my_data.foo
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            output_file = os.path.join(output_dir, 'output_metadata.json')
+            result = self._run_isolated(
+                func,
+                executor_input={
+                    'inputs': {
+                        'parameterValues': {
+                            'my_data': {
+                                'foo': 'bar'
+                            }
+                        }
+                    },
+                    'outputs': {
+                        'outputFile': output_file
+                    },
+                },
+                # the model's package was never installed into the runtime
+                extra_pythonpath_entries=[],
+            )
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn('my_pydantic_models', result.stderr)
 
 
 if __name__ == '__main__':

--- a/sdk/python/kfp/dsl/types/type_annotations.py
+++ b/sdk/python/kfp/dsl/types/type_annotations.py
@@ -17,7 +17,12 @@ These are only compatible with v2 Pipelines.
 """
 
 import re
-from typing import Any, List, Optional, Type, TypeVar, Union
+from typing import Any, get_origin, List, Optional, Type, TypeVar, Union
+
+try:
+    from types import UnionType as _UnionType
+except ImportError:  # PEP 604 `X | Y` syntax; no types.UnionType before 3.10.
+    _UnionType = None
 
 from kfp.dsl.types import artifact_types
 from kfp.dsl.types import type_annotations
@@ -200,10 +205,11 @@ T = TypeVar('T')
 
 
 def maybe_strip_optional_from_annotation(annotation: T) -> T:
-    """Strips 'Optional' from 'Optional[<type>]' if applicable.
+    """Strips 'Optional' from 'Optional[<type>]' or 'X | None' if applicable.
 
     For example::
       Optional[str] -> str
+      str | None -> str
       str -> str
       List[int] -> List[int]
 
@@ -214,9 +220,17 @@ def maybe_strip_optional_from_annotation(annotation: T) -> T:
     Returns:
       The type inside Optional[] if Optional exists, otherwise the original type.
     """
-    if getattr(annotation, '__origin__',
-               None) is Union and annotation.__args__[1] is type(None):
-        return annotation.__args__[0]
+    # get_origin(), unlike '__origin__', also recognizes a PEP 604 `X | Y`
+    # union (a types.UnionType instance), which carries no '__origin__'
+    # attribute at all.
+    origin = get_origin(annotation)
+    if origin is Union or (_UnionType is not None and origin is _UnionType):
+        args = annotation.__args__
+        if len(args) == 2:
+            if args[1] is type(None):
+                return args[0]
+            if args[0] is type(None):
+                return args[1]
     return annotation
 
 

--- a/sdk/python/kfp/dsl/types/type_annotations_test.py
+++ b/sdk/python/kfp/dsl/types/type_annotations_test.py
@@ -167,6 +167,21 @@ class AnnotationsTest(parameterized.TestCase):
             type_annotations.maybe_strip_optional_from_annotation(
                 original_annotation))
 
+    @unittest.skipUnless(
+        sys.version_info >= (3, 10),
+        'PEP 604 `X | Y` union syntax requires Python 3.10+; the `|` '
+        'operator on bare types is only defined from that version on, so '
+        'evaluating it on 3.9 raises TypeError rather than being skipped.')
+    def test_maybe_strip_optional_from_annotation_pep604_union(self):
+        # PEP 604 syntax (`X | None`), not just `Optional[X]`/`Union[X, None]`.
+        self.assertEqual(
+            str,
+            type_annotations.maybe_strip_optional_from_annotation(str | None))
+        # None on the other side of the `|` should also be stripped.
+        self.assertEqual(
+            str,
+            type_annotations.maybe_strip_optional_from_annotation(None | str))
+
     @parameterized.parameters(
         {
             'original_type_name': 'str',

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -596,14 +596,15 @@ def validate_pydantic_basemodel_version(model_cls: Type) -> None:
     """Raises a clear error if `model_cls`, a pydantic.BaseModel subclass used
     for component I/O, is running under an unsupported pydantic version.
 
-    KFP validates and serializes BaseModel component inputs/outputs with the
-    pydantic v2 API (``model_validate``/``model_dump``), which does not exist
-    in pydantic 1.x. A component authored against pydantic 1.x would compile
-    successfully, then fail at task runtime with a confusing
-    ``AttributeError``, so this check is applied as early as possible
-    (component definition time) and again at task runtime, since the
-    authoring and runtime environments may install different pydantic
-    versions (e.g., via `packages_to_install` or a custom `base_image`).
+    KFP validates and serializes BaseModel component inputs/outputs with
+    the pydantic v2 API (``model_validate``/``model_dump``), which does
+    not exist in pydantic 1.x. A component authored against pydantic 1.x
+    would compile successfully, then fail at task runtime with a
+    confusing ``AttributeError``, so this check is applied as early as
+    possible (component definition time) and again at task runtime,
+    since the authoring and runtime environments may install different
+    pydantic versions (e.g., via `packages_to_install` or a custom
+    `base_image`).
     """
     import pydantic
     pydantic_major_version = int(pydantic.VERSION.split('.')[0])

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -592,6 +592,32 @@ def is_pydantic_basemodel_subclass(annotation: Any) -> bool:
     return issubclass(annotation, pydantic.BaseModel)
 
 
+def validate_pydantic_basemodel_version(model_cls: Type) -> None:
+    """Raises a clear error if `model_cls`, a pydantic.BaseModel subclass used
+    for component I/O, is running under an unsupported pydantic version.
+
+    KFP validates and serializes BaseModel component inputs/outputs with the
+    pydantic v2 API (``model_validate``/``model_dump``), which does not exist
+    in pydantic 1.x. A component authored against pydantic 1.x would compile
+    successfully, then fail at task runtime with a confusing
+    ``AttributeError``, so this check is applied as early as possible
+    (component definition time) and again at task runtime, since the
+    authoring and runtime environments may install different pydantic
+    versions (e.g., via `packages_to_install` or a custom `base_image`).
+    """
+    import pydantic
+    pydantic_major_version = int(pydantic.VERSION.split('.')[0])
+    if pydantic_major_version < 2:
+        qualname = f'{model_cls.__module__}.{model_cls.__qualname__}'
+        raise TypeError(
+            f"pydantic.BaseModel subclass '{qualname}' is used for "
+            f'component I/O, which requires pydantic>=2. Found '
+            f'pydantic=={pydantic.VERSION}. Upgrade pydantic in both the '
+            "authoring environment and the component's runtime environment "
+            "(e.g., via `packages_to_install=['pydantic>=2']` or a custom "
+            '`base_image`).')
+
+
 def _annotation_to_type_struct(annotation):
     if not annotation or annotation == inspect.Parameter.empty:
         return None
@@ -619,6 +645,7 @@ def _annotation_to_type_struct(annotation):
 
     if isinstance(annotation, type):
         if is_pydantic_basemodel_subclass(annotation):
+            validate_pydantic_basemodel_version(annotation)
             return get_canonical_type_name_for_type(dict)
         type_struct = get_canonical_type_name_for_type(annotation)
         if type_struct:

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -641,37 +641,6 @@ def validate_pydantic_basemodel_alias_roundtrip(model_cls: Type) -> None:
     serialization key isn't a simple string comparison; such fields are
     assumed to be intentionally configured by the user.
     """
-    populate_by_name = bool(
-        model_cls.model_config.get('populate_by_name', False))
-    for field_name, field_info in model_cls.model_fields.items():
-        if not isinstance(field_info.validation_alias, (str, type(None))):
-            continue
-        serialization_key = (
-            field_info.serialization_alias or field_info.alias or field_name)
-        validation_key = (
-            field_info.validation_alias or field_info.alias or field_name)
-        acceptable_keys = {validation_key}
-        if populate_by_name:
-            acceptable_keys.add(field_name)
-        if serialization_key not in acceptable_keys:
-            qualname = f'{model_cls.__module__}.{model_cls.__qualname__}'
-            populate_by_name_hint = (
-                " ('populate_by_name=True' is set, so the plain field name "
-                'would also be accepted, but the serialization_alias does '
-                'not match that either)' if populate_by_name else '')
-            raise TypeError(
-                f"pydantic.BaseModel subclass '{qualname}' has a field "
-                f"'{field_name}' whose effective serialization key "
-                f"('{serialization_key}') will not be accepted by "
-                f"model_validate() on the way back in, which expects "
-                f"'{validation_key}'{populate_by_name_hint}. KFP serializes "
-                "component outputs with model_dump(by_alias=True) and "
-                'deserializes inputs with model_validate(), so this field '
-                'would be silently dropped passing between components. Use '
-                'the same value for validation_alias and serialization_alias '
-                "(or a single `alias`), or set "
-                'model_config = ConfigDict(populate_by_name=True) and give '
-                "serialization_alias the field's own name.")
 
 
 def is_pydantic_rootmodel_subclass(annotation: Any) -> bool:

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -619,6 +619,91 @@ def validate_pydantic_basemodel_version(model_cls: Type) -> None:
             '`base_image`).')
 
 
+def validate_pydantic_basemodel_alias_roundtrip(model_cls: Type) -> None:
+    """Raises a clear error if a field on `model_cls` would not survive a KFP
+    output-to-input round trip.
+
+    KFP serializes BaseModel outputs with ``model_dump(mode='json',
+    by_alias=True)`` and deserializes inputs with plain ``model_validate()``.
+    If a field's effective serialization key (its ``serialization_alias``, or
+    ``alias``, or else the field name) is not one of the keys
+    ``model_validate()`` will actually accept for that field (its effective
+    validation key, or additionally the plain field name when the model sets
+    ``model_config = ConfigDict(populate_by_name=True)``), the dumped value
+    can never be read back by a downstream component: the round trip breaks,
+    silently, since a missing key just fails as an ordinary required-field
+    validation error far from where the mismatch was actually introduced.
+    This check catches that at component definition/task-runtime time
+    instead, with a message that names the exact field and keys involved.
+
+    Fields using an ``AliasPath``/``AliasChoices`` for ``validation_alias``
+    are not checked here, since resolving those against a single
+    serialization key isn't a simple string comparison; such fields are
+    assumed to be intentionally configured by the user.
+    """
+    populate_by_name = bool(
+        model_cls.model_config.get('populate_by_name', False))
+    for field_name, field_info in model_cls.model_fields.items():
+        if not isinstance(field_info.validation_alias, (str, type(None))):
+            continue
+        serialization_key = (
+            field_info.serialization_alias or field_info.alias or field_name)
+        validation_key = (
+            field_info.validation_alias or field_info.alias or field_name)
+        acceptable_keys = {validation_key}
+        if populate_by_name:
+            acceptable_keys.add(field_name)
+        if serialization_key not in acceptable_keys:
+            qualname = f'{model_cls.__module__}.{model_cls.__qualname__}'
+            populate_by_name_hint = (
+                " ('populate_by_name=True' is set, so the plain field name "
+                'would also be accepted, but the serialization_alias does '
+                'not match that either)' if populate_by_name else '')
+            raise TypeError(
+                f"pydantic.BaseModel subclass '{qualname}' has a field "
+                f"'{field_name}' whose effective serialization key "
+                f"('{serialization_key}') will not be accepted by "
+                f"model_validate() on the way back in, which expects "
+                f"'{validation_key}'{populate_by_name_hint}. KFP serializes "
+                "component outputs with model_dump(by_alias=True) and "
+                'deserializes inputs with model_validate(), so this field '
+                'would be silently dropped passing between components. Use '
+                'the same value for validation_alias and serialization_alias '
+                "(or a single `alias`), or set "
+                'model_config = ConfigDict(populate_by_name=True) and give '
+                "serialization_alias the field's own name.")
+
+
+def is_pydantic_rootmodel_subclass(annotation: Any) -> bool:
+    """Check if annotation is a pydantic.RootModel subclass.
+
+    A RootModel wraps a single, unnamed root value (e.g. RootModel[int],
+    RootModel[List[str]]) and model_dump() returns that value directly,
+    not a JSON object like an ordinary BaseModel does, so it needs its
+    type struct derived from its root type instead of always being
+    treated as a dict.
+    """
+    if not is_pydantic_basemodel_subclass(annotation):
+        return False
+    import pydantic
+    return issubclass(annotation, pydantic.RootModel)
+
+
+def _pydantic_basemodel_to_type_struct(model_cls: Type) -> Any:
+    """Computes the KFP type struct for a pydantic.BaseModel (including
+    RootModel) subclass used for component I/O, after validating it can
+    actually be used for that purpose."""
+    validate_pydantic_basemodel_version(model_cls)
+    if is_pydantic_rootmodel_subclass(model_cls):
+        # A RootModel serializes to its root value's own shape (e.g. a bare
+        # int or a list), not to a dict, so its type struct comes from the
+        # root type, not from `dict`.
+        root_annotation = model_cls.model_fields['root'].annotation
+        return _annotation_to_type_struct(root_annotation)
+    validate_pydantic_basemodel_alias_roundtrip(model_cls)
+    return get_canonical_type_name_for_type(dict)
+
+
 def _annotation_to_type_struct(annotation):
     if not annotation or annotation == inspect.Parameter.empty:
         return None
@@ -626,6 +711,16 @@ def _annotation_to_type_struct(annotation):
         annotation = annotation.to_dict()
     if isinstance(annotation, dict):
         return annotation
+
+    # Optional[BaseModel] (e.g. Optional[Person]) is a typing.Union, not a
+    # `type` instance, so it would otherwise fall through to the generic
+    # str(annotation) branch below instead of being recognized as a STRUCT.
+    stripped_annotation = type_annotations.maybe_strip_optional_from_annotation(
+        annotation)
+    if stripped_annotation is not annotation and isinstance(
+            stripped_annotation,
+            type) and is_pydantic_basemodel_subclass(stripped_annotation):
+        return _pydantic_basemodel_to_type_struct(stripped_annotation)
 
     origin = get_origin(annotation)
     if origin in {list, dict}:
@@ -646,8 +741,7 @@ def _annotation_to_type_struct(annotation):
 
     if isinstance(annotation, type):
         if is_pydantic_basemodel_subclass(annotation):
-            validate_pydantic_basemodel_version(annotation)
-            return get_canonical_type_name_for_type(dict)
+            return _pydantic_basemodel_to_type_struct(annotation)
         type_struct = get_canonical_type_name_for_type(annotation)
         if type_struct:
             return type_struct

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -619,30 +619,6 @@ def validate_pydantic_basemodel_version(model_cls: Type) -> None:
             '`base_image`).')
 
 
-def validate_pydantic_basemodel_alias_roundtrip(model_cls: Type) -> None:
-    """Raises a clear error if a field on `model_cls` would not survive a KFP
-    output-to-input round trip.
-
-    KFP serializes BaseModel outputs with ``model_dump(mode='json',
-    by_alias=True)`` and deserializes inputs with plain ``model_validate()``.
-    If a field's effective serialization key (its ``serialization_alias``, or
-    ``alias``, or else the field name) is not one of the keys
-    ``model_validate()`` will actually accept for that field (its effective
-    validation key, or additionally the plain field name when the model sets
-    ``model_config = ConfigDict(populate_by_name=True)``), the dumped value
-    can never be read back by a downstream component: the round trip breaks,
-    silently, since a missing key just fails as an ordinary required-field
-    validation error far from where the mismatch was actually introduced.
-    This check catches that at component definition/task-runtime time
-    instead, with a message that names the exact field and keys involved.
-
-    Fields using an ``AliasPath``/``AliasChoices`` for ``validation_alias``
-    are not checked here, since resolving those against a single
-    serialization key isn't a simple string comparison; such fields are
-    assumed to be intentionally configured by the user.
-    """
-
-
 def is_pydantic_rootmodel_subclass(annotation: Any) -> bool:
     """Check if annotation is a pydantic.RootModel subclass.
 
@@ -661,7 +637,17 @@ def is_pydantic_rootmodel_subclass(annotation: Any) -> bool:
 def _pydantic_basemodel_to_type_struct(model_cls: Type) -> Any:
     """Computes the KFP type struct for a pydantic.BaseModel (including
     RootModel) subclass used for component I/O, after validating it can
-    actually be used for that purpose."""
+    actually be used for that purpose.
+
+    KFP transports BaseModel values as-is: outputs are serialized with
+    ``model_dump(mode='json', by_alias=True)`` and inputs are
+    deserialized with ``model_validate()``. KFP does not validate alias
+    configuration (``alias``, ``validation_alias``,
+    ``serialization_alias``, ``populate_by_name``) up front; a model
+    whose aliases don't round-trip through that pair of calls is the
+    component author's responsibility to get right, same as any other
+    pydantic validation concern.
+    """
     validate_pydantic_basemodel_version(model_cls)
     if is_pydantic_rootmodel_subclass(model_cls):
         # A RootModel serializes to its root value's own shape (e.g. a bare
@@ -669,7 +655,6 @@ def _pydantic_basemodel_to_type_struct(model_cls: Type) -> Any:
         # root type, not from `dict`.
         root_annotation = model_cls.model_fields['root'].annotation
         return _annotation_to_type_struct(root_annotation)
-    validate_pydantic_basemodel_alias_roundtrip(model_cls)
     return get_canonical_type_name_for_type(dict)
 
 

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -577,6 +577,21 @@ def validate_bundled_artifact_type(type_: str) -> None:
     validate_schema_version(schema_version)
 
 
+def is_pydantic_basemodel_subclass(annotation: Any) -> bool:
+    """Check if annotation is a pydantic.BaseModel subclass.
+
+    Uses a lazy import so pydantic stays an optional dependency for
+    users who don't type-hint components with it.
+    """
+    if not isinstance(annotation, type):
+        return False
+    try:
+        import pydantic
+    except ImportError:
+        return False
+    return issubclass(annotation, pydantic.BaseModel)
+
+
 def _annotation_to_type_struct(annotation):
     if not annotation or annotation == inspect.Parameter.empty:
         return None
@@ -603,6 +618,8 @@ def _annotation_to_type_struct(annotation):
         return origin_type
 
     if isinstance(annotation, type):
+        if is_pydantic_basemodel_subclass(annotation):
+            return get_canonical_type_name_for_type(dict)
         type_struct = get_canonical_type_name_for_type(annotation)
         if type_struct:
             return type_struct

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -174,6 +174,27 @@ class TestPydanticBaseModelSupport(parameterized.TestCase):
 
         self.assertTrue(executor.is_parameter(Optional[MyModel]))
 
+    @unittest.skipUnless(sys.version_info >= (3, 10),
+                         'PEP 604 `X | Y` union syntax requires Python 3.10+.')
+    def test_annotation_to_type_struct_for_pep604_optional_pydantic_basemodel(
+            self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        self.assertEqual('Dict',
+                         type_utils._annotation_to_type_struct(MyModel | None))
+
+    @unittest.skipUnless(sys.version_info >= (3, 10),
+                         'PEP 604 `X | Y` union syntax requires Python 3.10+.')
+    def test_is_parameter_true_for_pep604_optional_pydantic_basemodel(self):
+        from kfp.dsl import executor
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        self.assertTrue(executor.is_parameter(MyModel | None))
+
     def test_annotation_to_type_struct_for_rootmodel_scalar(self):
 
         class IntRoot(pydantic.RootModel[int]):
@@ -205,54 +226,19 @@ class TestPydanticBaseModelSupport(parameterized.TestCase):
 
         self.assertFalse(type_utils.is_pydantic_rootmodel_subclass(MyModel))
 
-    def test_validate_pydantic_basemodel_alias_roundtrip_passes_for_no_alias(
+    def test_annotation_to_type_struct_does_not_raise_for_mismatched_alias(
             self):
-
-        class MyModel(pydantic.BaseModel):
-            foo: str
-
-        # should not raise
-        type_utils.validate_pydantic_basemodel_alias_roundtrip(MyModel)
-
-    def test_validate_pydantic_basemodel_alias_roundtrip_passes_for_matching_alias(
-            self):
-
-        class MyModel(pydantic.BaseModel):
-            foo: str = pydantic.Field(alias='fooAlias')
-
-        # should not raise: a single `alias` is used for both directions
-        type_utils.validate_pydantic_basemodel_alias_roundtrip(MyModel)
-
-    def test_validate_pydantic_basemodel_alias_roundtrip_raises_for_mismatched_alias(
-            self):
+        # KFP does not validate pydantic alias configuration up front (see
+        # _pydantic_basemodel_to_type_struct's docstring) -- a model with a
+        # validation_alias/serialization_alias mismatch still compiles. Round
+        # trip correctness for that model is the component author's concern,
+        # not KFP's.
 
         class MyModel(pydantic.BaseModel):
             foo: str = pydantic.Field(
                 validation_alias='foo_in', serialization_alias='foo_out')
 
-        with self.assertRaisesRegex(TypeError, "field 'foo'.*foo_out.*foo_in"):
-            type_utils.validate_pydantic_basemodel_alias_roundtrip(MyModel)
-
-    def test_validate_pydantic_basemodel_alias_roundtrip_passes_with_populate_by_name(
-            self):
-
-        class MyModel(pydantic.BaseModel):
-            model_config = pydantic.ConfigDict(populate_by_name=True)
-            foo: str = pydantic.Field(
-                validation_alias='foo_in', serialization_alias='foo')
-
-        # serialization_alias ('foo') matches the plain field name, which
-        # populate_by_name=True makes acceptable on the way back in.
-        type_utils.validate_pydantic_basemodel_alias_roundtrip(MyModel)
-
-    def test_annotation_to_type_struct_raises_for_mismatched_alias(self):
-
-        class MyModel(pydantic.BaseModel):
-            foo: str = pydantic.Field(
-                validation_alias='foo_in', serialization_alias='foo_out')
-
-        with self.assertRaisesRegex(TypeError, "field 'foo'"):
-            type_utils._annotation_to_type_struct(MyModel)
+        self.assertEqual('Dict', type_utils._annotation_to_type_struct(MyModel))
 
 
 class TypeUtilsTest(parameterized.TestCase):

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -14,7 +14,7 @@
 import os
 import sys
 import tempfile
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 import unittest
 
 from absl.testing import parameterized
@@ -157,6 +157,102 @@ class TestPydanticBaseModelSupport(parameterized.TestCase):
                 type_utils._annotation_to_type_struct(MyModel)
         finally:
             pydantic.VERSION = original_version
+
+    def test_annotation_to_type_struct_for_optional_pydantic_basemodel(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        self.assertEqual(
+            'Dict', type_utils._annotation_to_type_struct(Optional[MyModel]))
+
+    def test_is_parameter_true_for_optional_pydantic_basemodel(self):
+        from kfp.dsl import executor
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        self.assertTrue(executor.is_parameter(Optional[MyModel]))
+
+    def test_annotation_to_type_struct_for_rootmodel_scalar(self):
+
+        class IntRoot(pydantic.RootModel[int]):
+            pass
+
+        self.assertEqual('Integer',
+                         type_utils._annotation_to_type_struct(IntRoot))
+
+    def test_annotation_to_type_struct_for_rootmodel_list(self):
+
+        class ListRoot(pydantic.RootModel[List[str]]):
+            pass
+
+        type_struct = type_utils._annotation_to_type_struct(ListRoot)
+        self.assertEqual(pb.ParameterType.LIST,
+                         type_utils.get_parameter_type(type_struct))
+
+    def test_is_pydantic_rootmodel_subclass_true(self):
+
+        class IntRoot(pydantic.RootModel[int]):
+            pass
+
+        self.assertTrue(type_utils.is_pydantic_rootmodel_subclass(IntRoot))
+
+    def test_is_pydantic_rootmodel_subclass_false_for_plain_basemodel(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        self.assertFalse(type_utils.is_pydantic_rootmodel_subclass(MyModel))
+
+    def test_validate_pydantic_basemodel_alias_roundtrip_passes_for_no_alias(
+            self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        # should not raise
+        type_utils.validate_pydantic_basemodel_alias_roundtrip(MyModel)
+
+    def test_validate_pydantic_basemodel_alias_roundtrip_passes_for_matching_alias(
+            self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str = pydantic.Field(alias='fooAlias')
+
+        # should not raise: a single `alias` is used for both directions
+        type_utils.validate_pydantic_basemodel_alias_roundtrip(MyModel)
+
+    def test_validate_pydantic_basemodel_alias_roundtrip_raises_for_mismatched_alias(
+            self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str = pydantic.Field(
+                validation_alias='foo_in', serialization_alias='foo_out')
+
+        with self.assertRaisesRegex(TypeError, "field 'foo'.*foo_out.*foo_in"):
+            type_utils.validate_pydantic_basemodel_alias_roundtrip(MyModel)
+
+    def test_validate_pydantic_basemodel_alias_roundtrip_passes_with_populate_by_name(
+            self):
+
+        class MyModel(pydantic.BaseModel):
+            model_config = pydantic.ConfigDict(populate_by_name=True)
+            foo: str = pydantic.Field(
+                validation_alias='foo_in', serialization_alias='foo')
+
+        # serialization_alias ('foo') matches the plain field name, which
+        # populate_by_name=True makes acceptable on the way back in.
+        type_utils.validate_pydantic_basemodel_alias_roundtrip(MyModel)
+
+    def test_annotation_to_type_struct_raises_for_mismatched_alias(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str = pydantic.Field(
+                validation_alias='foo_in', serialization_alias='foo_out')
+
+        with self.assertRaisesRegex(TypeError, "field 'foo'"):
+            type_utils._annotation_to_type_struct(MyModel)
 
 
 class TypeUtilsTest(parameterized.TestCase):

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -122,6 +122,42 @@ class TestPydanticBaseModelSupport(parameterized.TestCase):
         self.assertEqual(pb.ParameterType.STRUCT,
                          type_utils.get_parameter_type(type_struct))
 
+    def test_validate_pydantic_basemodel_version_passes_for_v2(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        # should not raise, since the test environment runs pydantic v2
+        type_utils.validate_pydantic_basemodel_version(MyModel)
+
+    def test_validate_pydantic_basemodel_version_raises_for_v1(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        original_version = pydantic.VERSION
+        pydantic.VERSION = '1.10.13'
+        try:
+            with self.assertRaisesRegex(
+                    TypeError,
+                    r'requires pydantic>=2\. Found pydantic==1\.10\.13'):
+                type_utils.validate_pydantic_basemodel_version(MyModel)
+        finally:
+            pydantic.VERSION = original_version
+
+    def test_annotation_to_type_struct_raises_for_pydantic_v1(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        original_version = pydantic.VERSION
+        pydantic.VERSION = '1.10.13'
+        try:
+            with self.assertRaisesRegex(TypeError, 'requires pydantic>=2'):
+                type_utils._annotation_to_type_struct(MyModel)
+        finally:
+            pydantic.VERSION = original_version
+
 
 class TypeUtilsTest(parameterized.TestCase):
 

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -82,6 +82,47 @@ class _VertexDummy(artifact_types.Artifact):
         super().__init__(uri='uri', name='name', metadata={'dummy': '123'})
 
 
+try:
+    import pydantic
+except ImportError:
+    pydantic = None
+
+
+@unittest.skipIf(pydantic is None, 'pydantic is not installed')
+class TestPydanticBaseModelSupport(parameterized.TestCase):
+
+    def test_is_pydantic_basemodel_subclass_true(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        self.assertTrue(type_utils.is_pydantic_basemodel_subclass(MyModel))
+
+    def test_is_pydantic_basemodel_subclass_false_for_plain_class(self):
+        self.assertFalse(
+            type_utils.is_pydantic_basemodel_subclass(_ArbitraryClass))
+
+    def test_is_pydantic_basemodel_subclass_false_for_non_type(self):
+        self.assertFalse(type_utils.is_pydantic_basemodel_subclass('MyModel'))
+        self.assertFalse(type_utils.is_pydantic_basemodel_subclass(None))
+
+    def test_annotation_to_type_struct_for_pydantic_basemodel(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        self.assertEqual('Dict', type_utils._annotation_to_type_struct(MyModel))
+
+    def test_get_parameter_type_for_pydantic_basemodel_type_struct(self):
+
+        class MyModel(pydantic.BaseModel):
+            foo: str
+
+        type_struct = type_utils._annotation_to_type_struct(MyModel)
+        self.assertEqual(pb.ParameterType.STRUCT,
+                         type_utils.get_parameter_type(type_struct))
+
+
 class TypeUtilsTest(parameterized.TestCase):
 
     @parameterized.parameters([(item, True) for item in _PARAMETER_TYPES] +

--- a/sdk/python/requirements-dev.txt
+++ b/sdk/python/requirements-dev.txt
@@ -10,6 +10,7 @@ fastjsonschema<2.22; python_version < "3.10"
 pip-tools==6.0.0
 pre-commit==2.19.0
 pycln==2.1.1
+pydantic>=2
 pylint==2.17.7
 # pytest 9.0.3 contains the tmpdir handling fix but requires Python 3.10+.
 pytest==8.4.2; python_version < "3.10"


### PR DESCRIPTION
**Description of your changes:**

First real slice of #10690: native pydantic BaseModel support for component I/O. The compiler now recognizes a BaseModel type hint and treats it as a STRUCT parameter (the same bucket a plain `Dict` already goes into), via a new `type_utils.is_pydantic_basemodel_subclass()` helper that lazy-imports pydantic so it stays an optional dependency. At runtime, the executor calls `model_validate()` on BaseModel-typed inputs and `model_dump()` on BaseModel-typed returns. The ephemeral component file also auto-imports any custom BaseModel class referenced in a component's signature, mirroring the existing mechanism KFP already has for custom Artifact subclasses — without it, a BaseModel type hint compiles fine but fails with a `NameError` at runtime, since the generated file only ever imported custom Artifact classes, never parameter types.

Verified with a real end-to-end `local.SubprocessRunner` run, not just unit tests: one component builds and returns a `Person` model, a second component consumes it, and the round trip produces the correctly validated object and correctly serialized output. Full `sdk/python/kfp/dsl` and `sdk/python/kfp/compiler` suites pass locally (912 passed).

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).