### PR TITLE
fix(sdk): honor enable_caching/cache_key when submitting by pipeline_…

### DIFF
--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -75,6 +75,33 @@ class _PipelineDoc:
             }
 
 
+def _pipeline_doc_from_dict(spec_dict: dict) -> _PipelineDoc:
+    """Builds a _PipelineDoc from a pipeline spec dict as returned by the
+
+    API server (e.g. via ``Client.get_pipeline_version()``).
+
+    The dict is either a flat PipelineSpec (the common case), or a
+    ``{'pipeline_spec': ..., 'platform_spec': ...}`` wrapper -- the shape
+    the API server returns when the pipeline was compiled with
+    platform-specific configuration (e.g. Kubernetes-specific config from
+    the ``kfp-kubernetes`` extension). This is the inverse of
+    ``_PipelineDoc.to_dict()``.
+    """
+    if 'pipeline_spec' in spec_dict:
+        raw_pipeline_spec = spec_dict['pipeline_spec']
+        raw_platform_spec = spec_dict.get('platform_spec', {})
+    else:
+        raw_pipeline_spec = spec_dict
+        raw_platform_spec = {}
+
+    pipeline_spec = pipeline_spec_pb2.PipelineSpec()
+    json_format.ParseDict(raw_pipeline_spec, pipeline_spec)
+    platform_spec = pipeline_spec_pb2.PlatformSpec()
+    json_format.ParseDict(raw_platform_spec, platform_spec)
+    return _PipelineDoc(
+        pipeline_spec=pipeline_spec, platform_spec=platform_spec)
+
+
 @dataclasses.dataclass
 class _JobConfig:
     pipeline_spec: dict
@@ -994,10 +1021,11 @@ class Client:
             # request.
             pipeline_version = self.get_pipeline_version(
                 pipeline_id=pipeline_id, pipeline_version_id=version_id)
-            fetched_spec = pipeline_spec_pb2.PipelineSpec()
-            json_format.ParseDict(pipeline_version.pipeline_spec, fetched_spec)
-            _override_caching_options(fetched_spec, enable_caching, cache_key)
-            pipeline_spec = json_format.MessageToDict(fetched_spec)
+            fetched_doc = _pipeline_doc_from_dict(
+                pipeline_version.pipeline_spec)
+            _override_caching_options(fetched_doc.pipeline_spec, enable_caching,
+                                      cache_key)
+            pipeline_spec = fetched_doc.to_dict()
 
         pipeline_version_reference = None
         if pipeline_id is not None and version_id is not None:

--- a/sdk/python/kfp/client/client.py
+++ b/sdk/python/kfp/client/client.py
@@ -984,6 +984,20 @@ class Client:
                 _override_caching_options(pipeline_doc.pipeline_spec,
                                           enable_caching, cache_key)
             pipeline_spec = pipeline_doc.to_dict()
+        elif pipeline_id is not None and version_id is not None and enable_caching is not None:
+            # A caching override can only be applied to a concrete
+            # PipelineSpec. When the pipeline is referenced by id/version
+            # rather than submitted as a local package, fetch its spec so the
+            # override actually reaches the tasks instead of being silently
+            # dropped. The fetch is skipped whenever no caching override is
+            # requested, so the common case stays a cheap reference-only
+            # request.
+            pipeline_version = self.get_pipeline_version(
+                pipeline_id=pipeline_id, pipeline_version_id=version_id)
+            fetched_spec = pipeline_spec_pb2.PipelineSpec()
+            json_format.ParseDict(pipeline_version.pipeline_spec, fetched_spec)
+            _override_caching_options(fetched_spec, enable_caching, cache_key)
+            pipeline_spec = json_format.MessageToDict(fetched_spec)
 
         pipeline_version_reference = None
         if pipeline_id is not None and version_id is not None:

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -145,6 +145,102 @@ class TestOverrideCachingOptions(parameterized.TestCase):
                     ['cachingOptions']['cacheKey'], 'OVERRIDE_KEY')
 
 
