### PR TITLE
feat(backend): add KFP launcher ConfigMap volume and mount support #14180

### DIFF
--- a/backend/src/v2/compiler/argocompiler/common.go
+++ b/backend/src/v2/compiler/argocompiler/common.go
@@ -20,12 +20,14 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/kubeflow/pipelines/backend/src/v2/component"
+	"github.com/kubeflow/pipelines/backend/src/v2/config"
 	k8score "k8s.io/api/core/v1"
 )
 
 const (
-	MLPipelineTLSEnabledEnvVar  = "ML_PIPELINE_TLS_ENABLED"
-	DefaultMLPipelineTLSEnabled = false
+	MLPipelineTLSEnabledEnvVar     = "ML_PIPELINE_TLS_ENABLED"
+	DefaultMLPipelineTLSEnabled    = false
+	volumeNameKFPLauncherConfigMap = "kfp-launcher-config"
 )
 
 // env vars in metadata-grpc-configmap is defined in component package
@@ -73,6 +75,27 @@ func setRuntimeRole(tmpl *wfapi.Template, role util.ExecutionRuntimeRole) {
 		tmpl.Metadata.Annotations = make(map[string]string)
 	}
 	tmpl.Metadata.Annotations[util.AnnotationKeyRuntimeRole] = string(role)
+}
+
+func ConfigureKFPLauncherConfigMap(tmpl *wfapi.Template) {
+	optional := true
+	tmpl.Volumes = append(tmpl.Volumes, k8score.Volume{
+		Name: volumeNameKFPLauncherConfigMap,
+		VolumeSource: k8score.VolumeSource{
+			ConfigMap: &k8score.ConfigMapVolumeSource{
+				LocalObjectReference: k8score.LocalObjectReference{
+					Name: config.KFPLauncherConfigMapName,
+				},
+				Optional: &optional,
+			},
+		},
+	})
+
+	tmpl.Container.VolumeMounts = append(tmpl.Container.VolumeMounts, k8score.VolumeMount{
+		Name:      volumeNameKFPLauncherConfigMap,
+		MountPath: config.KFPLauncherConfigMountPath,
+		ReadOnly:  true,
+	})
 }
 
 // ConfigureCustomCABundle adds CABundle environment variables and volume mounts if CABUNDLE_SECRET_NAME is set.

--- a/backend/src/v2/compiler/argocompiler/container.go
+++ b/backend/src/v2/compiler/argocompiler/container.go
@@ -571,6 +571,7 @@ func (c *workflowCompiler) addContainerExecutorTemplate(task *pipelinespec.Pipel
 			Env:     commonEnvs,
 		},
 	}
