### PR TITLE
fix(deployment): require edit access to start or delete TensorBoard viewers

### DIFF
--- a/manifests/kustomize/base/installs/multi-user/view-edit-cluster-roles.yaml
+++ b/manifests/kustomize/base/installs/multi-user/view-edit-cluster-roles.yaml
@@ -87,6 +87,13 @@ rules:
   resources:
   - scheduledworkflows
 - apiGroups:
+  - kubeflow.org
+  resources:
+  - viewers
+  verbs:
+  - create
+  - delete
+- apiGroups:
   - argoproj.io
   verbs:
   - '*'
@@ -131,9 +138,7 @@ rules:
   resources:
   - viewers
   verbs:
-  - create
   - get
-  - delete
 - apiGroups:
   - pipelines.kubeflow.org
   resources:


### PR DESCRIPTION
**Description of your changes:**

Viewer creation launches a caller-selected image from a caller-supplied PodTemplateSpec, so it is a workload-creation capability rather than a read-only operation. The pipelines view aggregate role currently grants Viewer create and delete even though it does not grant equivalent Pod or Workflow authoring access.

This change moves Viewer create and delete to the pipelines edit aggregate role, whose users can already create Argo Workflows. Read-only users retain Viewer get access. Existing custom images, pod templates, volume credentials, and Workload Identity behavior remain unchanged.

Testing:
- Rendered manifests/kustomize/base/installs/multi-user with Kustomize v5.2.1.
- Verified the rendered edit role grants Viewer create, delete, and get.
- Verified the rendered view role grants Viewer get only.
- git diff --check

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) follows the project title convention.