### PR TITLE
feat(sdk): support Azure and HDFS remote artifact URIs in kfp.local cache (#14013)

### DIFF
--- a/sdk/python/kfp/local/cache.py
+++ b/sdk/python/kfp/local/cache.py
@@ -19,6 +19,7 @@ import os
 import tempfile
 import threading
 from typing import Any, Dict, List, Optional
+import urllib.parse
 
 from kfp import dsl
 from kfp.dsl import executor
@@ -224,12 +225,28 @@ class _MissingArtifactError(Exception):
         self.uri = uri
 
 
-_REMOTE_URI_PREFIXES = ('gs://', 's3://', 'minio://', 'oci://', 'http://',
-                        'https://')
+_REMOTE_URI_PREFIXES = (
+    'gs://',
+    'gcs://',
+    's3://',
+    'minio://',
+    'oci://',
+    'abfs://',
+    'abfss://',
+    'wasb://',
+    'wasbs://',
+    'hdfs://',
+    'cos://',
+    'http://',
+    'https://',
+)
 
 
 def _is_remote_uri(uri: str) -> bool:
-    return uri.startswith(_REMOTE_URI_PREFIXES)
+    if uri.startswith(_REMOTE_URI_PREFIXES):
+        return True
+    scheme = urllib.parse.urlparse(uri).scheme
+    return bool(scheme and scheme.lower() not in ('file', 'c', 'd', 'e', 'f'))
 
 
 # ----- config helpers -----

--- a/sdk/python/kfp/local/cache_test.py
+++ b/sdk/python/kfp/local/cache_test.py
@@ -204,6 +204,19 @@ class LocalCachePutGetTest(unittest.TestCase):
         self.assertIsNotNone(got)
         self.assertEqual(got['out_art'].uri, 'gs://bucket/a')
 
+    def test_azure_and_hdfs_remote_artifact_uri_is_hit(self):
+        azure_art = dsl.Artifact(
+            name='a1',
+            uri='abfs://container@account.blob.core.windows.net/data.parquet')
+        hdfs_art = dsl.Artifact(
+            name='a2', uri='hdfs://namenode:8020/user/data.csv')
+        outputs = {'a1': azure_art, 'a2': hdfs_art}
+        self.cache.put('k_remote', outputs)
+        got = self.cache.get('k_remote')
+        self.assertIsNotNone(got)
+        self.assertEqual(got['a1'].uri, azure_art.uri)
+        self.assertEqual(got['a2'].uri, hdfs_art.uri)
+
     def test_atomic_write_no_partial(self):
         # Concurrent writers should not corrupt entries.
         def writer(i):


### PR DESCRIPTION
### Description
In `kfp.local`, `LocalCache._deserialize_artifact()` validates whether cached output artifacts exist on disk. For remote artifact URIs, it delegates to `_is_remote_uri(uri)` to bypass local filesystem checks.

Previously, `_REMOTE_URI_PREFIXES` hardcoded only 6 schemes (`gs://`, `s3://`, `minio://`, `oci://`, `http://`, `https://`). When pipelines produced or consumed artifacts in Azure Blob Storage (`abfs://`, `abfss://`, `wasb://`, `wasbs://`), HDFS (`hdfs://`), IBM COS (`cos://`), or GCS alternate scheme (`gcs://`), `_is_remote_uri(uri)` returned `False`. `os.path.exists()` then attempted to check local path existence for URIs like `abfs://...`, raising `_MissingArtifactError` and causing a 100% cache miss rate.

This PR expands `_REMOTE_URI_PREFIXES` to recognize Azure, HDFS, COS, and GCS schemes, and adds scheme parsing fallback via `urllib.parse.urlparse`.

### Related Issue
Fixes #14013

### Changes Made
- Updated `_REMOTE_URI_PREFIXES` and `_is_remote_uri()` in `sdk/python/kfp/local/cache.py`.
- Added unit test `test_azure_and_hdfs_remote_artifact_uri_is_hit` in `sdk/python/kfp/local/cache_test.py`.

### Contributor Checklist
- [x] Target branch is `master`
- [x] Followed Conventional Commits format
- [x] DCO sign-off included (`Signed-off-by`)
