### PR TITLE
fix(ci): install only Flask-WTF for the MLflow basic-auth lane

### DIFF
--- a/.github/resources/mlflow-direct/manifests/mlflow.yaml
+++ b/.github/resources/mlflow-direct/manifests/mlflow.yaml
@@ -43,8 +43,10 @@ spec:
           set -e
           auth_args=""
           if [ "${MLFLOW_AUTH_TYPE}" = "basic-auth" ]; then
+            # Only Flask-WTF is missing; mlflow[auth] would shadow the image's deps.
+            # Pinned because --no-deps bypasses MLflow's own Flask-WTF<2 constraint.
             python -m pip install --no-cache-dir --target /mlflow/python-packages \
-              "mlflow[auth]==$(python -c 'import mlflow; print(mlflow.__version__)')"
+              --no-deps "Flask-WTF==1.3.0" "WTForms==3.2.2"
             export PYTHONPATH="/mlflow/python-packages${PYTHONPATH:+:${PYTHONPATH}}"
             python -m mlflow.server.auth db upgrade --url sqlite:////mlflow/basic_auth.db
             cd /mlflow


### PR DESCRIPTION
**Context:**
CI failing on #13386 due to unrelated MLflow tests

**Description of your changes:**

Issue: Currently the CI script installed `mlflow[auth]` into an isolated directory, which re-resolved MLflow's entire dependency tree. This is slow and is currently installing incompatible versions (anyio 4.15.0 was published  [2026-09-02](https://github.com/agronholm/anyio/releases/tag/4.15.0), that pulls versions incompatible with the image's starlette)

Fix: only Flask-WTF was actually missing, so we install just that with --no-deps and leave the image's versions alone. Resolves version incompatibility  issues + increases speed

**Checklist:**
- [ ] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
