### PR TITLE
fix(backend): add service account authorization for runs and recurring runs

### DIFF
--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -30,6 +30,7 @@ const (
 	PodNamespace                            string = "POD_NAMESPACE"
 	CacheEnabled                            string = "CacheEnabled"
 	DefaultPipelineRunnerServiceAccountFlag string = "DEFAULTPIPELINERUNNERSERVICEACCOUNT"
+	AllowedServiceAccountsFlag              string = "ALLOWEDSERVICEACCOUNTS"
 	KubeflowUserIDHeader                    string = "KUBEFLOW_USERID_HEADER"
 	KubeflowUserIDPrefix                    string = "KUBEFLOW_USERID_PREFIX"
 	UpdatePipelineVersionByDefault          string = "AUTO_UPDATE_PIPELINE_DEFAULT_VERSION"
@@ -328,4 +329,25 @@ func GetRunsGCBatchSize() int {
 		return 1000
 	}
 	return configuredBatchSize
+}
+
+func ValidateServiceAccountAllowList(serviceAccount string) error {
+	if serviceAccount == "" {
+		return nil
+	}
+	defaultServiceAccount := GetStringConfigWithDefault(DefaultPipelineRunnerServiceAccountFlag, DefaultPipelineRunnerServiceAccount)
+	if serviceAccount == defaultServiceAccount {
+		return nil
+	}
+
+	allowedServiceAccounts := GetStringConfigWithDefault(AllowedServiceAccountsFlag, "")
+	if allowedServiceAccounts == "" {
+		return fmt.Errorf("service account %q is not allowed; contact your administrator to configure the allowed service accounts", serviceAccount)
+	}
+	for allowed := range strings.SplitSeq(allowedServiceAccounts, ",") {
+		if strings.TrimSpace(allowed) == serviceAccount {
+			return nil
+		}
+	}
+	return fmt.Errorf("service account %q is not allowed; contact your administrator to configure the allowed service accounts", serviceAccount)
 }

--- a/backend/src/apiserver/common/config_test.go
+++ b/backend/src/apiserver/common/config_test.go
@@ -847,3 +847,67 @@ func TestGetPluginLimitsConfigConflictingSourceUsesGetterContract(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, 9, limits.MaxKeys)
 }
+
+func TestValidateServiceAccountAllowList_AllowedSA(t *testing.T) {
+	viper.Reset()
+	viper.Set(AllowedServiceAccountsFlag, "custom-sa")
+	err := ValidateServiceAccountAllowList("custom-sa")
+	assert.Nil(t, err)
+}
+
+func TestValidateServiceAccountAllowList_DisallowedSA(t *testing.T) {
+	viper.Reset()
+	viper.Set(AllowedServiceAccountsFlag, "other-sa")
+	err := ValidateServiceAccountAllowList("evil-sa")
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+}
+
+func TestValidateServiceAccountAllowList_DefaultAlwaysAllowed(t *testing.T) {
+	viper.Reset()
+	err := ValidateServiceAccountAllowList(DefaultPipelineRunnerServiceAccount)
+	assert.Nil(t, err)
+}
+
+func TestValidateServiceAccountAllowList_EmptyListRejectsCustom(t *testing.T) {
+	viper.Reset()
+	err := ValidateServiceAccountAllowList("custom-sa")
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+}
+
+func TestValidateServiceAccountAllowList_MultipleSAs(t *testing.T) {
+	viper.Reset()
+	viper.Set(AllowedServiceAccountsFlag, "sa1,sa2,sa3")
+	err := ValidateServiceAccountAllowList("sa2")
+	assert.Nil(t, err)
+}
+
+func TestValidateServiceAccountAllowList_WhitespaceTrimming(t *testing.T) {
+	viper.Reset()
+	viper.Set(AllowedServiceAccountsFlag, " sa1 , sa2 ")
+	err := ValidateServiceAccountAllowList("sa1")
+	assert.Nil(t, err)
+}
+
+func TestValidateServiceAccountAllowList_EmptyStringAllowed(t *testing.T) {
+	viper.Reset()
+	err := ValidateServiceAccountAllowList("")
+	assert.Nil(t, err)
+}
+
+func TestValidateServiceAccountAllowList_ErrorDoesNotLeakAllowList(t *testing.T) {
+	viper.Reset()
+	viper.Set(AllowedServiceAccountsFlag, "secret-sa-1,secret-sa-2")
+	err := ValidateServiceAccountAllowList("evil-sa")
+	require.NotNil(t, err)
+	assert.NotContains(t, err.Error(), "secret-sa-1")
+	assert.NotContains(t, err.Error(), "secret-sa-2")
+}
+
+func TestValidateServiceAccountAllowList_ConfiguredDefaultAllowed(t *testing.T) {
+	viper.Reset()
+	viper.Set(DefaultPipelineRunnerServiceAccountFlag, "my-runner")
+	err := ValidateServiceAccountAllowList("my-runner")
+	assert.Nil(t, err)
+}

