### PR TITLE
fix(swf): scope workflow counting by namespace

### DIFF
--- a/backend/src/common/util/execution_client.go
+++ b/backend/src/common/util/execution_client.go
@@ -54,8 +54,8 @@ type ExecutionInformer interface {
 	// Use Lister interface to get a specific ExecutionSpec under a namespace
 	// second return value indicates if no ExecutionSpec is found
 	Get(namespace string, name string) (ExecutionSpec, bool, error)
-	// List all ExecutionSpecs that match the label selector
-	List(labels *labels.Selector) (ExecutionSpecList, error)
+	// List all ExecutionSpecs in the given namespace that match the label selector
+	List(namespace string, labels *labels.Selector) (ExecutionSpecList, error)
 	// Start initializes the informer.
 	InformerFactoryStart(stopCh <-chan struct{})
 }

--- a/backend/src/common/util/workflow.go
+++ b/backend/src/common/util/workflow.go
@@ -998,8 +998,8 @@ func (wfi *WorkflowInformer) Get(namespace string, name string) (ExecutionSpec, 
 	return NewWorkflow(workflow), false, nil
 }
 
-func (wfi *WorkflowInformer) List(labels *labels.Selector) (ExecutionSpecList, error) {
-	workflows, err := wfi.informer.Lister().List(*labels)
+func (wfi *WorkflowInformer) List(namespace string, labels *labels.Selector) (ExecutionSpecList, error) {
+	workflows, err := wfi.informer.Lister().Workflows(namespace).List(*labels)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/src/common/util/workflow_test.go
+++ b/backend/src/common/util/workflow_test.go
@@ -2769,9 +2769,15 @@ func TestWorkflowInformer_List(t *testing.T) {
 	}
 
 	selector := labels.Everything()
-	result, err := wfi.List(&selector)
+	result, err := wfi.List("default", &selector)
 	assert.Nil(t, err)
 	assert.Len(t, result, 1)
+
+	// A different namespace must not return the workflow, confirming the list
+	// is scoped to the requested namespace.
+	otherNamespaceResult, err := wfi.List("other-namespace", &selector)
+	assert.Nil(t, err)
+	assert.Len(t, otherNamespaceResult, 0)
 	// ---------- UpsertRuntimeEnvVars tests ----------
 }
 

--- a/backend/src/crd/controller/scheduledworkflow/client/workflow_client.go
+++ b/backend/src/crd/controller/scheduledworkflow/client/workflow_client.go
@@ -60,14 +60,17 @@ func (p *WorkflowClient) Get(namespace string, name string) (
 	return p.informer.Get(namespace, name)
 }
 
-// List returns a list of workflows given the name of their ScheduledWorkflow,
-// whether they are completed, and their minimum index (to avoid returning the whole list).
-func (p *WorkflowClient) List(swfName string, completed bool, minIndex int64) (
+// List returns a list of workflows in the given namespace given the name of
+// their ScheduledWorkflow, whether they are completed, and their minimum index
+// (to avoid returning the whole list). The namespace scope prevents workflows
+// in other namespaces from being counted against this ScheduledWorkflow when
+// the controller runs cluster-wide in multi-user mode.
+func (p *WorkflowClient) List(namespace string, swfName string, completed bool, minIndex int64) (
 	status []swfapi.WorkflowStatus, err error) {
 
 	labelSelector := getLabelSelectorToGetWorkflows(swfName, completed, minIndex)
 
-	workflows, err := p.informer.List(labelSelector)
+	workflows, err := p.informer.List(namespace, labelSelector)
 	if err != nil {
 		return nil, wraperror.Wrapf(err,
 			"Could not retrieve workflows for scheduled workflow (%v): %v", swfName, err)

--- a/backend/src/crd/controller/scheduledworkflow/controller.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller.go
@@ -504,6 +504,7 @@ func (c *Controller) syncHandler(ctx context.Context, key string) (
 	// Get active workflows for this ScheduledWorkflow.
 	startTime = time.Time{}
 	active, err := c.workflowClient.List(
+		swf.Namespace,
 		swf.Name,
 		// active workflow
 		false,
@@ -520,7 +521,8 @@ func (c *Controller) syncHandler(ctx context.Context, key string) (
 
 	startTime = time.Now()
 	// Get completed workflows for this ScheduledWorkflow.
-	completed, err := c.workflowClient.List(swf.Name,
+	completed, err := c.workflowClient.List(swf.Namespace,
+		swf.Name,
 		true, /* completed workflows */
 		swf.MinIndex())
 	if err != nil {

--- a/backend/src/crd/controller/scheduledworkflow/controller_test.go
+++ b/backend/src/crd/controller/scheduledworkflow/controller_test.go
@@ -366,7 +366,7 @@ func (f *fakeExecutionInformer) Get(namespace string, name string) (commonutil.E
 	return nil, true, errors.New("not found")
 }
 
-func (f *fakeExecutionInformer) List(labels *labels.Selector) (commonutil.ExecutionSpecList, error) {
+func (f *fakeExecutionInformer) List(namespace string, labels *labels.Selector) (commonutil.ExecutionSpecList, error) {
 	return commonutil.ExecutionSpecList{}, nil
 }
 


### PR DESCRIPTION
**Description of your changes:**

The ScheduledWorkflow controller runs cluster-wide but lists active and completed workflows only by labels. A similarly labeled workflow in another namespace can therefore affect maxConcurrency decisions and contaminate status history.

This change requires a namespace for ExecutionInformer.List and uses the ScheduledWorkflow namespace for both active and completed workflow queries. The informer delegates to the namespace-scoped Argo lister, while the focused tests cover the new namespace argument.

Testing:
- go test ./backend/src/common/util ./backend/src/crd/controller/scheduledworkflow/... -count=1
- go vet ./backend/src/common/util ./backend/src/crd/controller/scheduledworkflow/...
- git diff --check

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) follows the project title convention.