+	ConfigureKFPLauncherConfigMap(executor)
 	setRuntimeRole(executor, util.ExecutionRuntimeRoleLauncher)
 	// If CABUNDLE_SECRET_NAME or CABUNDLE_CONFIGMAP_NAME is set, add the custom CA bundle to the executor.
 	if common.GetCaBundleSecretName() != "" || common.GetCaBundleConfigMapName() != "" {

--- a/backend/src/v2/compiler/argocompiler/container_test.go
+++ b/backend/src/v2/compiler/argocompiler/container_test.go
@@ -20,10 +20,44 @@ import (
 	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/config/proxy"
+	"github.com/kubeflow/pipelines/backend/src/v2/config"
 	"github.com/kubeflow/pipelines/kubernetes_platform/go/kubernetesplatform"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func assertKFPLauncherConfigMapMounted(t *testing.T, tmpl *wfapi.Template) {
+	t.Helper()
+
+	require.NotNil(t, tmpl)
+	require.NotNil(t, tmpl.Container)
+
+	var foundVolume bool
+	for _, volume := range tmpl.Volumes {
+		if volume.Name != volumeNameKFPLauncherConfigMap {
+			continue
+		}
+		foundVolume = true
+		require.NotNil(t, volume.ConfigMap)
+		assert.Equal(t, config.KFPLauncherConfigMapName, volume.ConfigMap.Name)
+		require.NotNil(t, volume.ConfigMap.Optional)
+		assert.True(t, *volume.ConfigMap.Optional)
+		break
+	}
+	assert.True(t, foundVolume, "template should include kfp-launcher ConfigMap volume")
+
+	var foundMount bool
+	for _, mount := range tmpl.Container.VolumeMounts {
+		if mount.Name != volumeNameKFPLauncherConfigMap {
+			continue
+		}
+		foundMount = true
+		assert.Equal(t, config.KFPLauncherConfigMountPath, mount.MountPath)
+		assert.True(t, mount.ReadOnly)
+		break
+	}
+	assert.True(t, foundMount, "template should mount kfp-launcher ConfigMap volume")
+}
 
 func TestAddContainerExecutorTemplate(t *testing.T) {
 	tests := []struct {
@@ -68,6 +102,22 @@ func TestAddContainerExecutorTemplate(t *testing.T) {
 		})
 	}
 
+}
+
+func TestContainerExecutorTemplate_IncludesKFPLauncherConfigMapVolumeMount(t *testing.T) {
+	c := &workflowCompiler{
+		templates: make(map[string]*wfapi.Template),
+		wf: &wfapi.Workflow{
+			Spec: wfapi.WorkflowSpec{
+				Templates: []wfapi.Template{},
+			},
+		},
+	}
+
+	c.addContainerExecutorTemplate(&pipelinespec.PipelineTaskSpec{ComponentRef: &pipelinespec.ComponentRef{Name: "comp-test-ref"}}, &kubernetesplatform.KubernetesExecutorConfig{})
+	tmpl, exists := c.templates["system-container-impl"]
+	require.True(t, exists, "container implementation template should exist")
+	assertKFPLauncherConfigMapMounted(t, tmpl)
 }
 
 func TestContainerDriverTemplate_IncludesKFPPodNameEnv(t *testing.T) {

--- a/backend/src/v2/compiler/argocompiler/dag.go
+++ b/backend/src/v2/compiler/argocompiler/dag.go
@@ -638,6 +638,7 @@ func (c *workflowCompiler) addDAGDriverTemplate() string {
 			Env:       proxy.GetConfig().GetEnvVars(),
 		},
 	}
+	ConfigureKFPLauncherConfigMap(template)
 	setRuntimeRole(template, util.ExecutionRuntimeRoleDriver)
 	applySecurityContextToTemplate(template)
 

--- a/backend/src/v2/compiler/argocompiler/dag_test.go
+++ b/backend/src/v2/compiler/argocompiler/dag_test.go
@@ -185,3 +185,29 @@ func TestDAGDriverTemplate_IncludesPipelineJobCreateTimeArg(t *testing.T) {
 	assert.Contains(t, tmpl.Container.Args, "--pipeline_job_create_time_utc")
 	assert.Contains(t, tmpl.Container.Args, runCreationTimeUTC())
 }
+
+func TestDAGDriverTemplate_IncludesKFPLauncherConfigMapVolumeMount(t *testing.T) {
+	proxy.InitializeConfigWithEmptyForTests()
+
+	c := &workflowCompiler{
+		templates: make(map[string]*wfapi.Template),
+		wf: &wfapi.Workflow{
+			Spec: wfapi.WorkflowSpec{
+				Templates: []wfapi.Template{},
+			},
+		},
+		spec: &pipelinespec.PipelineSpec{
+			PipelineInfo: &pipelinespec.PipelineInfo{
+				Name: "test-pipeline",
+			},
+		},
+		job: &pipelinespec.PipelineJob{
+			DisplayName: "test-pipeline-run",
+		},
+	}
+
+	name := c.addDAGDriverTemplate()
+	tmpl, exists := c.templates[name]
+	require.True(t, exists, "system-dag-driver template should exist")
+	assertKFPLauncherConfigMapMounted(t, tmpl)
+}

--- a/backend/src/v2/compiler/argocompiler/importer.go
+++ b/backend/src/v2/compiler/argocompiler/importer.go
@@ -142,6 +142,7 @@ func (c *workflowCompiler) addImporterTemplate(downloadToWorkspace bool) string 
 		Volumes: volumes,
 	}
 
