### PR TITLE
chore(ci): group @mui updates in one Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,14 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
+      # @mui/icons-material declares a peer dependency on the matching
+      # @mui/material version, so bumping either one alone leaves the other
+      # outside its peer range and `npm install` fails to resolve. They have to
+      # land together. Listed before npm-dependencies because a dependency
+      # joins the first group whose patterns match.
+      mui:
+        patterns:
+          - "@mui/*"
       # Update a shared package in one PR across all npm projects.
       npm-dependencies:
         group-by: dependency-name


### PR DESCRIPTION
## Summary

Group `@mui/*` updates into a single Dependabot PR.

## Why

`@mui/icons-material` declares a peer dependency on the matching `@mui/material` version, so the two cannot be updated independently. The npm ecosystem currently groups only by dependency name, so Dependabot opened one PR per package — #14070 and #14071 — and both fail at install:

```
npm error peer @mui/material@"^9.3.1" from @mui/icons-material@9.3.1
npm error Conflicting peer dependency: @mui/material@9.3.1
```

Master has both at `^5.18.0`. Bumping either alone leaves the other outside its peer range, so **neither PR can ever go green on its own** and retesting will not help. Every regeneration reproduces the same pair.

A patterns-based group makes them land together. It is listed before `npm-dependencies` because a dependency joins the first group whose patterns match.

## Note on the current pair

This fixes the grouping, not the upgrade itself. #14070/#14071 are a `5.18.0 → 9.3.1` jump — four major versions — which is a real MUI migration (theme API, styled engine, Grid) rather than a routine bump. Grouping means the regenerated PR will at least be installable and reviewable as one unit; it will still need deliberate migration work.

## Verification

- `.github/resources/scripts` suite: 194 tests pass, including `dependabot_config_test`
- Confirmed the `mui` group is ordered ahead of `npm-dependencies` within the npm block
