### PR TITLE
fix(backend): use filtered query to look up mlmd context. Fixes #13713

### DIFF
--- a/backend/metadata_writer/src/metadata_helpers.py
+++ b/backend/metadata_writer/src/metadata_helpers.py
@@ -17,6 +17,7 @@ import json
 import os
 import sys
 from time import sleep
+from ml_metadata.errors import AlreadyExistsError
 from ml_metadata.proto import metadata_store_pb2
 from ml_metadata.metadata_store import metadata_store
 from ipaddress import ip_address, IPv4Address 
@@ -190,12 +191,15 @@ def create_context_with_type(
 def get_context_by_name(
     store,
     context_name: str,
+    type_name: str,
 ) -> metadata_store_pb2.Context:
-    matching_contexts = [context for context in store.get_contexts() if context.name == context_name]
-    assert len(matching_contexts) <= 1
-    if len(matching_contexts) == 0:
+    context = store.get_context_by_type_and_name(
+        type_name=type_name,
+        context_name=context_name,
+    )
+    if context is None:
         raise ValueError('Context with name "{}" was not found'.format(context_name))
-    return matching_contexts[0]
+    return context
 
 
 def get_or_create_context_with_type(
@@ -207,16 +211,21 @@ def get_or_create_context_with_type(
     custom_properties: dict = None,
 ) -> metadata_store_pb2.Context:
     try:
-        context = get_context_by_name(store, context_name)
-    except:
-        context = create_context_with_type(
-            store=store,
-            context_name=context_name,
-            type_name=type_name,
-            properties=properties,
-            type_properties=type_properties,
-            custom_properties=custom_properties,
-        )
+        context = get_context_by_name(store, context_name, type_name)
+    except ValueError:
+        try:
+            context = create_context_with_type(
+                store=store,
+                context_name=context_name,
+                type_name=type_name,
+                properties=properties,
+                type_properties=type_properties,
+                custom_properties=custom_properties,
+            )
+        except AlreadyExistsError:
+            # Another writer created the context between our lookup and
+            # create. Look it up again instead of failing.
+            context = get_context_by_name(store, context_name, type_name)
         return context
 
     # Verifying that the context has the expected type name

--- a/backend/metadata_writer/src/metadata_helpers_test.py
+++ b/backend/metadata_writer/src/metadata_helpers_test.py
@@ -1,0 +1,153 @@
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+import metadata_helpers
+from ml_metadata.errors import AlreadyExistsError, ResourceExhaustedError
+from ml_metadata.proto import metadata_store_pb2
+
+
+def _make_context_type(type_id=1, type_name="KfpRun"):
+    return metadata_store_pb2.ContextType(id=type_id, name=type_name)
+
+
+def _make_context(context_id=1, context_name="run-1", type_id=1):
+    return metadata_store_pb2.Context(
+        id=context_id,
+        name=context_name,
+        type_id=type_id,
+    )
+
+
+class GetContextByNameTest(unittest.TestCase):
+    def setUp(self):
+        # clear the lru cache between tests.
+        metadata_helpers.get_context_by_name.cache_clear()
+
+    def test_returns_context_when_found(self):
+        store = MagicMock()
+        ctx = _make_context(context_id=99, context_name="run-1")
+        store.get_context_by_type_and_name.return_value = ctx
+
+        result = metadata_helpers.get_context_by_name(
+            store, "run-1", type_name="KfpRun"
+        )
+
+        self.assertEqual(result.id, 99)
+        store.get_context_by_type_and_name.assert_called_once_with(
+            type_name="KfpRun", context_name="run-1"
+        )
+
+    def test_raises_value_error_when_not_found(self):
+        store = MagicMock()
+        store.get_context_by_type_and_name.return_value = None
+
+        with self.assertRaises(ValueError):
+            metadata_helpers.get_context_by_name(
+                store, "nonexistent", type_name="KfpRun"
+            )
+
+    def test_propagates_transport_error(self):
+        store = MagicMock()
+        store.get_context_by_type_and_name.side_effect = ResourceExhaustedError(
+            "too big"
+        )
+
+        with self.assertRaises(ResourceExhaustedError):
+            metadata_helpers.get_context_by_name(store, "run-1", type_name="KfpRun")
+
+
+class GetOrCreateContextWithTypeTest(unittest.TestCase):
+    def setUp(self):
+        # clear the lru cache between tests.
+        metadata_helpers.get_context_by_name.cache_clear()
+
+    def test_returns_existing_context_when_found(self):
+        store = MagicMock()
+        existing = _make_context(context_id=7, context_name="run-1", type_id=1)
+        store.get_context_by_type_and_name.return_value = existing
+        store.get_context_types_by_id.return_value = [_make_context_type()]
+
+        result = metadata_helpers.get_or_create_context_with_type(
+            store=store, context_name="run-1", type_name="KfpRun"
+        )
+
+        self.assertEqual(result.id, 7)
+        store.get_contexts.assert_not_called()
+        store.put_contexts.assert_not_called()
+
+    def test_creates_context_when_it_does_not_exist(self):
+        store = MagicMock()
+        store.get_context_by_type_and_name.return_value = None  # not found
+        store.get_context_type.return_value = _make_context_type()
+        store.put_contexts.return_value = [42]
+
+        result = metadata_helpers.get_or_create_context_with_type(
+            store=store, context_name="run-1", type_name="KfpRun"
+        )
+
+        self.assertEqual(result.id, 42)
+        self.assertEqual(result.name, "run-1")
+        store.get_contexts.assert_not_called()
+        store.put_contexts.assert_called_once()
+
+    def test_propagates_resource_exhausted_error(self):
+        store = MagicMock()
+        store.get_context_by_type_and_name.side_effect = ResourceExhaustedError(
+            "Received message larger than max (6146499 vs. 4194304)"
+        )
+
+        with self.assertRaises(ResourceExhaustedError):
+            metadata_helpers.get_or_create_context_with_type(
+                store=store, context_name="run-1", type_name="KfpRun"
+            )
+
+        # the transport error should not trigger the create path
+        store.put_contexts.assert_not_called()
+
+    def test_recovers_from_already_exists_error(self):
+        store = MagicMock()
+        existing = _make_context(context_id=7, context_name="run-1", type_id=1)
+        # First lookup misses, create races and fails, recovery lookup finds it.
+        store.get_context_by_type_and_name.side_effect = [None, existing]
+        store.get_context_type.return_value = _make_context_type()
+        store.put_contexts.side_effect = AlreadyExistsError("already exists")
+
+        result = metadata_helpers.get_or_create_context_with_type(
+            store=store, context_name="run-1", type_name="KfpRun"
+        )
+
+        self.assertEqual(result.id, 7)
+        self.assertEqual(store.get_context_by_type_and_name.call_count, 2)
+        store.put_contexts.assert_called_once()
+
+    def test_raises_when_name_collides_with_different_type(self):
+        store = MagicMock()
+        # A context named "run-1" exists with a different type. The typed
+        # lookup misses (get_context_by_type_and_name filters by type), and
+        # creating collides on MLMD's globally unique context name.
+        store.get_context_by_type_and_name.return_value = None
+        store.get_context_type.return_value = _make_context_type()
+        store.put_contexts.side_effect = AlreadyExistsError("already exists")
+
+        with self.assertRaises(ValueError):
+            metadata_helpers.get_or_create_context_with_type(
+                store=store, context_name="run-1", type_name="KfpRun"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Description of your changes:**

https://github.com/kubeflow/pipelines/pull/13721 is proposed to fix #13713

That PR seems to address the symptom rather than the root cause.

In metadata_helpers.py a call is made to get_or_create_context_with_type() which has this code
```
    try:
      context = get_context_by_name(store, context_name)
    except:
      context = create_context_with_type(
        store=store,
        context_name=context_name,
        type_name=type_name,
        properties=properties,
        type_properties=type_properties,
        custom_properties=custom_properties,
      )
      return context
```     

Note the bare `except`. This means that on *any* error, it is treated as "context not found" and create_context_with_type() is called. So if the context *does* exist, we get the ml_metadata.errors.AlreadyExistsError.

To reproduce it, and observe a continual crash loop, I needed to make get_context_by_name() fail. Note: the proposed fix in the #13721 is premised on the notion that there's a race condition in context creation, but I'm not so sure (explanation below [1]). What I did was force store.get_contexts() to fail by inserting (large) dummy contexts into the mlmd db. This results in a ResourceExhaustedError and thus the loop: create context -> already exists -> crash -> get contexts -> resource error -> create context ...

Side note - the code does this:
```
    matching_contexts = [context for context in store.get_contexts() if context.name == context_name]
```

The use of client side filtering seems wrong. The API supports passing context name to the get_contexts call. That would materially help mitigate one of the root causes of a server side error by not returning all contexts from the api call, only to discard all but the required one anyway.

The client side api method is "get_context_by_type_and_name()"
 
So, #13721 does this:
```
    try:
      context = get_context_by_name(store, context_name)
    except:
      context_type = get_or_create_context_type(...)
      context = metadata_store_pb2.Context(...)
      try:
        context.id = store.put_contexts([context])[0]
      except AlreadyExistsError:
        context = get_context_by_name(store, context_name)  # ← recovery
      return context
```  

It still keeps the bare except. And it calls get_context_by_name() which will still fail in the case of the reproducer I did. And in that case the error that is surfaced becomes ResourceExhaustedError rather than AlreadyExists.

[1] #13721 mentions that it is fixing a race condition in context creation. But as far as I can see, the LRU cache `@functools.lru_cache(maxsize=128)` would prevent this from happening for a single process. The issue #13713 was observed on a charmed kubeflow deployment and the charm provisions a kfp-metadata-writer statefulset with replicas = 1 so that pathway to triggering a race seems like it can't happen.

My reproduction triggered a crash loop since the context query failed every time. There could be a single transient error which causes the incorrect context creation. #13721 would indeed catch this and handle it gracefully. But even without that fix, the kfp-metadata-writer pod would crash once and self heal on the subsequent restart as the context query would succeed again.

In summary - #13721 is correct for single, transient failures, not crash loops. And a case comment "Pebble-managed workload service repeatedly enters backoff" indicates it's a crash loop.

So, my proposal:
- change the bare except to "except ValueError"; allows transient errors to propagte up and only attempt to create the context on actual "not found" errors
- use a filtered query to narrow the context fetch result set server side

**QA**

I live patched my system with my proposed changes and ran the same reproducer as I used before. This time the crash from before is totally eliminated - no pod restarts, no tracebacks etc.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
