### PR TITLE
feat(backend): fix resolve latest pipeline version bug. Fixes #14049

### DIFF
--- a/backend/src/apiserver/storage/pipeline_store.go
+++ b/backend/src/apiserver/storage/pipeline_store.go
@@ -1010,7 +1010,8 @@ func (s *PipelineStore) GetLatestPipelineVersion(pipelineId string) (*model.Pipe
 		Select(pipelineVersionColumns...).
 		From("pipeline_versions").
 		Where(sq.And{sq.Eq{"pipeline_versions.PipelineId": pipelineId}, sq.Eq{"pipeline_versions.Status": model.PipelineVersionReady}}).
-		OrderBy("pipeline_versions.CreatedAtInSec DESC").
+		// CreatedAtInSec has second granularity; UUID breaks ties so results are stable.
+		OrderBy("pipeline_versions.CreatedAtInSec DESC", "pipeline_versions.UUID DESC").
 		Limit(1).
 		ToSql()
 	if err != nil {

--- a/backend/src/apiserver/storage/pipeline_store_kubernetes.go
+++ b/backend/src/apiserver/storage/pipeline_store_kubernetes.go
@@ -345,7 +345,7 @@ func (k *PipelineStoreKubernetes) GetLatestPipelineVersion(pipelineId string) (*
 	var latestK8sPipelineVersion *v2beta1.PipelineVersion
 
 	for _, k8sPipelineVersion := range k8sPipelineVersions.Items {
-		if latestK8sPipelineVersion == nil || k8sPipelineVersion.CreationTimestamp.Time.After(latestK8sPipelineVersion.CreationTimestamp.Time) {
+		if latestK8sPipelineVersion == nil || isNewerPipelineVersion(&k8sPipelineVersion, latestK8sPipelineVersion) {
 			latestK8sPipelineVersion = &k8sPipelineVersion
 		}
 	}
@@ -355,6 +355,17 @@ func (k *PipelineStoreKubernetes) GetLatestPipelineVersion(pipelineId string) (*
 	}
 
 	return latestK8sPipelineVersion.ToModel()
+}
+
+// isNewerPipelineVersion reports whether a should be preferred over b. CreationTimestamp has second
+// granularity, so same-second versions tie; the UID breaks the tie so repeated calls agree.
+func isNewerPipelineVersion(a, b *v2beta1.PipelineVersion) bool {
+	aCreated, bCreated := a.CreationTimestamp.Time, b.CreationTimestamp.Time
+	if !aCreated.Equal(bCreated) {
+		return aCreated.After(bCreated)
+	}
+
+	return string(a.UID) > string(b.UID)
 }
 
 func (k *PipelineStoreKubernetes) GetPipelineVersion(pipelineVersionId string) (*model.PipelineVersion, error) {

--- a/backend/src/apiserver/storage/pipeline_store_kubernetes_compat_test.go
+++ b/backend/src/apiserver/storage/pipeline_store_kubernetes_compat_test.go
@@ -217,15 +217,33 @@ func TestBackwardCompat_GetLatestPipelineVersion_MixedCRs(t *testing.T) {
 	viper.Set("POD_NAMESPACE", "Test")
 	defer viper.Set("POD_NAMESPACE", podNamespace)
 
-	store := NewPipelineStoreKubernetes(getClient())
+	k8sClient, k8sClientNoCache := getClient()
+	store := NewPipelineStoreKubernetes(k8sClient, k8sClientNoCache)
 
-	// Create a new-style version (will have a later creation timestamp)
+	// Create a new-style version alongside the pre-seeded legacy "test-pipeline-version-3".
 	_, err := store.CreatePipelineVersion(&model.PipelineVersion{
 		Name:         "new-latest-version",
 		PipelineId:   DefaultFakePipelineIdTwo,
 		PipelineSpec: model.LargeText(getBasicPipelineSpecYAML()),
 	})
 	require.NoError(t, err)
+
+	// The fake client leaves creationTimestamp at zero, so stamp the new version to make it
+	// genuinely newer than the legacy CR rather than relying on list ordering.
+	ctx := context.Background()
+	versions := &v2beta1.PipelineVersionList{}
+	require.NoError(t, k8sClient.List(ctx, versions, client.InNamespace("Test")))
+
+	stamped := false
+	for i := range versions.Items {
+		if versions.Items[i].Spec.VersionName != "new-latest-version" {
+			continue
+		}
+		versions.Items[i].CreationTimestamp = metav1.Unix(1700000000, 0)
+		require.NoError(t, k8sClient.Update(ctx, &versions.Items[i]))
+		stamped = true
+	}
+	require.True(t, stamped, "expected the newly created pipeline version to be present")
 
 	latest, err := store.GetLatestPipelineVersion(DefaultFakePipelineIdTwo)
 	require.NoError(t, err)

--- a/backend/src/apiserver/storage/pipeline_store_kubernetes_test.go
+++ b/backend/src/apiserver/storage/pipeline_store_kubernetes_test.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/codes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -637,6 +638,96 @@ func TestGetPipelineVersionByName_NotFound(t *testing.T) {
 	_, err := store.GetPipelineVersionByName(DefaultFakePipelineIdTwo, "nonexistent")
 	require.NotNil(t, err)
 	assert.Equal(t, err.(*util.UserError).ExternalStatusCode(), codes.NotFound)
+}
+
+func TestIsNewerPipelineVersion(t *testing.T) {
+	earlier := metav1.Unix(1700000000, 0)
+	later := metav1.Unix(1700000001, 0)
+
+	newerVersion := func(uid string, created metav1.Time) *v2beta1.PipelineVersion {
+		return &v2beta1.PipelineVersion{
+			ObjectMeta: metav1.ObjectMeta{UID: types.UID(uid), CreationTimestamp: created},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		a        *v2beta1.PipelineVersion
+		b        *v2beta1.PipelineVersion
+		expected bool
+	}{
+		{"later timestamp wins", newerVersion("aaa", later), newerVersion("zzz", earlier), true},
+		{"earlier timestamp loses", newerVersion("zzz", earlier), newerVersion("aaa", later), false},
+		{"tie broken by higher uid", newerVersion("bbb", earlier), newerVersion("aaa", earlier), true},
+		{"tie broken against lower uid", newerVersion("aaa", earlier), newerVersion("bbb", earlier), false},
+		{"identical is not newer", newerVersion("aaa", earlier), newerVersion("aaa", earlier), false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, isNewerPipelineVersion(test.a, test.b))
+		})
+	}
+}
+
+// Versions created within the same second tie on CreationTimestamp.
+func TestGetLatestK8sPipelineVersion_SameCreationSecondIsDeterministic(t *testing.T) {
+	podNamespace := viper.Get("POD_NAMESPACE")
+	viper.Set("POD_NAMESPACE", "Test")
+	defer viper.Set("POD_NAMESPACE", podNamespace)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v2beta1.AddToScheme(scheme))
+
+	const pipelineID = "e1b2c3d4-0000-4000-8000-000000000001"
+	sameSecond := metav1.Unix(1700000000, 0)
+
+	pipeline := &v2beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{UID: pipelineID, Name: "tie-pipeline", Namespace: "Test"},
+	}
+
+	version := func(name, uid string) *v2beta1.PipelineVersion {
+		return &v2beta1.PipelineVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				UID:               types.UID(uid),
+				Name:              name,
+				Namespace:         "Test",
+				CreationTimestamp: sameSecond,
+				Labels:            map[string]string{"pipelines.kubeflow.org/pipeline-id": pipelineID},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v2beta1.GroupVersion.String(),
+					Kind:       "Pipeline",
+					Name:       "tie-pipeline",
+					UID:        pipelineID,
+				}},
+			},
+			Spec: v2beta1.PipelineVersionSpec{
+				VersionName:  name,
+				PipelineName: "tie-pipeline",
+				PipelineSpec: getBasicPipelineSpec(),
+			},
+		}
+	}
+
+	lowUID := version("tie-version-low", "00000000-0000-4000-8000-000000000001")
+	highUID := version("tie-version-high", "ffffffff-0000-4000-8000-000000000002")
+
+	// Seed both orderings; the same version must win regardless of list order.
+	for _, ordering := range [][]client.Object{
+		{lowUID, highUID},
+		{highUID, lowUID},
+	} {
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(append([]client.Object{pipeline}, ordering...)...).
+			Build()
+
+		store := NewPipelineStoreKubernetes(k8sClient, k8sClient)
+
+		latest, err := store.GetLatestPipelineVersion(pipelineID)
+		require.NoError(t, err)
+		assert.Equal(t, "tie-version-high", latest.Name)
+	}
 }
 
 func getClient() (client.Client, client.Client) {

--- a/backend/src/apiserver/storage/pipeline_store_test.go
+++ b/backend/src/apiserver/storage/pipeline_store_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 )
 
