### PR TITLE
feat(sdk): support typing.Literal input parameters

### DIFF
--- a/sdk/python/kfp/compiler/pipeline_spec_builder.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder.py
@@ -417,6 +417,11 @@ def _build_component_spec_from_component_spec_structure(
             if input_spec.description:
                 component_spec.input_definitions.parameters[
                     input_name].description = input_spec.description
+            if input_spec.literals:
+                component_spec.input_definitions.parameters[
+                    input_name].literals.extend(
+                        to_protobuf_value(value)
+                        for value in input_spec.literals)
 
         else:
             component_spec.input_definitions.artifacts[

--- a/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
+++ b/sdk/python/kfp/compiler/pipeline_spec_builder_test.py
@@ -15,6 +15,7 @@
 
 import os
 import tempfile
+from typing import Literal
 import unittest
 
 from absl.testing import parameterized
@@ -139,6 +140,30 @@ class PipelineSpecBuilderTest(parameterized.TestCase):
             expected,
             component_spec.input_definitions.parameters['input1'].default_value,
         )
+
+    def test_literal_parameter_populates_literals_field(self):
+
+        @dsl.component
+        def pick(choice: Literal['a', 'b', 'c'] = 'a') -> str:
+            return choice
+
+        component_spec = pick.pipeline_spec.components['comp-pick']
+        param_spec = component_spec.input_definitions.parameters['choice']
+        self.assertEqual(pipeline_spec_pb2.ParameterType.STRING,
+                         param_spec.parameter_type)
+        self.assertEqual(
+            [struct_pb2.Value(string_value=v) for v in ('a', 'b', 'c')],
+            list(param_spec.literals))
+
+    def test_non_literal_parameter_has_empty_literals_field(self):
+
+        @dsl.component
+        def comp(name: str) -> str:
+            return name
+
+        component_spec = comp.pipeline_spec.components['comp-comp']
+        param_spec = component_spec.input_definitions.parameters['name']
+        self.assertEqual([], list(param_spec.literals))
 
     def test_merge_deployment_spec_and_component_spec(self):
         main_deployment_config = pipeline_spec_pb2.PipelineDeploymentConfig()

--- a/sdk/python/kfp/dsl/component_factory.py
+++ b/sdk/python/kfp/dsl/component_factory.py
@@ -314,7 +314,9 @@ def get_name_to_specs(
             type_string = type_utils._annotation_to_type_struct(annotation)
             name_to_input_specs[maybe_make_unique(
                 name, list(name_to_input_specs))] = make_input_spec(
-                    type_string, func_param)
+                    type_string,
+                    func_param,
+                    literals=type_utils.get_literal_values(annotation))
 
     ### handle return annotations ###
     return_ann = signature.return_annotation
@@ -399,9 +401,24 @@ def make_output_spec(annotation: Any) -> structures.OutputSpec:
     return structures.OutputSpec(**args)
 
 
-def make_input_spec(annotation: Any,
-                    inspect_param: inspect.Parameter) -> structures.InputSpec:
-    """Makes an InputSpec from a cleaned output annotation."""
+def make_input_spec(
+    annotation: Any,
+    inspect_param: inspect.Parameter,
+    literals: Optional[Union[List[str], List[int], List[float]]] = None
+) -> structures.InputSpec:
+    """Makes an InputSpec from a cleaned output annotation.
+
+    Args:
+        annotation: The input's type annotation. By the time this is called,
+            callers in `get_name_to_specs` have already converted most
+            parameter-type annotations (str, int, List[...], Literal[...],
+            etc.) to their compiled type-struct string, so `literals` must be
+            extracted from the original annotation by the caller and passed
+            in explicitly rather than derived here.
+        inspect_param: The `inspect.Parameter` for this input.
+        literals: The input's allowed values, if it was declared with a
+            `typing.Literal[...]` annotation.
+    """
     annotation = canonicalize_annotation(annotation)
     input_output_spec_args = make_input_output_spec_args(annotation)
 
@@ -425,6 +442,7 @@ def make_input_spec(annotation: Any,
         **input_output_spec_args,
         default=default,
         optional=optional,
+        literals=literals,
     )
 
 

--- a/sdk/python/kfp/dsl/component_factory_test.py
+++ b/sdk/python/kfp/dsl/component_factory_test.py
@@ -14,7 +14,7 @@
 
 import re
 from tempfile import TemporaryDirectory
-from typing import List
+from typing import List, Literal, Optional
 import unittest
 
 from kfp import dsl
@@ -357,6 +357,56 @@ class TestBuiltinGenericParameterAnnotations(unittest.TestCase):
             type_utils.get_canonical_name_for_outer_generic(
                 spec.outputs['Output'].type), 'Dict')
         self.assertFalse(spec.outputs['Output'].is_artifact_list)
