### PR TITLE
fix(apiserver): prevent stale workflow reports from overwriting cancellation

### DIFF
--- a/backend/src/apiserver/gc/run_gc_test.go
+++ b/backend/src/apiserver/gc/run_gc_test.go
@@ -82,6 +82,14 @@ func (f *fakeRunStore) UpdateRunIfRuntimeManifestsUnchanged(
 ) (bool, error) {
 	return true, nil
 }
+func (f *fakeRunStore) UpdateRunFromWorkflow(
+	_ *model.Run,
+	_ model.RuntimeState,
+	_ model.LargeText,
+	_ model.LargeText,
+) (bool, error) {
+	return true, nil
+}
 func (f *fakeRunStore) UpdateRunPluginsOutput(_ string, _ *model.LargeText) error { return nil }
 func (f *fakeRunStore) ArchiveRun(_ string) error                                 { return nil }
 func (f *fakeRunStore) UnarchiveRun(_ string) error                               { return nil }

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -2002,12 +2002,14 @@ func (r *ResourceManager) reportWorkflowResource(
 	}
 	var expectedWorkflowRuntimeManifest model.LargeText
 	var expectedPipelineRuntimeManifest model.LargeText
+	var expectedState model.RuntimeState
 	var verifiedExistingWorkflow util.ExecutionSpec
 	existingWorkflowMissing := false
 	var expectedStoredWorkflowIdentityManifest model.LargeText
 	if updateError == nil {
 		expectedWorkflowRuntimeManifest = run.WorkflowRuntimeManifest
 		expectedPipelineRuntimeManifest = run.PipelineRuntimeManifest
+		expectedState = run.State
 		expectedStoredWorkflowIdentityManifest = storedWorkflowIdentityManifest(run)
 		legacySingleUserRow := !common.IsMultiUserMode() && r.IsEmptyNamespace(run.Namespace)
 		var legacyStoredIdentity storedWorkflowIdentity
@@ -2345,11 +2347,20 @@ func (r *ResourceManager) reportWorkflowResource(
 		run.FinishedAtInSec = execStatus.FinishedAt()
 		run.WorkflowRuntimeManifest = model.LargeText(execSpec.ToStringForStore())
 		var updated bool
-		updated, updateError = r.runStore.UpdateRunIfRuntimeManifestsUnchanged(
-			run,
-			expectedWorkflowRuntimeManifest,
-			expectedPipelineRuntimeManifest,
-		)
+		if execStatus.IsInFinalState() {
+			updated, updateError = r.runStore.UpdateRunIfRuntimeManifestsUnchanged(
+				run,
+				expectedWorkflowRuntimeManifest,
+				expectedPipelineRuntimeManifest,
+			)
+		} else {
+			updated, updateError = r.runStore.UpdateRunFromWorkflow(
+				run,
+				expectedState,
+				expectedWorkflowRuntimeManifest,
+				expectedPipelineRuntimeManifest,
+			)
+		}
 		if updateError != nil {
 			return nil, util.Wrapf(updateError, "Failed to report a workflow for existing run %s during updating the run. Check if the run entry is corrupted", runId)
 		}

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -4468,6 +4468,103 @@ func TestReportWorkflowResource_ScheduledWorkflowIDEmpty_Success(t *testing.T) {
 	assert.Equal(t, expectedRun.ToV1(), run.ToV1())
 }
 
+type runStoreWithBeforeWorkflowUpdateHook struct {
+	storage.RunStoreInterface
+	beforeUpdate func()
+}
+
+func (s *runStoreWithBeforeWorkflowUpdateHook) UpdateRunFromWorkflow(
+	run *model.Run,
+	expectedState model.RuntimeState,
+	expectedWorkflowRuntimeManifest model.LargeText,
+	expectedPipelineRuntimeManifest model.LargeText,
+) (bool, error) {
+	if s.beforeUpdate != nil {
+		beforeUpdate := s.beforeUpdate
+		s.beforeUpdate = nil
+		beforeUpdate()
+	}
+	return s.RunStoreInterface.UpdateRunFromWorkflow(
+		run,
+		expectedState,
+		expectedWorkflowRuntimeManifest,
+		expectedPipelineRuntimeManifest,
+	)
+}
+
+func TestReportWorkflowResource_DoesNotOverwriteConcurrentTermination(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	liveWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	liveWorkflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowRunning
+	liveWorkflow, err = store.ExecClient().Execution(run.Namespace).Update(
+		ctx, liveWorkflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	beforeTermination, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	runStore := manager.runStore.(*storage.RunStore)
+	manager.runStore = &runStoreWithBeforeWorkflowUpdateHook{
+		RunStoreInterface: runStore,
+		beforeUpdate: func() {
+			require.NoError(t, runStore.TerminateRun(run.UUID))
+		},
+	}
+
+	_, err = manager.ReportWorkflowResource(ctx, liveWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable))
+	assert.Contains(t, err.Error(), "stored run changed concurrently")
+
+	persistedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateCancelling, persistedRun.State)
+	assert.Equal(t, "Terminating", persistedRun.Conditions)
+	assert.Equal(t, beforeTermination.WorkflowRuntimeManifest, persistedRun.WorkflowRuntimeManifest)
+	assert.Equal(t, beforeTermination.StateHistory, persistedRun.StateHistory)
+
+	// Model a retry after the first request committed CANCELING but exited
+	// before patching the Workflow. The repeated termination must finish it.
+	require.NoError(t, manager.TerminateRun(ctx, run.UUID))
+	isTerminated, err := store.ExecClientFake.IsTerminatedInNamespace(run.Namespace, run.K8SName)
+	require.NoError(t, err)
+	assert.True(t, isTerminated)
+}
+
+func TestReportWorkflowResource_DoesNotOverwriteExistingCancellation(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	liveWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	liveWorkflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowRunning
+	liveWorkflow, err = store.ExecClient().Execution(run.Namespace).Update(
+		ctx, liveWorkflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	beforeTermination, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	require.NoError(t, manager.runStore.TerminateRun(run.UUID))
+
+	_, err = manager.ReportWorkflowResource(ctx, liveWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable))
+	assert.Contains(t, err.Error(), "stored run changed concurrently")
+
+	persistedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateCancelling, persistedRun.State)
+	assert.Equal(t, "Terminating", persistedRun.Conditions)
+	assert.Equal(t, beforeTermination.WorkflowRuntimeManifest, persistedRun.WorkflowRuntimeManifest)
+	assert.Equal(t, beforeTermination.StateHistory, persistedRun.StateHistory)
+}
+
 func TestReportWorkflowResource_UsesLiveWorkflowState(t *testing.T) {
 	store, manager, run := initWithOneTimeRun(t)
 	defer store.Close()

--- a/backend/src/apiserver/server/report_server_test.go
+++ b/backend/src/apiserver/server/report_server_test.go
@@ -23,6 +23,7 @@ import (
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	apiv2 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/stretchr/testify/assert"
@@ -150,6 +151,49 @@ func TestReportWorkflow(t *testing.T) {
 	run, err = resourceManager.GetRun(run.UUID)
 	assert.Nil(t, err)
 	assert.NotNil(t, run)
+}
+
+func TestReportWorkflow_DoesNotPersistTasksFromStalePreTerminationSnapshot(t *testing.T) {
+	clientManager, resourceManager, run := initWithOneTimeRun(t)
+	defer clientManager.Close()
+	reportServer := NewReportServer(resourceManager)
+	ctx := context.Background()
+
+	liveWorkflow, err := clientManager.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	liveWorkflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowRunning
+	liveWorkflow.(*util.Workflow).Status.Nodes = map[string]v1alpha1.NodeStatus{
+		"node-1": {
+			ID:          "node-1",
+			DisplayName: "task-1",
+			Phase:       v1alpha1.NodeRunning,
+		},
+	}
+	liveWorkflow, err = clientManager.ExecClient().Execution(run.Namespace).Update(
+		ctx, liveWorkflow, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Model the recovery window where cancellation committed to SQL but the
+	// API server has not yet patched the Workflow.
+	require.NoError(t, clientManager.RunStore().TerminateRun(run.UUID))
+	_, err = reportServer.ReportWorkflow(ctx, &apiv2.ReportWorkflowRequest{
+		Workflow: liveWorkflow.ToStringForStore(),
+	})
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable))
+
+	persistedRun, err := resourceManager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateCancelling, persistedRun.State)
+
+	var taskCount int
+	err = clientManager.DB().QueryRow(
+		"SELECT COUNT(*) FROM tasks WHERE RunUUID = ?",
+		run.UUID,
+	).Scan(&taskCount)
+	require.NoError(t, err)
+	assert.Zero(t, taskCount)
 }
 
 func TestReportWorkflow_ValidationFailed(t *testing.T) {

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -164,6 +164,17 @@ type RunStoreInterface interface {
 		expectedPipelineRuntimeManifest model.LargeText,
 	) (bool, error)
 
+	// Updates a run from a nonterminal Workflow observation only when its
+	// persisted state, runtime manifests, and retry generation still match the
+	// values loaded by the reporter. Returns false when another lifecycle
+	// operation won the race.
+	UpdateRunFromWorkflow(
+		run *model.Run,
+		expectedState model.RuntimeState,
+		expectedWorkflowRuntimeManifest model.LargeText,
+		expectedPipelineRuntimeManifest model.LargeText,
+	) (bool, error)
+
 	// Updates only the PluginsOutput column for a run. Use this when plugin
 	// handlers need to persist output without touching core run fields (State,
 	// Conditions, etc.) to avoid redundant writes and potential clobbering.
@@ -740,11 +751,106 @@ func (s *RunStore) UpdateRunIfRuntimeManifestsUnchanged(
 	})
 }
 
