### PR TITLE
test(ci): stop pinning action versions in workflow assertions

### DIFF
--- a/.github/resources/scripts/artifact_download_retry_test.py
+++ b/.github/resources/scripts/artifact_download_retry_test.py
@@ -65,7 +65,7 @@ class ArtifactDownloadRetryTest(unittest.TestCase):
     def test_retry_action_preserves_inputs_and_output(self):
         action = RETRY_ACTION.read_text(encoding='utf-8')
 
-        self.assertEqual(action.count('uses: actions/download-artifact@v7'), 2)
+        self.assertEqual(action.count('uses: actions/download-artifact@'), 2)
         self.assertIn("steps.primary.outcome == 'failure'", action)
         self.assertIn('sleep "$RETRY_DELAY_SECONDS"', action)
         self.assertIn('pattern: ${{ inputs.pattern }}', action)

--- a/.github/resources/scripts/artifact_upload_retry_test.py
+++ b/.github/resources/scripts/artifact_upload_retry_test.py
@@ -33,7 +33,7 @@ class ArtifactUploadRetryTest(unittest.TestCase):
     def test_retry_action_preserves_outputs_and_supports_stable_names(self):
         action = RETRY_ACTION.read_text(encoding='utf-8')
 
-        self.assertEqual(action.count('uses: actions/upload-artifact@v7'), 2)
+        self.assertEqual(action.count('uses: actions/upload-artifact@'), 2)
         self.assertIn("steps.primary.outcome == 'failure'", action)
         self.assertIn('sleep "$RETRY_DELAY_SECONDS"', action)
         self.assertIn(
@@ -61,7 +61,7 @@ class ArtifactUploadRetryTest(unittest.TestCase):
             action.count('uses: ./.github/actions/upload-artifact-with-retry'),
             3,
         )
-        self.assertNotIn('uses: actions/upload-artifact@v7', action)
+        self.assertNotIn('uses: actions/upload-artifact@', action)
 
         for step_name in (
             'Upload Kind cluster logs',

--- a/.github/resources/scripts/external_bootstrap_retry_test.py
+++ b/.github/resources/scripts/external_bootstrap_retry_test.py
@@ -205,7 +205,7 @@ class ExternalBootstrapRetryTest(unittest.TestCase):
             '- name: Set up Docker Buildx', maxsplit=1)[1].split(
                 '- name: Create and Push Manifest', maxsplit=1)[0]
 
-        self.assertIn('uses: docker/setup-buildx-action@v3', setup_step)
+        self.assertIn('uses: docker/setup-buildx-action@', setup_step)
         self.assertIn('driver: docker', setup_step)
 
     def test_manifest_workflow_changes_run_ci_script_tests(self):


### PR DESCRIPTION
## Summary

Four assertions in the `.github` script tests matched a specific action version while testing something else entirely. The version was incidental to what each test protects, so every action bump broke a test that was never checking the version.

## The four sites

| file | assertion | what it actually protects |
|---|---|---|
| `artifact_download_retry_test.py:68` | `count('...download-artifact@v7') == 2` | there are two download steps, primary and retry |
| `artifact_upload_retry_test.py:36` | `count('...upload-artifact@v7') == 2` | there are two upload steps |
| `artifact_upload_retry_test.py:64` | `assertNotIn('...upload-artifact@v7')` | no step calls `actions/upload-artifact` directly |
| `external_bootstrap_retry_test.py:208` | `assertIn('...setup-buildx-action@v3')` | the manifest job uses `driver: docker` |

In the buildx case the step is already located by splitting on `- name: Set up Docker Buildx`, so the version assertion added no coverage at all. The real invariant is the `driver: docker` line immediately below it.

## The one that mattered

`assertNotIn('uses: actions/upload-artifact@v7', action)` enforces that every upload in `test-and-report` routes through `upload-artifact-with-retry` rather than calling the action directly. Pinned to `@v7` it **fails open**: as soon as `upload-artifact` moves to v8, a direct `uses: actions/upload-artifact@v8` step satisfies the assertion and the guard silently stops protecting anything.

That is the asymmetry across these four. `assertIn`/`count` pinned to a version fail closed — noisy on every bump, but safe. `assertNotIn` pinned to a version fails open, and the failure is invisible.

Matching on the bare `uses: <action>@` prefix keeps it closed.

## Not a rule against versions in tests

Where the version *is* the invariant, pinning is correct and should stay. `argo_version_consistency_test` deliberately cross-checks that `workflow-controller`, `argoexec`, `runtime-base-images.txt`, and the CI matrices all agree; failing on a partial bump is the entire point of that test. This PR does not touch it.

## Verification

`.github/resources/scripts`, 212 tests, plus the 7 `junit-summary` tests:

- passes unchanged
- passes with `download-artifact` bumped to v8 and `setup-buildx-action` to v4, which is what #14067 and #14082 do
- each rewritten assertion still fails under mutation:
  - injecting a direct `actions/upload-artifact@v8` step into `test-and-report`
  - removing one of the two download steps
  - removing the buildx setup step

The injected `@v8` step is precisely the case the old `@v7` assertion let through, and the new one catches.

## Related

Unblocks #14067 and #14082. Neither can go green on its own, because Dependabot cannot make the accompanying test change — the same situation as #14088 and #14089.
