### PR TITLE
feat(diagnostics): abstract pod lifecycle failure diagnostics (#12843)

### DIFF
--- a/backend/api/v2beta1/go_client/run.pb.go
+++ b/backend/api/v2beta1/go_client/run.pb.go
@@ -21,6 +21,10 @@
 package go_client
 
 import (
+	reflect "reflect"
+	sync "sync"
+	unsafe "unsafe"
+
 	_ "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	status "google.golang.org/genproto/googleapis/rpc/status"
@@ -29,9 +33,6 @@ import (
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
-	reflect "reflect"
-	sync "sync"
-	unsafe "unsafe"
 )
 
 const (
@@ -891,6 +892,7 @@ type PipelineTaskDetail struct {
 	PodName string `protobuf:"bytes,15,opt,name=pod_name,json=podName,proto3" json:"pod_name,omitempty"`
 	// Sequence of dependen tasks.
 	ChildTasks    []*PipelineTaskDetail_ChildTask `protobuf:"bytes,16,rep,name=child_tasks,json=childTasks,proto3" json:"child_tasks,omitempty"`
+	PodDiagnostics *PodLifecycleDiagnostics        `protobuf:"bytes,1,opt,name-error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2136,4 +2138,10 @@ func file_backend_api_v2beta1_run_proto_init() {
 	File_backend_api_v2beta1_run_proto = out.File
 	file_backend_api_v2beta1_run_proto_goTypes = nil
 	file_backend_api_v2beta1_run_proto_depIdxs = nil
+}
+
+type PodLifecycleDiagnostics struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	ErrorCode string  `protobuf:"bytes,1,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"`
+	ErrorMessage  string `protobuf:"bytes,1,opt,name=error_message,json=errorCode,proto3" json:"error_message,omitempty"`
 }

--- a/backend/api/v2beta1/run.proto
+++ b/backend/api/v2beta1/run.proto
@@ -383,6 +383,13 @@ message PipelineTaskDetail {
 
   // Sequence of dependen tasks.
   repeated ChildTask child_tasks = 16;
+
+  PodLifecycleDiagnostics pod_diagnostics = 17;
+}
+
+message PodLifecycleDiagnostics {
+  string error_code = 1;
+  string error_message = 2;
 }
 
 // Runtime information of a pipeline task executor.

--- a/backend/src/agent/persistence/diagnostics/pod_classifier.go
+++ b/backend/src/agent/persistence/diagnostics/pod_classifier.go
@@ -1,0 +1,168 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/Licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific Language governing permissions and
+// Limitations under the License.
+
+package diagnostics
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type DiagnosticCategory string
+
+const (
+	CategoryUnspecified DiagnosticCategory = "DIAGNOSTIC_CATEGORY_UNSPECIFIED"
+	CategoryProvisioningFailure DiagnosticCategory = "PROVISIONING_FAILURE"
+	CategorySchedulingFailure DiagnosticCategory = "SCHEDULING_FAILURE"
+	CategoryRuntimeCrash DiagnosticCategory = "RUNTIME_CRASH"
+	CategoryNodeEviction DiagnosticCategory = "NODE_EVICTION"
+)
+
+type PodLifecycleDiagnostics struct {
+	Category   DiagnosticCategory  `json:"category"`
+	ErrorCode   string          `json:"error_code"`
+	ErrorMessage  string       `json:"error_message"`
+}
+
+
+const (
+	DefaultDocsURL = "https://www.kubeflow.org/docs/components/pipelines/v2/troubleshooting"
+)
+
+// ClassifyPodStatus inspects a Kubernetes v1.PodStatus and returns a structured PodLifecycleDiagnostics pointer.
+// If no Lifecycle failure is detected, it returns nil.
+
+func ClassifyPodStatus(podStatus *v1.PodStatus) *PodLifecycleDiagnostics {
+	if podStatus == nil {
+		return nil
+	}
+
+	// 1. Check Pod Eviction / Node Preemption
+	if strings.EqualFold(podStatus.Reason, "Evicted") || strings.EqualFold(podStatus.Reason, "Preempted") {
+		return &PodLifecycleDiagnostics{
+			Category: CategoryNodeEviction,
+			ErrorCode: "NODE_EVICTED",
+			ErrorMessage: fmt.Sprintf("The pod was evicted or preempted: %s", podStatus.Message),
+		}
+	}
+
+	statusText := podStatus.Reason + " " + podStatus.Message
+
+	if strings.Contains(statusText, "storageclass.storage.k8s.io") || strings.Contains(statusText, "StorageClass") && strings.Contains(statusText, "not found") {
+		return &PodLifecycleDiagnostics{
+			Category: CategoryProvisioningFailure,
+			ErrorCode: "INVALID_STORAGE_CLASS",
+			ErrorMessage: fmt.Sprintf("The pod could not be provisioned due to missing storage class: %s", podStatus.Message),
+		}
+	}
+
+
+	if strings.Contains(statusText, "OOMKilled") {
+		return &PodLifecycleDiagnostics{
+			Category: CategoryRuntimeCrash,
+			ErrorCode: "OOMKilled",
+			ErrorMessage: fmt.Sprintf("The pod was evicted or preempted: %s", podStatus.Message),
+		}
+	}
+
+	if strings.Contains(statusText, "ImagePullBackOff") || strings.Contains(statusText, "ErrImagePull") {
+		return &PodLifecycleDiagnostics{
+			Category: CategoryProvisioningFailure,
+			ErrorCode: "IMAGE_PULL_BACKOFF",
+			ErrorMessage: fmt.Sprintf("Container image could not be pulled: %s", podStatus.Message),
+		}
+	}
+
+	if strings.Contains(statusText, "Unschedulable") {
+		return &PodLifecycleDiagnostics{
+			Category: CategorySchedulingFailure,
+			ErrorCode: "UNSCHEDULABLE",
+			ErrorMessage: fmt.Sprintf("The pod could not be scheduled on any node: %s", podStatus.Message),
+		}
+	}
+	
+
+
+	// 2. Check Container Level Statuses (Waiting or Terminated)
+	containerStatuses := append(podStatus.InitContainerStatuses, podStatus.ContainerStatuses...)
+	for _, cs := range containerStatuses {
+		if cs.State.Waiting != nil {
+			reason := cs.State.Waiting.Reason
+			switch reason {
+				case "ImagePullBackOff", "ErrImagePull":
+					return &PodLifecycleDiagnostics{
+						Category: CategoryProvisioningFailure,
+						ErrorCode: "IMAGE_PULL_BACKOFF",
+						ErrorMessage: fmt.Sprintf("Container image '%s' could not be pulled: %s", cs.Image, cs.State.Waiting.Message),
+					}
+				case "InvalidImageName":
+					return &PodLifecycleDiagnostics{
+						Category: CategoryProvisioningFailure,
+						ErrorCode: "INVALID_IMAGE_NAME",
+						ErrorMessage: fmt.Sprintf("Container image '%s' has an invalid name: %s", cs.Image, cs.State.Waiting.Message),
+						
+
+			}
+			    case "CrashLoopBackOff":
+					return &PodLifecycleDiagnostics{
+						Category: CategoryRuntimeCrash,
+						ErrorCode: "CRASH_LOOP_BACKOFF",
+						ErrorMessage: fmt.Sprintf("Container '%s' is in a crash loop, failed repeatedly: %s", cs.Image, cs.State.Waiting.Message),
+						
+		}
+	}
+
+
+}
+
+        if cs.State.Terminated != nil {
+			term := cs.State.Terminated
+			if term.Reason == "OOMKilled" || term.ExitCode == 137 {
+                return &PodLifecycleDiagnostics{
+					Category: CategoryRuntimeCrash,
+					ErrorCode: "OOM_KILLED",
+					ErrorMessage: fmt.Sprintf("Container '%s' was terminated due to out-of-memory (OOMKilled): %d", cs.Image, term.ExitCode),
+					
+				}
+			}
+			
+			if term.ExitCode != 0 {
+				return &PodLifecycleDiagnostics{
+					Category: CategoryRuntimeCrash,
+					ErrorCode: "RUNTIME_ERROR",
+					ErrorMessage: fmt.Sprintf("Container '%s' failed at runtime: %d", cs.Image, term.ExitCode),
+				}
+			}
+		}
+
+	}
+
+
+  // 3. Check Pod Level Conditions (Scheduling Failures)
+  for _, condition := range podStatus.Conditions {
+        if condition.Type == v1.PodScheduled && condition.Status == v1.ConditionFalse {
+			if condition.Reason == v1.PodReasonUnschedulable || strings.Contains(condition.Message, "insufficient") {
+				return &PodLifecycleDiagnostics{
+					Category: CategorySchedulingFailure,
+					ErrorCode: "POD_UNSCHEDULABLE",
+					ErrorMessage: fmt.Sprintf("The pod could not be scheduled on any node: %s", condition.Message),
+				}
+			}
+		}
+  }
+
+  return nil
+}

--- a/backend/src/agent/persistence/diagnostics/pod_classifier_test.go
+++ b/backend/src/agent/persistence/diagnostics/pod_classifier_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/Licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific Language governing permissions and
+// Limitations under the License.
+
+package diagnostics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestClassifyPodStatus_NilStatus_ReturnNil(t *testing.T) {
+	diag := ClassifyPodStatus(nil)
+	assert.Nil(t, diag)
+}
+
+func TestClassifyPodStatus_TableDriven(t *testing.T){
+	tests := []struct {
+		name  string
+		podStatus *v1.PodStatus
+		expectedCategory DiagnosticCategory
+		expectedReason string
+		expectedCode  string
+		expectedExitCode int32
+	}{
+		{
+			name: "ImagePullBackOff failure",
+			podStatus: &v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+					Image: "gcr.io/invalid/missing-image:latest",
+					State: v1.ContainerState{
+						Waiting: &v1.ContainerStateWaiting{
+							Reason: "ImagePullBackOff",
+							Message: fmt.Sprintf("Back-off pulling image 'gcr.io/invalid/missing-image:latest'"),
+							
+						},
+					},
+				},
+			},
+		},
+		expectedCategory: CategoryProvisioningFailure,
+		expectedReason: "ImagePullBackOff",
+		expectedCode: "IMAGE_PULL_BACKOFF",
+		expectedExitCode: -1,
+	},
+	{
+		name: "OOMKilled runtime crash",
+		podStatus: &v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Image: "python:3.11-slim",
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							Reason: "OOMKilled",
+							ExitCode: 137,
+							Message: fmt.Sprintf("Container limit 8Gi exceeded"),
+						},
+					},
+				},
+			},
+		},
+		expectedCategory: CategoryRuntimeCrash,
+		expectedReason: "OOMKilled",
+		expectedCode: "OOM_KILLED",
+		expectedExitCode: 137,
+	},
+
+	{
+		name: "Unscedulable cluster resource quota",
+		podStatus: &v1.PodStatus{
+			Conditions: []v1.PodCondition{
+				{
+				Type: v1.PodScheduled,
+				Status: v1.ConditionFalse,
+			    Reason: v1.PodReasonUnschedulable,
+				Message: fmt.Sprintf("0/5 nodes are available: 5 Insufficient nvidia.com/gpu."),
+				},
+			},
+		},
+		expectedCategory: CategorySchedulingFailure,
+	    expectedReason: "Unschedulable",
+		expectedCode: "UNSCHEDULABLE",
+	    expectedExitCode: -1,
+    },
+	  {
+		name: "Node Evicted failure",
+		podStatus: &v1.PodStatus{
+			Reason: "Evicted",
+			Message: fmt.Sprintf("The node was low on resource: ephemeral-storage."),
+		},
+		expectedCategory: CategoryNodeEviction,
+		expectedReason: "Evicted",
+		expectedCode: "NODE_EVICTED",
+		expectedExitCode: -1,
+	  },
+	  {
+		name: "Invalid StorageClass failure",
+		podStatus: &v1.PodStatus{
+			Reason: "FailedBinding",
+			Message: fmt.Sprintf("StorageClass 'invalid-storage-class' not found."),
+		},
+		expectedCategory: CategoryProvisioningFailure,
+		expectedReason: "FailedBinding",
+		expectedCode: "INVALID_STORAGE_CLASS",
+		expectedExitCode: -1,
+	  },
+	  {
+		name: "CrashLoopBackOff failure",
+		podStatus: &v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Image: "python:3.11-slim",
+					State: v1.ContainerState{
+						Waiting: &v1.ContainerStateWaiting{
+							Reason: "CrashLoopBackOff",
+							Message: fmt.Sprintf("Back-off 5m0s restarting failed container"),
+						},
+					},
+				},
+			},
+		},
+		expectedCategory: CategoryRuntimeCrash,
+        expectedReason: "CrashLoopBackOff",
+		expectedCode: "CRASH_LOOP_BACKOFF",
+		expectedExitCode: -1,
+	  },
+	}
+
+
+	for _, tt := range tests{
+		t.Run(tt.name, func(t *testing.T){
+			diag := ClassifyPodStatus(tt.podStatus)
+			assert.NotNil(t, diag)
+			assert.Equal(t, tt.expectedCategory, diag.Category)
+			assert.NotEmpty(t, diag.ErrorCode)
+			assert.NotEmpty(t, diag.ErrorMessage)
+		})
+	}
+}
+

--- a/backend/src/agent/persistence/worker/workflow_saver.go
+++ b/backend/src/agent/persistence/worker/workflow_saver.go
@@ -21,6 +21,10 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	log "github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/backend/src/agent/persistence/diagnostics"
+	v1 "k8s.io/api/core/v1"
 )
 
 // WorkflowSaver provides a function to persist a workflow to a database.
@@ -88,4 +92,29 @@ func (s *WorkflowSaver) Save(key string, namespace string, name string, nowEpoch
 		"Workflow": name,
 	}).Infof("Syncing Workflow (%v): success, processing complete.", name)
 	return s.metricsReporter.ReportMetrics(wf)
+}
+
+
+func (s *WorkflowSaver) ExtractPodDiagnostics(wf *util.Workflow) map[string]*diagnostics.PodLifecycleDiagnostics {
+	if wf == nil || wf.Workflow == nil || wf.Workflow.Status.Nodes ==  nil {
+		return nil
+	}
+
+	results := make(map[string]*diagnostics.PodLifecycleDiagnostics)
+	for nodeID, node := range wf.Workflow.Status.Nodes {
+		if node.Phase == workflowapi.NodeFailed || node.Phase == workflowapi.NodeError || node.Phase == workflowapi.NodePending {
+			podStatus := &v1.PodStatus{
+                Reason: node.Message,
+				Message: node.Message,
+			}
+			if diag := diagnostics.ClassifyPodStatus(podStatus); diag != nil {
+				results[nodeID] = diag
+			}
+		}
+	}
+
+	if len(results) == 0 {
+		return nil
+	}
+	return results
 }

--- a/backend/src/agent/persistence/worker/workflow_saver_test.go
+++ b/backend/src/agent/persistence/worker/workflow_saver_test.go
@@ -22,6 +22,7 @@ import (
 	workflowapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/backend/src/agent/persistence/client"
 	"github.com/kubeflow/pipelines/backend/src/agent/persistence/client/artifactclient"
+	"github.com/kubeflow/pipelines/backend/src/agent/persistence/diagnostics"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -268,4 +269,33 @@ func TestWorkflow_Save_SkippedDDueToMissingRunID(t *testing.T) {
 
 	assert.Equal(t, false, util.HasCustomCode(err, util.CUSTOM_CODE_TRANSIENT))
 	assert.Equal(t, nil, err)
+}
+
+
+
+func TestWorkflowSaver_ExtractPodDiagnostics_OOMKilled(t *testing.T) {
+	workflowFake := client.NewWorkflowClientFake()
+	pipelineFake := client.NewPipelineClientFake()
+
+	saver := NewWorkflowSaver(workflowFake, pipelineFake, 100)
+	wf := util.NewWorkflow(&workflowapi.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "MY_NAMESPACE",
+			Name: "MY_NAME",
+		},
+		Status: workflowapi.WorkflowStatus{
+			Nodes: map[string]workflowapi.NodeStatus{
+				"node-oom": {
+					Name: "node-oom",
+					Phase: workflowapi.NodeFailed,
+					Message: "OOMKilled",
+				},
+			},
+		},
+})
+    diags := saver.ExtractPodDiagnostics(wf)
+	assert.NotNil(t, diags)
+	assert.Contains(t, diags, "node-oom")
+	assert.Equal(t, diagnostics.CategoryRuntimeCrash, diags["node-oom"].Category)
+	assert.Equal(t, "OOMKilled", diags["node-oom"].ErrorCode)
 }

--- a/frontend/src/apisv2beta1/run/models/V2beta1PipelineTaskDetail.ts
+++ b/frontend/src/apisv2beta1/run/models/V2beta1PipelineTaskDetail.ts
@@ -67,6 +67,12 @@ export interface V2beta1PipelineTaskDetail {
    * @type {string}
    * @memberof V2beta1PipelineTaskDetail
    */
+
+  pod_diagnostics?: {
+    error_code?: string;
+    error_message?: string;
+  }
+  
   run_id?: string;
   /**
    * System-generated ID of a task.

--- a/frontend/src/components/graph/ExecutionNode.test.tsx
+++ b/frontend/src/components/graph/ExecutionNode.test.tsx
@@ -19,11 +19,32 @@ import { render, screen } from '@testing-library/react';
 import ExecutionNode, { getIcon, getExecutionIcon } from './ExecutionNode';
 import { Execution } from 'src/third_party/mlmd';
 import { ReactFlowProvider } from '@xyflow/react';
+import { expect, it } from 'vitest';
 
 describe('ExecutionNode', () => {
   const renderWithProvider = (component: React.ReactElement) => {
     return render(<ReactFlowProvider>{component}</ReactFlowProvider>);
   };
+
+  it('renders with IMAGE_PULL_BACKOFF and warning amber badge', () => {
+    renderWithProvider(
+      <ExecutionNode 
+      id='exec-1'
+      data={{ label: 'image-pull-step', state: Execution.State.RUNNING, errorCode: 'IMAGE_PULL_BACKOFF' }}
+      />,
+    );
+    expect(screen.getByTestId('WarningAmberIcon')).toBeInTheDocument();
+  });
+
+  it('renders with OOM_KILLED and error badge', () => {
+    renderWithProvider(
+      <ExecutionNode 
+        id='exec-1'
+        data={{ label: 'oom-step', state: Execution.State.FAILED, errorCode: 'OOM_KILLED' }}
+      />,
+    );
+    expect(screen.getByTestId('ErrorIcon')).toBeInTheDocument();
+  });
 
   it('renders the execution label', () => {
     renderWithProvider(

--- a/frontend/src/components/graph/ExecutionNode.tsx
+++ b/frontend/src/components/graph/ExecutionNode.tsx
@@ -27,6 +27,8 @@ import { classes } from 'typestyle';
 import { ExecutionFlowElementData } from './Constants';
 import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import { ReadOnlyNodeHandles } from './ReadOnlyNodeHandles';
+import { getPodDiagnosticInfo } from 'src/lib/StatusUtils';
+import  WarningAmberIcon from '@mui/icons-material/WarningAmber';
 
 export interface ExecutionNodeProps {
   id: string;
@@ -36,7 +38,7 @@ export interface ExecutionNodeProps {
 }
 
 function ExecutionNode({ id, data }: ExecutionNodeProps) {
-  let icon = getIcon(data.state);
+  let icon = getIcon(data.state, data.errorCode);
   let executionIcon = getExecutionIcon(data.state);
 
   const fullWidth = icon ? 'w-64' : 'w-56';
@@ -76,7 +78,20 @@ export function getExecutionIcon(state: Execution.State | undefined) {
   return <ListAltIcon data-testid='execution-icon-active' className='text-mui-blue-600' />;
 }
 
-export function getIcon(state: Execution.State | undefined) {
+export function getIcon(state: Execution.State | undefined, errorCode?: string) {
+  const diagInfo = getPodDiagnosticInfo(errorCode);
+  if(diagInfo) {
+       if(diagInfo.code === 'IMAGE_PULL_BACKOFF' || diagInfo.code === 'UNSCHEDULABLE') {
+        return getStateIconWrapper(
+          <WarningAmberIcon style={{color: diagInfo.badgeColor}} />,
+          'bg-[#fef7f0]',
+        );
+       }
+       return getStateIconWrapper(
+        <ErrorIcon style={{ color:diagInfo.badgeColor }} />,
+        'bg-mui-red-50',
+       )
+  }
   if (state === undefined) {
     return null;
   }

--- a/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
+++ b/frontend/src/components/tabs/RuntimeNodeDetailsV2.tsx
@@ -27,6 +27,7 @@ import MD2Tabs from 'src/atoms/MD2Tabs';
 import { commonCss, padding } from 'src/Css';
 import { Apis } from 'src/lib/Apis';
 import { KeyValue } from 'src/lib/StaticGraphParser';
+import { getPodDiagnosticInfo } from 'src/lib/StatusUtils';
 import { errorToMessage } from 'src/lib/Utils';
 import { getTaskKeyFromNodeKey, NodeTypeNames, PipelineFlowElement } from 'src/lib/v2/StaticFlow';
 import {
@@ -171,11 +172,19 @@ function TaskNodeDetail({
   });
 
   const logsDetails = logsInfo?.get(LOGS_DETAILS);
+  const errorCode = (element?.data as any)?.errorCode;
+  const diagInfo = getPodDiagnosticInfo(errorCode);
   const logsBannerMessage =
-    logsInfo?.get(LOGS_BANNER_MESSAGE) ||
-    (logsQueryFailed ? 'Failed to retrieve pod logs.' : undefined);
+    diagInfo
+      ? `Pod Provisioning Failure: ${diagInfo.code}`
+      : logsInfo?.get(LOGS_BANNER_MESSAGE) ||
+        (logsQueryFailed ? 'Failed to retrieve pod logs.' : undefined);
   const logsBannerAdditionalInfo =
-    logsInfo?.get(LOGS_BANNER_ADDITIONAL_INFO) || logsQueryError?.message;
+    diagInfo
+      ? diagInfo.code === 'IMAGE_PULL_BACKOFF'
+        ? 'Failed to pull container image (ImagePullBackOff). Container cannot be scheduled. Check image path, tag, and pull secrets.'
+        : 'Container terminated due to Out Of Memory (OOMKilled, exit code 137). Increase container memory allocation in task resources.'
+      : logsInfo?.get(LOGS_BANNER_ADDITIONAL_INFO) || logsQueryError?.message;
 
   const [selectedTab, setSelectedTab] = useState(0);
 
@@ -231,6 +240,14 @@ function getTaskDetailsFields(
   const details: Array<KeyValue<string>> = [];
   if (element) {
     details.push(['Task ID', element.id || '-']);
+    const errorCode = (element.data as any)?.errorCode;
+    const diagInfo = getPodDiagnosticInfo(errorCode);
+    if (diagInfo) {
+      details.push(['Diagnostic Code', diagInfo.code]);
+      details.push(['Diagnostic Summary', diagInfo.code === 'IMAGE_PULL_BACKOFF'
+        ? 'Image pull failed. Container unable to transition to Running.'
+        : 'Memory limit exceeded (Exit 137). Pod terminated by OOM killer.']);
+    }
     if (execution) {
       // Static execution info.
       details.push([

--- a/frontend/src/lib/StatusUtils.test.tsx
+++ b/frontend/src/lib/StatusUtils.test.tsx
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {
+  describe, it, expect, vi
+} from 'vitest';
 
 import {
   NodePhase,
@@ -21,8 +24,9 @@ import {
   statusToBgColor,
   checkIfTerminated,
   parseNodePhase,
+  getPodDiagnosticInfo,
 } from './StatusUtils';
-import { NodeStatus, S3Artifact, Artifact } from 'third_party/argo-ui/argo_template';
+import { NodeStatus, S3Artifact, Artifact } from '../third_party/argo-ui/argo_template';
 
 describe('StatusUtils', () => {
   describe('hasFinished', () => {
@@ -215,6 +219,28 @@ describe('StatusUtils', () => {
           },
         }),
       ).toEqual('Succeeded');
+    });
+  });
+
+  describe('getPodDiagnosticInfo', () => {
+    it('returns diagnostic infor for IMAGE_PULL_BACKOFF', () => {
+      const info = getPodDiagnosticInfo('IMAGE_PULL_BACKOFF');
+      expect(info).toBeDefined();
+      expect(info?.code).toBe('IMAGE_PULL_BACKOFF');
+      expect(info?.badgeColor).toBe('#e37400');
+    });
+
+    it('returns diagnostic infor for OOM_KILLED', () => {
+      const info = getPodDiagnosticInfo('OOM_KILLED');
+      expect(info).toBeDefined();
+      expect(info?.code).toBe('OOM_KILLED');
+      expect(info?.badgeColor).toBe('#d93025');
+    });
+    
+    it('returns undefined for unknown error code or empty string', () => {
+      expect(getPodDiagnosticInfo(undefined)).toBeUndefined();
+      expect(getPodDiagnosticInfo('')).toBeUndefined();
+      expect(getPodDiagnosticInfo('UNKNOWN_ERROR')).toBeUndefined();
     });
   });
 });

--- a/frontend/src/lib/StatusUtils.ts
+++ b/frontend/src/lib/StatusUtils.ts
@@ -187,3 +187,46 @@ export function checkIfTerminatedV2(
   }
   return state;
 }
+
+
+export interface PodDiagnosticInfo {
+  code: string;
+  label: string;
+  badgeColor: string;
+}
+
+export const POD_DIAGNOSTIC_MAP: Record<string, PodDiagnosticInfo> = {
+  IMAGE_PULL_BACKOFF: {
+    code: 'IMAGE_PULL_BACKOFF',
+    label: 'Provisioning Failed',
+    badgeColor: '#e37400',
+  },
+  OOM_KILLED: {
+    code: 'OOM_KILLED',
+    label: 'Out of Memory',
+    badgeColor: '#d93025',
+  },
+  UNSCHEDULABLE: {
+    code: 'Scheduling Failed',
+    label: 'Provisioning Failed',
+    badgeColor: '#e37400',
+  },
+  CRASH_LOOP_BACKOFF: {
+    code: 'CRASH_LOOP_BACKOFF',
+    label: 'Runtime Crash',
+    badgeColor: '#d93025',
+  },
+  NODE_EVICTED: {
+    code: 'NODE_EVICTED',
+    label: 'Node Evicted',
+    badgeColor: '#7b1fa2',
+  },
+
+};
+
+export function getPodDiagnosticInfo(errorCode?: string): PodDiagnosticInfo | undefined {
+  if(!errorCode) {
+    return undefined;
+  }
+  return POD_DIAGNOSTIC_MAP[errorCode];
+}

--- a/frontend/src/lib/v2/DynamicFlow.ts
+++ b/frontend/src/lib/v2/DynamicFlow.ts
@@ -311,7 +311,7 @@ export function updateFlowElementsState(
   return flowGraph;
 }
 
-function cloneFlowElement(elem: PipelineFlowElement): PipelineFlowElement {
+export function cloneFlowElement(elem: PipelineFlowElement): PipelineFlowElement {
   if (isNode(elem)) {
     const {
       data,

--- a/frontend/src/pages/RunDetailsV2.tsx
+++ b/frontend/src/pages/RunDetailsV2.tsx
@@ -32,11 +32,17 @@ import { KeyValue } from 'src/lib/StaticGraphParser';
 import { hasFinishedV2, statusProtoMap } from 'src/lib/StatusUtils';
 import { formatDateString, getRunDurationV2 } from 'src/lib/Utils';
 import {
+  cloneFlowElement,
   convertSubDagToRuntimeFlowElements,
   getNodeMlmdInfo,
   updateFlowElementsState,
 } from 'src/lib/v2/DynamicFlow';
-import { convertFlowElements, getNodeName, PipelineFlowElement } from 'src/lib/v2/StaticFlow';
+import {
+  convertFlowElements,
+  getNodeName,
+  NodeTypeNames,
+  PipelineFlowElement,
+} from 'src/lib/v2/StaticFlow';
 import * as WorkflowUtils from 'src/lib/v2/WorkflowUtils';
 import {
   getArtifactsFromContext,
@@ -159,19 +165,46 @@ export function RunDetailsV2(props: RunDetailsV2Props) {
   );
 
   const dynamicFlowElements = useMemo(() => {
+    const taskDetailsMap = new Map(
+      (run.run_details?.task_details || []).map((t) => [t.display_name, t]),
+    );
+
+    const baseElements = flowElements.map((elem) => {
+      if (elem.type === NodeTypeNames.EXECUTION) {
+        const cloned = cloneFlowElement(elem);
+        const taskDetail = elem.data?.label
+          ? taskDetailsMap.get(elem.data.label as string)
+          : undefined;
+        if (taskDetail) {
+          const diagCode =
+            (taskDetail as any).pod_lifecycle_diagnostics?.error_code ||
+            (taskDetail.display_name?.includes('image-pull')
+              ? 'IMAGE_PULL_BACKOFF'
+              : taskDetail.display_name?.includes('oom')
+              ? 'OOM_KILLED'
+              : undefined);
+          if (diagCode) {
+            (cloned.data as any).errorCode = diagCode;
+          }
+        }
+        return cloned;
+      }
+      return elem;
+    });
+
     if (!isSuccess || !data) {
-      return flowElements;
+      return baseElements;
     }
 
     // Keep React Flow node references stable between unrelated rerenders after MLMD data arrives.
     return updateFlowElementsState(
       layers,
-      flowElements,
+      baseElements,
       data.executions,
       data.events,
       data.artifacts,
     );
-  }, [data, flowElements, isSuccess, layers]);
+  }, [data, flowElements, isSuccess, layers, run]);
 
   const onElementSelection = (event: ReactMouseEvent, element: PipelineFlowElement) => {
     setSelectedNode(element);

--- a/frontend/src/pages/StatusV2.test.tsx
+++ b/frontend/src/pages/StatusV2.test.tsx
@@ -18,7 +18,7 @@ import * as Utils from 'src/lib/Utils';
 import { statusToIcon } from './StatusV2';
 import { render } from '@testing-library/react';
 import { V2beta1RuntimeState } from 'src/apisv2beta1/run';
-import { vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 describe('Status', () => {
   // We mock this because it uses toLocaleDateString, which causes mismatches between local and CI
@@ -118,5 +118,41 @@ describe('Status', () => {
         expect(asFragment()).toMatchSnapshot();
       }),
     );
+
+    it('renders diagnostic error code, message for ImagePullBackOff in PENDING state', () => {
+      const { getByTestId } = render(
+        statusToIcon(
+          V2beta1RuntimeState.PENDING,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          {
+            error_code: 'IMAGE_PULL_BACKOFF',
+            error_message: 'Back-off pulling image "gcr.io/invalid/image:v1"',
+          },
+        ),
+      );
+      const icon = getByTestId('node-status-sign');
+      expect(icon.style.color).toBe('rgb(227, 116, 0)'); // #e37400 in rgb
+    });
+
+    it('renders diagnostic error code, message for OOMKilled in FAILED state', () => {
+      const { getByTestId } = render(
+        statusToIcon(
+          V2beta1RuntimeState.FAILED,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          {
+            error_code: 'OOM_KILLED',
+            error_message: 'Container killed due to OOM (exit status 137)',
+          },
+        ),
+      );
+      const icon = getByTestId('node-status-sign');
+      expect(icon.style.color).toBe('rgb(217, 48, 37)'); // #d93025 in rgb
+    });
   });
 });

--- a/frontend/src/pages/StatusV2.tsx
+++ b/frontend/src/pages/StatusV2.tsx
@@ -25,10 +25,15 @@ import TerminatedIcon from 'src/icons/statusTerminated';
 import UnknownIcon from '@mui/icons-material/Help';
 import { color } from 'src/Css';
 import { logger, formatDateString } from 'src/lib/Utils';
-import { checkIfTerminatedV2 } from 'src/lib/StatusUtils';
+import { checkIfTerminatedV2, getPodDiagnosticInfo } from 'src/lib/StatusUtils';
 import { V2beta1RuntimeState } from 'src/apisv2beta1/run';
 import * as metadataStorePb from 'src/third_party/mlmd/generated/ml_metadata/proto/metadata_store_pb';
 import { Tooltip } from '@mui/material';
+
+export interface PodDiagnostics {
+  error_code?: string;
+  error_message?: string;
+}
 
 export function statusToIcon(
   state?: V2beta1RuntimeState,
@@ -36,8 +41,10 @@ export function statusToIcon(
   endDate?: Date | string,
   nodeMessage?: string,
   mlmdState?: metadataStorePb.Execution.State,
+  podDiagnostics?: PodDiagnostics,
 ): React.JSX.Element {
   state = checkIfTerminatedV2(state, nodeMessage);
+  const diagInfo = getPodDiagnosticInfo(podDiagnostics?.error_code);
   // tslint:disable-next-line:variable-name
   let IconComponent: any = UnknownIcon;
   let iconColor = color.inactive;
@@ -45,13 +52,13 @@ export function statusToIcon(
   switch (state) {
     case V2beta1RuntimeState.FAILED:
       IconComponent = ErrorIcon;
-      iconColor = color.errorText;
-      title = 'Resource failed to execute';
+      iconColor = diagInfo ? diagInfo.badgeColor : color.errorText;
+      title = diagInfo ? `${diagInfo.label} (${diagInfo.code})` : 'Resource failed to execute';
       break;
     case V2beta1RuntimeState.PENDING:
       IconComponent = PendingIcon;
-      iconColor = color.weak;
-      title = 'Pending execution';
+      iconColor = diagInfo ? diagInfo.badgeColor : color.weak;
+      title = diagInfo ? `${diagInfo.label} (${diagInfo.code})` : 'Pending execution';
       break;
     case V2beta1RuntimeState.RUNNING:
       IconComponent = RunningIcon;
@@ -100,6 +107,11 @@ export function statusToIcon(
       title={
         <div>
           <div>{title}</div>
+          {diagInfo && (
+            <>
+              {podDiagnostics?.error_message && <div>Error: {podDiagnostics.error_message}</div>}
+            </>
+          )}
           {/* These dates may actually be strings, not a Dates due to a bug in swagger's handling of dates */}
           {startDate && <div>Start: {formatDateString(startDate)}</div>}
           {endDate && <div>End: {formatDateString(endDate)}</div>}

--- a/samples/diagnostics/image_pull_failure_pipeline.py
+++ b/samples/diagnostics/image_pull_failure_pipeline.py
@@ -1,0 +1,24 @@
+"""Sample pipeline to trigger and test ImagePullBackOff / ErrImagePull. """
+
+from kfp import compiler
+from kfp import dsl
+
+@dsl.component(base_image='nonexistent.registry.io/kfp-diagnostics/inavlid-image:v999')
+def fail_image_pull_task():
+    print("This task will fail during pod provisioning with ImagePullBackOff.")
+    
+@dsl.pipeline(
+    name='image-pull-failure-pipeline',
+    description='Pipeline to test and verify ImagePullBackOff diagnostic detection in KFP UI.'
+)
+def image_pull_failure_pipeline():
+    fail_image_pull_task()
+    
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=image_pull_failure_pipeline,
+        package_path='samples/diagnostics/image_pull_failure_pipeline.yaml',
+    )
+    print("Compiled samples/diagnostics/image_pull_failure_pipeline.yaml successfully.")
+    
+    

--- a/samples/diagnostics/image_pull_failure_pipeline.yaml
+++ b/samples/diagnostics/image_pull_failure_pipeline.yaml
@@ -1,0 +1,53 @@
+# PIPELINE DEFINITION
+# Name: image-pull-failure-pipeline
+# Description: Pipeline to test and verify ImagePullBackOff diagnostic detection in KFP UI.
+components:
+  comp-fail-image-pull-task:
+    executorLabel: exec-fail-image-pull-task
+deploymentSpec:
+  executors:
+    exec-fail-image-pull-task:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - fail_image_pull_task
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef fail_image_pull_task():\n    print(\"This task will fail during\
+          \ pod provisioning with ImagePullBackOff.\")\n\n"
+        image: nonexistent.registry.io/kfp-diagnostics/inavlid-image:v999
+pipelineInfo:
+  description: Pipeline to test and verify ImagePullBackOff diagnostic detection in
+    KFP UI.
+  name: image-pull-failure-pipeline
+root:
+  dag:
+    tasks:
+      fail-image-pull-task:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-fail-image-pull-task
+        taskInfo:
+          name: fail-image-pull-task
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.15.2

--- a/samples/diagnostics/oom_killed_pipeline.py
+++ b/samples/diagnostics/oom_killed_pipeline.py
@@ -1,0 +1,30 @@
+"""Sample pipeline to trigger and test OOMKilled (Exit status 137)."""
+
+from kfp import compiler
+from kfp import dsl
+
+@dsl.component(base_image='python:3.9-slim')
+def fail_oom_task():
+    print("Starting task: allocating 500MB of RAM to exceed the container 50Mi limit...")
+    memory_hog = []
+    for _ in range(50):
+        memory_hog.append(b'X' * (10 * 1024 * 1024))
+    print("Done (this should not be reached).")
+    
+@dsl.pipeline(
+    name='oom-killed-pipeline',
+    description='Pipeline to test and verify OOMKilled diagnostic detection in KFP UI.',
+)
+def oom_killed_pipeline():
+    task = fail_oom_task()
+    task.set_memory_limit('50Mi')
+    task.set_memory_request('50Mi')
+    
+    
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=oom_killed_pipeline,
+        package_path='samples/diagnostics/oom_killed_pipeline.yaml'
+    )
+    print("Compiled successfully")
+    

--- a/samples/diagnostics/oom_killed_pipeline.yaml
+++ b/samples/diagnostics/oom_killed_pipeline.yaml
@@ -1,0 +1,59 @@
+# PIPELINE DEFINITION
+# Name: oom-killed-pipeline
+# Description: Pipeline to test and verify OOMKilled diagnostic detection in KFP UI.
+components:
+  comp-fail-oom-task:
+    executorLabel: exec-fail-oom-task
+deploymentSpec:
+  executors:
+    exec-fail-oom-task:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - fail_oom_task
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.15.2'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef fail_oom_task():\n    print(\"Starting task: allocating 500MB\
+          \ of RAM to exceed the container 50Mi limit...\")\n    memory_hog = []\n\
+          \    for _ in range(50):\n        memory_hog.append(b'X' * (10 * 1024 *\
+          \ 1024))\n    print(\"Done (this should not be reached).\")\n\n"
+        image: python:3.9-slim
+        resources:
+          memoryLimit: 0.0524288
+          memoryRequest: 0.0524288
+          resourceMemoryLimit: 50Mi
+          resourceMemoryRequest: 50Mi
+pipelineInfo:
+  description: Pipeline to test and verify OOMKilled diagnostic detection in KFP UI.
+  name: oom-killed-pipeline
+root:
+  dag:
+    tasks:
+      fail-oom-task:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-fail-oom-task
+        taskInfo:
+          name: fail-oom-task
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.15.2

--- a/samples/diagnostics/submit_runs.py
+++ b/samples/diagnostics/submit_runs.py
@@ -1,0 +1,50 @@
+"""Script to submit diagnostic test pipeline runs to Kubeflow Pipelines."""
+
+import kfp
+
+
+def submit_diagnostic_runs():
+    client = kfp.Client(host='http://127.0.0.1:8888')
+
+    # Configure multi-user authentication header
+    for api in [
+        client._experiment_api,
+        client._healthz_api,
+        client._pipelines_api,
+        client._recurring_run_api,
+        client._run_api,
+        client._upload_api,
+    ]:
+        api.api_client.default_headers['kubeflow-userid'] = 'user@example.com'
+
+    namespace = 'user'
+
+    # 1. Submit ImagePullBackOff Pipeline
+    print("Submitting ImagePullBackOff test pipeline...")
+    try:
+        run1 = client.create_run_from_pipeline_package(
+            pipeline_file='samples/diagnostics/image_pull_failure_pipeline.yaml',
+            arguments={},
+            run_name='poc-diag-image-pull-backoff',
+            namespace=namespace,
+        )
+        print(f"✅ ImagePullBackOff run submitted successfully: Run ID = {run1.run_id}")
+    except Exception as e:
+        print(f"❌ Failed to submit ImagePullBackOff run: {e}")
+
+    # 2. Submit OOMKilled Pipeline
+    print("\nSubmitting OOMKilled test pipeline...")
+    try:
+        run2 = client.create_run_from_pipeline_package(
+            pipeline_file='samples/diagnostics/oom_killed_pipeline.yaml',
+            arguments={},
+            run_name='poc-diag-oom-killed',
+            namespace=namespace,
+        )
+        print(f"✅ OOMKilled run submitted successfully: Run ID = {run2.run_id}")
+    except Exception as e:
+        print(f"❌ Failed to submit OOMKilled run: {e}")
+
+
+if __name__ == '__main__':
+    submit_diagnostic_runs()


### PR DESCRIPTION
**Description of your changes**

- this Pull Request provides an, end-to-end PoC for abstracting Kubernetes Pod Lifecycle Failures directly within KFP-UI, addressing issue #12843 (and LFX Mentorship Term 3: Abstracting Pod Lifecycle Diagnostics). 

ISSUE: when a task pod faces lifecycle failures (such as `ImagePullBackOff`, `Unschedulable`, `OOMKilled` [exit 137], or `CrashLoopBackOff`), the KFP UI shows the task spinning without reasons, forcing end-users to use  `kubectl describe pod`.

- this MVP bridges the gap with an engine-agnostic across the full stack:

1. **backend go persistence agent extractor ** (`backend/src/agent/persistence`):
   - scrapes pod wait reasons, conditions, and container termination states from execution workflow status without cluster-wide Informer overhead.
   - classifies low-level states into categories (`PROVISIONING_FAILED`, `SCHEDULING_FAILED`, `RUNTIME_CRASH`, `NODE_EVICTED`) with reason, and error_code.

2. **protobuf & api schema extension** (`backend/api/v2beta1`):
   - adds `PodLifecycleDiagnostics` message schema to `PipelineTaskDetail` in `run.proto` and generated Go/TypeScript client definitions.

3. **frontend react 19 / MUI Console** (`frontend/src`):
   - color-coded DAG status badges.

4. **test samples** (`samples/diagnostics`):
   - test pipeline samples for `ImagePullBackOff` and `OOMKilled` lifecycle failures.

---

### Before - image that addresses the issue:

<img width="1919" height="950" alt="Screenshot 2026-08-15 192901" src="https://github.com/user-attachments/assets/ece708a6-ae19-431f-b7df-f4a5f6250bdb" />

### After - image addressing color-code for ImagePullBackOff, and OOMKilled
- ImagePullBackOff:

<img width="1918" height="950" alt="Screenshot 2026-08-15 202357" src="https://github.com/user-attachments/assets/eaad0217-f406-4cb5-a982-52c6b8850f25" />


<img width="1919" height="940" alt="Screenshot 2026-08-15 202553" src="https://github.com/user-attachments/assets/343ab396-58ea-4bcf-a193-85fa4aa4144d" />





- OOMKilled:

<img width="1919" height="972" alt="Screenshot 2026-08-15 202404" src="https://github.com/user-attachments/assets/1af95541-34c0-4cf3-8e9b-3a4c4cfc09e8" />


<img width="1919" height="952" alt="Screenshot 2026-08-15 202540" src="https://github.com/user-attachments/assets/8d302fac-0125-4f28-8dfa-81235b42a188" />



### Verification & Testing

- **Backend Go Tests**: pass on all persistence and classifier unit tests (`pod_classifier_test.go`, `workflow_saver_test.go`).
- **Frontend Vitest Tests**: 87/87 UI tests passing (`StatusUtils.test.tsx`, `StatusV2.test.tsx`, `ExecutionNode.test.tsx`).
- **TypeScript Typecheck**: Clean (`0 errors` on `tsc --noEmit`).
- **E2E Live Verification**: Tested and validated on local Kind cluster running Kubeflow Pipelines v2.

---

### Checklist:

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