+	ConfigureKFPLauncherConfigMap(importerTemplate)
 	setRuntimeRole(importerTemplate, util.ExecutionRuntimeRoleLauncher)
 	// If TLS is enabled (apiserver or metadata), add the custom CA bundle to the importer template.
 	if setCABundle {

--- a/backend/src/v2/compiler/argocompiler/importer_test.go
+++ b/backend/src/v2/compiler/argocompiler/importer_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package argocompiler
+
+import (
+	"testing"
+
+	wfapi "github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
+	"github.com/kubeflow/pipelines/api/v2alpha1/go/pipelinespec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImporterTemplate_IncludesKFPLauncherConfigMapVolumeMount(t *testing.T) {
+	c := &workflowCompiler{
+		templates: make(map[string]*wfapi.Template),
+		wf: &wfapi.Workflow{
+			Spec: wfapi.WorkflowSpec{
+				Templates: []wfapi.Template{},
+			},
+		},
+		spec: &pipelinespec.PipelineSpec{
+			PipelineInfo: &pipelinespec.PipelineInfo{
+				Name: "test-pipeline",
+			},
+		},
+	}
+
+	name := c.addImporterTemplate(false)
+	tmpl, exists := c.templates[name]
+	require.True(t, exists, "system-importer template should exist")
+	assertKFPLauncherConfigMapMounted(t, tmpl)
+}

--- a/backend/src/v2/component/importer_launcher.go
+++ b/backend/src/v2/component/importer_launcher.go
@@ -327,8 +327,8 @@ func (l *ImportLauncher) resolveBucketConfigForURI(ctx context.Context, uri stri
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse bucket config while resolving uri %q: %w", uri, err)
 	}
-	// Resolve and attach session info from kfp-launcher config for the artifact provider
-	if cfg, err := config.FromConfigMap(ctx, l.k8sClient, l.launcherV2Options.Namespace); err != nil {
+	// Resolve and attach session info from kfp-launcher config for the artifact provider.
+	if cfg, err := config.FromConfigMapVolume(config.KFPLauncherConfigMountPath); err != nil {
 		glog.Warningf("failed to load launcher config while resolving bucket config: %v", err)
 	} else if cfg != nil {
 		if sess, err := cfg.GetStoreSessionInfo(uri); err != nil {

--- a/backend/src/v2/config/env.go
+++ b/backend/src/v2/config/env.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -34,7 +35,10 @@ import (
 )
 
 const (
-	configMapName                = "kfp-launcher"
+	KFPLauncherConfigMapName   = "kfp-launcher"
+	KFPLauncherConfigMountPath = "/etc/kfp-launcher-config"
+
+	configMapName                = KFPLauncherConfigMapName
 	defaultPipelineRoot          = "minio://mlpipeline/v2/artifacts"
 	configKeyDefaultPipelineRoot = "defaultPipelineRoot"
 	configBucketProviders        = "providers"
@@ -66,6 +70,31 @@ type Config struct {
 type ServerConfig struct {
 	Address string
 	Port    string
+}
+
+// FromConfigMapVolume loads config from a mounted kfp-launcher ConfigMap volume.
+func FromConfigMapVolume(path string) (*Config, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			glog.Infof("cannot find launcher configmap volume: path=%q, will use default config", path)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read launcher configmap volume %q: %w", path, err)
+	}
+
+	data := make(map[string]string)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		value, err := os.ReadFile(filepath.Join(path, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read launcher configmap volume key %q: %w", entry.Name(), err)
+		}
+		data[entry.Name()] = string(value)
+	}
+	return &Config{data: data}, nil
 }
 
 // FromConfigMap loads config from a kfp-launcher Kubernetes config map.

--- a/backend/src/v2/config/env_test.go
+++ b/backend/src/v2/config/env_test.go
@@ -17,6 +17,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kubeflow/pipelines/backend/src/v2/objectstore"
@@ -50,6 +51,28 @@ func Test_getDefaultMinioSessionInfo(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedDefaultSession, actualDefaultSession)
+}
+
+func TestFromConfigMapVolume(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, configKeyDefaultPipelineRoot), []byte("s3://bucket/pipelines"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, configBucketProviders), []byte("s3:\n  default:\n    fromEnv: true\n"), 0600))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "ignored-dir"), 0700))
+
+	cfg, err := FromConfigMapVolume(dir)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.Equal(t, "s3://bucket/pipelines", cfg.data[configKeyDefaultPipelineRoot])
+	assert.Equal(t, "s3:\n  default:\n    fromEnv: true\n", cfg.data[configBucketProviders])
+	assert.NotContains(t, cfg.data, "ignored-dir")
+}
+
+func TestFromConfigMapVolume_MissingPath(t *testing.T) {
+	cfg, err := FromConfigMapVolume(filepath.Join(t.TempDir(), "missing"))
+
+	require.NoError(t, err)
+	assert.Nil(t, cfg)
 }
 
 func TestGetBucketSessionInfo(t *testing.T) {

--- a/backend/src/v2/driver/root_dag.go
+++ b/backend/src/v2/driver/root_dag.go
@@ -96,11 +96,7 @@ func RootDAG(ctx context.Context, opts Options, mlmd metadata.ClientInterface) (
 	// TODO(v2): in pipeline spec, rename GCS output directory to pipeline root.
 	pipelineRoot := opts.RuntimeConfig.GetGcsOutputDirectory()
 
-	k8sClient, err := buildK8sClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize kubernetes client set: %w", err)
-	}
-	cfg, err := config.FromConfigMap(ctx, k8sClient, opts.Namespace)
+	cfg, err := config.FromConfigMapVolume(config.KFPLauncherConfigMountPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does:**
Mounts the kfp-launcher ConfigMap as a volume in driver, launcher, and
executor containers, instead of accessing it via the Kubernetes API at
runtime.

- Adds `ConfigureKFPLauncherConfigMap` to set up the volume and mount path
  in workflow templates.
- Applies this configuration to the container executor, DAG driver, and
  importer templates.
- Follows the existing pattern used for mounting CA bundle ConfigMaps
  (see `ConfigureCustomCABundle`).

This reduces Kubernetes API server load at scale, narrows the RBAC surface
(pods only need pod-creation permission, not ConfigMap `get` access), and
improves observability since mounted ConfigMaps show up in
`kubectl describe pod`.

**Fixes:**
Fixes #14180

**Checklist:**
- [x] Unit tests have been added, verifying the ConfigMap volume is
      included in container executor, DAG driver, and importer templates
- [x] Code is well-formatted (gofmt, go vet clean)
- [x] Tested locally
- [x] DCO signed off