### PR TITLE
fix(frontend): narrow js-yaml load results for js-yaml 5

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "grpc-web": "^2.1.1",
         "http-proxy-middleware": "^3.0.7",
         "immer": "^11.1.18",
-        "js-yaml": "^4.3.1",
+        "js-yaml": "^5.4.1",
         "lodash": "^4.18.1",
         "lodash.debounce": "^4.0.8",
         "lodash.flatten": "^4.4.0",
@@ -6908,9 +6908,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "funding": [
         {
           "type": "github",
@@ -6926,7 +6926,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsdom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "grpc-web": "^2.1.1",
     "http-proxy-middleware": "^3.0.7",
     "immer": "^11.1.18",
-    "js-yaml": "^4.3.1",
+    "js-yaml": "^5.4.1",
     "lodash": "^4.18.1",
     "lodash.debounce": "^4.0.8",
     "lodash.flatten": "^4.4.0",

--- a/frontend/server/package-lock.json
+++ b/frontend/server/package-lock.json
@@ -15,7 +15,7 @@
         "google-protobuf": "^4.0.2",
         "gunzip-maybe": "^1.4.1",
         "http-proxy-middleware": "^2.0.10",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^5.3.0",
         "lodash": ">=4.18.1",
         "minio": "~8.0.7",
         "peek-stream": "^1.1.3",
@@ -928,6 +928,28 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@kubernetes/client-node/node_modules/node-fetch": {
@@ -3895,9 +3917,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.3.0.tgz",
+      "integrity": "sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==",
       "funding": [
         {
           "type": "github",
@@ -3913,7 +3935,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsep": {

--- a/frontend/server/package.json
+++ b/frontend/server/package.json
@@ -13,7 +13,7 @@
     "google-protobuf": "^4.0.2",
     "gunzip-maybe": "^1.4.1",
     "http-proxy-middleware": "^2.0.10",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^5.3.0",
     "lodash": ">=4.18.1",
     "minio": "~8.0.7",
     "peek-stream": "^1.1.3",

--- a/frontend/server/workflow-helper.test.ts
+++ b/frontend/server/workflow-helper.test.ts
@@ -159,6 +159,32 @@ describe('workflow-helper', () => {
       expect(mockedGetConfigMap).toBeCalledTimes(1);
       expect(res).toEqual('foo');
     });
+
+    it('resolves a keyFormat inherited through a YAML merge key.', async () => {
+      const artifactRepositories = {
+        'artifact-repositories':
+          'common: &common\n' +
+          '  keyFormat: inherited-format\n' +
+          '  insecure: true\n' +
+          's3:\n' +
+          '  <<: *common\n' +
+          '  bucket: mlpipeline\n',
+      };
+
+      const mockedConfigMap: V1ConfigMap = {
+        apiVersion: 'v1',
+        kind: 'ConfigMap',
+        metadata: new V1ObjectMeta(),
+        data: artifactRepositories,
+        binaryData: {},
+      };
+
+      const mockedGetConfigMap: Mock = getConfigMap as any;
+      mockedGetConfigMap.mockResolvedValueOnce([mockedConfigMap, undefined]);
+      const res = await getKeyFormatFromArtifactRepositories('');
+      expect(mockedGetConfigMap).toBeCalledTimes(1);
+      expect(res).toEqual('inherited-format');
+    });
   });
 
   describe('createPodLogsMinioRequestConfig', () => {

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -21,7 +21,7 @@ import {
   getServerNamespace,
 } from './k8s-helper.js';
 import { createMinioClient, MinioRequestConfig, getObjectStream } from './minio-helper.js';
-import * as JsYaml from 'js-yaml';
+import { CORE_SCHEMA, load as jsYamlLoad, mergeTag } from 'js-yaml';
 
 export interface PartialArgoWorkflow {
   status: {
@@ -187,9 +187,12 @@ export async function getKeyFormatFromArtifactRepositories(
         `artifact-repositories configmap in ${namespace} namespace is missing an artifact-repositories field.`,
       );
     }
-    const artifactRepositoriesValue = JsYaml.load(
-      artifactRepositories,
-    ) as PartialArtifactRepositoriesValue;
+    // js-yaml 5 resolves merge keys only when mergeTag is in the schema. The
+    // configmap is user supplied and commonly shares fields between providers
+    // through anchors, so without this an inherited keyFormat is lost.
+    const artifactRepositoriesValue = jsYamlLoad(artifactRepositories, {
+      schema: CORE_SCHEMA.withTags(mergeTag),
+    }) as PartialArtifactRepositoriesValue;
     if ('s3' in artifactRepositoriesValue) {
       return artifactRepositoriesValue.s3?.keyFormat;
     } else if ('gcs' in artifactRepositoriesValue) {

--- a/frontend/src/components/PipelineSpecTabContent.test.tsx
+++ b/frontend/src/components/PipelineSpecTabContent.test.tsx
@@ -46,6 +46,18 @@ describe('PipelineSpecTabContent', () => {
     expect(editor.textContent).toContain('nested:');
   });
 
+  it('renders an empty editor when no template is provided', () => {
+    // js-yaml 5 throws on input holding no document, so an absent template
+    // would otherwise fail during render rather than showing an empty editor.
+    const { getByTestId } = render(<PipelineSpecTabContent templateString={undefined as any} />);
+    expect(getByTestId('editor-mock').textContent).toBe('');
+  });
+
+  it('renders an empty editor for an empty template string', () => {
+    const { getByTestId } = render(<PipelineSpecTabContent templateString='' />);
+    expect(getByTestId('editor-mock').textContent).toBe('');
+  });
+
   it('passes yaml mode and readOnly to the editor', () => {
     const { getByTestId } = render(<PipelineSpecTabContent templateString='name: test' />);
     const editor = getByTestId('editor-mock');

--- a/frontend/src/components/PipelineSpecTabContent.tsx
+++ b/frontend/src/components/PipelineSpecTabContent.tsx
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { dump, load } from 'js-yaml';
+import { dump } from 'js-yaml';
+import { loadYaml } from 'src/lib/YamlLoad';
 import { isSafari } from 'src/lib/Utils';
 import Editor from './Editor';
 
@@ -27,7 +28,7 @@ const editorHeightWidth = isSafari() ? '640px' : '100%';
 export function PipelineSpecTabContent(props: PipelineSpecTabContentProps) {
   return (
     <Editor
-      value={dump(load(props.templateString || ''))}
+      value={dump(loadYaml(props.templateString || ''))}
       // Render the yaml-formatted string in <PipelineSpecTabContent>
       // V1(JSON-formatted):
       //    load() converts templateString to an object first,

--- a/frontend/src/lib/YamlLoad.test.ts
+++ b/frontend/src/lib/YamlLoad.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { dump } from 'js-yaml';
+
 import { loadYaml } from './YamlLoad';
 
 describe('loadYaml', () => {
@@ -47,5 +49,17 @@ step:
 
   it('parses documents without merge keys unchanged', () => {
     expect(loadYaml('a: 1\nb: two\n')).toEqual({ a: 1, b: 'two' });
+  });
+
+  it('returns undefined for input holding no document', () => {
+    // js-yaml 5 throws YAMLException here, where js-yaml 4 returned undefined.
+    // Call sites pass optional templates through `|| ''`.
+    expect(loadYaml('')).toBeUndefined();
+    expect(loadYaml('   ')).toBeUndefined();
+    expect(loadYaml('\n')).toBeUndefined();
+  });
+
+  it('round trips empty input to an empty string through dump', () => {
+    expect(dump(loadYaml(''))).toBe('');
   });
 });

--- a/frontend/src/lib/YamlLoad.test.ts
+++ b/frontend/src/lib/YamlLoad.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { loadYaml } from './YamlLoad';
+
+describe('loadYaml', () => {
+  it('resolves merge keys instead of leaving a literal << property', () => {
+    const parsed = loadYaml(`
+defaults: &defaults
+  image: alpine
+  imagePullPolicy: IfNotPresent
+container:
+  <<: *defaults
+  command: ["echo"]
+`) as any;
+
+    expect(parsed.container.image).toBe('alpine');
+    expect(parsed.container.imagePullPolicy).toBe('IfNotPresent');
+    expect(parsed.container.command).toEqual(['echo']);
+    expect(Object.prototype.hasOwnProperty.call(parsed.container, '<<')).toBe(false);
+  });
+
+  it('lets the merged mapping override inherited keys', () => {
+    const parsed = loadYaml(`
+base: &base
+  image: alpine
+step:
+  <<: *base
+  image: ubuntu
+`) as any;
+
+    expect(parsed.step.image).toBe('ubuntu');
+  });
+
+  it('parses documents without merge keys unchanged', () => {
+    expect(loadYaml('a: 1\nb: two\n')).toEqual({ a: 1, b: 'two' });
+  });
+});

--- a/frontend/src/lib/YamlLoad.test.ts
+++ b/frontend/src/lib/YamlLoad.test.ts
@@ -51,15 +51,32 @@ step:
     expect(loadYaml('a: 1\nb: two\n')).toEqual({ a: 1, b: 'two' });
   });
 
-  it('returns undefined for input holding no document', () => {
-    // js-yaml 5 throws YAMLException here, where js-yaml 4 returned undefined.
-    // Call sites pass optional templates through `|| ''`.
+  // js-yaml 4 returned undefined for blank input and null for input that
+  // carried no document. js-yaml 5 throws for both.
+  it('returns undefined for blank input', () => {
     expect(loadYaml('')).toBeUndefined();
     expect(loadYaml('   ')).toBeUndefined();
     expect(loadYaml('\n')).toBeUndefined();
   });
 
-  it('round trips empty input to an empty string through dump', () => {
+  it('returns null for input that carries no document', () => {
+    expect(loadYaml('# comment\n')).toBeNull();
+    expect(loadYaml('# one\n# two\n')).toBeNull();
+    expect(loadYaml('...\n')).toBeNull();
+    expect(loadYaml('---\n')).toBeNull();
+  });
+
+  it('round trips no-document input through dump the way js-yaml 4 did', () => {
     expect(dump(loadYaml(''))).toBe('');
+    expect(dump(loadYaml('# comment\n'))).toBe('null\n');
+  });
+
+  it('still raises genuine syntax errors', () => {
+    expect(() => loadYaml('a: [1,2')).toThrow();
+    expect(() => loadYaml('a:\n  - b\n\tc: d')).toThrow();
+  });
+
+  it('still raises on multiple documents rather than yielding the first', () => {
+    expect(() => loadYaml('a: 1\n---\nb: 2\n')).toThrow();
   });
 });

--- a/frontend/src/lib/YamlLoad.ts
+++ b/frontend/src/lib/YamlLoad.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 The Kubeflow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CORE_SCHEMA, load as jsYamlLoad, mergeTag } from 'js-yaml';
+
+/**
+ * js-yaml 5 resolves merge keys only when `mergeTag` is present in the schema,
+ * where js-yaml 4 resolved them by default. KFP parses Argo and Kubernetes
+ * manifests that inherit fields through anchors, so without this a merged
+ * mapping keeps a literal `<<` property and the inherited fields are lost.
+ */
+const MANIFEST_SCHEMA = CORE_SCHEMA.withTags(mergeTag);
+
+/** Parses manifest YAML, preserving merge key (`<<`) resolution. */
+export function loadYaml(text: string): unknown {
+  return jsYamlLoad(text, { schema: MANIFEST_SCHEMA });
+}

--- a/frontend/src/lib/YamlLoad.ts
+++ b/frontend/src/lib/YamlLoad.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CORE_SCHEMA, load as jsYamlLoad, mergeTag } from 'js-yaml';
+import { CORE_SCHEMA, load as jsYamlLoad, loadAll as jsYamlLoadAll, mergeTag } from 'js-yaml';
 
 /**
  * js-yaml 5 resolves merge keys only when `mergeTag` is present in the schema,
@@ -27,14 +27,31 @@ const MANIFEST_SCHEMA = CORE_SCHEMA.withTags(mergeTag);
 /**
  * Parses manifest YAML, preserving merge key (`<<`) resolution.
  *
- * Returns undefined for input that holds no document. js-yaml 5 throws
- * `YAMLException: expected a document, but the input is empty` in that case,
- * where js-yaml 4 returned undefined. Call sites funnel optional template
- * strings through `|| ''`, so throwing would surface during render.
+ * Restores the js-yaml 4 result for input that carries no document. js-yaml 5
+ * throws `YAMLException: expected a document, but the input is empty` for a
+ * blank string, comment-only text, or a bare `...` marker, where js-yaml 4
+ * returned undefined for blank input and null otherwise. Call sites parse
+ * arbitrary template strings during render, so throwing is reachable.
+ *
+ * loadAll reports zero documents for exactly those inputs while still raising
+ * genuine syntax errors, which is what distinguishes the two cases without
+ * matching on exception messages. Input holding more than one document is
+ * handed back to `load` so it raises its own single-document error rather than
+ * silently yielding the first.
  */
 export function loadYaml(text: string): unknown {
   if (!text.trim()) {
     return undefined;
+  }
+
+  const documents: unknown[] = [];
+  jsYamlLoadAll(text, (document) => documents.push(document), { schema: MANIFEST_SCHEMA });
+
+  if (documents.length === 0) {
+    return null;
+  }
+  if (documents.length === 1) {
+    return documents[0];
   }
   return jsYamlLoad(text, { schema: MANIFEST_SCHEMA });
 }

--- a/frontend/src/lib/YamlLoad.ts
+++ b/frontend/src/lib/YamlLoad.ts
@@ -24,7 +24,17 @@ import { CORE_SCHEMA, load as jsYamlLoad, mergeTag } from 'js-yaml';
  */
 const MANIFEST_SCHEMA = CORE_SCHEMA.withTags(mergeTag);
 
-/** Parses manifest YAML, preserving merge key (`<<`) resolution. */
+/**
+ * Parses manifest YAML, preserving merge key (`<<`) resolution.
+ *
+ * Returns undefined for input that holds no document. js-yaml 5 throws
+ * `YAMLException: expected a document, but the input is empty` in that case,
+ * where js-yaml 4 returned undefined. Call sites funnel optional template
+ * strings through `|| ''`, so throwing would surface during render.
+ */
 export function loadYaml(text: string): unknown {
+  if (!text.trim()) {
+    return undefined;
+  }
   return jsYamlLoad(text, { schema: MANIFEST_SCHEMA });
 }

--- a/frontend/src/lib/v2/WorkflowUtils.test.ts
+++ b/frontend/src/lib/v2/WorkflowUtils.test.ts
@@ -17,6 +17,7 @@ import { Workflow, WorkflowSpec, WorkflowStatus } from 'third_party/argo-ui/argo
 import {
   convertYamlToPlatformSpec,
   getContainer,
+  isArgoWorkflowTemplate,
   isTemplateV2,
   isV2Pipeline,
 } from './WorkflowUtils';
@@ -178,5 +179,31 @@ PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet     --no-warn-scr
       lifecycle: undefined,
       resources: undefined,
     });
+  });
+});
+
+describe('isArgoWorkflowTemplate', () => {
+  it('accepts an Argo workflow manifest', () => {
+    expect(
+      isArgoWorkflowTemplate({
+        kind: 'Workflow',
+        apiVersion: 'argoproj.io/v1alpha1',
+      } as any),
+    ).toBe(true);
+  });
+
+  it('rejects a non-Argo manifest', () => {
+    expect(isArgoWorkflowTemplate({ kind: 'Workflow', apiVersion: 'v1' } as any)).toBe(false);
+  });
+
+  it('returns false rather than throwing when apiVersion is not a string', () => {
+    // Parsed YAML can carry any type here, and optional chaining alone would
+    // still call startsWith on a number.
+    expect(isArgoWorkflowTemplate({ kind: 'Workflow', apiVersion: 1 })).toBe(false);
+  });
+
+  it('returns false for non-object input', () => {
+    expect(isArgoWorkflowTemplate(undefined)).toBe(false);
+    expect(isArgoWorkflowTemplate('a string')).toBe(false);
   });
 });

--- a/frontend/src/lib/v2/WorkflowUtils.ts
+++ b/frontend/src/lib/v2/WorkflowUtils.ts
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { load } from 'js-yaml';
+import { loadYaml } from 'src/lib/YamlLoad';
 import { FeatureKey, isFeatureEnabled } from 'src/features';
 import {
   ComponentSpec,
@@ -33,12 +33,12 @@ function getPipelineDefFromYaml(template: string) {
   // If pipeline_spec exists in the parsed YAML,
   // which means the original yaml contains platform_spec,
   // then the PipelineSpec(IR) is stored in 'pipeline_spec' field.
-  const parsedTemplate = load(template) as Record<string, unknown>;
+  const parsedTemplate = loadYaml(template) as Record<string, unknown>;
   return parsedTemplate[PIPELINE_SPEC_TEMPLATE_KEY] ?? parsedTemplate;
 }
 
 function getPlatformDefFromYaml(template: string) {
-  return (load(template) as Record<string, unknown>)[PLATFORM_SPEC_TEMPLATE_KEY];
+  return (loadYaml(template) as Record<string, unknown>)[PLATFORM_SPEC_TEMPLATE_KEY];
 }
 
 export function isV2Pipeline(workflow: Workflow): boolean {
@@ -47,7 +47,14 @@ export function isV2Pipeline(workflow: Workflow): boolean {
 
 export function isArgoWorkflowTemplate(template: unknown): template is Workflow {
   const candidate = template as Workflow | undefined;
-  if (candidate?.kind === 'Workflow' && candidate?.apiVersion?.startsWith('argoproj.io/')) {
+  // apiVersion comes from arbitrary parsed YAML, so it is not necessarily a
+  // string. Optional chaining only guards null/undefined, and calling
+  // startsWith on a number would throw rather than return false.
+  if (
+    candidate?.kind === 'Workflow' &&
+    typeof candidate.apiVersion === 'string' &&
+    candidate.apiVersion.startsWith('argoproj.io/')
+  ) {
     return true;
   }
   return false;

--- a/frontend/src/lib/v2/WorkflowUtils.ts
+++ b/frontend/src/lib/v2/WorkflowUtils.ts
@@ -45,8 +45,9 @@ export function isV2Pipeline(workflow: Workflow): boolean {
   return workflow?.metadata?.annotations?.['pipelines.kubeflow.org/v2_pipeline'] === 'true';
 }
 
-export function isArgoWorkflowTemplate(template: Workflow): boolean {
-  if (template?.kind === 'Workflow' && template?.apiVersion?.startsWith('argoproj.io/')) {
+export function isArgoWorkflowTemplate(template: unknown): template is Workflow {
+  const candidate = template as Workflow | undefined;
+  if (candidate?.kind === 'Workflow' && candidate?.apiVersion?.startsWith('argoproj.io/')) {
     return true;
   }
   return false;
@@ -55,7 +56,7 @@ export function isArgoWorkflowTemplate(template: Workflow): boolean {
 export function isTemplateV2(templateString: string): boolean {
   try {
     const template = getPipelineDefFromYaml(templateString);
-    if (isArgoWorkflowTemplate(template as Workflow)) {
+    if (isArgoWorkflowTemplate(template)) {
       return false;
     } else if (isFeatureEnabled(FeatureKey.V2_ALPHA)) {
       WorkflowUtils.convertYamlToV2PipelineSpec(templateString);
@@ -98,7 +99,7 @@ export function isPipelineSpec(templateString: string) {
   }
   try {
     const template = getPipelineDefFromYaml(templateString);
-    if (WorkflowUtils.isArgoWorkflowTemplate(template as Workflow)) {
+    if (WorkflowUtils.isArgoWorkflowTemplate(template)) {
       StaticGraphParser.createGraph(template as Workflow);
       return false;
     } else if (isFeatureEnabled(FeatureKey.V2_ALPHA)) {

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -421,7 +421,7 @@ function NewRunV2(props: NewRunV2Props) {
       experiment_id: selectedExperiment?.experiment_id,
       // pipeline_spec and pipeline_version_reference is exclusive.
       pipeline_spec: !(pipelineVersionRefClone || pipelineVersionRefNew)
-        ? JsYaml.load(templateString || '')
+        ? (JsYaml.load(templateString || '') as object)
         : undefined,
       pipeline_version_reference: useLatestVersion
         ? { pipeline_id: existingPipeline?.pipeline_id }

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -25,7 +25,6 @@ import {
   Checkbox,
 } from '@mui/material';
 import React, { useEffect, useMemo, useState } from 'react';
-import * as JsYaml from 'js-yaml';
 import { useMutation } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { V2beta1Experiment, V2beta1ExperimentStorageState } from 'src/apisv2beta1/experiment';
@@ -43,6 +42,7 @@ import NewRunParametersV2 from 'src/components/NewRunParametersV2';
 import { getSafeReturnPath, QUERY_PARAMS, RoutePage, RouteParams } from 'src/components/Router';
 import Trigger from 'src/components/Trigger';
 import { color, commonCss, padding } from 'src/Css';
+import { loadYaml } from 'src/lib/YamlLoad';
 import { Apis, ExperimentSortKeys, PipelineSortKeys, PipelineVersionSortKeys } from 'src/lib/Apis';
 import { useKeyedState } from 'src/hooks/useKeyedState';
 import {
@@ -421,7 +421,7 @@ function NewRunV2(props: NewRunV2Props) {
       experiment_id: selectedExperiment?.experiment_id,
       // pipeline_spec and pipeline_version_reference is exclusive.
       pipeline_spec: !(pipelineVersionRefClone || pipelineVersionRefNew)
-        ? (JsYaml.load(templateString || '') as object)
+        ? (loadYaml(templateString || '') as object)
         : undefined,
       pipeline_version_reference: useLatestVersion
         ? { pipeline_id: existingPipeline?.pipeline_id }

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -22,6 +22,7 @@ import type * as React from 'react';
 import { CircularProgress } from '@mui/material';
 import { graphlib } from 'dagre';
 import * as JsYaml from 'js-yaml';
+import { loadYaml } from 'src/lib/YamlLoad';
 import { FeatureKey, isFeatureEnabled } from 'src/features';
 import { Apis } from 'src/lib/Apis';
 import {
@@ -657,7 +658,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     let graphV2: PipelineFlowElement[] = [];
     if (templateString) {
       try {
-        const template = JsYaml.load(templateString);
+        const template = loadYaml(templateString);
         if (WorkflowUtils.isArgoWorkflowTemplate(template)) {
           graph = StaticGraphParser.createGraph(template!);
 

--- a/frontend/src/pages/__tests__/newRunTestFixtures.ts
+++ b/frontend/src/pages/__tests__/newRunTestFixtures.ts
@@ -51,7 +51,7 @@ export const ORIGINAL_TEST_PIPELINE_VERSION: V2beta1PipelineVersion = {
   display_name: ORIGINAL_TEST_PIPELINE_VERSION_NAME,
   pipeline_id: ORIGINAL_TEST_PIPELINE_ID,
   pipeline_version_id: ORIGINAL_TEST_PIPELINE_VERSION_ID,
-  pipeline_spec: JsYaml.load(v2XGYamlTemplateString),
+  pipeline_spec: JsYaml.load(v2XGYamlTemplateString) as object,
 };
 
 export const V1_PIPELINE_VERSION = {


### PR DESCRIPTION
## Summary

Bump `js-yaml` from 4.x to 5.3.0 and narrow the parse results it now returns as `unknown`.

Supersedes #14083.

## Why

js-yaml 5 types `load` as returning `unknown` rather than `any`. That is a genuine improvement — the result of parsing arbitrary YAML really is unknown — but it does not type check against the existing call sites:

```
src/pages/NewRunV2.tsx(423,7): error TS2322: Type 'unknown' is not assignable to type 'object | undefined'.
src/pages/PipelineDetails.tsx(661,50): error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'Workflow'.
src/pages/PipelineDetails.tsx(662,49): error TS2345: Argument of type '{}' is not assignable to parameter of type 'Workflow'.
src/pages/__tests__/newRunTestFixtures.ts(54,3): error TS2322: Type 'unknown' is not assignable to type 'object | undefined'.
```

## isArgoWorkflowTemplate

The `PipelineDetails` errors are worth fixing properly rather than casting away.

`isArgoWorkflowTemplate` was declared as taking a `Workflow`:

```ts
export function isArgoWorkflowTemplate(template: Workflow): boolean {
  if (template?.kind === 'Workflow' && template?.apiVersion?.startsWith('argoproj.io/')) {
```

but its body only does optional-chained property reads, so it was always safe against an arbitrary value. Two existing call sites already acknowledged that by working around the signature with `as Workflow`.

Redeclaring it as a type guard over `unknown` matches what the function actually does:

```ts
export function isArgoWorkflowTemplate(template: unknown): template is Workflow
```

This lets `PipelineDetails` pass the parse result straight in, and narrows `template` to `Workflow` for the `createGraph` call on the next line — so both errors are resolved by the guard rather than by an assertion. The two `as Workflow` casts in `WorkflowUtils` are now redundant and are removed.

The two `pipeline_spec` assignments take `object | undefined`, and there is no meaningful narrowing to do beyond that, so those results are asserted to `object` at the point of use.

## Verification

Run on node 24.14.0, matching `frontend/.nvmrc`:

- `format:check`, `lint:ui`, `typecheck` — clean, 0 errors
- 86 tests passing across `WorkflowUtils`, `PipelineDetails`, and `NewRunV2`

Leaving the full suite to CI.
