### PR TITLE
fix(sdk): resolve kfp.dsl.pipeline_context circular import. Fixes #12522

### DIFF
--- a/sdk/python/kfp/dsl/base_component.py
+++ b/sdk/python/kfp/dsl/base_component.py
@@ -16,7 +16,6 @@
 import abc
 from typing import List
 
-from kfp.dsl import pipeline_context
 from kfp.dsl import pipeline_task
 from kfp.dsl import structures
 from kfp.dsl.types import type_utils
@@ -98,6 +97,7 @@ class BaseComponent(abc.ABC):
                 f'{self.name}() missing {len(missing_arguments)} required '
                 f'{argument_or_arguments}: {arguments}.')
 
+        from kfp.dsl import pipeline_context
         return pipeline_task.PipelineTask(
             component_spec=self.component_spec,
             args=task_inputs,

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import base64
 import dataclasses
 import errno

--- a/sdk/python/kfp/dsl/graph_component.py
+++ b/sdk/python/kfp/dsl/graph_component.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 """Pipeline as a component (aka graph component)."""
 
+from __future__ import annotations
+
 import inspect
 from typing import Callable, List, Optional
 import uuid
 
 from kfp import dsl
-from kfp.compiler import pipeline_spec_builder as builder
 from kfp.dsl import base_component
 from kfp.dsl import pipeline_channel
 from kfp.dsl import pipeline_config
@@ -73,6 +74,8 @@ class GraphComponent(base_component.BaseComponent):
         # templates
         pipeline_group = dsl_pipeline.groups[0]
         pipeline_group.name = uuid.uuid4().hex
+
+        from kfp.compiler import pipeline_spec_builder as builder
 
         pipeline_spec, platform_spec = builder.create_pipeline_spec(
             pipeline=dsl_pipeline,

--- a/sdk/python/kfp/dsl/graph_component_test.py
+++ b/sdk/python/kfp/dsl/graph_component_test.py
@@ -1,0 +1,69 @@
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for import order robustness of kfp.dsl.graph_component."""
+
+import os
+import subprocess
+import sys
+import unittest
+
+
+class GraphComponentImportTest(unittest.TestCase):
+    """Regression tests for https://github.com/kubeflow/pipelines/issues/12522.
+
+    Under ``_KFP_RUNTIME=true``, importing ``kfp.dsl.graph_component`` or
+    ``kfp.dsl.pipeline_context`` used to raise ``AttributeError: partially
+    initialized module 'kfp.dsl.pipeline_context' has no attribute 'Pipeline'``
+    because of a circular import between the kfp.dsl modules and the kfp.compiler
+    package.
+    """
+
+    def _run_in_subprocess(self, code: str) -> None:
+        env = os.environ.copy()
+        env['_KFP_RUNTIME'] = 'true'
+        result = subprocess.run(
+            [sys.executable, '-c', code],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f'Import failed.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}',
+        )
+
+    def test_import_graph_component_in_runtime_mode(self) -> None:
+        self._run_in_subprocess('import kfp.dsl.graph_component\n'
+                                'assert kfp.dsl.graph_component.GraphComponent')
+
+    def test_import_pipeline_context_in_runtime_mode(self) -> None:
+        self._run_in_subprocess('import kfp.dsl.pipeline_context\n'
+                                'assert kfp.dsl.pipeline_context.Pipeline')
+
+    def test_import_pipeline_context_inside_function_in_runtime_mode(
+            self) -> None:
+        self._run_in_subprocess('def task():\n'
+                                '    from kfp.dsl import pipeline_context\n'
+                                '    return pipeline_context.Pipeline\n'
+                                'task()')
+
+    def test_import_dsl_then_graph_component_in_runtime_mode(self) -> None:
+        self._run_in_subprocess('import kfp.dsl\n'
+                                'import kfp.dsl.graph_component\n'
+                                'assert kfp.dsl.graph_component.GraphComponent')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of your changes:**

Fixes #12522.

Under `_KFP_RUNTIME=true` (e.g., when the Kubeflow Pipelines runtime or Vertex AI executes a pipeline function), importing `kfp.dsl.graph_component` or `kfp.dsl.pipeline_context` raised:

```
AttributeError: partially initialized module 'kfp.dsl.pipeline_context' has no attribute 'Pipeline' (most likely due to a circular import)
```

The failure was caused by a circular import between the `kfp.dsl` package and the `kfp.compiler` package:

- `graph_component.py` imported `kfp.compiler.pipeline_spec_builder` at module import time, which pulls in `kfp.compiler.compiler_utils`, which imports `kfp.dsl.pipeline_context`, which imports `kfp.dsl.component_factory`, which imports `kfp.dsl.graph_component` (still partially initialized), and an eagerly evaluated return annotation (`-> graph_component.GraphComponent`) crashed.
- The regression was introduced by #12234, which added `_validate_workspace_requirements` with an eagerly evaluated `pipeline: pipeline_context.Pipeline` parameter annotation in `graph_component.py`.

Changes:

- `sdk/python/kfp/dsl/graph_component.py`: import `kfp.compiler.pipeline_spec_builder` lazily inside `__init__` instead of at module import time, breaking the circular import at its source; add `from __future__ import annotations` to defer annotation evaluation.
- `sdk/python/kfp/dsl/component_factory.py`: add `from __future__ import annotations` so the `-> graph_component.GraphComponent` return annotation is no longer evaluated eagerly.
- `sdk/python/kfp/dsl/base_component.py`: import `pipeline_context` lazily inside `__call__` (its only use), removing the `base_component -> pipeline_context -> component_factory -> container_component_class/python_component -> base_component` cycle from the DSL-internal import graph.
- `sdk/python/kfp/dsl/graph_component_test.py`: new regression test that imports `kfp.dsl.graph_component` and `kfp.dsl.pipeline_context` in subprocesses with `_KFP_RUNTIME=true`.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
