### PR TITLE
ci: derive generator tool versions from modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
     directories:
       - "/"
       - "/api"
+      - "/backend/api/tools"
       - "/kubernetes_platform"
       - "/third_party/ml-metadata"
       - "/test/tools/project-cleaner"

--- a/.github/resources/scripts/argo_version_consistency_test.py
+++ b/.github/resources/scripts/argo_version_consistency_test.py
@@ -48,12 +48,6 @@ class ArgoVersionConsistencyTest(unittest.TestCase):
         checks = (
             ('go.mod',
              r'github\.com/argoproj/argo-workflows/v\d+ (v\d+\.\d+\.\d+)'),
-            ('backend/Dockerfile', r'ARGO_VERSION=(v\d+\.\d+\.\d+)'),
-            (
-                'backend/src/common/types.go',
-                r'argo-workflows/v\d+@(v\d+\.\d+\.\d+)',
-            ),
-            ('test/install-argo-cli.sh', r'ARGO_VERSION=(v\d+\.\d+\.\d+)'),
             ('third_party/argo/UPGRADE.md', r'ARGO_TAG=(v\d+\.\d+\.\d+)'),
             (
                 'manifests/kustomize/third-party/argo/base/kustomization.yaml',
@@ -89,6 +83,25 @@ class ArgoVersionConsistencyTest(unittest.TestCase):
         for relative_path, pattern in checks:
             with self.subTest(path=relative_path):
                 self.assert_version_matches(relative_path, pattern)
+
+    def test_backend_dockerfile_derives_argo_cli_from_go_module(self):
+        contents = (REPOSITORY_ROOT / 'backend/Dockerfile').read_text(
+            encoding='utf-8')
+        self.assertIn(
+            "go list -mod=readonly -m -f '{{.Version}}' "
+            'github.com/argoproj/argo-workflows/v4',
+            contents,
+        )
+        self.assertIn('ARGO_VERSION="$(cat /tmp/argo-version)"', contents)
+
+    def test_argo_install_script_reads_canonical_version_file(self):
+        contents = (REPOSITORY_ROOT / 'test/install-argo-cli.sh').read_text(
+            encoding='utf-8')
+        self.assertIn(
+            'ARGO_VERSION="$(cat ${REPO_ROOT}/third_party/argo/VERSION)"',
+            contents,
+        )
+        self.assertNotRegex(contents, r'ARGO_VERSION=v\d+\.\d+\.\d+')
 
 
 if __name__ == '__main__':

--- a/.github/resources/scripts/generated_files_dependency_change.py
+++ b/.github/resources/scripts/generated_files_dependency_change.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Detect dependency-only changes that require generated-file validation."""
+
+import argparse
+from pathlib import PurePosixPath
+import subprocess
+
+
+TRACKED_MODULES = {
+    'go.mod': (
+        'github.com/grpc-ecosystem/grpc-gateway/v2',
+        'google.golang.org/grpc/cmd/protoc-gen-go-grpc',
+        'google.golang.org/protobuf',
+    ),
+    'backend/api/tools/go.mod': (
+        'github.com/go-swagger/go-swagger',
+    ),
+}
+
+
+def module_version(go_mod: str, module: str) -> str | None:
+    """Return a required module version from go.mod text."""
+    for line in go_mod.splitlines():
+        fields = line.split()
+        if len(fields) >= 2 and fields[0] == module:
+            return fields[1]
+        if len(fields) >= 3 and fields[:2] == ['require', module]:
+            return fields[2]
+    return None
+
+
+def is_go_module_metadata(path: str) -> bool:
+    return PurePosixPath(path).name in {'go.mod', 'go.sum'}
+
+
+def requires_validation(
+    changed_paths: list[str],
+    base_manifests: dict[str, str],
+    head_manifests: dict[str, str],
+) -> bool:
+    """Return whether generator inputs or tracked tool versions changed."""
+    if any(not is_go_module_metadata(path) for path in changed_paths):
+        return True
+
+    for manifest, modules in TRACKED_MODULES.items():
+        for module in modules:
+            if module_version(base_manifests[manifest], module) != module_version(
+                head_manifests[manifest], module
+            ):
+                return True
+    return False
+
+
+def git_output(*args: str) -> str:
+    return subprocess.run(
+        ('git', *args),
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout
+
+
+def git_file_at_ref(ref: str, path: str) -> str:
+    result = subprocess.run(
+        ('git', 'show', f'{ref}:{path}'),
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return result.stdout if result.returncode == 0 else ''
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--base', required=True)
+    parser.add_argument('--head', required=True)
+    args = parser.parse_args()
+
+    changed_paths = git_output(
+        'diff', '--name-only', args.base, args.head
+    ).splitlines()
+    base_manifests = {
+        path: git_file_at_ref(args.base, path) for path in TRACKED_MODULES
+    }
+    head_manifests = {
+        path: git_file_at_ref(args.head, path) for path in TRACKED_MODULES
+    }
+    print(str(requires_validation(
+        changed_paths, base_manifests, head_manifests
+    )).lower())
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/resources/scripts/generated_files_dependency_change_test.py
+++ b/.github/resources/scripts/generated_files_dependency_change_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for generated-file dependency change detection."""
+
+import unittest
+from pathlib import Path
+
+from generated_files_dependency_change import module_version
+from generated_files_dependency_change import requires_validation
+
+
+ROOT_BASE = """require (
+    github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
+    google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2
+    google.golang.org/protobuf v1.36.11
+)
+"""
+TOOLS_BASE = "require github.com/go-swagger/go-swagger v0.32.3\n"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def manifests(root: str = ROOT_BASE, tools: str = TOOLS_BASE) -> dict[str, str]:
+    return {
+        'go.mod': root,
+        'backend/api/tools/go.mod': tools,
+    }
+
+
+class GeneratedFilesDependencyChangeTest(unittest.TestCase):
+
+    def test_module_version_reads_require_block(self):
+        self.assertEqual(
+            module_version(
+                ROOT_BASE, 'github.com/grpc-ecosystem/grpc-gateway/v2'
+            ),
+            'v2.29.0',
+        )
+
+    def test_untracked_go_module_updates_skip_validation(self):
+        changed = [
+            'go.mod',
+            'go.sum',
+            'test/tools/project-cleaner/go.mod',
+            'test/tools/project-cleaner/go.sum',
+        ]
+        self.assertFalse(requires_validation(
+            changed, manifests(), manifests()
+        ))
+
+    def test_runtime_coupled_generator_update_requires_validation(self):
+        updated = ROOT_BASE.replace('v2.29.0', 'v2.30.0')
+        self.assertTrue(requires_validation(
+            ['go.mod', 'go.sum'], manifests(), manifests(root=updated)
+        ))
+
+    def test_standalone_generator_update_requires_validation(self):
+        updated = TOOLS_BASE.replace('v0.32.3', 'v0.33.0')
+        self.assertTrue(requires_validation(
+            ['backend/api/tools/go.mod'],
+            manifests(),
+            manifests(tools=updated),
+        ))
+
+    def test_existing_generator_input_requires_validation(self):
+        self.assertTrue(requires_validation(
+            ['backend/api/v2beta1/run.proto'], manifests(), manifests()
+        ))
+
+    def test_generator_version_sources_are_wired_to_automation(self):
+        dockerfile = (REPOSITORY_ROOT / 'backend/api/Dockerfile').read_text(
+            encoding='utf-8')
+        for removed_pin in (
+            'GRPC_GATEWAY_VERSION',
+            'GO_SWAGGER_VERSION',
+            'GRPC_VERSION',
+            'PROTOC_GEN_GO_GRPC',
+            'PROTOBUF_GO',
+        ):
+            self.assertNotIn(f'ENV {removed_pin}=', dockerfile)
+        self.assertIn('COPY go.mod /tmp/kfp-module/go.mod', dockerfile)
+        self.assertIn(
+            'COPY backend/api/tools/go.mod '
+            '/tmp/api-generator-tools/go.mod',
+            dockerfile,
+        )
+
+        dependabot = (REPOSITORY_ROOT / '.github/dependabot.yml').read_text(
+            encoding='utf-8')
+        self.assertIn('- "/backend/api/tools"', dependabot)
+
+        makefile = (REPOSITORY_ROOT / 'backend/api/Makefile').read_text(
+            encoding='utf-8')
+        self.assertIn(
+            '.image-built: Dockerfile ../../go.mod tools/go.mod', makefile
+        )
+
+    def test_workflow_runs_detector_and_preserves_required_check(self):
+        workflow = (
+            REPOSITORY_ROOT / '.github/workflows/validate-generated-files.yml'
+        ).read_text(encoding='utf-8')
+        self.assertIn("- 'go.mod'", workflow)
+        self.assertIn('generated_files_dependency_change.py', workflow)
+        self.assertIn('detect-generator-changes:', workflow)
+        self.assertIn('generate-and-check:', workflow)
+        self.assertIn('validate-generated-files:', workflow)
+
+        ci_scripts_workflow = (
+            REPOSITORY_ROOT / '.github/workflows/ci-scripts-tests.yml'
+        ).read_text(encoding='utf-8')
+        self.assertIn(
+            "- '.github/workflows/validate-generated-files.yml'",
+            ci_scripts_workflow,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/workflows/ci-scripts-tests.yml
+++ b/.github/workflows/ci-scripts-tests.yml
@@ -24,6 +24,7 @@ on:
       - '.github/workflows/create-manifest.yml'
       - '.github/workflows/e2e-test.yml'
       - '.github/workflows/image-builds.yml'
+      - '.github/workflows/validate-generated-files.yml'
       - '.github/workflows/ci-scripts-tests.yml'
       - '.github/workflows/gh-workflow-approve.yml'
       - 'manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml'

--- a/.github/workflows/validate-generated-files.yml
+++ b/.github/workflows/validate-generated-files.yml
@@ -6,9 +6,14 @@ on:
   pull_request:
     paths:
       - '.github/workflows/validate-generated-files.yml'
+      - '.github/resources/scripts/generated_files_dependency_change.py'
       - '.github/actions/setup-python-pip-cache/**'
+      - 'go.mod'
+      - 'go.sum'
       - 'backend/api/Dockerfile'
       - 'backend/api/Makefile'
+      - 'backend/api/tools/go.mod'
+      - 'backend/api/tools/go.sum'
       - 'backend/api/**/*.proto'
       - 'backend/api/**/go_http_client/**'
       - 'backend/api/**/go_client/**'
@@ -34,7 +39,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate-generated-files:
+  detect-generator-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      required: ${{ steps.detect.outputs.required }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect relevant generator changes
+        id: detect
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            required="$(python3 .github/resources/scripts/generated_files_dependency_change.py \
+              --base "$BASE_SHA" --head "$HEAD_SHA")"
+          else
+            required=true
+          fi
+          echo "required=$required" >> "$GITHUB_OUTPUT"
+
+  generate-and-check:
+    needs: detect-generator-changes
+    if: needs.detect-generator-changes.outputs.required == 'true'
     runs-on: ubuntu-latest
     env:
       USE_PREBUILT_IMAGE: false
@@ -102,6 +134,8 @@ jobs:
         run: make check-diff
 
   validate-backwards-compabitiblity:
+    needs: detect-generator-changes
+    if: needs.detect-generator-changes.outputs.required == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -114,3 +148,25 @@ jobs:
         env:
           UPDATE_EXPORTED: false
         run: go test .
+
+  # Preserve the existing required-check name even when an unrelated Go module
+  # update skips the expensive generation job.
+  validate-generated-files:
+    needs:
+      - detect-generator-changes
+      - generate-and-check
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report validation result
+        env:
+          DETECTION_RESULT: ${{ needs.detect-generator-changes.result }}
+          GENERATION_REQUIRED: ${{ needs.detect-generator-changes.outputs.required }}
+          GENERATION_RESULT: ${{ needs.generate-and-check.result }}
+        run: |
+          [[ "$DETECTION_RESULT" == "success" ]]
+          if [[ "$GENERATION_REQUIRED" == "true" ]]; then
+            [[ "$GENERATION_RESULT" == "success" ]]
+          else
+            [[ "$GENERATION_RESULT" == "skipped" ]]
+          fi

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,6 +26,7 @@ COPY ./api/go.mod ./api/go.mod
 # transient proxy.golang.org failure cannot fail the build.
 ENV GOPROXY=https://proxy.golang.org|direct
 RUN GO111MODULE=on go mod download
+RUN go list -mod=readonly -m -f '{{.Version}}' github.com/argoproj/argo-workflows/v4 > /tmp/argo-version
 
 COPY . .
 RUN GO111MODULE=on go build -o /bin/apiserver backend/src/apiserver/*.go
@@ -40,9 +41,11 @@ RUN python3 -m pip install -r requirements.txt --no-cache-dir
 ARG TARGETARCH
 RUN echo "Building for architecture: ${TARGETARCH}"
 
-# Downloading Argo CLI so that the samples are validated
-ENV ARGO_VERSION=v4.0.8
-RUN curl -sL -H "Accept: application/octet-stream" \
+# Download the Argo CLI matching the runtime module so that the samples are
+# validated with the same release KFP builds against.
+COPY --from=builder /tmp/argo-version /tmp/argo-version
+RUN ARGO_VERSION="$(cat /tmp/argo-version)" && \
+    curl -fsSL -H "Accept: application/octet-stream" \
         https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-$TARGETARCH.gz \
     -o argo-linux-$TARGETARCH.gz && \
     gunzip argo-linux-$TARGETARCH.gz && \

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -14,31 +14,17 @@
 
 # Generate client code (go & json) from API protocol buffers
 FROM golang:1.26.5@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 AS generator
-ENV GRPC_GATEWAY_VERSION=v2.29.0
-ENV GO_SWAGGER_VERSION=v0.32.3
-ENV GRPC_VERSION=v1.82.0
 ENV PROTOC_VERSION=31.1
 ENV GOBIN=/go/bin
 # The googleapis repo doesn't use GitHub releases or version tags,
 # so we pin a specific commit to make the clone reproducible.
 ENV GOOGLEAPIS_COMMIT=68d5196a529174df97c28c70622ffc1c3721815f
 
-# **Note** that protoc-gen-go-grpc is packaged with grpc-go but is versioned
-# separately. You can find the releases for protoc-gen-go-grpc here:
-# https://github.com/grpc/grpc-go/releases
-# **Note** that these also include releases for grpc-go which is the grpc Go
-# runtime package. protoc-gen-go-grpc is the package used for generating
-# Go GRPC code from .proto files.
-# to list recent protoc-gen-go-grpc versions you can also do:
-# go list -m -versions google.golang.org/grpc/cmd/protoc-gen-go-grpc
-# PROTOC_GEN_GO_GRPC & PROTOBUF_GO versions should match reasonably close to each other.
-# You can check the protobuf in the go.mod for protoc-gen-go-grpc, like here:
-# https://github.com/grpc/grpc-go/blob/cmd/protoc-gen-go-grpc/v1.5.1/cmd/protoc-gen-go-grpc/go.mod#L7
-# **Note** That BOTH PROTOC_GEN_GO_GRPC & PROTOBUF_GO here are used for
-# Generating GO Code. These versions should be identical to the
-# runtime Go packages (in the project go.mod)
-ENV PROTOC_GEN_GO_GRPC=v1.6.2
-ENV PROTOBUF_GO=v1.36.12-0.20260120151049-f2248ac996af
+# Runtime-coupled Go generators use the exact versions selected by the root
+# module. Standalone generator tools use the dedicated tools module so
+# Dependabot can update them without adding build-only dependencies to KFP.
+COPY go.mod /tmp/kfp-module/go.mod
+COPY backend/api/tools/go.mod /tmp/api-generator-tools/go.mod
 
 # Install protoc and Java (needed for KFP server API package generation).
 RUN apt-get update -y && apt-get install -y jq sed unzip default-jdk
@@ -52,10 +38,19 @@ RUN rm -f protoc.zip
 ENV PROTOCCOMPILER=/usr/bin/protoc
 ENV PROTOCINCLUDE=/usr/include/google/protobuf
 
-# Need grpc-gateway source code for -I in protoc command.
-# Install protoc-gen-rpc-gateway && protoc-gen-swagger.
-RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@${GRPC_GATEWAY_VERSION}
-RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@${GRPC_GATEWAY_VERSION}
+# Install the Go-based generators at their manifest-selected versions. Keep the
+# grpc-gateway options alongside the plugins because protoc imports them.
+RUN set -eu; \
+    module_version() { cd "$1" && go mod edit -json | jq -er --arg module "$2" '.Require[] | select(.Path == $module) | .Version'; }; \
+    grpc_gateway_version="$(module_version /tmp/kfp-module github.com/grpc-ecosystem/grpc-gateway/v2)"; \
+    protobuf_go_version="$(module_version /tmp/kfp-module google.golang.org/protobuf)"; \
+    protoc_gen_go_grpc_version="$(module_version /tmp/kfp-module google.golang.org/grpc/cmd/protoc-gen-go-grpc)"; \
+    go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@"${grpc_gateway_version}"; \
+    go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@"${grpc_gateway_version}"; \
+    go install google.golang.org/protobuf/cmd/protoc-gen-go@"${protobuf_go_version}"; \
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@"${protoc_gen_go_grpc_version}"; \
+    mkdir -p /protoc-gen-openapiv2; \
+    cp -r "/go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway/v2@${grpc_gateway_version}/protoc-gen-openapiv2/options" /protoc-gen-openapiv2/options
 
 # Need to explicitly provide the googleapis protos and the OpenAPI options that were previously present in the grpc-gateway repo.
 RUN git init /googleapis && \
@@ -63,17 +58,11 @@ RUN git init /googleapis && \
     git remote add origin https://github.com/googleapis/googleapis.git && \
     git fetch --depth 1 origin ${GOOGLEAPIS_COMMIT} && \
     git checkout FETCH_HEAD
-RUN mkdir -p /protoc-gen-openapiv2 && \
-    cp -r /go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway/v2@${GRPC_GATEWAY_VERSION}/protoc-gen-openapiv2/options /protoc-gen-openapiv2/options
-
 # Download go-swagger binary.
-RUN curl -LO "https://github.com/go-swagger/go-swagger/releases/download/${GO_SWAGGER_VERSION}/swagger_linux_amd64"
-RUN chmod +x swagger_linux_amd64 && mv swagger_linux_amd64 /usr/bin/swagger
-
-# Need protobuf source code for -I in protoc command.
-# Install protoc-gen-go.
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOBUF_GO}
-RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC}
+RUN set -eu; \
+    go_swagger_version="$(cd /tmp/api-generator-tools && go mod edit -json | jq -er '.Require[] | select(.Path == "github.com/go-swagger/go-swagger") | .Version')"; \
+    curl -fL -o /usr/bin/swagger "https://github.com/go-swagger/go-swagger/releases/download/${go_swagger_version}/swagger_linux_amd64"; \
+    chmod +x /usr/bin/swagger
 
 # Needed for buildling python packages requiring protoc
 RUN apt-get update && apt-get install -y python3-pip

--- a/backend/api/Makefile
+++ b/backend/api/Makefile
@@ -125,7 +125,7 @@ push: image
 
 # .image-built is a local token file to help Make determine the latest successful build.
 # Uses Docker layer caching for improved performance.
-.image-built: Dockerfile
+.image-built: Dockerfile ../../go.mod tools/go.mod
 	DOCKER_BUILDKIT=1 ${CONTAINER_ENGINE} build ../.. -t $(IMAGE_TAG) -f Dockerfile \
 		--cache-from $(IMAGE_TAG):latest
 	touch .image-built

--- a/backend/api/tools/go.mod
+++ b/backend/api/tools/go.mod
@@ -1,0 +1,7 @@
+module github.com/kubeflow/pipelines/backend/api/tools
+
+go 1.26.0
+
+// Version source for standalone Go tools downloaded by the API generator
+// image. Runtime-coupled generators derive their versions from the root module.
+require github.com/go-swagger/go-swagger v0.32.3

--- a/backend/src/common/types.go
+++ b/backend/src/common/types.go
@@ -21,7 +21,7 @@ package common
 type ExecutionPhase string
 
 // borrow from Workflow.Status.Phase:
-// https://pkg.go.dev/github.com/argoproj/argo-workflows/v4@v4.0.8/pkg/apis/workflow/v1alpha1#WorkflowPhase
+// https://pkg.go.dev/github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1#WorkflowPhase
 const (
 	ExecutionUnknown   ExecutionPhase = ""
 	ExecutionPending   ExecutionPhase = "Pending" // pending some set-up - rarely used

--- a/docs/agents/ci.md
+++ b/docs/agents/ci.md
@@ -5,7 +5,7 @@ GitHub Actions workflows are in `.github/workflows/`; reusable composite actions
 - Update this guide when changing workflows, CI matrices, commands, generated outputs, or common failure handling.
 - CI covers supported Kubernetes and Argo versions, database and Kubernetes pipeline stores, proxy/cache variants, and GPU scheduling. Preserve the relevant matrix coverage when changing a lane.
 - Use `.github/actions/setup-python-pip-cache` for pip caching. Give each dependency set a distinct `cache-scope` and hash every installed requirements file; do not use `setup-python`'s built-in pip cache.
-- `validate-generated-files.yml` validates backend-generated outputs. `frontend.yml` runs `npm run apis:all` and rejects stale frontend clients.
+- `validate-generated-files.yml` validates backend-generated outputs. Go-based API generator versions come from the root or `backend/api/tools` Go modules; a lightweight change detector skips this expensive validation for unrelated Go module updates. `frontend.yml` runs `npm run apis:all` and rejects stale frontend clients.
 - Changes to `frontend/server/handlers/artifacts.ts` trigger `e2e-test.yml` so the multi-user artifact-proxy and SeaweedFS namespace-isolation checks run before artifact authorization changes merge.
 - For workflow-only changes, verify referenced working directories, Docker contexts/files, scripts, and local action paths exist.
 

--- a/docs/agents/generation.md
+++ b/docs/agents/generation.md
@@ -13,6 +13,7 @@ Never edit generated files. Update their source and regenerate them.
 
 - `api/v2alpha1/python/kfp/pipeline_spec/pipeline_spec_pb2.py` is generated but not committed.
 - For backend generator changes, use `USE_PREBUILT_IMAGE=false make -C backend/api API_VERSION=<version> generate`.
+- Go-based API generator versions are selected by the root `go.mod` when they must match runtime libraries, or by `backend/api/tools/go.mod` for standalone tooling.
 - `backend/api/v2beta1/python_http_client` is generated from `kfp_api_single_file.swagger.json` with `cd backend/api && make generate-kfp-server-api-package`.
 - `pipeline.upload.swagger.json` is manually maintained.
 - Schema changes require both `make -C api python` and `make -C api golang`.

--- a/test/install-argo-cli.sh
+++ b/test/install-argo-cli.sh
@@ -19,7 +19,6 @@ set -ex
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 REPO_ROOT="${DIR}/.."
 ARGO_VERSION="$(cat ${REPO_ROOT}/third_party/argo/VERSION)"
-# ARGO_VERSION=v4.0.8
 OS=${OS:-"linux-amd64"}
 
 # if argo is not installed

--- a/third_party/argo/Makefile
+++ b/third_party/argo/Makefile
@@ -1,12 +1,10 @@
 REPO_ROOT=../..
 ARGO_DIR=$(REPO_ROOT)/third_party/argo
 MANIFESTS_DIR=$(REPO_ROOT)/manifests/kustomize/third-party/argo
-BACKEND_CODE_DIR=$(REPO_ROOT)/backend
-TESTS_DIR=$(REPO_ROOT)/test
 DOCS_DIR=$(ARGO_DIR)
 SYNC_SCRIPT=$(REPO_ROOT)/.github/resources/scripts/sync_argo_versions.py
 
-update: update_ci update_manifests update_backend update_tests update_docs
+update: update_ci update_manifests update_backend update_docs
 
 update_ci:
 	@echo "Updating Argo Workflows versions in CI and project documentation..."
@@ -37,22 +35,9 @@ update_backend:
 	echo "Updating go dependency..."; \
 	sed -i.bak -E "s|github.com/argoproj/argo-workflows/v[0-9]+ v[0-9]+\.[0-9]+\.[0-9]+|github.com/argoproj/argo-workflows/v$$MAJOR $$VERSION|g" $(REPO_ROOT)/go.mod && \
 	(cd $(REPO_ROOT) && go mod tidy) && \
-	echo "Updating code refs in backend..."; \
-	sed -i.bak -E "s|ARGO_VERSION=v[0-9]+\.[0-9]+\.[0-9]+|ARGO_VERSION=$$VERSION|g" $(BACKEND_CODE_DIR)/Dockerfile && \
-	sed -i.bak -E "s|argo-workflows/v[0-9]+@v[0-9]+\.[0-9]+\.[0-9]+|argo-workflows/v$$MAJOR@$$VERSION|g" $(BACKEND_CODE_DIR)/src/common/types.go && \
 	echo "Cleaning up temp backups..."; \
-	rm -f $(REPO_ROOT)/go.mod.bak $(BACKEND_CODE_DIR)/Dockerfile.bak $(BACKEND_CODE_DIR)/src/common/types.go.bak; \
-	echo "Successfully updated backend code refs to use $$VERSION"
-
-update_tests:
-	@echo "Updating Argo Workflows version references in tests..."
-	@set -e; VERSION=$$(cat $(ARGO_DIR)/VERSION); \
-	echo "Using Argo Workflows version: $$VERSION"; \
-	echo "Updating code refs in tests..."; \
-	sed -i.bak -E "s|ARGO_VERSION=v[0-9]+\.[0-9]+\.[0-9]+|ARGO_VERSION=$$VERSION|g" $(TESTS_DIR)/install-argo-cli.sh && \
-	echo "Cleaning up temp backups..."; \
-	rm -f $(TESTS_DIR)/install-argo-cli.sh.bak; \
-	echo "Successfully updated tests to use $$VERSION"
+	rm -f $(REPO_ROOT)/go.mod.bak; \
+	echo "Successfully updated backend dependency to use $$VERSION"
 
 update_docs:
 	@echo "Updating Argo Workflows version references in docs..."


### PR DESCRIPTION
## Summary

- derive the grpc-gateway, protobuf, protoc-gen-go-grpc, and Argo CLI versions from their canonical Go module metadata
- track go-swagger in a dedicated Dependabot-managed tools module and remove dead or duplicated version pins
- run generated-file validation only for relevant generator changes while preserving the required check name

## Why

Generator versions could drift from the modules they serve because Dependabot updated `go.mod` without updating arbitrary Dockerfile environment variables. This makes the module manifests the source of truth and teaches CI which grouped Go updates actually require regeneration.

Standalone release downloads such as protoc and googleapis remain explicit pins because the configured Dependabot ecosystems cannot track them reliably.

## Verification

- built `backend/api/Dockerfile` successfully
- checked all installed generator versions in the resulting image
- regenerated the v2beta1 API and confirmed no generated-file diff
- ran all 158 CI script unit tests successfully
- ran `go mod verify` for the tools module
- parsed the modified workflows and checked Makefile dependency wiring
- ran `git diff --check`
