### PR TITLE
fix(backend): preserve optional defaults when resolving container args [release-2.17]

### DIFF
--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -422,7 +422,7 @@ func executeV2(
 	// Add parameter default values to executorInput, if there is not already a user input.
 	// This process is done in the launcher because we let the component resolve default values internally.
 	// Variable executorInputWithDefault is a copy so we don't alter the original data.
-	executorInputWithDefault, err := addDefaultParams(executorInput, component)
+	executorInputWithDefault, err := AddDefaultParams(executorInput, component)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1306,11 +1306,15 @@ func prepareOutputFolders(executorInput *pipelinespec.ExecutorInput) error {
 	return nil
 }
 
-// Adds default parameter values if there is no user provided value
-func addDefaultParams(
+// AddDefaultParams returns a copy of executorInput with component parameter
+// defaults populated for inputs that have no user-provided value.
+func AddDefaultParams(
 	executorInput *pipelinespec.ExecutorInput,
 	component *pipelinespec.ComponentSpec,
 ) (*pipelinespec.ExecutorInput, error) {
+	if executorInput == nil {
+		executorInput = &pipelinespec.ExecutorInput{}
+	}
 	// Make a deep copy so we don't alter the original data
 	executorInputWithDefaultMsg := proto.Clone(executorInput)
 	executorInputWithDefault, ok := executorInputWithDefaultMsg.(*pipelinespec.ExecutorInput)
@@ -1318,6 +1322,9 @@ func addDefaultParams(
 		return nil, fmt.Errorf("bug: cloned executor input message does not have expected type")
 	}
 
+	if executorInputWithDefault.GetInputs() == nil {
+		executorInputWithDefault.Inputs = &pipelinespec.ExecutorInput_Inputs{}
+	}
 	if executorInputWithDefault.GetInputs().GetParameterValues() == nil {
 		executorInputWithDefault.Inputs.ParameterValues = make(map[string]*structpb.Value)
 	}

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -304,19 +304,10 @@ func initPodSpecPatch(
 		setOnTaskConfig = map[pipelinespec.TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum]bool{}
 	}
 
-	userCmdArgs := make([]string, 0, len(container.Command)+len(container.Args))
-
-	resolvedCommand, err := resolveContainerArgs(container.Command, executorInput)
+	userCmdArgs, err := resolveContainerCommandAndArgs(container, componentSpec, executorInput)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve container command: %w", err)
+		return nil, err
 	}
-	userCmdArgs = append(userCmdArgs, resolvedCommand...)
-
-	resolvedArgs, err := resolveContainerArgs(container.Args, executorInput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve container args: %w", err)
-	}
-	userCmdArgs = append(userCmdArgs, resolvedArgs...)
 	launcherCmd := []string{
 		component.KFPLauncherPath,
 		// TODO(Bobgy): no need to pass pipeline_name and run_id, these info can be fetched via pipeline context and pipeline run context which have been created by root DAG driver.
@@ -515,6 +506,30 @@ func initPodSpecPatch(
 	}
 
 	return podSpec, nil
+}
+
+func resolveContainerCommandAndArgs(
+	container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec,
+	componentSpec *pipelinespec.ComponentSpec,
+	executorInput *pipelinespec.ExecutorInput,
+) ([]string, error) {
+	executorInputWithDefaults, err := component.AddDefaultParams(executorInput, componentSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply component parameter defaults: %w", err)
+	}
+
+	userCmdArgs := make([]string, 0, len(container.Command)+len(container.Args))
+	resolvedCommand, err := resolveContainerArgs(container.Command, executorInputWithDefaults)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve container command: %w", err)
+	}
+	userCmdArgs = append(userCmdArgs, resolvedCommand...)
+
+	resolvedArgs, err := resolveContainerArgs(container.Args, executorInputWithDefaults)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve container args: %w", err)
+	}
+	return append(userCmdArgs, resolvedArgs...), nil
 }
 
 // needsWorkspaceMount checks if the component needs workspace mounting based on input parameters and artifacts.

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -33,6 +33,58 @@ import (
 	k8sres "k8s.io/apimachinery/pkg/api/resource"
 )
 
