### PR TITLE
fix(backend): reject retrying an archived run. Fixes #14164

### DIFF
--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1064,6 +1064,13 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	if err != nil {
 		return util.Wrapf(err, "Failed to retry run %s due to error fetching the run", runId)
 	}
+	// Archived runs are GC deletion candidates, so a retry would race the collector.
+	if run.StorageState.ToV2() == model.StorageStateArchived {
+		return util.NewFailedPreconditionError(
+			errors.New("Unarchive the run first to allow it to be retried"),
+			"Failed to retry run %s as it is archived", runId,
+		)
+	}
 	// TODO(gkcalat): consider using run.Namespace after migration logic will be available.
 	namespace, err := r.getNamespaceFromRunId(runId)
 	if err != nil {

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1065,10 +1065,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 		return util.Wrapf(err, "Failed to retry run %s due to error fetching the run", runId)
 	}
 	if run.StorageState.ToV2() == model.StorageStateArchived {
-		return util.NewFailedPreconditionError(
-			errors.New("Archived runs are garbage collection candidates, so retrying one would race the collector"),
-			"Failed to retry run %s as it is archived. Unarchive the run first to allow it to be retried", runId,
-		)
+		return storage.NewArchivedRunRetryError(runId)
 	}
 	// TODO(gkcalat): consider using run.Namespace after migration logic will be available.
 	namespace, err := r.getNamespaceFromRunId(runId)

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -1064,11 +1064,10 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	if err != nil {
 		return util.Wrapf(err, "Failed to retry run %s due to error fetching the run", runId)
 	}
