### PR TITLE
fix(frontend): return TensorBoard errors as plain text

### DIFF
--- a/frontend/server/handlers/tensorboard.ts
+++ b/frontend/server/handlers/tensorboard.ts
@@ -55,7 +55,7 @@ export const getTensorboardHandlers = (
         req,
       );
       if (authError) {
-        res.status(401).send(authError.message);
+        res.status(401).type('text/plain').send(authError.message);
         return;
       }
       const tensorboardInstance = await k8sHelper.getTensorboardInstance(
@@ -76,7 +76,10 @@ export const getTensorboardHandlers = (
     } catch (err) {
       const details = await parseError(err);
       console.error(`Failed to list Tensorboard pods: ${details.message}`, details.additionalInfo);
-      res.status(500).send(`Failed to list Tensorboard pods: ${details.message}`);
+      res
+        .status(500)
+        .type('text/plain')
+        .send(`Failed to list Tensorboard pods: ${details.message}`);
     }
   };
 
@@ -119,7 +122,7 @@ export const getTensorboardHandlers = (
       try {
         podTemplateSpec = JSON.parse(podTemplateSpecRaw as string);
       } catch (err) {
-        res.status(400).send(`podtemplatespec is not valid JSON: ${err}`);
+        res.status(400).type('text/plain').send(`podtemplatespec is not valid JSON: ${err}`);
         return;
       }
     }
@@ -134,7 +137,7 @@ export const getTensorboardHandlers = (
         req,
       );
       if (authError) {
-        res.status(401).send(authError.message);
+        res.status(401).type('text/plain').send(authError.message);
         return;
       }
       await k8sHelper.newTensorboardInstance(
@@ -159,7 +162,13 @@ export const getTensorboardHandlers = (
     } catch (err) {
       const details = await parseError(err);
       console.error(`Failed to start Tensorboard app: ${details.message}`, details.additionalInfo);
-      res.status(500).send(`Failed to start Tensorboard app: ${details.message}`);
+      // The error message echoes the caller-supplied logdir, so send it as plain
+      // text rather than the res.send() default of text/html to avoid reflecting
+      // an unescaped payload as executable markup.
+      res
+        .status(500)
+        .type('text/plain')
+        .send(`Failed to start Tensorboard app: ${details.message}`);
     }
   };
 
@@ -192,7 +201,7 @@ export const getTensorboardHandlers = (
         req,
       );
       if (authError) {
-        res.status(401).send(authError.message);
+        res.status(401).type('text/plain').send(authError.message);
         return;
       }
       await k8sHelper.deleteTensorboardInstance(logdir as string, namespace as string);
@@ -200,7 +209,10 @@ export const getTensorboardHandlers = (
     } catch (err) {
       const details = await parseError(err);
       console.error(`Failed to delete Tensorboard app: ${details.message}`, details.additionalInfo);
-      res.status(500).send(`Failed to delete Tensorboard app: ${details.message}`);
+      res
+        .status(500)
+        .type('text/plain')
+        .send(`Failed to delete Tensorboard app: ${details.message}`);
     }
   };
 

--- a/frontend/server/integration-tests/tensorboard.test.ts
+++ b/frontend/server/integration-tests/tensorboard.test.ts
@@ -145,6 +145,27 @@ describe('/apps/tensorboard', () => {
         .expect(400, 'namespace argument is required');
     });
 
