### PR TITLE
[release-2.17] fix(backend): preserve optional defaults in container args

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Contact one of chensun, HumairAK if this remote image needs an update.
-PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:master
+PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:release-2.17
 
 .PHONY: all
 all: golang python

--- a/backend/api/Makefile
+++ b/backend/api/Makefile
@@ -21,7 +21,7 @@ REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator
 API_VERSION ?= v2beta1
 
 # Keep in sync with the version used in release/Dockerfile.release
-PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:master
+PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:release-2.17
 RELEASE_IMAGE=ghcr.io/kubeflow/kfp-release:master
 CONTAINER_ENGINE ?= docker
 

--- a/backend/src/v2/component/launcher_v2.go
+++ b/backend/src/v2/component/launcher_v2.go
@@ -422,7 +422,7 @@ func executeV2(
 	// Add parameter default values to executorInput, if there is not already a user input.
 	// This process is done in the launcher because we let the component resolve default values internally.
 	// Variable executorInputWithDefault is a copy so we don't alter the original data.
-	executorInputWithDefault, err := addDefaultParams(executorInput, component)
+	executorInputWithDefault, err := AddDefaultParams(executorInput, component)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1306,11 +1306,15 @@ func prepareOutputFolders(executorInput *pipelinespec.ExecutorInput) error {
 	return nil
 }
 
-// Adds default parameter values if there is no user provided value
-func addDefaultParams(
+// AddDefaultParams returns a copy of executorInput with component parameter
+// defaults populated for inputs that have no user-provided value.
+func AddDefaultParams(
 	executorInput *pipelinespec.ExecutorInput,
 	component *pipelinespec.ComponentSpec,
 ) (*pipelinespec.ExecutorInput, error) {
+	if executorInput == nil {
+		executorInput = &pipelinespec.ExecutorInput{}
+	}
 	// Make a deep copy so we don't alter the original data
 	executorInputWithDefaultMsg := proto.Clone(executorInput)
 	executorInputWithDefault, ok := executorInputWithDefaultMsg.(*pipelinespec.ExecutorInput)
@@ -1318,6 +1322,9 @@ func addDefaultParams(
 		return nil, fmt.Errorf("bug: cloned executor input message does not have expected type")
 	}
 
+	if executorInputWithDefault.GetInputs() == nil {
+		executorInputWithDefault.Inputs = &pipelinespec.ExecutorInput_Inputs{}
+	}
 	if executorInputWithDefault.GetInputs().GetParameterValues() == nil {
 		executorInputWithDefault.Inputs.ParameterValues = make(map[string]*structpb.Value)
 	}

--- a/backend/src/v2/driver/driver.go
+++ b/backend/src/v2/driver/driver.go
@@ -304,19 +304,10 @@ func initPodSpecPatch(
 		setOnTaskConfig = map[pipelinespec.TaskConfigPassthroughType_TaskConfigPassthroughTypeEnum]bool{}
 	}
 
-	userCmdArgs := make([]string, 0, len(container.Command)+len(container.Args))
-
-	resolvedCommand, err := resolveContainerArgs(container.Command, executorInput)
+	userCmdArgs, err := resolveContainerCommandAndArgs(container, componentSpec, executorInput)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve container command: %w", err)
+		return nil, err
 	}
-	userCmdArgs = append(userCmdArgs, resolvedCommand...)
-
-	resolvedArgs, err := resolveContainerArgs(container.Args, executorInput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve container args: %w", err)
-	}
-	userCmdArgs = append(userCmdArgs, resolvedArgs...)
 	launcherCmd := []string{
 		component.KFPLauncherPath,
 		// TODO(Bobgy): no need to pass pipeline_name and run_id, these info can be fetched via pipeline context and pipeline run context which have been created by root DAG driver.
@@ -515,6 +506,30 @@ func initPodSpecPatch(
 	}
 
 	return podSpec, nil
+}
+
+func resolveContainerCommandAndArgs(
+	container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec,
+	componentSpec *pipelinespec.ComponentSpec,
+	executorInput *pipelinespec.ExecutorInput,
+) ([]string, error) {
+	executorInputWithDefaults, err := component.AddDefaultParams(executorInput, componentSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to apply component parameter defaults: %w", err)
+	}
+
+	userCmdArgs := make([]string, 0, len(container.Command)+len(container.Args))
+	resolvedCommand, err := resolveContainerArgs(container.Command, executorInputWithDefaults)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve container command: %w", err)
+	}
+	userCmdArgs = append(userCmdArgs, resolvedCommand...)
+
+	resolvedArgs, err := resolveContainerArgs(container.Args, executorInputWithDefaults)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve container args: %w", err)
+	}
+	return append(userCmdArgs, resolvedArgs...), nil
 }
 
 // needsWorkspaceMount checks if the component needs workspace mounting based on input parameters and artifacts.

