### PR TITLE
docs(components): fix "patern" typo in split_materialized_data docstring

### DIFF
--- a/components/google-cloud/google_cloud_pipeline_components/preview/automl/forecasting/learn_to_learn_forecasting_pipeline.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/preview/automl/forecasting/learn_to_learn_forecasting_pipeline.yaml
@@ -5302,17 +5302,17 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized eval split.
+          description: Path pattern to materialized eval split.
         materialized_test_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized test split.
+          description: Path pattern to materialized test split.
         materialized_train_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized train split.
+          description: Path pattern to materialized train split.
   comp-string-not-empty:
     executorLabel: exec-string-not-empty
     inputDefinitions:
@@ -6842,9 +6842,9 @@ deploymentSpec:
           \  \"\"\"Splits materialized_data into materialized_data test, train, and\
           \ eval splits.\n\n  Necessary adapter between FTE pipeline and trainer.\n\
           \n  Args:\n    materialized_data: materialized_data dataset output by FTE.\n\
-          \    materialized_train_split: Path patern to materialized_train_split.\n\
-          \    materialized_eval_split: Path patern to materialized_eval_split.\n\
-          \    materialized_test_split: Path patern to materialized_test_split.\n\
+          \    materialized_train_split: Path pattern to materialized_train_split.\n\
+          \    materialized_eval_split: Path pattern to materialized_eval_split.\n\
+          \    materialized_test_split: Path pattern to materialized_test_split.\n\
           \  \"\"\"\n  # pylint: disable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \  import json\n  import tensorflow as tf\n  # pylint: enable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \n  with tf.io.gfile.GFile(materialized_data.path, 'r') as f:\n    artifact_path\

--- a/components/google-cloud/google_cloud_pipeline_components/preview/automl/forecasting/sequence_to_sequence_forecasting_pipeline.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/preview/automl/forecasting/sequence_to_sequence_forecasting_pipeline.yaml
@@ -5284,17 +5284,17 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized eval split.
+          description: Path pattern to materialized eval split.
         materialized_test_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized test split.
+          description: Path pattern to materialized test split.
         materialized_train_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized train split.
+          description: Path pattern to materialized train split.
   comp-string-not-empty:
     executorLabel: exec-string-not-empty
     inputDefinitions:
@@ -6824,9 +6824,9 @@ deploymentSpec:
           \  \"\"\"Splits materialized_data into materialized_data test, train, and\
           \ eval splits.\n\n  Necessary adapter between FTE pipeline and trainer.\n\
           \n  Args:\n    materialized_data: materialized_data dataset output by FTE.\n\
-          \    materialized_train_split: Path patern to materialized_train_split.\n\
-          \    materialized_eval_split: Path patern to materialized_eval_split.\n\
-          \    materialized_test_split: Path patern to materialized_test_split.\n\
+          \    materialized_train_split: Path pattern to materialized_train_split.\n\
+          \    materialized_eval_split: Path pattern to materialized_eval_split.\n\
+          \    materialized_test_split: Path pattern to materialized_test_split.\n\
           \  \"\"\"\n  # pylint: disable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \  import json\n  import tensorflow as tf\n  # pylint: enable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \n  with tf.io.gfile.GFile(materialized_data.path, 'r') as f:\n    artifact_path\

--- a/components/google-cloud/google_cloud_pipeline_components/preview/automl/forecasting/temporal_fusion_transformer_forecasting_pipeline.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/preview/automl/forecasting/temporal_fusion_transformer_forecasting_pipeline.yaml
@@ -5277,17 +5277,17 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized eval split.
+          description: Path pattern to materialized eval split.
         materialized_test_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized test split.
+          description: Path pattern to materialized test split.
         materialized_train_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized train split.
+          description: Path pattern to materialized train split.
   comp-string-not-empty:
     executorLabel: exec-string-not-empty
     inputDefinitions:
@@ -6817,9 +6817,9 @@ deploymentSpec:
           \  \"\"\"Splits materialized_data into materialized_data test, train, and\
           \ eval splits.\n\n  Necessary adapter between FTE pipeline and trainer.\n\
           \n  Args:\n    materialized_data: materialized_data dataset output by FTE.\n\
-          \    materialized_train_split: Path patern to materialized_train_split.\n\
-          \    materialized_eval_split: Path patern to materialized_eval_split.\n\
-          \    materialized_test_split: Path patern to materialized_test_split.\n\
+          \    materialized_train_split: Path pattern to materialized_train_split.\n\
+          \    materialized_eval_split: Path pattern to materialized_eval_split.\n\
+          \    materialized_test_split: Path pattern to materialized_test_split.\n\
           \  \"\"\"\n  # pylint: disable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \  import json\n  import tensorflow as tf\n  # pylint: enable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \n  with tf.io.gfile.GFile(materialized_data.path, 'r') as f:\n    artifact_path\

