### PR TITLE
fix: reject percent signs in pipeline root

### DIFF
--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -79,6 +79,16 @@ func FromConfigMap(ctx context.Context, clientSet kubernetes.Interface, namespac
 		}
 		return nil, err
 	}
+
+	if pipelineRoot := config.Data[configKeyDefaultPipelineRoot]; pipelineRoot != "" {
+		if _, err := objectstore.ParseBucketPathToConfig(pipelineRoot); err != nil {
+			return nil, fmt.Errorf(
+				"invalid default pipeline root %q: %w",
+				pipelineRoot,
+				err,
+			)
+		}
+	}
 	return &Config{data: config.Data}, nil
 }
 

--- a/backend/src/v2/config/env_test.go
+++ b/backend/src/v2/config/env_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -22,6 +23,9 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/yaml"
 )
 
@@ -603,4 +607,64 @@ func fetchProviderFromData(cases TestcaseData, name string) string {
 		}
 	}
 	return ""
+}
+func TestFromConfigMapRejectsPercentInDefaultPipelineRoot(t *testing.T) {
+	clientSet := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			configKeyDefaultPipelineRoot: "s3://bucket/root%20dir",
+		},
+	})
+
+	_, err := FromConfigMap(context.Background(), clientSet, "default")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "s3://bucket/root%20dir")
+}
+
+func TestFromConfigMapAcceptsValidDefaultPipelineRoot(t *testing.T) {
+	tests := []struct {
+		name string
+		root string
+	}{
+		{
+			name: "literal space",
+			root: "s3://bucket/root dir",
+		},
+		{
+			name: "unicode",
+			root: "s3://bucket/root/测试",
+		},
+		{
+			name: "ampersand",
+			root: "s3://bucket/root&dir",
+		},
+		{
+			name: "question mark",
+			root: "s3://bucket/root?dir",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientSet := fake.NewSimpleClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: "default",
+				},
+				Data: map[string]string{
+					configKeyDefaultPipelineRoot: tt.root,
+				},
+			})
+
+			config, err := FromConfigMap(context.Background(), clientSet, "default")
+
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			assert.Equal(t, tt.root, config.DefaultPipelineRoot())
+		})
+	}
 }

--- a/backend/src/v2/objectstore/config.go
+++ b/backend/src/v2/objectstore/config.go
@@ -139,6 +139,13 @@ func ParseBucketPathToConfig(path string) (*Config, error) {
 	}
 
 	prefix := strings.TrimPrefix(ms[3], "/")
+
+	if strings.Contains(prefix, "%") {
+		return nil, fmt.Errorf(
+			"parse bucket config failed: pipeline root prefix %q contains unsupported percent sign",
+			prefix,
+		)
+	}
 	if len(prefix) > 0 && !strings.HasSuffix(prefix, "/") {
 		prefix = prefix + "/"
 	}

--- a/backend/src/v2/objectstore/config_test.go
+++ b/backend/src/v2/objectstore/config_test.go
@@ -47,3 +47,52 @@ func TestHasStructuredS3Settings(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBucketPathToConfigPercentInPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		wantErr     bool
+		wantErrText string
+	}{
+		{
+			name:        "percent encoded space",
+			path:        "s3://bucket/root%20dir",
+			wantErr:     true,
+			wantErrText: "root%20dir",
+		},
+		{
+			name:    "literal space",
+			path:    "s3://bucket/root dir",
+			wantErr: false,
+		},
+		{
+			name:    "unicode",
+			path:    "s3://bucket/root/测试",
+			wantErr: false,
+		},
+		{
+			name:    "ampersand",
+			path:    "s3://bucket/root&dir",
+			wantErr: false,
+		},
+		{
+			name:    "question mark",
+			path:    "s3://bucket/root?dir",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseBucketPathToConfig(tt.path)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrText)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description of your changes:**

Reject percent signs in pipeline root paths to prevent invalid percent-encoded paths from being accepted by the object store configuration parser.

This adds validation in `ParseBucketPathToConfig` and validates the default pipeline root loaded from the Kubernetes ConfigMap.

**Tests:**

- Added a test to reject percent signs in pipeline root prefixes.
- Added tests to ensure valid pipeline roots containing spaces, Unicode, `&`, and `?` are accepted.
- `go test ./src/v2/objectstore ./src/v2/config` passes.
- `git diff --cached --check` passes.

**Checklist:**

- [x] You have signed off your commits.
- [x] The title for your pull request (PR) should follow our title convention.

Fixes #14101