### PR TITLE
fix(backend): close and clean up temp CA bundle file in compileTempCABundleWithCustomCA

### DIFF
--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -739,6 +739,15 @@ func compileTempCABundleWithCustomCA(customCAPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// Always close the file handle, and remove the temp file if we return
+	// early due to an error after it was created.
+	succeeded := false
+	defer func() {
+		tmpCaBundle.Close()
+		if !succeeded {
+			os.Remove(tmpCaBundle.Name())
+		}
+	}()
 	var systemCaBundle []byte
 	for _, file := range systemCAs {
 		systemCaBundle, err = os.ReadFile(file)
@@ -765,6 +774,7 @@ func compileTempCABundleWithCustomCA(customCAPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	succeeded = true
 	// Return filepath for tmpCaBundle
 	return tmpCaBundle.Name(), nil
 }

--- a/backend/src/v2/component/launcher_v2_test.go
+++ b/backend/src/v2/component/launcher_v2_test.go
@@ -918,3 +918,37 @@ func Test_retrieve_artifact_path(t *testing.T) {
 		})
 	}
 }
+
+// Tests that compileTempCABundleWithCustomCA writes the custom CA into the
+// bundle and does not leak the temp file when it returns an error.
+func Test_compileTempCABundleWithCustomCA(t *testing.T) {
+	// Success case: the returned bundle should contain the custom CA content,
+	// and the temp file should be readable (i.e. properly closed/flushed).
+	customCA, err := os.CreateTemp("", "custom-ca-*.crt")
+	assert.Nil(t, err)
+	defer os.Remove(customCA.Name())
+	_, err = customCA.WriteString("custom-ca-content")
+	assert.Nil(t, err)
+	customCA.Close()
+
+	bundlePath, err := compileTempCABundleWithCustomCA(customCA.Name())
+	assert.Nil(t, err)
+	defer os.Remove(bundlePath)
+
+	content, err := os.ReadFile(bundlePath)
+	assert.Nil(t, err)
+	assert.Contains(t, string(content), "custom-ca-content")
+
+	// Failure case: an invalid custom CA path should not leave an orphaned
+	// ca-bundle-*.crt temp file behind.
+	pattern := filepath.Join(os.TempDir(), "ca-bundle-*.crt")
+	before, err := filepath.Glob(pattern)
+	assert.Nil(t, err)
+
+	_, err = compileTempCABundleWithCustomCA(filepath.Join(os.TempDir(), "does-not-exist.crt"))
+	assert.NotNil(t, err)
+
+	after, err := filepath.Glob(pattern)
+	assert.Nil(t, err)
+	assert.Equal(t, len(before), len(after), "compileTempCABundleWithCustomCA should not leave an orphaned temp file on error")
+}


### PR DESCRIPTION
Fixes #13998

compileTempCABundleWithCustomCA created a temp file via os.CreateTemp but never closed the file handle, and never removed the file on any error path after creation, leaving it orphaned on disk for the container's lifetime even on success.

Adds a defer that always closes the file handle and removes the temp file if the function returns early after creation.

Added Test_compileTempCABundleWithCustomCA covering the success path (bundle contains custom CA content, file closed and readable) and the failure path (invalid custom CA path leaves no orphaned ca-bundle-*.crt file).

go test ./backend/src/v2/component/ -v — all passing.