### PR TITLE
fix(backend): eliminate redundant artifactFileExists probe and fix nil error in ReadArtifact. Fixes #14094

### DIFF
--- a/backend/src/apiserver/server/run_artifact_server.go
+++ b/backend/src/apiserver/server/run_artifact_server.go
@@ -74,24 +74,23 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 		return
 	}
 
-	artifactFileExists, err := s.artifactFileExists(r.Context(), runID, nodeID, artifactName)
-	if err != nil {
-		s.writeErrorToResponse(response, http.StatusInternalServerError, err)
-		return
-	} else if !artifactFileExists {
-		s.writeErrorToResponse(response, http.StatusNotFound, fmt.Errorf("artifact not found: %v", err))
-		return
-	}
-
 	artifactPath, err := s.resourceManager.ResolveArtifactPath(runID, nodeID, artifactName)
 	if err != nil {
-		s.writeErrorToResponse(response, http.StatusInternalServerError, err)
+		if isNotFoundError(err) {
+			s.writeErrorToResponse(response, http.StatusNotFound, util.Wrap(err, "Failed to read artifact"))
+		} else {
+			s.writeErrorToResponse(response, http.StatusInternalServerError, err)
+		}
 		return
 	}
 
 	reader, err := s.resourceManager.ObjectStore().GetFileReader(r.Context(), artifactPath)
 	if err != nil {
-		s.writeErrorToResponse(response, http.StatusInternalServerError, fmt.Errorf("failed to get file reader: %v", err))
+		if isNotFoundError(err) {
+			s.writeErrorToResponse(response, http.StatusNotFound, fmt.Errorf("artifact file not found at path %q: %w", artifactPath, err))
+		} else {
+			s.writeErrorToResponse(response, http.StatusInternalServerError, fmt.Errorf("failed to get file reader: %v", err))
+		}
 		return
 	}
 	defer func() {
@@ -129,31 +128,6 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 		glog.Errorf("Failed to write JSON closing: %v", err)
 		return
 	}
-}
-
-func (s *RunArtifactServer) artifactFileExists(ctx context.Context, runID string, nodeID string, artifactName string) (bool, error) {
-	artifactPath, err := s.resourceManager.ResolveArtifactPath(runID, nodeID, artifactName)
-	if err != nil {
-		if isNotFoundError(err) {
-			return false, nil
-		} else {
-			return false, err
-		}
-	}
-	reader, err := s.resourceManager.ObjectStore().GetFileReader(ctx, artifactPath)
-	if err != nil {
-		if isNotFoundError(err) {
-			return false, nil
-		} else {
-			return false, err
-		}
-	}
-	defer func() {
-		if closeErr := reader.Close(); closeErr != nil {
-			glog.Warningf("Failed to close artifact reader: %v", closeErr)
-		}
-	}()
-	return true, nil
 }
 
 // ReadArtifactV1 handles v1 artifact reading (delegates to v2 implementation)

