### PR TITLE
fix(frontend): supply DataTransfer items for react-dropzone 20

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,7 +39,7 @@
         "react": "^19",
         "react-ace": "^15.0.0",
         "react-dom": "^19",
-        "react-dropzone": "^14.4.1",
+        "react-dropzone": "^20.1.1",
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
         "react-textarea-autosize": "^8.5.9",
@@ -4754,12 +4754,12 @@
       "license": "MIT"
     },
     "node_modules/attr-accept": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
-      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-4.0.0.tgz",
+      "integrity": "sha512-hmCnJClmeKNKlsBHgbM8yLZRiQZ4/20UXbLJb6OUT16eWcM5/xNZerr80a/zCYob768KIGq++aLrQNTuwPsIOQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">= 22"
       }
     },
     "node_modules/autoprefixer": {
@@ -6218,15 +6218,12 @@
       }
     },
     "node_modules/file-selector": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
-      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-5.0.1.tgz",
+      "integrity": "sha512-v0g/PTeuQgvKCBrVRsfVudvwXlRHSWHEQkVgKawgCGHkEpKA1clp3Om5jvEVhz8G9W/mOYjJH9FhkH4C888PgQ==",
       "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.7.0"
-      },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 22"
       }
     },
     "node_modules/fill-range": {
@@ -8516,20 +8513,25 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "14.4.1",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.4.1.tgz",
-      "integrity": "sha512-QDuV76v3uKbHiH34SpwifZ+gOLi1+RdsCO1kl5vxMT4wW8R82+sthjvBw4th3NHF/XX6FBsqDYZVNN+pnhaw0g==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-20.1.1.tgz",
+      "integrity": "sha512-2cilRFP8bsjDOHpV0sJ6XY8pzJhmz4/cQ6s9yeckOACWYDR+n4MGGtnJh3Rycq/9SLhDWugqDx1z5mtfmOOZhw==",
       "license": "MIT",
       "dependencies": {
-        "attr-accept": "^2.2.4",
-        "file-selector": "^2.1.0",
-        "prop-types": "^15.8.1"
+        "attr-accept": "^4.0.0",
+        "file-selector": "^5.0.0"
       },
       "engines": {
-        "node": ">= 10.13"
+        "node": ">= 22"
       },
       "peerDependencies": {
-        "react": ">= 16.8 || 18.0.0"
+        "@types/react": "*",
+        "react": ">= 18"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -9767,6 +9769,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "react": "^19",
     "react-ace": "^15.0.0",
     "react-dom": "^19",
-    "react-dropzone": "^14.4.1",
+    "react-dropzone": "^20.1.1",
     "react-router": "^5.3.4",
     "react-router-dom": "^5.3.4",
     "react-textarea-autosize": "^8.5.9",

--- a/frontend/src/atoms/DropzoneArea.test.tsx
+++ b/frontend/src/atoms/DropzoneArea.test.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import DropzoneArea, { DropzoneAreaHandle } from './DropzoneArea';
+import { dataTransferWithFiles } from 'src/testUtils/dataTransfer';
 
 function createFile(name: string, type: string): File {
   return new File(['contents'], name, { type });
@@ -56,7 +57,7 @@ describe('DropzoneArea', () => {
     const file = createFile('pipeline.yaml', 'application/yaml');
     await act(async () => {
       fireEvent.drop(screen.getByTestId('dz'), {
-        dataTransfer: { files: [file], types: ['Files'] },
+        dataTransfer: dataTransferWithFiles(file),
       });
     });
 
@@ -81,7 +82,7 @@ describe('DropzoneArea', () => {
     const file = createFile('readme.txt', 'text/plain');
     await act(async () => {
       fireEvent.drop(screen.getByTestId('dz'), {
-        dataTransfer: { files: [file], types: ['Files'] },
+        dataTransfer: dataTransferWithFiles(file),
       });
     });
 

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -18,6 +18,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import * as React from 'react';
 import { NewRun } from 'src/pages/NewRun';
 import TestUtils, { flushPromisesInAct, invokeAndFlush } from 'src/TestUtils';
+import { dataTransferWithFiles } from 'src/testUtils/dataTransfer';
 import { PageProps } from 'src/pages/Page';
 import { Apis } from 'src/lib/Apis';
 import { RoutePage, RouteParams, QUERY_PARAMS } from 'src/components/Router';
@@ -853,7 +854,7 @@ describe('NewRun', () => {
       const file = new File(['file contents'], 'test-pipeline.yaml', { type: 'text/yaml' });
       await invokeAndFlush(() => {
         fireEvent.drop(dropZone, {
-          dataTransfer: { files: [file], types: ['Files'] },
+          dataTransfer: dataTransferWithFiles(file),
         });
       });
 

--- a/frontend/src/testUtils/dataTransfer.ts
+++ b/frontend/src/testUtils/dataTransfer.ts
@@ -1,0 +1,20 @@
+/**
+ * Builds the `dataTransfer` payload for a synthetic drop event.
+ *
+ * react-dropzone reads dropped files through file-selector, which for a `drop`
+ * event takes them from `DataTransfer.items` and never looks at
+ * `DataTransfer.files`. Real browsers populate both, so a stub carrying only
+ * `files` silently yields no files.
+ *
+ * Each item is the minimal shape file-selector needs: `kind: 'file'` so it
+ * survives filtering, and `getAsFile()` to read the File. Omitting
+ * `webkitGetAsEntry` and `getAsFileSystemHandle` keeps it on the plain-file
+ * path rather than directory traversal or the File System Access API.
+ */
+export function dataTransferWithFiles(...files: File[]) {
+  return {
+    files,
+    items: files.map((file) => ({ kind: 'file', type: file.type, getAsFile: () => file })),
+    types: ['Files'],
+  };
+}


### PR DESCRIPTION
Supersedes #14222.

Carries the same `react-dropzone` bump Dependabot proposed (`^14.4.1` -> `^20.1.1`, pulling `file-selector` `^2.1.0` -> `^5.0.0`) plus the test change it needs to go green. #14222 failed `frontend-tests` on two files and could not fix itself.

## Why the bump fails on its own

`react-dropzone` 20 reads a drop's files through `file-selector` 5, which for a `drop` event takes them from `DataTransfer.items` and never consults `DataTransfer.files`:

```ts
async function getDataTransferFiles(dt: DataTransfer, type: string) {
  const items = fromList<DataTransferItem>(dt.items).filter(item => item.kind === "file");
  ...
}

function fromList<T>(items: DataTransferItemList | FileList | null): T[] {
  if (items === null) {   // guards null, not undefined
    return [];
  }
  return Array.from(items as unknown as ArrayLike<T>);
}
```

Our synthetic drop events supplied only `{ files, types }`, so `dt.items` was `undefined`, the `=== null` guard did not catch it, and `Array.from(undefined)` threw:

```
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at fromList             (file-selector/dist/index.js:111:15)
    at getDataTransferFiles (file-selector/dist/index.js:98:16)
    at fromEvent            (file-selector/dist/index.js:70:16)
```

Real browsers populate both `items` and `files` on a drop, so this only affects synthetic events in tests. `DropzoneArea` itself needs no change, and no production code is touched.

## The change

Adds `dataTransferWithFiles` and uses it at the three drop sites (two in `DropzoneArea.test.tsx`, one in `NewRun.test.tsx`). Each item carries the minimal shape `file-selector` needs: `kind: 'file'` so it survives the filter, and `getAsFile()` to read the `File`. Omitting `webkitGetAsEntry` and `getAsFileSystemHandle` deliberately keeps it on the plain-file path rather than directory traversal or the File System Access API.

The helper lives in `src/testUtils/` rather than `src/TestUtils.ts`: the latter imports the generated tailwind stylesheet, so putting it there would pull app-level scaffolding into an otherwise dependency-free atom test.

## Verification

- `vitest run` full suite: **149 files, 2054 tests, all passing**
- `DropzoneArea.test.tsx` 7/7 and `NewRun.test.tsx` 81/81 in isolation
- `tsc --noEmit` clean
- `eslint` 0 errors on the new file; `prettier --check` clean

## Note for reviewers

The bumped transitive dependencies (`file-selector` 5, and its own deps) now declare `"node": ">= 22"`. Worth confirming that matches the Node version the frontend builds against, though nothing in CI flagged it.