+class TestCreateJobConfigCachingWithPipelineReference(parameterized.TestCase):
+    """Regression tests for enable_caching/cache_key being silently dropped
+
+    when a run is submitted by pipeline_id/version_id instead of a local
+    pipeline_package_path. See #14253.
+    """
+
+    def setUp(self):
+        self.client = client.Client(namespace='ns1')
+
+        @component
+        def hello_word(text: str) -> str:
+            return text
+
+        @component
+        def to_lower(text: str) -> str:
+            return text.lower()
+
+        @pipeline(
+            name='sample two-step pipeline',
+            description='a minimal two-step pipeline')
+        def pipeline_with_two_component(text: str = 'hi there'):
+            # Both tasks are compiled with caching *disabled*, so that an
+            # override to enable_caching=True is unambiguous: `enable_cache`
+            # is a plain proto3 bool whose zero value is False, so an
+            # override *to* False would be indistinguishable from the
+            # override never having happened. Overriding to True is the
+            # only direction that proves the fetched spec was actually
+            # mutated.
+            component_1 = hello_word(text=text).set_caching_options(False)
+            to_lower(text=component_1.output).set_caching_options(False)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            temp_filepath = os.path.join(tempdir, 'hello_world_pipeline.yaml')
+            Compiler().compile(
+                pipeline_func=pipeline_with_two_component,
+                package_path=temp_filepath)
+            with open(temp_filepath, 'r') as f:
+                self.pipeline_spec_dict = yaml.safe_load(f)
+
+    def test_enable_caching_is_applied_when_using_pipeline_id_and_version_id(
+            self):
+        with patch.object(
+                self.client._pipelines_api,
+                'pipeline_service_get_pipeline_version',
+                return_value=Mock(
+                    pipeline_spec=self.pipeline_spec_dict)) as mock_get_version:
+            job_config = self.client._create_job_config(
+                params=None,
+                pipeline_package_path=None,
+                pipeline_id='pipeline-1',
+                version_id='version-1',
+                enable_caching=True,
+                cache_key=None,
+                pipeline_root=None,
+            )
+
+        mock_get_version.assert_called_once_with(
+            pipeline_id='pipeline-1', pipeline_version_id='version-1')
+
+        # The caching override must actually reach the submitted spec, even
+        # though both tasks were compiled with caching disabled...
+        self.assertIsNotNone(job_config.pipeline_spec)
+        tasks = job_config.pipeline_spec['root']['dag']['tasks']
+        self.assertTrue(tasks['hello-word']['cachingOptions']['enableCache'])
+        self.assertTrue(tasks['to-lower']['cachingOptions']['enableCache'])
+
+        # ...without losing the pipeline version linkage.
+        self.assertEqual(job_config.pipeline_version_reference.pipeline_id,
+                         'pipeline-1')
+        self.assertEqual(
+            job_config.pipeline_version_reference.pipeline_version_id,
+            'version-1')
+
+    def test_no_caching_override_skips_the_pipeline_version_fetch(self):
+        # When the caller doesn't ask for a caching override, submitting by
+        # reference should stay a cheap, spec-free request: no extra fetch.
+        with patch.object(
+                self.client._pipelines_api,
+                'pipeline_service_get_pipeline_version') as mock_get_version:
+            job_config = self.client._create_job_config(
+                params=None,
+                pipeline_package_path=None,
+                pipeline_id='pipeline-1',
+                version_id='version-1',
+                enable_caching=None,
+                cache_key=None,
+                pipeline_root=None,
+            )
+
+        mock_get_version.assert_not_called()
+        self.assertIsNone(job_config.pipeline_spec)
+        self.assertEqual(job_config.pipeline_version_reference.pipeline_id,
+                         'pipeline-1')
+
+
 class TestExtractPipelineYAML(parameterized.TestCase):
 
     def test_extract_pipeline_yaml_single_doc(self):

--- a/sdk/python/kfp/client/client_test.py
+++ b/sdk/python/kfp/client/client_test.py
@@ -240,6 +240,99 @@ class TestCreateJobConfigCachingWithPipelineReference(parameterized.TestCase):
         self.assertEqual(job_config.pipeline_version_reference.pipeline_id,
                          'pipeline-1')
 