--- a/components/google-cloud/google_cloud_pipeline_components/preview/automl/forecasting/time_series_dense_encoder_forecasting_pipeline.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/preview/automl/forecasting/time_series_dense_encoder_forecasting_pipeline.yaml
@@ -5302,17 +5302,17 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized eval split.
+          description: Path pattern to materialized eval split.
         materialized_test_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized test split.
+          description: Path pattern to materialized test split.
         materialized_train_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized train split.
+          description: Path pattern to materialized train split.
   comp-string-not-empty:
     executorLabel: exec-string-not-empty
     inputDefinitions:
@@ -6842,9 +6842,9 @@ deploymentSpec:
           \  \"\"\"Splits materialized_data into materialized_data test, train, and\
           \ eval splits.\n\n  Necessary adapter between FTE pipeline and trainer.\n\
           \n  Args:\n    materialized_data: materialized_data dataset output by FTE.\n\
-          \    materialized_train_split: Path patern to materialized_train_split.\n\
-          \    materialized_eval_split: Path patern to materialized_eval_split.\n\
-          \    materialized_test_split: Path patern to materialized_test_split.\n\
+          \    materialized_train_split: Path pattern to materialized_train_split.\n\
+          \    materialized_eval_split: Path pattern to materialized_eval_split.\n\
+          \    materialized_test_split: Path pattern to materialized_test_split.\n\
           \  \"\"\"\n  # pylint: disable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \  import json\n  import tensorflow as tf\n  # pylint: enable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \n  with tf.io.gfile.GFile(materialized_data.path, 'r') as f:\n    artifact_path\

--- a/components/google-cloud/google_cloud_pipeline_components/preview/automl/tabular/automl_tabular_v2_pipeline.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/preview/automl/tabular/automl_tabular_v2_pipeline.yaml
@@ -9004,17 +9004,17 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized eval split.
+          description: Path pattern to materialized eval split.
         materialized_test_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized test split.
+          description: Path pattern to materialized test split.
         materialized_train_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized train split.
+          description: Path pattern to materialized train split.
   comp-split-materialized-data-2:
     executorLabel: exec-split-materialized-data-2
     inputDefinitions:
@@ -9032,17 +9032,17 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized eval split.
+          description: Path pattern to materialized eval split.
         materialized_test_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized test split.
+          description: Path pattern to materialized test split.
         materialized_train_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized train split.
+          description: Path pattern to materialized train split.
   comp-string-not-empty:
     executorLabel: exec-string-not-empty
     inputDefinitions:
@@ -11434,9 +11434,9 @@ deploymentSpec:
           \  \"\"\"Splits materialized_data into materialized_data test, train, and\
           \ eval splits.\n\n  Necessary adapter between FTE pipeline and trainer.\n\
           \n  Args:\n    materialized_data: materialized_data dataset output by FTE.\n\
-          \    materialized_train_split: Path patern to materialized_train_split.\n\
-          \    materialized_eval_split: Path patern to materialized_eval_split.\n\
-          \    materialized_test_split: Path patern to materialized_test_split.\n\
+          \    materialized_train_split: Path pattern to materialized_train_split.\n\
+          \    materialized_eval_split: Path pattern to materialized_eval_split.\n\
+          \    materialized_test_split: Path pattern to materialized_test_split.\n\
           \  \"\"\"\n  # pylint: disable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \  import json\n  import tensorflow as tf\n  # pylint: enable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \n  with tf.io.gfile.GFile(materialized_data.path, 'r') as f:\n    artifact_path\
@@ -11480,9 +11480,9 @@ deploymentSpec:
           \  \"\"\"Splits materialized_data into materialized_data test, train, and\
           \ eval splits.\n\n  Necessary adapter between FTE pipeline and trainer.\n\
           \n  Args:\n    materialized_data: materialized_data dataset output by FTE.\n\
-          \    materialized_train_split: Path patern to materialized_train_split.\n\
-          \    materialized_eval_split: Path patern to materialized_eval_split.\n\
-          \    materialized_test_split: Path patern to materialized_test_split.\n\
+          \    materialized_train_split: Path pattern to materialized_train_split.\n\
+          \    materialized_eval_split: Path pattern to materialized_eval_split.\n\
+          \    materialized_test_split: Path pattern to materialized_test_split.\n\
           \  \"\"\"\n  # pylint: disable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \  import json\n  import tensorflow as tf\n  # pylint: enable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \n  with tf.io.gfile.GFile(materialized_data.path, 'r') as f:\n    artifact_path\

--- a/components/google-cloud/google_cloud_pipeline_components/preview/automl/tabular/tabnet_hyperparameter_tuning_job_pipeline.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/preview/automl/tabular/tabnet_hyperparameter_tuning_job_pipeline.yaml
@@ -2443,17 +2443,17 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized eval split.
+          description: Path pattern to materialized eval split.
         materialized_test_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized test split.
+          description: Path pattern to materialized test split.
         materialized_train_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized train split.
