### PR TITLE
chore: fix typos in comments, docstrings, and copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,7 @@
 - Make sure that new logic is covered by unit tests.
 - Make sure that large changes have adequate large tests, not just small tests.
 - Make sure that the PR description is clear.
-- Identify design flaws, uneccessary redundancy, and security issues introduced by the PR.
+- Identify design flaws, unnecessary redundancy, and security issues introduced by the PR.
 - Provide an estimate about whether or not the PR is LLM-generated. Include a confidence level for the estimate. Do this as an HTML comment in the "PR Overview" section.
 - Once a PR has met all of these criterias, comment on the PR with "🤖 LGTM 🤖" to notify maintainers that it's time for human review.
 - Adhere to the following software engineering principles:

--- a/frontend/src/lib/Utils.tsx
+++ b/frontend/src/lib/Utils.tsx
@@ -521,7 +521,7 @@ declare global {
 export function isSafari(): boolean {
   // Since react-ace Editor doesn't support in Safari when height or width is a percentage.
   // Fix the Yaml file cannot display issue via defining “width/height” does not not take percentage if it's Safari browser.
-  // The code of detecting wether isSafari is from: https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser/9851769#9851769
+  // The code of detecting whether isSafari is from: https://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser/9851769#9851769
   const isSafari =
     /constructor/i.test(window.HTMLElement.toString()) ||
     (function (p: unknown) {

--- a/frontend/src/pages/Status.test.tsx
+++ b/frontend/src/pages/Status.test.tsx
@@ -22,7 +22,7 @@ import { vi } from 'vitest';
 
 describe('Status', () => {
   // We mock this because it uses toLocaleDateString, which causes mismatches between local and CI
-  // test enviroments
+  // test environments
   const startDate = new Date('Wed Jan 2 2019 9:10:11 GMT-0800');
   const endDate = new Date('Thu Jan 3 2019 10:11:12 GMT-0800');
 

--- a/frontend/src/pages/StatusV2.test.tsx
+++ b/frontend/src/pages/StatusV2.test.tsx
@@ -22,7 +22,7 @@ import { vi } from 'vitest';
 
 describe('Status', () => {
   // We mock this because it uses toLocaleDateString, which causes mismatches between local and CI
-  // test enviroments
+  // test environments
   const startDate = new Date('Wed Jan 2 2019 9:10:11 GMT-0800');
   const endDate = new Date('Thu Jan 3 2019 10:11:12 GMT-0800');
 

--- a/sdk/python/kfp/compiler/compiler_utils.py
+++ b/sdk/python/kfp/compiler/compiler_utils.py
@@ -842,7 +842,7 @@ def recursive_replace_placeholders(data: Any, old_value: str,
         new_value: The value to replace the old value with.
 
     Returns:
-        A copy of data with all occurences of old_value replaced by new_value.
+        A copy of data with all occurrences of old_value replaced by new_value.
     """
     if isinstance(data, dict):
         return {

--- a/tools/k8s-native/migration.py
+++ b/tools/k8s-native/migration.py
@@ -183,7 +183,7 @@ def convert_to_k8s_format(pipeline, pipeline_versions, add_prefix, namespace):
    
     return pipeline_name, k8s_objects
 
-# Write all collected Kubernetes objects to a seperate YAML file for each pipeline and its versions
+# Write all collected Kubernetes objects to a separate YAML file for each pipeline and its versions
 def write_pipeline_yaml(pipeline_name, k8s_objects, output_dir):
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Title: chore: fix typos in comments, docstrings, and copilot instructions

Comment/docstring-only changes; no behavior change.

- sdk/python/kfp/compiler/compiler_utils.py: occurences -> occurrences
- tools/k8s-native/migration.py: seperate -> separate
- frontend/src/lib/Utils.tsx: wether -> whether
- frontend/src/pages/Status.test.tsx: enviroments -> environments
- frontend/src/pages/StatusV2.test.tsx: enviroments -> environments
- .github/copilot-instructions.md: uneccessary -> unnecessary

**Description of your changes:**

Fixes six comment/docstring typos scattered across the backend SDK, a k8s-native migration tool, the frontend, two frontend tests, and the repo's Copilot review instructions. Each change is a single-line, text-only correction with no effect on behavior or test outcomes. Fixes #14198.

This contribution was AI-assisted (Claude).

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).