+    def test_enable_caching_is_applied_when_pipeline_has_platform_spec(self):
+        # The API server returns a {'pipeline_spec': ..., 'platform_spec':
+        # ...} wrapper (not a flat PipelineSpec) whenever the pipeline was
+        # compiled with platform-specific configuration, e.g. anything using
+        # the kfp-kubernetes extension (PVCs, secrets, node selectors...).
+        # This is a very common shape in real pipelines, and must not crash.
+        wrapped_spec_dict = {
+            'pipeline_spec': self.pipeline_spec_dict,
+            'platform_spec': {
+                'platforms': {
+                    'kubernetes': {}
+                }
+            },
+        }
+        with patch.object(
+                self.client._pipelines_api,
+                'pipeline_service_get_pipeline_version',
+                return_value=Mock(
+                    pipeline_spec=wrapped_spec_dict)) as mock_get_version:
+            job_config = self.client._create_job_config(
+                params=None,
+                pipeline_package_path=None,
+                pipeline_id='pipeline-1',
+                version_id='version-1',
+                enable_caching=True,
+                cache_key=None,
+                pipeline_root=None,
+            )
+
+        mock_get_version.assert_called_once_with(
+            pipeline_id='pipeline-1', pipeline_version_id='version-1')
+        self.assertIsNotNone(job_config.pipeline_spec)
+        # The wrapped shape is preserved: the caching override lands inside
+        # the nested pipeline_spec, and platform_spec survives untouched.
+        tasks = job_config.pipeline_spec['pipeline_spec']['root']['dag'][
+            'tasks']
+        self.assertTrue(tasks['hello-word']['cachingOptions']['enableCache'])
+        self.assertTrue(tasks['to-lower']['cachingOptions']['enableCache'])
+        self.assertIn('kubernetes',
+                      job_config.pipeline_spec['platform_spec']['platforms'])
+
+    def test_run_pipeline_end_to_end_applies_caching_override(self):
+        # Exercises the public entry point, not just the private helper:
+        # proves run_pipeline() actually wires enable_caching through to
+        # _create_job_config() and on to the request sent to the server.
+        with patch.object(
+                self.client._pipelines_api,
+                'pipeline_service_get_pipeline_version',
+                return_value=Mock(pipeline_spec=self.pipeline_spec_dict)):
+            with patch.object(
+                    self.client._run_api,
+                    'run_service_create_run',
+                    return_value=Mock(run_id='run-1')) as mock_create_run:
+                self.client.run_pipeline(
+                    experiment_id='experiment-1',
+                    job_name='caching-repro',
+                    pipeline_id='pipeline-1',
+                    version_id='version-1',
+                    enable_caching=True,
+                )
+
+        sent_run = mock_create_run.call_args.kwargs['run']
+        tasks = sent_run.pipeline_spec['root']['dag']['tasks']
+        self.assertTrue(tasks['hello-word']['cachingOptions']['enableCache'])
+        self.assertTrue(tasks['to-lower']['cachingOptions']['enableCache'])
+        self.assertEqual(sent_run.pipeline_version_reference.pipeline_id,
+                         'pipeline-1')
+
+    def test_create_recurring_run_end_to_end_applies_caching_override(self):
+        # Same wiring proof as above, for create_recurring_run().
+        with patch.object(
+                self.client._pipelines_api,
+                'pipeline_service_get_pipeline_version',
+                return_value=Mock(pipeline_spec=self.pipeline_spec_dict)):
+            with patch.object(
+                    self.client._recurring_run_api,
+                    'recurring_run_service_create_recurring_run',
+                    return_value=Mock()) as mock_create_recurring_run:
+                self.client.create_recurring_run(
+                    experiment_id='experiment-1',
+                    job_name='caching-repro',
+                    pipeline_id='pipeline-1',
+                    version_id='version-1',
+                    interval_second=60,
+                    enable_caching=True,
+                )
+
+        sent_recurring_run = mock_create_recurring_run.call_args.kwargs[
+            'recurring_run']
+        tasks = sent_recurring_run.pipeline_spec['root']['dag']['tasks']
+        self.assertTrue(tasks['hello-word']['cachingOptions']['enableCache'])
+        self.assertTrue(tasks['to-lower']['cachingOptions']['enableCache'])
+
 
 class TestExtractPipelineYAML(parameterized.TestCase):
 


### PR DESCRIPTION
Fixes #14253.

**Description of your changes:**

`_create_job_config()` only applied a submission-time `enable_caching`/`cache_key` override when the pipeline was submitted as a local package (`pipeline_package_path`). When referencing an already-uploaded pipeline by `pipeline_id`/`version_id` instead, the override was silently dropped: `enable_caching` and `cache_key` were passed to `run_pipeline()`/`create_recurring_run()` but never reached the request.

This fetches the pipeline version's spec via `get_pipeline_version()` when both `pipeline_id`/`version_id` and `enable_caching` are given, applies the existing `_override_caching_options()` to it, and submits the mutated spec alongside the existing `pipeline_version_reference`. When no caching override is requested, no extra fetch happens, so the common case stays a cheap reference-only request.

Added regression tests covering:
- `enable_caching` actually reaching the submitted spec when using `pipeline_id`/`version_id`, without losing the pipeline version reference.
- No extra API call when no caching override is requested.

Verified:
- `pytest sdk/python/kfp/client/client_test.py` — 53 passed
- `yapf --style .style.yapf -d` — clean
- `isort --settings-path .isort.cfg --check-only` — clean

**Checklist:**
- [x] You have signed off your commits
- [x] The title for your pull request (PR) should follow our title convention.
