### PR TITLE
test(sdk): add unit tests for CLI experiment, recurring_run, diagnose_me, and __main__ modules

### DIFF
--- a/sdk/python/kfp/cli/__main__test.py
+++ b/sdk/python/kfp/cli/__main__test.py
@@ -1,0 +1,48 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for kfp.cli.__main__."""
+
+import sys
+import unittest
+from unittest import mock
+
+from kfp.cli import __main__
+
+
+class TestMain(unittest.TestCase):
+
+    @mock.patch('kfp.cli.__main__.cli.cli')
+    def test_main_success(self, mock_cli):
+        __main__.main()
+        mock_cli.assert_called_once_with(obj={}, auto_envvar_prefix='KFP')
+
+    @mock.patch('kfp.cli.__main__.cli.cli')
+    @mock.patch('kfp.cli.__main__.click.echo')
+    @mock.patch('kfp.cli.__main__.sys.exit')
+    def test_main_exception(self, mock_exit, mock_echo, mock_cli):
+        mock_cli.side_effect = Exception('test error')
+        __main__.main()
+        mock_echo.assert_called_once_with('test error', err=True)
+        mock_exit.assert_called_once_with(1)
+
+    @mock.patch('kfp.cli.__main__.logging.basicConfig')
+    def test_main_logging_config(self, mock_basic_config):
+        with mock.patch('kfp.cli.__main__.cli.cli'):
+            __main__.main()
+        mock_basic_config.assert_called_once_with(
+            format='%(message)s', level=20)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/cli/diagnose_me_cli_test.py
+++ b/sdk/python/kfp/cli/diagnose_me_cli_test.py
@@ -1,0 +1,243 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for kfp.cli.diagnose_me_cli."""
+
+import json
+import unittest
+from unittest import mock
+
+from click import testing
+from kfp.cli import diagnose_me_cli
+from kfp.cli.diagnose_me import gcp
+
+
+def make_executor_response(has_error=False,
+                           json_output=None,
+                           parsed_output='',
+                           stderr=''):
+    """Helper to create mock ExecutorResponse."""
+    m = mock.MagicMock()
+    m.has_error = has_error
+    m.json_output = json_output or {}
+    m.parsed_output = parsed_output
+    m.stderr = stderr
+    return m
+
+
+class TestDiagnoseMeCLI(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = testing.CliRunner()
+
+    def invoke(self, args, catch_exceptions=False):
+        return self.runner.invoke(
+            diagnose_me_cli.diagnose_me,
+            args,
+            catch_exceptions=catch_exceptions,
+        )
+
+    @mock.patch('kfp.cli.diagnose_me_cli.gcp.get_gcp_configuration')
+    def test_diagnose_me_missing_gcloud(self, mock_get_gcp):
+        mock_get_gcp.return_value = make_executor_response(json_output={})
+        result = self.invoke([], catch_exceptions=True)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('gcloud, gsutil and kubectl are required',
+                      str(result.exception))
+
+    def _make_side_effect(self, validation_response, gcp_responses,
+                          k8s_responses, dev_responses):
+        """Create side_effect that returns responses in order and then
+        cycles."""
+        all_responses = [validation_response
+                        ] + gcp_responses + k8s_responses + dev_responses
+
+        def side_effect(*args, **kwargs):
+            return all_responses.pop(0)
+
+        return side_effect
+
+    @mock.patch('kfp.cli.diagnose_me_cli.gcp.get_gcp_configuration')
+    @mock.patch(
+        'kfp.cli.diagnose_me_cli.kubernetes_cluster.get_kubectl_configuration')
+    @mock.patch('kfp.cli.diagnose_me_cli.dev_env.get_dev_env_configuration')
+    def test_diagnose_me_human_readable(self, mock_dev_env, mock_k8s, mock_gcp):
+        validation_response = make_executor_response(json_output={
+            'Google Cloud SDK': '1.0',
+            'gsutil': '1.0',
+            'kubectl': '1.0'
+        })
+
+        # gcp.Commands has 12 values, k8.Commands has 8, dev_env.Commands has 6
+        gcp_responses = [
+            make_executor_response(
+                json_output={'test': f'gcp{i}'},
+                parsed_output=f'gcp output {i}') for i in range(12)
+        ]
+        k8s_responses = [
+            make_executor_response(
+                json_output={'test': f'k8s{i}'},
+                parsed_output=f'k8s output {i}') for i in range(8)
+        ]
+        dev_responses = [
+            make_executor_response(
+                json_output={'test': f'dev{i}'},
+                parsed_output=f'dev output {i}') for i in range(6)
+        ]
+
+        mock_gcp.side_effect = self._make_side_effect(validation_response,
+                                                      gcp_responses,
+                                                      k8s_responses,
+                                                      dev_responses)
+        mock_k8s.side_effect = k8s_responses[:]  # copy
+        mock_dev_env.side_effect = dev_responses[:]
+
+        result = self.invoke([])
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('================', result.output)
+
+    @mock.patch('kfp.cli.diagnose_me_cli.gcp.get_gcp_configuration')
+    @mock.patch(
+        'kfp.cli.diagnose_me_cli.kubernetes_cluster.get_kubectl_configuration')
+    @mock.patch('kfp.cli.diagnose_me_cli.dev_env.get_dev_env_configuration')
+    def test_diagnose_me_json(self, mock_dev_env, mock_k8s, mock_gcp):
+        validation_response = make_executor_response(json_output={
+            'Google Cloud SDK': '1.0',
+            'gsutil': '1.0',
+            'kubectl': '1.0'
+        })
+
+        gcp_responses = [
+            make_executor_response(
+                json_output={'test': f'gcp{i}'},
+                parsed_output=f'gcp output {i}') for i in range(12)
+        ]
+        k8s_responses = [
+            make_executor_response(
+                json_output={'test': f'k8s{i}'},
+                parsed_output=f'k8s output {i}') for i in range(8)
+        ]
+        dev_responses = [
+            make_executor_response(
+                json_output={'test': f'dev{i}'},
+                parsed_output=f'dev output {i}') for i in range(6)
+        ]
+
+        mock_gcp.side_effect = self._make_side_effect(validation_response,
+                                                      gcp_responses,
+                                                      k8s_responses,
+                                                      dev_responses)
+        mock_k8s.side_effect = k8s_responses[:]
+        mock_dev_env.side_effect = dev_responses[:]
+
+        result = self.invoke(['--json'])
+        self.assertEqual(result.exit_code, 0)
+        # Output has "Collecting diagnostic information ...\n" prefix
+        json_start = result.output.find('{')
+        output_data = json.loads(result.output[json_start:])
+        self.assertIn('GET_GCLOUD_VERSION', output_data)
+
+    @mock.patch('kfp.cli.diagnose_me_cli.gcp.get_gcp_configuration')
+    @mock.patch(
+        'kfp.cli.diagnose_me_cli.kubernetes_cluster.get_kubectl_configuration')
+    @mock.patch('kfp.cli.diagnose_me_cli.dev_env.get_dev_env_configuration')
+    def test_diagnose_me_with_error(self, mock_dev_env, mock_k8s, mock_gcp):
+        validation_response = make_executor_response(json_output={
+            'Google Cloud SDK': '1.0',
+            'gsutil': '1.0',
+            'kubectl': '1.0'
+        })
+
+        gcp_responses = [
+            make_executor_response(has_error=True, stderr='command failed'),
+            make_executor_response(
+                json_output={'test': 'gcp1'}, parsed_output='gcp output 1'), *[
+                    make_executor_response(
+                        json_output={'test': f'gcp{i}'},
+                        parsed_output=f'gcp output {i}') for i in range(2, 12)
+                ]
+        ]
+        k8s_responses = [
+            make_executor_response(
+                json_output={'test': f'k8s{i}'},
+                parsed_output=f'k8s output {i}') for i in range(8)
+        ]
+        dev_responses = [
+            make_executor_response(
+                json_output={'test': f'dev{i}'},
+                parsed_output=f'dev output {i}') for i in range(6)
+        ]
+
+        mock_gcp.side_effect = self._make_side_effect(validation_response,
+                                                      gcp_responses,
+                                                      k8s_responses,
+                                                      dev_responses)
+        mock_k8s.side_effect = k8s_responses[:]
+        mock_dev_env.side_effect = dev_responses[:]
+
+        result = self.invoke(['--json'])
+        self.assertEqual(result.exit_code, 0)
+        # Check JSON output for error
+        json_start = result.output.find('{')
+        output_data = json.loads(result.output[json_start:])
+        # Find the key with error
+        error_found = any(
+            'Following error occurred during the diagnoses' in str(v)
+            for v in output_data.values())
+        self.assertTrue(error_found)
+
+    @mock.patch('kfp.cli.diagnose_me_cli.gcp.get_gcp_configuration')
+    @mock.patch(
+        'kfp.cli.diagnose_me_cli.kubernetes_cluster.get_kubectl_configuration')
+    @mock.patch('kfp.cli.diagnose_me_cli.dev_env.get_dev_env_configuration')
+    def test_diagnose_me_with_project_and_namespace(self, mock_dev_env,
+                                                    mock_k8s, mock_gcp):
+        validation_response = make_executor_response(json_output={
+            'Google Cloud SDK': '1.0',
+            'gsutil': '1.0',
+            'kubectl': '1.0'
+        })
+
+        gcp_responses = [
+            make_executor_response(
+                json_output={'test': f'gcp{i}'},
+                parsed_output=f'gcp output {i}') for i in range(12)
+        ]
+        k8s_responses = [
+            make_executor_response(
+                json_output={'test': f'k8s{i}'},
+                parsed_output=f'k8s output {i}') for i in range(8)
+        ]
+        dev_responses = [
+            make_executor_response(
+                json_output={'test': f'dev{i}'},
+                parsed_output=f'dev output {i}') for i in range(6)
+        ]
+
+        mock_gcp.side_effect = self._make_side_effect(validation_response,
+                                                      gcp_responses,
+                                                      k8s_responses,
+                                                      dev_responses)
+        mock_k8s.side_effect = k8s_responses[:]
+        mock_dev_env.side_effect = dev_responses[:]
+
+        result = self.invoke(
+            ['--project-id', 'my-project', '--namespace', 'my-namespace'])
+        self.assertEqual(result.exit_code, 0)
+        # Verify the project_id was passed to gcp calls
+        for call in mock_gcp.call_args_list:
+            self.assertEqual(call.kwargs.get('project_id'), 'my-project')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/cli/experiment_test.py
+++ b/sdk/python/kfp/cli/experiment_test.py
@@ -1,0 +1,178 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for kfp.cli.experiment."""
+
+import functools
+import unittest
+from unittest import mock
+
+from click import testing
+from kfp.cli import cli
+
+
+class TestExperimentCommands(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = testing.CliRunner()
+        self.client_mock = mock.MagicMock()
+
+    def invoke(self, args, catch_exceptions=False, input_data=None):
+        with mock.patch(
+                'kfp.cli.cli.client.Client', return_value=self.client_mock):
+            return self.runner.invoke(
+                cli.cli,
+                args,
+                catch_exceptions=catch_exceptions,
+                obj={
+                    'client': self.client_mock,
+                    'output': 'json'
+                },
+                input=input_data,
+            )
+
+    def test_experiment_create(self):
+        self.client_mock.create_experiment.return_value = mock.MagicMock(
+            experiment_id='exp-123')
+        result = self.invoke(
+            ['experiment', 'create', '--description', 'desc', 'my-exp'])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.create_experiment.assert_called_once_with(
+            'my-exp', description='desc')
+
+    def test_experiment_create_no_description(self):
+        self.client_mock.create_experiment.return_value = mock.MagicMock(
+            experiment_id='exp-123')
+        result = self.invoke(['experiment', 'create', 'my-exp'])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.create_experiment.assert_called_once_with(
+            'my-exp', description=None)
+
+    def test_experiment_list(self):
+        self.client_mock.list_experiments.return_value = mock.MagicMock(
+            experiments=[])
+        result = self.invoke(['experiment', 'list'])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.list_experiments.assert_called_once_with(
+            page_token='',
+            page_size=100,
+            sort_by='created_at desc',
+            filter=None)
+
+    def test_experiment_list_with_options(self):
+        self.client_mock.list_experiments.return_value = mock.MagicMock(
+            experiments=[])
+        result = self.invoke([
+            'experiment', 'list', '--page-token', 'token123', '--max-size',
+            '50', '--sort-by', 'name', '--filter', 'name=test'
+        ])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.list_experiments.assert_called_once_with(
+            page_token='token123',
+            page_size=50,
+            sort_by='name',
+            filter='name=test')
+
+    def test_experiment_get(self):
+        self.client_mock.get_experiment.return_value = mock.MagicMock(
+            experiment_id='exp-123')
+        result = self.invoke(['experiment', 'get', 'exp-123'])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.get_experiment.assert_called_once_with('exp-123')
+
+    def test_experiment_delete(self):
+        self.client_mock.delete_experiment.return_value = None
+        result = self.invoke(['experiment', 'delete', 'exp-123'],
+                             input_data='y\n')
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.delete_experiment.assert_called_once_with('exp-123')
+
+    def test_experiment_archive_with_id(self):
+        self.client_mock.archive_experiment.return_value = None
+        exp_mock = mock.MagicMock(experiment_id='exp-123')
+        self.client_mock.get_experiment.return_value = exp_mock
+        result = self.invoke(
+            ['experiment', 'archive', '--experiment-id', 'exp-123'])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.archive_experiment.assert_called_once_with(
+            experiment_id='exp-123')
+        self.assertEqual(self.client_mock.get_experiment.call_count, 1)
+        self.client_mock.get_experiment.assert_called_with(
+            experiment_id='exp-123')
+
+    def test_experiment_archive_with_name(self):
+        self.client_mock.archive_experiment.return_value = None
+        exp_mock = mock.MagicMock(experiment_id='exp-123')
+        self.client_mock.get_experiment.return_value = exp_mock
+        result = self.invoke(
+            ['experiment', 'archive', '--experiment-name', 'my-exp'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(self.client_mock.get_experiment.call_count, 2)
+        self.client_mock.get_experiment.assert_any_call(
+            experiment_name='my-exp')
+        self.client_mock.get_experiment.assert_any_call(experiment_id='exp-123')
+        self.client_mock.archive_experiment.assert_called_once_with(
+            experiment_id='exp-123')
+
+    def test_experiment_archive_requires_either(self):
+        result = self.invoke(['experiment', 'archive'], catch_exceptions=True)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Either --experiment-id or --experiment-name is required',
+                      str(result.exception))
+
+    def test_experiment_archive_not_both(self):
+        result = self.invoke([
+            'experiment', 'archive', '--experiment-id', 'exp-1',
+            '--experiment-name', 'exp-2'
+        ],
+                             catch_exceptions=True)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Either --experiment-id or --experiment-name is required',
+                      str(result.exception))
+
+    def test_experiment_unarchive_with_id(self):
+        self.client_mock.unarchive_experiment.return_value = None
+        exp_mock = mock.MagicMock(experiment_id='exp-123')
+        self.client_mock.get_experiment.return_value = exp_mock
+        result = self.invoke(
+            ['experiment', 'unarchive', '--experiment-id', 'exp-123'])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.unarchive_experiment.assert_called_once_with(
+            experiment_id='exp-123')
+        self.assertEqual(self.client_mock.get_experiment.call_count, 1)
+        self.client_mock.get_experiment.assert_called_with(
+            experiment_id='exp-123')
+
+    def test_experiment_unarchive_with_name(self):
+        self.client_mock.unarchive_experiment.return_value = None
+        exp_mock = mock.MagicMock(experiment_id='exp-123')
+        self.client_mock.get_experiment.return_value = exp_mock
+        result = self.invoke(
+            ['experiment', 'unarchive', '--experiment-name', 'my-exp'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(self.client_mock.get_experiment.call_count, 2)
+        self.client_mock.get_experiment.assert_any_call(
+            experiment_name='my-exp')
+        self.client_mock.get_experiment.assert_any_call(experiment_id='exp-123')
+        self.client_mock.unarchive_experiment.assert_called_once_with(
+            experiment_id='exp-123')
+
+    def test_experiment_unarchive_requires_either(self):
+        result = self.invoke(['experiment', 'unarchive'], catch_exceptions=True)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Either --experiment-id or --experiment-name is required',
+                      str(result.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sdk/python/kfp/cli/recurring_run_test.py
+++ b/sdk/python/kfp/cli/recurring_run_test.py
@@ -1,0 +1,213 @@
+# Copyright 2024 The Kubeflow Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for kfp.cli.recurring_run."""
+
+import unittest
+from unittest import mock
+
+from click import testing
+from kfp.cli import cli
+
+
+class TestRecurringRunCommands(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = testing.CliRunner()
+        self.client_mock = mock.MagicMock()
+
+    def invoke(self, args, catch_exceptions=False, input_data=None):
+        with mock.patch(
+                'kfp.cli.cli.client.Client', return_value=self.client_mock):
+            return self.runner.invoke(
+                cli.cli,
+                args,
+                catch_exceptions=catch_exceptions,
+                obj={
+                    'client': self.client_mock,
+                    'output': 'json'
+                },
+                input=input_data,
+            )
+
+    def test_recurring_run_create_with_interval(self):
+        self.client_mock.create_recurring_run.return_value = mock.MagicMock(
+            recurring_run_id='rr-123')
+        self.client_mock.create_experiment.return_value = mock.MagicMock(
+            experiment_id='exp-123')
+        result = self.invoke([
+            'recurring-run', 'create', '--job-name', 'my-job',
+            '--interval-second', '3600', '--experiment-name', 'my-exp'
+        ])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.create_recurring_run.assert_called_once()
+        call_kwargs = self.client_mock.create_recurring_run.call_args.kwargs
+        self.assertEqual(call_kwargs['job_name'], 'my-job')
+        self.assertEqual(call_kwargs['interval_second'], '3600')
+        self.assertEqual(call_kwargs['experiment_id'], 'exp-123')
+
+    def test_recurring_run_create_with_cron(self):
+        self.client_mock.create_recurring_run.return_value = mock.MagicMock(
+            recurring_run_id='rr-123')
+        self.client_mock.create_experiment.return_value = mock.MagicMock(
+            experiment_id='exp-123')
+        result = self.invoke([
+            'recurring-run', 'create', '--job-name', 'my-job',
+            '--cron-expression', '0 * * * *', '--experiment-id', 'exp-456'
+        ])
+        self.assertEqual(result.exit_code, 0)
+        call_kwargs = self.client_mock.create_recurring_run.call_args.kwargs
+        self.assertEqual(call_kwargs['cron_expression'], '0 * * * *')
+        self.assertEqual(call_kwargs['experiment_id'], 'exp-456')
+
+    def test_recurring_run_create_requires_interval_or_cron(self):
+        result = self.invoke([
+            'recurring-run', 'create', '--job-name', 'my-job',
+            '--experiment-name', 'my-exp'
+        ],
+                             catch_exceptions=True)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn(
+            'Either of --interval-second or --cron-expression options is required',
+            str(result.exception))
+
+    def test_recurring_run_create_not_both_interval_and_cron(self):
+        result = self.invoke([
+            'recurring-run', 'create', '--job-name', 'my-job',
+            '--interval-second', '3600', '--cron-expression', '0 * * * *',
+            '--experiment-name', 'my-exp'
+        ],
+                             catch_exceptions=True)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn(
+            'Either of --interval-second or --cron-expression options is required',
+            str(result.exception))
+
+    def test_recurring_run_create_requires_experiment(self):
+        result = self.invoke([
+            'recurring-run', 'create', '--job-name', 'my-job',
+            '--interval-second', '3600'
+        ],
+                             catch_exceptions=True)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn('Either --experiment-id or --experiment-name is required',
+                      str(result.exception))
+
+    def test_recurring_run_create_with_params(self):
+        self.client_mock.create_recurring_run.return_value = mock.MagicMock(
+            recurring_run_id='rr-123')
+        self.client_mock.create_experiment.return_value = mock.MagicMock(
+            experiment_id='exp-123')
+        result = self.invoke([
+            'recurring-run', 'create', '--job-name', 'my-job',
+            '--interval-second', '3600', '--experiment-name', 'my-exp',
+            'param1=value1', 'param2=value2'
+        ])
+        self.assertEqual(result.exit_code, 0)
+        call_kwargs = self.client_mock.create_recurring_run.call_args.kwargs
+        self.assertEqual(call_kwargs['params'], {
+            'param1': 'value1',
+            'param2': 'value2'
+        })
+
+    def test_recurring_run_create_with_all_options(self):
+        self.client_mock.create_recurring_run.return_value = mock.MagicMock(
+            recurring_run_id='rr-123')
+        self.client_mock.create_experiment.return_value = mock.MagicMock(
+            experiment_id='exp-123')
+        result = self.invoke([
+            'recurring-run', 'create', '--job-name', 'my-job',
+            '--interval-second', '3600', '--experiment-name', 'my-exp',
+            '--description', 'test desc', '--enabled', '--catchup',
+            '--start-time', '2024-01-01T00:00:00Z', '--end-time',
+            '2024-12-31T23:59:59Z', '--max-concurrency', '5', '--pipeline-id',
+            'pipe-123', '--version-id', 'ver-123', 'key=value'
+        ])
+        self.assertEqual(result.exit_code, 0)
+        call_kwargs = self.client_mock.create_recurring_run.call_args.kwargs
+        self.assertEqual(call_kwargs['description'], 'test desc')
+        self.assertEqual(call_kwargs['enabled'], True)
+        self.assertEqual(call_kwargs['no_catchup'], False)
+        self.assertEqual(call_kwargs['start_time'], '2024-01-01T00:00:00Z')
+        self.assertEqual(call_kwargs['end_time'], '2024-12-31T23:59:59Z')
+        self.assertEqual(call_kwargs['max_concurrency'], 5)
+        self.assertEqual(call_kwargs['pipeline_id'], 'pipe-123')
+        self.assertEqual(call_kwargs['version_id'], 'ver-123')
+
+    def test_recurring_run_list(self):
+        self.client_mock.list_recurring_runs.return_value = mock.MagicMock(
+            recurring_runs=[])
+        result = self.invoke(['recurring-run', 'list'])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.list_recurring_runs.assert_called_once_with(
+            experiment_id=None,
+            page_token='',
+            page_size=100,
+            sort_by='created_at desc',
+            filter=None)
+
+    def test_recurring_run_list_with_options(self):
+        self.client_mock.list_recurring_runs.return_value = mock.MagicMock(
+            recurring_runs=[])
+        result = self.invoke([
+            'recurring-run', 'list', '--experiment-id', 'exp-123',
+            '--page-token', 'token123', '--max-size', '50', '--sort-by', 'name',
+            '--filter', 'name=test'
+        ])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.list_recurring_runs.assert_called_once_with(
+            experiment_id='exp-123',
+            page_token='token123',
+            page_size=50,
+            sort_by='name',
+            filter='name=test')
+
+    def test_recurring_run_get(self):
+        self.client_mock.get_recurring_run.return_value = mock.MagicMock(
+            recurring_run_id='rr-123')
+        result = self.invoke(['recurring-run', 'get', 'rr-123'])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.get_recurring_run.assert_called_once_with('rr-123')
+
+    def test_recurring_run_delete(self):
+        self.client_mock.delete_recurring_run.return_value = None
+        result = self.invoke(['recurring-run', 'delete', 'rr-123'],
+                             input_data='y\n')
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.delete_recurring_run.assert_called_once_with('rr-123')
+
+    def test_recurring_run_enable(self):
+        self.client_mock.enable_recurring_run.return_value = None
+        rr_mock = mock.MagicMock(recurring_run_id='rr-123')
+        self.client_mock.get_recurring_run.return_value = rr_mock
+        result = self.invoke(['recurring-run', 'enable', 'rr-123'])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.enable_recurring_run.assert_called_once_with(
+            recurring_run_id='rr-123')
+        self.client_mock.get_recurring_run.assert_called_once_with(
+            recurring_run_id='rr-123')
+
+    def test_recurring_run_disable(self):
+        self.client_mock.disable_recurring_run.return_value = None
+        rr_mock = mock.MagicMock(recurring_run_id='rr-123')
+        self.client_mock.get_recurring_run.return_value = rr_mock
+        result = self.invoke(['recurring-run', 'disable', 'rr-123'])
+        self.assertEqual(result.exit_code, 0)
+        self.client_mock.disable_recurring_run.assert_called_once_with(
+            recurring_run_id='rr-123')
+        self.client_mock.get_recurring_run.assert_called_once_with(
+            recurring_run_id='rr-123')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Add unit tests for previously untested CLI modules in `sdk/python/kfp/cli/`:

- `cli/experiment.py`: tests for create, list, get, delete, archive, unarchive commands
- `cli/recurring_run.py`: tests for create, list, get, delete, enable, disable commands
- `cli/diagnose_me_cli.py`: tests for human-readable output, JSON output, error handling, project/namespace options
- `cli/__main__.py`: tests for main entry point success, exception handling, logging config

## Related Issue
Closes #14199

## Changes
- `sdk/python/kfp/cli/experiment_test.py`: 13 test cases covering all experiment commands
- `sdk/python/kfp/cli/recurring_run_test.py`: 12 test cases covering all recurring run commands
- `sdk/python/kfp/cli/diagnose_me_cli_test.py`: 5 test cases covering diagnose_me functionality
- `sdk/python/kfp/cli/__main__test.py`: 3 test cases covering main entry point

## How to Test
Run the new tests:
```bash
pytest sdk/python/kfp/cli/experiment_test.py sdk/python/kfp/cli/recurring_run_test.py sdk/python/kfp/cli/diagnose_me_cli_test.py sdk/python/kfp/cli/__main__test.py -v
```

All tests pass locally with `yapf`, `isort`, and `docformatter` formatting applied.

## Checklist
- [x] Code follows the project's style guidelines (yapf, isort, docformatter)
- [x] Tests have been added for all new functionality
- [x] DCO sign-off on all commits (`git commit -s`)
- [x] All CI checks should pass