+          description: Path pattern to materialized train split.
   comp-tabnet-hyperparameter-tuning-job:
     executorLabel: exec-tabnet-hyperparameter-tuning-job
     inputDefinitions:
@@ -3894,9 +3894,9 @@ deploymentSpec:
           \  \"\"\"Splits materialized_data into materialized_data test, train, and\
           \ eval splits.\n\n  Necessary adapter between FTE pipeline and trainer.\n\
           \n  Args:\n    materialized_data: materialized_data dataset output by FTE.\n\
-          \    materialized_train_split: Path patern to materialized_train_split.\n\
-          \    materialized_eval_split: Path patern to materialized_eval_split.\n\
-          \    materialized_test_split: Path patern to materialized_test_split.\n\
+          \    materialized_train_split: Path pattern to materialized_train_split.\n\
+          \    materialized_eval_split: Path pattern to materialized_eval_split.\n\
+          \    materialized_test_split: Path pattern to materialized_test_split.\n\
           \  \"\"\"\n  # pylint: disable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \  import json\n  import tensorflow as tf\n  # pylint: enable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \n  with tf.io.gfile.GFile(materialized_data.path, 'r') as f:\n    artifact_path\

--- a/components/google-cloud/google_cloud_pipeline_components/preview/automl/tabular/tabnet_trainer_pipeline.yaml
+++ b/components/google-cloud/google_cloud_pipeline_components/preview/automl/tabular/tabnet_trainer_pipeline.yaml
@@ -2398,17 +2398,17 @@ components:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized eval split.
+          description: Path pattern to materialized eval split.
         materialized_test_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized test split.
+          description: Path pattern to materialized test split.
         materialized_train_split:
           artifactType:
             schemaTitle: system.Artifact
             schemaVersion: 0.0.1
-          description: Path patern to materialized train split.
+          description: Path pattern to materialized train split.
   comp-tabnet-trainer:
     executorLabel: exec-tabnet-trainer
     inputDefinitions:
@@ -3362,9 +3362,9 @@ deploymentSpec:
           \  \"\"\"Splits materialized_data into materialized_data test, train, and\
           \ eval splits.\n\n  Necessary adapter between FTE pipeline and trainer.\n\
           \n  Args:\n    materialized_data: materialized_data dataset output by FTE.\n\
-          \    materialized_train_split: Path patern to materialized_train_split.\n\
-          \    materialized_eval_split: Path patern to materialized_eval_split.\n\
-          \    materialized_test_split: Path patern to materialized_test_split.\n\
+          \    materialized_train_split: Path pattern to materialized_train_split.\n\
+          \    materialized_eval_split: Path pattern to materialized_eval_split.\n\
+          \    materialized_test_split: Path pattern to materialized_test_split.\n\
           \  \"\"\"\n  # pylint: disable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \  import json\n  import tensorflow as tf\n  # pylint: enable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n\
           \n  with tf.io.gfile.GFile(materialized_data.path, 'r') as f:\n    artifact_path\

--- a/components/google-cloud/google_cloud_pipeline_components/v1/automl/tabular/split_materialized_data.py
+++ b/components/google-cloud/google_cloud_pipeline_components/v1/automl/tabular/split_materialized_data.py
@@ -45,9 +45,9 @@ def split_materialized_data(
         Transform Engine.
 
   Returns:
-      materialized_train_split: Path patern to materialized train split.
-      materialized_eval_split: Path patern to materialized eval split.
-      materialized_test_split: Path patern to materialized test split.
+      materialized_train_split: Path pattern to materialized train split.
+      materialized_eval_split: Path pattern to materialized eval split.
+      materialized_test_split: Path pattern to materialized test split.
   """
   # fmt: on
 
@@ -75,10 +75,10 @@ def split_materialized_data(
               ' train, and eval splits.\n\n  Necessary adapter between FTE'
               ' pipeline and trainer.\n\n  Args:\n    materialized_data:'
               ' materialized_data dataset output by FTE.\n   '
-              ' materialized_train_split: Path patern to'
+              ' materialized_train_split: Path pattern to'
               ' materialized_train_split.\n    materialized_eval_split: Path'
-              ' patern to materialized_eval_split.\n   '
-              ' materialized_test_split: Path patern to'
+              ' pattern to materialized_eval_split.\n   '
+              ' materialized_test_split: Path pattern to'
               ' materialized_test_split.\n  """\n  # pylint:'
               ' disable=g-import-not-at-top,import-outside-toplevel,redefined-outer-name,reimported\n'
               '  import json\n  import tensorflow as tf\n  # pylint:'


### PR DESCRIPTION
**Description of your changes:**

Fix "patern" -> "pattern" in the split_materialized_data component's docstring (both the user-facing Args/Returns section and the embedded runtime-executor copy of the same text), and mirror the same fix in the compiled pipeline YAML files that embed this component.

No behavior change.

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 