+func Test_resolveContainerCommandAndArgs_OptionalParameterDefault(t *testing.T) {
+	componentSpec := &pipelinespec.ComponentSpec{
+		InputDefinitions: &pipelinespec.ComponentInputsSpec{
+			Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+				"message": {
+					ParameterType: pipelinespec.ParameterType_STRING,
+					DefaultValue:  structpb.NewStringValue("hello"),
+					IsOptional:    true,
+				},
+			},
+		},
+	}
+	executorInput := &pipelinespec.ExecutorInput{
+		Inputs: &pipelinespec.ExecutorInput_Inputs{
+			ParameterValues: map[string]*structpb.Value{},
+		},
+	}
+	tests := []struct {
+		name      string
+		container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec
+		expected  []string
+	}{
+		{
+			name: "direct placeholder",
+			container: &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{
+				Command: []string{"echo"},
+				Args:    []string{"{{$.inputs.parameters['message']}}"},
+			},
+			expected: []string{"echo", "hello"},
+		},
+		{
+			name: "IfPresent condition",
+			container: &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{
+				Command: []string{"echo"},
+				Args: []string{
+					`{"IfPresent": {"InputName": "message", "Then": ["--message", "{{$.inputs.parameters['message']}}"], "Else": ["--no-message"]}}`,
+				},
+			},
+			expected: []string{"echo", "--message", "hello"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := resolveContainerCommandAndArgs(test.container, componentSpec, executorInput)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
+			assert.Empty(t, executorInput.GetInputs().GetParameterValues())
+		})
+	}
+}
+
 func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 	viper.Set("KFP_POD_NAME", "MyWorkflowPod")
 	viper.Set("KFP_POD_UID", "a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6")

--- a/backend/src/v2/driver/util.go
+++ b/backend/src/v2/driver/util.go
@@ -208,23 +208,27 @@ func isConditionClause(arg string) bool {
 	return strings.HasPrefix(strings.TrimSpace(arg), `{"IfPresent":`)
 }
 