+// UpdateRunFromWorkflow applies nonterminal Workflow-derived fields with a
+// database-side compare-and-set. The transition check handles the opposite
+// race ordering: when cancellation committed before the reporter read the run,
+// matching the observed CANCELING state must not authorize a stale RUNNING
+// report.
+func (s *RunStore) UpdateRunFromWorkflow(
+	run *model.Run,
+	expectedState model.RuntimeState,
+	expectedWorkflowRuntimeManifest model.LargeText,
+	expectedPipelineRuntimeManifest model.LargeText,
+) (bool, error) {
+	expectedState = expectedState.ToV2()
+	incomingState := run.State.ToV2()
+
+	switch expectedState {
+	case model.RuntimeStateCancelling:
+		switch incomingState {
+		case model.RuntimeStateCancelling,
+			model.RuntimeStateSucceeded,
+			model.RuntimeStateSkipped,
+			model.RuntimeStateFailed,
+			model.RuntimeStateCanceled:
+			// A canceling run may remain canceling or reach a terminal state.
+		default:
+			return false, nil
+		}
+	case model.RuntimeStateSucceeded,
+		model.RuntimeStateSkipped,
+		model.RuntimeStateFailed,
+		model.RuntimeStateCanceled:
+		if incomingState != expectedState {
+			return false, nil
+		}
+	}
+
+	return s.updateRun(run, &runRuntimeManifestPrecondition{
+		workflow:        expectedWorkflowRuntimeManifest,
+		pipeline:        expectedPipelineRuntimeManifest,
+		retryGeneration: run.RetryGeneration,
+		state:           &expectedState,
+	})
+}
+
+// storedRuntimeStates returns the known raw database values that normalize to
+// state. Older rows may use v1 values or keep the value only in Conditions.
+func storedRuntimeStates(state model.RuntimeState) []string {
+	switch state.ToV2() {
+	case model.RuntimeStateUnspecified:
+		return []string{"RUNTIME_STATE_UNSPECIFIED", "UNKNOWN", "NO_STATUS"}
+	case model.RuntimeStatePending:
+		return []string{"PENDING"}
+	case model.RuntimeStateRunning:
+		return []string{"RUNNING", "ENABLED", "READY"}
+	case model.RuntimeStateSucceeded:
+		return []string{"SUCCEEDED", "DONE"}
+	case model.RuntimeStateSkipped:
+		return []string{"SKIPPED"}
+	case model.RuntimeStateFailed:
+		return []string{"FAILED", "ERROR"}
+	case model.RuntimeStateCancelling:
+		return []string{"CANCELING", "TERMINATING"}
+	case model.RuntimeStateCanceled:
+		return []string{"CANCELED", "DISABLED"}
+	case model.RuntimeStatePaused:
+		return []string{"PAUSED"}
+	default:
+		return nil
+	}
+}
+
+// effectiveStatePredicate mirrors model.Run's legacy state reconstruction:
+// State wins when present; otherwise Conditions supplies the effective state.
+func effectiveStatePredicate(states ...model.RuntimeState) sq.Sqlizer {
+	stored := make([]string, 0, len(states))
+	matchesUnspecified := false
+	for _, state := range states {
+		stored = append(stored, storedRuntimeStates(state)...)
+		if state.ToV2() == model.RuntimeStateUnspecified {
+			matchesUnspecified = true
+		}
+	}
+
+	stateAbsent := sq.Or{sq.Eq{"State": nil}, sq.Eq{"State": ""}}
+	fromConditions := sq.Or{sq.And{stateAbsent, sq.Eq{"UPPER(Conditions)": stored}}}
+	if matchesUnspecified {
+		fromConditions = append(fromConditions, sq.And{
+			stateAbsent,
+			sq.Or{sq.Eq{"Conditions": nil}, sq.Eq{"Conditions": ""}},
+		})
+	}
+
+	return sq.Or{sq.Eq{"UPPER(State)": stored}, fromConditions}
+}
+
 type runRuntimeManifestPrecondition struct {
 	workflow        model.LargeText
 	pipeline        model.LargeText
 	retryGeneration int64
 	namespace       *string
+	state           *model.RuntimeState
 }
 
 func lockRunForRuntimeManifestWrite(
@@ -761,6 +867,9 @@ func lockRunForRuntimeManifestWrite(
 	if expected.namespace != nil {
 		lockColumns = append(lockColumns, "Namespace")
 	}
+	if expected.state != nil {
+		lockColumns = append(lockColumns, "State", "Conditions")
+	}
 	lockColumns = append(lockColumns, "RetryGeneration")
 	lockSQL, lockArgs, err := sq.
 		Select(lockColumns...).
@@ -773,6 +882,8 @@ func lockRunForRuntimeManifestWrite(
 	var currentWorkflowRuntimeManifest model.LargeText
 	var currentPipelineRuntimeManifest model.LargeText
 	var currentNamespace string
+	var currentState sql.NullString
+	var currentConditions sql.NullString
 	var currentRetryGeneration sql.NullInt64
 	lockScanTargets := []any{&currentWorkflowRuntimeManifest}
 	if checkPipelineRuntimeManifest {
@@ -781,6 +892,9 @@ func lockRunForRuntimeManifestWrite(
 	if expected.namespace != nil {
 		lockScanTargets = append(lockScanTargets, &currentNamespace)
 	}
+	if expected.state != nil {
+		lockScanTargets = append(lockScanTargets, &currentState, &currentConditions)
+	}
 	lockScanTargets = append(lockScanTargets, &currentRetryGeneration)
 	if err := tx.QueryRow(db.SelectForUpdate(lockSQL), lockArgs...).Scan(lockScanTargets...); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -788,9 +902,16 @@ func lockRunForRuntimeManifestWrite(
 		}
 		return false, false, err
 	}
+	effectiveState := model.RuntimeStateUnspecified
+	if currentState.Valid && currentState.String != "" {
+		effectiveState = model.RuntimeState(currentState.String).ToV2()
+	} else if currentConditions.Valid {
+		effectiveState = model.RuntimeState(currentConditions.String).ToV2()
+	}
 	matches := currentWorkflowRuntimeManifest == expected.workflow &&
 		(!checkPipelineRuntimeManifest || currentPipelineRuntimeManifest == expected.pipeline) &&
 		(expected.namespace == nil || currentNamespace == *expected.namespace) &&
+		(expected.state == nil || effectiveState == expected.state.ToV2()) &&
 		currentRetryGeneration.Int64 == expected.retryGeneration
 	return true, matches, nil
 }
@@ -830,14 +951,14 @@ func (s *RunStore) updateRun(
 			return false, nil
 		}
 	}
-	if len(run.RunDetails.StateHistory) == 0 || run.RunDetails.StateHistory[len(run.RunDetails.StateHistory)-1].State != run.RunDetails.State {
-		run.RunDetails.StateHistory = append(run.RunDetails.StateHistory, &model.RuntimeStatus{
+	if len(run.StateHistory) == 0 || run.StateHistory[len(run.StateHistory)-1].State != run.State {
+		run.StateHistory = append(run.StateHistory, &model.RuntimeStatus{
 			UpdateTimeInSec: s.time.Now().Unix(),
-			State:           run.RunDetails.State,
+			State:           run.State,
 		})
 	}
 	stateHistoryString := ""
-	if historyString, err := json.Marshal(run.RunDetails.StateHistory); err == nil {
+	if historyString, err := json.Marshal(run.StateHistory); err == nil {
 		stateHistoryString = string(historyString)
 	}
 	updateFields := sq.Eq{
@@ -1534,24 +1655,38 @@ func NewRunStore(db *DB, time util.TimeInterface) *RunStore {
 
 func (s *RunStore) TerminateRun(runId string) error {
 	// TODO(gkcalat): append CANCELLING to StateHistory
-	result, err := s.db.Exec(`
-		UPDATE run_details
-		SET Conditions = ?, State = ?
-		WHERE UUID = ? AND (State = ? OR State = ? OR State = ? OR State = ?)`,
-		string(model.RuntimeStateCancelling.ToV1()),
-		model.RuntimeStateCancelling.ToString(),
-		runId,
-		model.RuntimeStatePaused.ToString(),
-		model.RuntimeStatePending.ToString(),
-		model.RuntimeStateRunning.ToString(),
-		model.RuntimeStateUnspecified.ToString(),
-	)
+	sql, args, err := sq.
+		Update("run_details").
+		SetMap(sq.Eq{
+			"Conditions": string(model.RuntimeStateCancelling.ToV1()),
+			"State":      model.RuntimeStateCancelling.ToString(),
+		}).
+		Where(sq.And{
+			sq.Eq{"UUID": runId},
+			effectiveStatePredicate(
+				model.RuntimeStatePaused,
+				model.RuntimeStatePending,
+				model.RuntimeStateRunning,
+				model.RuntimeStateUnspecified,
+				model.RuntimeStateCancelling,
+			),
+		}).
+		ToSql()
+	if err != nil {
+		return util.NewInternalServerError(err, "Failed to build query for terminating run %s", runId)
+	}
+	result, err := s.db.Exec(sql, args...)
 	if err != nil {
 		return util.NewInternalServerError(err,
 			"Failed to terminate a run %s. Error: '%v'", runId, err.Error())
 	}
 
-	if r, _ := result.RowsAffected(); r != 1 {
+	r, err := result.RowsAffected()
+	if err != nil {
+		return util.NewInternalServerError(err,
+			"Failed to verify termination of run %s", runId)
+	}
+	if r != 1 {
 		return util.NewInvalidInputError("Failed to terminate a run %s. Row not found", runId)
 	}
 	return nil

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -1147,12 +1147,145 @@ func TestUpdateRun_RunNotExist(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
+func TestUpdateRunFromWorkflow_RejectsTerminationRace(t *testing.T) {
+	for _, test := range []struct {
+		name                string
+		terminateBeforeRead bool
+		incomingState       model.RuntimeState
+	}{
+		{name: "termination after read with running report", incomingState: model.RuntimeStateRunning},
+		{name: "termination after read with unspecified report", incomingState: model.RuntimeStateUnspecified},
+		{name: "termination before read with running report", terminateBeforeRead: true, incomingState: model.RuntimeStateRunning},
+		{name: "termination before read with unspecified report", terminateBeforeRead: true, incomingState: model.RuntimeStateUnspecified},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, runStore := initializeRunStore()
+			defer db.Close()
+
+			if test.terminateBeforeRead {
+				require.NoError(t, runStore.TerminateRun("1"))
+			}
+			staleRun, err := runStore.GetRun("1")
+			require.NoError(t, err)
+			expectedState := staleRun.State
+			expectedWorkflowRuntimeManifest := staleRun.WorkflowRuntimeManifest
+			expectedPipelineRuntimeManifest := staleRun.PipelineRuntimeManifest
+			originalHistory := append([]*model.RuntimeStatus(nil), staleRun.StateHistory...)
+			if !test.terminateBeforeRead {
+				require.NoError(t, runStore.TerminateRun("1"))
+			}
+
+			staleRun.State = test.incomingState
+			staleRun.Conditions = string(test.incomingState.ToV1())
+			staleRun.WorkflowRuntimeManifest = "stale-workflow"
+			updated, err := runStore.UpdateRunFromWorkflow(
+				staleRun,
+				expectedState,
+				expectedWorkflowRuntimeManifest,
+				expectedPipelineRuntimeManifest,
+			)
+			require.NoError(t, err)
+			assert.False(t, updated)
+			assert.Equal(t, originalHistory, staleRun.StateHistory)
+
+			persistedRun, err := runStore.GetRun("1")
+			require.NoError(t, err)
+			assert.Equal(t, model.RuntimeStateCancelling, persistedRun.State)
+			assert.Equal(t, "Terminating", persistedRun.Conditions)
+			assert.Equal(t, model.LargeText("workflow1"), persistedRun.WorkflowRuntimeManifest)
+			assert.Equal(t, []*model.RuntimeStatus{{
+				UpdateTimeInSec: 1,
+				State:           model.RuntimeStateRunning,
+			}}, persistedRun.StateHistory)
+		})
+	}
+}
+
+func TestUpdateRunFromWorkflow_MatchesLegacyStateRepresentations(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		state      interface{}
+		conditions string
+	}{
+		{name: "canonical state", state: "RUNNING", conditions: "Running"},
+		{name: "mixed-case state", state: "rUnNiNg", conditions: "Running"},
+		{name: "null state", state: nil, conditions: "rUnNiNg"},
+		{name: "empty state", state: "", conditions: "Ready"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, runStore := initializeRunStore()
+			defer db.Close()
+
+			_, err := db.Exec(
+				"UPDATE run_details SET State = ?, Conditions = ? WHERE UUID = ?",
+				test.state,
+				test.conditions,
+				"1",
+			)
+			require.NoError(t, err)
+
+			reportedRun, err := runStore.GetRun("1")
+			require.NoError(t, err)
+			require.Equal(t, model.RuntimeStateRunning, reportedRun.State)
+			expectedWorkflowRuntimeManifest := reportedRun.WorkflowRuntimeManifest
+			expectedPipelineRuntimeManifest := reportedRun.PipelineRuntimeManifest
+			reportedRun.Conditions = "Running"
+			reportedRun.WorkflowRuntimeManifest = "fresh-workflow"
+
+			updated, err := runStore.UpdateRunFromWorkflow(
+				reportedRun,
+				model.RuntimeStateRunning,
+				expectedWorkflowRuntimeManifest,
+				expectedPipelineRuntimeManifest,
+			)
+			require.NoError(t, err)
+			require.True(t, updated)
+
+			persistedRun, err := runStore.GetRun("1")
+			require.NoError(t, err)
+			assert.Equal(t, model.RuntimeStateRunning, persistedRun.State)
+			assert.Equal(t, model.LargeText("fresh-workflow"), persistedRun.WorkflowRuntimeManifest)
+		})
+	}
+}
+
+func TestUpdateRunFromWorkflow_RejectsStaleRetryGeneration(t *testing.T) {
+	db, runStore := initializeRunStore()
+	defer db.Close()
+
+	staleRun, err := runStore.GetRun("1")
+	require.NoError(t, err)
+	expectedWorkflowRuntimeManifest := staleRun.WorkflowRuntimeManifest
+	expectedPipelineRuntimeManifest := staleRun.PipelineRuntimeManifest
+	originalHistory := append([]*model.RuntimeStatus(nil), staleRun.StateHistory...)
+	_, err = db.Exec("UPDATE run_details SET RetryGeneration = RetryGeneration + 1 WHERE UUID = ?", "1")
+	require.NoError(t, err)
+
+	staleRun.WorkflowRuntimeManifest = "stale-workflow"
+	updated, err := runStore.UpdateRunFromWorkflow(
+		staleRun,
+		model.RuntimeStateRunning,
+		expectedWorkflowRuntimeManifest,
+		expectedPipelineRuntimeManifest,
+	)
+	require.NoError(t, err)
+	assert.False(t, updated)
+	assert.Equal(t, originalHistory, staleRun.StateHistory)
+
+	persistedRun, err := runStore.GetRun("1")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), persistedRun.RetryGeneration)
+	assert.Equal(t, model.LargeText("workflow1"), persistedRun.WorkflowRuntimeManifest)
+}
+
 func TestTerminateRun(t *testing.T) {
 	db, runStore := initializeRunStore()
 	defer db.Close()
 
 	err := runStore.TerminateRun("1")
 	assert.Nil(t, err)
+	err = runStore.TerminateRun("1")
+	assert.Nil(t, err, "terminating an already-canceling run should be idempotent")
 
 	expectedRun := &model.Run{
 		UUID:         "1",
@@ -1194,6 +1327,37 @@ func TestTerminateRun(t *testing.T) {
 	runDetail, err := runStore.GetRun("1")
 	assert.Nil(t, err)
 	assert.Equal(t, expectedRun.ToV1(), runDetail.ToV1())
+}
+
+func TestTerminateRun_LegacyStateRepresentations(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		state      interface{}
+		conditions string
+	}{
+		{name: "mixed-case state", state: "rUnNiNg", conditions: "Running"},
+		{name: "null state", state: nil, conditions: "rUnNiNg"},
+		{name: "empty state", state: "", conditions: "Ready"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			db, runStore := initializeRunStore()
+			defer db.Close()
+
+			_, err := db.Exec(
+				"UPDATE run_details SET State = ?, Conditions = ? WHERE UUID = ?",
+				test.state,
+				test.conditions,
+				"1",
+			)
+			require.NoError(t, err)
+
+			require.NoError(t, runStore.TerminateRun("1"))
+			persistedRun, err := runStore.GetRun("1")
+			require.NoError(t, err)
+			assert.Equal(t, model.RuntimeStateCancelling, persistedRun.State)
+			assert.Equal(t, "Terminating", persistedRun.Conditions)
+		})
+	}
 }
 
 func TestTerminateRun_RunDoesNotExist(t *testing.T) {


### PR DESCRIPTION
## Summary

- condition nonterminal Workflow-derived run updates on UUID, retry generation, and the effective state observed by the reporter
- return retryable `Unavailable` when a concurrent lifecycle update wins, before task or metric persistence can proceed
- make `TerminateRun` idempotent for an existing `CANCELING` row so a retry can finish the Kubernetes Workflow patch

## Problem

`ReportWorkflowResource` reads a run and later updates it without checking whether the row changed in between. A termination can therefore commit `CANCELING`, then a report based on an older Workflow snapshot can overwrite it with `RUNNING` or `RUNTIME_STATE_UNSPECIFIED`. The latter is omitted from the API JSON response, producing the recurrent `terminated run should have a State` integration failure.

This can happen in either order: termination may commit after the report reads the row, or a stale Workflow snapshot may be reported after termination already committed.

## Fix

Nonterminal Workflow reports now use one conditional SQL update. A state/retry-generation mismatch returns `updated=false` without a follow-up read, and the resource manager translates that result to `Unavailable` so the persistence agent retries from a fresh observation. An explicit transition check prevents a report that observes `CANCELING` from writing a stale active or unspecified state.

The state predicate recognizes canonical and legacy `State`/`Conditions` representations case-insensitively. Repeated termination also matches `CANCELING`, which makes client retry safe if the database transition committed but the request failed before patching the Workflow.

This is an API-server-only hotfix. It intentionally does not add a schema, finalizer, outbox, controller, persistence-agent change, or broader lifecycle redesign. A DB-only partial termination still relies on the caller retrying the failed request; this change makes that retry idempotent.

## Testing

- `go test ./backend/src/apiserver/storage ./backend/src/apiserver/resource ./backend/src/apiserver/server ./backend/src/apiserver/gc -count=1`
- `go vet ./backend/src/apiserver/storage ./backend/src/apiserver/resource ./backend/src/apiserver/server ./backend/src/apiserver/gc`
- deterministic coverage for both termination/report orderings, `RUNNING` and unspecified stale reports, legacy state rows, retry-generation fencing, repeated termination, and task-write suppression

Related to #13731. This is a focused replacement for the original termination/report race addressed in #13924.