--- a/backend/src/v2/driver/driver_test.go
+++ b/backend/src/v2/driver/driver_test.go
@@ -33,6 +33,58 @@ import (
 	k8sres "k8s.io/apimachinery/pkg/api/resource"
 )
 
+func Test_resolveContainerCommandAndArgs_OptionalParameterDefault(t *testing.T) {
+	componentSpec := &pipelinespec.ComponentSpec{
+		InputDefinitions: &pipelinespec.ComponentInputsSpec{
+			Parameters: map[string]*pipelinespec.ComponentInputsSpec_ParameterSpec{
+				"message": {
+					ParameterType: pipelinespec.ParameterType_STRING,
+					DefaultValue:  structpb.NewStringValue("hello"),
+					IsOptional:    true,
+				},
+			},
+		},
+	}
+	executorInput := &pipelinespec.ExecutorInput{
+		Inputs: &pipelinespec.ExecutorInput_Inputs{
+			ParameterValues: map[string]*structpb.Value{},
+		},
+	}
+	tests := []struct {
+		name      string
+		container *pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec
+		expected  []string
+	}{
+		{
+			name: "direct placeholder",
+			container: &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{
+				Command: []string{"echo"},
+				Args:    []string{"{{$.inputs.parameters['message']}}"},
+			},
+			expected: []string{"echo", "hello"},
+		},
+		{
+			name: "IfPresent condition",
+			container: &pipelinespec.PipelineDeploymentConfig_PipelineContainerSpec{
+				Command: []string{"echo"},
+				Args: []string{
+					`{"IfPresent": {"InputName": "message", "Then": ["--message", "{{$.inputs.parameters['message']}}"], "Else": ["--no-message"]}}`,
+				},
+			},
+			expected: []string{"echo", "--message", "hello"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := resolveContainerCommandAndArgs(test.container, componentSpec, executorInput)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
+			assert.Empty(t, executorInput.GetInputs().GetParameterValues())
+		})
+	}
+}
+
 func Test_initPodSpecPatch_acceleratorConfig(t *testing.T) {
 	viper.Set("KFP_POD_NAME", "MyWorkflowPod")
 	viper.Set("KFP_POD_UID", "a1b2c3d4-a1b2-a1b2-a1b2-a1b2c3d4e5f6")

--- a/backend/src/v2/driver/util.go
+++ b/backend/src/v2/driver/util.go
@@ -208,61 +208,96 @@ func isConditionClause(arg string) bool {
 	return strings.HasPrefix(strings.TrimSpace(arg), `{"IfPresent":`)
 }
 
+func isInputPresent(inputName string, executorInput *pipelinespec.ExecutorInput) bool {
+	if value, ok := executorInput.GetInputs().GetParameterValues()[inputName]; ok {
+		if value == nil {
+			return false
+		}
+		_, isNull := value.GetKind().(*structpb.Value_NullValue)
+		return !isNull
+	}
+
+	artifacts, ok := executorInput.GetInputs().GetArtifacts()[inputName]
+	return ok && len(artifacts.GetArtifacts()) > 0
+}
+
+func resolveCommandLineValue(value any, executorInput *pipelinespec.ExecutorInput) ([]string, error) {
+	switch typedValue := value.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		resolvedArg, err := resolveInputParameterPlaceholders(typedValue, executorInput)
+		if err != nil {
+			return nil, err
+		}
+		return []string{resolvedArg}, nil
+	case []any:
+		var resolved []string
+		for _, item := range typedValue {
+			resolvedItem, err := resolveCommandLineValue(item, executorInput)
+			if err != nil {
+				return nil, err
+			}
+			resolved = append(resolved, resolvedItem...)
+		}
+		return resolved, nil
+	case map[string]any:
+		if concat, ok := typedValue["Concat"]; ok {
+			resolved, err := resolveCommandLineValue(concat, executorInput)
+			if err != nil {
+				return nil, err
+			}
+			return []string{strings.Join(resolved, "")}, nil
+		}
+
+		ifPresentValue, ok := typedValue["IfPresent"]
+		if !ok {
+			return nil, fmt.Errorf("unexpected structured command-line value")
+		}
+		ifPresent, ok := ifPresentValue.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("unexpected IfPresent value type: %T", ifPresentValue)
+		}
+		inputName, ok := ifPresent["InputName"].(string)
+		if !ok || inputName == "" {
+			return nil, fmt.Errorf("IfPresent InputName must be a non-empty string")
+		}
+		if isInputPresent(inputName, executorInput) {
+			return resolveCommandLineValue(ifPresent["Then"], executorInput)
+		}
+		return resolveCommandLineValue(ifPresent["Else"], executorInput)
+	default:
+		return nil, fmt.Errorf("unexpected command-line value type: %T", value)
+	}
+}
+
 func resolveCondition(arg string, executorInput *pipelinespec.ExecutorInput) ([]string, error) {
 	var ifPresent ifPresentCondition
 	if err := json.Unmarshal([]byte(arg), &ifPresent); err != nil {
 		return nil, fmt.Errorf("failed to parse IfPresent JSON: %w", err)
 	}
 
-	val, isPresent := executorInput.GetInputs().GetParameterValues()[ifPresent.IfPresent.InputName]
-	// Treat null values as absent for IfPresent semantics.
-	// The driver can set optional pipeline inputs to structpb.NewNullValue(),
-	// which should be treated as "not present".
-	if isPresent {
-		if _, isNull := val.GetKind().(*structpb.Value_NullValue); isNull {
-			isPresent = false
-		}
-	}
 	var values interface{}
-	if isPresent {
+	if isInputPresent(ifPresent.IfPresent.InputName, executorInput) {
 		values = ifPresent.IfPresent.Then
 	} else {
 		values = ifPresent.IfPresent.Else
 	}
-
-	if values == nil {
-		return []string{}, nil
-	}
-
-	var resolved []string
-	switch v := values.(type) {
-	case string:
-		resolvedArg, err := resolveInputParameterPlaceholders(v, executorInput)
-		if err != nil {
-			return nil, err
-		}
-		resolved = []string{resolvedArg}
-	case []interface{}:
-		for _, item := range v {
-			str, ok := item.(string)
-			if !ok {
-				return nil, fmt.Errorf("non-string item in IfPresent Then/Else array: %T", item)
-			}
-			resolvedArg, err := resolveInputParameterPlaceholders(str, executorInput)
-			if err != nil {
-				return nil, err
-			}
-			resolved = append(resolved, resolvedArg)
-		}
-	default:
-		return nil, fmt.Errorf("unexpected type in IfPresent Then/Else: %T", v)
-	}
-	return resolved, nil
+	return resolveCommandLineValue(values, executorInput)
 }
 
 func resolveContainerArgs(args []string, executorInput *pipelinespec.ExecutorInput) ([]string, error) {
 	var resolvedArgs []string
 	for _, arg := range args {
+		if isConditionClause(arg) {
+			resolved, err := resolveCondition(arg, executorInput)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve condition: %w", err)
+			}
+			resolvedArgs = append(resolvedArgs, resolved...)
+			continue
+		}
+
 		// Skip args containing output placeholders - these need to be resolved by Argo at runtime
 		// Example: {{$.outputs.parameters['sum'].output_file}}
 		if strings.Contains(arg, "$.outputs") {
@@ -270,19 +305,11 @@ func resolveContainerArgs(args []string, executorInput *pipelinespec.ExecutorInp
 			continue
 		}
 
-		if isConditionClause(arg) {
-			resolved, err := resolveCondition(arg, executorInput)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve condition: %w", err)
-			}
-			resolvedArgs = append(resolvedArgs, resolved...)
-		} else {
-			resolvedArg, err := resolveInputParameterPlaceholders(arg, executorInput)
-			if err != nil {
-				return nil, fmt.Errorf("failed to resolve input parameters: %w", err)
-			}
-			resolvedArgs = append(resolvedArgs, resolvedArg)
+		resolvedArg, err := resolveInputParameterPlaceholders(arg, executorInput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve input parameters: %w", err)
 		}
+		resolvedArgs = append(resolvedArgs, resolvedArg)
 	}
 	return resolvedArgs, nil
 }

--- a/backend/src/v2/driver/util_test.go
+++ b/backend/src/v2/driver/util_test.go
@@ -426,6 +426,38 @@ func Test_resolveContainerArgs(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "IfPresent with artifact present",
+			args: []string{
+				`{"IfPresent": {"InputName": "model", "Then": ["--model", "{{$.inputs.artifacts['model'].uri}}"], "Else": ["--no-model"]}}`,
+			},
+			executorInput: &pipelinespec.ExecutorInput{
+				Inputs: &pipelinespec.ExecutorInput_Inputs{
+					Artifacts: map[string]*pipelinespec.ArtifactList{
+						"model": {
+							Artifacts: []*pipelinespec.RuntimeArtifact{{Uri: "s3://bucket/model"}},
+						},
+					},
+				},
+			},
+			expected: []string{"--model", "{{$.inputs.artifacts['model'].uri}}"},
+			wantErr:  false,
+		},
+		{
+			name: "IfPresent with empty artifact list",
+			args: []string{
+				`{"IfPresent": {"InputName": "model", "Then": ["--model"], "Else": ["--no-model"]}}`,
+			},
+			executorInput: &pipelinespec.ExecutorInput{
+				Inputs: &pipelinespec.ExecutorInput_Inputs{
+					Artifacts: map[string]*pipelinespec.ArtifactList{
+						"model": {},
+					},
+				},
+			},
+			expected: []string{"--no-model"},
+			wantErr:  false,
+		},
+		{
 			name: "input parameter channel",
 			args: []string{
 				"{{$.inputs.parameters['pipelinechannel--someParameterName']}}",
@@ -526,6 +558,37 @@ func Test_resolveContainerArgs(t *testing.T) {
 				"mkdir -p /tmp/kfp/outputs && echo {{$.inputs.parameters['result']}} > {{$.outputs.parameters['sum'].output_file}}",
 			},
 			wantErr: false,
+		},
+		{
+			name: "output placeholder in selected IfPresent branch should be preserved",
+			args: []string{
+				`{"IfPresent": {"InputName": "write_output", "Then": ["{{$.outputs.parameters['result'].output_file}}"], "Else": ["--skip-output"]}}`,
+			},
+			executorInput: &pipelinespec.ExecutorInput{
+				Inputs: &pipelinespec.ExecutorInput_Inputs{
+					ParameterValues: map[string]*structpb.Value{
+						"write_output": structpb.NewBoolValue(true),
+					},
+				},
+			},
+			expected: []string{"{{$.outputs.parameters['result'].output_file}}"},
+			wantErr:  false,
+		},
+		{
+			name: "structured placeholders in selected IfPresent branch",
+			args: []string{
+				`{"IfPresent": {"InputName": "write_output", "Then": {"Concat": ["--out=", {"IfPresent": {"InputName": "use_uri", "Then": "{{$.outputs.artifacts['result'].uri}}", "Else": "disabled"}}]}}}`,
+			},
+			executorInput: &pipelinespec.ExecutorInput{
+				Inputs: &pipelinespec.ExecutorInput_Inputs{
+					ParameterValues: map[string]*structpb.Value{
+						"write_output": structpb.NewBoolValue(true),
+						"use_uri":      structpb.NewBoolValue(true),
+					},
+				},
+			},
+			expected: []string{"--out={{$.outputs.artifacts['result'].uri}}"},
+			wantErr:  false,
 		},
 		{
 			name: "embedded placeholder in fstring should be template-substituted",

--- a/kubernetes_platform/Makefile
+++ b/kubernetes_platform/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:master
+PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:release-2.17
 
 # Set USE_FIND_LINKS=true to use local sdk and pipeline_spec for buildling python builds rather than pulling from pypi
 # applies to `make python` and make pythone-dev` commands.

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Contact one of chensun, HumairAK if this remote image needs an update.
-PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:master
+PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:release-2.17
 
 .PHONY: python
 python: python

--- a/sdk/python/test/compilation/pipeline_compilation_test.py
+++ b/sdk/python/test/compilation/pipeline_compilation_test.py
@@ -52,6 +52,8 @@ from test_data.sdk_compiled_pipelines.valid.container_with_if_placeholder import
     container_with_if_placeholder
 from test_data.sdk_compiled_pipelines.valid.container_with_if_placeholder import \
     container_with_if_placeholder as pipeline_with_if_placeholder_pipeline
+from test_data.sdk_compiled_pipelines.valid.container_with_if_placeholder_default import \
+    pipeline as container_with_if_placeholder_default_pipeline
 from test_data.sdk_compiled_pipelines.valid.container_with_placeholder_in_fstring import \
     container_with_placeholder_in_fstring
 from test_data.sdk_compiled_pipelines.valid.containerized_python_component import \
@@ -269,6 +271,7 @@ class TestPipelineCompilation:
         pipeline_func_args: Optional[dict]
         compiled_file_name: str
         expected_compiled_file_path: str
+        sdk_version_override: Optional[str] = None
 
         def __str__(self) -> str:
             return (f"Compilation Data: name={self.pipeline_name} "
@@ -763,6 +766,14 @@ class TestPipelineCompilation:
                 expected_compiled_file_path=f'{_VALID_PIPELINE_FILES}/container_with_if_placeholder.yaml'
             ),
             TestData(
+                pipeline_name='container-with-if-placeholder-default',
+                pipeline_func=container_with_if_placeholder_default_pipeline,
+                pipeline_func_args=None,
+                compiled_file_name='container_with_if_placeholder_default.yaml',
+                expected_compiled_file_path=f'{_VALID_PIPELINE_FILES}/container_with_if_placeholder_default.yaml',
+                sdk_version_override='2.17.0',
+            ),
+            TestData(
                 pipeline_name='container-with-placeholder-in-fstring',
                 pipeline_func=container_with_placeholder_in_fstring,
                 pipeline_func_args=None,
@@ -1132,7 +1143,11 @@ class TestPipelineCompilation:
     def test_compilation(self, pipeline_data: TestData):
         temp_compiled_pipeline_file = os.path.join(
             tempfile.gettempdir(), pipeline_data.compiled_file_name)
+        original_sdk_version = pipeline_data.pipeline_func.pipeline_spec.sdk_version
         try:
+            if pipeline_data.sdk_version_override:
+                pipeline_data.pipeline_func.pipeline_spec.sdk_version = (
+                    f'kfp-{pipeline_data.sdk_version_override}')
             Compiler().compile(
                 pipeline_func=pipeline_data.pipeline_func,
                 pipeline_name=pipeline_data.pipeline_name,
@@ -1156,11 +1171,13 @@ class TestPipelineCompilation:
                 expected=expected_pipeline_specs,
                 name=pipeline_data.pipeline_name,
                 runtime_params=pipeline_data.pipeline_func_args,
+                sdk_version=pipeline_data.sdk_version_override,
             )
             ComparisonUtils.compare_pipeline_spec_dicts(
                 actual=generated_platform_specs,
                 expected=expected_platform_specs)
         finally:
+            pipeline_data.pipeline_func.pipeline_spec.sdk_version = original_sdk_version
             print(f'Deleting temp compiled file: {temp_compiled_pipeline_file}')
             os.remove(temp_compiled_pipeline_file)
             print(f'Deleted temp compiled file: {temp_compiled_pipeline_file}')

--- a/sdk/python/test/test_utils/comparison_utils.py
+++ b/sdk/python/test/test_utils/comparison_utils.py
@@ -51,9 +51,9 @@ class ComparisonUtils:
                     cls.compare_pipeline_spec_dicts(actual[key], value,
                                                     **kwargs)
                 else:
-                    # Override SDK Version to match the current version
+                    # Override SDK version to match the requested test version.
                     if key == 'sdkVersion':
-                        value = f'kfp-{kfp.__version__}'
+                        value = f"kfp-{kwargs.get('sdk_version') or kfp.__version__}"
                     # Override SDK Version in the args as well to match the current version
                     if key == 'command':
                         # Currently this check is disabled because when doing releases this will fail

--- a/test_data/compiled-workflows/container_with_if_placeholder_default.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder_default.yaml
@@ -1,0 +1,426 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: container-with-if-placeholder-default-
+spec:
+  arguments:
+    parameters:
+    - name: components-07061110db156c25345008b7cb59f43a8df744cc7f20ada43ebd2285121eff41
+      value: '{"executorLabel":"exec-container-with-if-placeholder-default","inputDefinitions":{"parameters":{"optional_input":{"defaultValue":"default","isOptional":true,"parameterType":"STRING"}}},"outputDefinitions":{"artifacts":{"dataset":{"artifactType":{"schemaTitle":"system.Dataset","schemaVersion":"0.0.1"}}}}}'
+    - name: implementations-07061110db156c25345008b7cb59f43a8df744cc7f20ada43ebd2285121eff41
+      value: '{"command":["my_program","{\"IfPresent\": {\"InputName\": \"optional_input\",
+        \"Then\": {\"Concat\": [\"--dataset=\", \"{{$.outputs.artifacts[''dataset''].uri}}\"]},
+        \"Else\": \"--no-dataset\"}}"],"image":"registry.access.redhat.com/ubi9/python-311:latest"}'
+    - name: components-root
+      value: '{"dag":{"tasks":{"container-with-if-placeholder-default":{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-container-with-if-placeholder-default"},"taskInfo":{"name":"container-with-if-placeholder-default"}}}}}'
+  entrypoint: entrypoint
+  podMetadata:
+    annotations:
+      pipelines.kubeflow.org/v2_component: "true"
+    labels:
+      pipelines.kubeflow.org/v2_component: "true"
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  serviceAccountName: pipeline-runner
+  templates:
+  - container:
+      args:
+      - --type
+      - CONTAINER
+      - --pipeline_name
+      - container-with-if-placeholder-default
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --container
+      - '{{inputs.parameters.container}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --cached_decision_path
+      - '{{outputs.parameters.cached-decision.path}}'
+      - --pod_spec_patch_path
+      - '{{outputs.parameters.pod-spec-patch.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --kubernetes_config
+      - '{{inputs.parameters.kubernetes-config}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      - --cache_disabled=false
+      - --log_level
+      - "1"
+      - --publish_logs
+      - "true"
+      - --ml_pipeline_tls_enabled=false
+      - --metadata_tls_enabled=false
+      - --ca_cert_path
+      - ""
+      command:
+      - driver
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - name: task
+      - name: container
+      - name: task-name
+      - name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: ""
+        name: kubernetes-config
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: driver
+    name: system-container-driver
+    outputs:
+      parameters:
+      - name: pod-spec-patch
+        valueFrom:
+          default: ""
+          path: /tmp/outputs/pod-spec-patch
+      - default: "false"
+        name: cached-decision
+        valueFrom:
+          default: "false"
+          path: /tmp/outputs/cached-decision
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{inputs.parameters.pod-spec-patch}}'
+        name: executor
+        template: system-container-impl
+        when: '{{inputs.parameters.cached-decision}} != true'
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+      - default: "false"
+        name: cached-decision
+    metadata: {}
+    name: system-container-executor
+    outputs: {}
+  - container:
+      command:
+      - should-be-overridden-during-runtime
+      env:
+      - name: KFP_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: KFP_POD_UID
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.uid
+      envFrom:
+      - configMapRef:
+          name: metadata-grpc-configmap
+          optional: true
+      image: gcr.io/ml-pipeline/should-be-overridden-during-runtime
+      name: ""
+      resources: {}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+      - mountPath: /gcs
+        name: gcs-scratch
+      - mountPath: /s3
+        name: s3-scratch
+      - mountPath: /minio
+        name: minio-scratch
+      - mountPath: /.local
+        name: dot-local-scratch
+      - mountPath: /.cache
+        name: dot-cache-scratch
+      - mountPath: /.config
+        name: dot-config-scratch
+    initContainers:
+    - args:
+      - --copy
+      - /kfp-launcher/launch
+      command:
+      - launcher-v2
+      image: ghcr.io/kubeflow/kfp-launcher:latest
+      name: kfp-launcher
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+      - mountPath: /kfp-launcher
+        name: kfp-launcher
+    inputs:
+      parameters:
+      - name: pod-spec-patch
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: launcher
+    name: system-container-impl
+    outputs: {}
+    podSpecPatch: '{{inputs.parameters.pod-spec-patch}}'
+    securityContext:
+      seccompProfile:
+        type: RuntimeDefault
+    volumes:
+    - emptyDir: {}
+      name: kfp-launcher
+    - emptyDir: {}
+      name: gcs-scratch
+    - emptyDir: {}
+      name: s3-scratch
+    - emptyDir: {}
+      name: minio-scratch
+    - emptyDir: {}
+      name: dot-local-scratch
+    - emptyDir: {}
+      name: dot-cache-scratch
+    - emptyDir: {}
+      name: dot-config-scratch
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-07061110db156c25345008b7cb59f43a8df744cc7f20ada43ebd2285121eff41}}'
+          - name: task
+            value: '{"cachingOptions":{"enableCache":true},"componentRef":{"name":"comp-container-with-if-placeholder-default"},"taskInfo":{"name":"container-with-if-placeholder-default"}}'
+          - name: container
+            value: '{{workflow.parameters.implementations-07061110db156c25345008b7cb59f43a8df744cc7f20ada43ebd2285121eff41}}'
+          - name: task-name
+            value: container-with-if-placeholder-default
+          - name: parent-dag-id
+            value: '{{inputs.parameters.parent-dag-id}}'
+        name: container-with-if-placeholder-default-driver
+        template: system-container-driver
+      - arguments:
+          parameters:
+          - name: pod-spec-patch
+            value: '{{tasks.container-with-if-placeholder-default-driver.outputs.parameters.pod-spec-patch}}'
+          - default: "false"
+            name: cached-decision
+            value: '{{tasks.container-with-if-placeholder-default-driver.outputs.parameters.cached-decision}}'
+        depends: container-with-if-placeholder-default-driver.Succeeded
+        name: container-with-if-placeholder-default
+        template: system-container-executor
+    inputs:
+      parameters:
+      - name: parent-dag-id
+    metadata: {}
+    name: root
+    outputs: {}
+  - container:
+      args:
+      - --type
+      - '{{inputs.parameters.driver-type}}'
+      - --pipeline_name
+      - container-with-if-placeholder-default
+      - --run_id
+      - '{{workflow.uid}}'
+      - --run_name
+      - '{{workflow.name}}'
+      - --run_display_name
+      - ""
+      - --pipeline_job_create_time_utc
+      - '{{workflow.creationTimestamp}}'
+      - --dag_execution_id
+      - '{{inputs.parameters.parent-dag-id}}'
+      - --component
+      - '{{inputs.parameters.component}}'
+      - --task
+      - '{{inputs.parameters.task}}'
+      - --task_name
+      - '{{inputs.parameters.task-name}}'
+      - --runtime_config
+      - '{{inputs.parameters.runtime-config}}'
+      - --iteration_index
+      - '{{inputs.parameters.iteration-index}}'
+      - --execution_id_path
+      - '{{outputs.parameters.execution-id.path}}'
+      - --iteration_count_path
+      - '{{outputs.parameters.iteration-count.path}}'
+      - --condition_path
+      - '{{outputs.parameters.condition.path}}'
+      - --http_proxy
+      - ""
+      - --https_proxy
+      - ""
+      - --no_proxy
+      - ""
+      - --ml_pipeline_server_address
+      - ml-pipeline.kubeflow.svc.cluster.local
+      - --ml_pipeline_server_port
+      - "8887"
+      - --mlmd_server_address
+      - metadata-grpc-service.kubeflow.svc.cluster.local
+      - --mlmd_server_port
+      - "8080"
+      - --cache_disabled=false
+      - --log_level
+      - "1"
+      - --publish_logs
+      - "true"
+      - --ml_pipeline_tls_enabled=false
+      - --metadata_tls_enabled=false
+      - --ca_cert_path
+      - ""
+      command:
+      - driver
+      image: ghcr.io/kubeflow/kfp-driver:latest
+      name: ""
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    inputs:
+      parameters:
+      - name: component
+      - default: ""
+        name: runtime-config
+      - default: ""
+        name: task
+      - default: ""
+        name: task-name
+      - default: "0"
+        name: parent-dag-id
+      - default: "-1"
+        name: iteration-index
+      - default: DAG
+        name: driver-type
+    metadata:
+      annotations:
+        pipelines.kubeflow.org/runtime-role: driver
+    name: system-dag-driver
+    outputs:
+      parameters:
+      - name: execution-id
+        valueFrom:
+          path: /tmp/outputs/execution-id
+      - name: iteration-count
+        valueFrom:
+          default: "0"
+          path: /tmp/outputs/iteration-count
+      - name: condition
+        valueFrom:
+          default: "true"
+          path: /tmp/outputs/condition
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+  - dag:
+      tasks:
+      - arguments:
+          parameters:
+          - name: component
+            value: '{{workflow.parameters.components-root}}'
+          - name: runtime-config
+            value: '{}'
+          - name: driver-type
+            value: ROOT_DAG
+        name: root-driver
+        template: system-dag-driver
+      - arguments:
+          parameters:
+          - name: parent-dag-id
+            value: '{{tasks.root-driver.outputs.parameters.execution-id}}'
+          - name: condition
+            value: ""
+        depends: root-driver.Succeeded
+        name: root
+        template: root
+    inputs: {}
+    metadata: {}
+    name: entrypoint
+    outputs: {}
+status:
+  finishedAt: null
+  startedAt: null