+func isInputPresent(inputName string, executorInput *pipelinespec.ExecutorInput) bool {
+	if value, ok := executorInput.GetInputs().GetParameterValues()[inputName]; ok {
+		if value == nil {
+			return false
+		}
+		_, isNull := value.GetKind().(*structpb.Value_NullValue)
+		return !isNull
+	}
+
+	artifacts, ok := executorInput.GetInputs().GetArtifacts()[inputName]
+	return ok && len(artifacts.GetArtifacts()) > 0
+}
+
 func resolveCondition(arg string, executorInput *pipelinespec.ExecutorInput) ([]string, error) {
 	var ifPresent ifPresentCondition
 	if err := json.Unmarshal([]byte(arg), &ifPresent); err != nil {
 		return nil, fmt.Errorf("failed to parse IfPresent JSON: %w", err)
 	}
 
-	val, isPresent := executorInput.GetInputs().GetParameterValues()[ifPresent.IfPresent.InputName]
-	// Treat null values as absent for IfPresent semantics.
-	// The driver can set optional pipeline inputs to structpb.NewNullValue(),
-	// which should be treated as "not present".
-	if isPresent {
-		if _, isNull := val.GetKind().(*structpb.Value_NullValue); isNull {
-			isPresent = false
-		}
-	}
 	var values interface{}
-	if isPresent {
+	if isInputPresent(ifPresent.IfPresent.InputName, executorInput) {
 		values = ifPresent.IfPresent.Then
 	} else {
 		values = ifPresent.IfPresent.Else
@@ -263,6 +267,15 @@ func resolveCondition(arg string, executorInput *pipelinespec.ExecutorInput) ([]
 func resolveContainerArgs(args []string, executorInput *pipelinespec.ExecutorInput) ([]string, error) {
 	var resolvedArgs []string
 	for _, arg := range args {
+		if isConditionClause(arg) {
+			resolved, err := resolveCondition(arg, executorInput)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve condition: %w", err)
+			}
+			resolvedArgs = append(resolvedArgs, resolved...)
+			continue
+		}
+
 		// Skip args containing output placeholders - these need to be resolved by Argo at runtime
 		// Example: {{$.outputs.parameters['sum'].output_file}}
 		if strings.Contains(arg, "$.outputs") {
@@ -270,19 +283,11 @@ func resolveContainerArgs(args []string, executorInput *pipelinespec.ExecutorInp
 			continue
 		}
 
-		if isConditionClause(arg) {
-			resolved, err := resolveCondition(arg, executorInput)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve condition: %w", err)
-			}
-			resolvedArgs = append(resolvedArgs, resolved...)
-		} else {
-			resolvedArg, err := resolveInputParameterPlaceholders(arg, executorInput)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve input parameters: %w", err)
-			}
-			resolvedArgs = append(resolvedArgs, resolvedArg)
+		resolvedArg, err := resolveInputParameterPlaceholders(arg, executorInput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve input parameters: %w", err)
 		}
+		resolvedArgs = append(resolvedArgs, resolvedArg)
 	}
 	return resolvedArgs, nil
 }

--- a/backend/src/v2/driver/util_test.go
+++ b/backend/src/v2/driver/util_test.go
@@ -426,6 +426,38 @@ func Test_resolveContainerArgs(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "IfPresent with artifact present",
+			args: []string{
+				`{"IfPresent": {"InputName": "model", "Then": ["--model", "{{$.inputs.artifacts['model'].uri}}"], "Else": ["--no-model"]}}`,
+			},
+			executorInput: &pipelinespec.ExecutorInput{
+				Inputs: &pipelinespec.ExecutorInput_Inputs{
+					Artifacts: map[string]*pipelinespec.ArtifactList{
+						"model": {
+							Artifacts: []*pipelinespec.RuntimeArtifact{{Uri: "s3://bucket/model"}},
+						},
+					},
+				},
+			},
+			expected: []string{"--model", "{{$.inputs.artifacts['model'].uri}}"},
+			wantErr:  false,
+		},
+		{
+			name: "IfPresent with empty artifact list",
+			args: []string{
+				`{"IfPresent": {"InputName": "model", "Then": ["--model"], "Else": ["--no-model"]}}`,
+			},
+			executorInput: &pipelinespec.ExecutorInput{
+				Inputs: &pipelinespec.ExecutorInput_Inputs{
+					Artifacts: map[string]*pipelinespec.ArtifactList{
+						"model": {},
+					},
+				},
+			},
+			expected: []string{"--no-model"},
+			wantErr:  false,
+		},
+		{
 			name: "input parameter channel",
 			args: []string{
 				"{{$.inputs.parameters['pipelinechannel--someParameterName']}}",
@@ -526,6 +558,21 @@ func Test_resolveContainerArgs(t *testing.T) {
 				"mkdir -p /tmp/kfp/outputs && echo {{$.inputs.parameters['result']}} > {{$.outputs.parameters['sum'].output_file}}",
 			},
 			wantErr: false,
+		},
+		{
+			name: "output placeholder in selected IfPresent branch should be preserved",
+			args: []string{
+				`{"IfPresent": {"InputName": "write_output", "Then": ["{{$.outputs.parameters['result'].output_file}}"], "Else": ["--skip-output"]}}`,
+			},
+			executorInput: &pipelinespec.ExecutorInput{
+				Inputs: &pipelinespec.ExecutorInput_Inputs{
+					ParameterValues: map[string]*structpb.Value{
+						"write_output": structpb.NewBoolValue(true),
+					},
+				},
+			},
+			expected: []string{"{{$.outputs.parameters['result'].output_file}}"},
+			wantErr:  false,
 		},
 		{
 			name: "embedded placeholder in fstring should be template-substituted",

--- a/sdk/python/test/compilation/pipeline_compilation_test.py
+++ b/sdk/python/test/compilation/pipeline_compilation_test.py
@@ -52,6 +52,8 @@ from test_data.sdk_compiled_pipelines.valid.container_with_if_placeholder import
     container_with_if_placeholder
 from test_data.sdk_compiled_pipelines.valid.container_with_if_placeholder import \
     container_with_if_placeholder as pipeline_with_if_placeholder_pipeline
+from test_data.sdk_compiled_pipelines.valid.container_with_if_placeholder_default import \
+    pipeline as container_with_if_placeholder_default_pipeline
 from test_data.sdk_compiled_pipelines.valid.container_with_placeholder_in_fstring import \
     container_with_placeholder_in_fstring
 from test_data.sdk_compiled_pipelines.valid.containerized_python_component import \
@@ -761,6 +763,13 @@ class TestPipelineCompilation:
                 pipeline_func_args=None,
                 compiled_file_name='container_with_if_placeholder.yaml',
                 expected_compiled_file_path=f'{_VALID_PIPELINE_FILES}/container_with_if_placeholder.yaml'
+            ),
+            TestData(
+                pipeline_name='container-with-if-placeholder-default',
+                pipeline_func=container_with_if_placeholder_default_pipeline,
+                pipeline_func_args=None,
+                compiled_file_name='container_with_if_placeholder_default.yaml',
+                expected_compiled_file_path=f'{_VALID_PIPELINE_FILES}/container_with_if_placeholder_default.yaml'
             ),
             TestData(
                 pipeline_name='container-with-placeholder-in-fstring',

--- a/test_data/compiled-workflows/container_with_if_placeholder_default.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder_default.yaml
@@ -74,15 +74,6 @@ spec:
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
       - "8080"
-      - --cache_disabled=false
-      - --log_level
-      - "1"
-      - --publish_logs
-      - "true"
-      - --ml_pipeline_tls_enabled=false
-      - --metadata_tls_enabled=false
-      - --ca_cert_path
-      - ""
       command:
       - driver
       env:
@@ -333,15 +324,6 @@ spec:
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
       - "8080"
-      - --cache_disabled=false
-      - --log_level
-      - "1"
-      - --publish_logs
-      - "true"
-      - --ml_pipeline_tls_enabled=false
-      - --metadata_tls_enabled=false
-      - --ca_cert_path
-      - ""
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/compiled-workflows/container_with_if_placeholder_default.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder_default.yaml
@@ -1,0 +1,427 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: container-with-if-placeholder-default-
+spec:
+  arguments:
+    parameters:
+    - name: components-502206b7d3a41c997ec283e01d80608bbba6df6ed21b45c64a70b4797c28830a
+      value: '{"executorLabel":"exec-container-with-if-placeholder","inputDefinitions":{"parameters":{"optional_input":{"defaultValue":"default","isOptional":true,"parameterType":"STRING"}}},"outputDefinitions":{"artifacts":{"dataset":{"artifactType":{"schemaTitle":"system.Dataset","schemaVersion":"0.0.1"}}},"parameters":{"output_path":{"parameterType":"STRING"}}}}'
+    - name: implementations-502206b7d3a41c997ec283e01d80608bbba6df6ed21b45c64a70b4797c28830a
+      value: '{"args":["--output_path","{{$.outputs.parameters[''output_path''].output_file}}"],"command":["my_program","{\"IfPresent\":
+        {\"InputName\": \"optional_input\", \"Then\": [\"{{$.inputs.parameters[''optional_input'']}}\"],
+        \"Else\": [\"bye\"]}}","--dataset","{\"IfPresent\": {\"InputName\": \"optional_input\",
+        \"Then\": [\"{{$.outputs.artifacts[''dataset''].uri}}\"], \"Else\": [\"bye\"]}}"],"image":"registry.access.redhat.com/ubi9/python-311:latest"}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"container-with-if-placeholder":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-container-with-if-placeholder"},"taskInfo":{"name":"container-with-if-placeholder"}}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - container-with-if-placeholder-default
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      - --cache_disabled=false
+      - --log_level
+      - "1"
+      - --publish_logs
+      - "true"
+      - --ml_pipeline_tls_enabled=false
+      - --metadata_tls_enabled=false
+      - --ca_cert_path
+      - ""
+      command:
+      - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: task-name
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: driver
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+        name: executor
+        template: system-container-impl
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+    metadata: {}
+    name: system-container-executor
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher:latest
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: launcher
+    name: system-container-impl
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-502206b7d3a41c997ec283e01d80608bbba6df6ed21b45c64a70b4797c28830a}}'
+          - name: task
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-container-with-if-placeholder"},"taskInfo":{"name":"container-with-if-placeholder"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-502206b7d3a41c997ec283e01d80608bbba6df6ed21b45c64a70b4797c28830a}}'
+          - name: task-name
+            value: container-with-if-placeholder
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: container-with-if-placeholder-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.container-with-if-placeholder-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.container-with-if-placeholder-driver.outputs.parameters.cached-decision}}'
+        depends: container-with-if-placeholder-driver.Succeeded
+        name: container-with-if-placeholder
+        template: system-container-executor
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - container-with-if-placeholder-default
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      - --cache_disabled=false
+      - --log_level
+      - "1"
+      - --publish_logs
+      - "true"
+      - --ml_pipeline_tls_enabled=false
+      - --metadata_tls_enabled=false
+      - --ca_cert_path
+      - ""
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: ""
+        name: task-name
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: driver
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/test_data/sdk_compiled_pipelines/valid/container_with_if_placeholder_default.py
+++ b/test_data/sdk_compiled_pipelines/valid/container_with_if_placeholder_default.py
@@ -1,0 +1,28 @@
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import compiler
+from kfp import dsl
+from test_data.sdk_compiled_pipelines.valid.container_with_if_placeholder import \
+    container_with_if_placeholder
+
+
+@dsl.pipeline(name='container-with-if-placeholder-default')
+def pipeline():
+    container_with_if_placeholder()
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=pipeline, package_path=__file__.replace('.py', '.yaml'))

