### PR TITLE
fix: preserve duplicate metrics in Compare view

### DIFF
--- a/frontend/src/lib/CompareUtils.test.ts
+++ b/frontend/src/lib/CompareUtils.test.ts
@@ -274,6 +274,49 @@ describe('CompareUtils', () => {
         yLabels: ['some-metric', 'another-metric'],
       });
     });
+
+    it('returns all values when a run has duplicate metric names', () => {
+      const runs = [
+        {
+          metrics: [
+            { name: 'some-metric', number_value: 0.33 },
+            { name: 'some-metric', number_value: 0.66 },
+          ],
+          name: 'run1',
+        } as ApiRun,
+      ];
+
+      expect(CompareUtils.multiRunMetricsCompareProps(runs)).toEqual({
+        rows: [['0.330'], ['0.660']],
+        xLabels: ['run1'],
+        yLabels: ['some-metric', 'some-metric (2)'],
+      });
+    });
+
+    it('returns duplicate metric values based on the maximum occurrences in a run', () => {
+      const runs = [
+        {
+          metrics: [
+            { name: 'some-metric', number_value: 0.33 },
+            { name: 'some-metric', number_value: 0.66 },
+          ],
+          name: 'run1',
+        } as ApiRun,
+        {
+          metrics: [{ name: 'some-metric', number_value: 0.99 }],
+          name: 'run2',
+        } as ApiRun,
+      ];
+
+      expect(CompareUtils.multiRunMetricsCompareProps(runs)).toEqual({
+        rows: [
+          ['0.330', '0.990'],
+          ['0.660', ''],
+        ],
+        xLabels: ['run1', 'run2'],
+        yLabels: ['some-metric', 'some-metric (2)'],
+      });
+    });
   });
 
   describe('singleRunToMetricsCompareProps', () => {

--- a/frontend/src/lib/CompareUtils.ts
+++ b/frontend/src/lib/CompareUtils.ts
@@ -65,23 +65,39 @@ export default class CompareUtils {
   public static multiRunMetricsCompareProps(runs: ApiRun[]): CompareTableProps {
     const metricMetadataMap = RunUtils.runsToMetricMetadataMap(runs);
 
-    const yLabels = Array.from(metricMetadataMap.keys());
+    const metricRows = Array.from(metricMetadataMap.keys()).flatMap((name) => {
+      const maxOccurrences = Math.max(
+        ...runs.map(
+          (r) =>
+            (r.metrics || []).filter(
+              (m) => m.name === name && m.number_value !== undefined && !isNaN(m.number_value),
+            ).length,
+        ),
+      );
 
-    const rows = yLabels.map((name) =>
-      runs.map((r) =>
-        // TODO(rjbauer): This logic isn't quite right. A single run can have multiple metrics
-        // with the same name, but here we're stopping once we find one.
-        MetricUtils.getMetricDisplayString((r.metrics || []).find((m) => m.name === name)),
-      ),
+      return Array.from({ length: maxOccurrences }, (_, occurrence) => ({
+        name,
+        occurrence,
+        label: occurrence === 0 ? name : `${name} (${occurrence + 1})`,
+      }));
+    });
+
+    const rows = metricRows.map(({ name, occurrence }) =>
+      runs.map((r) => {
+        const metrics = (r.metrics || []).filter(
+          (m) => m.name === name && m.number_value !== undefined && !isNaN(m.number_value),
+        );
+
+        return MetricUtils.getMetricDisplayString(metrics[occurrence]);
+      }),
     );
 
     return {
       rows,
       xLabels: runs.map((r) => r.name!),
-      yLabels,
+      yLabels: metricRows.map((row) => row.label),
     };
   }
-
   /**
    * For a given run and its runtime workflow, a CompareTableProps object is returned containing:
    * xLabels: an array of unique meeric names produced during the run's execution


### PR DESCRIPTION
Fixes #13988

## What does this PR do?

Preserves duplicate metric values in the Compare Runs view instead of silently dropping subsequent metrics with the same name.

When a run contains multiple metrics with the same name, each occurrence is now displayed separately using labels such as `metric` and `metric (2)`.

## Changes

- Preserve all duplicate metric occurrences in `multiRunMetricsCompareProps`.
- Generate additional rows based on the maximum number of occurrences in any run.
- Add regression tests for duplicate metrics within a run and across multiple runs.

## Testing

- `npx vitest run src/lib/CompareUtils.test.ts`
- 25 tests passed.