### PR TITLE
chore(deps): bump http-proxy-middleware to v4.2.0

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "dagre": "^0.8.5",
         "google-protobuf": "^4.0.2",
         "grpc-web": "^2.1.1",
-        "http-proxy-middleware": "^3.0.7",
+        "http-proxy-middleware": "^4.2.0",
         "immer": "^11.1.18",
         "js-yaml": "^5.4.1",
         "lodash": "^4.18.1",
@@ -3551,13 +3551,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/http-proxy": {
-      "version": "1.17.16",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/js-yaml": {
       "version": "3.12.3",
       "dev": true,
@@ -6261,26 +6254,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/form-data": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
@@ -6616,37 +6589,26 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
-      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.2.0.tgz",
+      "integrity": "sha512-ZA+oNOoM+GLoFTIzhkJptVQov73Srep2LBqhF8hG8CIPKO3nam1jonXVQ/QUH8RbwsmaaVz2SOJdzBNBHNtKbw==",
       "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.15",
-        "debug": "^4.3.6",
-        "http-proxy": "^1.18.1",
+        "debug": "^4.4.3",
+        "httpxy": "^0.5.4",
         "is-glob": "^4.0.3",
-        "is-plain-object": "^5.0.0",
+        "is-plain-obj": "^4.1.0",
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
+        "node": "^22.15.0 || ^24.0.0 || >=26.0.0"
       }
     },