+
+
+class TestLiteralParameterAnnotations(unittest.TestCase):
+
+    def test_string_literal(self):
+
+        @dsl.component
+        def comp(choice: Literal['a', 'b', 'c'] = 'a') -> str:
+            return choice
+
+        spec = comp.component_spec
+        self.assertEqual('String', spec.inputs['choice'].type)
+        self.assertEqual(['a', 'b', 'c'], spec.inputs['choice'].literals)
+
+    def test_int_literal(self):
+
+        @dsl.component
+        def comp(n: Literal[1, 2, 3] = 1) -> int:
+            return n
+
+        spec = comp.component_spec
+        self.assertEqual('Integer', spec.inputs['n'].type)
+        self.assertEqual([1, 2, 3], spec.inputs['n'].literals)
+
+    def test_optional_literal(self):
+
+        @dsl.component
+        def comp(choice: Optional[Literal['a', 'b']] = None) -> str:
+            return choice
+
+        spec = comp.component_spec
+        self.assertEqual('String', spec.inputs['choice'].type)
+        self.assertEqual(['a', 'b'], spec.inputs['choice'].literals)
+
+    def test_non_literal_parameter_has_no_literals(self):
+
+        @dsl.component
+        def comp(name: str) -> str:
+            return name
+
+        spec = comp.component_spec
+        self.assertIsNone(spec.inputs['name'].literals)
+
+    def test_mixed_type_literal_raises(self):
+        with self.assertRaisesRegex(
+                TypeError, 'KFP supports Literals of a single type only.'):
+
+            @dsl.component
+            def comp(choice: Literal['a', 1]) -> str:
+                return choice
 
 
 class TestArtifactStringInInputpathOutputpath(unittest.TestCase):

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -145,11 +145,12 @@ class InputSpec:
             )
 
     def _validate_default_against_literals(self) -> None:
-        """Validates that a default value is one of the input's allowed
-        Literal values, if any.
+        """Validates that a default value is one of the input's allowed Literal
+        values, if any.
 
         A default value is a hard-coded input value, same as one passed
-        explicitly to a task; it must satisfy the same Literal constraint.
+        explicitly to a task; it must satisfy the same Literal
+        constraint.
         """
         if self.literals and self.default is not None and self.default not in self.literals:
             raise ValueError(

--- a/sdk/python/kfp/dsl/structures.py
+++ b/sdk/python/kfp/dsl/structures.py
@@ -47,6 +47,7 @@ class InputSpec:
         optional: Wether the input is optional. An input is optional when it has an explicit default value.
         is_artifact_list: True if `type` represents a list of the artifact type. Only applies when `type` is an artifact.
         description: Input description.
+        literals: The allowed values for this input, if it was declared with a `typing.Literal[...]` annotation. Only applies when `type` is a parameter type.
     """
     type: Union[str, dict]
     default: Optional[Any] = None
@@ -54,10 +55,12 @@ class InputSpec:
     # This special flag for lists of artifacts allows type to be used the same way for list of artifacts and single artifacts. This is aligned with how IR represents lists of artifacts (same as for single artifacts), as well as simplifies downstream type handling/checking operations in the SDK since we don't need to parse the string `type` to determine if single artifact or list.
     is_artifact_list: bool = False
     description: Optional[str] = None