--- a/test_data/sdk_compiled_pipelines/valid/container_with_if_placeholder_default.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/container_with_if_placeholder_default.yaml
@@ -1,0 +1,49 @@
+# PIPELINE DEFINITION
+# Name: container-with-if-placeholder-default
+components:
+  comp-container-with-if-placeholder:
+    executorLabel: exec-container-with-if-placeholder
+    inputDefinitions:
+      parameters:
+        optional_input:
+          defaultValue: default
+          isOptional: true
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        dataset:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+      parameters:
+        output_path:
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-container-with-if-placeholder:
+      container:
+        args:
+        - --output_path
+        - '{{$.outputs.parameters[''output_path''].output_file}}'
+        command:
+        - my_program
+        - '{"IfPresent": {"InputName": "optional_input", "Then": ["{{$.inputs.parameters[''optional_input'']}}"],
+          "Else": ["bye"]}}'
+        - --dataset
+        - '{"IfPresent": {"InputName": "optional_input", "Then": ["{{$.outputs.artifacts[''dataset''].uri}}"],
+          "Else": ["bye"]}}'
+        image: registry.access.redhat.com/ubi9/python-311:latest
+pipelineInfo:
+  name: container-with-if-placeholder-default
+root:
+  dag:
+    tasks:
+      container-with-if-placeholder:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-container-with-if-placeholder
+        taskInfo:
+          name: container-with-if-placeholder
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.15.2


### PR DESCRIPTION
## PR Overview

Backport of #14175 for the Kubeflow Pipelines 2.17.1 release. This cherry-picks master commit `2fc3f8921b6e4384217760ebaf5e8baea4c2b039` and regenerates the backend compiler golden with the release-2.17 compiler so it does not include driver flags introduced after 2.17.

<!-- LLM-generated estimate: likely LLM-assisted; confidence: high. -->

## Changes

- Applies component parameter defaults before driver command, argument, and `IfPresent` resolution.
- Recognizes optional artifact presence when evaluating `IfPresent`.
- Keeps selected output placeholders deferred for runtime resolution.
- Adds the SDK IR and backend compiler golden coverage from #14175, adjusted only for release-2.17 driver arguments.

## Validation

- `go test ./backend/src/v2/driver ./backend/src/v2/component -count=1`
- `go test ./backend/test/compiler -run TestCompilation -count=1 -ginkgo.focus='container_with_if_placeholder_default.yaml'`
- `.venv/bin/python -m pytest sdk/python/test/compilation/pipeline_compilation_test.py -q -k 'placeholder and default'`
