### PR TITLE
feat(backend): add kubeflow-pipelines tag to S3 user agent

### DIFF
--- a/backend/src/apiserver/client_manager/client_manager.go
+++ b/backend/src/apiserver/client_manager/client_manager.go
@@ -24,11 +24,13 @@ import (
 	"time"
 
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
+	awsMiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	awsv2cfg "github.com/aws/aws-sdk-go-v2/config"
 	awsv2creds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
+	smithyMiddleware "github.com/aws/smithy-go/middleware"
 	"github.com/cenkalti/backoff"
 	mysqlStd "github.com/go-sql-driver/mysql"
 	"github.com/golang/glog"
@@ -1034,10 +1036,17 @@ func newS3BucketClient(ctx context.Context, config *blobStorageConfig) (*s3.Clie
 }
 
 func loadAWSConfig(ctx context.Context, config *blobStorageConfig) (awsv2.Config, error) {
+	tagName := common.GetStringConfigWithDefault("TAG_NAME", "unknown")
+	if tagName == "" {
+		tagName = "unknown"
+	}
 	opts := []func(*awsv2cfg.LoadOptions) error{
 		awsv2cfg.WithRegion(config.region),
 		awsv2cfg.WithRequestChecksumCalculation(awsv2.RequestChecksumCalculationWhenRequired),
 		awsv2cfg.WithResponseChecksumValidation(awsv2.ResponseChecksumValidationWhenRequired),
+		awsv2cfg.WithAPIOptions([]func(*smithyMiddleware.Stack) error{
+			awsMiddleware.AddUserAgentKeyValue("kubeflow-pipelines", tagName),
+		}),
 	}
 	if config.accessKey != "" && config.secretKey != "" {
 		opts = append(opts, awsv2cfg.WithCredentialsProvider(

--- a/backend/src/apiserver/client_manager/client_manager_test.go
+++ b/backend/src/apiserver/client_manager/client_manager_test.go
@@ -26,6 +26,7 @@ import (
 	awsv2 "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
@@ -477,4 +478,64 @@ func TestAutoMigrateSucceeds(t *testing.T) {
 	assertColumnExists("run_metrics", "RunUUID")
 	assertColumnExists("tasks", "RunUUID")
 	assertColumnExists("resource_references", "ResourceUUID")
+}
+
+func TestLoadAWSConfig_UserAgentHeader(t *testing.T) {
+	tests := []struct {
+		name          string
+		tagNameEnv    string
+		expectedUAKey string
+	}{
+		{
+			name:          "custom TAG_NAME configured",
+			tagNameEnv:    "2.4.0",
+			expectedUAKey: "kubeflow-pipelines/2.4.0",
+		},
+		{
+			name:          "unset TAG_NAME uses default fallback",
+			tagNameEnv:    "",
+			expectedUAKey: "kubeflow-pipelines/unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.tagNameEnv != "" {
+				viper.Set("TAG_NAME", tt.tagNameEnv)
+			} else {
+				viper.Set("TAG_NAME", "")
+			}
+			t.Cleanup(func() {
+				viper.Set("TAG_NAME", "")
+			})
+
+			var capturedUserAgent string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedUserAgent = r.Header.Get("User-Agent")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			endpoint := strings.TrimPrefix(server.URL, "http://")
+			cfg := &blobStorageConfig{
+				bucketName: "test-bucket",
+				endpoint:   endpoint,
+				region:     "us-east-1",
+				secure:     false,
+				accessKey:  "key",
+				secretKey:  "secret",
+			}
+
+			s3Client, err := newS3BucketClient(context.Background(), cfg)
+			require.NoError(t, err)
+
+			_, _ = s3Client.HeadBucket(context.Background(), &s3.HeadBucketInput{
+				Bucket: awsv2.String("test-bucket"),
+			})
+
+			require.NotEmpty(t, capturedUserAgent, "User-Agent header should be sent in S3 HTTP request")
+			assert.Contains(t, capturedUserAgent, "aws-sdk-go-v2/", "User-Agent should preserve standard AWS SDK user agent")
+			assert.Contains(t, capturedUserAgent, tt.expectedUAKey, "User-Agent should contain appended Kubeflow Pipelines tag")
+		})
+	}
 }


### PR DESCRIPTION
## Description of your changes

Fixes #13941.

This change appends a `kubeflow-pipelines/<TAG_NAME>` identifier to the API server's S3 `User-Agent` using the AWS SDK for Go v2's `AddUserAgentKeyValue` middleware.

### Implementation

- Read the existing API server `TAG_NAME` configuration.
- Fall back to `unknown` when `TAG_NAME` is unset or empty.
- Use AWS SDK v2 middleware to append:
  `kubeflow-pipelines/<TAG_NAME>`
- Preserve the default `aws-sdk-go-v2/...` User-Agent information.
- Scope the change to the API server S3 client only.

### Tests

Added a regression test that:
- Sends an actual S3 `HeadBucket` request to an `httptest.Server`.
- Verifies the standard `aws-sdk-go-v2/` User-Agent is preserved.
- Verifies `kubeflow-pipelines/2.4.0` is added when `TAG_NAME` is configured.
- Verifies `kubeflow-pipelines/unknown` is added when `TAG_NAME` is unset.

Tests run successfully:

```text
go test ./backend/src/apiserver/client_manager -run TestLoadAWSConfig_UserAgentHeader -v
go test ./backend/src/apiserver/client_manager/... -v
```

There is already a draft PR, #13942, associated with issue #13941. This PR is being opened to provide the completed implementation for the issue after the previous work was left as a draft.