--- a/backend/src/apiserver/common/const.go
+++ b/backend/src/apiserver/common/const.go
@@ -42,6 +42,7 @@ const (
 	RbacResourceVerbReportMetrics = "reportMetrics"
 	RbacResourceVerbReadArtifact  = "readArtifact"
 	RbacResourceVerbReport        = "report"
+	RbacResourceVerbUse           = "use"
 )
 
 const (

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -704,6 +704,10 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		executionSpec.SetCannonicalLabels(swf.Name, run.CreatedAtInSec, nextIndex)
 	}
 
+	if err := r.authorizeServiceAccount(ctx, executionSpec.ServiceAccount(), k8sNamespace); err != nil {
+		return nil, util.Wrap(err, "Failed to create a run due to service account authorization error")
+	}
+
 	// Run plugin lifecycle hooks before workflow creation.
 	pendingRun := &apiserverPlugins.PendingRun{
 		RunID:             run.UUID,
@@ -1525,13 +1529,14 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 			return nil, util.Wrap(err, "Failed to fetch a template with an invalid pipeline spec manifest")
 		}
 
-		if v2Tmpl, ok := tmpl.(*template.V2Spec); ok {
-			err = v2Tmpl.ValidateJobInputs(job)
-		} else {
-			_, err = tmpl.ScheduledWorkflow(job)
-		}
+		validatedScheduledWorkflow, err := tmpl.ScheduledWorkflow(job)
 		if err != nil {
 			return nil, util.Wrap(err, "Failed to validate the input parameters on the latest pipeline version")
+		}
+		if v2Tmpl, ok := tmpl.(*template.V2Spec); ok {
+			if err = v2Tmpl.ValidateJobInputs(job); err != nil {
+				return nil, util.Wrap(err, "Failed to validate the input parameters on the latest pipeline version")
+			}
 		}
 
 		scheduledWorkflow, err = template.NewGenericScheduledWorkflow(job)
@@ -1547,10 +1552,19 @@ func (r *ResourceManager) CreateJob(ctx context.Context, job *model.Job) (*model
 		scheduledWorkflow.Spec.Workflow = &scheduledworkflow.WorkflowResource{
 			Parameters: parameters, PipelineRoot: string(job.PipelineRoot),
 		}
+		scheduledWorkflow.Spec.ServiceAccount = validatedScheduledWorkflow.Spec.ServiceAccount
 	}
 
 	if tmpl != nil && util.IsV1PipelinesBlocked(k8sNamespace) && tmpl.GetTemplateType() == template.V1 {
 		return nil, util.NewInvalidInputError("Namespace %s is not allowed to run v1 pipelines. Please migrate to using KFP V2 pipelines.", k8sNamespace)
+	}
+
+	resolvedJobServiceAccount := scheduledWorkflow.Spec.ServiceAccount
+	if resolvedJobServiceAccount == "" {
+		resolvedJobServiceAccount = job.ServiceAccount
+	}
+	if err := r.authorizeServiceAccount(ctx, resolvedJobServiceAccount, k8sNamespace); err != nil {
+		return nil, util.Wrap(err, "Failed to create a recurring run due to service account authorization error")
 	}
 
 	newScheduledWorkflow, err := r.getScheduledWorkflowClient(k8sNamespace).Create(ctx, scheduledWorkflow)
@@ -2791,4 +2805,23 @@ func (r *ResourceManager) GetTask(taskId string) (*model.Task, error) {
 		return nil, util.Wrapf(err, "Failed to fetch task %v", taskId)
 	}
 	return task, nil
