### PR TITLE
fix(frontend): import produce as a named export for immer 11

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "google-protobuf": "^4.0.2",
         "grpc-web": "^2.1.1",
         "http-proxy-middleware": "^3.0.7",
-        "immer": "^9.0.6",
+        "immer": "^11.1.18",
         "js-yaml": "^4.3.1",
         "lodash": "^4.18.1",
         "lodash.debounce": "^4.0.8",
@@ -2660,16 +2660,6 @@
         "react-redux": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -6685,7 +6675,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.6",
+      "version": "11.1.18",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.18.tgz",
+      "integrity": "sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "google-protobuf": "^4.0.2",
     "grpc-web": "^2.1.1",
     "http-proxy-middleware": "^3.0.7",
-    "immer": "^9.0.6",
+    "immer": "^11.1.18",
     "js-yaml": "^4.3.1",
     "lodash": "^4.18.1",
     "lodash.debounce": "^4.0.8",

--- a/frontend/src/components/ExperimentList.tsx
+++ b/frontend/src/components/ExperimentList.tsx
@@ -29,7 +29,7 @@ import { Apis, ExperimentSortKeys, ListRequest } from 'src/lib/Apis';
 import { V2beta1RunStorageState } from 'src/apisv2beta1/run';
 import { V2beta1Filter, V2beta1PredicateOperation } from 'src/apisv2beta1/filter';
 import RunList from 'src/pages/RunList';
-import immerProduce from 'immer';
+import { produce as immerProduce } from 'immer';
 import { Tooltip } from '@mui/material';
 
 export interface ExperimentListProps extends RouteComponentProps {

--- a/frontend/src/pages/ExperimentList.tsx
+++ b/frontend/src/pages/ExperimentList.tsx
@@ -23,7 +23,7 @@ import CustomTable, {
   CustomRendererProps,
 } from 'src/components/CustomTable';
 import RunList from './RunList';
-import immerProduce from 'immer';
+import { produce as immerProduce } from 'immer';
 import {
   V2beta1ListExperimentsResponse,
   V2beta1Experiment,

--- a/frontend/src/pages/PipelineList.tsx
+++ b/frontend/src/pages/PipelineList.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import immerProduce from 'immer';
+import { produce as immerProduce } from 'immer';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { classes } from 'typestyle';

--- a/frontend/src/pages/RecurringRunList.test.tsx
+++ b/frontend/src/pages/RecurringRunList.test.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 import { act, render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
-import produce from 'immer';
+import { produce } from 'immer';
 import { range } from 'lodash';
 import * as Utils from 'src/lib/Utils';
 import TestUtils from 'src/TestUtils';

--- a/frontend/src/pages/RunList.test.tsx
+++ b/frontend/src/pages/RunList.test.tsx
@@ -19,7 +19,7 @@ import * as Utils from 'src/lib/Utils';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import RunList, { RunListProps } from './RunList';
 import TestUtils, { flushPromisesInAct } from 'src/TestUtils';
-import produce from 'immer';
+import { produce } from 'immer';
 import { V2beta1Filter, V2beta1PredicateOperation } from 'src/apisv2beta1/filter';
 import { V2beta1Run, V2beta1RunStorageState, V2beta1RuntimeState } from 'src/apisv2beta1/run';
 import { Apis, RunSortKeys, ListRequest } from 'src/lib/Apis';

--- a/frontend/src/pages/RunListsRouter.test.tsx
+++ b/frontend/src/pages/RunListsRouter.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { render, screen, waitFor } from '@testing-library/react';
-import produce from 'immer';
+import { produce } from 'immer';
 import RunListsRouter, { RunListsRouterProps } from './RunListsRouter';
 import { RouteParams } from 'src/components/Router';
 import { V2beta1Run, V2beta1RunStorageState } from 'src/apisv2beta1/run';


### PR DESCRIPTION
## Summary

Bump `immer` from 9.x to 11.1.18 and switch every import to the named `produce` export.

Supersedes #14122.

## Why

immer 11 removed the default export. `produce` is now available only as a named export:

```ts
export { Draft, Immer, ..., produce, produceWithPatches, ... };
```

Every `immer` import in the frontend was a default import, so all six became invalid.

Three are in application code, and these are the errors reported on #14122:

```
src/components/ExperimentList.tsx(177,32): error TS2349: This expression is not callable.
src/components/ExperimentList.tsx(177,77): error TS7006: Parameter 'draft' implicitly has an 'any' type.
src/pages/ExperimentList.tsx(265,32): error TS2349: This expression is not callable.
src/pages/ExperimentList.tsx(265,77): error TS7006: Parameter 'draft' implicitly has an 'any' type.
src/pages/PipelineList.tsx(139,30): error TS2349: This expression is not callable.
src/pages/PipelineList.tsx(139,73): error TS7006: Parameter 'draft' implicitly has an 'any' type.
```

The remaining three are in test files:

- `src/pages/RecurringRunList.test.tsx`
- `src/pages/RunList.test.tsx`
- `src/pages/RunListsRouter.test.tsx`

Those did **not** surface as type errors, despite calling `produce` the same way. Fixing only the six reported errors would have left those three importing a binding that no longer exists, so they are included here.

Application call sites keep their local `immerProduce` name via `produce as immerProduce`, which keeps the diff to the import line in each file.

## Verification

Run on node 24.14.0, matching `frontend/.nvmrc`:

- `format:check`, `lint:ui`, `typecheck` — clean, 0 errors
- 136 tests passing across the affected files and their component suites: `RunList`, `RecurringRunList`, `RunListsRouter`, `components/ExperimentList`, `pages/ExperimentList`, `pages/PipelineList`

Leaving the full suite to CI.
