### PR TITLE
fix(backend): fail run creation on plugin runtime env injection failure

### DIFF
--- a/backend/src/apiserver/plugins/dispatcher.go
+++ b/backend/src/apiserver/plugins/dispatcher.go
@@ -124,12 +124,18 @@ func (d *RunPluginDispatcherImpl) OnBeforeRunCreation(ctx context.Context, run *
 	if err != nil {
 		return fmt.Errorf("failed to retrieve launcher namespace plugin configs for run %q: %v", run.RunID, err)
 	}
+
 	for _, handler := range d.handlers {
-		func(ctx context.Context, run *PendingRun, executionSpec util.ExecutionSpec, handler RunPluginHandler) {
+		err := func(ctx context.Context, run *PendingRun, executionSpec util.ExecutionSpec, handler RunPluginHandler) error {
 			input := pluginInputs[handler.Name()]
 
 			launcherNamespacePluginCfgStr := launcherNamespacePluginCfgs[handler.Name()]
-			resolvedRunPluginCfg, err := handler.ResolveRunPluginConfig(ctx, d.kubeClients.GetClientSet(), launcherNamespacePluginCfgStr, run.Namespace)
+			resolvedRunPluginCfg, err := handler.ResolveRunPluginConfig(
+				ctx,
+				d.kubeClients.GetClientSet(),
+				launcherNamespacePluginCfgStr,
+				run.Namespace,
+			)
 			if err != nil {
 				message := fmt.Sprintf("%s config resolution failed; run creation will continue: ", handler.Name()) + err.Error()
 				glog.Warningf("MLflow OnBeforeRunCreation failed for run %q (%s)", run.RunID, message)
@@ -137,34 +143,59 @@ func (d *RunPluginDispatcherImpl) OnBeforeRunCreation(ctx context.Context, run *
 				if outputErr := SetPendingRunPluginOutput(run, handler.Name(), pluginOutput); outputErr != nil {
 					glog.Warningf("Failed to persist %s plugin output for run %q: %v", handler.Name(), run.RunID, outputErr)
 				}
-				return
+				return nil
 			}
+
 			if resolvedRunPluginCfg == nil {
-				return
+				return nil
 			}
-			// Size the context to several per-call timeouts so the idempotent create
-			// retries in the client can fit within the budget, while still honoring
-			// parent request cancellation.
+
 			pluginOperationBudget := handler.GetPluginOperationTimeout(resolvedRunPluginCfg)
 			pluginCtx, cancel := context.WithTimeout(ctx, pluginOperationBudget)
 			defer cancel()
-			pluginOutput, pluginRuntimeEnv, pluginErr := handler.OnBeforeRunCreation(pluginCtx, run, resolvedRunPluginCfg, input)
+
+			pluginOutput, pluginRuntimeEnv, pluginErr := handler.OnBeforeRunCreation(
+				pluginCtx,
+				run,
+				resolvedRunPluginCfg,
+				input,
+			)
 			if pluginErr != nil {
-				glog.Warningf("%s OnBeforeRunCreation failed for run %q (run creation will continue): %v", handler.Name(), run.RunID, pluginErr)
+				glog.Warningf(
+					"%s OnBeforeRunCreation failed for run %q (run creation will continue): %v",
+					handler.Name(),
+					run.RunID,
+					pluginErr,
+				)
 			}
+
 			if pluginOutput == nil {
-				return
+				return nil
 			}
+
 			if err := SetPendingRunPluginOutput(run, handler.Name(), pluginOutput); err != nil {
 				glog.Warningf("failed to persist %s plugin output for run %q: %v", handler.Name(), run.RunID, err)
 			}
+
 			if len(pluginRuntimeEnv) != 0 {
 				if err := InjectPluginRuntimeEnv(executionSpec, pluginRuntimeEnv); err != nil {
-					glog.Warningf("Failed to inject %s runtime env for run %q: %v", handler.Name(), run.RunID, err)
+					return fmt.Errorf(
+						"failed to inject %s runtime env for run %q: %w",
+						handler.Name(),
+						run.RunID,
+						err,
+					)
 				}
 			}
+
+			return nil
 		}(ctx, run, executionSpec, handler)
+
+		if err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 

--- a/backend/src/apiserver/plugins/dispatcher_test.go
+++ b/backend/src/apiserver/plugins/dispatcher_test.go
@@ -99,6 +99,17 @@ func newFakeExecutionSpec() util.ExecutionSpec {
 	})
 }
 
+type failingRuntimeEnvExecutionSpec struct {
+	util.ExecutionSpec
+}
+
+func (f *failingRuntimeEnvExecutionSpec) UpsertRuntimeEnvVars(
+	envVars []corev1.EnvVar,
+	roles ...util.ExecutionRuntimeRole,
+) error {
+	return fmt.Errorf("failed to inject plugin runtime env")
+}
+
 func newFakeDispatcher(handlers []RunPluginHandler) (*RunPluginDispatcherImpl, error) {
 	return NewRunPluginDispatcherImpl(handlers, &fakeKubeClientProvider{}, &fakeRunPluginOutputStore{})
 }
@@ -638,6 +649,31 @@ func TestOnBeforeRunCreation_HandlerFailure_ContinuesExecution(t *testing.T) {
 	err := dispatcher.OnBeforeRunCreation(context.Background(), pendingRun, newFakeExecutionSpec())
 
 	require.NoError(t, err)
+}
+
+func TestOnBeforeRunCreation_RuntimeEnvInjectionFailure_ReturnsError(t *testing.T) {
+	handler := &fakeHandler{
+		name:         "FakePlugin",
+		pluginConfig: &PluginConfig{},
+		pluginOutput: &apiv2beta1.PluginOutput{},
+		envVars: []corev1.EnvVar{
+			{Name: "PLUGIN_TEST", Value: "test"},
+		},
+	}
+	dispatcher, _ := newFakeDispatcher([]RunPluginHandler{handler})
+
+	executionSpec := &failingRuntimeEnvExecutionSpec{
+		ExecutionSpec: newFakeExecutionSpec(),
+	}
+
+	err := dispatcher.OnBeforeRunCreation(
+		context.Background(),
+		pendingRun,
+		executionSpec,
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to inject plugin runtime env")
 }
 
 func TestOnRunEnd_HandlerFailure_ReturnsTrueWithoutParentRun(t *testing.T) {

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -859,14 +859,6 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		PipelineVersionID: run.PipelineSpec.PipelineVersionId, //nolint:staticcheck // QF1008
 		PluginsInput:      (*string)(run.PluginsInputString),
 	}
-	if err := r.pluginDispatcher.OnBeforeRunCreation(ctx, pendingRun, executionSpec); err != nil {
-		return nil, err
-	}
-	// Copy plugin output back to the model.
-	if pendingRun.PluginsOutput != nil {
-		lt := model.LargeText(*pendingRun.PluginsOutput)
-		run.PluginsOutputString = &lt
-	}
 
 	runPersisted := false
 
@@ -877,6 +869,20 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 			}
 		}
 	}()