+}
+
+func (r *ResourceManager) authorizeServiceAccount(ctx context.Context, serviceAccount, namespace string) error {
+	if serviceAccount == "" {
+		return nil
+	}
+	if err := common.ValidateServiceAccountAllowList(serviceAccount); err != nil {
+		return util.NewInvalidInputError("%s", err)
+	}
+	defaultServiceAccount := common.GetStringConfigWithDefault(common.DefaultPipelineRunnerServiceAccountFlag, common.DefaultPipelineRunnerServiceAccount)
+	if serviceAccount == defaultServiceAccount {
+		return nil
+	}
+	return r.IsAuthorized(ctx, &authorizationv1.ResourceAttributes{
+		Verb:      common.RbacResourceVerbUse,
+		Namespace: namespace,
+		Resource:  "serviceaccounts",
+		Name:      serviceAccount,
+	})
 }

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -51,6 +51,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	authzv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2524,6 +2526,8 @@ func TestCreateRun_ThroughWorkflowSpecSameManifest(t *testing.T) {
 }
 
 func TestCreateRun_ThroughPipelineVersion(t *testing.T) {
+	viper.Set(common.AllowedServiceAccountsFlag, "sa1")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
 	// Create experiment, pipeline, and pipeline version.
 	store, manager, experiment, pipeline, _ := initWithExperimentAndPipeline(t)
 	defer store.Close()
@@ -2603,6 +2607,8 @@ func TestCreateRun_ThroughPipelineVersion(t *testing.T) {
 }
 
 func TestCreateRun_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
+	viper.Set(common.AllowedServiceAccountsFlag, "sa1")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
 	// Create experiment, pipeline, and pipeline version.
 	store, manager, experiment, pipeline, _ := initWithExperimentAndPipeline(t)
 	defer store.Close()
@@ -6302,4 +6308,588 @@ func TestReportWorkflowResource_RunStoreErrorFailsClosedBeforeDeletion(t *testin
 	// have gone through and be visible here.
 	_, err = store.ExecClientFake.Execution("ns1").Get(context.Background(), run.K8SName, v1.GetOptions{})
 	assert.Nil(t, err, "the workflow must not be deleted when the run-store read fails")
+}
+
+// --- ServiceAccount SAR authorization tests ---
+
+func multiUserContext() context.Context {
+	md := metadata.New(map[string]string{common.GoogleIAPUserIdentityHeader: common.GoogleIAPUserIdentityPrefix + "user@google.com"})
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+func initWithExperimentAndUnauthorizedSAR(t *testing.T) (*FakeClientManager, *ResourceManager, *model.Experiment) {
+	initEnvVars()
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	store.SubjectAccessReviewClientFake = client.NewFakeSubjectAccessReviewClientUnauthorized()
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	apiExperiment := &model.Experiment{Name: "e1", Namespace: "ns1"}
+	experiment, err := manager.CreateExperiment(apiExperiment)
+	require.Nil(t, err)
+	return store, manager, experiment
+}
+
+func TestCreateRun_ServiceAccountSAR_MultiUserUnauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	_, err := manager.CreateRun(multiUserContext(), apiRun)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+}
+
+func TestCreateRun_ServiceAccountSAR_MultiUserAuthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	_, manager, experiment := initWithExperiment(t)
+
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	run, err := manager.CreateRun(multiUserContext(), apiRun)
+	require.Nil(t, err)
+	assert.Equal(t, "custom-sa", run.ServiceAccount)
+}
+
+func TestCreateRun_ServiceAccountSAR_SingleUserSkipped(t *testing.T) {
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	run, err := manager.CreateRun(context.Background(), apiRun)
+	require.Nil(t, err)
+	assert.Equal(t, "custom-sa", run.ServiceAccount)
+}
+
+func TestCreateRun_ServiceAccountSAR_DefaultSASkipped(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+		ExperimentId: experiment.UUID,
+	}
+	run, err := manager.CreateRun(multiUserContext(), apiRun)
+	require.Nil(t, err)
+	assert.Equal(t, common.DefaultPipelineRunnerServiceAccount, run.ServiceAccount)
+}
+
+func TestCreateJob_ServiceAccountSAR_MultiUserUnauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	_, err := manager.CreateJob(multiUserContext(), job)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+}
+
+func TestCreateJob_ServiceAccountSAR_MultiUserAuthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	_, manager, experiment := initWithExperiment(t)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	createdJob, err := manager.CreateJob(multiUserContext(), job)
+	require.Nil(t, err)
+	assert.Equal(t, "custom-sa", createdJob.ServiceAccount)
+}
+
+func TestCreateJob_ServiceAccountSAR_SingleUserSkipped(t *testing.T) {
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	createdJob, err := manager.CreateJob(context.Background(), job)
+	require.Nil(t, err)
+	assert.Equal(t, "custom-sa", createdJob.ServiceAccount)
+}
+
+func TestCreateJob_ServiceAccountSAR_DefaultSASkipped(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+		},
+		ExperimentId: experiment.UUID,
+	}
+	createdJob, err := manager.CreateJob(multiUserContext(), job)
+	assert.Nil(t, err)
+	assert.NotNil(t, createdJob)
+}
+
+// --- V2 pipeline spec SAR tests ---
+
+func TestCreateRun_ServiceAccountSAR_V2Spec_MultiUserUnauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			PipelineSpecManifest: model.LargeText(v2SpecHelloWorld),
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters: "{\"text\":\"world\"}",
+			},
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	_, err := manager.CreateRun(multiUserContext(), apiRun)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+}
+
+func TestCreateJob_ServiceAccountSAR_V2Spec_MultiUserUnauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			PipelineSpecManifest: model.LargeText(v2SpecHelloWorld),
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters:   "{\"text\":\"world\"}",
+				PipelineRoot: "job-1-root",
+			},
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	_, err := manager.CreateJob(multiUserContext(), job)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+}
+
+// --- Confused deputy: privileged SA name ---
+
+func TestCreateRun_ServiceAccountSAR_ConfusedDeputy_PrivilegedSA(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "ds-pipeline-dspa",
+	}
+	_, err := manager.CreateRun(multiUserContext(), apiRun)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+}
+
+func TestCreateJob_ServiceAccountSAR_ConfusedDeputy_PrivilegedSA(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "ds-pipeline-dspa",
+	}
+	_, err := manager.CreateJob(multiUserContext(), job)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+}
+
+// --- SAR ResourceAttributes verification ---
+
+type capturingSARClient struct {
+	lastReview *authzv1.SubjectAccessReview
+}
+
+func (c *capturingSARClient) Create(_ context.Context, sar *authzv1.SubjectAccessReview, _ v1.CreateOptions) (*authzv1.SubjectAccessReview, error) {
+	c.lastReview = sar
+	return &authzv1.SubjectAccessReview{Status: authzv1.SubjectAccessReviewStatus{Allowed: true}}, nil
+}
+
+func initWithExperimentAndCapturingSAR(t *testing.T) (*FakeClientManager, *ResourceManager, *model.Experiment, *capturingSARClient) {
+	initEnvVars()
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	capturingClient := &capturingSARClient{}
+	store.SubjectAccessReviewClientFake = capturingClient
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	apiExperiment := &model.Experiment{Name: "e1", Namespace: "ns1"}
+	experiment, err := manager.CreateExperiment(apiExperiment)
+	require.Nil(t, err)
+	return store, manager, experiment, capturingClient
+}
+
+func TestCreateRun_ServiceAccountSAR_CorrectResourceAttributes(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "my-special-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	_, manager, experiment, capturingClient := initWithExperimentAndCapturingSAR(t)
+
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "my-special-sa",
+	}
+	_, err := manager.CreateRun(multiUserContext(), apiRun)
+	require.Nil(t, err)
+
+	require.NotNil(t, capturingClient.lastReview)
+	attrs := capturingClient.lastReview.Spec.ResourceAttributes
+	assert.Equal(t, common.RbacResourceVerbUse, attrs.Verb)
+	assert.Equal(t, "serviceaccounts", attrs.Resource)
+	assert.Equal(t, "my-special-sa", attrs.Name)
+	assert.Equal(t, "ns1", attrs.Namespace)
+}
+
+// --- CreateJob allowlist bypass tests ---
+
+func TestCreateJob_PipelineIdOnly_DisallowedSA_Rejected(t *testing.T) {
+	initEnvVars()
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+
+	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "e1", Namespace: "ns1"})
+	require.Nil(t, err)
+
+	p, _ := manager.CreatePipeline(createPipeline("p1", "", "ns1"))
+	pv := createPipelineVersion(
+		p.UUID, "p1/v1", "v1", "",
+		v2SpecHelloWorld,
+		"", "ns1",
+	)
+	_, err = manager.CreatePipelineVersion(pv)
+	require.Nil(t, err)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			PipelineId: p.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters: "{\"text\":\"world\"}",
+			},
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "disallowed-sa",
+	}
+	_, err = manager.CreateJob(context.Background(), job)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
+}
+
+func TestCreateJob_PipelineIdOnly_AllowedSA_Succeeds(t *testing.T) {
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+	initEnvVars()
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+
+	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "e1", Namespace: "ns1"})
+	require.Nil(t, err)
+
+	p, _ := manager.CreatePipeline(createPipeline("p1", "", "ns1"))
+	pv := createPipelineVersion(p.UUID, "p1/v1", "v1", "", v2SpecHelloWorld, "", "ns1")
+	_, err = manager.CreatePipelineVersion(pv)
+	require.Nil(t, err)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			PipelineId: p.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters: "{\"text\":\"world\"}",
+			},
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	createdJob, err := manager.CreateJob(context.Background(), job)
+	require.Nil(t, err)
+	assert.Equal(t, "custom-sa", createdJob.ServiceAccount)
+}
+
+func TestCreateJob_PipelineIdOnly_SAR_MultiUserUnauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	initEnvVars()
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	store.SubjectAccessReviewClientFake = client.NewFakeSubjectAccessReviewClientUnauthorized()
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+
+	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "e1", Namespace: "ns1"})
+	require.Nil(t, err)
+
+	p, _ := manager.CreatePipeline(createPipeline("p1", "", "ns1"))
+	pv := createPipelineVersion(p.UUID, "p1/v1", "v1", "", v2SpecHelloWorld, "", "ns1")
+	_, err = manager.CreatePipelineVersion(pv)
+	require.Nil(t, err)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			PipelineId: p.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters: "{\"text\":\"world\"}",
+			},
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	_, err = manager.CreateJob(multiUserContext(), job)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+}
+
+func TestCreateJob_ServiceAccountSAR_CorrectResourceAttributes(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "my-special-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	_, manager, experiment, capturingClient := initWithExperimentAndCapturingSAR(t)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "my-special-sa",
+	}
+	_, err := manager.CreateJob(multiUserContext(), job)
+	require.Nil(t, err)
+
+	require.NotNil(t, capturingClient.lastReview)
+	attrs := capturingClient.lastReview.Spec.ResourceAttributes
+	assert.Equal(t, common.RbacResourceVerbUse, attrs.Verb)
+	assert.Equal(t, "serviceaccounts", attrs.Resource)
+	assert.Equal(t, "my-special-sa", attrs.Name)
+	assert.Equal(t, "ns1", attrs.Namespace)
+}
+
+func TestCreateRun_ServiceAccountSAR_DefaultSA_NotCalled(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	_, manager, experiment, capturingClient := initWithExperimentAndCapturingSAR(t)
+
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+		ExperimentId: experiment.UUID,
+	}
+	run, err := manager.CreateRun(multiUserContext(), apiRun)
+	require.Nil(t, err)
+	assert.Equal(t, common.DefaultPipelineRunnerServiceAccount, run.ServiceAccount)
+	assert.Nil(t, capturingClient.lastReview)
+}
+
+// --- PipelineVersionId path SA authorization ---
+
+func TestCreateJob_PipelineVersionId_SAR_MultiUserUnauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	initEnvVars()
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	store.SubjectAccessReviewClientFake = client.NewFakeSubjectAccessReviewClientUnauthorized()
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+
+	experiment, err := manager.CreateExperiment(&model.Experiment{Name: "e1", Namespace: "ns1"})
+	require.Nil(t, err)
+
+	p, _ := manager.CreatePipeline(createPipeline("p1", "", "ns1"))
+	pv := createPipelineVersion(p.UUID, "p1/v1", "v1", "", v2SpecHelloWorld, "", "ns1")
+	version, err := manager.CreatePipelineVersion(pv)
+	require.Nil(t, err)
+
+	job := &model.Job{
+		DisplayName: "j1",
+		Enabled:     true,
+		PipelineSpec: model.PipelineSpec{
+			PipelineVersionId: version.UUID,
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters:   "{\"text\":\"world\"}",
+				PipelineRoot: "job-1-root",
+			},
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	_, err = manager.CreateJob(multiUserContext(), job)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Unauthorized")
+}
+
+// --- Unauthorized request must not create k8s resources ---
+
+func TestCreateRun_ServiceAccountSAR_Unauthorized_NoWorkflowCreated(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+	viper.Set(common.AllowedServiceAccountsFlag, "custom-sa")
+	defer viper.Set(common.AllowedServiceAccountsFlag, "")
+
+	store, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+		ExperimentId:   experiment.UUID,
+		ServiceAccount: "custom-sa",
+	}
+	_, err := manager.CreateRun(multiUserContext(), apiRun)
+	require.NotNil(t, err)
+	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowCount(), "no Workflow CRD should be created when SA authorization fails")
+}
+
+// --- SA embedded in workflow spec ---
+
+func TestCreateRun_ServiceAccountSAR_EmbeddedSA_Unauthorized(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	defer viper.Set(common.MultiUserMode, "false")
+
+	_, manager, experiment := initWithExperimentAndUnauthorizedSAR(t)
+
+	workflowWithEmbeddedSA := util.NewWorkflow(&v1alpha1.Workflow{
+		TypeMeta:   v1.TypeMeta{APIVersion: "argoproj.io/v1alpha1", Kind: "Workflow"},
+		ObjectMeta: v1.ObjectMeta{Name: "workflow-name", UID: "workflow1", Namespace: "ns1"},
+		Spec: v1alpha1.WorkflowSpec{
+			Entrypoint:         "testy",
+			ServiceAccountName: "evil-sa",
+			Templates: []v1alpha1.Template{{
+				Name: "testy",
+				Container: &corev1.Container{
+					Image:   "docker/whalesay",
+					Command: []string{"cowsay"},
+					Args:    []string{"hello world"},
+				},
+			}},
+			Arguments: v1alpha1.Arguments{Parameters: []v1alpha1.Parameter{{Name: "param1"}}},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(workflowWithEmbeddedSA.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+		ExperimentId: experiment.UUID,
+	}
+	_, err := manager.CreateRun(multiUserContext(), apiRun)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "not allowed")
 }

--- a/backend/src/apiserver/template/template_test.go
+++ b/backend/src/apiserver/template/template_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	commonutil "github.com/kubeflow/pipelines/backend/src/common/util"
 	scheduledworkflow "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -794,6 +795,30 @@ func TestSetDefaultServiceAccount_EmptyFallsToConfig(t *testing.T) {
 	setDefaultServiceAccount(wf, "")
 	// When no SA is set on workflow and empty is passed, it falls back to config default.
 	assert.Equal(t, common.DefaultPipelineRunnerServiceAccount, wf.ServiceAccount())
+}
+
+func TestSetDefaultServiceAccount_DefaultSAPreserved(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+	wf := util.NewWorkflow(unmarshalWf(awfTemplate))
+	setDefaultServiceAccount(wf, common.DefaultPipelineRunnerServiceAccount)
+	assert.Equal(t, common.DefaultPipelineRunnerServiceAccount, wf.ServiceAccount())
+}
+
+func TestSetDefaultServiceAccount_WorkflowEmbeddedSAPreserved(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+	wf := util.NewWorkflow(unmarshalWf(awfTemplate))
+	wf.SetServiceAccount("custom-sa")
+	setDefaultServiceAccount(wf, "")
+	assert.Equal(t, "custom-sa", wf.ServiceAccount())
+}
+
+func TestSetDefaultServiceAccount_ConfiguredDefaultApplied(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+	viper.Set(common.DefaultPipelineRunnerServiceAccountFlag, "my-custom-runner")
+	defer viper.Set(common.DefaultPipelineRunnerServiceAccountFlag, "")
+	wf := util.NewWorkflow(unmarshalWf(awfTemplate))
+	setDefaultServiceAccount(wf, "")
+	assert.Equal(t, "my-custom-runner", wf.ServiceAccount())
 }
 
 // --- validatePipelineJobInputs tests ---


### PR DESCRIPTION
## Summary

- Adds two-layer ServiceAccount authorization to prevent confused deputy attacks when creating runs and recurring runs
- Allow-list validation via `ALLOWEDSERVICEACCOUNTS` env var restricts which service accounts can be specified
- SubjectAccessReview check verifies the caller has "use" permission on the requested serviceaccount in multi-user mode
- Fixes a bug in CreateJob's PipelineId-only path where the `ScheduledWorkflow()` return value was discarded, losing the resolved ServiceAccount

## Breaking change

After this change, specifying a non-default ServiceAccount on run or recurring run creation requires the SA to be listed in the `ALLOWEDSERVICEACCOUNTS` configuration. In multi-user mode, the caller must also have `use` permission on the serviceaccount resource via SubjectAccessReview. Requests using unlisted service accounts will be rejected.