### PR TITLE
feat: Updated dockerfile to support ppc64le

### DIFF
--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -16,6 +16,7 @@
 FROM golang:1.27.0@sha256:65b6f280bf050ec5af12716857e8ea8439d694dbba8f31ceeb7630670071f2bb AS generator
 ENV PROTOC_VERSION=31.1
 ENV GOBIN=/go/bin
+ARG TARGETARCH
 # The googleapis repo doesn't use GitHub releases or version tags,
 # so we pin a specific commit to make the clone reproducible.
 ENV GOOGLEAPIS_COMMIT=68d5196a529174df97c28c70622ffc1c3721815f
@@ -28,7 +29,13 @@ COPY backend/api/tools/go.mod /tmp/api-generator-tools/go.mod
 
 # Install protoc and Java (needed for KFP server API package generation).
 RUN apt-get update -y && apt-get install -y jq sed unzip default-jdk
-RUN curl -L -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+RUN set -eu; \
+    if [ "$TARGETARCH" = "ppc64le" ]; then \
+        PROTOC_ARCH=ppcle_64; \
+    else \
+        PROTOC_ARCH=x86_64; \
+    fi; \
+    curl -L -o protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip"
 RUN unzip -o protoc.zip -d /tmp/protoc && \
     mv /tmp/protoc/bin/protoc /usr/bin/protoc && \
     chmod +x /usr/bin/protoc
@@ -60,6 +67,11 @@ RUN git init /googleapis && \
     git checkout FETCH_HEAD
 # Download go-swagger binary.
 RUN set -eu; \
+    if [ "$TARGETARCH" = "ppc64le" ]; then \
+        SWAGGER_ARCH=ppc64le; \
+    else \
+        SWAGGER_ARCH=amd64; \
+    fi; \
     go_swagger_version="$(cd /tmp/api-generator-tools && go mod edit -json | jq -er '.Require[] | select(.Path == "github.com/go-swagger/go-swagger") | .Version')"; \
     curl -fL -o /usr/bin/swagger "https://github.com/go-swagger/go-swagger/releases/download/${go_swagger_version}/swagger_linux_amd64"; \
     chmod +x /usr/bin/swagger

--- a/backend/api/Makefile
+++ b/backend/api/Makefile
@@ -35,6 +35,7 @@ endif
 PREBUILT_REMOTE_IMAGE=ghcr.io/kubeflow/kfp-api-generator:master
 RELEASE_IMAGE=ghcr.io/kubeflow/kfp-release:master
 CONTAINER_ENGINE ?= docker
+PLATFORM ?= linux/$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 
 # Generate clients using either pre-built image (fast) or source build (current tools).
 # Use USE_PREBUILT_IMAGE=false when pre-built image may have outdated dependencies.
@@ -126,6 +127,6 @@ push: image
 # .image-built is a local token file to help Make determine the latest successful build.
 # Uses Docker layer caching for improved performance.
 .image-built: Dockerfile ../../go.mod tools/go.mod
-	DOCKER_BUILDKIT=1 ${CONTAINER_ENGINE} build ../.. -t $(IMAGE_TAG) -f Dockerfile \
+	DOCKER_BUILDKIT=1 ${CONTAINER_ENGINE} build ../.. -t $(IMAGE_TAG) --platform $(PLATFORM) -f Dockerfile \
 		--cache-from $(IMAGE_TAG):latest
 	touch .image-built


### PR DESCRIPTION
**Description of your changes:** 
Hi Team,
We are porting Kubeflow and Kserve components for the Power architecture.
Added conditional architecture logic (PROTOC_ARCH and SWAGGER_ARCH) to select the correct protoc and go-swagger binaries for ppc64le vs. x86_64.
The image can now be build on power using below command:
`make image`


**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