--- a/test_data/compiled-workflows/container_with_if_placeholder_default.yaml
+++ b/test_data/compiled-workflows/container_with_if_placeholder_default.yaml
@@ -73,15 +73,6 @@ spec:
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
       - "8080"
-      - --cache_disabled=false
-      - --log_level
-      - "1"
-      - --publish_logs
-      - "true"
-      - --ml_pipeline_tls_enabled=false
-      - --metadata_tls_enabled=false
-      - --ca_cert_path
-      - ""
       command:
       - driver
       env:
@@ -332,15 +323,6 @@ spec:
       - metadata-grpc-service.kubeflow.svc.cluster.local
       - --mlmd_server_port
       - "8080"
-      - --cache_disabled=false
-      - --log_level
-      - "1"
-      - --publish_logs
-      - "true"
-      - --ml_pipeline_tls_enabled=false
-      - --metadata_tls_enabled=false
-      - --ca_cert_path
-      - ""
       command:
       - driver
       image: ghcr.io/kubeflow/kfp-driver:latest

--- a/test_data/sdk_compiled_pipelines/valid/container_with_if_placeholder_default.py
+++ b/test_data/sdk_compiled_pipelines/valid/container_with_if_placeholder_default.py
@@ -1,0 +1,42 @@
+# Copyright 2026 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from kfp import compiler
+from kfp import dsl
+
+
+@dsl.container_component
+def container_with_if_placeholder_default(
+    dataset: dsl.Output[dsl.Dataset],
+    optional_input: str = 'default',
+):
+    return dsl.ContainerSpec(
+        image='registry.access.redhat.com/ubi9/python-311:latest',
+        command=[
+            'my_program',
+            dsl.IfPresentPlaceholder(
+                input_name='optional_input',
+                then=dsl.ConcatPlaceholder(['--dataset=', dataset.uri]),
+                else_='--no-dataset'),
+        ])
+
+
+@dsl.pipeline(name='container-with-if-placeholder-default')
+def pipeline():
+    container_with_if_placeholder_default()
+
+
+if __name__ == '__main__':
+    compiler.Compiler().compile(
+        pipeline_func=pipeline, package_path=__file__.replace('.py', '.yaml'))

