### PR TITLE
ci: fix MLflow basic-auth tests and add deployment diagnostics

### DIFF
--- a/.github/resources/mlflow-direct/manifests/mlflow.yaml
+++ b/.github/resources/mlflow-direct/manifests/mlflow.yaml
@@ -44,7 +44,8 @@ spec:
           auth_args=""
           if [ "${MLFLOW_AUTH_TYPE}" = "basic-auth" ]; then
             python -m pip install --no-cache-dir --target /mlflow/python-packages \
-              "mlflow[auth]==$(python -c 'import mlflow; print(mlflow.__version__)')"
+              "mlflow[auth]==$(python -c 'import mlflow; print(mlflow.__version__)')" \
+              "anyio<4.15"
             export PYTHONPATH="/mlflow/python-packages${PYTHONPATH:+:${PYTHONPATH}}"
             python -m mlflow.server.auth db upgrade --url sqlite:////mlflow/basic_auth.db
             cd /mlflow
@@ -108,9 +109,9 @@ spec:
           httpGet:
             path: /mlflow/health
             port: 5000
-          initialDelaySeconds: 10
-          periodSeconds: 5
-          failureThreshold: 24
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 54
         resources:
           requests:
             cpu: 100m

--- a/.github/resources/scripts/deploy-direct-mlflow.sh
+++ b/.github/resources/scripts/deploy-direct-mlflow.sh
@@ -72,6 +72,72 @@ kubectl kustomize "$MANIFESTS_DIR" \
   | sed "s#ghcr.io/mlflow/mlflow:v3.13.0-full#${MLFLOW_IMAGE}#g" \
   | kubectl apply -f -
 
