### PR TITLE
fix(frontend): support dotted S3 bucket names

### DIFF
--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -18,6 +18,7 @@ import {
   findFileOnPodVolume,
   parseJSONString,
   isAllowedResourceName,
+  isAllowedBucketName,
   openFileWithinRoot,
 } from '../utils.js';
 import {
@@ -278,7 +279,7 @@ export function getArtifactsHandler({
       return;
     }
     const { source, bucket, key, peek, providerInfo, namespace } = artifactRequest;
-    if (!isAllowedResourceName(bucket)) {
+    if (!isAllowedBucketName(bucket)) {
       res.status(500).send('Invalid bucket name');
       return;
     }

--- a/frontend/server/utils.test.ts
+++ b/frontend/server/utils.test.ts
@@ -18,10 +18,12 @@ import * as path from 'path';
 import {
   PreviewStream,
   findFileOnPodVolume,
+  isAllowedBucketName,
   openFileWithinRoot,
   parseError,
   resolveFilePathOnVolume,
 } from './utils.js';
+import { describe, expect, it } from 'vitest';
 
 describe('utils', () => {
   describe('PreviewStream', () => {
@@ -376,6 +378,26 @@ describe('utils', () => {
         message: 'plain text failure',
         additionalInfo: 'plain text failure',
       });
+    });
+  });
+  describe('isAllowedBucketName', () => {
+    it('accepts valid bucket names, including names containing dots', () => {
+      expect(isAllowedBucketName('my-bucket')).toBe(true);
+      expect(isAllowedBucketName('my.bucket')).toBe(true);
+      expect(isAllowedBucketName('my-org.my-env.pipelines')).toBe(true);
+    });
+
+    it('rejects invalid bucket names', () => {
+      expect(isAllowedBucketName('.bucket')).toBe(false);
+      expect(isAllowedBucketName('bucket.')).toBe(false);
+      expect(isAllowedBucketName('-bucket')).toBe(false);
+      expect(isAllowedBucketName('bucket-')).toBe(false);
+    });
+
+    it('rejects non-string and overlong values', () => {
+      expect(isAllowedBucketName('')).toBe(false);
+      expect(isAllowedBucketName(123)).toBe(false);
+      expect(isAllowedBucketName('a'.repeat(64))).toBe(false);
     });
   });
 });

--- a/frontend/server/utils.ts
+++ b/frontend/server/utils.ts
@@ -506,3 +506,12 @@ export function isAllowedResourceName(name: unknown): name is string {
     /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(name)
   );
 }
+
+export function isAllowedBucketName(name: unknown): name is string {
+  return (
+    typeof name === 'string' &&
+    name.length > 0 &&
+    name.length <= 63 &&
+    /^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/.test(name)
+  );
+}


### PR DESCRIPTION
**Description of your changes:**

Fix S3 artifact retrieval for bucket names containing dots by using
S3-compatible bucket-name validation instead of the Kubernetes resource
name validation.

This allows valid S3 bucket names such as `my.bucket.name` to be
accepted by the frontend server.

**Testing:**

- `npx vitest run utils.test.ts`
- All 25 tests passed.

**Before:**
Valid S3 bucket names containing dots (for example, `my.bucket.name`) were rejected.

**After:**
S3 bucket names are validated using `isAllowedBucketName()`, which accepts valid dotted bucket names.