### PR TITLE
chore(deps): bump @xyflow/react to 12.11.3

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "@tanstack/react-query": "^5.91.2",
         "@types/lodash.groupby": "^4.6.9",
         "@types/pako": "^1.0.3",
-        "@xyflow/react": "^12.10.1",
+        "@xyflow/react": "^12.11.3",
         "ace-builds": "^1.44.0",
         "d3-dsv": "^3.0.1",
         "dagre": "^0.8.5",
@@ -3472,6 +3472,8 @@
     },
     "node_modules/@types/d3-drag": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-selection": "*"
@@ -3508,6 +3510,8 @@
     },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
       "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
@@ -3527,6 +3531,8 @@
     },
     "node_modules/@types/d3-transition": {
       "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-selection": "*"
@@ -3534,6 +3540,8 @@
     },
     "node_modules/@types/d3-zoom": {
       "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-interpolate": "*",
@@ -3690,7 +3698,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4587,20 +4595,34 @@
       "license": "MIT"
     },
     "node_modules/@xyflow/react": {
-      "version": "12.10.1",
+      "version": "12.11.3",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.3.tgz",
+      "integrity": "sha512-G3jogHz2GWUtIOkhavUGno2YzY9u6fILIJBttfsBendb0/HWB90JG+sOTAvlIMEwyvq9zgy9V9ZQSwyQjR5QzQ==",
       "license": "MIT",
       "dependencies": {
-        "@xyflow/system": "0.0.75",
+        "@xyflow/system": "0.0.80",
         "classcat": "^5.0.3",
         "zustand": "^4.4.0"
       },
       "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
         "react": ">=17",
         "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xyflow/system": {
-      "version": "0.0.75",
+      "version": "0.0.80",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.80.tgz",
+      "integrity": "sha512-ywc3ZqG91brzWrH1WlwMdIX4goOfrpBy6AbLdVSaof/Xx9l138ijIKRExM6EkMro2F+OImGmSiA/WKcXvKVcfA==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-drag": "^3.0.7",
@@ -4612,65 +4634,6 @@
         "d3-interpolate": "^3.0.1",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0"
-      }
-    },
-    "node_modules/@xyflow/system/node_modules/d3-drag": {
-      "version": "3.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-selection": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@xyflow/system/node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@xyflow/system/node_modules/d3-selection": {
-      "version": "3.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@xyflow/system/node_modules/d3-transition": {
-      "version": "3.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-dispatch": "1 - 3",
-        "d3-ease": "1 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "d3-selection": "2 - 3"
-      }
-    },
-    "node_modules/@xyflow/system/node_modules/d3-zoom": {
-      "version": "3.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "2 - 3",
-        "d3-transition": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -5361,8 +5324,26 @@
       }
     },
     "node_modules/d3-dispatch": {
-      "version": "1.0.5",
-      "license": "BSD-3-Clause"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-dsv": {
       "version": "3.0.1",
@@ -5390,12 +5371,38 @@
       }
     },
     "node_modules/d3-ease": {
-      "version": "1.0.5",
-      "license": "BSD-3-Clause"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-format": {
       "version": "1.3.2",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-time": {
       "version": "1.0.10",
@@ -5409,8 +5416,48 @@
       }
     },
     "node_modules/d3-timer": {
-      "version": "1.0.9",
-      "license": "BSD-3-Clause"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dagre": {
       "version": "0.8.5",
@@ -10304,23 +10351,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/victory-vendor/node_modules/d3-ease": {
-      "version": "3.0.1",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/victory-vendor/node_modules/d3-path": {
       "version": "3.1.0",
       "license": "ISC",
@@ -10358,13 +10388,6 @@
       "dependencies": {
         "d3-array": "2 - 3"
       },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/victory-vendor/node_modules/d3-timer": {
-      "version": "3.0.1",
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "@tanstack/react-query": "^5.91.2",
     "@types/lodash.groupby": "^4.6.9",
     "@types/pako": "^1.0.3",
-    "@xyflow/react": "^12.10.1",
+    "@xyflow/react": "^12.11.3",
     "ace-builds": "^1.44.0",
     "d3-dsv": "^3.0.1",
     "dagre": "^0.8.5",

--- a/frontend/src/pages/v2/DagCanvas.tsx
+++ b/frontend/src/pages/v2/DagCanvas.tsx
@@ -23,6 +23,7 @@ import {
   Edge,
   MiniMap,
   Node,
+  OnNodeDrag,
 } from '@xyflow/react';
 import { FlowElementDataBase } from 'src/components/graph/Constants';
 import SubDagLayer from 'src/components/graph/SubDagLayer';
@@ -75,8 +76,8 @@ export default function DagCanvas({
   );
   const edges = useMemo(() => elements.filter((el): el is Edge => !isNode(el)), [elements]);
 
-  const onNodeDragStop = useCallback(
-    (_event: ReactMouseEvent, draggedNode: PipelineNode) => {
+  const onNodeDragStop = useCallback<OnNodeDrag<PipelineNode>>(
+    (_event, draggedNode) => {
       const updatedElements = elements.map((el) =>
         isNode(el) && el.id === draggedNode.id ? { ...el, position: draggedNode.position } : el,
       );


### PR DESCRIPTION
## Summary

Bump `@xyflow/react` from 12.10.1 to 12.11.3 and adapt `DagCanvas` to the updated `OnNodeDrag` signature.

Supersedes #14077.

## Why

React Flow 12.11 types the node drag event as the native `MouseEvent | TouchEvent` rather than React's synthetic `MouseEvent`. The existing annotation on `onNodeDragStop` therefore no longer matched, and #14077 failed `frontend-tests` with:

```
src/pages/v2/DagCanvas.tsx(117,13): error TS2322: Type '((_event: MouseEvent<Element, MouseEvent>, draggedNode: PipelineNode) => void) | undefined'
  is not assignable to type 'OnNodeDrag<PipelineNode> | undefined'.
```

Dependabot cannot make the accompanying source change, so its PR could not go green on its own.

Rather than widen the parameter annotation by hand, the callback is now typed as `useCallback<OnNodeDrag<PipelineNode>>`, so the parameter types come from the library. A future signature change then fails at the handler definition rather than at the `ReactFlow` call site.

The `package-lock.json` diff is larger than the single version bump because the updated `@xyflow/system` d3 ranges now overlap with `victory-vendor`'s, so npm hoists `d3-drag`, `d3-interpolate`, `d3-selection`, `d3-transition`, and `d3-zoom` to the top level.

## Verification

- `npx tsc --noEmit` — clean
- `npx prettier --check src/pages/v2/DagCanvas.tsx` — clean
- `npm test` — 149 files, 2050 tests, all passing
- Ran on node 24.14.0, matching `frontend/.nvmrc`