-    "node_modules/http-proxy/node_modules/eventemitter3": {
-      "version": "4.0.7",
+    "node_modules/httpxy": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+      "integrity": "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==",
       "license": "MIT"
     },
     "node_modules/iconv-lite": {
@@ -6816,13 +6778,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -8781,6 +8746,7 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/reselect": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "dagre": "^0.8.5",
     "google-protobuf": "^4.0.2",
     "grpc-web": "^2.1.1",
-    "http-proxy-middleware": "^3.0.7",
+    "http-proxy-middleware": "^4.2.0",
     "immer": "^11.1.18",
     "js-yaml": "^5.4.1",
     "lodash": "^4.18.1",

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -254,8 +254,10 @@ function createUIServer(options: UIConfigs) {
       '/k8s/pod/logs',
       createProxyMiddleware({
         changeOrigin: true,
-        onProxyReq: (proxyReq) => {
-          console.log('Proxied log request: ', proxyReq.path);
+        on: {
+          proxyReq: (proxyReq) => {
+            console.log('Proxied log request: ', proxyReq.path);
+          },
         },
         headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
         pathRewrite: (pathStr: string, req: any) => {
@@ -286,8 +288,10 @@ function createUIServer(options: UIConfigs) {
       '/k8s/pod/logs',
       createProxyMiddleware({
         changeOrigin: true,
-        onProxyReq: (proxyReq) => {
-          console.log('Proxied log request: ', proxyReq.path);
+        on: {
+          proxyReq: (proxyReq) => {
+            console.log('Proxied log request: ', proxyReq.path);
+          },
         },
         headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
         pathRewrite: (pathStr: string, req: any) => {
@@ -334,8 +338,10 @@ function createUIServer(options: UIConfigs) {
     '/ml_metadata.*',
     createProxyMiddleware({
       changeOrigin: true,
-      onProxyReq: (proxyReq) => {
-        console.log('Metadata proxied request: ', (proxyReq as any).path);
+      on: {
+        proxyReq: (proxyReq) => {
+          console.log('Metadata proxied request: ', (proxyReq as any).path);
+        },
       },
       headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
       target: envoyServiceAddress,
@@ -373,8 +379,10 @@ function createUIServer(options: UIConfigs) {
     `/${apiVersion1Prefix}/*`,
     createProxyMiddleware({
       changeOrigin: true,
-      onProxyReq: (proxyReq) => {
-        console.log('Proxied request: ', proxyReq.path);
+      on: {
+        proxyReq: (proxyReq) => {
+          console.log('Proxied request: ', proxyReq.path);
+        },
       },
       headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
       target: apiServerAddress,
@@ -384,8 +392,10 @@ function createUIServer(options: UIConfigs) {
     `/${apiVersion2Prefix}/*`,
     createProxyMiddleware({
       changeOrigin: true,
-      onProxyReq: (proxyReq) => {
-        console.log('Proxied request: ', proxyReq.path);
+      on: {
+        proxyReq: (proxyReq) => {
+          console.log('Proxied request: ', proxyReq.path);
+        },
       },
       headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
       target: apiServerAddress,
@@ -396,8 +406,10 @@ function createUIServer(options: UIConfigs) {
     `${basePath}/${apiVersion1Prefix}/*`,
     createProxyMiddleware({
       changeOrigin: true,
-      onProxyReq: (proxyReq) => {
-        console.log('Proxied request: ', proxyReq.path);
+      on: {
+        proxyReq: (proxyReq) => {
+          console.log('Proxied request: ', proxyReq.path);
+        },
       },
       headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
       pathRewrite: (pathStr) =>
@@ -409,8 +421,10 @@ function createUIServer(options: UIConfigs) {
     `${basePath}/${apiVersion2Prefix}/*`,
     createProxyMiddleware({
       changeOrigin: true,
-      onProxyReq: (proxyReq) => {
-        console.log('Proxied request: ', proxyReq.path);
+      on: {
+        proxyReq: (proxyReq) => {
+          console.log('Proxied request: ', proxyReq.path);
+        },
       },
       headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
       pathRewrite: (pathStr) =>

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -1020,38 +1020,38 @@ export function getArtifactsProxyHandler({
   if (!enabled) {
     return (_req, _res, next) => next();
   }
-  const proxy = createProxyMiddleware(
-    (_pathname, req) => {
+  const proxy = createProxyMiddleware({
+    pathFilter: (_pathname, req) => {
       // only proxy requests with namespace query parameter
       return !!getNamespaceFromUrl(req.url || '');
     },
-    {
-      changeOrigin: true,
-      onProxyReq: (proxyReq) => {
+    changeOrigin: true,
+    on: {
+      proxyReq: (proxyReq) => {
         console.log('Proxied artifact request: ', proxyReq.path);
       },
-      pathRewrite: (pathStr, _req) => {
-        const url = new URL(pathStr || '', DUMMY_BASE_PATH);
-        url.searchParams.delete(QUERIES.NAMESPACE);
-        return url.pathname + url.search;
-      },
-      router: (req) => {
-        const namespace = getNamespaceFromUrl(req.url || '');
-        if (!namespace) {
-          console.log(`namespace query param expected in ${req.url}.`);
-          throw new Error(`namespace query param expected.`);
-        }
-        const urlStr = namespacedServiceGetter(namespace!);
-        if (!isAllowedDomain(urlStr, allowedDomain)) {
-          console.log(`Domain is not allowed.`);
-          throw new Error(`Domain is not allowed.`);
-        }
-        return namespacedServiceGetter(namespace!);
-      },
-      target: '/artifacts',
-      headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
     },
-  );
+    pathRewrite: (pathStr, _req) => {
+      const url = new URL(pathStr || '', DUMMY_BASE_PATH);
+      url.searchParams.delete(QUERIES.NAMESPACE);
+      return url.pathname + url.search;
+    },
+    router: (req) => {
+      const namespace = getNamespaceFromUrl(req.url || '');
+      if (!namespace) {
+        console.log(`namespace query param expected in ${req.url}.`);
+        throw new Error(`namespace query param expected.`);
+      }
+      const urlStr = namespacedServiceGetter(namespace!);
+      if (!isAllowedDomain(urlStr, allowedDomain)) {
+        console.log(`Domain is not allowed.`);
+        throw new Error(`Domain is not allowed.`);
+      }
+      return namespacedServiceGetter(namespace!);
+    },
+    target: '/artifacts',
+    headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
+  });
   return (req, res, next) => {
     const namespace = getNamespaceFromUrl(req.url || '');
     if (namespace && !isAllowedResourceName(namespace)) {

--- a/frontend/server/handlers/tensorboard-proxy.ts
+++ b/frontend/server/handlers/tensorboard-proxy.ts
@@ -342,7 +342,6 @@ export default function registerTensorboardProxy(
     proxyRoutes,
     createProxyMiddleware({
       changeOrigin: true,
-      logLevel: process.env.NODE_ENV === 'test' ? 'warn' : 'debug',
       target: 'http://127.0.0.1',
       router: (req: any) => {
         const { namespace, viewerName } = req.tensorboardProxy as TensorboardProxyPayload;

--- a/frontend/server/package-lock.json
+++ b/frontend/server/package-lock.json
@@ -14,7 +14,7 @@
         "google-auth-library": "^7.14.1",
         "google-protobuf": "^4.0.2",
         "gunzip-maybe": "^1.4.1",
-        "http-proxy-middleware": "^2.0.10",
+        "http-proxy-middleware": "^4.2.0",
         "js-yaml": "^5.3.0",
         "lodash": ">=4.18.1",
         "minio": "~8.0.7",
@@ -1903,7 +1903,7 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -1925,7 +1925,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1963,7 +1963,7 @@
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1976,7 +1976,7 @@
       "version": "4.19.8",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
       "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1999,17 +1999,8 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/http-proxy": {
-      "version": "1.17.17",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
-      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
@@ -2028,7 +2019,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minipass": {
@@ -2080,21 +2071,21 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2104,7 +2095,7 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
       "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -2116,7 +2107,7 @@
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
       "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -3062,12 +3053,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
-    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -3614,42 +3599,20 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
-      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.2.0.tgz",
+      "integrity": "sha512-ZA+oNOoM+GLoFTIzhkJptVQov73Srep2LBqhF8hG8CIPKO3nam1jonXVQ/QUH8RbwsmaaVz2SOJdzBNBHNtKbw==",
       "license": "MIT",
       "dependencies": {
-        "@types/http-proxy": "^1.17.8",
-        "http-proxy": "^1.18.1",
-        "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "debug": "^4.4.3",
+        "httpxy": "^0.5.4",
+        "is-glob": "^4.0.3",
+        "is-plain-obj": "^4.1.0",
+        "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
-      },
-      "peerDependenciesMeta": {
-        "@types/express": {
-          "optional": true
-        }
+        "node": "^22.15.0 || ^24.0.0 || >=26.0.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -3664,6 +3627,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/httpxy": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+      "integrity": "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -3771,12 +3740,12 @@
       }
     },
     "node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4853,12 +4822,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/rfc4648": {
       "version": "1.5.4",

--- a/frontend/server/package.json
+++ b/frontend/server/package.json
@@ -12,7 +12,7 @@
     "google-auth-library": "^7.14.1",
     "google-protobuf": "^4.0.2",
     "gunzip-maybe": "^1.4.1",
-    "http-proxy-middleware": "^2.0.10",
+    "http-proxy-middleware": "^4.2.0",
     "js-yaml": "^5.3.0",
     "lodash": ">=4.18.1",
     "minio": "~8.0.7",


### PR DESCRIPTION
## Summary

- update http-proxy-middleware to v4.2.0 in both frontend packages
- migrate proxy request callbacks to the v4 event API
- migrate the artifact proxy filter to pathFilter
- remove the obsolete logLevel option

## Verification

- frontend/server: npm run build
- frontend/server: npm run format:check
- frontend/server: npm test -- integration-tests/artifact-proxy.test.ts (13 tests passed)

Supersedes #14120.