@@ -1323,6 +1324,59 @@ func TestGetLatestPipelineVersion(t *testing.T) {
 			Status:         model.PipelineVersionReady,
 		},
 		*pipelineVersion, "Got unexpected pipeline version")
+}
+
+// Versions uploaded within the same second tie on CreatedAtInSec.
+func TestGetLatestPipelineVersion_SameCreationSecond(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	pipelineStore := NewPipelineStore(
+		db,
+		util.NewFakeTimeForEpoch(),
+		util.NewFakeUUIDGeneratorOrFatal(DefaultFakePipelineId, nil))
+
+	pipelineStore.CreatePipeline(
+		&model.Pipeline{
+			Name:   "pipeline_1",
+			Status: model.PipelineReady,
+		},
+	)
+
+	// Ascending UUID order, so insertion order and UUID order disagree: without the tiebreaker
+	// this returns the first-inserted version and the assertion below fails.
+	for _, versionID := range []string{
+		DefaultFakePipelineIdTwo,
+		DefaultFakePipelineIdThree,
+		DefaultFakePipelineIdFour,
+	} {
+		pipelineStore.uuid = util.NewFakeUUIDGeneratorOrFatal(versionID, nil)
+		_, err := pipelineStore.CreatePipelineVersion(
+			&model.PipelineVersion{
+				Name:       "version_" + versionID,
+				PipelineId: DefaultFakePipelineId,
+				Status:     model.PipelineVersionReady,
+			},
+		)
+		require.Nil(t, err)
+	}
+
+	// Force the tie that the fake clock's per-call increment otherwise hides.
+	_, err := db.Exec(
+		"UPDATE pipeline_versions SET CreatedAtInSec = ? WHERE PipelineId = ?",
+		100, DefaultFakePipelineId,
+	)
+	require.Nil(t, err)
+
+	for i := 0; i < 5; i++ {
+		pipelineVersion, err := pipelineStore.GetLatestPipelineVersion(DefaultFakePipelineId)
+		require.Nil(t, err)
+		require.Equal(
+			t,
+			DefaultFakePipelineIdFour,
+			pipelineVersion.UUID,
+			"a tie on CreatedAtInSec must resolve to the highest UUID on every call",
+		)
+	}
 }
 
 func TestGetPipelineVersion_InternalError(t *testing.T) {


### PR DESCRIPTION
**Description of your changes:**

fixes #14049

In the case where pipelineVersions are created in parallel (exact second), resolve by UUID to break the tie. This will ensure runs are created deterministically in this edge case

Note: #14049 is scoped for k8s native setup, however this PR also addresses the same issue that lies in the DB logic as well  


** Live Cluster Testing Evidence **

<img width="1310" height="735" alt="Screenshot 2026-08-15 at 12 26 02 PM" src="https://github.com/user-attachments/assets/b77af4b4-da76-4a12-a545-2138d90105aa" />
(all consistent pipelineVersion)

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