-kubectl -n "$MLFLOW_NAMESPACE" wait --for=condition=available deployment/postgres-deployment --timeout=180s
-kubectl -n "$MLFLOW_NAMESPACE" wait --for=condition=available deployment/mlflow --timeout=300s
+echo "Waiting for postgres deployment (timeout 180s)..."
+kubectl -n "$MLFLOW_NAMESPACE" get pods -l app=postgres -o wide
+
+if ! kubectl -n "$MLFLOW_NAMESPACE" wait --for=condition=available deployment/postgres-deployment --timeout=180s; then
+  echo "ERROR: postgres deployment timeout after 180s"
+  echo "=== Pod status ==="
+  kubectl -n "$MLFLOW_NAMESPACE" get pods -l app=postgres -o wide
+  echo "=== Pod describe ==="
+  kubectl -n "$MLFLOW_NAMESPACE" describe pods -l app=postgres
+  echo "=== Pod logs (last 50 lines) ==="
+  kubectl -n "$MLFLOW_NAMESPACE" logs deployment/postgres-deployment --tail=50 --all-containers=true || echo "No logs available"
+  echo "=== Namespace events (last 20) ==="
+  kubectl -n "$MLFLOW_NAMESPACE" get events --sort-by='.lastTimestamp' | tail -20
+  exit 1
+fi
+
+echo "Waiting for mlflow deployment (timeout 600s)..."
+kubectl -n "$MLFLOW_NAMESPACE" get pods -l app=mlflow -o wide
+
+# Background wait with timeout
+(kubectl -n "$MLFLOW_NAMESPACE" wait --for=condition=available deployment/mlflow --timeout=600s) &
+WAIT_PID=$!
+
+# Cleanup trap for background process
+cleanup_mlflow_wait() {
+  if [ -n "$WAIT_PID" ] && kill -0 $WAIT_PID 2>/dev/null; then
+    kill $WAIT_PID 2>/dev/null
+  fi
+}
+trap cleanup_mlflow_wait EXIT INT TERM
+
+# Poll health endpoint while waiting
+MLFLOW_POD=""
+POLL_COUNT=0
+while kill -0 $WAIT_PID 2>/dev/null; do
+  POLL_COUNT=$((POLL_COUNT + 1))
+
+  # Get pod name
+  MLFLOW_POD=$(kubectl -n "$MLFLOW_NAMESPACE" get pods -l app=mlflow -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+  if [ -n "$MLFLOW_POD" ]; then
+    # Check if container is running before exec
+    POD_PHASE=$(kubectl -n "$MLFLOW_NAMESPACE" get pod "$MLFLOW_POD" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    if [ "$POD_PHASE" = "Running" ]; then
+      echo "[Poll $POLL_COUNT] Testing health endpoint in pod $MLFLOW_POD..."
+      kubectl -n "$MLFLOW_NAMESPACE" exec "$MLFLOW_POD" -- sh -c 'command -v curl >/dev/null && curl -s -o /dev/null -w "HTTP %{http_code}" http://localhost:5000/mlflow/health' 2>&1 || echo "Health check exec failed"
+    fi
+  fi
+
+  sleep 10
+done
+
+# Check if wait succeeded
+if ! wait $WAIT_PID; then
+  echo "ERROR: mlflow deployment timeout after 600s"
+  echo "=== Pod status ==="
+  kubectl -n "$MLFLOW_NAMESPACE" get pods -l app=mlflow -o wide
+  echo "=== Pod describe ==="
+  kubectl -n "$MLFLOW_NAMESPACE" describe pods -l app=mlflow
+  echo "=== Full pod logs (all containers) ==="
+  kubectl -n "$MLFLOW_NAMESPACE" logs deployment/mlflow --all-containers=true --prefix=true || echo "No logs available"
+  echo "=== Previous container logs (if restarted) ==="
+  kubectl -n "$MLFLOW_NAMESPACE" logs deployment/mlflow --all-containers=true --previous --prefix=true 2>/dev/null || echo "No previous container logs"
+  echo "=== Namespace events (last 20) ==="
+  kubectl -n "$MLFLOW_NAMESPACE" get events --sort-by='.lastTimestamp' | tail -20
+  exit 1
+fi
+
 kubectl -n "$MLFLOW_NAMESPACE" get pods -l app=mlflow -o wide

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -392,7 +392,25 @@ jobs:
         shell: bash
         if: ${{ steps.deploy-mlflow.outcome == 'success' || steps.deploy_direct_mlflow.outcome == 'success' }}
         run: |
-          kubectl wait --for=condition=Ready pods --field-selector=status.phase=Running -n opendatahub --timeout=180s
+          echo "Checking pod readiness (timeout 180s)..."
+          kubectl get pods -n opendatahub -o wide
+
+          if ! kubectl wait --for=condition=Ready pods --field-selector=status.phase=Running -n opendatahub --timeout=180s; then
+            echo "ERROR: Pod readiness timeout after 180s"
+            echo "=== Pod status ==="
+            kubectl get pods -n opendatahub -o wide
+            echo "=== Pod describe ==="
+            kubectl describe pods -n opendatahub || true
+            echo "=== Pod logs (last 50 lines per container) ==="
+            for pod in $(kubectl get pods -n opendatahub -o jsonpath='{.items[*].metadata.name}'); do
+              echo "--- $pod ---"
+              kubectl logs -n opendatahub "$pod" --all-containers=true --tail=50 || true
+            done
+            echo "=== Namespace events (last 30) ==="
+            kubectl get events -n opendatahub --sort-by='.lastTimestamp' | tail -30
+            exit 1
+          fi
+
           echo "All running pods in opendatahub are Ready"
 
       - name: Configure MLflow Plugin and Forward Ports


### PR DESCRIPTION
## Summary

- Pin `anyio<4.15` in MLflow basic-auth pip install to work around
  lazy-import breakage in anyio 4.15.0 that prevents starlette WSGI
  middleware from resolving `anyio.from_thread`
- Increase MLflow deployment wait timeout from 300s to 600s and relax
  readiness probe timing to accommodate slow PyPI downloads on CI runners
- Add health endpoint polling during MLflow deployment wait with full
  pod logs, describe, and events on timeout
- Enhance E2E workflow readiness step with per-pod diagnostics

## Root cause

anyio 4.15.0 (released 2026-09-02) changed `__init__.py` to lazy imports
via AST parsing. The MLflow basic-auth container does `pip install --target`
at startup, installing anyio 4.15.0 alongside the base image's 4.13.0.
The lazy import mechanism in 4.15.0 fails to resolve `from_thread` as a
module attribute, causing `AttributeError` in starlette's WSGI middleware
and preventing the server from starting.

Failure: https://github.com/kubeflow/pipelines/actions/runs/33772806642/job/100707037070?pr=14261