### PR TITLE
fix(frontend): confine archived pod logs to trusted storage. Part of #9889

### DIFF
--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -277,6 +277,7 @@ function createUIServer(options: UIConfigs) {
         options.pod.logContainerName,
         authorizeFn,
         options.auth.enabled,
+        options.viewer.tensorboard.clusterDomain,
       ),
     );
   }
@@ -309,6 +310,7 @@ function createUIServer(options: UIConfigs) {
         options.pod.logContainerName,
         authorizeFn,
         options.auth.enabled,
+        options.viewer.tensorboard.clusterDomain,
       ),
     );
   }

--- a/frontend/server/configs.test.ts
+++ b/frontend/server/configs.test.ts
@@ -33,6 +33,13 @@ describe('loadConfigs', () => {
     expect(configs.viewer.tensorboard.clusterDomain).toBe('.svc.cluster.local');
   });
 
+  it('default archive key format matches the namespace-scoped Argo manifest layout', () => {
+    const configs = loadConfigs(['node', 'dist/server.js', os.tmpdir()], {});
+    expect(configs.argo.keyFormat).toBe(
+      'private-artifacts/{{workflow.namespace}}/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}',
+    );
+  });
+
   it('clusterDomain should use CLUSTER_DOMAIN env var when set', () => {
     const tmpdir = os.tmpdir();
     const configs = loadConfigs(['node', 'dist/server.js', tmpdir], {

--- a/frontend/server/configs.ts
+++ b/frontend/server/configs.ts
@@ -97,16 +97,21 @@ export function loadConfigs(argv: string[], env: ProcessEnv): UIConfigs {
     ARGO_ARCHIVE_ARTIFACTORY = 'minio',
     /** Bucket to retrive logs from */
     ARGO_ARCHIVE_BUCKETNAME = 'mlpipeline',
-    /** This should match the keyFormat specified in the Argo workflow-controller-configmap.
-     * It's set here in the manifests:
-     * https://github.com/kubeflow/pipelines/blob/7b7918ebf8c30e6ceec99283ef20dbc02fdf6a42/manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml#L28
+    /** This must match the keyFormat in
+     * manifests/kustomize/third-party/argo/base/workflow-controller-configmap-patch.yaml.
+     * The namespace-scoped default is required for multi-user isolation. Existing
+     * archives written with a legacy format need an explicit ARGO_KEYFORMAT during
+     * migration and remain unavailable in multi-user mode if the format cannot be
+     * proven namespace-scoped.
      */
-    ARGO_KEYFORMAT = 'artifacts/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}',
+    ARGO_KEYFORMAT = 'private-artifacts/{{workflow.namespace}}/{{workflow.name}}/{{workflow.creationTimestamp.Y}}/{{workflow.creationTimestamp.m}}/{{workflow.creationTimestamp.d}}/{{pod.name}}',
     /** Argo Workflows lets you specify a unique artifact repository for each
      * namespace by adding an appropriately formatted configmap to the namespace
      * as documented here:
      * https://argo-workflows.readthedocs.io/en/latest/artifact-repository-ref/.
-     * Use this field to enable this lookup. It defaults to false.
+     * Use this field to enable this lookup. It defaults to false. In multi-user
+     * mode the operator-owned endpoint, bucket, and key format remain authoritative;
+     * tenant ConfigMaps cannot override shared-store trust or key confinement.
      */
     ARGO_ARTIFACT_REPOSITORIES_LOOKUP = 'false',
     /** Should use server API for log streaming? */

--- a/frontend/server/handlers/pod-logs.test.ts
+++ b/frontend/server/handlers/pod-logs.test.ts
@@ -1,0 +1,157 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { PassThrough } from 'stream';
+import express from 'express';
+import requests from 'supertest';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import * as workflowHelper from '../workflow-helper.js';
+import { getPodLogsHandler } from './pod-logs.js';
+
+vi.mock('../workflow-helper.js', () => ({
+  composePodLogsStreamHandler: vi.fn(
+    (
+      primary: (...args: any[]) => Promise<PassThrough>,
+      fallback?: (...args: any[]) => Promise<PassThrough>,
+    ) =>
+      async (...args: any[]) => {
+        try {
+          return await primary(...args);
+        } catch (error) {
+          if (!fallback) throw error;
+          return fallback(...args);
+        }
+      },
+  ),
+  createPodLogsMinioRequestConfig: vi.fn(() => vi.fn()),
+  getPodLogsMinioRequestConfigfromWorkflow: vi.fn(async () => ({
+    bucket: 'bucket',
+    client: {},
+    key: 'key',
+  })),
+  getPodLogsStreamFromK8s: vi.fn(async () => {
+    throw new Error('pod logs unavailable');
+  }),
+  toGetPodLogsStream: vi.fn(
+    (createRequest: (...args: any[]) => Promise<unknown>) =>
+      async (...args: any[]) => {
+        await createRequest(...args);
+        const stream = new PassThrough();
+        stream.end('archived logs');
+        return stream;
+      },
+  ),
+}));
+
+describe('getPodLogsHandler', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('wires operator archive trust options into the workflow-status fallback', async () => {
+    const trustedStore = {
+      accessKey: 'server-access',
+      endPoint: 'seaweedfs.kubeflow',
+      port: 9000,
+      secretKey: 'server-secret',
+      useSSL: false,
+    };
+    const app = express();
+    app.get(
+      '/logs',
+      getPodLogsHandler(
+        {
+          archiveArtifactory: 'minio',
+          archiveBucketName: 'mlpipeline',
+          archiveLogs: true,
+          artifactRepositoriesLookup: false,
+          keyFormat: 'private-artifacts/{{workflow.namespace}}/{{pod.name}}',
+        },
+        {
+          minio: trustedStore,
+          aws: {
+            accessKey: '',
+            endPoint: 's3.amazonaws.com',
+            region: 'us-east-1',
+            secretKey: '',
+            useSSL: true,
+          },
+        },
+        'main',
+        vi.fn(async () => undefined),
+        true,
+        'cluster.corp',
+      ),
+    );
+
+    await requests(app)
+      .get('/logs?podname=workflow-pod&createdat=2026-08-23&podnamespace=user-ns')
+      .expect(200, 'archived logs');
+
+    expect(workflowHelper.getPodLogsMinioRequestConfigfromWorkflow as Mock).toHaveBeenCalledWith(
+      'workflow-pod',
+      '2026-08-23',
+      'user-ns',
+      {
+        authEnabled: true,
+        trustedBucket: 'mlpipeline',
+        trustedKeyFormat: 'private-artifacts/{{workflow.namespace}}/{{pod.name}}',
+        clusterDomain: 'cluster.corp',
+        trustedStore,
+      },
+    );
+  });
+
+  it('reaches the configured archive fallback without podnamespace in standalone mode', async () => {
+    const archiveRequest = vi.fn(async () => ({ bucket: 'bucket', client: {}, key: 'key' }));
+    (workflowHelper.createPodLogsMinioRequestConfig as Mock).mockReturnValue(archiveRequest);
+    (workflowHelper.getPodLogsMinioRequestConfigfromWorkflow as Mock).mockRejectedValue(
+      new Error('workflow unavailable'),
+    );
+    const app = express();
+    app.get(
+      '/logs',
+      getPodLogsHandler(
+        {
+          archiveArtifactory: 'minio',
+          archiveBucketName: 'mlpipeline',
+          archiveLogs: true,
+          artifactRepositoriesLookup: false,
+          keyFormat: 'private-artifacts/{{workflow.namespace}}/{{pod.name}}',
+        },
+        {
+          minio: {
+            accessKey: 'server-access',
+            endPoint: 'seaweedfs.kubeflow',
+            port: 9000,
+            secretKey: 'server-secret',
+            useSSL: false,
+          },
+          aws: {
+            accessKey: '',
+            endPoint: 's3.amazonaws.com',
+            region: 'us-east-1',
+            secretKey: '',
+            useSSL: true,
+          },
+        },
+        'main',
+        vi.fn(async () => undefined),
+        false,
+      ),
+    );
+
+    await requests(app)
+      .get('/logs?podname=workflow-pod&createdat=2026-08-23')
+      .expect(200, 'archived logs');
+    expect(archiveRequest).toHaveBeenCalledWith('workflow-pod', '2026-08-23', undefined);
+  });
+});

--- a/frontend/server/handlers/pod-logs.ts
+++ b/frontend/server/handlers/pod-logs.ts
@@ -16,7 +16,7 @@ import {
   createPodLogsMinioRequestConfig,
   composePodLogsStreamHandler,
   getPodLogsStreamFromK8s,
-  getPodLogsStreamFromWorkflow,
+  getPodLogsMinioRequestConfigfromWorkflow,
   toGetPodLogsStream,
 } from '../workflow-helper.js';
 import { ArgoConfigs, MinioConfigs, AWSConfigs } from '../configs.js';
@@ -46,6 +46,7 @@ export function getPodLogsHandler(
   podLogContainerName: string,
   authorizeFn: AuthorizeFn,
   authEnabled: boolean,
+  clusterDomain: string = '.svc.cluster.local',
 ): Handler {
   const {
     archiveLogs,
@@ -62,7 +63,23 @@ export function getPodLogsHandler(
       archiveBucketName,
       keyFormat,
       artifactRepositoriesLookup,
+      authEnabled,
     ),
+  );
+
+  // get pod log from the workflow status. Bind authEnabled so that, in
+  // multi-user mode, the workflow-recorded log key is confined to the authorized
+  // namespace (this path is attempted before the configured archive fallback).
+  const getPodLogsStreamFromWorkflow = toGetPodLogsStream(
+    (podName: string, createdAt: string, namespace?: string) =>
+      getPodLogsMinioRequestConfigfromWorkflow(podName, createdAt, namespace, {
+        authEnabled,
+        trustedKeyFormat: keyFormat,
+        trustedBucket: archiveBucketName,
+        clusterDomain,
+        trustedStore:
+          archiveArtifactory === 'minio' ? artifactsOptions.minio : artifactsOptions.aws,
+      }),
   );
 
   // get the pod log stream (with fallbacks).

--- a/frontend/server/workflow-helper.test.ts
+++ b/frontend/server/workflow-helper.test.ts
@@ -19,6 +19,7 @@ import {
   composePodLogsStreamHandler,
   getPodLogsStreamFromK8s,
   getPodLogsStreamFromWorkflow,
+  getPodLogsMinioRequestConfigfromWorkflow,
   toGetPodLogsStream,
   getKeyFormatFromArtifactRepositories,
 } from './workflow-helper.js';
@@ -61,6 +62,7 @@ describe('workflow-helper', () => {
     });
 
     it('returns the stream from the fallback handler if there is any error.', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       const fallbackStream = new PassThrough();
       const defaultHandler = vi.fn((_podName: string, _createdAt: string, _namespace?: string) =>
         Promise.reject('unknown error'),
@@ -75,6 +77,9 @@ describe('workflow-helper', () => {
       );
       expect(defaultHandler).toBeCalledWith('podName', '2024-08-13', 'namespace');
       expect(fallbackHandler).toBeCalledWith('podName', '2024-08-13', 'namespace');
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Primary pod-log source failed; falling back to archive'),
+      );
       expect(stream).toBe(fallbackStream);
     });
 
@@ -183,6 +188,191 @@ describe('workflow-helper', () => {
         'artifacts/workflow-name/2024/08/13/workflow-name-system-container-impl-foo/main.log',
       );
     });
+
+    it('scopes the key to the namespace when auth is enabled and the keyFormat embeds it.', async () => {
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}',
+        false,
+        true, // authEnabled
+      );
+      const request = await requestFunc(
+        'workflow-name-system-container-impl-foo',
+        '2024-08-13',
+        'user-ns',
+      );
+      expect(request.key).toBe(
+        'artifacts/user-ns/workflow-name/workflow-name-system-container-impl-foo/main.log',
+      );
+    });
+
+    it('uses the server namespace for a namespace-scoped archive key in standalone mode.', async () => {
+      const mockedGetServerNamespace: Mock = getServerNamespace as any;
+      mockedGetServerNamespace.mockReturnValue('kubeflow');
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'private-artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}',
+        false,
+        false,
+      );
+
+      const request = await requestFunc(
+        'workflow-name-system-container-impl-foo',
+        '2024-08-13',
+        '',
+      );
+
+      expect(request.key).toBe(
+        'private-artifacts/kubeflow/workflow-name/workflow-name-system-container-impl-foo/main.log',
+      );
+    });
+
+    it('ignores a tenant-controlled keyFormat override when auth is enabled.', async () => {
+      const mockedGetConfigMap: Mock = getConfigMap as any;
+      mockedGetConfigMap.mockResolvedValueOnce([
+        {
+          data: {
+            'artifact-repositories':
+              's3:\n  keyFormat: artifacts/victim-ns/{{workflow.namespace}}/{{pod.name}}\n',
+          },
+        },
+        undefined,
+      ]);
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}',
+        true, // artifactRepositoriesLookup
+        true, // authEnabled
+      );
+
+      const request = await requestFunc(
+        'workflow-name-system-container-impl-foo',
+        '2024-08-13',
+        'user-ns',
+      );
+
+      expect(mockedGetConfigMap).not.toBeCalled();
+      expect(request.key).toBe(
+        'artifacts/user-ns/workflow-name/workflow-name-system-container-impl-foo/main.log',
+      );
+    });
+
+    it('fails closed when auth is enabled but the keyFormat is not namespace-scoped.', async () => {
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'artifacts/{{workflow.name}}/{{pod.name}}',
+        false,
+        true, // authEnabled
+      );
+      await expect(
+        requestFunc('workflow-name-system-container-impl-foo', '2024-08-13', 'user-ns'),
+      ).rejects.toThrow(/{{workflow.namespace}}/);
+    });
+
+    it('fails closed when auth is enabled but no namespace is provided.', async () => {
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'artifacts/{{workflow.namespace}}/{{pod.name}}',
+        false,
+        true, // authEnabled
+      );
+      await expect(
+        requestFunc('workflow-name-system-container-impl-foo', '2024-08-13', ''),
+      ).rejects.toThrow(/namespace/);
+    });
+
+    it('rejects a key containing a ".." path segment.', async () => {
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'artifacts/{{workflow.namespace}}/{{pod.name}}',
+        false,
+        true, // authEnabled
+      );
+      await expect(requestFunc('..', '2024-08-13', 'user-ns')).rejects.toThrow(/\.\./);
+    });
+
+    it('fails closed when the namespace tag is not its own path segment (concatenated).', async () => {
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'artifacts/{{workflow.namespace}}{{pod.name}}',
+        false,
+        true, // authEnabled
+      );
+      await expect(
+        requestFunc('workflow-name-system-container-impl-foo', '2024-08-13', 'user-ns'),
+      ).rejects.toThrow(/path segment/);
+    });
+
+    it('fails closed when the namespace tag is adjacent to another field via a delimiter.', async () => {
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'artifacts/{{workflow.namespace}}-{{pod.name}}/main',
+        false,
+        true, // authEnabled
+      );
+      await expect(
+        requestFunc('workflow-name-system-container-impl-foo', '2024-08-13', 'user-ns'),
+      ).rejects.toThrow(/path segment/);
+    });
+
+    it('fails closed when a caller-controlled field precedes the namespace tag.', async () => {
+      // Namespace is a bounded segment, but {{pod.name}} appears before it, so
+      // the namespace is not a deterministic prefix: a tenant whose namespace name
+      // coincides with a pod/workflow segment of another namespace's key could
+      // collide with it. This must be rejected.
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'archive/{{pod.name}}/{{workflow.namespace}}',
+        false,
+        true, // authEnabled
+      );
+      await expect(
+        requestFunc('workflow-name-system-container-impl-foo', '2024-08-13', 'user-ns'),
+      ).rejects.toThrow(/caller-controlled field/);
+    });
+
+    it.each([
+      'archive/{{custom.tenantValue}}/{{workflow.namespace}}/{{pod.name}}',
+      'archive/{{workflow.namespace}}/{{workflow.namespace}}/{{pod.name}}',
+    ])('fails closed for an ambiguous namespace prefix template %s', async (keyFormat) => {
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        keyFormat,
+        false,
+        true,
+      );
+      await expect(
+        requestFunc('workflow-name-system-container-impl-foo', '2024-08-13', 'user-ns'),
+      ).rejects.toThrow(/namespace/);
+    });
+
+    it('accepts the namespace tag as a bounded prefix segment ahead of caller fields.', async () => {
+      const requestFunc = await createPodLogsMinioRequestConfig(
+        minioConfig,
+        'bucket',
+        'logs/archive/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}',
+        false,
+        true, // authEnabled
+      );
+      const request = await requestFunc(
+        'workflow-name-system-container-impl-foo',
+        '2024-08-13',
+        'user-ns',
+      );
+      expect(request.key).toBe(
+        'logs/archive/user-ns/workflow-name/workflow-name-system-container-impl-foo/main.log',
+      );
+    });
   });
 
   describe('getPodLogsStreamFromWorkflow', () => {
@@ -243,6 +433,7 @@ describe('workflow-helper', () => {
         'workflow-name-system-container-impl-abc',
         '2024-07-09',
         'kubeflow',
+        { authEnabled: false },
       );
 
       expect(mockedGetArgoWorkflow).toBeCalledWith('workflow-name', 'kubeflow');
@@ -330,6 +521,7 @@ describe('workflow-helper', () => {
           'workflow-name-system-container-impl-abc',
           '2024-07-09',
           'my-user-namespace',
+          { authEnabled: false },
         );
       } finally {
         process.env.MINIO_ACCESS_KEY = previousAccessKey;
@@ -404,6 +596,7 @@ describe('workflow-helper', () => {
         'workflow-name-system-container-impl-abc',
         '2024-07-09',
         undefined,
+        { authEnabled: false },
       );
 
       // The Secret is read from the server namespace, never a user namespace.
@@ -480,6 +673,7 @@ describe('workflow-helper', () => {
           'workflow-name-system-container-impl-abc',
           '2024-07-09',
           undefined,
+          { authEnabled: false },
         );
       } finally {
         process.env.MINIO_ACCESS_KEY = previousAccessKey;
@@ -496,6 +690,400 @@ describe('workflow-helper', () => {
         secretKey: 'server-secret-key',
         useSSL: false,
       });
+    });
+
+    it('fails closed in multi-user mode when the workflow-recorded log key is not scoped to the authorized namespace.', async () => {
+      const sampleWorkflow = {
+        status: {
+          artifactRepositoryRef: {
+            artifactRepository: {
+              archiveLogs: true,
+              s3: { bucket: 'bucket', endpoint: 'seaweedfs.kubeflow', insecure: true, key: 'x' },
+            },
+          },
+          nodes: {
+            'workflow-name-abc': {
+              outputs: {
+                artifacts: [
+                  {
+                    name: 'main-logs',
+                    // Key belongs to a different namespace / is not namespace-scoped.
+                    s3: { key: 'artifacts/other-ns/workflow-name/pod/main.log' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+      const mockedGetArgoWorkflow: Mock = getArgoWorkflow as any;
+      mockedGetArgoWorkflow.mockResolvedValueOnce(sampleWorkflow);
+
+      await expect(
+        getPodLogsMinioRequestConfigfromWorkflow(
+          'workflow-name-system-container-impl-abc',
+          '2024-07-09',
+          'user-ns',
+          {
+            authEnabled: true,
+            trustedKeyFormat: 'artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}',
+          },
+        ),
+      ).rejects.toThrow(/authorized namespace/);
+    });
+
+    it('allows a workflow-recorded log key that embeds the authorized namespace as a segment.', async () => {
+      const sampleWorkflow = {
+        status: {
+          artifactRepositoryRef: {
+            artifactRepository: {
+              archiveLogs: true,
+              s3: { bucket: 'bucket', endpoint: 'seaweedfs.kubeflow', insecure: true, key: 'x' },
+            },
+          },
+          nodes: {
+            'workflow-name-abc': {
+              outputs: {
+                artifacts: [
+                  {
+                    name: 'main-logs',
+                    s3: { key: 'artifacts/user-ns/workflow-name/pod/main.log' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+      const mockedGetArgoWorkflow: Mock = getArgoWorkflow as any;
+      mockedGetArgoWorkflow.mockResolvedValueOnce(sampleWorkflow);
+      const mockedGetServerNamespace: Mock = getServerNamespace as any;
+      mockedGetServerNamespace.mockReturnValue('kubeflow');
+
+      const previousAccessKey = process.env.MINIO_ACCESS_KEY;
+      const previousSecretKey = process.env.MINIO_SECRET_KEY;
+      process.env.MINIO_ACCESS_KEY = 'server-access-key';
+      process.env.MINIO_SECRET_KEY = 'server-secret-key';
+      try {
+        const request = await getPodLogsMinioRequestConfigfromWorkflow(
+          'workflow-name-system-container-impl-abc',
+          '2024-07-09',
+          'user-ns',
+          {
+            authEnabled: true,
+            trustedKeyFormat: 'artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}',
+            trustedBucket: 'bucket',
+            trustedStore: {
+              accessKey: 'server-access',
+              endPoint: 'seaweedfs.kubeflow',
+              port: 80,
+              secretKey: 'server-secret',
+              useSSL: false,
+            },
+          },
+        );
+        expect(request.bucket).toBe('bucket');
+        expect(request.key).toBe('artifacts/user-ns/workflow-name/pod/main.log');
+      } finally {
+        process.env.MINIO_ACCESS_KEY = previousAccessKey;
+        process.env.MINIO_SECRET_KEY = previousSecretKey;
+      }
+    });
+
+    it.each([
+      {
+        bucket: 'bucket',
+        endpoint: '169.254.169.254:80',
+        name: 'workflow-controlled endpoint',
+        namespace: 'user-ns',
+      },
+      {
+        bucket: 'other-bucket',
+        endpoint: 'seaweedfs.kubeflow',
+        name: 'workflow-controlled bucket',
+        namespace: 'user-ns',
+      },
+      {
+        bucket: 'bucket',
+        endpoint: 'https://seaweedfs.kubeflow',
+        name: 'TLS-conflicting workflow-controlled endpoint',
+        namespace: 'user-ns',
+      },
+      {
+        bucket: 'bucket',
+        endpoint: '169.254.169.254:80',
+        name: 'server-namespace workflow-controlled endpoint',
+        namespace: 'kubeflow',
+      },
+    ])('rejects a $name when auth is enabled', async ({ bucket, endpoint, namespace }) => {
+      const sampleWorkflow = {
+        status: {
+          artifactRepositoryRef: {
+            artifactRepository: {
+              archiveLogs: true,
+              s3: { bucket, endpoint, insecure: true, key: 'x' },
+            },
+          },
+          nodes: {
+            'workflow-name-abc': {
+              outputs: {
+                artifacts: [
+                  {
+                    name: 'main-logs',
+                    s3: { key: `artifacts/${namespace}/workflow-name/pod/main.log` },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+      const mockedGetArgoWorkflow: Mock = getArgoWorkflow as any;
+      mockedGetArgoWorkflow.mockResolvedValueOnce(sampleWorkflow);
+      const mockedClient: Mock = MinioClient as any;
+
+      await expect(
+        getPodLogsMinioRequestConfigfromWorkflow(
+          'workflow-name-system-container-impl-abc',
+          '2024-07-09',
+          namespace,
+          {
+            authEnabled: true,
+            trustedKeyFormat: 'artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}',
+            trustedBucket: 'bucket',
+            trustedStore: { endPoint: 'seaweedfs.kubeflow', port: 80, useSSL: false },
+          },
+        ),
+      ).rejects.toThrow(/workflow-controlled artifact (endpoint|bucket)|invalid or conflicts/);
+      expect(mockedClient).not.toBeCalled();
+    });
+
+    it('pairs a trusted cross-namespace AWS store with its AWS credentials', async () => {
+      const sampleWorkflow = {
+        status: {
+          artifactRepositoryRef: {
+            artifactRepository: {
+              archiveLogs: true,
+              s3: { bucket: 'bucket', endpoint: 's3.example.test', insecure: false, key: 'x' },
+            },
+          },
+          nodes: {
+            'workflow-name-abc': {
+              outputs: {
+                artifacts: [
+                  {
+                    name: 'main-logs',
+                    s3: { key: 'artifacts/user-ns/workflow-name/pod/main.log' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+      const mockedGetArgoWorkflow: Mock = getArgoWorkflow as any;
+      mockedGetArgoWorkflow.mockResolvedValueOnce(sampleWorkflow);
+      const mockedGetServerNamespace: Mock = getServerNamespace as any;
+      mockedGetServerNamespace.mockReturnValue('kubeflow');
+      const mockedClient: Mock = MinioClient as any;
+
+      await getPodLogsMinioRequestConfigfromWorkflow(
+        'workflow-name-system-container-impl-abc',
+        '2024-07-09',
+        'user-ns',
+        {
+          authEnabled: true,
+          trustedKeyFormat: 'artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}',
+          trustedBucket: 'bucket',
+          trustedStore: {
+            accessKey: 'aws-access-key',
+            endPoint: 's3.example.test',
+            region: 'eu-west-1',
+            secretKey: 'aws-secret-key',
+            useSSL: true,
+          },
+        },
+      );
+
+      expect(mockedClient).toBeCalledWith({
+        accessKey: 'aws-access-key',
+        endPoint: 's3.example.test',
+        port: 443,
+        region: 'eu-west-1',
+        secretKey: 'aws-secret-key',
+        useSSL: true,
+      });
+    });
+
+    it('fails closed when the trusted keyFormat is not namespace-scoped, even if the key contains the namespace.', async () => {
+      const sampleWorkflow = {
+        status: {
+          artifactRepositoryRef: {
+            artifactRepository: {
+              archiveLogs: true,
+              s3: { bucket: 'bucket', endpoint: 'seaweedfs.kubeflow', insecure: true, key: 'x' },
+            },
+          },
+          nodes: {
+            'workflow-name-abc': {
+              outputs: {
+                artifacts: [
+                  {
+                    name: 'main-logs',
+                    // 'user-ns' appears only as a coincidental (non-prefix) segment.
+                    s3: { key: 'artifacts/other-ns/user-ns/pod/main.log' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+      const mockedGetArgoWorkflow: Mock = getArgoWorkflow as any;
+      mockedGetArgoWorkflow.mockResolvedValueOnce(sampleWorkflow);
+
+      await expect(
+        getPodLogsMinioRequestConfigfromWorkflow(
+          'workflow-name-system-container-impl-abc',
+          '2024-07-09',
+          'user-ns',
+          {
+            authEnabled: true,
+            // Trusted keyFormat has no {{workflow.namespace}} → no safe prefix.
+            trustedKeyFormat: 'artifacts/{{workflow.name}}/{{pod.name}}',
+          },
+        ),
+      ).rejects.toThrow(/namespace/);
+    });
+
+    // Regression: the workflow-recorded endpoint and the trusted store endpoint
+    // are the same in-cluster Service written with different DNS forms. Manifests
+    // write `seaweedfs.<ns>.svc[.cluster.local]:9000` while configs.ts builds the
+    // trusted `seaweedfs.<ns>`. These must compare equal, or the workflow-status
+    // path is dead on arrival in multi-user mode.
+    for (const [workflowEndpoint, clusterDomain] of [
+      ['seaweedfs.kubeflow.svc:9000', '.svc.cluster.local'],
+      ['seaweedfs.kubeflow.svc.cluster.local:9000', '.svc.cluster.local'],
+      ['seaweedfs.kubeflow.svc.cluster.corp:9000', 'cluster.corp'],
+    ]) {
+      it(`accepts the manifest endpoint form "${workflowEndpoint}" as the trusted store`, async () => {
+        const sampleWorkflow = {
+          status: {
+            artifactRepositoryRef: {
+              artifactRepository: {
+                archiveLogs: true,
+                s3: {
+                  bucket: 'mlpipeline',
+                  endpoint: workflowEndpoint,
+                  insecure: true,
+                  key: 'x',
+                },
+              },
+            },
+            nodes: {
+              'workflow-name-abc': {
+                outputs: {
+                  artifacts: [
+                    {
+                      name: 'main-logs',
+                      s3: { key: 'private-artifacts/user-ns/workflow-name/pod/main.log' },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        };
+        const mockedGetArgoWorkflow: Mock = getArgoWorkflow as any;
+        mockedGetArgoWorkflow.mockResolvedValueOnce(sampleWorkflow);
+        const mockedGetServerNamespace: Mock = getServerNamespace as any;
+        mockedGetServerNamespace.mockReturnValue('kubeflow');
+        const mockedClient: Mock = MinioClient as any;
+
+        const request = await getPodLogsMinioRequestConfigfromWorkflow(
+          'workflow-name-system-container-impl-abc',
+          '2024-07-09',
+          'user-ns',
+          {
+            authEnabled: true,
+            trustedKeyFormat:
+              'private-artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}',
+            trustedBucket: 'mlpipeline',
+            clusterDomain,
+            trustedStore: {
+              endPoint: 'seaweedfs.kubeflow',
+              port: 9000,
+              useSSL: false,
+              accessKey: 'server-access-key',
+              secretKey: 'server-secret-key',
+            },
+          },
+        );
+
+        // The read is accepted (no throw); the client connects to the real
+        // workflow-recorded host, and the shared trusted-store credentials are used.
+        expect(request.bucket).toBe('mlpipeline');
+        expect(request.key).toBe('private-artifacts/user-ns/workflow-name/pod/main.log');
+        expect(mockedClient).toBeCalledWith(
+          expect.objectContaining({
+            accessKey: 'server-access-key',
+            secretKey: 'server-secret-key',
+            endPoint: workflowEndpoint.split(':')[0],
+            port: 9000,
+            useSSL: false,
+          }),
+        );
+      });
+    }
+
+    it('still rejects a genuinely foreign endpoint host', async () => {
+      const sampleWorkflow = {
+        status: {
+          artifactRepositoryRef: {
+            artifactRepository: {
+              archiveLogs: true,
+              s3: {
+                bucket: 'mlpipeline',
+                endpoint: 'attacker.evil.example:9000',
+                insecure: true,
+                key: 'x',
+              },
+            },
+          },
+          nodes: {
+            'workflow-name-abc': {
+              outputs: {
+                artifacts: [
+                  {
+                    name: 'main-logs',
+                    s3: { key: 'private-artifacts/user-ns/workflow-name/pod/main.log' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+      const mockedGetArgoWorkflow: Mock = getArgoWorkflow as any;
+      mockedGetArgoWorkflow.mockResolvedValueOnce(sampleWorkflow);
+      const mockedGetServerNamespace: Mock = getServerNamespace as any;
+      mockedGetServerNamespace.mockReturnValue('kubeflow');
+
+      await expect(
+        getPodLogsMinioRequestConfigfromWorkflow(
+          'workflow-name-system-container-impl-abc',
+          '2024-07-09',
+          'user-ns',
+          {
+            authEnabled: true,
+            trustedKeyFormat:
+              'private-artifacts/{{workflow.namespace}}/{{workflow.name}}/{{pod.name}}',
+            trustedBucket: 'mlpipeline',
+            clusterDomain: '.svc.cluster.local',
+            trustedStore: { endPoint: 'seaweedfs.kubeflow', port: 9000, useSSL: false },
+          },
+        ),
+      ).rejects.toThrow(/workflow-controlled artifact endpoint/);
     });
   });
 });

--- a/frontend/server/workflow-helper.ts
+++ b/frontend/server/workflow-helper.ts
@@ -88,6 +88,7 @@ export function composePodLogsStreamHandler<T = Stream>(
       return await handler(podName, createdAt, namespace);
     } catch (err) {
       if (fallback) {
+        console.warn(`Primary pod-log source failed; falling back to archive: ${err}`);
         return await fallback(podName, createdAt, namespace);
       }
       console.warn(err);
@@ -124,9 +125,16 @@ export async function getPodLogsStreamFromK8s(
  * @param createdAt YYYY-MM-DD run was created. Not used.
  * @param namespace namespace of the pod (uses the same namespace as the server if not provided).
  */
-export const getPodLogsStreamFromWorkflow = toGetPodLogsStream(
-  getPodLogsMinioRequestConfigfromWorkflow,
-);
+export async function getPodLogsStreamFromWorkflow(
+  podName: string,
+  createdAt: string,
+  namespace: string | undefined,
+  options: WorkflowLogStoreOptions & { authEnabled: boolean },
+) {
+  return toGetPodLogsStream((name, created, ns) =>
+    getPodLogsMinioRequestConfigfromWorkflow(name, created, ns, options),
+  )(podName, createdAt, namespace);
+}
 
 /**
  * Returns a function that retrieves the pod log streams using the provided
@@ -210,6 +218,53 @@ export async function getKeyFormatFromArtifactRepositories(
 }
 
 /**
+ * Derives the deterministic, namespace-scoped object-key prefix implied by a
+ * keyFormat template, or returns null when the template does not place
+ * {{workflow.namespace}} as a complete '/'-delimited path segment ahead of every
+ * caller-influenced field. When null, no safe namespace prefix can be derived and
+ * callers must fail closed.
+ *
+ * In multi-user mode the archived-log object key must be provably confined to the
+ * authorized namespace. Merely containing {{workflow.namespace}} somewhere is not
+ * sufficient: if a caller-controlled field (pod name, workflow name, creation
+ * timestamp) precedes it, the resolved namespace value is not an unambiguous
+ * prefix, and a key belonging to another namespace could coincidentally contain
+ * the authorized namespace as a later segment (e.g. as a workflow-name segment).
+ * Requiring the namespace tag as a bounded segment before all such fields yields
+ * a fixed prefix ("<static>/<namespace>") that scopes every resolved key to the
+ * namespace's own subtree.
+ */
+export function namespaceScopedKeyPrefix(keyFormat: string, namespace: string): string | null {
+  if (!namespace) {
+    return null;
+  }
+  const template = keyFormat.replace(/\s+/g, '');
+  const namespaceTag = '{{workflow.namespace}}';
+  // Multiple namespace tags make the effective boundary ambiguous and can leave
+  // unresolved tags in generated keys.
+  if (template.split(namespaceTag).length !== 2) {
+    return null;
+  }
+  // The namespace tag must be a complete '/'-delimited path segment.
+  const namespaceSegment = /(^|\/)\{\{workflow\.namespace\}\}(\/|$)/;
+  if (!namespaceSegment.test(template)) {
+    return null;
+  }
+  const namespaceIndex = template.indexOf(namespaceTag);
+  const staticPrefix = template.slice(0, namespaceIndex);
+  // No template tag of any kind may precede the namespace boundary. Limiting
+  // this to the tags understood today would let a newly supported or custom tag
+  // silently become caller-controlled input ahead of the authorization prefix.
+  if (/\{\{[^{}]+\}\}/.test(staticPrefix) || staticPrefix.split('/').includes('..')) {
+    return null;
+  }
+  // Everything up to the namespace tag is static (verified above to contain no
+  // caller-controlled field); append the substituted namespace to form the
+  // deterministic prefix.
+  return staticPrefix + namespace;
+}
+
+/**
  * Returns a MinioRequestConfig with the provided minio options (a
  * MinioRequestConfig object contains the artifact bucket and keys, with the
  * corresponding minio client).
@@ -224,12 +279,17 @@ export function createPodLogsMinioRequestConfig(
   bucket: string,
   keyFormatDefault: string,
   artifactRepositoriesLookup: boolean,
+  authEnabled: boolean = false,
 ) {
   return async (
     podName: string,
     createdAt: string,
     namespace: string = '',
   ): Promise<MinioRequestConfig> => {
+    // Standalone callers historically omit podnamespace. The shipped archive
+    // layout is namespace-scoped, so resolve that omission to the frontend's
+    // operator-controlled server namespace rather than generating a `//` key.
+    const archiveNamespace = namespace || getServerNamespace() || '';
     // create a new client each time to ensure session token has not expired
     const client = await createMinioClient(minioOptions, 's3');
     const createdAtArray = createdAt.split('-');
@@ -238,14 +298,37 @@ export function createPodLogsMinioRequestConfig(
     // from the configmap. Otherwise, just used the default keyFormat specified
     // in configs.ts.
     let keyFormatFromConfigMap = undefined;
-    if (artifactRepositoriesLookup) {
-      keyFormatFromConfigMap = await getKeyFormatFromArtifactRepositories(namespace);
+    // A namespace owner can control this ConfigMap. In multi-user mode it must
+    // not define the authorization boundary for a shared-store object read;
+    // use only the operator-controlled default key format instead.
+    if (artifactRepositoriesLookup && !authEnabled) {
+      keyFormatFromConfigMap = await getKeyFormatFromArtifactRepositories(archiveNamespace);
     }
     let key: string;
     if (keyFormatFromConfigMap !== undefined) {
       key = keyFormatFromConfigMap;
     } else {
       key = keyFormatDefault;
+    }
+
+    // Fail closed in multi-user mode: the caller-supplied podname/createdat are
+    // interpolated into the object key, but the namespace access check upstream
+    // only authorizes `namespace`. Require the key template to scope the key to
+    // {{workflow.namespace}} as a deterministic prefix (a complete '/'-delimited
+    // segment ahead of every caller-controlled field), so any resolved key stays
+    // confined to the authorized namespace's subtree. Merely *containing* the tag
+    // is not enough: placing it adjacent to a caller-controlled field, e.g.
+    // "{{workflow.namespace}}{{pod.name}}", or after one, e.g.
+    // "{{pod.name}}/{{workflow.namespace}}", would let a tenant reach keys under
+    // another namespace, so those templates are rejected.
+    if (authEnabled && namespaceScopedKeyPrefix(key, archiveNamespace) === null) {
+      throw new Error(
+        `Refusing to read archived pod logs: the keyFormat, which is defined in config.ts or through the ` +
+          `ARGO_KEYFORMAT env var, does not place {{workflow.namespace}} as a complete '/'-delimited path ` +
+          `segment ahead of every caller-controlled field (pod name, workflow name, creation timestamp). In ` +
+          `multi-user mode the log key must be scoped to the authorized namespace as a deterministic prefix; ` +
+          `otherwise archived logs from other namespaces in the shared bucket would be readable.`,
+      );
     }
 
     key = key
@@ -255,7 +338,7 @@ export function createPodLogsMinioRequestConfig(
       .replace('{{workflow.creationTimestamp.m}}', createdAtArray[1])
       .replace('{{workflow.creationTimestamp.d}}', createdAtArray[2])
       .replace('{{pod.name}}', podName)
-      .replace('{{workflow.namespace}}', namespace);
+      .replace('{{workflow.namespace}}', archiveNamespace);
 
     if (!key.endsWith('/')) {
       key = key + '/';
@@ -279,6 +362,15 @@ export function createPodLogsMinioRequestConfig(
       );
     }
 
+    // The regex above permits '.' and '/', so reject any '..' segment. The
+    // caller-supplied podname is interpolated into the key, and a '..' would
+    // let it climb out of the (namespace-scoped) key prefix.
+    if (key.split('/').includes('..')) {
+      throw new Error(
+        `The log key, ${key}, contains a '..' path segment and is therefore invalid.`,
+      );
+    }
+
     return { bucket, client, key };
   };
 }
@@ -289,11 +381,37 @@ export function createPodLogsMinioRequestConfig(
  *
  * @param podName name of the pod to retrieve the logs.
  */
+export interface WorkflowLogStoreOptions {
+  authEnabled?: boolean;
+  trustedKeyFormat?: string;
+  trustedBucket?: string;
+  // Kubernetes cluster DNS suffix (e.g. '.svc.cluster.local'), used to treat the
+  // short, '.svc', and fully-qualified forms of a Service host as equivalent when
+  // comparing the workflow-recorded endpoint against the trusted store.
+  clusterDomain?: string;
+  trustedStore?: {
+    endPoint: string;
+    port?: number;
+    region?: string;
+    useSSL?: boolean;
+    accessKey?: string;
+    secretKey?: string;
+  };
+}
+
 export async function getPodLogsMinioRequestConfigfromWorkflow(
   podName: string,
   _createdAt?: string,
   namespace?: string,
+  options: WorkflowLogStoreOptions = {},
 ): Promise<MinioRequestConfig> {
+  const {
+    authEnabled = false,
+    trustedKeyFormat = '',
+    trustedBucket = '',
+    clusterDomain = '.svc.cluster.local',
+    trustedStore,
+  } = options;
   let workflow: PartialArgoWorkflow;
   // We should probably parameterize this replace statement. It's brittle to
   // changes in implementation. But brittle is better than completely broken.
@@ -328,12 +446,65 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
     throw new Error('No artifact named "main-logs" for node.');
   }
 
+  // Fail closed in multi-user mode: confine the workflow-derived log key to the
+  // authorized namespace. `logKey` comes from the workflow status (shaped by the
+  // per-namespace artifact-repositories keyFormat, which a tenant may be able to
+  // influence) and is read below with the shared object-store credentials, so
+  // without this check a tenant could point the main-logs artifact at another
+  // namespace's log object and read it. Require the key to begin with the
+  // deterministic namespace-scoped prefix derived from the trusted (operator)
+  // keyFormat, and reject any '..' segment. This mirrors the confinement applied
+  // to the configured archive fallback in createPodLogsMinioRequestConfig. If the
+  // trusted keyFormat does not scope by {{workflow.namespace}} ahead of every
+  // caller-controlled field, no safe prefix exists and we fail closed.
+  const serverNamespace = getServerNamespace();
+  const validateWorkflowScope = authEnabled;
+  const usesSharedCredentials = authEnabled && Boolean(namespace && namespace !== serverNamespace);
+  if (validateWorkflowScope) {
+    const prefix = namespaceScopedKeyPrefix(trustedKeyFormat, namespace || '');
+    if (prefix === null || !logKey.startsWith(prefix + '/') || logKey.split('/').includes('..')) {
+      throw new Error(
+        `Refusing to read archived pod logs: the workflow-recorded log key "${logKey}" is not confined to ` +
+          `the authorized namespace under the namespace-scoped prefix derived from the trusted keyFormat. In ` +
+          `multi-user mode the archive key must begin with that deterministic namespace prefix.`,
+      );
+    }
+  }
+
   const s3Artifact = workflow.status.artifactRepositoryRef.artifactRepository.s3 || false;
   if (!s3Artifact) {
     throw new Error('Unable to find artifact repository information from workflow status.');
   }
 
-  const { host, port } = urlSplit(s3Artifact.endpoint, s3Artifact.insecure);
+  const workflowEndpoint = parseArtifactStoreEndpoint(s3Artifact.endpoint, s3Artifact.insecure);
+  if (!workflowEndpoint) {
+    throw new Error('Artifact repository endpoint is invalid or conflicts with its TLS setting.');
+  }
+
+  if (validateWorkflowScope) {
+    const trustedEndpoint = trustedStore
+      ? parseArtifactStoreEndpoint(
+          trustedStore.endPoint,
+          trustedStore.useSSL === false,
+          trustedStore.port,
+        )
+      : undefined;
+    if (
+      !trustedEndpoint ||
+      canonicalArtifactOrigin(workflowEndpoint, clusterDomain) !==
+        canonicalArtifactOrigin(trustedEndpoint, clusterDomain)
+    ) {
+      throw new Error(
+        'Refusing to read archived pod logs from a workflow-controlled artifact endpoint.',
+      );
+    }
+    if (!trustedBucket || s3Artifact.bucket !== trustedBucket) {
+      throw new Error(
+        'Refusing to read archived pod logs from a workflow-controlled artifact bucket.',
+      );
+    }
+  }
+
   // Security: Only read the object-store credential Secret from the server's own
   // namespace. In multi-user deployments the run namespace is a customer/user
   // namespace, and the ml-pipeline-ui service account may not read Secrets there;
@@ -350,7 +521,6 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
   // therefore treat a missing namespace as the server namespace and read the
   // workflow-referenced Secret so custom object-store credentials are honored,
   // while still refusing to read Secrets from any user namespace.
-  const serverNamespace = getServerNamespace();
   let accessKey: string | undefined;
   let secretKey: string | undefined;
   if (namespace && namespace === serverNamespace) {
@@ -370,8 +540,12 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
   } else {
     // Cross-namespace (user-namespace) run, or an unknown server namespace: never
     // read a user-namespace Secret; use the frontend's own configured credentials.
-    accessKey = process.env.MINIO_ACCESS_KEY || 'minio';
-    secretKey = process.env.MINIO_SECRET_KEY || 'minio123';
+    accessKey = usesSharedCredentials
+      ? trustedStore?.accessKey
+      : process.env.MINIO_ACCESS_KEY || 'minio';
+    secretKey = usesSharedCredentials
+      ? trustedStore?.secretKey
+      : process.env.MINIO_SECRET_KEY || 'minio123';
   }
 
   const client = await createMinioClient(
@@ -381,8 +555,9 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
       // start-proxy-and-server.sh sets MINIO_HOST=localhost, but it doesn't
       // seem to be respected when running the server in development mode.
       // Investigate and fix this.
-      endPoint: host,
-      port,
+      endPoint: workflowEndpoint.host,
+      port: workflowEndpoint.port,
+      ...(usesSharedCredentials && trustedStore?.region ? { region: trustedStore.region } : {}),
       secretKey,
       useSSL: !s3Artifact.insecure,
     },
@@ -393,6 +568,69 @@ export async function getPodLogsMinioRequestConfigfromWorkflow(
     client,
     key: logKey,
   };
+}
+
+/**
+ * Reduces a Kubernetes Service host to its shortest equivalent form so that the
+ * short (`svc.ns`), `.svc` (`svc.ns.svc`), and fully-qualified
+ * (`svc.ns.svc.<clusterDomain>`) spellings of the same in-cluster Service compare
+ * equal. This is used only for the trusted-endpoint equality check; the real,
+ * workflow-recorded host is still what the client connects to. A trailing dot
+ * (absolute DNS name) is also stripped.
+ */
+function canonicalizeServiceHost(host: string, clusterDomain: string): string {
+  let h = host.toLowerCase().replace(/\.+$/, '');
+  const domain = (clusterDomain || '').toLowerCase().replace(/^\.+/, '').replace(/\.+$/, '');
+  if (domain && h.endsWith('.' + domain)) {
+    h = h.slice(0, h.length - domain.length - 1);
+  }
+  if (h.endsWith('.svc')) {
+    h = h.slice(0, h.length - '.svc'.length);
+  }
+  return h;
+}
+
+/**
+ * Builds an origin string (`<scheme>//<canonical-host>:<port>`) for endpoint
+ * equality, canonicalizing the Service host so DNS-equivalent spellings match.
+ */
+function canonicalArtifactOrigin(
+  endpoint: { host: string; port: number; origin: string },
+  clusterDomain: string,
+): string {
+  const scheme = endpoint.origin.slice(0, endpoint.origin.indexOf('//'));
+  return `${scheme}//${canonicalizeServiceHost(endpoint.host, clusterDomain)}:${endpoint.port}`;
+}
+
+function parseArtifactStoreEndpoint(
+  endpoint: string,
+  insecure: boolean,
+  configuredPort?: number,
+): { host: string; port: number; origin: string } | undefined {
+  try {
+    const protocol = insecure ? 'http:' : 'https:';
+    const hasExplicitProtocol = endpoint.includes('://');
+    const parsed = new URL(hasExplicitProtocol ? endpoint : `${protocol}//${endpoint}`);
+    if (
+      !['http:', 'https:'].includes(parsed.protocol) ||
+      (hasExplicitProtocol && parsed.protocol !== protocol) ||
+      parsed.username ||
+      parsed.password ||
+      (parsed.pathname && parsed.pathname !== '/') ||
+      parsed.search ||
+      parsed.hash
+    ) {
+      return undefined;
+    }
+    const port = parsed.port ? Number(parsed.port) : configuredPort || (insecure ? 80 : 443);
+    return {
+      host: parsed.hostname,
+      port,
+      origin: `${protocol}//${parsed.hostname.toLowerCase()}:${port}`,
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -409,18 +647,4 @@ async function getMinioClientSecrets(
   const accessKey = await getK8sSecret(accessKeySecret.name, accessKeySecret.key, namespace);
   const secretKey = await getK8sSecret(secretKeySecret.name, secretKeySecret.key, namespace);
   return { accessKey, secretKey };
-}
-
-/**
- * Split an uri into host and port.
- * @param uri uri to split
- * @param insecure if port is not provided in uri, return port depending on whether ssl is enabled.
- */
-
-function urlSplit(uri: string, insecure: boolean) {
-  const chunks = uri.split(':');
-  if (chunks.length === 1) {
-    return { host: chunks[0], port: insecure ? 80 : 443 };
-  }
-  return { host: chunks[0], port: parseInt(chunks[1], 10) };
 }


### PR DESCRIPTION
**Description of your changes:**

This follow-up to #9889 confines every multi-user archived pod-log read that uses shared object-store credentials to operator-owned storage configuration.

The frontend now:

- requires workflow-recorded log keys to remain under a deterministic namespace-scoped prefix;
- validates workflow-recorded endpoints and buckets against the configured archive store;
- ignores tenant-controlled artifact-repository key-format overrides when shared credentials are used;
- rejects traversal, TLS conflicts, user information, and layouts that cannot prove namespace confinement; and
- aligns the default ARGO_KEYFORMAT with the namespace-scoped layout shipped in the Argo manifests.

Standalone behavior and the existing Kubernetes-log-to-archive fallback remain supported. Multi-user installations with legacy non-namespaced archive layouts must migrate their keys or configure a namespace-scoped ARGO_KEYFORMAT before those archives can be read.

This builds on the publicly tracked artifact-isolation work in #9889 and the merged fixes #12860, #13433, and #13683.

Validation performed on Node 24.14.0 from current upstream master:

- 44 focused frontend-server tests passed;
- all 413 frontend-server tests passed, with 2 existing TODOs;
- all 2,054 frontend UI tests passed;
- production frontend build passed;
- frontend and server ESLint passed;
- frontend and server TypeScript compilation passed;
- Prettier format check passed;
- mock-backend type checking passed; and
- React 19 peer-dependency validation passed.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) follows the repository title convention.