+    literals: Optional[Union[List[str], List[int], List[float]]] = None
 
     def __post_init__(self) -> None:
         self._validate_type()
         self._validate_usage_of_optional()
+        self._validate_default_against_literals()
 
     @classmethod
     def from_ir_component_inputs_dict(
@@ -140,6 +143,18 @@ class InputSpec:
             raise ValueError(
                 f'`optional` argument to {self.__class__.__name__} must be True if `default` is not None.'
             )
+
+    def _validate_default_against_literals(self) -> None:
+        """Validates that a default value is one of the input's allowed
+        Literal values, if any.
+
+        A default value is a hard-coded input value, same as one passed
+        explicitly to a task; it must satisfy the same Literal constraint.
+        """
+        if self.literals and self.default is not None and self.default not in self.literals:
+            raise ValueError(
+                f'Default value {self.default!r} is not one of the allowed '
+                f'values {self.literals!r}.')
 
 
 @dataclasses.dataclass

--- a/sdk/python/kfp/dsl/structures_test.py
+++ b/sdk/python/kfp/dsl/structures_test.py
@@ -596,6 +596,24 @@ class TestInputSpec(unittest.TestCase):
                                     r'must be True if `default` is not None'):
             input_spec = structures.InputSpec(type='String', default='text')
 
+    def test_default_matching_literals_is_valid(self):
+        input_spec = structures.InputSpec(
+            type='String', default='a', optional=True, literals=['a', 'b'])
+        self.assertEqual(input_spec.default, 'a')
+
+    def test_default_not_in_literals_raises(self):
+        with self.assertRaisesRegex(
+                ValueError,
+                r"Default value 'z' is not one of the allowed values \['a', 'b'\]"
+        ):
+            structures.InputSpec(
+                type='String', default='z', optional=True, literals=['a', 'b'])
+
+    def test_no_default_with_literals_is_valid(self):
+        input_spec = structures.InputSpec(
+            type='String', optional=False, literals=['a', 'b'])
+        self.assertIsNone(input_spec.default)
+
 
 class TestOutputSpec(parameterized.TestCase):
 

--- a/sdk/python/kfp/dsl/types/type_utils.py
+++ b/sdk/python/kfp/dsl/types/type_utils.py
@@ -15,7 +15,7 @@
 
 import inspect
 import json
-from typing import Any, Callable, Dict, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Type, Union
 
 try:
     from typing import get_args, get_origin
@@ -357,6 +357,31 @@ def verify_type_compatibility(
         else:
             warnings.warn(InconsistentTypeWarning(error_text))
 
+    # Literal-constrained inputs: statically verify a hard-coded argument
+    # value against the expected input's allowed values. A value coming from
+    # a PipelineChannel (a pipeline input or an upstream task's output)
+    # can't be checked at compile time; that's left to the driver, which
+    # validates the resolved value at runtime (see ValidateLiteralParameter
+    # in the backend).
+    expected_literals = getattr(expected_spec, 'literals', None)
+    if types_are_compatible and expected_literals:
+        # avoid circular imports
+        from kfp.dsl import pipeline_channel
+        is_channel = isinstance(given_value, pipeline_channel.PipelineChannel)
+        # PipelineChannel.__eq__ builds a ConditionOperation rather than
+        # returning a bool, so `given_value in expected_literals` is only
+        # safe for constants, not channels.
+        if not is_channel and given_value not in expected_literals:
+            types_are_compatible = False
+            error_text = (
+                error_message_prefix +
+                f'Value {given_value!r} is not one of the allowed values '
+                f'{expected_literals!r}')
+            if raise_on_error:
+                raise InconsistentTypeException(error_text)
+            else:
+                warnings.warn(InconsistentTypeWarning(error_text))
+
     return types_are_compatible
 
 
@@ -658,6 +683,35 @@ def _pydantic_basemodel_to_type_struct(model_cls: Type) -> Any:
     return get_canonical_type_name_for_type(dict)
 
 
+def get_literal_values(
+        annotation: Any) -> Optional[Union[List[str], List[int], List[float]]]:
+    """Extracts the values out of a `typing.Literal[...]` annotation.
+
+    Args:
+        annotation: The annotation to inspect. May be wrapped in
+            `Optional[...]`.
+
+    Returns:
+        The Literal's values, or None if `annotation` is not a Literal.
+
+    Raises:
+        TypeError: If the Literal mixes value types, or uses a value type
+            other than str, int, or float (KFP supports Literals of a
+            single str/int/float type only).
+    """
+    stripped_annotation = type_annotations.maybe_strip_optional_from_annotation(
+        annotation)
+    if get_origin(stripped_annotation) is not Literal:
+        return None
+
+    values = list(get_args(stripped_annotation))
+    value_types = {type(value) for value in values}
+    if len(value_types) != 1 or next(
+            iter(value_types)) not in (str, int, float):
+        raise TypeError('KFP supports Literals of a single type only.')
+    return values
+
+
 def _annotation_to_type_struct(annotation):
     if not annotation or annotation == inspect.Parameter.empty:
         return None
@@ -675,6 +729,12 @@ def _annotation_to_type_struct(annotation):
             stripped_annotation,
             type) and is_pydantic_basemodel_subclass(stripped_annotation):
         return _pydantic_basemodel_to_type_struct(stripped_annotation)