-	// Archived runs are GC deletion candidates, so a retry would race the collector.
 	if run.StorageState.ToV2() == model.StorageStateArchived {
 		return util.NewFailedPreconditionError(
-			errors.New("Unarchive the run first to allow it to be retried"),
-			"Failed to retry run %s as it is archived", runId,
+			errors.New("Archived runs are garbage collection candidates, so retrying one would race the collector"),
+			"Failed to retry run %s as it is archived. Unarchive the run first to allow it to be retried", runId,
 		)
 	}
 	// TODO(gkcalat): consider using run.Namespace after migration logic will be available.

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3327,11 +3327,24 @@ func TestRetryRun_Failed_RunArchived(t *testing.T) {
 
 	err := manager.ArchiveRun(runDetail.UUID)
 	assert.Nil(t, err)
+	before, err := manager.GetRun(runDetail.UUID)
+	assert.Nil(t, err)
 
 	err = manager.RetryRun(context.Background(), runDetail.UUID)
 	assert.NotNil(t, err)
-	assert.Equal(t, codes.FailedPrecondition, err.(*util.UserError).ExternalStatusCode())
-	assert.Contains(t, err.Error(), "Unarchive the run first")
+	userError := err.(*util.UserError)
+	assert.Equal(t, codes.FailedPrecondition, userError.ExternalStatusCode())
+	assert.Equal(t,
+		fmt.Sprintf("Failed to retry run %s as it is archived. Unarchive the run first to allow it to be retried", runDetail.UUID),
+		userError.ExternalMessage())
+
+	after, err := manager.GetRun(runDetail.UUID)
+	assert.Nil(t, err)
+	assert.Equal(t, model.StorageStateArchived, after.StorageState.ToV2())
+	assert.Equal(t, before.State, after.State)
+	assert.Equal(t, before.RetryGeneration, after.RetryGeneration)
+	assert.Equal(t, before.RetryClaimedAtInSec, after.RetryClaimedAtInSec)
+	assert.Equal(t, before.WorkflowRuntimeManifest, after.WorkflowRuntimeManifest)
 }
 
 func TestRetryRun_UnarchivedRunStillRetries(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3360,6 +3360,45 @@ func TestRetryRun_UnarchivedRunStillRetries(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+// archiveOnClaimRunStore archives the run inside the window RetryRun leaves
+// between its GetRun pre-check and the claim taking the row lock, which is what
+// ArchiveExpiredRuns does when it commits concurrently.
+type archiveOnClaimRunStore struct {
+	storage.RunStoreInterface
+	runID string
+}
+
+func (s *archiveOnClaimRunStore) ClaimRunForRetry(runID string, takeoverExpiredClaim bool) (string, string, int64, int64, error) {
+	if runID == s.runID {
+		if err := s.RunStoreInterface.ArchiveRun(runID); err != nil {
+			return "", "", 0, 0, err
+		}
+	}
+	return s.RunStoreInterface.ClaimRunForRetry(runID, takeoverExpiredClaim)
+}
+
+func TestRetryRun_Failed_RunArchivedDuringClaim(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	manager.runStore = &archiveOnClaimRunStore{RunStoreInterface: manager.runStore, runID: runDetail.UUID}
+
+	err := manager.RetryRun(context.Background(), runDetail.UUID)
+	assert.NotNil(t, err)
+	userError := err.(*util.UserError)
+	assert.Equal(t, codes.FailedPrecondition, userError.ExternalStatusCode())
+	assert.Equal(t,
+		fmt.Sprintf("Failed to retry run %s as it is archived. Unarchive the run first to allow it to be retried", runDetail.UUID),
+		userError.ExternalMessage())
+
+	after, err := manager.GetRun(runDetail.UUID)
+	assert.Nil(t, err)
+	assert.Equal(t, model.StorageStateArchived, after.StorageState.ToV2())
+	assert.Equal(t, model.RuntimeStateFailed, after.State)
+	assert.Equal(t, int64(0), after.RetryGeneration)
+	assert.Equal(t, int64(0), after.RetryClaimedAtInSec)
+}
+
 func TestUnarchiveRun_OK(t *testing.T) {
 	store, manager, runDetail := initWithOneTimeRun(t)
 	defer store.Close()

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -3321,6 +3321,32 @@ func TestRetryRun_UpdateAndCreateFailed(t *testing.T) {
 	assert.Contains(t, err.Error(), "error getting workflow")
 }
 
+func TestRetryRun_Failed_RunArchived(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	err := manager.ArchiveRun(runDetail.UUID)
+	assert.Nil(t, err)
+
+	err = manager.RetryRun(context.Background(), runDetail.UUID)
+	assert.NotNil(t, err)
+	assert.Equal(t, codes.FailedPrecondition, err.(*util.UserError).ExternalStatusCode())
+	assert.Contains(t, err.Error(), "Unarchive the run first")
+}
+
+func TestRetryRun_UnarchivedRunStillRetries(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+
+	err := manager.ArchiveRun(runDetail.UUID)
+	assert.Nil(t, err)
+	err = manager.UnarchiveRun(runDetail.UUID)
+	assert.Nil(t, err)
+
+	err = manager.RetryRun(context.Background(), runDetail.UUID)
+	assert.Nil(t, err)
+}
+
 func TestUnarchiveRun_OK(t *testing.T) {
 	store, manager, runDetail := initWithOneTimeRun(t)
 	defer store.Close()

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -131,6 +131,14 @@ var archivedStorageStateStrings = []string{
 	model.LegacyStateDisabled,
 }
 
+// NewArchivedRunRetryError is shared by the RetryRun pre-check and the recheck
+// inside ClaimRunForRetry's row lock so both report the archived run the same way.
+func NewArchivedRunRetryError(runID string) error {
+	return util.NewFailedPreconditionError(
+		errors.New("Archived runs are garbage collection candidates, so retrying one would race the collector"),
+		"Failed to retry run %s as it is archived. Unarchive the run first to allow it to be retried", runID)
+}
+
 type RunStoreInterface interface {
 	// Creates a run entry. Does not create children tasks.
 	CreateRun(run *model.Run) (*model.Run, error)
@@ -923,7 +931,7 @@ func (s *RunStore) ClaimRunForRetry(runID string, takeoverExpiredClaim bool) (st
 	// Lock the row and read current state. Use sql.NullString for State
 	// because legacy runs intentionally have State NULL.
 	selectSQL, selectArgs, err := sq.
-		Select("State", "Conditions", "FinishedAtInSec", "RetryGeneration", "RetryClaimedAtInSec").
+		Select("State", "Conditions", "FinishedAtInSec", "RetryGeneration", "RetryClaimedAtInSec", "StorageState").
 		From("run_details").
 		Where(sq.Eq{"UUID": runID}).
 		ToSql()
@@ -937,7 +945,9 @@ func (s *RunStore) ClaimRunForRetry(runID string, takeoverExpiredClaim bool) (st
 	var originalFinishedAtInSec int64
 	var currentGeneration int64
 	var retryClaimedAtInSec int64
-	if err := row.Scan(&nullableState, &originalConditions, &originalFinishedAtInSec, &currentGeneration, &retryClaimedAtInSec); err != nil {
+	// Legacy rows predate the column, so it can still be NULL.
+	var nullableStorageState sql.NullString
+	if err := row.Scan(&nullableState, &originalConditions, &originalFinishedAtInSec, &currentGeneration, &retryClaimedAtInSec, &nullableStorageState); err != nil {
 		tx.Rollback()
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", "", 0, 0, util.NewResourceNotFoundError("Run", runID)
@@ -947,6 +957,14 @@ func (s *RunStore) ClaimRunForRetry(runID string, takeoverExpiredClaim bool) (st
 	originalState := ""
 	if nullableState.Valid {
 		originalState = nullableState.String
+	}
+
+	// RetryRun checks this before taking the lock, but ArchiveExpiredRuns can
+	// commit ARCHIVED between that read and this one. Rejecting here, before any
+	// mutation, keeps a run from ending up RUNNING and ARCHIVED at once.
+	if model.StorageState(nullableStorageState.String).ToV2() == model.StorageStateArchived {
+		tx.Rollback()
+		return "", "", 0, 0, NewArchivedRunRetryError(runID)
 	}
 
 	// Verify the locked row is still in a terminal state. Between the

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -2388,6 +2388,50 @@ func TestRollbackRetryClaim_ClearsClaimTimestamp(t *testing.T) {
 	assert.Equal(t, claimGeneration, restored.RetryGeneration, "generation must stay monotonic across rollback")
 }
 
+// Regression: ArchiveExpiredRuns can commit ARCHIVED between RetryRun's
+// pre-check and this claim taking its row lock. The locked read must catch it,
+// otherwise the claim leaves the row PENDING and ARCHIVED at the same time.
+func TestClaimRunForRetry_RejectsArchivedRun(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	_, err := runStore.CreateRun(&model.Run{
+		UUID:         "run-archived-claim",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "run-archived-claim",
+		DisplayName:  "run-archived-claim",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:          1,
+			FinishedAtInSec:         100,
+			State:                   model.RuntimeStateFailed,
+			Conditions:              string(model.RuntimeStateFailedV1),
+			WorkflowRuntimeManifest: "wf1",
+		},
+	})
+	require.Nil(t, err)
+	require.Nil(t, runStore.ArchiveRun("run-archived-claim"))
+
+	_, _, _, _, claimErr := runStore.ClaimRunForRetry("run-archived-claim", false)
+	require.NotNil(t, claimErr)
+	userError := claimErr.(*util.UserError)
+	assert.Equal(t, codes.FailedPrecondition, userError.ExternalStatusCode())
+	assert.Equal(t,
+		"Failed to retry run run-archived-claim as it is archived. Unarchive the run first to allow it to be retried",
+		userError.ExternalMessage())
+
+	unchanged, err := runStore.GetRun("run-archived-claim")
+	require.Nil(t, err)
+	assert.Equal(t, model.RuntimeStateFailed, unchanged.State)
+	assert.Equal(t, int64(100), unchanged.FinishedAtInSec)
+	assert.Equal(t, int64(0), unchanged.RetryGeneration)
+	assert.Equal(t, int64(0), unchanged.RetryClaimedAtInSec)
+}
+
 func TestClaimRunForRetry_RunNotFound(t *testing.T) {
 	db := NewFakeDBOrFatal()
 	defer db.Close()


### PR DESCRIPTION
**Description of your changes:**

`RetryRun` never read `run.StorageState`, so an archived run could be retried. Since the run garbage collector landed in #13532 archived runs are deletion candidates, so the retry starts a workflow the collector is still free to delete, and the deletion timer keeps counting from the original `ArchivedAtInSec` rather than from the retry.

This adds a guard immediately after `GetRun`, so the request fails before any pods are deleted or a workflow is created:

```
Failed to retry run <id> as it is archived
Unarchive the run first to allow it to be retried
```

Rejecting rather than auto-unarchiving, as agreed on #14164. It also matches `UnarchiveRun`, the only other place in the backend that refuses this class of request: it tells you to unarchive the parent experiment rather than doing it for you.

Two details worth calling out:

`NewFailedPreconditionError` gives `codes.FailedPrecondition`, which grpc-gateway maps to 400 Bad Request. `NewBadRequestError` would look like the obvious choice from its name, but it returns `codes.Aborted`, which maps to 409 Conflict.

The check goes through `StorageState.ToV2()`, which is the same classification the collector uses: `archivedStorageStateStrings` in `run_store.go` is documented as the closed set of values `ToV2()` maps to ARCHIVED. So the guard and the GC agree on what counts as archived, legacy `STORAGESTATE_ARCHIVED` and `DISABLED` rows included.

Tests: one for the rejection and its status code, one covering unarchive-then-retry so the remedy the error message suggests is actually exercised. The existing 22 `RetryRun` and `Unarchive` tests still pass.

#14168 covered the same issue and was closed by its author. The review on it asked for `FailedPrecondition`, the unarchive instruction in the external message, and a regression test asserting both plus no retry mutation. All three are here.

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
