### PR TITLE
docs: fix two broken links in README files

### DIFF
--- a/frontend/mock-backend/data/v2/pipeline/README.md
+++ b/frontend/mock-backend/data/v2/pipeline/README.md
@@ -3,4 +3,4 @@
 This folder is for KFP UI to mock backend response, the files here are copied from 
 [test_data/sdk_compiled_pipelines/](../../../../../test_data/sdk_compiled_pipelines/). This folder doesn't need to be in sync with the compiled pipeline specs in that directory, but you can do it manually if there is a need to facilitate frontend development by using newer version of compiled pipeline definition.
 
-Also, make sure to update the corresponding PipelineSpec files in [frontend/src/data/test](frontend/src/data/test). These files are used for unit testing.
+Also, make sure to update the corresponding PipelineSpec files in [frontend/src/data/test](/frontend/src/data/test). These files are used for unit testing.

--- a/tools/metadatastore-upgrade/README.md
+++ b/tools/metadatastore-upgrade/README.md
@@ -21,7 +21,7 @@ go run main.go --new_image_tag=<image-tag> --kubeconfig=<kubeconfig-path> --name
 ```
 
 Arguments:
-* `--new_image_tag`(Required) - The image tag for the gRPC server version to upgrade to. The list of available images can be found [here](gcr.io/tfx-oss-public/ml_metadata_store_server)
+* `--new_image_tag`(Required) - The image tag for the gRPC server version to upgrade to. The list of available images can be found [here](https://gcr.io/tfx-oss-public/ml_metadata_store_server)
 * `--kubeconfig`(Optional) - Absolute path to a kubeconfig file. If this argument is not specified `.kubecofing` in user's home directory is used.
 * `--namespace`(Optional) - Namespace where `metadata-deployment` is deployed in the KFP cluster. Defaults to `kubeflow`.
 


### PR DESCRIPTION
**Description of your changes:**

frontend/mock-backend/data/v2/pipeline/README.md: the link to frontend/src/data/test was written relative to this file's own directory instead of the repo root, so it resolved to a nonexistent path. Add the leading slash, same fix as frontend/CONTRIBUTING.md.

tools/metadatastore-upgrade/README.md: the link to the gcr.io didn't include https://, so it led to a nonexistent page within this repo. Solved by adding https://.

No behavior change.

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 