+
+    # get_literal_values() strips Optional[...] itself, so Optional[Literal[...]]
+    # is recognized the same as a bare Literal[...].
+    literal_values = get_literal_values(annotation)
+    if literal_values is not None:
+        return get_canonical_type_name_for_type(type(literal_values[0]))
 
     origin = get_origin(annotation)
     if origin in {list, dict}:

--- a/sdk/python/kfp/dsl/types/type_utils_test.py
+++ b/sdk/python/kfp/dsl/types/type_utils_test.py
@@ -14,7 +14,7 @@
 import os
 import sys
 import tempfile
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 import unittest
 
 from absl.testing import parameterized
@@ -239,6 +239,100 @@ class TestPydanticBaseModelSupport(parameterized.TestCase):
                 validation_alias='foo_in', serialization_alias='foo_out')
 
         self.assertEqual('Dict', type_utils._annotation_to_type_struct(MyModel))
+
+
+class TestLiteralParameterSupport(parameterized.TestCase):
+
+    @parameterized.parameters(
+        {
+            'annotation': Literal['a', 'b', 'c'],
+            'expected': ['a', 'b', 'c'],
+        },
+        {
+            'annotation': Literal[1, 2, 3],
+            'expected': [1, 2, 3],
+        },
+        {
+            'annotation': Literal[1.0, 2.0],
+            'expected': [1.0, 2.0],
+        },
+        {
+            'annotation': Optional[Literal['a', 'b']],
+            'expected': ['a', 'b'],
+        },
+        {
+            'annotation': Literal['solo'],
+            'expected': ['solo'],
+        },
+    )
+    def test_get_literal_values(self, annotation, expected):
+        self.assertEqual(expected, type_utils.get_literal_values(annotation))
+
+    @parameterized.parameters(
+        {
+            'annotation': str,
+        },
+        {
+            'annotation': int,
+        },
+        {
+            'annotation': List[str],
+        },
+        {
+            'annotation': Optional[str],
+        },
+        {
+            'annotation': None,
+        },
+    )
+    def test_get_literal_values_returns_none_for_non_literal(self, annotation):
+        self.assertIsNone(type_utils.get_literal_values(annotation))
+
+    @parameterized.parameters(
+        {
+            'annotation': Literal['a', 1, 'b'],
+        },
+        {
+            'annotation': Literal[1, 2.0],
+        },
+        {
+            'annotation': Literal[True, False],
+        },
+        {
+            'annotation': Literal[True, 1],
+        },
+    )
+    def test_get_literal_values_raises_for_unsupported_types(self, annotation):
+        with self.assertRaisesRegex(
+                TypeError, 'KFP supports Literals of a single type only.'):
+            type_utils.get_literal_values(annotation)
+
+    @parameterized.parameters(
+        {
+            'annotation': Literal['a', 'b', 'c'],
+            'expected': 'String',
+        },
+        {
+            'annotation': Literal[1, 2, 3],
+            'expected': 'Integer',
+        },
+        {
+            'annotation': Literal[1.0, 2.0],
+            'expected': 'Float',
+        },
+        {
+            'annotation': Optional[Literal['a', 'b']],
+            'expected': 'String',
+        },
+    )
+    def test_annotation_to_type_struct_for_literal(self, annotation, expected):
+        self.assertEqual(expected,
+                         type_utils._annotation_to_type_struct(annotation))
+
+    def test_annotation_to_type_struct_raises_for_mixed_type_literal(self):
+        with self.assertRaisesRegex(
+                TypeError, 'KFP supports Literals of a single type only.'):
+            type_utils._annotation_to_type_struct(Literal['a', 1])
 
 
 class TypeUtilsTest(parameterized.TestCase):
