### PR TITLE
fix(frontend): handle PAUSED state in hasFinishedV2 and statusToBgColorV2   Fixes #14193

### DIFF
--- a/frontend/src/lib/StatusUtils.test.tsx
+++ b/frontend/src/lib/StatusUtils.test.tsx
@@ -243,11 +243,15 @@ describe('StatusUtils', () => {
         expect(hasFinishedV2(state)).toBe(false);
       });
     });
+
+    it('does not throw for undefined state', () => {
+      expect(() => hasFinishedV2(undefined)).not.toThrow();
+    });
   });
 
   describe('statusToBgColorV2', () => {
-    it("returns 'warning' color for PAUSED state", () => {
-      expect(statusToBgColorV2(V2beta1RuntimeState.PAUSED)).toEqual(statusBgColors.warning);
+    it("returns 'notStarted' color for PAUSED state", () => {
+      expect(statusToBgColorV2(V2beta1RuntimeState.PAUSED)).toEqual(statusBgColors.notStarted);
     });
 
     it("returns 'running' color for RUNNING state", () => {

--- a/frontend/src/lib/StatusUtils.test.tsx
+++ b/frontend/src/lib/StatusUtils.test.tsx
@@ -17,12 +17,15 @@
 import {
   NodePhase,
   hasFinished,
+  hasFinishedV2,
   statusBgColors,
   statusToBgColor,
+  statusToBgColorV2,
   checkIfTerminated,
   parseNodePhase,
 } from './StatusUtils';
 import { NodeStatus, S3Artifact, Artifact } from 'third_party/argo-ui/argo_template';
+import { V2beta1RuntimeState } from 'src/apisv2beta1/run';
 
 describe('StatusUtils', () => {
   describe('hasFinished', () => {
@@ -215,6 +218,58 @@ describe('StatusUtils', () => {
           },
         }),
       ).toEqual('Succeeded');
+    });
+  });
+  describe('hasFinishedV2', () => {
+    [
+      V2beta1RuntimeState.SUCCEEDED,
+      V2beta1RuntimeState.FAILED,
+      V2beta1RuntimeState.CANCELED,
+      V2beta1RuntimeState.SKIPPED,
+    ].forEach((state) => {
+      it(`returns 'true' for finished state: ${state}`, () => {
+        expect(hasFinishedV2(state)).toBe(true);
+      });
+    });
+
+    [
+      V2beta1RuntimeState.PENDING,
+      V2beta1RuntimeState.RUNNING,
+      V2beta1RuntimeState.CANCELING,
+      V2beta1RuntimeState.PAUSED,
+      V2beta1RuntimeState.RUNTIME_STATE_UNSPECIFIED,
+    ].forEach((state) => {
+      it(`returns 'false' for non-finished state: ${state}`, () => {
+        expect(hasFinishedV2(state)).toBe(false);
+      });
+    });
+  });
+
+  describe('statusToBgColorV2', () => {
+    it("returns 'warning' color for PAUSED state", () => {
+      expect(statusToBgColorV2(V2beta1RuntimeState.PAUSED)).toEqual(statusBgColors.warning);
+    });
+
+    it("returns 'running' color for RUNNING state", () => {
+      expect(statusToBgColorV2(V2beta1RuntimeState.RUNNING)).toEqual(statusBgColors.running);
+    });
+
+    it("returns 'running' color for CANCELING state", () => {
+      expect(statusToBgColorV2(V2beta1RuntimeState.CANCELING)).toEqual(statusBgColors.running);
+    });
+
+    it("returns 'succeeded' color for SUCCEEDED state", () => {
+      expect(statusToBgColorV2(V2beta1RuntimeState.SUCCEEDED)).toEqual(statusBgColors.succeeded);
+    });
+
+    it("returns 'error' color for FAILED state", () => {
+      expect(statusToBgColorV2(V2beta1RuntimeState.FAILED)).toEqual(statusBgColors.error);
+    });
+
+    [V2beta1RuntimeState.SKIPPED, V2beta1RuntimeState.CANCELED].forEach((state) => {
+      it(`returns 'terminatedOrSkipped' color for state: ${state}`, () => {
+        expect(statusToBgColorV2(state)).toEqual(statusBgColors.terminatedOrSkipped);
+      });
     });
   });
 });

--- a/frontend/src/lib/StatusUtils.ts
+++ b/frontend/src/lib/StatusUtils.ts
@@ -148,7 +148,7 @@ export function hasFinishedV2(state?: V2beta1RuntimeState): boolean {
       return false;
     default:
       logger.warn('Unknown state:', state);
-      throw new Error('Unexpected runtime state!');
+      return false;
   }
 }
 
@@ -164,7 +164,7 @@ export function statusToBgColorV2(state?: V2beta1RuntimeState, nodeMessage?: str
     case V2beta1RuntimeState.RUNNING:
       return statusBgColors.running;
     case V2beta1RuntimeState.PAUSED:
-      return statusBgColors.warning;
+      return statusBgColors.notStarted;
     case V2beta1RuntimeState.SUCCEEDED:
       return statusBgColors.succeeded;
     case V2beta1RuntimeState.SKIPPED:

--- a/frontend/src/lib/StatusUtils.ts
+++ b/frontend/src/lib/StatusUtils.ts
@@ -143,6 +143,7 @@ export function hasFinishedV2(state?: V2beta1RuntimeState): boolean {
     case V2beta1RuntimeState.PENDING: // Fall through
     case V2beta1RuntimeState.RUNNING: // Fall through
     case V2beta1RuntimeState.CANCELING: // Fall through
+    case V2beta1RuntimeState.PAUSED: // Fall through
     case V2beta1RuntimeState.RUNTIME_STATE_UNSPECIFIED:
       return false;
     default:
@@ -162,6 +163,8 @@ export function statusToBgColorV2(state?: V2beta1RuntimeState, nodeMessage?: str
     // fall through
     case V2beta1RuntimeState.RUNNING:
       return statusBgColors.running;
+    case V2beta1RuntimeState.PAUSED:
+      return statusBgColors.warning;
     case V2beta1RuntimeState.SUCCEEDED:
       return statusBgColors.succeeded;
     case V2beta1RuntimeState.SKIPPED:


### PR DESCRIPTION
Fixes #14193

Description of your changes:

- hasFinishedV2() had a default branch that threw new Error('Unexpected runtime state!'). Since state is optional on V2beta1Run and the API omits it for unspecified states, any unrecognized or missing state reaching this function would crash the Run Details page.

Changes made:

- hasFinishedV2() default branch — replaced throw new Error(...) with return false (keeps existing logger.warn). This matches the safe-fallback pattern used by all other status functions in the file and prevents unrecognized or undefined states from crashing the page.

- statusToBgColorV2() PAUSED case — returns statusBgColors.notStarted instead of statusBgColors.warning, matching StatusV2.tsx which already renders PAUSED with the same muted/pending icon as PENDING.


Tests added:

- hasFinishedV2(undefined)  does not throw
- statusToBgColorV2(PAUSED)  returns notStarted


**Checklist:**
- [X] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [X] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
