### PR TITLE
fix(backend): prevent retrying archived runs. Fixes #14164

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1064,6 +1064,15 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	if err != nil {
 		return util.Wrapf(err, "Failed to retry run %s due to error fetching the run", runId)
 	}
+	if run.StorageState.ToV2() == model.StorageStateArchived {
+		return util.NewBadRequestError(
+			util.NewInvalidInputError(
+				"Cannot retry an archived run. Unarchive the run first.",
+			),
+			"Failed to retry run %s because it is archived",
+			runId,
+		)
+	}
 	// TODO(gkcalat): consider using run.Namespace after migration logic will be available.
 	namespace, err := r.getNamespaceFromRunId(runId)
 	if err != nil {


### PR DESCRIPTION
**Description of your changes:**
Fixes #14164

This PR prevents retrying archived runs. `RetryRun` now returns a bad request error when the run is archived and tells users to unarchive the run before retrying.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).

**Tests:**
- [x] `go test -v ./backend/src/apiserver/resource -run TestRetryRun`


<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
