### PR TITLE
fix(sdk): preserve direct custom artifact input classes

### DIFF
--- a/sdk/python/kfp/dsl/types/custom_artifact_types.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types.py
@@ -55,7 +55,7 @@ def get_param_to_custom_artifact_class(func: Callable) -> Dict[str, type]:
                 param_to_artifact_cls[name] = artifact_class
         elif type_annotations.issubclass_of_artifact(annotation):
             if annotation not in kfp_artifact_classes:
-                param_to_artifact_cls[name] = artifact_class
+                param_to_artifact_cls[name] = annotation
 
     return_annotation = signature.return_annotation
 

--- a/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
+++ b/sdk/python/kfp/dsl/types/custom_artifact_types_test.py
@@ -39,6 +39,11 @@ from kfp.dsl.types.type_annotations import OutputPath
 Alias = Artifact
 artifact_types_alias = artifact_types
 
+
+class CustomArtifact(Artifact):
+    pass
+
+
 try:
     import pydantic
 except ImportError:
@@ -198,6 +203,22 @@ class TestGetParamToCustomArtifactClass(_TestCaseWithThirdPartyPackage):
                 'c': aiplatform.VertexDataset,
                 'd': aiplatform.VertexDataset,
             })
+
+    def test_direct_custom_artifact_input(self):
+
+        def func(a: CustomArtifact):
+            pass
+
+        actual = custom_artifact_types.get_param_to_custom_artifact_class(func)
+        self.assertEqual(actual, {'a': CustomArtifact})
+
+    def test_direct_custom_artifact_input_after_wrapped_artifact(self):
+
+        def func(a: Input[Dataset], b: CustomArtifact):
+            pass
+
+        actual = custom_artifact_types.get_param_to_custom_artifact_class(func)
+        self.assertEqual(actual, {'b': CustomArtifact})
 
     def test_return_google_artifact1(self):
         import aiplatform


### PR DESCRIPTION
## Problem

Lightweight components support direct artifact input annotations, but direct custom artifact inputs fail while the SDK derives imports for generated component code. A component function such as `def consume(artifact: CustomArtifact): ...` can therefore fail before compilation or receive the wrong import mapping when it follows a wrapped artifact input.

## Root cause

`get_param_to_custom_artifact_class()` handles two forms of artifact input:

- `Input[T]` / `Output[T]`, where it assigns a local `artifact_class`.
- A direct lightweight-component artifact annotation, where it previously wrote that same local variable instead of the direct annotation.

In the direct form, `artifact_class` is uninitialized unless a wrapped artifact parameter happened to precede it. If one did precede it, the previous parameter's class could be recorded for the direct input.

## Solution

Record the direct annotation in the direct-artifact branch. This keeps the mapping aligned with the component signature and lets existing import-generation code emit the correct custom artifact import.

## Tests

Added regressions that verify:

1. A direct custom artifact input maps to its own class.
2. A direct custom artifact input remains correct when it follows a wrapped built-in artifact input.

## Validation performed

- `python3 -m py_compile sdk/python/kfp/dsl/types/custom_artifact_types.py sdk/python/kfp/dsl/types/custom_artifact_types_test.py`
- Isolated execution of the affected helper for both regression scenarios.
- `git diff --check`

The full SDK test suite was not runnable in this checkout because generated `kfp.pipeline_spec.pipeline_spec_pb2` sources are absent. CI should run the repository's standard SDK tests in its generated-protobuf environment.

## Scope

This is a focused SDK correctness fix; it changes no public API and adds no dependencies.