@@ -972,6 +1066,50 @@ class TestTypeChecking(parameterized.TestCase):
             'is_compatible':
                 True,
         },
+        {
+            'argument_value':
+                'a',
+            'parameter_input_spec':
+                structures.InputSpec('String', literals=['a', 'b', 'c']),
+            'is_compatible':
+                True,
+        },
+        {
+            'argument_value':
+                'z',
+            'parameter_input_spec':
+                structures.InputSpec('String', literals=['a', 'b', 'c']),
+            'is_compatible':
+                False,
+        },
+        {
+            'argument_value':
+                1,
+            'parameter_input_spec':
+                structures.InputSpec('Integer', literals=[1, 2, 3]),
+            'is_compatible':
+                True,
+        },
+        {
+            'argument_value':
+                4,
+            'parameter_input_spec':
+                structures.InputSpec('Integer', literals=[1, 2, 3]),
+            'is_compatible':
+                False,
+        },
+        {
+            # A channel (pipeline input or task output) can't be checked
+            # against a Literal constraint at compile time; that's left to
+            # the driver, which validates the resolved value at runtime.
+            'argument_value':
+                pipeline_channel.create_pipeline_channel(
+                    'dummy_channel', 'String', task_name='upstream-task'),
+            'parameter_input_spec':
+                structures.InputSpec('String', literals=['a', 'b', 'c']),
+            'is_compatible':
+                True,
+        },
     )
     def test_verify_type_compatibility(
         self,
@@ -1115,6 +1253,134 @@ def compile_and_load_component(
         output_path = os.path.join(tempdir, 'pipeline.yaml')
         compiler.Compiler().compile(comp, output_path)
         return components.load_component_from_file(output_path)
+
+
+def _compile(comp: base_component.BaseComponent) -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        compiler.Compiler().compile(comp, os.path.join(tempdir, 'p.yaml'))
+
+
+class TestLiteralSDKCompilerKEPScenarios(unittest.TestCase):
+    """Covers the KEP-11385 Test Plan rows marked for the SDK Compiler.
+
+    See the "SDK Compiler" column of
+    proposals/11385-literal-input-parameters/README.md#test-plan.
+    """
+
+    def test_pipeline_level_literal_valid_hardcoded_input(self):
+        # expected to pass: "Pipeline-level Literal input: valid hard-coded
+        # input"
+        @dsl.component
+        def consume(x: str) -> str:
+            return x
+
+        @dsl.pipeline
+        def sub_pipeline(x: Literal['a', 'b']):
+            consume(x=x)
+
+        @dsl.pipeline
+        def main_pipeline():
+            sub_pipeline(x='a')
+
+        _compile(main_pipeline)
+
+    def test_pipeline_level_literal_no_input(self):
+        # expected to pass: "Pipeline-level Literal input: no input (SDK
+        # only)"
+        @dsl.component
+        def consume(x: str) -> str:
+            return x
+
+        @dsl.pipeline
+        def my_pipeline(x: Literal['a', 'b']):
+            consume(x=x)
+
+        _compile(my_pipeline)
+
+    def test_component_level_literal_input(self):
+        # expected to pass: "Component-level Literal input"
+        @dsl.component
+        def pick(choice: Literal['a', 'b', 'c'] = 'a') -> str:
+            return choice
+
+        _compile(pick)
+
+    def test_pipeline_and_component_level_valid_hardcoded_input(self):
+        # expected to pass: "Pipeline & component-level: valid hard-coded
+        # input"
+        @dsl.component
+        def pick(choice: Literal['a', 'b', 'c']) -> str:
+            return choice
+
+        @dsl.pipeline
+        def my_pipeline(top: Literal['x', 'y'] = 'x'):
+            pick(choice='a')
+
+        _compile(my_pipeline)
+
+    def test_component_level_literal_input_from_task_output(self):
+        # expected to pass: "Component-level Literal input: valid input
+        # passed in from a preceding component's output"
+        @dsl.component
+        def produce() -> str:
+            return 'a'
+
+        @dsl.component
+        def pick(choice: Literal['a', 'b', 'c']) -> str:
+            return choice
+
+        @dsl.pipeline
+        def my_pipeline():
+            t = produce()
+            pick(choice=t.output)
+
+        _compile(my_pipeline)
+
+    def test_literal_elements_mismatch_across_levels_not_caught_by_sdk(self):
+        # expected to fail overall, but marked X (not caught) under SDK
+        # Compiler: "Pipeline & component-level Literal input: Literal
+        # elements do not match." Cross-checking a pipeline-level Literal's
+        # values against the component-level Literal it feeds is out of
+        # scope for #12601 and is left to the driver at runtime (see
+        # ValidateLiteralParameter in the backend); the SDK compiler
+        # succeeds here.
+        @dsl.component
+        def pick(choice: Literal['a', 'b']) -> str:
+            return choice
+
+        @dsl.pipeline
+        def my_pipeline(top: Literal['a', 'b', 'z']):
+            pick(choice=top)
+
+        _compile(my_pipeline)
+
+    def test_pipeline_level_literal_invalid_hardcoded_input(self):
+        # expected to fail: "Pipeline-level Literal input: invalid
+        # hard-coded input". NOTE: the KEP's own table marks this X (not
+        # caught) under SDK Compiler, which contradicts both the issue's
+        # acceptance criteria ("Compiler validates hard-coded input values
+        # against their Literal parameters... throws an error if input is
+        # invalid") and the KEP's Design Details prose. This implementation
+        # follows the acceptance criteria and prose: using a Literal-typed
+        # pipeline as a nested sub-pipeline task with an invalid hard-coded
+        # value raises, the same way an invalid component call does, since
+        # both go through the same PipelineTask construction path.
+        @dsl.component
+        def consume(x: str) -> str:
+            return x
+
+        @dsl.pipeline
+        def sub_pipeline(x: Literal['a', 'b']):
+            consume(x=x)
+
+        # Tracing the pipeline body (which happens at decoration time, when
+        # `sub_pipeline(x='z')` is called) is what raises here, not the
+        # later compile() call.
+        with self.assertRaises(InconsistentTypeException):
+
+            @dsl.pipeline
+            def main_pipeline():
+                sub_pipeline(x='z')
 
 
 class TestGetCanonicalNameForOuterGeneric(parameterized.TestCase):


### PR DESCRIPTION
**Description of your changes:**

Teaches the compiler to recognize typing.Literal on pipeline and component parameters, the SDK compiler slice of KEP-11385. A Literal now maps to its underlying scalar type (str, int, or float) and its allowed values are recorded on the compiled spec's literals field, which the backend, driver, and frontend dropdown already support.

Mixed type Literals and invalid hard coded or default values now fail at decoration time with a clear message, instead of the previous confusing "must have a schema_title and schema_version" artifact type error.

Fixes #12601

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