--- a/test_data/sdk_compiled_pipelines/valid/container_with_if_placeholder_default.yaml
+++ b/test_data/sdk_compiled_pipelines/valid/container_with_if_placeholder_default.yaml
@@ -1,0 +1,40 @@
+# PIPELINE DEFINITION
+# Name: container-with-if-placeholder-default
+components:
+  comp-container-with-if-placeholder-default:
+    executorLabel: exec-container-with-if-placeholder-default
+    inputDefinitions:
+      parameters:
+        optional_input:
+          defaultValue: default
+          isOptional: true
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        dataset:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+deploymentSpec:
+  executors:
+    exec-container-with-if-placeholder-default:
+      container:
+        command:
+        - my_program
+        - '{"IfPresent": {"InputName": "optional_input", "Then": {"Concat": ["--dataset=",
+          "{{$.outputs.artifacts[''dataset''].uri}}"]}, "Else": "--no-dataset"}}'
+        image: registry.access.redhat.com/ubi9/python-311:latest
+pipelineInfo:
+  name: container-with-if-placeholder-default
+root:
+  dag:
+    tasks:
+      container-with-if-placeholder-default:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-container-with-if-placeholder-default
+        taskInfo:
+          name: container-with-if-placeholder-default
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.17.0


### PR DESCRIPTION
## Summary

