### PR TITLE
Fix (backend) : compileCmdAndArgs placeholder bug

### DIFF
--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -1050,6 +1050,9 @@ func fetchNonDefaultBuckets(
 
 func compileCmdAndArgs(executorInput *pipelinespec.ExecutorInput, cmd string, args []string) (string, []string, error) {
 	placeholders, err := getPlaceholders(executorInput)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get placeholders: %w", err)
+	}
 
 	executorInputJSON, err := protojson.Marshal(executorInput)
 	if err != nil {
@@ -1061,7 +1064,7 @@ func compileCmdAndArgs(executorInput *pipelinespec.ExecutorInput, cmd string, ar
 	compiledCmd := strings.ReplaceAll(cmd, executorInputJSONKey, executorInputJSONString)
 	compiledArgs := make([]string, 0, len(args))
 	for placeholder, replacement := range placeholders {
-		cmd = strings.ReplaceAll(cmd, placeholder, replacement)
+		compiledCmd = strings.ReplaceAll(compiledCmd, placeholder, replacement)
 	}
 	for _, arg := range args {
 		compiledArgTemplate := strings.ReplaceAll(arg, executorInputJSONKey, executorInputJSONString)


### PR DESCRIPTION
**Description of your changes:**
the `getplaceholders` error was never checked it was immediately overwritten by the error from the following `protojson.Marshal` call, so a failure in `getPlaceholders` would go unnoticed as long as Marshal succeeded.

the second change `compiledCmd` was computed from cmd before the placeholder-substitution loop ran. That loop then reassigned cmd (not compiledCmd), so the substituted result was discarded and the function returned a command string with only {{$}} replaced , any other placeholders (e.g. {{output_path}}) were left unsubstituted in cmd, while the same placeholders in args were correctly replaced. This meant unresolved template placeholders could leak into the actual executed command.

**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