+    it('returns get failures as plain text', async () => {
+      const reflectedLogDir = '<img src=x onerror=alert(1)>';
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const viewer = newGetTensorboardResponse();
+      (viewer.spec.tensorboardSpec.tensorflowImage as any) = {
+        split: () => {
+          throw new Error(`could not parse viewer for ${reflectedLogDir}`);
+        },
+      };
+      k8sGetCustomObjectSpy.mockResolvedValue(viewer);
+
+      app = new UIServer(loadConfigs(argv, {}));
+      const response = await requests(app.app)
+        .get(`/apps/tensorboard?logdir=${encodeURIComponent(reflectedLogDir)}&namespace=test-ns`)
+        .expect(500);
+
+      expect(response.headers['content-type']).toMatch(/^text\/plain/);
+      expect(response.text).toContain(reflectedLogDir);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    });
+
     it('does not crash with a weird query', async () => {
       app = new UIServer(loadConfigs(argv, {}));
       k8sGetCustomObjectSpy.mockImplementation(() => Promise.resolve(newGetTensorboardResponse()));
@@ -212,13 +233,14 @@ describe('/apps/tensorboard', () => {
     it('rejects user requests when KFP auth api rejected', async () => {
       const errorSpy = vi.spyOn(console, 'error');
       errorSpy.mockImplementation(() => {});
+      const authApiError = 'User xxx is not authorized to list viewers <script>alert(1)</script>';
 
       const apiServerPort = 3001;
       kfpApiServer = express()
         .get('/apis/v1beta1/auth', (_, res) => {
           res.status(400).send(
             JSON.stringify({
-              error: 'User xxx is not unauthorized to list viewers',
+              error: authApiError,
               details: ['unauthorized', 'callstack'],
             }),
           );
@@ -234,13 +256,11 @@ describe('/apps/tensorboard', () => {
       k8sGetCustomObjectSpy.mockImplementation(() => Promise.resolve(newGetTensorboardResponse()));
       await requests(app.app)
         .get(`/apps/tensorboard?logdir=some-log-dir&namespace=test-ns`)
-        .expect(
-          401,
-          'User is not authorized to GET VIEWERS in namespace test-ns: User xxx is not unauthorized to list viewers',
-        );
+        .expect('Content-Type', /^text\/plain/)
+        .expect(401, `User is not authorized to GET VIEWERS in namespace test-ns: ${authApiError}`);
       expect(errorSpy).toHaveBeenCalledTimes(1);
       expect(errorSpy).toHaveBeenCalledWith(
-        'User is not authorized to GET VIEWERS in namespace test-ns: User xxx is not unauthorized to list viewers',
+        `User is not authorized to GET VIEWERS in namespace test-ns: ${authApiError}`,
         ['unauthorized', 'callstack'],
       );
     });
@@ -348,6 +368,22 @@ describe('/apps/tensorboard', () => {
       await requests(app.app)
         .post('/apps/tensorboard?logdir=some-log-dir&namespace=test-ns')
         .expect(400, 'missing required argument: tfversion (tensorflow version) or image');
+    });
+
+    it('returns malformed pod template errors as plain text', async () => {
+      app = new UIServer(loadConfigs(argv, {}));
+      const malformedPodTemplate = '{"image":"<img src=x onerror=alert(1)>"';
+
+      const response = await requests(app.app)
+        .post(
+          `/apps/tensorboard?logdir=some-log-dir&namespace=test-ns&tfversion=2.0.0&podtemplatespec=${encodeURIComponent(
+            malformedPodTemplate,
+          )}`,
+        )
+        .expect(400);
+
+      expect(response.headers['content-type']).toMatch(/^text\/plain/);
+      expect(response.text).toContain('podtemplatespec is not valid JSON');
     });
 
     it('creates tensorboard viewer custom object and waits for it', async () => {
@@ -712,7 +748,7 @@ describe('/apps/tensorboard', () => {
         loadConfigs(argv, { VIEWER_TENSORBOARD_POD_TEMPLATE_SPEC_PATH: tempPath }),
       );
 
-      await requests(app.app)
+      const response = await requests(app.app)
         .post(
           `/apps/tensorboard?logdir=${encodeURIComponent(
             'volume://notexistvolume/logs/log-dir-1',
@@ -722,6 +758,7 @@ describe('/apps/tensorboard', () => {
           500,
           `Failed to start Tensorboard app: Cannot find file "volume://notexistvolume/logs/log-dir-1" in pod "unknown": volume "notexistvolume" not configured`,
         );
+      expect(response.headers['content-type']).toMatch(/^text\/plain/);
       expect(errorSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -845,6 +882,29 @@ describe('/apps/tensorboard', () => {
           },
         ]
       `);
+    });
+
+    it('returns delete failures as plain text', async () => {
+      const reflectedLogDir = '<img src=x onerror=alert(1)>';
+      k8sGetCustomObjectSpy.mockImplementation(() =>
+        Promise.resolve(
+          newGetTensorboardResponse({
+            name: 'viewer-abcdefg',
+            logDir: reflectedLogDir,
+          }),
+        ),
+      );
+      k8sDeleteCustomObjectSpy.mockRejectedValue(
+        new Error(`could not delete viewer for ${reflectedLogDir}`),
+      );
+
+      app = new UIServer(loadConfigs(argv, {}));
+      const response = await requests(app.app)
+        .delete(`/apps/tensorboard?logdir=${encodeURIComponent(reflectedLogDir)}&namespace=test-ns`)
+        .expect(500);
+
+      expect(response.headers['content-type']).toMatch(/^text\/plain/);
+      expect(response.text).toContain(reflectedLogDir);
     });
   });
 });


### PR DESCRIPTION
**Description of your changes:**

TensorBoard handler errors can contain caller-derived or downstream text. Express string responses otherwise default to an HTML content type, allowing reflected markup in an error body to be interpreted as HTML by a browser.

This change gives lookup, create, malformed podtemplatespec, and delete errors an explicit text/plain content type. The integration tests cover each affected error path.

Testing:
- vitest run --root frontend/server integration-tests/tensorboard.test.ts (26 tests passed)
- tsc --project frontend/server
- prettier --check on both changed files
- git diff --check

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) follows the project title convention.