- Backports #14175 for KFP 2.17.1 from merge commit `0836ba657a6162256c818abd3ab381c3d99ad3bc`.
- Preserves component parameter defaults while resolving container command/argument placeholders.
- Keeps the original merge commit as a standalone cherry-pick for traceability.

## Release-only compatibility

Regenerates only `test_data/compiled-workflows/container_with_if_placeholder_default.yaml` in a separate commit. The release-2.17 compiler predates nine master-only launcher flags (`cache_disabled`, logging/publication, TLS, and CA-path flags), so the master-generated Argo golden does not match otherwise-equivalent release output. No runtime semantics were changed for this adjustment.

Pins API generation Makefiles to `ghcr.io/kubeflow/kfp-api-generator:release-2.17`. The previous mutable `:master` tag now uses protoc-gen-go v1.36.12, go-swagger v0.36.4, and Go 1.27, which rewrites hundreds of release-2.17 generated files. The release image matches the branch's committed toolchain: protoc-gen-go v1.36.11, go-swagger v0.32.3, and Go 1.26.2.

## Tests

- `go test ./backend/src/v2/driver ./backend/src/v2/component`
- `go test ./backend/test/compiler -ginkgo.focus='container_with_if_placeholder_default.yaml' -ginkgo.v`
- Focused SDK 2.17.0 fixture compilation in a `uv` Python 3.11 environment, diffed against `test_data/sdk_compiled_pipelines/valid/container_with_if_placeholder_default.yaml`
- Regenerated API, backend API, and Kubernetes platform outputs with the release-2.17 generator image; `make check-diff`

This PR contains only the cherry-pick/backport stage for 2.17.1; it does not perform version bumps, tagging, publication, or release creation.