### PR TITLE
fix(backend): guard toModelRun against a malformed PipelineInfo in the pipeline spec

### DIFF
--- a/backend/src/apiserver/server/api_converter.go
+++ b/backend/src/apiserver/server/api_converter.go
@@ -1331,8 +1331,9 @@ func toModelRun(r interface{}) (*model.Run, error) {
 
 		specMap := apiRunV2.GetPipelineSpec().AsMap()
 		if pv, ok := specMap["PipelineInfo"]; ok {
-			if pName, ok := pv.(map[string]interface{})["Name"]; ok {
-				resources := common.ParseResourceIdsFromFullName(pName.(string))
+			pvMap, pvIsMap := pv.(map[string]interface{})
+			if pName, ok := pvMap["Name"].(string); pvIsMap && ok {
+				resources := common.ParseResourceIdsFromFullName(pName)
 				if namespace == "" {
 					namespace = resources["Namespace"]
 				}

--- a/backend/src/apiserver/server/api_converter_test.go
+++ b/backend/src/apiserver/server/api_converter_test.go
@@ -4344,6 +4344,38 @@ func TestToModelRun(t *testing.T) {
 	}
 }
 
+func TestToModelRun_MalformedPipelineInfoDoesNotPanic(t *testing.T) {
+	// Regression: toModelRun reads specMap["PipelineInfo"] straight out of a
+	// client-submitted PipelineSpec (a structpb.Struct, i.e. arbitrary JSON), then
+	// asserts it's a map and asserts its "Name" is a string, both without checking
+	// ok. A pipeline spec where PipelineInfo isn't an object, or has a non-string
+	// Name, used to panic instead of returning an error.
+	tests := []struct {
+		name         string
+		pipelineInfo interface{}
+	}{
+		{"PipelineInfo is not an object", "not-an-object"},
+		{"PipelineInfo.Name is not a string", map[string]interface{}{"Name": 123}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pipelineSpec, err := structpb.NewStruct(map[string]interface{}{
+				"PipelineInfo": tt.pipelineInfo,
+			})
+			require.NoError(t, err)
+			run := &apiv2beta1.Run{
+				RunId: "run1",
+				PipelineSource: &apiv2beta1.Run_PipelineSpec{
+					PipelineSpec: pipelineSpec,
+				},
+			}
+			assert.NotPanics(t, func() {
+				_, _ = toModelRun(run)
+			})
+		})
+	}
+}
+
 func Test_toApiRun(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

`toModelRun` reads `specMap["PipelineInfo"]` directly out of the client-submitted `PipelineSpec` (a `structpb.Struct`, i.e. arbitrary JSON from the API request), then does two unguarded type assertions:

```go
if pName, ok := pv.(map[string]interface{})["Name"]; ok {
    resources := common.ParseResourceIdsFromFullName(pName.(string))
```

A v2 run submitted with a `PipelineInfo` that isn't an object, or whose `Name` isn't a string, panics the API server instead of returning an error, since neither assertion checks its `ok` result.

## Change

Guard both assertions with their two-value form, so a malformed `PipelineInfo`/`Name` is skipped the same way a *missing* one already is, instead of panicking:

```go
pvMap, pvIsMap := pv.(map[string]interface{})
if pName, ok := pvMap["Name"].(string); pvIsMap && ok {
    resources := common.ParseResourceIdsFromFullName(pName)
```

## Test plan

- Added `TestToModelRun_MalformedPipelineInfoDoesNotPanic` in `api_converter_test.go`, covering both a non-object `PipelineInfo` and a non-string `Name`.
- Could not run this package's Go test binary directly on this machine — `backend/src/apiserver/storage` depends on a CGO sqlite3 driver, and this box has no C compiler (`gcc` not found), so the build fails on an unrelated package before the test can run.
- Instead verified the fix at the logic level: extracted both the original and fixed type-assertion patterns into a standalone, dependency-free reproduction and ran it directly. Original panics on both malformed inputs; fixed does not, and still returns the correct name for a well-formed `PipelineInfo`. Noting this honestly rather than claiming a full test run I didn't do.
- `gofmt`-checked both changed files (on an LF-normalized copy — this repo checks out CRLF via `core.autocrlf`, which `gofmt` doesn't understand natively).

## Notes

Happy to have a maintainer (or CI) run the actual test if the logic-level verification isn't sufficient — I just don't have a working CGO toolchain here to confirm it myself.