+
+	if err := r.pluginDispatcher.OnBeforeRunCreation(ctx, pendingRun, executionSpec); err != nil {
+		if pendingRun.PluginsOutput != nil {
+			lt := model.LargeText(*pendingRun.PluginsOutput)
+			run.PluginsOutputString = &lt
+		}
+		return nil, err
+	}
+
+	// Copy plugin output back to the model.
+	if pendingRun.PluginsOutput != nil {
+		lt := model.LargeText(*pendingRun.PluginsOutput)
+		run.PluginsOutputString = &lt
+	}
 
 	newExecSpec, err := r.getWorkflowClient(k8sNamespace).Create(ctx, executionSpec, v1.CreateOptions{})
 	if err != nil {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -301,6 +301,41 @@ func (d *countingTerminalReportDispatcher) PluginsRegistered() bool {
 	return true
 }
 
+type failingRunCreationDispatcher struct {
+	onRunEndCalls int
+	onRunEndRun   *apiserverPlugins.PersistedRun
+}
+
+func (d *failingRunCreationDispatcher) OnBeforeRunCreation(
+	_ context.Context,
+	run *apiserverPlugins.PendingRun,
+	_ util.ExecutionSpec,
+) error {
+	output := `{"test-plugin":{}}`
+	run.PluginsOutput = &output
+	return fmt.Errorf("failed to inject plugin runtime env")
+}
+
+func (d *failingRunCreationDispatcher) OnRunEnd(
+	_ context.Context,
+	run *apiserverPlugins.PersistedRun,
+) bool {
+	d.onRunEndCalls++
+	d.onRunEndRun = run
+	return true
+}
+
+func (d *failingRunCreationDispatcher) OnRunRetry(
+	context.Context,
+	*apiserverPlugins.PersistedRun,
+) error {
+	return nil
+}
+
+func (d *failingRunCreationDispatcher) PluginsRegistered() bool {
+	return true
+}
+
 func TestReadRunLogFromArchiveStreamsObjectStoreFile(t *testing.T) {
 	logArchive := archive.NewLogArchive("/logs", "main.log")
 	execSpec, err := util.NewExecutionSpecJSON(util.CurrentExecutionType(), []byte(testWorkflow.ToStringForStore()))
@@ -2992,6 +3027,42 @@ func TestCreateRun_StoreRunMetadataError(t *testing.T) {
 	assert.Contains(t, err.Error(), "database is closed")
 }
 
+func TestCreateRun_PluginFailureStillCallsOnRunEnd(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	defer store.Close()
+
+	manager := NewResourceManager(
+		store,
+		&ResourceManagerOptions{CollectMetrics: false},
+	)
+
+	experimentID, err := manager.CreateDefaultExperiment("")
+	require.NoError(t, err)
+
+	dispatcher := &failingRunCreationDispatcher{}
+	manager.pluginDispatcher = dispatcher
+
+	apiRun := &model.Run{
+		DisplayName:  "plugin-failure-run",
+		ExperimentId: experimentID,
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+	}
+
+	_, err = manager.CreateRun(context.Background(), apiRun)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to inject plugin runtime env")
+
+	assert.Equal(t, 1, dispatcher.onRunEndCalls,
+		"OnRunEnd should be called when run creation fails after plugin output is produced")
+
+	require.NotNil(t, dispatcher.onRunEndRun)
+	require.Equal(t, apiRun.UUID, dispatcher.onRunEndRun.RunID)
+	require.Contains(t, dispatcher.onRunEndRun.PluginsOutput, "test-plugin")
+}
 func TestCreateRun_WithMLflowPlugin(t *testing.T) {
 	// Set up a fake MLflow server that handles experiment lookup and run creation.
 	// Tags are passed inline in the CreateRun body (atomic tagging).


### PR DESCRIPTION
Fixes #14179

### What was happening

When a plugin's `OnBeforeRunCreation` hook successfully created plugin-side resources but failed while injecting its runtime environment variables, the error from `InjectPluginRuntimeEnv` was only logged and not propagated.

As a result, run creation could continue even though the plugin setup was incomplete.

There was also a cleanup problem: if plugin setup failed before the KFP run was persisted, the existing `OnRunEnd` hook was not invoked, leaving partially-created plugin resources without the normal terminal cleanup path.

### What this changes

- Propagate `InjectPluginRuntimeEnv` failures from `OnBeforeRunCreation`.
- Register the `OnRunEnd` cleanup path before plugin setup begins, so it also runs when run creation fails before persistence.
- Preserve plugin output produced before `OnBeforeRunCreation` fails so `OnRunEnd` can use it for cleanup.
- Add regression tests covering both runtime environment injection failures and cleanup after partial plugin setup.

### Tests

- `go test ./backend/src/apiserver/plugins -run '^TestOnBeforeRunCreation_' -count=1 -timeout=120s`
- `go test ./backend/src/apiserver/resource -run '^TestCreateRun_' -count=1 -timeout=120s`
- `go test ./backend/src/apiserver/plugins ./backend/src/apiserver/resource -count=1 -timeout=180s`