--- a/backend/src/apiserver/server/run_artifact_server.go
+++ b/backend/src/apiserver/server/run_artifact_server.go
@@ -76,7 +76,7 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 	artifactPath, err := s.resourceManager.ResolveArtifactPath(runID, nodeID, artifactName)
 	if err != nil {
 		if isNotFoundError(err) {
-			s.writeErrorToResponse(response, http.StatusNotFound, util.Wrap(err, "Failed to read artifact"))
+			s.writeErrorToResponse(response, http.StatusNotFound, util.NewNotFoundError(err, "Failed to read artifact: %v", err))
 		} else {
 			s.writeErrorToResponse(response, http.StatusInternalServerError, err)
 		}
@@ -86,7 +86,7 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 	reader, err := s.resourceManager.ObjectStore().GetFileReader(r.Context(), artifactPath)
 	if err != nil {
 		if isNotFoundError(err) {
-			s.writeErrorToResponse(response, http.StatusNotFound, util.Wrap(err, "Failed to read artifact"))
+			s.writeErrorToResponse(response, http.StatusNotFound, util.NewNotFoundError(err, "Failed to read artifact: artifact file not found at path %q", artifactPath))
 		} else {
 			s.writeErrorToResponse(response, http.StatusInternalServerError, fmt.Errorf("failed to get file reader: %v", err))
 		}

--- a/backend/src/apiserver/server/run_artifact_server.go
+++ b/backend/src/apiserver/server/run_artifact_server.go
@@ -76,7 +76,7 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 	artifactPath, err := s.resourceManager.ResolveArtifactPath(runID, nodeID, artifactName)
 	if err != nil {
 		if isNotFoundError(err) {
-			s.writeErrorToResponse(response, http.StatusNotFound, util.NewNotFoundError(err, "Failed to read artifact"))
+			s.writeErrorToResponse(response, http.StatusNotFound, util.NewNotFoundError(err, "Failed to read artifact: resource not found"))
 		} else {
 			s.writeErrorToResponse(response, http.StatusInternalServerError, err)
 		}
@@ -86,7 +86,7 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 	reader, err := s.resourceManager.ObjectStore().GetFileReader(r.Context(), artifactPath)
 	if err != nil {
 		if isNotFoundError(err) {
-			s.writeErrorToResponse(response, http.StatusNotFound, util.NewNotFoundError(err, "Failed to read artifact file at path %q", artifactPath))
+			s.writeErrorToResponse(response, http.StatusNotFound, util.NewNotFoundError(err, "Failed to read artifact: artifact file not found at path %q", artifactPath))
 		} else {
 			s.writeErrorToResponse(response, http.StatusInternalServerError, fmt.Errorf("failed to get file reader: %v", err))
 		}

--- a/backend/src/apiserver/server/run_artifact_server.go
+++ b/backend/src/apiserver/server/run_artifact_server.go
@@ -76,7 +76,7 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 	artifactPath, err := s.resourceManager.ResolveArtifactPath(runID, nodeID, artifactName)
 	if err != nil {
 		if isNotFoundError(err) {
-			s.writeErrorToResponse(response, http.StatusNotFound, util.NewNotFoundError(err, "Failed to read artifact: %v", err))
+			s.writeErrorToResponse(response, http.StatusNotFound, util.NewNotFoundError(err, "Failed to read artifact"))
 		} else {
 			s.writeErrorToResponse(response, http.StatusInternalServerError, err)
 		}
@@ -86,7 +86,7 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 	reader, err := s.resourceManager.ObjectStore().GetFileReader(r.Context(), artifactPath)
 	if err != nil {
 		if isNotFoundError(err) {
-			s.writeErrorToResponse(response, http.StatusNotFound, util.NewNotFoundError(err, "Failed to read artifact: artifact file not found at path %q", artifactPath))
+			s.writeErrorToResponse(response, http.StatusNotFound, util.NewNotFoundError(err, "Failed to read artifact file at path %q", artifactPath))
 		} else {
 			s.writeErrorToResponse(response, http.StatusInternalServerError, fmt.Errorf("failed to get file reader: %v", err))
 		}
@@ -139,7 +139,11 @@ func (s *RunArtifactServer) writeErrorToResponse(response http.ResponseWriter, c
 	glog.Errorf("Failed to read artifact. Error: %+v", err)
 	response.WriteHeader(code)
 	response.Header().Set("Content-Type", "application/json")
-	errorResponse := &api.Error{ErrorMessage: err.Error(), ErrorDetails: fmt.Sprintf("%+v", err)}
+	errMsg := err.Error()
+	if userErr, ok := err.(*util.UserError); ok && userErr.ExternalMessage() != "" {
+		errMsg = userErr.ExternalMessage()
+	}
+	errorResponse := &api.Error{ErrorMessage: errMsg, ErrorDetails: fmt.Sprintf("%+v", err)}
 	errBytes, err := json.Marshal(errorResponse)
 	if err != nil {
 		if _, writeErr := response.Write([]byte(`{"error_message": "Error streaming artifact"}`)); writeErr != nil {

--- a/backend/src/apiserver/server/run_artifact_server.go
+++ b/backend/src/apiserver/server/run_artifact_server.go
@@ -15,7 +15,6 @@
 package server
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -87,7 +86,7 @@ func (s *RunArtifactServer) ReadArtifact(response http.ResponseWriter, r *http.R
 	reader, err := s.resourceManager.ObjectStore().GetFileReader(r.Context(), artifactPath)
 	if err != nil {
 		if isNotFoundError(err) {
-			s.writeErrorToResponse(response, http.StatusNotFound, fmt.Errorf("artifact file not found at path %q: %w", artifactPath, err))
+			s.writeErrorToResponse(response, http.StatusNotFound, util.Wrap(err, "Failed to read artifact"))
 		} else {
 			s.writeErrorToResponse(response, http.StatusInternalServerError, fmt.Errorf("failed to get file reader: %v", err))
 		}

--- a/backend/src/apiserver/server/run_artifact_server_test.go
+++ b/backend/src/apiserver/server/run_artifact_server_test.go
@@ -160,7 +160,13 @@ func TestReadArtifactV1_RunNotFound(t *testing.T) {
 
 	runArtifactServer.ReadArtifactV1(rr, req)
 
-	require.NotEqual(t, http.StatusOK, rr.Code)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	var errorResponse api.Error
+	err := json.Unmarshal(rr.Body.Bytes(), &errorResponse)
+	require.NoError(t, err)
+	require.Contains(t, errorResponse.ErrorMessage, "not found")
+	require.NotContains(t, errorResponse.ErrorMessage, "<nil>")
 }
 
 // TestReadArtifactV1_ChunkedResponse validates that the HTTP endpoint
@@ -291,7 +297,51 @@ func TestReadArtifactV1_ArtifactNotFound(t *testing.T) {
 
 	runArtifactServer.ReadArtifactV1(rr, req)
 
-	require.NotEqual(t, http.StatusOK, rr.Code)
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	var errorResponse api.Error
+	err = json.Unmarshal(rr.Body.Bytes(), &errorResponse)
+	require.NoError(t, err)
+	require.Contains(t, errorResponse.ErrorMessage, "artifact file not found")
+	require.NotContains(t, errorResponse.ErrorMessage, "<nil>")
+}
+
+func TestReadArtifactV1_ArtifactNameNotFoundInManifest(t *testing.T) {
+	resourceManager, manager, run := initWithOneTimeRun(t)
+	defer resourceManager.Close()
+
+	defer func() {
+		if err := manager.DeleteRun(context.Background(), run.UUID); err != nil {
+			t.Logf("Failed to clean up test run: %v", err)
+		}
+	}()
+
+	workflow := createWorkflowWithArtifact(run.UUID, "node-1", "artifact-1", "test/artifact.txt")
+	_, err := manager.ReportWorkflowResource(context.Background(), workflow)
+	require.NoError(t, err, "Failed to report workflow resource")
+
+	runArtifactServer := NewRunArtifactServer(manager)
+
+	url := fmt.Sprintf("/apis/v1beta1/runs/%s/nodes/node-1/artifacts/nonexistent-artifact:read", run.UUID)
+	req := httptest.NewRequest("GET", url, nil)
+
+	req = mux.SetURLVars(req, map[string]string{
+		"run_id":        run.UUID,
+		"node_id":       "node-1",
+		"artifact_name": "nonexistent-artifact",
+	})
+
+	rr := httptest.NewRecorder()
+
+	runArtifactServer.ReadArtifactV1(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+
+	var errorResponse api.Error
+	err = json.Unmarshal(rr.Body.Bytes(), &errorResponse)
+	require.NoError(t, err)
+	require.Contains(t, errorResponse.ErrorMessage, "not found")
+	require.NotContains(t, errorResponse.ErrorMessage, "<nil>")
 }
 
 func TestReadArtifactV1_MissingParameters(t *testing.T) {

--- a/backend/src/apiserver/server/run_artifact_server_test.go
+++ b/backend/src/apiserver/server/run_artifact_server_test.go
@@ -302,7 +302,7 @@ func TestReadArtifactV1_ArtifactNotFound(t *testing.T) {
 	var errorResponse api.Error
 	err = json.Unmarshal(rr.Body.Bytes(), &errorResponse)
 	require.NoError(t, err)
-	require.Contains(t, errorResponse.ErrorMessage, "artifact file not found")
+	require.Contains(t, errorResponse.ErrorMessage, "not found")
 	require.NotContains(t, errorResponse.ErrorMessage, "<nil>")
 }
 


### PR DESCRIPTION
**Description of your changes:**

### Problem & Root Cause
In `RunArtifactServer.ReadArtifact` (`backend/src/apiserver/server/run_artifact_server.go`), every artifact read request called a pre-flight probe `artifactFileExists` before streaming the artifact. This probe called `ResolveArtifactPath` (performing a DB run lookup and unmarshaling the Argo workflow JSON manifest) and `GetFileReader` (initiating and immediately closing an object store connection), only for `ReadArtifact` to repeat both operations a second time.

Furthermore, when an artifact was missing, `artifactFileExists` returned `(false, nil)`, causing `ReadArtifact` to format `fmt.Errorf("artifact not found: %v", err)` with a nil error, emitting `"artifact not found: <nil>"` in 404 responses.

### Solution
- Resolve the artifact path and obtain the remote reader in a single pass in `ReadArtifact`.
- Handle not-found conditions directly on the primary lookup and reader retrieval with descriptive error messages.
- Remove the redundant `artifactFileExists` helper.
- Update and add regression tests in `run_artifact_server_test.go` verifying 404 error responses for missing runs, missing artifact names in workflow manifests, and missing files in object storage.

Fixes #14094

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
