### PR TITLE
fix(frontend): sanitize pipeline source links

### DIFF
--- a/frontend/src/components/navigators/PipelineVersionCard.test.tsx
+++ b/frontend/src/components/navigators/PipelineVersionCard.test.tsx
@@ -26,6 +26,7 @@ const TEST_PIPELINE_ID = 'pipeline-id';
 
 const OLD_TEST_PIPELINE_VERSION_ID = 'old-version-id';
 const OLD_TEST_PIPELINE_VERSION: V2beta1PipelineVersion = {
+  code_source_url: 'https://github.com/kubeflow/pipelines',
   created_at: new Date('2021-11-24T20:58:23.000Z'),
   description: 'This is old version description.',
   display_name: OLD_VERSION_NAME,
@@ -107,11 +108,35 @@ describe('PipelineVersionCard', () => {
     screen.getByText(TEST_PIPELINE_ID);
     screen.getByText('Version');
     screen.getByText(OLD_VERSION_NAME);
-    screen.getByText('Version source');
+    const versionSource = screen.getByText('Version source');
+    expect(versionSource).toHaveAttribute('href', 'https://github.com/kubeflow/pipelines');
     screen.getByText('Uploaded on');
     screen.getByText('Pipeline Description');
     screen.getByText('This is pipeline level description.');
     screen.getByText('This is old version description.');
+  });
+
+  it('does not render the Version source link for an unsafe code_source_url scheme', async () => {
+    render(
+      <PipelineVersionCard
+        pipeline={TEST_PIPELINE}
+        selectedVersion={{
+          ...OLD_TEST_PIPELINE_VERSION,
+          // eslint-disable-next-line no-script-url
+          code_source_url: 'javascript:alert(1)',
+        }}
+        versions={TEST_PIPELINE_VERSIONS_LIST}
+        handleVersionSelected={(versionId) => {
+          return Promise.resolve();
+        }}
+      ></PipelineVersionCard>,
+    );
+
+    await userEvent.click(screen.getByText('Show Summary'));
+
+    // The summary still renders, but the unsafe link is dropped entirely.
+    screen.getByText('Uploaded on');
+    expect(screen.queryByText('Version source')).toBeNull();
   });
 
   it('shows version list', async () => {

--- a/frontend/src/components/navigators/PipelineVersionCard.tsx
+++ b/frontend/src/components/navigators/PipelineVersionCard.tsx
@@ -18,7 +18,7 @@ import { useState } from 'react';
 import { V2beta1Pipeline, V2beta1PipelineVersion } from 'src/apisv2beta1/pipeline';
 import { Description } from 'src/components/Description';
 import { commonCss } from 'src/Css';
-import { formatDateString } from 'src/lib/Utils';
+import { formatDateString, sanitizeExternalHref } from 'src/lib/Utils';
 
 import { Button, FormControl, InputLabel, MenuItem, Paper, Select } from '@mui/material';
 
@@ -38,7 +38,7 @@ export function PipelineVersionCard({
   const [summaryShown, setSummaryShown] = useState(false);
 
   const createVersionUrl = () => {
-    return selectedVersion?.code_source_url;
+    return sanitizeExternalHref(selectedVersion?.code_source_url);
   };
 
   return (
@@ -76,11 +76,13 @@ export function PipelineVersionCard({
                   </FormControl>
                 </form>
               </div>
-              <div className='text-blue-500 mt-5'>
-                <a href={createVersionUrl()} target='_blank' rel='noopener noreferrer'>
-                  Version source
-                </a>
-              </div>
+              {createVersionUrl() && (
+                <div className='text-blue-500 mt-5'>
+                  <a href={createVersionUrl()} target='_blank' rel='noopener noreferrer'>
+                    Version source
+                  </a>
+                </div>
+              )}
             </>
           )}
           <div className='text-gray-900 mt-5'>Uploaded on</div>

--- a/frontend/src/lib/Utils.test.ts
+++ b/frontend/src/lib/Utils.test.ts
@@ -27,11 +27,37 @@ import {
   getRunDurationFromWorkflow,
   logger,
   mergeApiParametersByNames,
+  sanitizeExternalHref,
 } from './Utils';
 import { V2beta1RecurringRunStatus } from 'src/apisv2beta1/recurringrun';
 import { expectErrors } from 'src/TestUtils';
 
 describe('Utils', () => {
+  describe('sanitizeExternalHref', () => {
+    it('returns http and https URLs unchanged', () => {
+      expect(sanitizeExternalHref('http://example.com/x')).toEqual('http://example.com/x');
+      expect(sanitizeExternalHref('https://example.com/x')).toEqual('https://example.com/x');
+      expect(sanitizeExternalHref('HTTPS://example.com/x')).toEqual('HTTPS://example.com/x');
+    });
+
+    it('rejects javascript: and other unsafe schemes', () => {
+      // eslint-disable-next-line no-script-url
+      expect(sanitizeExternalHref('javascript:alert(1)')).toBeUndefined();
+      // eslint-disable-next-line no-script-url
+      expect(sanitizeExternalHref('JAVASCRIPT:alert(1)')).toBeUndefined();
+      expect(sanitizeExternalHref('data:text/html,<script>alert(1)</script>')).toBeUndefined();
+      expect(sanitizeExternalHref('vbscript:msgbox(1)')).toBeUndefined();
+      expect(sanitizeExternalHref('ftp://example.com/x')).toBeUndefined();
+      expect(sanitizeExternalHref('//example.com')).toBeUndefined();
+      expect(sanitizeExternalHref('not a URL')).toBeUndefined();
+    });
+
+    it('returns undefined for empty or missing input', () => {
+      expect(sanitizeExternalHref('')).toBeUndefined();
+      expect(sanitizeExternalHref(undefined)).toBeUndefined();
+    });
+  });
+
   describe('log', () => {
     it('logs to console', () => {
       // tslint:disable-next-line:no-console

--- a/frontend/src/lib/Utils.tsx
+++ b/frontend/src/lib/Utils.tsx
@@ -457,6 +457,30 @@ export function generateS3ArtifactUrl(s3Uri: string): string | undefined {
   });
 }
 
+/**
+ * Returns the given URL only when it uses a browsable, safe scheme (http/https),
+ * otherwise undefined. Used to gate user-supplied values (for example a pipeline
+ * version's code_source_url) before placing them in an anchor href, so that
+ * untrusted schemes such as `javascript:` are never rendered as clickable links.
+ *
+ * @param url Candidate URL, typically user-supplied.
+ * @returns The URL when it has an HTTP(S) scheme, otherwise undefined.
+ */
+export function sanitizeExternalHref(url?: string): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return url;
+    }
+  } catch {
+    // Malformed and relative URLs are not safe external links.
+  }
+  return undefined;
+}
+
 export function buildQuery(queriesMap: { [key: string]: string | number | undefined }): string {
   const queryContent = Object.entries(queriesMap)
     .filter((entry): entry is [string, string | number] => entry[1] != null)

--- a/frontend/src/pages/PipelineDetailsV1.tsx
+++ b/frontend/src/pages/PipelineDetailsV1.tsx
@@ -29,7 +29,7 @@ import SidePanel from '../components/SidePanel';
 import StaticNodeDetails from '../components/StaticNodeDetails';
 import { color, commonCss, fonts, fontsize, padding, zIndex } from '../Css';
 import * as StaticGraphParser from '../lib/StaticGraphParser';
-import { formatDateString, logger } from '../lib/Utils';
+import { formatDateString, logger, sanitizeExternalHref } from '../lib/Utils';
 
 import { Button, FormControl, InputLabel, MenuItem, Paper, Select } from '@mui/material';
 
@@ -116,7 +116,7 @@ const PipelineDetailsV1: React.FC<PipelineDetailsV1Props> = ({
   }
 
   const createVersionUrl = () => {
-    return selectedVersion!.code_source_url!;
+    return sanitizeExternalHref(selectedVersion?.code_source_url);
   };
 
   return (
@@ -171,11 +171,13 @@ const PipelineDetailsV1: React.FC<PipelineDetailsV1Props> = ({
                             </Select>
                           </FormControl>
                         </form>
-                        <div className={css.summaryKey}>
-                          <a href={createVersionUrl()} target='_blank' rel='noopener noreferrer'>
-                            Version source
-                          </a>
-                        </div>
+                        {createVersionUrl() && (
+                          <div className={css.summaryKey}>
+                            <a href={createVersionUrl()} target='_blank' rel='noopener noreferrer'>
+                              Version source
+                            </a>
+                          </div>
+                        )}
                       </React.Fragment>
                     )}
                     <div className={css.summaryKey}>Uploaded on</div>


### PR DESCRIPTION
**Description of your changes:**

Pipeline version `code_source_url` values are persisted and rendered as links in the pipeline-version card and details page. This change parses those values at the rendering sink, permits only absolute HTTP and HTTPS URLs, and omits malformed, relative, or unsafe-scheme links.

The shared sanitizer and both rendering paths have regression coverage for safe mixed-case HTTP(S) URLs and unsafe `javascript:`, `data:`, and `vbscript:` values.

**Testing:**

- `npm run test:ui -- src/lib/Utils.test.ts src/components/navigators/PipelineVersionCard.test.tsx` — 53 tests passed
- `npm run typecheck`
- `npm run lint:ui`
- Prettier check on all changed files

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request follows the repository title convention.