### PR TITLE
fix(sdk): preserve pip_trusted_hosts when pip_index_urls is not set. Fixes #13806

### DIFF
--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -92,30 +92,32 @@ def make_index_url_options(pip_index_urls: Optional[List[str]],
 
     Returns:
         str:
-            - An empty string if pip_index_urls is empty or None.
+            - An empty string if both pip_index_urls and pip_trusted_hosts are
+              empty or None.
             - '--index-url url ' if pip_index_urls contains 1 URL.
             - The above followed by '--extra-index-url url ' for each additional URL in pip_index_urls
             if pip_index_urls contains more than 1 URL.
             - If pip_trusted_hosts is None or an empty List:
                 - No --trusted-host information will be added.
             - If pip_trusted_hosts contains any hosts:
-                - The above followed by '--trusted-host host ' for each host in pip_trusted_hosts.
+                - '--trusted-host host ' for each host in pip_trusted_hosts, added
+                  regardless of whether pip_index_urls is provided.
     Note:
-        In case pip_index_urls is not empty, the returned string will contain a space at the end.
+        If any options are generated, the returned string will contain a space at the end.
     """
-    if not pip_index_urls:
-        return ''
+    options = []
 
-    index_url = pip_index_urls[0]
-    extra_index_urls = pip_index_urls[1:]
-
-    options = [f'--index-url {index_url}']
-    options.extend(f'--extra-index-url {extra_index_url}'
-                   for extra_index_url in extra_index_urls)
+    if pip_index_urls:
+        options.append(f'--index-url {pip_index_urls[0]}')
+        options.extend(f'--extra-index-url {extra_index_url}'
+                       for extra_index_url in pip_index_urls[1:])
 
     if pip_trusted_hosts:
         options.extend(f'--trusted-host {trusted_host}'
                        for trusted_host in pip_trusted_hosts)
+
+    if not options:
+        return ''
 
     return ' '.join(options) + ' '
 

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -247,6 +247,74 @@ class TestGetPackagesToInstallCommand(unittest.TestCase):
                 '\'typing-extensions>=3.7.4,<5; python_version<"3.9"\' && "$0" "$@"\n'
             ]))
 
+    def test_with_packages_to_install_with_pip_trusted_hosts_only(self):
+        packages_to_install = ['package1', 'package2']
+        pip_trusted_hosts = ['myurl.org']
+
+        command = component_factory._get_packages_to_install_command(
+            packages_to_install=packages_to_install,
+            pip_trusted_hosts=pip_trusted_hosts,
+        )
+
+        self.assertEqual(
+            strip_kfp_version(command),
+            strip_kfp_version([
+                'sh', '-c', '\n'
+                'if ! [ -x "$(command -v pip)" ]; then\n'
+                '    python3 -m ensurepip || python3 -m ensurepip --user || apt-get install '
+                'python3-pip\n'
+                'fi\n'
+                '\n'
+                'PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet '
+                "--no-warn-script-location --trusted-host myurl.org 'package1' 'package2'  &&  "
+                'python3 -m pip install --quiet --no-warn-script-location --trusted-host '
+                "myurl.org kfp '--no-deps' 'typing-extensions>=3.7.4,<5; "
+                'python_version<"3.9"\' && "$0" "$@"\n'
+            ]))
+
+
+class TestMakeIndexUrlOptions(unittest.TestCase):
+
+    def test_with_no_index_urls_and_no_trusted_hosts(self):
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=None, pip_trusted_hosts=None), '')
+
+    def test_with_index_urls_only(self):
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=['https://myurl.org/simple'],
+                pip_trusted_hosts=None),
+            '--index-url https://myurl.org/simple ')
+
+    def test_with_multiple_index_urls_only(self):
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=[
+                    'https://myurl.org/simple', 'https://myurl2.org/simple'
+                ],
+                pip_trusted_hosts=None), '--index-url https://myurl.org/simple '
+            '--extra-index-url https://myurl2.org/simple ')
+
+    def test_with_index_urls_and_trusted_hosts(self):
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=['https://myurl.org/simple'],
+                pip_trusted_hosts=['myurl.org', 'myurl2.org']),
+            '--index-url https://myurl.org/simple '
+            '--trusted-host myurl.org --trusted-host myurl2.org ')
+
+    def test_with_trusted_hosts_only(self):
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=None, pip_trusted_hosts=['myurl.org']),
+            '--trusted-host myurl.org ')
+
+    def test_with_empty_lists(self):
+        self.assertEqual(
+            component_factory.make_index_url_options(
+                pip_index_urls=[], pip_trusted_hosts=[]), '')
+
 
 class TestInvalidParameterName(unittest.TestCase):
 


### PR DESCRIPTION
**Description of your changes:**

Fixes #13806.

When a lightweight Python component specifies `pip_trusted_hosts` without `pip_index_urls`, the `--trusted-host` arguments were silently dropped from the generated `pip install` command. `make_index_url_options` had an early `return ''` whenever `pip_index_urls` was empty or `None`, which discarded `pip_trusted_hosts` entirely.

This causes failures for users who configure a private PyPI mirror via a global `pip.conf` (e.g., baked into a custom `base_image`) and only need `--trusted-host` for their corporate proxy/mirror.

**Changes:**
- `sdk/python/kfp/dsl/component_factory.py`: refactor `make_index_url_options` to build `--index-url`/`--extra-index-url` and `--trusted-host` options independently, so `--trusted-host` flags are emitted even when `pip_index_urls` is not provided.
- `sdk/python/kfp/dsl/component_factory_test.py`: add `TestMakeIndexUrlOptions` unit tests covering the option combinations and an integration test for `_get_packages_to_install_command` with `pip_trusted_hosts` only.

**Reproducer (before/after):**
```python
from kfp.dsl.component_factory import make_index_url_options

# Before: ''
# After:  '--trusted-host pypi.org '
print(repr(make_index_url_options(pip_index_urls=None, pip_trusted_hosts=['pypi.org'])))
```

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
