### PR TITLE
fix(backend): reject cross-namespace workflow reports

### DIFF
--- a/backend/src/apiserver/client/argo_fake.go
+++ b/backend/src/apiserver/client/argo_fake.go
@@ -15,23 +15,33 @@
 package client
 
 import (
+	"sync"
+
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/pkg/errors"
 )
 
 type FakeExecClient struct {
-	workflowClientFake *FakeWorkflowClient
+	mu              sync.RWMutex
+	workflowClients map[string]*FakeWorkflowClient
 }
 
 func NewFakeExecClient() *FakeExecClient {
-	return &FakeExecClient{NewWorkflowClientFake()}
+	return &FakeExecClient{workflowClients: make(map[string]*FakeWorkflowClient)}
 }
 
 func (c *FakeExecClient) Execution(namespace string) util.ExecutionInterface {
 	if len(namespace) == 0 {
 		panic(util.NewResourceNotFoundError("Namespace", namespace))
 	}
-	return c.workflowClientFake
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	workflowClient, ok := c.workflowClients[namespace]
+	if !ok {
+		workflowClient = NewWorkflowClientFake()
+		c.workflowClients[namespace] = workflowClient
+	}
+	return workflowClient
 }
 
 func (c *FakeExecClient) Compare(old, new interface{}) bool {
@@ -39,19 +49,55 @@ func (c *FakeExecClient) Compare(old, new interface{}) bool {
 }
 
 func (c *FakeExecClient) GetWorkflowCount() int {
-	return len(c.workflowClientFake.workflows)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	count := 0
+	for _, workflowClient := range c.workflowClients {
+		workflowClient.mu.RLock()
+		count += len(workflowClient.workflows)
+		workflowClient.mu.RUnlock()
+	}
+	return count
 }
 
-func (c *FakeExecClient) GetWorkflowKeys() map[string]bool {
+func (c *FakeExecClient) GetWorkflowKeysInNamespace(namespace string) map[string]bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	result := map[string]bool{}
-	for key := range c.workflowClientFake.workflows {
+	workflowClient, ok := c.workflowClients[namespace]
+	if !ok {
+		return result
+	}
+	workflowClient.mu.RLock()
+	defer workflowClient.mu.RUnlock()
+	for key := range workflowClient.workflows {
 		result[key] = true
 	}
 	return result
 }
 
-func (c *FakeExecClient) IsTerminated(name string) (bool, error) {
-	workflow, ok := c.workflowClientFake.workflows[name]
+func (c *FakeExecClient) GetWorkflowDeleteCountInNamespace(namespace, name string) int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	workflowClient, ok := c.workflowClients[namespace]
+	if !ok {
+		return 0
+	}
+	workflowClient.mu.RLock()
+	defer workflowClient.mu.RUnlock()
+	return workflowClient.deleteCalls[name]
+}
+
+func (c *FakeExecClient) IsTerminatedInNamespace(namespace, name string) (bool, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	workflowClient, ok := c.workflowClients[namespace]
+	if !ok {
+		return false, errors.New("No workflow found with name: " + name)
+	}
+	workflowClient.mu.RLock()
+	defer workflowClient.mu.RUnlock()
+	workflow, ok := workflowClient.workflows[name]
 	if !ok {
 		return false, errors.New("No workflow found with name: " + name)
 	}

--- a/backend/src/apiserver/client/argo_fake_test.go
+++ b/backend/src/apiserver/client/argo_fake_test.go
@@ -68,7 +68,7 @@ func TestFakeExecClient_GetWorkflowCount(t *testing.T) {
 	}
 }
 
-func TestFakeExecClient_GetWorkflowKeys(t *testing.T) {
+func TestFakeExecClient_GetWorkflowKeysInNamespace(t *testing.T) {
 	client := NewFakeExecClient()
 	ctx := context.Background()
 
@@ -79,9 +79,33 @@ func TestFakeExecClient_GetWorkflowKeys(t *testing.T) {
 		t.Fatalf("setup: Create() unexpected error: %v", err)
 	}
 
-	keys := client.GetWorkflowKeys()
+	keys := client.GetWorkflowKeysInNamespace("default")
 	if !keys["key-workflow"] {
-		t.Errorf("GetWorkflowKeys() missing expected key, got: %v", keys)
+		t.Errorf("GetWorkflowKeysInNamespace() missing expected key, got: %v", keys)
+	}
+}
+
+func TestFakeExecClient_IsolatesWorkflowNamespaces(t *testing.T) {
+	client := NewFakeExecClient()
+	ctx := context.Background()
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{Name: "shared-name"},
+	})
+
+	if _, err := client.Execution("ns1").Create(ctx, workflow, v1.CreateOptions{}); err != nil {
+		t.Fatalf("setup: Create() unexpected error: %v", err)
+	}
+	if _, err := client.Execution("ns2").Get(ctx, "shared-name", v1.GetOptions{}); err == nil {
+		t.Fatal("Get() unexpectedly found a workflow from another namespace")
+	}
+	if err := client.Execution("ns2").Delete(ctx, "shared-name", v1.DeleteOptions{}); err == nil {
+		t.Fatal("Delete() unexpectedly removed a workflow from another namespace")
+	}
+	if count := client.GetWorkflowDeleteCountInNamespace("ns1", "shared-name"); count != 0 {
+		t.Fatalf("namespace-scoped delete count = %d, want 0", count)
+	}
+	if _, err := client.Execution("ns1").Get(ctx, "shared-name", v1.GetOptions{}); err != nil {
+		t.Fatalf("Get() in owning namespace returned error: %v", err)
 	}
 }
 
@@ -100,7 +124,7 @@ func TestFakeExecClient_IsTerminated(t *testing.T) {
 		t.Fatalf("setup: Create() unexpected error: %v", err)
 	}
 
-	isTerminated, err := client.IsTerminated("terminated-wf")
+	isTerminated, err := client.IsTerminatedInNamespace("default", "terminated-wf")
 	if err != nil {
 		t.Fatalf("IsTerminated() unexpected error: %v", err)
 	}
@@ -124,7 +148,7 @@ func TestFakeExecClient_IsNotTerminated(t *testing.T) {
 		t.Fatalf("setup: Create() unexpected error: %v", err)
 	}
 
-	isTerminated, err := client.IsTerminated("running-wf")
+	isTerminated, err := client.IsTerminatedInNamespace("default", "running-wf")
 	if err != nil {
 		t.Fatalf("IsTerminated() unexpected error: %v", err)
 	}
@@ -136,7 +160,7 @@ func TestFakeExecClient_IsNotTerminated(t *testing.T) {
 func TestFakeExecClient_IsTerminatedNotFound(t *testing.T) {
 	client := NewFakeExecClient()
 
-	_, err := client.IsTerminated("nonexistent")
+	_, err := client.IsTerminatedInNamespace("default", "nonexistent")
 	if err == nil {
 		t.Error("IsTerminated() expected error for nonexistent workflow, got nil")
 	}
@@ -153,7 +177,7 @@ func TestFakeExecClient_IsTerminatedNoDeadline(t *testing.T) {
 		t.Fatalf("setup: Create() unexpected error: %v", err)
 	}
 
-	_, err := client.IsTerminated("no-deadline")
+	_, err := client.IsTerminatedInNamespace("default", "no-deadline")
 	if err == nil {
 		t.Error("IsTerminated() expected error for workflow without ActiveDeadlineSeconds, got nil")
 	}

--- a/backend/src/apiserver/client/workflow_fake.go
+++ b/backend/src/apiserver/client/workflow_fake.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/golang/glog"
@@ -33,8 +34,12 @@ import (
 )
 
 type FakeWorkflowClient struct {
-	workflows       map[string]*v1alpha1.Workflow
-	lastGeneratedId int
+	mu                  sync.RWMutex
+	workflows           map[string]*v1alpha1.Workflow
+	deleteCalls         map[string]int
+	lastGeneratedID     int
+	lastCreationID      int64
+	lastResourceVersion int64
 }
 
 type jsonPatchOperation struct {
@@ -46,25 +51,37 @@ type jsonPatchOperation struct {
 func NewWorkflowClientFake() *FakeWorkflowClient {
 	return &FakeWorkflowClient{
 		workflows:       make(map[string]*v1alpha1.Workflow),
-		lastGeneratedId: -1,
+		deleteCalls:     make(map[string]int),
+		lastGeneratedID: -1,
 	}
 }
 
 func (c *FakeWorkflowClient) Create(ctx context.Context, execSpec util.ExecutionSpec, opts v1.CreateOptions) (util.ExecutionSpec, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	workflow, ok := execSpec.(*util.Workflow)
 	if !ok {
 		return nil, fmt.Errorf("not a valid ExecutionSpec for Workflow")
 	}
 	if workflow.GenerateName != "" {
-		c.lastGeneratedId += 1
-		workflow.Name = workflow.GenerateName + strconv.Itoa(c.lastGeneratedId)
+		c.lastGeneratedID += 1
+		workflow.Name = workflow.GenerateName + strconv.Itoa(c.lastGeneratedID)
 		workflow.GenerateName = ""
 	}
+	// Kubernetes owns UID and resourceVersion. Always replace caller-supplied
+	// values so recreation and concurrency tests cannot preserve the identity or
+	// version of a deleted object, which the real API server would never do.
+	c.lastCreationID++
+	c.lastResourceVersion++
+	workflow.UID = types.UID(fmt.Sprintf("workflow%d", c.lastCreationID))
+	workflow.ResourceVersion = strconv.FormatInt(c.lastResourceVersion, 10)
 	c.workflows[workflow.Name] = workflow.Workflow
 	return workflow, nil
 }
 
 func (c *FakeWorkflowClient) Get(ctx context.Context, name string, options v1.GetOptions) (util.ExecutionSpec, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	workflow, ok := c.workflows[name]
 	if ok {
 		return util.NewWorkflow(workflow), nil
@@ -83,6 +100,8 @@ func (c *FakeWorkflowClient) Watch(ctx context.Context, opts v1.ListOptions) (wa
 }
 
 func (c *FakeWorkflowClient) Update(ctx context.Context, execSpec util.ExecutionSpec, opts v1.UpdateOptions) (util.ExecutionSpec, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	workflow, ok := execSpec.(*util.Workflow)
 	if !ok {
 		return nil, fmt.Errorf("not a valid ExecutionSpec for Workflow")
@@ -90,6 +109,8 @@ func (c *FakeWorkflowClient) Update(ctx context.Context, execSpec util.Execution
 	name := workflow.GetObjectMeta().GetName()
 	_, ok = c.workflows[name]
 	if ok {
+		c.lastResourceVersion++
+		workflow.ResourceVersion = strconv.FormatInt(c.lastResourceVersion, 10)
 		c.workflows[name] = workflow.Workflow
 		return workflow, nil
 	}
@@ -97,8 +118,28 @@ func (c *FakeWorkflowClient) Update(ctx context.Context, execSpec util.Execution
 }
 
 func (c *FakeWorkflowClient) Delete(ctx context.Context, name string, options v1.DeleteOptions) error {
-	_, ok := c.workflows[name]
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	workflow, ok := c.workflows[name]
 	if ok {
+		if options.Preconditions != nil && options.Preconditions.UID != nil && workflow.UID != *options.Preconditions.UID {
+			return k8errors.NewConflict(
+				k8schema.ParseGroupResource("workflows.argoproj.io"),
+				name,
+				fmt.Errorf("workflow UID %q does not match delete precondition %q", workflow.UID, *options.Preconditions.UID),
+			)
+		}
+		if options.Preconditions != nil && options.Preconditions.ResourceVersion != nil &&
+			workflow.ResourceVersion != *options.Preconditions.ResourceVersion {
+			return k8errors.NewConflict(
+				k8schema.ParseGroupResource("workflows.argoproj.io"),
+				name,
+				fmt.Errorf("workflow resourceVersion %q does not match delete precondition %q",
+					workflow.ResourceVersion, *options.Preconditions.ResourceVersion),
+			)
+		}
+		c.deleteCalls[name]++
+		delete(c.workflows, name)
 		return nil
 	}
 	return k8errors.NewNotFound(k8schema.ParseGroupResource("workflows.argoproj.io"), name)
@@ -114,13 +155,20 @@ func (c *FakeWorkflowClient) DeleteCollection(ctx context.Context, options v1.De
 func (c *FakeWorkflowClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v1.PatchOptions,
 	subresources ...string,
 ) (util.ExecutionSpec, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	workflow, ok := c.workflows[name]
 	if !ok {
 		return nil, k8errors.NewNotFound(k8schema.ParseGroupResource("workflows.argoproj.io"), name)
 	}
 
 	if pt == types.JSONPatchType {
-		return applyJSONPatchToFakeWorkflow(workflow, name, data)
+		patchedWorkflow, err := applyJSONPatchToFakeWorkflow(workflow, name, data)
+		if err == nil {
+			c.lastResourceVersion++
+			workflow.ResourceVersion = strconv.FormatInt(c.lastResourceVersion, 10)
+		}
+		return patchedWorkflow, err
 	}
 
 	var dat map[string]interface{}
@@ -138,6 +186,8 @@ func (c *FakeWorkflowClient) Patch(ctx context.Context, name string, pt types.Pa
 			if ok {
 				newActiveDeadlineSeconds := int64(0)
 				workflow.Spec.ActiveDeadlineSeconds = &newActiveDeadlineSeconds
+				c.lastResourceVersion++
+				workflow.ResourceVersion = strconv.FormatInt(c.lastResourceVersion, 10)
 				return util.NewWorkflow(workflow), nil
 			}
 		}
@@ -150,6 +200,8 @@ func (c *FakeWorkflowClient) Patch(ctx context.Context, name string, pt types.Pa
 				workflow.Labels = map[string]string{}
 			}
 			workflow.Labels[util.LabelKeyWorkflowPersistedFinalState] = "true"
+			c.lastResourceVersion++
+			workflow.ResourceVersion = strconv.FormatInt(c.lastResourceVersion, 10)
 			return util.NewWorkflow(workflow), nil
 		}
 	}
@@ -205,11 +257,11 @@ type FakeBadWorkflowClient struct {
 	FakeWorkflowClient
 }
 
-func (FakeBadWorkflowClient) Create(context.Context, util.ExecutionSpec, v1.CreateOptions) (util.ExecutionSpec, error) {
+func (*FakeBadWorkflowClient) Create(context.Context, util.ExecutionSpec, v1.CreateOptions) (util.ExecutionSpec, error) {
 	return nil, errors.New("some error")
 }
 
-func (FakeBadWorkflowClient) Get(ctx context.Context, name string, options v1.GetOptions) (util.ExecutionSpec, error) {
+func (*FakeBadWorkflowClient) Get(ctx context.Context, name string, options v1.GetOptions) (util.ExecutionSpec, error) {
 	return nil, errors.New("some error")
 }
 

--- a/backend/src/apiserver/client/workflow_fake_test.go
+++ b/backend/src/apiserver/client/workflow_fake_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -30,7 +31,9 @@ func TestFakeWorkflowClient_Create(t *testing.T) {
 
 	workflow := util.NewWorkflow(&v1alpha1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
-			Name: "my-workflow",
+			Name:            "my-workflow",
+			UID:             "caller-supplied-uid",
+			ResourceVersion: "caller-supplied-version",
 		},
 	})
 
@@ -40,6 +43,12 @@ func TestFakeWorkflowClient_Create(t *testing.T) {
 	}
 	if result.ExecutionName() != "my-workflow" {
 		t.Errorf("Create() name = %q, want %q", result.ExecutionName(), "my-workflow")
+	}
+	if result.ExecutionObjectMeta().UID == "" || result.ExecutionObjectMeta().UID == "caller-supplied-uid" {
+		t.Errorf("Create() UID = %q, want a server-assigned identity", result.ExecutionObjectMeta().UID)
+	}
+	if result.Version() == "" || result.Version() == "caller-supplied-version" {
+		t.Errorf("Create() resourceVersion = %q, want a server-assigned version", result.Version())
 	}
 }
 
@@ -60,6 +69,31 @@ func TestFakeWorkflowClient_CreateWithGenerateName(t *testing.T) {
 	expectedName := "workflow-0"
 	if result.ExecutionName() != expectedName {
 		t.Errorf("Create() name = %q, want %q", result.ExecutionName(), expectedName)
+	}
+}
+
+func TestFakeWorkflowClient_RecreateAssignsNewUID(t *testing.T) {
+	client := NewWorkflowClientFake()
+	ctx := context.Background()
+
+	first, err := client.Create(ctx, util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{Name: "recreated-workflow"},
+	}), v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("first Create() unexpected error: %v", err)
+	}
+	if err := client.Delete(ctx, first.ExecutionName(), v1.DeleteOptions{}); err != nil {
+		t.Fatalf("Delete() unexpected error: %v", err)
+	}
+	second, err := client.Create(ctx, util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{Name: "recreated-workflow"},
+	}), v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("second Create() unexpected error: %v", err)
+	}
+
+	if first.ExecutionObjectMeta().UID == second.ExecutionObjectMeta().UID {
+		t.Fatalf("recreated workflow UID = %q, want a new object identity", second.ExecutionObjectMeta().UID)
 	}
 }
 
@@ -107,6 +141,69 @@ func TestFakeWorkflowClient_Delete(t *testing.T) {
 	err := client.Delete(ctx, "to-delete", v1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Delete() unexpected error: %v", err)
+	}
+	if _, err := client.Get(ctx, "to-delete", v1.GetOptions{}); !k8errors.IsNotFound(err) {
+		t.Fatalf("Get() after Delete() error = %v, want NotFound", err)
+	}
+}
+
+func TestFakeWorkflowClient_DeleteHonorsUIDPrecondition(t *testing.T) {
+	client := NewWorkflowClientFake()
+	ctx := context.Background()
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{Name: "to-delete", UID: "current-uid"},
+	})
+	created, err := client.Create(ctx, workflow, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("setup: Create() unexpected error: %v", err)
+	}
+
+	staleUID := types.UID("stale-uid")
+	err = client.Delete(ctx, "to-delete", v1.DeleteOptions{
+		Preconditions: &v1.Preconditions{UID: &staleUID},
+	})
+	if !k8errors.IsConflict(err) {
+		t.Fatalf("Delete() error = %v, want Conflict", err)
+	}
+	if _, err := client.Get(ctx, "to-delete", v1.GetOptions{}); err != nil {
+		t.Fatalf("Get() after rejected Delete() error = %v, want workflow retained", err)
+	}
+
+	currentUID := created.ExecutionObjectMeta().UID
+	if err := client.Delete(ctx, "to-delete", v1.DeleteOptions{
+		Preconditions: &v1.Preconditions{UID: &currentUID},
+	}); err != nil {
+		t.Fatalf("Delete() with current UID unexpected error: %v", err)
+	}
+}
+
+func TestFakeWorkflowClient_DeleteHonorsResourceVersionPrecondition(t *testing.T) {
+	client := NewWorkflowClientFake()
+	ctx := context.Background()
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{Name: "to-delete", ResourceVersion: "current-version"},
+	})
+	created, err := client.Create(ctx, workflow, v1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("setup: Create() unexpected error: %v", err)
+	}
+
+	staleVersion := "stale-version"
+	err = client.Delete(ctx, "to-delete", v1.DeleteOptions{
+		Preconditions: &v1.Preconditions{ResourceVersion: &staleVersion},
+	})
+	if !k8errors.IsConflict(err) {
+		t.Fatalf("Delete() error = %v, want Conflict", err)
+	}
+	if _, err := client.Get(ctx, "to-delete", v1.GetOptions{}); err != nil {
+		t.Fatalf("Get() after rejected Delete() error = %v, want workflow retained", err)
+	}
+
+	currentVersion := created.Version()
+	if err := client.Delete(ctx, "to-delete", v1.DeleteOptions{
+		Preconditions: &v1.Preconditions{ResourceVersion: &currentVersion},
+	}); err != nil {
+		t.Fatalf("Delete() with current resourceVersion unexpected error: %v", err)
 	}
 }
 

--- a/backend/src/apiserver/common/config.go
+++ b/backend/src/apiserver/common/config.go
@@ -74,10 +74,12 @@ type PluginLimitsConfig struct {
 	MaxNestingDepth      int
 }
 
-// GetWorkflowGCGracePeriodSeconds returns the grace period in seconds before
-// a workflow without a corresponding DB entry is eligible for garbage collection.
-// This prevents race conditions where the persistence agent reports a workflow
-// before the API server has finished writing the run record to the database.
+// GetWorkflowGCGracePeriodSeconds returns the grace period in seconds during
+// which a workflow without a corresponding DB entry receives a retryable
+// response. After the grace period the API server re-reads the live workflow
+// and deletes it only when its UID and run ID label identify the orphan; it
+// never deletes based on caller-controlled report metadata. This prevents races
+// while the run record is being written.
 func GetWorkflowGCGracePeriodSeconds() int {
 	return GetIntConfigWithDefault(WorkflowGCGracePeriodSeconds, 120)
 }

--- a/backend/src/apiserver/gc/run_gc_test.go
+++ b/backend/src/apiserver/gc/run_gc_test.go
@@ -74,7 +74,14 @@ func (f *fakeRunStore) GetRun(_ string) (*model.Run, error)        { return nil,
 func (f *fakeRunStore) ListRuns(_ *model.FilterContext, _ *list.Options) ([]*model.Run, int, string, error) {
 	return nil, 0, "", nil
 }
-func (f *fakeRunStore) UpdateRun(_ *model.Run) error                              { return nil }
+func (f *fakeRunStore) UpdateRun(_ *model.Run) error { return nil }
+func (f *fakeRunStore) UpdateRunIfRuntimeManifestsUnchanged(
+	_ *model.Run,
+	_ model.LargeText,
+	_ model.LargeText,
+) (bool, error) {
+	return true, nil
+}
 func (f *fakeRunStore) UpdateRunPluginsOutput(_ string, _ *model.LargeText) error { return nil }
 func (f *fakeRunStore) ArchiveRun(_ string) error                                 { return nil }
 func (f *fakeRunStore) UnarchiveRun(_ string) error                               { return nil }

--- a/backend/src/apiserver/resource/resource_manager.go
+++ b/backend/src/apiserver/resource/resource_manager.go
@@ -15,7 +15,9 @@
 package resource
 
 import (
+	containerlist "container/list"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,6 +25,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -54,6 +57,13 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+const (
+	workflowReportRejectionIdentityMismatch    = "identity_mismatch"
+	workflowReportRejectionNamespaceMismatch   = "namespace_mismatch"
+	workflowReportRejectionOwnershipUnresolved = "ownership_unresolved"
+	storedWorkflowIdentityCacheCapacity        = 10_000
+)
+
 // Metric variables. Please prefix the metric names with resource_manager_.
 var (
 	extraLabels = []string{
@@ -69,6 +79,14 @@ var (
 		Name: "resource_manager_workflow_gc",
 		Help: "The number of garbage-collected workflows",
 	})
+
+	// Count reports rejected before they can mutate a run or delete a Workflow.
+	// The reason label is restricted to constants so the metric has
+	// bounded cardinality and can be used for operator alerts.
+	workflowReportRejectedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "resource_manager_workflow_reports_rejected_total",
+		Help: "The number of workflow reports rejected before persistence or garbage collection",
+	}, []string{"reason"})
 
 	// Count the successful workflow runs
 	workflowSuccessCounter = promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -150,6 +168,130 @@ type ResourceManager struct {
 	authenticators            []kfpauth.Authenticator
 	options                   *ResourceManagerOptions
 	pluginDispatcher          apiserverPlugins.RunPluginDispatcher
+	storedWorkflowIdentities  storedWorkflowIdentityCache
+}
+
+type storedWorkflowIdentity struct {
+	name            string
+	namespace       string
+	uid             types.UID
+	retryGeneration int64
+	manifestDigest  [sha256.Size]byte
+}
+
+type cachedStoredWorkflowIdentity struct {
+	identity storedWorkflowIdentity
+	element  *containerlist.Element
+}
+
+type storedWorkflowIdentityCache struct {
+	mu      sync.Mutex
+	entries map[string]cachedStoredWorkflowIdentity
+	recency *containerlist.List
+}
+
+func (c *storedWorkflowIdentityCache) load(runID string) (storedWorkflowIdentity, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, found := c.entries[runID]
+	if !found {
+		return storedWorkflowIdentity{}, false
+	}
+	c.recency.MoveToBack(entry.element)
+	return entry.identity, true
+}
+
+func (c *storedWorkflowIdentityCache) loadOrStore(
+	runID string,
+	identity storedWorkflowIdentity,
+) storedWorkflowIdentity {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry, found := c.entries[runID]; found {
+		c.recency.MoveToBack(entry.element)
+		// Retry generations are monotonic. A report that loaded an older run
+		// row must never replace the identity cached by a completed RetryRun.
+		if entry.identity.retryGeneration > identity.retryGeneration {
+			return entry.identity
+		}
+		// Cache entries are valid only for the exact persisted manifest they
+		// were decoded from. Identity repairs can update that manifest without
+		// incrementing the retry generation, including from another replica.
+		if entry.identity.retryGeneration == identity.retryGeneration &&
+			entry.identity.manifestDigest == identity.manifestDigest {
+			return entry.identity
+		}
+		entry.identity = identity
+		c.entries[runID] = entry
+		return identity
+	}
+	if c.entries == nil {
+		c.entries = make(map[string]cachedStoredWorkflowIdentity)
+		c.recency = containerlist.New()
+	}
+	if len(c.entries) >= storedWorkflowIdentityCacheCapacity {
+		oldest := c.recency.Front()
+		delete(c.entries, oldest.Value.(string))
+		c.recency.Remove(oldest)
+	}
+	element := c.recency.PushBack(runID)
+	c.entries[runID] = cachedStoredWorkflowIdentity{identity: identity, element: element}
+	return identity
+}
+
+func (c *storedWorkflowIdentityCache) replaceAfterPersist(
+	runID string,
+	expectedManifestDigest [sha256.Size]byte,
+	identity storedWorkflowIdentity,
+) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry, found := c.entries[runID]; found {
+		if entry.identity.retryGeneration > identity.retryGeneration {
+			c.recency.MoveToBack(entry.element)
+			return
+		}
+		// A later report can commit and refresh the cache before an earlier
+		// reporter resumes after its own commit. Only advance an entry from the
+		// manifest this write replaced (or accept the exact new manifest), so
+		// delayed post-commit work cannot restore an older cache digest.
+		if entry.identity.retryGeneration == identity.retryGeneration &&
+			entry.identity.manifestDigest != expectedManifestDigest &&
+			entry.identity.manifestDigest != identity.manifestDigest {
+			c.recency.MoveToBack(entry.element)
+			return
+		}
+		entry.identity = identity
+		c.entries[runID] = entry
+		c.recency.MoveToBack(entry.element)
+		return
+	}
+	if c.entries == nil {
+		c.entries = make(map[string]cachedStoredWorkflowIdentity)
+		c.recency = containerlist.New()
+	}
+	if len(c.entries) >= storedWorkflowIdentityCacheCapacity {
+		oldest := c.recency.Front()
+		delete(c.entries, oldest.Value.(string))
+		c.recency.Remove(oldest)
+	}
+	element := c.recency.PushBack(runID)
+	c.entries[runID] = cachedStoredWorkflowIdentity{identity: identity, element: element}
+}
+
+func (c *storedWorkflowIdentityCache) delete(runID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, found := c.entries[runID]
+	if !found {
+		return
+	}
+	delete(c.entries, runID)
+	c.recency.Remove(entry.element)
 }
 
 func NewResourceManager(clientManager ClientManagerInterface, options *ResourceManagerOptions) *ResourceManager {
@@ -744,6 +886,7 @@ func (r *ResourceManager) CreateRun(ctx context.Context, run *model.Run) (*model
 		return nil, util.NewInternalServerError(err, "Failed to create a workflow for (%s)", executionSpec.ExecutionName())
 	}
 	// Update the run with the new scheduled workflow
+	run.Namespace = k8sNamespace
 	run.K8SName = newExecSpec.ExecutionName()
 	run.ServiceAccount = newExecSpec.ServiceAccount()
 	run.RunDetails.State = model.RuntimeState(string(newExecSpec.ExecutionStatus().Condition())).ToV2()
@@ -950,6 +1093,7 @@ func (r *ResourceManager) DeleteRun(ctx context.Context, runId string) error {
 	if err != nil {
 		return util.Wrapf(err, "Failed to delete a run %v", runId)
 	}
+	r.storedWorkflowIdentities.delete(runId)
 
 	if r.options.CollectMetrics {
 		if run.Conditions == string(exec.ExecutionSucceeded) {
@@ -1041,7 +1185,6 @@ func (r *ResourceManager) TerminateRun(ctx context.Context, runId string) error 
 	if err != nil {
 		return util.Wrapf(err, "Failed to terminate run %s due to error fetching the run", runId)
 	}
-	// TODO(gkcalat): consider using run.Namespace after migration logic will be available.
 	namespace, err := r.getNamespaceFromRunId(runId)
 	if err != nil {
 		return util.Wrapf(err, "Failed to terminate run %s due to error fetching its namespace", runId)
@@ -1126,6 +1269,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 				run.State = model.RuntimeState(condition).ToV2()
 				run.FinishedAtInSec = liveWorkflow.ExecutionStatus().FinishedAt()
 				run.WorkflowRuntimeManifest = model.LargeText(liveWorkflow.ToStringForStore())
+				run.K8SName = liveWorkflow.ExecutionName()
 				// The crashed retry may not have reached plugin
 				// notification, so adoption fires it (mirrors the normal
 				// retry path); delivery is documented as at-least-once and
@@ -1139,6 +1283,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 				if updateError := r.runStore.UpdateRun(run); updateError != nil {
 					return util.NewInternalServerError(updateError, "Failed to adopt in-flight retry for run %s", runId)
 				}
+				r.storedWorkflowIdentities.delete(runId)
 				return nil
 			case readError != nil && !apierrors.IsNotFound(readError):
 				// Transient read: preserve the claim rather than risking a
@@ -1246,6 +1391,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	// when the reconciliation path adopted an already-terminal retry.
 	run.FinishedAtInSec = newExecSpec.ExecutionStatus().FinishedAt()
 	run.WorkflowRuntimeManifest = model.LargeText(newExecSpec.ToStringForStore())
+	run.K8SName = newExecSpec.ExecutionName()
 	run.State = model.RuntimeState(condition).ToV2()
 	// OnRunRetry persists plugin output independently; leave PluginsOutput unchanged here.
 	run.PluginsOutputString = nil
@@ -1253,6 +1399,7 @@ func (r *ResourceManager) RetryRun(ctx context.Context, runId string) error {
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to retry run %s due to error updating entry", runId)
 	}
+	r.storedWorkflowIdentities.delete(runId)
 	return nil
 }
 
@@ -1340,7 +1487,6 @@ func (r *ResourceManager) ReadLog(ctx context.Context, runId string, nodeId stri
 	if err != nil {
 		return util.NewBadRequestError(err, "Failed to read logs for run %v due to run fetching error", runId)
 	}
-	// TODO(gkcalat): consider using run.Namespace after migration logic will be available.
 	namespace, err := r.getNamespaceFromRunId(runId)
 	if err != nil {
 		return util.NewBadRequestError(err, "Failed to read logs for run %v due to namespace fetching error", runId)
@@ -1682,10 +1828,79 @@ func (r *ResourceManager) DeleteJob(ctx context.Context, jobID string, propagati
 
 // Creates new tasks or updates existing ones.
 // This is not a part of internal API exposed to persistence agent only.
-func (r *ResourceManager) CreateOrUpdateTasks(t []*model.Task, runID string) ([]*model.Task, error) {
-	tasks, err := r.taskStore.CreateOrUpdateTasks(t, runID)
+func (r *ResourceManager) CreateOrUpdateTasks(t []*model.Task, runID, workflowNamespace string) ([]*model.Task, error) {
+	run, err := r.GetRun(runID)
+	if err != nil {
+		return nil, util.Wrapf(err, "Failed to validate task ownership for run %s", runID)
+	}
+	return r.CreateOrUpdateTasksForRun(t, run, workflowNamespace)
+}
+
+// CreateOrUpdateTasksForRun creates or updates tasks using an already-loaded owning run.
+func (r *ResourceManager) CreateOrUpdateTasksForRun(
+	tasksToReport []*model.Task,
+	run *model.Run,
+	workflowNamespace string,
+) ([]*model.Task, error) {
+	if run == nil {
+		return nil, util.NewInvalidInputError("Failed to report tasks: owning run is missing")
+	}
+	runID := run.UUID
+	runNamespace, err := r.resolveWorkflowReportNamespace(
+		"run", runID, run.Namespace, run.ExperimentId, workflowNamespace)
+	if err != nil {
+		r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+		return nil, err
+	}
+	if err := r.validateWorkflowReportNamespace(
+		"run", runID, runNamespace, workflowNamespace, run.K8SName); err != nil {
+		return nil, err
+	}
+	for _, task := range tasksToReport {
+		if task.RunID != runID {
+			r.recordWorkflowReportRejection(workflowReportRejectionIdentityMismatch)
+			return nil, util.NewInvalidInputError(
+				"Failed to report tasks: task run ID does not match owning run")
+		}
+		if !r.IsEmptyNamespace(task.Namespace) && task.Namespace != workflowNamespace {
+			r.recordWorkflowReportRejection(workflowReportRejectionNamespaceMismatch)
+			return nil, util.NewInvalidInputError(
+				"Failed to report tasks: task namespace does not match owning run")
+		}
+	}
+	tasks, updated, err := r.taskStore.CreateOrUpdateTasksIfRunUnchanged(
+		tasksToReport,
+		runID,
+		run.Namespace,
+		run.WorkflowRuntimeManifest,
+		run.PipelineRuntimeManifest,
+		run.RetryGeneration,
+	)
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to create or update tasks")
+	}
+	if !updated {
+		// The workflow report and task upsert are separate transactions. If
+		// the run changed between them, reload its authoritative identity and
+		// retry the complete report rather than attaching stale tasks to a
+		// replacement row that reused the run ID.
+		r.storedWorkflowIdentities.delete(runID)
+		currentRun, readError := r.GetRun(runID)
+		if readError != nil {
+			return nil, util.NewUnavailableServerError(
+				readError,
+				"Failed to reload run %s after a concurrent task report - try again later",
+				runID,
+			)
+		}
+		if _, identityError := r.storedWorkflowIdentityForRun(currentRun); identityError != nil {
+			return nil, identityError
+		}
+		return nil, util.NewUnavailableServerError(
+			errors.New("stored run changed while processing task report"),
+			"Failed to report tasks for run %s because the stored run changed concurrently - try again later",
+			runID,
+		)
 	}
 	return tasks, nil
 }
@@ -1693,6 +1908,26 @@ func (r *ResourceManager) CreateOrUpdateTasks(t []*model.Task, runID string) ([]
 // Reports a workflow CR.
 // This is called to update runs.
 func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec util.ExecutionSpec) (util.ExecutionSpec, error) {
+	return r.reportWorkflowResource(ctx, execSpec, nil)
+}
+
+// ReportWorkflowResourceWithRun reports a workflow using an already-loaded owning run.
+func (r *ResourceManager) ReportWorkflowResourceWithRun(
+	ctx context.Context,
+	execSpec util.ExecutionSpec,
+	run *model.Run,
+) (util.ExecutionSpec, error) {
+	if run == nil {
+		return nil, util.NewInvalidInputError("Failed to report workflow: owning run is missing")
+	}
+	return r.reportWorkflowResource(ctx, execSpec, run)
+}
+
+func (r *ResourceManager) reportWorkflowResource(
+	ctx context.Context,
+	execSpec util.ExecutionSpec,
+	run *model.Run,
+) (util.ExecutionSpec, error) {
 	objMeta := execSpec.ExecutionObjectMeta()
 	execStatus := execSpec.ExecutionStatus()
 	if _, ok := objMeta.Labels[util.LabelKeyWorkflowRunId]; !ok {
@@ -1701,10 +1936,16 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 	}
 	runId := objMeta.Labels[util.LabelKeyWorkflowRunId]
 	jobId := execSpec.ScheduledWorkflowUUIDAsStringOrEmpty()
-	// TODO(gkcalat): consider adding namespace validation to catch mismatch in the namespaces and release resources.
 	if len(execSpec.ExecutionNamespace()) == 0 {
 		return nil, util.NewInvalidInputError("Failed to report a workflow. Namespace is empty")
 	}
+	// Evaluate the effective status at return time because identity validation
+	// can replace a stale non-terminal snapshot with the terminal live workflow.
+	defer func() {
+		if execStatus.IsInFinalState() {
+			r.storedWorkflowIdentities.delete(runId)
+		}
+	}()
 
 	// If the run was Running and got terminated (activeDeadlineSeconds set to 0),
 	// ignore its condition and mark it as such
@@ -1712,8 +1953,11 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 	if execSpec.IsTerminating() {
 		state = model.RuntimeState(string(exec.ExecutionPhase(model.RunTerminatingConditionsV1))).ToV2()
 	}
+	var verifiedLiveWorkflow util.ExecutionSpec
 	if execStatus.IsInFinalState() {
-		workflowStillMatchesReport, err := r.workflowStillMatchesReportedVersion(ctx, execSpec)
+		var workflowStillMatchesReport bool
+		var err error
+		verifiedLiveWorkflow, workflowStillMatchesReport, err = r.workflowStillMatchesReportedVersion(ctx, execSpec)
 		if err != nil {
 			return nil, err
 		}
@@ -1726,7 +1970,13 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 		}
 	}
 	// If run already exists, simply update it
-	run, updateError := r.GetRun(runId)
+	var updateError error
+	if run == nil {
+		run, updateError = r.GetRun(runId)
+	} else if run.UUID != runId {
+		return nil, util.NewInvalidInputError(
+			"Failed to report workflow: provided run does not match the workflow run ID")
+	}
 	if updateError != nil && !util.IsUserErrorCodeMatch(updateError, codes.NotFound) {
 		// Fail closed: a transient run-store read error must not skip the
 		// generation fence below and fall through into the
@@ -1736,6 +1986,272 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 		// grace-period handling further down).
 		return nil, util.Wrapf(updateError, "Failed to read run %s before applying workflow report", runId)
 	}
+	var expectedWorkflowRuntimeManifest model.LargeText
+	var expectedPipelineRuntimeManifest model.LargeText
+	var verifiedExistingWorkflow util.ExecutionSpec
+	existingWorkflowMissing := false
+	var expectedStoredWorkflowIdentityManifest model.LargeText
+	if updateError == nil {
+		expectedWorkflowRuntimeManifest = run.WorkflowRuntimeManifest
+		expectedPipelineRuntimeManifest = run.PipelineRuntimeManifest
+		expectedStoredWorkflowIdentityManifest = storedWorkflowIdentityManifest(run)
+		legacySingleUserRow := !common.IsMultiUserMode() && r.IsEmptyNamespace(run.Namespace)
+		var legacyStoredIdentity storedWorkflowIdentity
+		if legacySingleUserRow {
+			var err error
+			legacyStoredIdentity, err = r.storedWorkflowIdentityForRun(run)
+			if err != nil {
+				return nil, err
+			}
+		}
+		modelNamespace := run.Namespace
+		if legacySingleUserRow && legacyStoredIdentity.namespace != "" {
+			modelNamespace = legacyStoredIdentity.namespace
+		}
+		runNamespace, err := r.resolveWorkflowReportNamespace(
+			"run", runId, modelNamespace, run.ExperimentId, execSpec.ExecutionNamespace())
+		if err != nil {
+			r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+			return nil, err
+		}
+		if err := r.validateWorkflowReportNamespace("run", runId, runNamespace, execSpec.ExecutionNamespace(), execSpec.ExecutionName()); err != nil {
+			return nil, err
+		}
+		if run.K8SName == "" {
+			if legacyStoredIdentity.name != "" && legacyStoredIdentity.name != execSpec.ExecutionName() {
+				return nil, r.validateWorkflowReportName(
+					runId, legacyStoredIdentity.name, execSpec.ExecutionName())
+			}
+			liveWorkflow, err := r.validateLiveWorkflowReportIdentity(
+				ctx, execSpec, verifiedLiveWorkflow, runId, jobId, "", false)
+			if err != nil {
+				if !util.IsUserErrorCodeMatch(err, codes.NotFound) || !execStatus.IsInFinalState() {
+					r.recordWorkflowReportLiveLookupRejection(err)
+					return nil, err
+				}
+				if err := r.validateStoredWorkflowReportIdentity(run, execSpec); err != nil {
+					return nil, err
+				}
+				existingWorkflowMissing = true
+				run.K8SName = execSpec.ExecutionName()
+				if legacySingleUserRow {
+					run.Namespace = execSpec.ExecutionNamespace()
+				}
+			} else {
+				verifiedLiveWorkflow = liveWorkflow
+				verifiedExistingWorkflow = liveWorkflow
+				run.K8SName = liveWorkflow.ExecutionName()
+			}
+		} else if run.K8SName != execSpec.ExecutionName() {
+			storedIdentity, err := r.storedWorkflowIdentityForRun(run)
+			if err != nil {
+				return nil, err
+			}
+			if storedIdentity.name != execSpec.ExecutionName() {
+				return nil, r.validateWorkflowReportName(runId, run.K8SName, execSpec.ExecutionName())
+			}
+			// The immutable identity saved in the runtime manifest is
+			// authoritative when a legacy Name column has diverged. The live
+			// workflow and its UID are validated below before this correction is
+			// persisted.
+			run.K8SName = execSpec.ExecutionName()
+		}
+		if err := r.validateWorkflowReportRecurringRun(ctx, run, jobId, execSpec); err != nil {
+			return nil, err
+		}
+		if verifiedExistingWorkflow == nil && !existingWorkflowMissing {
+			recurringWorkflowName, err := r.recurringWorkflowNameForReport(jobId)
+			if err != nil {
+				return nil, err
+			}
+			verifiedExistingWorkflow, err = r.validateLiveWorkflowReportIdentity(
+				ctx, execSpec, verifiedLiveWorkflow, runId, jobId, recurringWorkflowName, false)
+			if err != nil {
+				if !util.IsUserErrorCodeMatch(err, codes.NotFound) || !execStatus.IsInFinalState() {
+					r.recordWorkflowReportLiveLookupRejection(err)
+					return nil, err
+				}
+				if err := r.validateStoredWorkflowReportIdentity(run, execSpec); err != nil {
+					return nil, err
+				}
+				existingWorkflowMissing = true
+			}
+			verifiedLiveWorkflow = verifiedExistingWorkflow
+		}
+		if verifiedExistingWorkflow != nil {
+			// A report matching the current live object is not sufficient: an
+			// editor can delete and recreate a same-name Workflow with copied
+			// labels. Bind the live object to the immutable UID saved for this run
+			// before allowing it to replace any persisted state. A pre-namespace
+			// single-user row may adopt identity only when its stored manifest
+			// genuinely lacks an immutable UID; otherwise its stored UID and any
+			// stored namespace remain authoritative.
+			legacyIdentityAdoption := legacySingleUserRow && legacyStoredIdentity.uid == ""
+			if !legacyIdentityAdoption {
+				_, err := r.validateStoredOrAdoptRetryWorkflowReportIdentity(run, verifiedExistingWorkflow)
+				if err != nil {
+					return nil, err
+				}
+			}
+			execSpec = verifiedExistingWorkflow
+			objMeta = execSpec.ExecutionObjectMeta()
+			execStatus = execSpec.ExecutionStatus()
+			state = workflowReportState(execSpec)
+			if legacySingleUserRow {
+				run.Namespace = execSpec.ExecutionNamespace()
+			}
+		}
+	}
+
+	// Resolve and validate a recurring run's owning namespace before any
+	// workflow deletion. A missing run row is normal for the first report from
+	// a ScheduledWorkflow, but the owner reference alone is not proof that the
+	// reporting workflow belongs to that recurring run.
+	var recurringJob *model.Job
+	var recurringExperimentID string
+	var recurringNamespace string
+	if updateError != nil && util.IsUserErrorCodeMatch(updateError, codes.NotFound) && jobId != "" {
+		var err error
+		recurringJob, recurringExperimentID, recurringNamespace, err = r.resolveRecurringWorkflowReport(
+			jobId, execSpec.ExecutionNamespace())
+		if err != nil {
+			r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+			glog.Errorf("Cannot establish ownership for workflow name=%q namespace=%q runId=%q recurringRunId=%q; refusing deletion and leaving the workflow for explicit cleanup: %v",
+				execSpec.ExecutionName(), execSpec.ExecutionNamespace(), runId, jobId, err)
+			return nil, util.Wrapf(err, "Failed to report a workflow for run %s due to error resolving recurring run %s", runId, jobId)
+		}
+		if err := r.validateWorkflowReportNamespace("recurring run", jobId, recurringNamespace, execSpec.ExecutionNamespace(), execSpec.ExecutionName()); err != nil {
+			return nil, err
+		}
+		liveWorkflow, err := r.validateLiveWorkflowReportIdentity(
+			ctx, execSpec, verifiedLiveWorkflow, runId, jobId, recurringJob.K8SName, false)
+		if err != nil {
+			r.recordWorkflowReportLiveLookupRejection(err)
+			return nil, err
+		}
+		verifiedLiveWorkflow = liveWorkflow
+		execSpec = liveWorkflow
+		objMeta = execSpec.ExecutionObjectMeta()
+		execStatus = execSpec.ExecutionStatus()
+		state = workflowReportState(execSpec)
+	}
+	if updateError != nil && util.IsUserErrorCodeMatch(updateError, codes.NotFound) && jobId == "" {
+		liveWorkflow, err := r.validateLiveWorkflowReportIdentity(
+			ctx, execSpec, verifiedLiveWorkflow, runId, "", "", false)
+		if err != nil {
+			r.recordWorkflowReportLiveLookupRejection(err)
+			return nil, err
+		}
+		execSpec = liveWorkflow
+		objMeta = execSpec.ExecutionObjectMeta()
+		// Preserve the startup grace period for an in-flight DB write. After it
+		// expires, the live UID and labels establish which orphan is safe to
+		// remove without trusting request metadata or deleting a replacement.
+		gracePeriod := time.Duration(common.GetWorkflowGCGracePeriodSeconds()) * time.Second
+		workflowAge := r.time.Now().Sub(objMeta.CreationTimestamp.Time)
+		if workflowAge < gracePeriod {
+			glog.Warningf(
+				"Workflow name=%q namespace=%q runId=%q not found in run store, "+
+					"but workflow is only %v old (grace period: %v). "+
+					"Skipping report to allow an in-flight DB write to complete.",
+				execSpec.ExecutionName(), execSpec.ExecutionNamespace(), runId,
+				workflowAge.Round(time.Second), gracePeriod)
+			return nil, util.NewUnavailableServerError(
+				fmt.Errorf("workflow %s is within run-creation grace period (%v old, threshold %v)",
+					execSpec.ExecutionName(), workflowAge.Round(time.Second), gracePeriod),
+				"Skipping report for workflow %s - will retry",
+				execSpec.ExecutionName())
+		}
+		deleteOperation := func() error {
+			currentWorkflow, err := r.validateLiveWorkflowReportIdentity(
+				ctx, execSpec, nil, runId, "", "", false)
+			if util.IsUserErrorCodeMatch(err, codes.NotFound) {
+				return nil
+			}
+			if err != nil {
+				if util.IsUserErrorCodeMatch(err, codes.InvalidArgument) {
+					return backoff.Permanent(err)
+				}
+				return err
+			}
+			if err := r.deleteLiveWorkflow(ctx, currentWorkflow); err != nil && !util.IsNotFound(err) {
+				return err
+			}
+			return nil
+		}
+		if err := backoff.Retry(deleteOperation, newStandardBackoffPolicy()); err != nil {
+			// backoff v2 unwraps PermanentError before returning, so preserve
+			// the original client-visible classification here.
+			if util.IsUserErrorCodeMatch(err, codes.InvalidArgument) {
+				return nil, err
+			}
+			return nil, util.NewInternalServerError(
+				err, "Failed to delete orphaned workflow for missing run %s after multiple retries", runId)
+		}
+		if r.options.CollectMetrics {
+			workflowGCCounter.Inc()
+		}
+		return nil, util.Wrapf(updateError, "Deleted orphaned workflow for missing run %s", runId)
+	}
+
+	// Persist a newly observed recurring run before processing a pre-existing
+	// persisted-final-state label. The label proves that this Workflow was
+	// handled previously, but it does not prove that this API server's database
+	// already contains the run row.
+	createdFromRecurringReport := false
+	if jobId != "" && updateError != nil {
+		experimentID := recurringExperimentID
+		namespace := recurringNamespace
+		pipelineSpec := recurringJob.PipelineSpec
+		pipelineSpec.WorkflowSpecManifest = model.LargeText(execSpec.GetExecutionSpec().ToStringForStore())
+		scheduledTimeInSec := execSpec.ScheduledAtInSecOr0()
+		if scheduledTimeInSec == 0 {
+			scheduledTimeInSec = objMeta.CreationTimestamp.Unix()
+		}
+		proposedRun := &model.Run{
+			UUID:           runId,
+			ExperimentId:   experimentID,
+			RecurringRunId: jobId,
+			DisplayName:    execSpec.ExecutionName(),
+			K8SName:        execSpec.ExecutionName(),
+			StorageState:   model.StorageStateAvailable,
+			Namespace:      namespace,
+			PipelineSpec:   pipelineSpec,
+			RunDetails: model.RunDetails{
+				WorkflowRuntimeManifest: model.LargeText(execSpec.ToStringForStore()),
+				CreatedAtInSec:          objMeta.CreationTimestamp.Unix(),
+				ScheduledAtInSec:        scheduledTimeInSec,
+				FinishedAtInSec:         execStatus.FinishedAt(),
+				Conditions:              string(state.ToV1()),
+				State:                   state,
+			},
+		}
+		createdRun, err := r.runStore.CreateRun(proposedRun)
+		if r.options.CollectMetrics && !execStatus.StartedAtTime().Time.IsZero() {
+			reportGap := time.Since(execStatus.StartedAtTime().Time).Seconds()
+			recurringPipelineRunReportGap.Observe(reportGap)
+		}
+		if err != nil {
+			return nil, util.Wrapf(err, "Failed to report a workflow due to error creating run %s", runId)
+		}
+		if err := r.validateRecurringRunAfterCreate(
+			createdRun,
+			jobId,
+			experimentID,
+			namespace,
+			execSpec,
+		); err != nil {
+			return nil, err
+		}
+		run = createdRun
+		runId = run.UUID
+		updateError = nil
+		createdFromRecurringReport = true
+		if err := r.experimentStore.SetLastRunTimestamp(run); err != nil {
+			return nil, util.Wrapf(err, "Failed to report a workflow for existing run %s during updating the owning experiment.", runId)
+		}
+	}
+
 	// Fence terminal reports from stale pre-retry workflow snapshots.
 	// A retried workflow carries the claim's RetryGeneration as an
 	// annotation; a snapshot taken before the retry carries an older
@@ -1781,14 +2297,97 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 				reportedGeneration, runId, run.RetryGeneration, retryClaimGracePeriod())
 		}
 	}
+
+	var verifiedPersistedWorkflow util.ExecutionSpec
+	if execSpec.PersistedFinalState() {
+		if !execStatus.IsInFinalState() {
+			r.recordWorkflowReportRejection(workflowReportRejectionIdentityMismatch)
+			return nil, util.NewInvalidInputError(
+				"Failed to report workflow: persisted final state requires a terminal workflow")
+		}
+		if existingWorkflowMissing {
+			verifiedPersistedWorkflow = execSpec
+		} else {
+			recurringWorkflowName, err := r.recurringWorkflowNameForReport(jobId)
+			if err != nil {
+				return nil, err
+			}
+			verifiedPersistedWorkflow, err = r.validateLiveWorkflowReportIdentity(
+				ctx, execSpec, verifiedLiveWorkflow, runId, jobId, recurringWorkflowName, true)
+			if err != nil {
+				r.recordWorkflowReportLiveLookupRejection(err)
+				return nil, err
+			}
+			execSpec = verifiedPersistedWorkflow
+			execStatus = execSpec.ExecutionStatus()
+			state = workflowReportState(execSpec)
+		}
+	}
+
+	if updateError == nil && !createdFromRecurringReport {
+		run.K8SName = execSpec.ExecutionName()
+		run.State = state
+		run.Conditions = string(state.ToV1())
+		run.FinishedAtInSec = execStatus.FinishedAt()
+		run.WorkflowRuntimeManifest = model.LargeText(execSpec.ToStringForStore())
+		var updated bool
+		updated, updateError = r.runStore.UpdateRunIfRuntimeManifestsUnchanged(
+			run,
+			expectedWorkflowRuntimeManifest,
+			expectedPipelineRuntimeManifest,
+		)
+		if updateError != nil {
+			return nil, util.Wrapf(updateError, "Failed to report a workflow for existing run %s during updating the run. Check if the run entry is corrupted", runId)
+		}
+		if !updated {
+			// Another report changed the row after this request loaded it. Do
+			// not let the stale snapshot delete a Workflow or persist tasks.
+			// Refresh the process-local identity cache from the authoritative
+			// row, then retry the complete RPC with a freshly loaded run.
+			r.storedWorkflowIdentities.delete(runId)
+			currentRun, readError := r.GetRun(runId)
+			if readError != nil {
+				return nil, util.NewUnavailableServerError(
+					readError,
+					"Failed to reload run %s after a concurrent workflow report - try again later",
+					runId,
+				)
+			}
+			if _, identityError := r.storedWorkflowIdentityForRun(currentRun); identityError != nil {
+				return nil, identityError
+			}
+			return nil, util.NewUnavailableServerError(
+				errors.New("stored run changed while processing workflow report"),
+				"Failed to report workflow for run %s because the stored run changed concurrently - try again later",
+				runId,
+			)
+		}
+		r.storedWorkflowIdentities.replaceAfterPersist(
+			runId,
+			sha256.Sum256([]byte(expectedStoredWorkflowIdentityManifest)),
+			storedWorkflowIdentity{
+				name:            execSpec.ExecutionName(),
+				namespace:       execSpec.ExecutionNamespace(),
+				uid:             execSpec.ExecutionObjectMeta().UID,
+				retryGeneration: run.RetryGeneration,
+				manifestDigest:  sha256.Sum256([]byte(run.WorkflowRuntimeManifest)),
+			})
+	}
 	// Delete a fully persisted workflow only after the version check above:
 	// a stale snapshot carrying the persisted-final-state label must not
 	// delete the live workflow object that a retry has since resubmitted
 	// under the same name.
 	if execSpec.PersistedFinalState() {
 		// If workflow's final state has being persisted, the workflow should be garbage collected.
-		err := r.getWorkflowClient(execSpec.ExecutionNamespace()).Delete(ctx, execSpec.ExecutionName(), v1.DeleteOptions{})
+		err := r.deleteLiveWorkflow(ctx, verifiedPersistedWorkflow)
 		if err != nil {
+			if apierrors.IsConflict(err) {
+				return nil, terminalWorkflowReportDeferredError(
+					runId,
+					execSpec,
+					"workflow changed before persisted-final-state cleanup",
+				)
+			}
 			// A fix for kubeflow/pipelines#4484, persistence agent might have an outdated item in its workqueue, so it will
 			// report workflows that no longer exist. It's important to return a not found error, so that persistence
 			// agent won't retry again.
@@ -1801,144 +2400,10 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 		if r.options.CollectMetrics {
 			workflowGCCounter.Inc()
 		}
-	}
-	if updateError == nil {
-		run.State = state
-		run.Conditions = string(state.ToV1())
-		run.FinishedAtInSec = execStatus.FinishedAt()
-		run.WorkflowRuntimeManifest = model.LargeText(execSpec.ToStringForStore())
-		if updateError = r.runStore.UpdateRun(run); updateError != nil {
-			return nil, util.Wrapf(updateError, "Failed to report a workflow for existing run %s during updating the run. Check if the run entry is corrupted", runId)
-		}
-	}
-	if jobId == "" {
-		// If a run doesn't have job ID, it's a one-time run created by Pipeline API server.
-		// In this case the DB entry should already been created when argo workflow CR is created.
-		if updateError != nil {
-			if !util.IsUserErrorCodeMatch(updateError, codes.NotFound) {
-				return nil, util.Wrap(updateError, "Failed to update the run")
-			}
-			// Handle run not found in run store error.
-			// Before GC, apply a grace period to avoid deleting workflows whose
-			// DB writes are still in-flight.
-			gracePeriodSeconds := common.GetWorkflowGCGracePeriodSeconds()
-			gracePeriod := time.Duration(gracePeriodSeconds) * time.Second
-			workflowAge := r.time.Now().Sub(objMeta.CreationTimestamp.Time)
-			if workflowAge < gracePeriod {
-				glog.Warningf(
-					"Workflow name=%q namespace=%q runId=%q not found in run store, "+
-						"but workflow is only %v old (grace period: %v). "+
-						"Skipping GC to allow in-flight DB write to complete. ",
-					execSpec.ExecutionName(), execSpec.ExecutionNamespace(), runId,
-					workflowAge.Round(time.Second), gracePeriod)
-				return nil, util.NewUnavailableServerError(
-					fmt.Errorf("workflow %s is within GC grace period (%v old, threshold %v)",
-						execSpec.ExecutionName(), workflowAge.Round(time.Second), gracePeriod),
-					"Skipping GC for workflow %s - will retry",
-					execSpec.ExecutionName())
-			}
-			// Workflow is beyond the grace period. To avoid letting the workflow
-			// leak forever, GC it since its record does not exist in KFP DB.
-			glog.Errorf("Cannot find reported workflow name=%q namespace=%q runId=%q in run store. "+
-				"Deleting the workflow to avoid resource leaking. "+
-				"This can be caused by installing two KFP instances that try to manage the same workflows "+
-				"or an unknown bug. If you encounter this, recommend reporting more details in https://github.com/kubeflow/pipelines/issues/6189",
-				execSpec.ExecutionName(), execSpec.ExecutionNamespace(), runId)
-			deleteOperation := func() error {
-				err := r.getWorkflowClient(execSpec.ExecutionNamespace()).Delete(ctx, execSpec.ExecutionName(), v1.DeleteOptions{})
-				if err != nil && !util.IsNotFound(err) {
-					return err
-				}
-				return nil
-			}
-			if err := backoff.Retry(deleteOperation, newStandardBackoffPolicy()); err != nil {
-				return nil, util.NewInternalServerError(err, "Failed to delete the obsolete workflow for run %s after multiple retries", runId)
-			}
-
-			if r.options.CollectMetrics {
-				workflowGCCounter.Inc()
-			}
-			// Note, persistence agent will not retry reporting this workflow again, because updateError is a not found error.
-			return nil, util.Wrapf(updateError, "Failed to report workflow name=%q namespace=%q runId=%q", execSpec.ExecutionName(), execSpec.ExecutionNamespace(), runId)
-		}
-	} else if run == nil || updateError != nil {
-		// TODO(gkcalat): consider adding manifest validation to catch mismatch, as runs should have the same pipeline spec as parent recurring run.
-		// Try to fetch the job.
-		existingJob, err := r.GetJob(jobId)
-		if err != nil {
-			return nil, util.Wrapf(err, "Failed to report a workflow for run %s due to error retrieving recurring run %s", runId, jobId)
-		}
-		experimentId := existingJob.ExperimentId
-		namespace := existingJob.Namespace
-		pipelineSpec := existingJob.PipelineSpec
-		pipelineSpec.WorkflowSpecManifest = model.LargeText(execSpec.GetExecutionSpec().ToStringForStore())
-
-		// Try to fetch experiment id from resource references if it is missing.
-		if experimentId == "" {
-			experimentRef, err := r.resourceReferenceStore.GetResourceReference(jobId, model.JobResourceType, model.ExperimentResourceType)
-			if err != nil {
-				return nil, util.Wrapf(err, "Failed to retrieve the experiment ID for the job %v that created the run", jobId)
-			}
-			experimentId = experimentRef.ReferenceUUID
-			if namespace == "" {
-				if namespaceRef, err := r.resourceReferenceStore.GetResourceReference(jobId, model.JobResourceType, model.NamespaceResourceType); err == nil {
-					namespace = namespaceRef.ReferenceUUID
-				}
-			}
-		}
-		if experimentId == "" {
-			experimentId, err = r.GetDefaultExperimentId()
-			if err != nil {
-				return nil, util.Wrapf(err, "Failed to report workflow for run %s. Fetching default experiment returned error. Check if you have experiment assigned for job %s", runId, jobId)
-			}
-		}
-		// TODO(gkcalat): consider adding namespace validation to catch mismatch in the namespaces and release resources.
-		if namespace == "" {
-			namespace, err = r.GetNamespaceFromExperimentId(experimentId)
-			if err != nil {
-				return nil, util.Wrapf(err, "Failed to report workflow for run %s. Fetching namespace for experiment %s returned error. Check if you have namespace assigned for job %s", runId, experimentId, jobId)
-			}
-		}
-		if namespace == "" {
-			namespace = execSpec.ExecutionNamespace()
-		}
-		// Scheduled time equals created time if it is not specified
-		scheduledTimeInSec := execSpec.ScheduledAtInSecOr0()
-		if scheduledTimeInSec == 0 {
-			scheduledTimeInSec = objMeta.CreationTimestamp.Unix()
-		}
-		run = &model.Run{
-			UUID:           runId,
-			ExperimentId:   experimentId,
-			RecurringRunId: jobId,
-			DisplayName:    execSpec.ExecutionName(),
-			K8SName:        execSpec.ExecutionName(),
-			StorageState:   model.StorageStateAvailable,
-			Namespace:      namespace,
-			PipelineSpec:   pipelineSpec,
-			RunDetails: model.RunDetails{
-				WorkflowRuntimeManifest: model.LargeText(execSpec.ToStringForStore()),
-				CreatedAtInSec:          objMeta.CreationTimestamp.Unix(),
-				ScheduledAtInSec:        scheduledTimeInSec,
-				FinishedAtInSec:         execStatus.FinishedAt(),
-				Conditions:              string(state.ToV1()),
-				State:                   state,
-			},
-		}
-		run, err = r.runStore.CreateRun(run)
-		if r.options.CollectMetrics && !execStatus.StartedAtTime().Time.IsZero() {
-			reportGap := time.Since(execStatus.StartedAtTime().Time).Seconds()
-			recurringPipelineRunReportGap.Observe(reportGap)
-		}
-		if err != nil {
-			return nil, util.Wrapf(err, "Failed to report a workflow due to error creating run %s", runId)
-		} else {
-			runId = run.UUID
-		}
-		// Upon run creation, update owning experiment
-		if updateError = r.experimentStore.SetLastRunTimestamp(run); updateError != nil {
-			return nil, util.Wrapf(updateError, "Failed to report a workflow for existing run %s during updating the owning experiment.", runId)
-		}
+		// The run was finalized by an earlier report and the workflow has now
+		// been deleted. Do not try to update or relabel the deleted object.
+		execSpec.SetLabels(util.LabelKeyWorkflowRunId, runId)
+		return execSpec, nil
 	}
 	if execStatus.IsInFinalState() {
 		// Notify plugins of terminal state. If terminal handling cannot be
@@ -2014,6 +2479,445 @@ func (r *ResourceManager) ReportWorkflowResource(ctx context.Context, execSpec u
 	return execSpec, nil
 }
 
+func (r *ResourceManager) resolveWorkflowReportNamespace(resourceType, resourceID, modelNamespace, experimentID, workflowNamespace string) (string, error) {
+	if !r.IsEmptyNamespace(modelNamespace) {
+		return modelNamespace, nil
+	}
+	if !common.IsMultiUserMode() {
+		// Namespace isolation is disabled in single-user mode. Use the
+		// workflow's actual namespace for legacy empty/model.NoNamespace rows
+		// instead of today's API-server namespace: the latter may have changed
+		// since the workflow was submitted and would permanently strand reports.
+		return workflowNamespace, nil
+	}
+	if experimentID == "" {
+		return "", util.NewInternalServerError(
+			errors.New("owning experiment is missing"),
+			"Failed to determine namespace for %s %s before applying workflow report", resourceType, resourceID,
+		)
+	}
+
+	namespace, err := r.GetNamespaceFromExperimentId(experimentID)
+	if err != nil {
+		return "", util.NewInternalServerError(err,
+			"Failed to determine namespace for %s %s before applying workflow report", resourceType, resourceID)
+	}
+	if r.IsEmptyNamespace(namespace) {
+		return "", util.NewInternalServerError(
+			errors.New("owning namespace is missing"),
+			"Failed to determine namespace for %s %s before applying workflow report", resourceType, resourceID,
+		)
+	}
+	return namespace, nil
+}
+
+func workflowReportState(execSpec util.ExecutionSpec) model.RuntimeState {
+	state := model.RuntimeState(string(execSpec.ExecutionStatus().Condition())).ToV2()
+	if execSpec.IsTerminating() {
+		return model.RuntimeState(string(exec.ExecutionPhase(model.RunTerminatingConditionsV1))).ToV2()
+	}
+	return state
+}
+
+func (r *ResourceManager) recurringWorkflowNameForReport(jobID string) (string, error) {
+	if jobID == "" {
+		return "", nil
+	}
+	job, err := r.GetJob(jobID)
+	if err != nil {
+		if util.IsUserErrorCodeMatch(err, codes.NotFound) {
+			// Orphan propagation can remove both the ScheduledWorkflow and the
+			// Workflow owner reference. The immutable owner UID remains the
+			// decisive check whenever the owner is still present.
+			return "", nil
+		}
+		return "", util.Wrapf(err, "Failed to validate recurring run %s against its live workflow", jobID)
+	}
+	return job.K8SName, nil
+}
+
+func (r *ResourceManager) validateLiveWorkflowReportIdentity(
+	ctx context.Context,
+	reportedWorkflow util.ExecutionSpec,
+	verifiedLiveWorkflow util.ExecutionSpec,
+	runID,
+	scheduledWorkflowID,
+	scheduledWorkflowName string,
+	requirePersistedFinalState bool,
+) (util.ExecutionSpec, error) {
+	liveWorkflow := verifiedLiveWorkflow
+	if liveWorkflow == nil {
+		var err error
+		liveWorkflow, err = r.getWorkflowClient(reportedWorkflow.ExecutionNamespace()).Get(
+			ctx, reportedWorkflow.ExecutionName(), v1.GetOptions{})
+		if err != nil {
+			if util.IsNotFound(err) {
+				return nil, util.NewNotFoundError(
+					err, "Failed to verify live workflow identity before reporting run %s", runID)
+			}
+			return nil, util.NewUnavailableServerError(
+				err, "Failed to verify live workflow identity before reporting run %s - will retry", runID)
+		}
+	}
+
+	reportedMeta := reportedWorkflow.ExecutionObjectMeta()
+	liveMeta := liveWorkflow.ExecutionObjectMeta()
+	liveScheduledWorkflowID := liveWorkflow.ScheduledWorkflowUUIDAsStringOrEmpty()
+	identityMatches := reportedMeta.UID != "" &&
+		liveMeta.UID != "" &&
+		reportedMeta.UID == liveMeta.UID &&
+		liveMeta.Labels[util.LabelKeyWorkflowRunId] == runID &&
+		liveScheduledWorkflowID == scheduledWorkflowID
+	if identityMatches && scheduledWorkflowID != "" && scheduledWorkflowName != "" {
+		identityMatches = false
+		for _, owner := range liveMeta.OwnerReferences {
+			if string(owner.UID) == scheduledWorkflowID && owner.Name == scheduledWorkflowName {
+				identityMatches = true
+				break
+			}
+		}
+	}
+	if !identityMatches {
+		r.recordWorkflowReportRejection(workflowReportRejectionIdentityMismatch)
+		glog.Warningf(
+			"Rejecting workflow report whose live identity does not match: runID=%q namespace=%q workflowName=%q",
+			runID, reportedWorkflow.ExecutionNamespace(), reportedWorkflow.ExecutionName())
+		return nil, util.NewInvalidInputError(
+			"Failed to report workflow: reported identity does not match the live workflow")
+	}
+	if requirePersistedFinalState &&
+		(!liveWorkflow.PersistedFinalState() || !liveWorkflow.ExecutionStatus().IsInFinalState()) {
+		r.recordWorkflowReportRejection(workflowReportRejectionIdentityMismatch)
+		return nil, util.NewInvalidInputError(
+			"Failed to report workflow: live workflow is not in persisted final state")
+	}
+	return liveWorkflow, nil
+}
+
+func storedWorkflowIdentityManifest(run *model.Run) model.LargeText {
+	storedManifest := run.WorkflowRuntimeManifest
+	if storedManifest == "" {
+		// V2 creation stores the authoritative created Argo Workflow in the
+		// V2-facing runtime field. Before the first persistence-agent update,
+		// WorkflowRuntimeManifest is intentionally empty, so use the equivalent
+		// stored object to validate a terminal snapshot whose live CR is gone.
+		storedManifest = run.PipelineRuntimeManifest
+	}
+	return storedManifest
+}
+
+func (r *ResourceManager) storedWorkflowIdentityForRun(run *model.Run) (storedWorkflowIdentity, error) {
+	storedManifest := storedWorkflowIdentityManifest(run)
+	if storedManifest == "" {
+		r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+		return storedWorkflowIdentity{}, util.NewInternalServerError(
+			errors.New("stored execution manifest is empty"),
+			"Failed to verify stored workflow identity before reporting run %s", run.UUID)
+	}
+	// Cache the persisted workflow identity in a bounded LRU so node-transition
+	// reports do not repeatedly decode a potentially large runtime manifest.
+	// The manifest digest keeps the cache coherent with repairs persisted by
+	// another API-server replica without requiring process-local invalidation.
+	manifestDigest := sha256.Sum256([]byte(storedManifest))
+	storedIdentity, found := r.storedWorkflowIdentities.load(run.UUID)
+	if found && (storedIdentity.retryGeneration != run.RetryGeneration ||
+		storedIdentity.manifestDigest != manifestDigest) {
+		found = false
+	}
+	if !found {
+		var storedWorkflow struct {
+			Metadata v1.ObjectMeta `json:"metadata"`
+		}
+		if err := json.Unmarshal([]byte(storedManifest), &storedWorkflow); err != nil {
+			r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+			return storedWorkflowIdentity{}, util.NewInternalServerError(
+				err, "Failed to verify stored workflow identity before reporting run %s", run.UUID)
+		}
+		storedIdentity = r.storedWorkflowIdentities.loadOrStore(run.UUID, storedWorkflowIdentity{
+			name:            storedWorkflow.Metadata.Name,
+			namespace:       storedWorkflow.Metadata.Namespace,
+			uid:             storedWorkflow.Metadata.UID,
+			retryGeneration: run.RetryGeneration,
+			manifestDigest:  manifestDigest,
+		})
+	}
+	return storedIdentity, nil
+}
+
+func storedWorkflowMatchesIdentity(storedIdentity storedWorkflowIdentity, reportedWorkflow util.ExecutionSpec) bool {
+	reportedMeta := reportedWorkflow.ExecutionObjectMeta()
+	return storedIdentity.uid != "" &&
+		reportedMeta.UID != "" &&
+		storedIdentity.uid == reportedMeta.UID &&
+		storedIdentity.name == reportedWorkflow.ExecutionName() &&
+		(storedIdentity.namespace == "" || storedIdentity.namespace == reportedWorkflow.ExecutionNamespace())
+}
+
+func retryWorkflowMatchesActiveClaim(
+	run *model.Run,
+	storedIdentity storedWorkflowIdentity,
+	reportedWorkflow util.ExecutionSpec,
+) bool {
+	return run.State == model.RuntimeStatePending &&
+		run.RetryGeneration > 0 &&
+		storedIdentity.name == reportedWorkflow.ExecutionName() &&
+		reportedRetryGeneration(reportedWorkflow.ExecutionObjectMeta()) == run.RetryGeneration
+}
+
+func (r *ResourceManager) validateStoredWorkflowReportIdentity(
+	run *model.Run,
+	reportedWorkflow util.ExecutionSpec,
+) error {
+	storedIdentity, err := r.storedWorkflowIdentityForRun(run)
+	if err != nil {
+		return err
+	}
+	if !storedWorkflowMatchesIdentity(storedIdentity, reportedWorkflow) {
+		r.recordWorkflowReportRejection(workflowReportRejectionIdentityMismatch)
+		return util.NewInvalidInputError(
+			"Failed to report workflow: reported identity does not match the stored workflow")
+	}
+	return nil
+}
+
+func (r *ResourceManager) validateStoredOrAdoptRetryWorkflowReportIdentity(
+	run *model.Run,
+	reportedWorkflow util.ExecutionSpec,
+) (bool, error) {
+	storedIdentity, err := r.storedWorkflowIdentityForRun(run)
+	if err != nil {
+		return false, err
+	}
+	if storedWorkflowMatchesIdentity(storedIdentity, reportedWorkflow) {
+		return false, nil
+	}
+	if retryWorkflowMatchesActiveClaim(run, storedIdentity, reportedWorkflow) {
+		return true, nil
+	}
+	r.recordWorkflowReportRejection(workflowReportRejectionIdentityMismatch)
+	return false, util.NewInvalidInputError(
+		"Failed to report workflow: reported identity does not match the stored workflow")
+}
+
+func (r *ResourceManager) deleteLiveWorkflow(ctx context.Context, workflow util.ExecutionSpec) error {
+	metadata := workflow.ExecutionObjectMeta()
+	uid := metadata.UID
+	if uid == "" {
+		return util.NewInvalidInputError("Failed to delete workflow: live workflow UID is empty")
+	}
+	preconditions := &v1.Preconditions{UID: &uid}
+	if metadata.ResourceVersion != "" {
+		resourceVersion := metadata.ResourceVersion
+		preconditions.ResourceVersion = &resourceVersion
+	}
+	return r.getWorkflowClient(workflow.ExecutionNamespace()).Delete(
+		ctx,
+		workflow.ExecutionName(),
+		v1.DeleteOptions{Preconditions: preconditions},
+	)
+}
+
+func (r *ResourceManager) resolveRecurringWorkflowReport(jobID, workflowNamespace string) (*model.Job, string, string, error) {
+	job, err := r.GetJob(jobID)
+	if err != nil {
+		return nil, "", "", util.Wrapf(err, "Failed to retrieve recurring run %s", jobID)
+	}
+	experimentID := job.ExperimentId
+	namespace := job.Namespace
+
+	// Legacy job rows can rely on resource references rather than columns.
+	if experimentID == "" {
+		experimentRef, err := r.resourceReferenceStore.GetResourceReference(jobID, model.JobResourceType, model.ExperimentResourceType)
+		if err != nil {
+			// Only a missing job proves that a reported workflow is orphaned.
+			// A job whose legacy ownership reference is absent is inconsistent
+			// storage and must be retried/repaired rather than interpreted as
+			// permission to garbage-collect a live workflow.
+			return nil, "", "", util.NewInternalServerError(
+				err,
+				"Failed to retrieve the experiment ID for the job %v that created the run",
+				jobID,
+			)
+		}
+		experimentID = experimentRef.ReferenceUUID
+		if r.IsEmptyNamespace(namespace) {
+			if namespaceRef, err := r.resourceReferenceStore.GetResourceReference(jobID, model.JobResourceType, model.NamespaceResourceType); err == nil {
+				namespace = namespaceRef.ReferenceUUID
+			}
+		}
+	}
+	if experimentID == "" {
+		experimentID, err = r.GetDefaultExperimentId()
+		if err != nil {
+			return nil, "", "", util.NewInternalServerError(err, "Failed to fetch the default experiment for recurring run %s", jobID)
+		}
+	}
+	namespace, err = r.resolveWorkflowReportNamespace(
+		"recurring run", jobID, namespace, experimentID, workflowNamespace)
+	if err != nil {
+		return nil, "", "", err
+	}
+	return job, experimentID, namespace, nil
+}
+
+func (r *ResourceManager) validateWorkflowReportNamespace(resourceType, resourceID, expectedNamespace, workflowNamespace, executionName string) error {
+	if r.IsEmptyNamespace(expectedNamespace) {
+		r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+		return util.NewInvalidInputError(
+			"Failed to report workflow: owning namespace cannot be determined",
+		)
+	}
+	if expectedNamespace != workflowNamespace {
+		r.recordWorkflowReportRejection(workflowReportRejectionNamespaceMismatch)
+		glog.Warningf("Rejecting workflow namespace mismatch: resourceType=%q resourceID=%q expectedNamespace=%q reportedNamespace=%q executionName=%q",
+			resourceType, resourceID, expectedNamespace, workflowNamespace, executionName)
+		return util.NewInvalidInputError(
+			"Failed to report workflow: reported namespace does not match owning resource")
+	}
+	return nil
+}
+
+func (r *ResourceManager) validateWorkflowReportName(runID, expectedName, reportedName string) error {
+	if expectedName == "" || expectedName != reportedName {
+		r.recordWorkflowReportRejection(workflowReportRejectionIdentityMismatch)
+		glog.Warningf(
+			"Rejecting workflow name mismatch: runID=%q expectedName=%q reportedName=%q",
+			runID, expectedName, reportedName)
+		return util.NewInvalidInputError(
+			"Failed to report workflow: reported name does not match owning run")
+	}
+	return nil
+}
+
+func (r *ResourceManager) validateWorkflowReportRecurringRun(
+	ctx context.Context,
+	run *model.Run,
+	reportedRecurringRunID string,
+	execSpec util.ExecutionSpec,
+) error {
+	runID := run.UUID
+	expectedRecurringRunID := run.RecurringRunId
+	if expectedRecurringRunID == reportedRecurringRunID {
+		return nil
+	}
+
+	// Kubernetes removes a dependent Workflow's owner reference when its
+	// ScheduledWorkflow is deleted with orphan propagation. Accept that one
+	// asymmetric case only after the job row is gone and the report still
+	// identifies the live Workflow object stored for this run.
+	if expectedRecurringRunID != "" && reportedRecurringRunID == "" {
+		_, jobErr := r.GetJob(expectedRecurringRunID)
+		switch {
+		case jobErr == nil:
+			r.recordWorkflowReportRejection(workflowReportRejectionIdentityMismatch)
+			return util.NewInvalidInputError(
+				"Failed to report workflow: recurring-run owner is missing while the recurring run still exists")
+		case !util.IsUserErrorCodeMatch(jobErr, codes.NotFound):
+			r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+			return util.Wrapf(jobErr,
+				"Failed to verify orphaned workflow ownership for run %s", runID)
+		}
+
+		liveWorkflow, liveErr := r.getWorkflowClient(execSpec.ExecutionNamespace()).Get(
+			ctx, execSpec.ExecutionName(), v1.GetOptions{})
+		if liveErr != nil {
+			if !util.IsNotFound(liveErr) {
+				r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+				return util.NewUnavailableServerError(liveErr,
+					"Cannot verify orphaned workflow ownership for run %s - will retry", runID)
+			}
+			// The persistence agent may have read the terminal orphan immediately
+			// before TTL collection or manual deletion. The job row is already
+			// gone, so accept only the exact immutable object stored for this run;
+			// the caller's normal terminal-NotFound path will then persist the
+			// snapshot before returning the final NotFound signal.
+			if execSpec.ExecutionStatus().IsInFinalState() {
+				if err := r.validateStoredWorkflowReportIdentity(run, execSpec); err != nil {
+					return err
+				}
+				return nil
+			}
+			r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+			return util.NewInvalidInputError(
+				"Failed to report workflow: orphaned workflow identity cannot be verified")
+		}
+
+		reportedMeta := execSpec.ExecutionObjectMeta()
+		liveMeta := liveWorkflow.ExecutionObjectMeta()
+		if reportedMeta.UID != "" &&
+			liveMeta.UID != "" &&
+			reportedMeta.UID == liveMeta.UID &&
+			liveMeta.Labels[util.LabelKeyWorkflowRunId] == runID &&
+			liveWorkflow.ScheduledWorkflowUUIDAsStringOrEmpty() == "" {
+			return nil
+		}
+	}
+
+	r.recordWorkflowReportRejection(workflowReportRejectionIdentityMismatch)
+	glog.Warningf(
+		"Rejecting workflow recurring-run mismatch: runID=%q expectedRecurringRunID=%q reportedRecurringRunID=%q",
+		runID, expectedRecurringRunID, reportedRecurringRunID)
+	return util.NewInvalidInputError(
+		"Failed to report workflow: reported owner does not match owning run")
+}
+
+func (r *ResourceManager) validateRecurringRunAfterCreate(
+	run *model.Run,
+	expectedRecurringRunID,
+	expectedExperimentID,
+	expectedNamespace string,
+	workflow util.ExecutionSpec,
+) error {
+	if run == nil {
+		return util.NewInternalServerError(
+			errors.New("run store returned an empty run"),
+			"Failed to validate recurring run after creation")
+	}
+	runNamespace, err := r.resolveWorkflowReportNamespace(
+		"run", run.UUID, run.Namespace, run.ExperimentId, workflow.ExecutionNamespace())
+	if err != nil {
+		r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+		return err
+	}
+	if runNamespace != expectedNamespace ||
+		run.RecurringRunId != expectedRecurringRunID ||
+		run.ExperimentId != expectedExperimentID ||
+		run.K8SName != workflow.ExecutionName() {
+		r.recordWorkflowReportRejection(workflowReportRejectionIdentityMismatch)
+		glog.Warningf(
+			"Rejecting recurring workflow after run creation conflict: runID=%q recurringRunID=%q experimentID=%q namespace=%q workflowName=%q",
+			run.UUID, run.RecurringRunId, run.ExperimentId, runNamespace, run.K8SName)
+		return util.NewInvalidInputError(
+			"Failed to report workflow: persisted run ownership does not match recurring run")
+	}
+	if err := r.validateWorkflowReportNamespace(
+		"run", run.UUID, runNamespace, workflow.ExecutionNamespace(), workflow.ExecutionName()); err != nil {
+		return err
+	}
+	// CreateRun returns an existing row when a concurrent report wins the
+	// recurring-run insert. Mutable owner fields and the Workflow name can all
+	// match across a same-name Kubernetes replacement, so bind the returned row
+	// to the already-live-verified Workflow's immutable UID before accepting it.
+	return r.validateStoredWorkflowReportIdentity(run, workflow)
+}
+
+func (r *ResourceManager) recordWorkflowReportRejection(reason string) {
+	if r.options != nil && r.options.CollectMetrics {
+		workflowReportRejectedCounter.WithLabelValues(reason).Inc()
+	}
+}
+
+// recordWorkflowReportLiveLookupRejection counts only live-object lookup
+// failures that make the current report permanently unusable. A transient
+// Kubernetes read failure is retried, and a terminal NotFound may be accepted
+// through stored identity validation, so callers invoke this only after
+// deciding to return the lookup error.
+func (r *ResourceManager) recordWorkflowReportLiveLookupRejection(err error) {
+	if util.IsUserErrorCodeMatch(err, codes.NotFound) {
+		r.recordWorkflowReportRejection(workflowReportRejectionOwnershipUnresolved)
+	}
+}
+
 func terminalWorkflowReportDeferredError(runID string, execSpec util.ExecutionSpec, reason string) error {
 	return util.NewUnavailableServerError(
 		errors.New(reason),
@@ -2050,10 +2954,13 @@ func reportedRetryGeneration(objMeta *v1.ObjectMeta) int64 {
 	return generation
 }
 
-func (r *ResourceManager) workflowStillMatchesReportedVersion(ctx context.Context, execSpec util.ExecutionSpec) (bool, error) {
+func (r *ResourceManager) workflowStillMatchesReportedVersion(
+	ctx context.Context,
+	execSpec util.ExecutionSpec,
+) (util.ExecutionSpec, bool, error) {
 	reportedVersion := execSpec.Version()
 	if reportedVersion == "" {
-		return true, nil
+		return nil, true, nil
 	}
 
 	currentWorkflow, err := r.getWorkflowClient(execSpec.ExecutionNamespace()).Get(ctx, execSpec.ExecutionName(), v1.GetOptions{})
@@ -2068,12 +2975,12 @@ func (r *ResourceManager) workflowStillMatchesReportedVersion(ctx context.Contex
 				"Workflow %q was not found while verifying the reported version; proceeding with the reported terminal state",
 				execSpec.ExecutionName(),
 			)
-			return true, nil
+			return nil, true, nil
 		}
-		return false, util.Wrapf(err, "Failed to verify current workflow version while reporting completed workflow %s", execSpec.ExecutionName())
+		return nil, false, util.Wrapf(err, "Failed to verify current workflow version while reporting completed workflow %s", execSpec.ExecutionName())
 	}
 	if currentWorkflow.Version() == reportedVersion {
-		return true, nil
+		return currentWorkflow, true, nil
 	}
 
 	glog.Warningf(
@@ -2082,7 +2989,7 @@ func (r *ResourceManager) workflowStillMatchesReportedVersion(ctx context.Contex
 		reportedVersion,
 		currentWorkflow.Version(),
 	)
-	return false, nil
+	return currentWorkflow, false, nil
 }
 
 func (r *ResourceManager) runStillMatchesReportedFinalState(runID string, state model.RuntimeState, finishedAtInSec int64) (bool, error) {
@@ -2702,6 +3609,9 @@ func (r *ResourceManager) getNamespaceFromRunId(runId string) (string, error) {
 	run, err := r.GetRun(runId)
 	if err != nil {
 		return "", util.Wrapf(err, "Failed to fetch namespace from run %v due to fetching error", runId)
+	}
+	if !r.IsEmptyNamespace(run.Namespace) {
+		return run.Namespace, nil
 	}
 	namespace, err := r.GetNamespaceFromExperimentId(run.ExperimentId)
 	if err != nil {

--- a/backend/src/apiserver/resource/resource_manager_test.go
+++ b/backend/src/apiserver/resource/resource_manager_test.go
@@ -17,6 +17,7 @@ package resource
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -47,6 +48,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/pkg/errors"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -62,6 +64,24 @@ import (
 
 // v1AllowedNamespaces mirrors the unexported constant in backend/src/common/util/v1_support.go.
 const v1AllowedNamespaces = "V1_ALLOWED_NAMESPACES"
+
+type duplicateRecurringRunStore struct {
+	storage.RunStoreInterface
+	firstGet    bool
+	existingRun *model.Run
+}
+
+func (s *duplicateRecurringRunStore) GetRun(string) (*model.Run, error) {
+	if s.firstGet {
+		s.firstGet = false
+		return nil, util.NewResourceNotFoundError("run", "concurrent-run")
+	}
+	return s.existingRun, nil
+}
+
+func (s *duplicateRecurringRunStore) CreateRun(*model.Run) (*model.Run, error) {
+	return s.existingRun, nil
+}
 
 func initEnvVars() {
 	viper.Set(common.PodNamespace, "ns1")
@@ -502,6 +522,35 @@ func initWithOneTimeRun(t *testing.T) (*FakeClientManager, *ResourceManager, *mo
 	return store, manager, runDetail
 }
 
+func syncWorkflowReportWithFakeCluster(t *testing.T, store *FakeClientManager, workflow *util.Workflow) {
+	t.Helper()
+	ctx := context.Background()
+	workflowClient := store.ExecClient().Execution(workflow.ExecutionNamespace())
+	liveWorkflow, err := workflowClient.Get(ctx, workflow.ExecutionName(), v1.GetOptions{})
+	if util.IsNotFound(err) {
+		_, err = workflowClient.Create(ctx, workflow, v1.CreateOptions{})
+		require.NoError(t, err)
+		return
+	}
+	require.NoError(t, err)
+	workflow.ExecutionObjectMeta().UID = liveWorkflow.ExecutionObjectMeta().UID
+	workflow.SetVersion(liveWorkflow.Version())
+	_, err = workflowClient.Update(ctx, workflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
+func storedWorkflowUID(t *testing.T, run *model.Run) types.UID {
+	t.Helper()
+	manifest := run.WorkflowRuntimeManifest
+	if manifest == "" {
+		manifest = run.PipelineRuntimeManifest
+	}
+	workflow, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(manifest))
+	require.NoError(t, err)
+	require.NoError(t, workflow.Decompress())
+	return workflow.ExecutionObjectMeta().UID
+}
+
 func initWithOneTimeRunV2(t *testing.T) (*FakeClientManager, *ResourceManager, *model.Run) {
 	store, manager, exp := initWithExperiment(t)
 	apiRun := &model.Run{
@@ -552,6 +601,7 @@ func initWithOneTimeFailedRun(t *testing.T) (*FakeClientManager, *ResourceManage
 	updatedWorkflow.SetLabels(util.LabelKeyWorkflowRunId, runDetail.UUID)
 	updatedWorkflow.Status.Phase = v1alpha1.WorkflowFailed
 	updatedWorkflow.Status.Nodes = map[string]v1alpha1.NodeStatus{"node1": {Name: "pod1", Type: v1alpha1.NodeTypePod, Phase: v1alpha1.NodeFailed}}
+	syncWorkflowReportWithFakeCluster(t, store, updatedWorkflow)
 	_, err = manager.ReportWorkflowResource(ctx, updatedWorkflow)
 	assert.Nil(t, err)
 	return store, manager, runDetail
@@ -577,6 +627,7 @@ func initWithOneTimeFailedRunCompressed(t *testing.T) (*FakeClientManager, *Reso
 	nodeData, err := json.Marshal(nodes)
 	assert.Nil(t, err)
 	updatedWorkflow.Status.CompressedNodes = file.CompressEncodeString(ctx, string(nodeData))
+	syncWorkflowReportWithFakeCluster(t, store, updatedWorkflow)
 	_, err = manager.ReportWorkflowResource(ctx, updatedWorkflow)
 	assert.Nil(t, err)
 	return store, manager, runDetail
@@ -599,6 +650,7 @@ func initWithOneTimeFailedRunOffloaded(t *testing.T) (*FakeClientManager, *Resou
 	updatedWorkflow.SetLabels(util.LabelKeyWorkflowRunId, runDetail.UUID)
 	updatedWorkflow.Status.Phase = v1alpha1.WorkflowFailed
 	updatedWorkflow.Status.OffloadNodeStatusVersion = "offload-hash"
+	syncWorkflowReportWithFakeCluster(t, store, updatedWorkflow)
 	_, err = manager.ReportWorkflowResource(ctx, updatedWorkflow)
 	assert.Nil(t, err)
 	return store, manager, runDetail
@@ -714,6 +766,139 @@ func (c *retryableUpdateFailureWorkflowClient) Create(ctx context.Context, execS
 type genericUpdateFailureWorkflowClient struct {
 	*client.FakeWorkflowClient
 	createCalls int
+}
+
+type deleteFailureWorkflowClient struct {
+	*client.FakeWorkflowClient
+}
+
+func (c *deleteFailureWorkflowClient) Delete(context.Context, string, v1.DeleteOptions) error {
+	return errors.New("failed to delete workflow")
+}
+
+type countingWorkflowClient struct {
+	*client.FakeWorkflowClient
+	getCalls int
+}
+
+func (c *countingWorkflowClient) Get(ctx context.Context, name string, options v1.GetOptions) (util.ExecutionSpec, error) {
+	c.getCalls++
+	return c.FakeWorkflowClient.Get(ctx, name, options)
+}
+
+type transientDeleteFailureWorkflowClient struct {
+	*client.FakeWorkflowClient
+	deleteFailuresRemaining int
+	deleteCalls             int
+}
+
+func (c *transientDeleteFailureWorkflowClient) Delete(ctx context.Context, name string, options v1.DeleteOptions) error {
+	c.deleteCalls++
+	if c.deleteFailuresRemaining > 0 {
+		c.deleteFailuresRemaining--
+		return apierrors.NewServiceUnavailable("apiserver temporarily unavailable")
+	}
+	return c.FakeWorkflowClient.Delete(ctx, name, options)
+}
+
+type disappearBeforeDeleteLookupWorkflowClient struct {
+	*client.FakeWorkflowClient
+	getCalls int
+}
+
+func (c *disappearBeforeDeleteLookupWorkflowClient) Get(ctx context.Context, name string, options v1.GetOptions) (util.ExecutionSpec, error) {
+	c.getCalls++
+	if c.getCalls == 2 {
+		if err := c.Delete(ctx, name, v1.DeleteOptions{}); err != nil {
+			return nil, err
+		}
+	}
+	return c.FakeWorkflowClient.Get(ctx, name, options)
+}
+
+type notFoundOnOrphanDeleteWorkflowClient struct {
+	*client.FakeWorkflowClient
+	getCalls    int
+	deleteCalls int
+}
+
+func (c *notFoundOnOrphanDeleteWorkflowClient) Get(ctx context.Context, name string, options v1.GetOptions) (util.ExecutionSpec, error) {
+	c.getCalls++
+	return c.FakeWorkflowClient.Get(ctx, name, options)
+}
+
+func (c *notFoundOnOrphanDeleteWorkflowClient) Delete(ctx context.Context, name string, options v1.DeleteOptions) error {
+	c.deleteCalls++
+	if err := c.FakeWorkflowClient.Delete(ctx, name, options); err != nil {
+		return err
+	}
+	return apierrors.NewNotFound(
+		schema.GroupResource{Group: "argoproj.io", Resource: "workflows"}, name)
+}
+
+type updateBeforeFirstDeleteWorkflowClient struct {
+	*client.FakeWorkflowClient
+	deleteCalls int
+}
+
+func (c *updateBeforeFirstDeleteWorkflowClient) Delete(ctx context.Context, name string, options v1.DeleteOptions) error {
+	c.deleteCalls++
+	if c.deleteCalls == 1 {
+		workflow, err := c.Get(ctx, name, v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if _, err := c.Update(ctx, workflow, v1.UpdateOptions{}); err != nil {
+			return err
+		}
+	}
+	return c.FakeWorkflowClient.Delete(ctx, name, options)
+}
+
+type replaceBeforeOrphanDeleteLookupWorkflowClient struct {
+	*client.FakeWorkflowClient
+	getCalls int
+}
+
+func (c *replaceBeforeOrphanDeleteLookupWorkflowClient) Get(ctx context.Context, name string, options v1.GetOptions) (util.ExecutionSpec, error) {
+	c.getCalls++
+	if c.getCalls != 2 {
+		return c.FakeWorkflowClient.Get(ctx, name, options)
+	}
+
+	current, err := c.FakeWorkflowClient.Get(ctx, name, options)
+	if err != nil {
+		return nil, err
+	}
+	metadata := current.ExecutionObjectMeta()
+	if err := c.Delete(ctx, name, v1.DeleteOptions{}); err != nil {
+		return nil, err
+	}
+	replacement := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              name,
+			Namespace:         current.ExecutionNamespace(),
+			Labels:            metadata.Labels,
+			CreationTimestamp: metadata.CreationTimestamp,
+		},
+	})
+	return c.Create(ctx, replacement, v1.CreateOptions{})
+}
+
+type retryBeforeDeleteWorkflowClient struct {
+	*client.FakeWorkflowClient
+	manager        *ResourceManager
+	runID          string
+	retryAttempted bool
+	retryErr       error
+}
+
+func (c *retryBeforeDeleteWorkflowClient) Delete(ctx context.Context, name string, options v1.DeleteOptions) error {
+	if !c.retryAttempted {
+		c.retryAttempted = true
+		c.retryErr = c.manager.RetryRun(ctx, c.runID)
+	}
+	return c.FakeWorkflowClient.Delete(ctx, name, options)
 }
 
 func (c *genericUpdateFailureWorkflowClient) Update(ctx context.Context, execSpec util.ExecutionSpec, opts v1.UpdateOptions) (util.ExecutionSpec, error) {
@@ -2312,6 +2497,7 @@ func TestCreateRun_ThroughPipelineID(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
 	expectedRuntimeWorkflow.Annotations = map[string]string{util.AnnotationKeyRunName: "run1"}
@@ -2328,6 +2514,7 @@ func TestCreateRun_ThroughPipelineID(t *testing.T) {
 		ExperimentId:   experiment.UUID,
 		DisplayName:    "run1",
 		K8SName:        "workflow-name",
+		Namespace:      "ns1",
 		ServiceAccount: "pipeline-runner",
 		StorageState:   model.StorageStateAvailable,
 		PipelineSpec: model.PipelineSpec{
@@ -2401,6 +2588,7 @@ func TestCreateRun_ThroughWorkflowSpec(t *testing.T) {
 	store, manager, runDetail := initWithOneTimeRun(t)
 	expectedExperimentUUID := runDetail.ExperimentId
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
 	expectedRuntimeWorkflow.Annotations = map[string]string{util.AnnotationKeyRunName: "run1"}
@@ -2417,6 +2605,7 @@ func TestCreateRun_ThroughWorkflowSpec(t *testing.T) {
 		ExperimentId:   expectedExperimentUUID,
 		DisplayName:    "run1",
 		K8SName:        "workflow-name",
+		Namespace:      "ns1",
 		ServiceAccount: "pipeline-runner",
 		StorageState:   model.StorageStateAvailable,
 		PipelineSpec: model.PipelineSpec{
@@ -2451,6 +2640,7 @@ func TestCreateRun_ThroughWorkflowSpecWithPatch(t *testing.T) {
 	store, manager, runDetail := initWithPatchedRun(t)
 	expectedExperimentUUID := runDetail.ExperimentId
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
 	expectedRuntimeWorkflow.Annotations = map[string]string{util.AnnotationKeyRunName: "run1"}
@@ -2467,6 +2657,7 @@ func TestCreateRun_ThroughWorkflowSpecWithPatch(t *testing.T) {
 		ExperimentId:   expectedExperimentUUID,
 		DisplayName:    "run1",
 		K8SName:        "workflow-name",
+		Namespace:      "ns1",
 		ServiceAccount: "pipeline-runner",
 		StorageState:   model.StorageStateAvailable,
 		RunDetails: model.RunDetails{
@@ -2559,6 +2750,7 @@ func TestCreateRun_ThroughPipelineVersion(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
 	expectedRuntimeWorkflow.Annotations = map[string]string{util.AnnotationKeyRunName: "run1"}
@@ -2576,6 +2768,7 @@ func TestCreateRun_ThroughPipelineVersion(t *testing.T) {
 		ExperimentId:   experiment.UUID,
 		DisplayName:    "run1",
 		K8SName:        "workflow-name",
+		Namespace:      "ns1",
 		ServiceAccount: "sa1",
 		StorageState:   model.StorageStateAvailable,
 		PipelineSpec: model.PipelineSpec{
@@ -2641,6 +2834,7 @@ func TestCreateRun_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: "123e4567-e89b-12d3-a456-426655440000"}
 	expectedRuntimeWorkflow.Annotations = map[string]string{util.AnnotationKeyRunName: "run1"}
@@ -2658,6 +2852,7 @@ func TestCreateRun_ThroughPipelineIdAndPipelineVersion(t *testing.T) {
 		ExperimentId:   experiment.UUID,
 		DisplayName:    "run1",
 		K8SName:        "workflow-name",
+		Namespace:      "ns1",
 		ServiceAccount: "sa1",
 		StorageState:   model.StorageStateAvailable,
 		RunDetails: model.RunDetails{
@@ -2912,12 +3107,138 @@ func TestCreateRun_NoMLflowConfig(t *testing.T) {
 func TestDeleteRun(t *testing.T) {
 	store, manager, runDetail := initWithOneTimeRun(t)
 	defer store.Close()
+	manager.storedWorkflowIdentities.loadOrStore(runDetail.UUID, storedWorkflowIdentity{
+		name: runDetail.K8SName,
+		uid:  types.UID(runDetail.UUID),
+	})
 	err := manager.DeleteRun(context.Background(), runDetail.UUID)
 	assert.Nil(t, err)
 
 	_, err = manager.GetRun(runDetail.UUID)
 	assert.Equal(t, codes.NotFound, err.(*util.UserError).ExternalStatusCode())
 	assert.Contains(t, err.Error(), "not found")
+	_, found := manager.storedWorkflowIdentities.load(runDetail.UUID)
+	assert.False(t, found)
+}
+
+func TestStoredWorkflowIdentityCacheIsBounded(t *testing.T) {
+	cache := storedWorkflowIdentityCache{}
+	for index := 0; index < storedWorkflowIdentityCacheCapacity; index++ {
+		runID := fmt.Sprintf("run-%d", index)
+		cache.loadOrStore(runID, storedWorkflowIdentity{name: runID, uid: types.UID(runID)})
+	}
+
+	_, found := cache.load("run-0")
+	require.True(t, found)
+	cache.loadOrStore("overflow", storedWorkflowIdentity{name: "overflow", uid: "overflow"})
+
+	cache.mu.Lock()
+	assert.Len(t, cache.entries, storedWorkflowIdentityCacheCapacity)
+	cache.mu.Unlock()
+	_, found = cache.load("run-0")
+	assert.True(t, found, "recently used identity should remain cached")
+	_, found = cache.load("run-1")
+	assert.False(t, found, "least recently used identity should be evicted")
+}
+
+func TestStoredWorkflowIdentityCacheRejectsOlderRetryGenerationReplacement(t *testing.T) {
+	cache := storedWorkflowIdentityCache{}
+	current := storedWorkflowIdentity{name: "workflow", uid: "new-uid", retryGeneration: 2}
+	stale := storedWorkflowIdentity{name: "workflow", uid: "old-uid", retryGeneration: 1}
+
+	cache.loadOrStore("run", current)
+	actual := cache.loadOrStore("run", stale)
+
+	assert.Equal(t, current, actual)
+	cached, found := cache.load("run")
+	require.True(t, found)
+	assert.Equal(t, current, cached)
+}
+
+func TestStoredWorkflowIdentityCacheRefreshesSameGenerationManifest(t *testing.T) {
+	cache := storedWorkflowIdentityCache{}
+	stale := storedWorkflowIdentity{
+		name:            "workflow",
+		uid:             "old-uid",
+		retryGeneration: 1,
+		manifestDigest:  sha256.Sum256([]byte("old-manifest")),
+	}
+	current := storedWorkflowIdentity{
+		name:            "workflow",
+		uid:             "new-uid",
+		retryGeneration: 1,
+		manifestDigest:  sha256.Sum256([]byte("new-manifest")),
+	}
+
+	cache.loadOrStore("run", stale)
+	actual := cache.loadOrStore("run", current)
+
+	assert.Equal(t, current, actual)
+	cached, found := cache.load("run")
+	require.True(t, found)
+	assert.Equal(t, current, cached)
+}
+
+func TestStoredWorkflowIdentityCacheRefreshesAfterPersistedAdoption(t *testing.T) {
+	cache := storedWorkflowIdentityCache{}
+	oldIdentity := storedWorkflowIdentity{
+		name:            "workflow",
+		uid:             "old-uid",
+		retryGeneration: 1,
+		manifestDigest:  sha256.Sum256([]byte("old-manifest")),
+	}
+	adoptedIdentity := storedWorkflowIdentity{
+		name:            "workflow",
+		uid:             "new-uid",
+		retryGeneration: 1,
+		manifestDigest:  sha256.Sum256([]byte("adopted-manifest")),
+	}
+
+	cache.loadOrStore("run", oldIdentity)
+	cache.replaceAfterPersist("run", oldIdentity.manifestDigest, adoptedIdentity)
+
+	actual, found := cache.load("run")
+	require.True(t, found)
+	assert.Equal(t, adoptedIdentity, actual)
+}
+
+func TestStoredWorkflowIdentityCacheReplaceRejectsOlderRetryGeneration(t *testing.T) {
+	cache := storedWorkflowIdentityCache{}
+	current := storedWorkflowIdentity{
+		name:            "workflow",
+		uid:             "new-uid",
+		retryGeneration: 2,
+		manifestDigest:  sha256.Sum256([]byte("current-manifest")),
+	}
+	stale := storedWorkflowIdentity{
+		name:            "workflow",
+		uid:             "old-uid",
+		retryGeneration: 1,
+		manifestDigest:  sha256.Sum256([]byte("stale-manifest")),
+	}
+
+	cache.replaceAfterPersist("run", sha256.Sum256([]byte("initial-manifest")), current)
+	cache.replaceAfterPersist("run", sha256.Sum256([]byte("initial-manifest")), stale)
+
+	cached, found := cache.load("run")
+	require.True(t, found)
+	assert.Equal(t, current, cached)
+}
+
+func TestStoredWorkflowIdentityCacheDelayedRefreshDoesNotReplaceNewerManifest(t *testing.T) {
+	cache := storedWorkflowIdentityCache{}
+	initial := storedWorkflowIdentity{retryGeneration: 1, manifestDigest: sha256.Sum256([]byte("manifest-0"))}
+	first := storedWorkflowIdentity{retryGeneration: 1, manifestDigest: sha256.Sum256([]byte("manifest-1"))}
+	second := storedWorkflowIdentity{retryGeneration: 1, manifestDigest: sha256.Sum256([]byte("manifest-2"))}
+
+	cache.loadOrStore("run", initial)
+	cache.replaceAfterPersist("run", initial.manifestDigest, first)
+	cache.replaceAfterPersist("run", first.manifestDigest, second)
+	cache.replaceAfterPersist("run", initial.manifestDigest, first)
+
+	cached, found := cache.load("run")
+	require.True(t, found)
+	assert.Equal(t, second, cached)
 }
 
 func TestDeleteRun_RunNotExist(t *testing.T) {
@@ -3017,7 +3338,11 @@ func TestTerminateRun(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "Terminating", actualRunDetail.Conditions)
 
-	isTerminated, err := store.ExecClientFake.IsTerminated(runDetail.K8SName)
+	workflowNamespace := runDetail.Namespace
+	if manager.IsEmptyNamespace(workflowNamespace) {
+		workflowNamespace = common.GetPodNamespace()
+	}
+	isTerminated, err := store.ExecClientFake.IsTerminatedInNamespace(workflowNamespace, runDetail.K8SName)
 	assert.Nil(t, err)
 	assert.True(t, isTerminated)
 }
@@ -3056,6 +3381,22 @@ func TestRetryRun(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, string(actualRunDetail.WorkflowRuntimeManifest), "Running")
 	assert.Equal(t, actualRunDetail.RunDetails.State, model.RuntimeStateRunning)
+}
+
+func TestRetryRun_RefreshesDivergentWorkflowName(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+	expectedWorkflowName := runDetail.K8SName
+
+	storedRun, err := manager.GetRun(runDetail.UUID)
+	require.NoError(t, err)
+	storedRun.K8SName = "stale-workflow-name"
+	require.NoError(t, manager.runStore.UpdateRun(storedRun))
+
+	require.NoError(t, manager.RetryRun(context.Background(), runDetail.UUID))
+	retriedRun, err := manager.GetRun(runDetail.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, expectedWorkflowName, retriedRun.K8SName)
 }
 
 func TestRetryRun_RetriesWorkflowUpdateConflict(t *testing.T) {
@@ -4058,12 +4399,14 @@ func TestReportWorkflowResource_ScheduledWorkflowIDEmpty_Success(t *testing.T) {
 	// report workflow
 	workflow := util.NewWorkflow(&v1alpha1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
 			UID:       types.UID(run.UUID),
 			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
 			Namespace: "ns1",
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, workflow)
 	_, err := manager.ReportWorkflowResource(context.Background(), workflow)
 	assert.Nil(t, err)
 	run, err = manager.GetRun(run.UUID)
@@ -4073,6 +4416,7 @@ func TestReportWorkflowResource_ScheduledWorkflowIDEmpty_Success(t *testing.T) {
 		ExperimentId:   expectedExperimentUUID,
 		DisplayName:    "run1",
 		K8SName:        "workflow-name",
+		Namespace:      "ns1",
 		ServiceAccount: "pipeline-runner",
 		StorageState:   model.StorageStateAvailable,
 		RunDetails: model.RunDetails{
@@ -4100,6 +4444,559 @@ func TestReportWorkflowResource_ScheduledWorkflowIDEmpty_Success(t *testing.T) {
 	assert.Equal(t, expectedRun.ToV1(), run.ToV1())
 }
 
+func TestReportWorkflowResource_UsesLiveWorkflowState(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	liveWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	liveWorkflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowRunning
+	_, err = store.ExecClient().Execution(run.Namespace).Update(
+		ctx, liveWorkflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	forgedReport := util.NewWorkflow(liveWorkflow.(*util.Workflow).DeepCopy())
+	forgedReport.Status.Phase = v1alpha1.WorkflowFailed
+	_, err = manager.ReportWorkflowResource(ctx, forgedReport)
+	require.NoError(t, err)
+
+	updatedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateRunning, updatedRun.State,
+		"request-controlled status must not override the live Workflow")
+}
+
+func TestReportWorkflowResource_AdoptsLegacyEmptyWorkflowName(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	_, err := store.DB().Exec(`UPDATE run_details SET Name = '' WHERE UUID = ?`, run.UUID)
+	require.NoError(t, err)
+	liveWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	liveWorkflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowRunning
+	_, err = store.ExecClient().Execution(run.Namespace).Update(
+		ctx, liveWorkflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(ctx, liveWorkflow)
+	require.NoError(t, err)
+	updatedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, run.K8SName, updatedRun.K8SName)
+}
+
+func TestReportWorkflowResource_RepairsDivergentWorkflowName(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	_, err := store.DB().Exec(`UPDATE run_details SET Name = ? WHERE UUID = ?`, "stale-workflow-name", run.UUID)
+	require.NoError(t, err)
+	liveWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	liveWorkflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowRunning
+	liveWorkflow, err = store.ExecClient().Execution(run.Namespace).Update(
+		ctx, liveWorkflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(ctx, liveWorkflow)
+	require.NoError(t, err)
+	updatedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, run.K8SName, updatedRun.K8SName)
+	assert.Equal(t, model.RuntimeStateRunning, updatedRun.State)
+}
+
+func TestReportWorkflowResource_NamespaceMismatch_Rejected(t *testing.T) {
+	store, manager, exp := initWithExperiment(t)
+	defer store.Close()
+	apiRun := &model.Run{
+		DisplayName: "run1",
+		Namespace:   "ns1",
+		PipelineSpec: model.PipelineSpec{
+			WorkflowSpecManifest: model.LargeText(testWorkflow.ToStringForStore()),
+			Parameters:           "[{\"name\":\"param1\",\"value\":\"world\"}]",
+		},
+		ExperimentId: exp.UUID,
+	}
+	run, err := manager.CreateRun(context.Background(), apiRun)
+	assert.Nil(t, err)
+	// The run must have a namespace for the cross-namespace guard to apply.
+	run, err = manager.GetRun(run.UUID)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, run.Namespace)
+	runBeforeReport := run.ToV1()
+
+	// A workflow reported from a different namespace must not be allowed to
+	// overwrite this run, even though it carries the run's ID label.
+	spoofed := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name: run.K8SName,
+			UID:  types.UID(run.UUID),
+			Labels: map[string]string{
+				util.LabelKeyWorkflowRunId:               run.UUID,
+				util.LabelKeyWorkflowPersistedFinalState: "true",
+			},
+			Namespace: "attacker-ns",
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
+	})
+	_, err = manager.ReportWorkflowResource(context.Background(), spoofed)
+	assert.NotNil(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: reported namespace does not match owning resource", err.(*util.UserError).ExternalMessage())
+	assert.NotContains(t, err.Error(), run.Namespace)
+	runAfterReport, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, runBeforeReport, runAfterReport.ToV1())
+
+	// A workflow reported from the run's own namespace still succeeds.
+	legit := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+			Namespace: run.Namespace,
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+	syncWorkflowReportWithFakeCluster(t, store, legit)
+	_, err = manager.ReportWorkflowResource(context.Background(), legit)
+	assert.Nil(t, err)
+}
+
+func TestReportWorkflowResource_PersistedRunNamespaceInMultiUserMode(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	experiment, err := manager.GetExperiment(run.ExperimentId)
+	require.NoError(t, err)
+	assert.Equal(t, experiment.Namespace, run.Namespace)
+	persistedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, experiment.Namespace, persistedRun.Namespace)
+	require.Equal(t, "ns1", experiment.Namespace)
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+
+	spoofed := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+			Namespace: "attacker-ns",
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+
+	_, err = manager.ReportWorkflowResource(context.Background(), spoofed)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: reported namespace does not match owning resource", err.(*util.UserError).ExternalMessage())
+	assert.NotContains(t, err.Error(), "ns1")
+
+	legitimate := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: experiment.Namespace,
+			UID:       types.UID(run.UUID),
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+	syncWorkflowReportWithFakeCluster(t, store, legitimate)
+	_, err = manager.ReportWorkflowResource(context.Background(), legitimate)
+	require.NoError(t, err)
+}
+
+func TestReportWorkflowResource_NoNamespaceRunUsesStoredWorkflowNamespaceInSingleUserMode(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	// Simulate a legacy row which used the namespace sentinel before the
+	// Kubernetes execution namespace was persisted on runs.
+	_, err := store.DB().Exec(`UPDATE run_details SET Namespace = ? WHERE UUID = ?`, model.NoNamespace, run.UUID)
+	require.NoError(t, err)
+	_, err = store.DB().Exec(
+		`DELETE FROM resource_references WHERE ResourceUUID = ? AND ResourceType = ? AND ReferenceType = ?`,
+		run.UUID,
+		model.RunResourceType,
+		model.NamespaceResourceType,
+	)
+	require.NoError(t, err)
+	// The API server may have moved since this legacy workflow was submitted.
+	// The created runtime manifest remains the authoritative mapping and avoids
+	// both stranding the run and accepting a replacement in another namespace.
+	previousPodNamespace := viper.GetString(common.PodNamespace)
+	viper.Set(common.PodNamespace, "new-api-server-namespace")
+	t.Cleanup(func() { viper.Set(common.PodNamespace, previousPodNamespace) })
+
+	workflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		context.Background(), run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	workflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowRunning
+	workflow, err = store.ExecClient().Execution(run.Namespace).Update(
+		context.Background(), workflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
+	require.NoError(t, err)
+	updatedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, run.Namespace, updatedRun.Namespace)
+}
+
+func TestReportWorkflowResource_NoNamespaceRunAdoptsMissingStoredUID(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+	liveWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+
+	legacyManifest := util.NewWorkflow(liveWorkflow.(*util.Workflow).DeepCopy())
+	legacyManifest.UID = ""
+	legacyManifest.Namespace = ""
+	_, err = store.DB().Exec(
+		`UPDATE run_details SET Namespace = ?, WorkflowRuntimeManifest = ? WHERE UUID = ?`,
+		model.NoNamespace, legacyManifest.ToStringForStore(), run.UUID)
+	require.NoError(t, err)
+	_, err = store.DB().Exec(
+		`DELETE FROM resource_references WHERE ResourceUUID = ? AND ResourceType = ? AND ReferenceType = ?`,
+		run.UUID,
+		model.RunResourceType,
+		model.NamespaceResourceType,
+	)
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(ctx, liveWorkflow)
+	require.NoError(t, err)
+	updatedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, run.Namespace, updatedRun.Namespace)
+	assert.Equal(t, liveWorkflow.ExecutionObjectMeta().UID, storedWorkflowUID(t, updatedRun))
+}
+
+func TestReportWorkflowResource_RefreshesIdentityCacheAfterAnotherReplicaRepairsLegacyRun(t *testing.T) {
+	store, firstManager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+	secondManager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	liveWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+
+	legacyManifest := util.NewWorkflow(liveWorkflow.(*util.Workflow).DeepCopy())
+	legacyManifest.UID = ""
+	legacyManifest.Namespace = ""
+	_, err = store.DB().Exec(
+		`UPDATE run_details SET Namespace = ?, WorkflowRuntimeManifest = ? WHERE UUID = ?`,
+		model.NoNamespace, legacyManifest.ToStringForStore(), run.UUID)
+	require.NoError(t, err)
+	_, err = store.DB().Exec(
+		`DELETE FROM resource_references WHERE ResourceUUID = ? AND ResourceType = ? AND ReferenceType = ?`,
+		run.UUID,
+		model.RunResourceType,
+		model.NamespaceResourceType,
+	)
+	require.NoError(t, err)
+
+	legacyRun, err := firstManager.GetRun(run.UUID)
+	require.NoError(t, err)
+	legacyIdentity, err := firstManager.storedWorkflowIdentityForRun(legacyRun)
+	require.NoError(t, err)
+	require.Empty(t, legacyIdentity.uid)
+
+	_, err = secondManager.ReportWorkflowResource(ctx, liveWorkflow)
+	require.NoError(t, err, "a second replica should repair the persisted workflow identity")
+	repairedRun, err := firstManager.GetRun(run.UUID)
+	require.NoError(t, err)
+	require.Equal(t, run.Namespace, repairedRun.Namespace)
+	require.Equal(t, liveWorkflow.ExecutionObjectMeta().UID, storedWorkflowUID(t, repairedRun))
+
+	_, err = firstManager.ReportWorkflowResource(ctx, liveWorkflow)
+	require.NoError(t, err, "the first replica must refresh its cache from the repaired manifest")
+	refreshedIdentity, found := firstManager.storedWorkflowIdentities.load(run.UUID)
+	require.True(t, found)
+	assert.Equal(t, liveWorkflow.ExecutionObjectMeta().UID, refreshedIdentity.uid)
+	assert.NotEqual(t, legacyIdentity.manifestDigest, refreshedIdentity.manifestDigest)
+}
+
+func TestReportWorkflowResource_RejectsStaleLegacyIdentityAfterConcurrentRepair(t *testing.T) {
+	store, staleManager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+	repairManager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	workflowClient := store.ExecClient().Execution(run.Namespace)
+	original, err := workflowClient.Get(ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+
+	legacyManifest := util.NewWorkflow(original.(*util.Workflow).DeepCopy())
+	legacyManifest.UID = ""
+	legacyManifest.Namespace = ""
+	_, err = store.DB().Exec(
+		`UPDATE run_details SET Namespace = ?, WorkflowRuntimeManifest = ? WHERE UUID = ?`,
+		model.NoNamespace, legacyManifest.ToStringForStore(), run.UUID)
+	require.NoError(t, err)
+	_, err = store.DB().Exec(
+		`DELETE FROM resource_references WHERE ResourceUUID = ? AND ResourceType = ? AND ReferenceType = ?`,
+		run.UUID,
+		model.RunResourceType,
+		model.NamespaceResourceType,
+	)
+	require.NoError(t, err)
+
+	staleRun, err := staleManager.GetRun(run.UUID)
+	require.NoError(t, err)
+	require.Empty(t, storedWorkflowUID(t, staleRun))
+
+	_, err = repairManager.ReportWorkflowResource(ctx, original)
+	require.NoError(t, err)
+	repairedRun, err := staleManager.GetRun(run.UUID)
+	require.NoError(t, err)
+	originalUID := original.ExecutionObjectMeta().UID
+	require.Equal(t, originalUID, storedWorkflowUID(t, repairedRun))
+	repairedIdentity, err := staleManager.storedWorkflowIdentityForRun(repairedRun)
+	require.NoError(t, err)
+	require.Equal(t, originalUID, repairedIdentity.uid)
+
+	require.NoError(t, workflowClient.Delete(ctx, run.K8SName, v1.DeleteOptions{}))
+	replacement, err := workflowClient.Create(ctx, util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: run.Namespace,
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	}), v1.CreateOptions{})
+	require.NoError(t, err)
+	require.NotEqual(t, originalUID, replacement.ExecutionObjectMeta().UID)
+
+	_, err = staleManager.ReportWorkflowResourceWithRun(ctx, replacement, staleRun)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable), "got %v", err)
+	afterConflict, err := staleManager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, originalUID, storedWorkflowUID(t, afterConflict))
+	refreshedIdentity, found := staleManager.storedWorkflowIdentities.load(run.UUID)
+	require.True(t, found)
+	assert.Equal(t, originalUID, refreshedIdentity.uid)
+
+	_, err = staleManager.ReportWorkflowResource(ctx, replacement)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.InvalidArgument), "got %v", err)
+	unchangedRun, err := staleManager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, originalUID, storedWorkflowUID(t, unchangedRun))
+}
+
+func TestReportWorkflowResource_RefreshesIdentityCacheAfterOrdinaryUpdate(t *testing.T) {
+	store, manager, run := initWithOneTimeRunV2(t)
+	defer store.Close()
+	ctx := context.Background()
+	workflowClient := store.ExecClient().Execution(run.Namespace)
+	liveWorkflow, err := workflowClient.Get(ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+
+	storedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	require.Empty(t, storedRun.WorkflowRuntimeManifest)
+	require.NotEmpty(t, storedRun.PipelineRuntimeManifest)
+	initialIdentity, err := manager.storedWorkflowIdentityForRun(storedRun)
+	require.NoError(t, err)
+
+	if liveWorkflow.ExecutionObjectMeta().Annotations == nil {
+		liveWorkflow.ExecutionObjectMeta().Annotations = map[string]string{}
+	}
+	liveWorkflow.ExecutionObjectMeta().Annotations["cache-refresh"] = "ordinary-report"
+	liveWorkflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowRunning
+	updatedWorkflow, err := workflowClient.Update(ctx, liveWorkflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+	_, err = manager.ReportWorkflowResource(ctx, updatedWorkflow)
+	require.NoError(t, err)
+
+	updatedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	require.NotEmpty(t, updatedRun.WorkflowRuntimeManifest)
+	updatedIdentity, found := manager.storedWorkflowIdentities.load(run.UUID)
+	require.True(t, found)
+	assert.Equal(t, sha256.Sum256([]byte(updatedRun.WorkflowRuntimeManifest)), updatedIdentity.manifestDigest)
+	assert.NotEqual(t, initialIdentity.manifestDigest, updatedIdentity.manifestDigest)
+	assert.Equal(t, updatedWorkflow.ExecutionName(), updatedIdentity.name)
+	assert.Equal(t, updatedWorkflow.ExecutionNamespace(), updatedIdentity.namespace)
+	assert.Equal(t, updatedWorkflow.ExecutionObjectMeta().UID, updatedIdentity.uid)
+	assert.Equal(t, updatedRun.RetryGeneration, updatedIdentity.retryGeneration)
+}
+
+func TestReportWorkflowResource_RejectsStaleReportAfterRunIDRecreation(t *testing.T) {
+	store, manager, originalRun := initWithOneTimeRunV2(t)
+	defer store.Close()
+	ctx := context.Background()
+	workflowClient := store.ExecClient().Execution(originalRun.Namespace)
+	originalLiveWorkflow, err := workflowClient.Get(ctx, originalRun.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	staleReport := util.NewWorkflow(originalLiveWorkflow.(*util.Workflow).DeepCopy())
+	if staleReport.Labels == nil {
+		staleReport.Labels = map[string]string{}
+	}
+	staleReport.Labels[util.LabelKeyWorkflowPersistedFinalState] = "true"
+	staleReport.Status.Phase = v1alpha1.WorkflowSucceeded
+	staleReport.Status.FinishedAt = v1.NewTime(time.Unix(123, 0))
+
+	staleRun, err := manager.GetRun(originalRun.UUID)
+	require.NoError(t, err)
+	require.Empty(t, staleRun.WorkflowRuntimeManifest)
+	require.NotEmpty(t, staleRun.PipelineRuntimeManifest)
+	require.NoError(t, manager.DeleteRun(ctx, originalRun.UUID))
+
+	replacementRun, err := manager.CreateRun(ctx, &model.Run{
+		UUID:         originalRun.UUID,
+		DisplayName:  originalRun.DisplayName,
+		ExperimentId: originalRun.ExperimentId,
+		Namespace:    originalRun.Namespace,
+		PipelineSpec: model.PipelineSpec{
+			PipelineSpecManifest: model.LargeText(v2SpecHelloWorld),
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters: "{\"text\":\"world\"}",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, replacementRun.WorkflowRuntimeManifest)
+	require.NotEmpty(t, replacementRun.PipelineRuntimeManifest)
+	require.NotEqual(t, staleRun.PipelineRuntimeManifest, replacementRun.PipelineRuntimeManifest)
+	require.NotEqual(t, storedWorkflowUID(t, staleRun), storedWorkflowUID(t, replacementRun))
+	replacementBeforeReport, err := manager.GetRun(replacementRun.UUID)
+	require.NoError(t, err)
+	replacementLiveWorkflow, err := workflowClient.Get(ctx, replacementRun.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResourceWithRun(ctx, staleReport, staleRun)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable), "got %v", err)
+
+	replacementAfterReport, err := manager.GetRun(replacementRun.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, replacementBeforeReport, replacementAfterReport)
+	stillLive, err := workflowClient.Get(ctx, replacementRun.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, replacementLiveWorkflow.ExecutionObjectMeta().UID, stillLive.ExecutionObjectMeta().UID)
+	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowDeleteCountInNamespace(
+		replacementRun.Namespace,
+		replacementRun.K8SName,
+	))
+}
+
+func TestReportWorkflowResource_NoNamespaceRunRejectsSameNameReplacementUID(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+	_, err := store.DB().Exec(`UPDATE run_details SET Namespace = ? WHERE UUID = ?`, model.NoNamespace, run.UUID)
+	require.NoError(t, err)
+	_, err = store.DB().Exec(
+		`DELETE FROM resource_references WHERE ResourceUUID = ? AND ResourceType = ? AND ReferenceType = ?`,
+		run.UUID,
+		model.RunResourceType,
+		model.NamespaceResourceType,
+	)
+	require.NoError(t, err)
+
+	workflowClient := store.ExecClient().Execution(run.Namespace)
+	original, err := workflowClient.Get(ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	require.NoError(t, workflowClient.Delete(ctx, run.K8SName, v1.DeleteOptions{}))
+	replacement, err := workflowClient.Create(ctx, util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: run.Namespace,
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	}), v1.CreateOptions{})
+	require.NoError(t, err)
+	require.NotEqual(t, original.ExecutionObjectMeta().UID, replacement.ExecutionObjectMeta().UID)
+
+	_, err = manager.ReportWorkflowResource(ctx, replacement)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: reported identity does not match the stored workflow", err.(*util.UserError).ExternalMessage())
+}
+
+func TestReportWorkflowResource_NoNamespaceRunRejectsDifferentWorkflowNamespace(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	_, err := store.DB().Exec(`UPDATE run_details SET Namespace = ? WHERE UUID = ?`, model.NoNamespace, run.UUID)
+	require.NoError(t, err)
+	_, err = store.DB().Exec(
+		`DELETE FROM resource_references WHERE ResourceUUID = ? AND ResourceType = ? AND ReferenceType = ?`,
+		run.UUID,
+		model.RunResourceType,
+		model.NamespaceResourceType,
+	)
+	require.NoError(t, err)
+
+	replacement := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: "replacement-namespace",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+	syncWorkflowReportWithFakeCluster(t, store, replacement)
+
+	_, err = manager.ReportWorkflowResource(context.Background(), replacement)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: reported namespace does not match owning resource", err.(*util.UserError).ExternalMessage())
+}
+
+func TestGetNamespaceFromRunID_PrefersPersistedRunNamespace(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+
+	_, err := store.DB().Exec(`UPDATE run_details SET Namespace = ? WHERE UUID = ?`, "run-namespace", run.UUID)
+	require.NoError(t, err)
+	_, err = store.DB().Exec(
+		`DELETE FROM resource_references WHERE ResourceUUID = ? AND ResourceType = ? AND ReferenceType = ?`,
+		run.UUID,
+		model.RunResourceType,
+		model.NamespaceResourceType,
+	)
+	require.NoError(t, err)
+
+	namespace, err := manager.getNamespaceFromRunId(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, "run-namespace", namespace)
+}
+
+func TestValidateWorkflowReportNamespace_EmptyNamespaceFailsPermanently(t *testing.T) {
+	manager := &ResourceManager{}
+	err := manager.validateWorkflowReportNamespace("recurring run", "job-id", "", "attacker-ns", "workflow")
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: owning namespace cannot be determined", err.(*util.UserError).ExternalMessage())
+}
+
+func TestResolveWorkflowReportNamespace_MultiUserEmptyExperimentIsRetryable(t *testing.T) {
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+	store, manager, _ := initWithExperiment(t)
+	defer store.Close()
+
+	_, err := manager.resolveWorkflowReportNamespace("run", "run-id", "", "", "attacker-ns")
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, err.(*util.UserError).ExternalStatusCode())
+	assert.Contains(t, err.Error(), "Failed to determine namespace")
+
+	_, err = manager.resolveWorkflowReportNamespace("run", "run-id", "", "missing-experiment", "attacker-ns")
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, err.(*util.UserError).ExternalStatusCode())
+}
+
 func TestReportWorkflowResource_ScheduledWorkflowIDNotEmpty_Success(t *testing.T) {
 	store, manager, job := initWithJob(t)
 	defer store.Close()
@@ -4108,18 +5005,19 @@ func TestReportWorkflowResource_ScheduledWorkflowIDNotEmpty_Success(t *testing.T
 	workflow := util.NewWorkflow(&v1alpha1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "MY_NAME",
-			Namespace: "MY_NAMESPACE",
+			Namespace: job.Namespace,
 			UID:       "WORKFLOW_1",
 			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "WORKFLOW_1"},
 			OwnerReferences: []v1.OwnerReference{{
 				APIVersion: "kubeflow.org/v1beta1",
 				Kind:       "ScheduledWorkflow",
-				Name:       "SCHEDULE_NAME",
+				Name:       job.K8SName,
 				UID:        types.UID(job.UUID),
 			}},
 			CreationTimestamp: v1.NewTime(time.Unix(11, 0).UTC()),
 		},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, workflow)
 	_, err := manager.ReportWorkflowResource(context.Background(), workflow)
 	assert.Nil(t, err)
 
@@ -4136,10 +5034,10 @@ func TestReportWorkflowResource_ScheduledWorkflowIDNotEmpty_Success(t *testing.T
 		RecurringRunId: job.UUID,
 		PipelineSpec: model.PipelineSpec{
 			WorkflowSpecManifest: model.LargeText(workflow.GetExecutionSpec().ToStringForStore()),
-			PipelineSpecManifest: job.PipelineSpec.PipelineSpecManifest,
-			PipelineId:           job.PipelineSpec.PipelineId,
-			PipelineName:         job.PipelineSpec.PipelineName,
-			PipelineVersionId:    job.PipelineSpec.PipelineVersionId,
+			PipelineSpecManifest: job.PipelineSpecManifest,
+			PipelineId:           job.PipelineId,
+			PipelineName:         job.PipelineName,
+			PipelineVersionId:    job.PipelineVersionId,
 		},
 		RunDetails: model.RunDetails{
 			WorkflowRuntimeManifest: model.LargeText(workflow.ToStringForStore()),
@@ -4157,6 +5055,774 @@ func TestReportWorkflowResource_ScheduledWorkflowIDNotEmpty_Success(t *testing.T
 		},
 	}
 	assert.Equal(t, expectedRunDetail.ToV1(), runDetail.ToV1())
+}
+
+func TestReportWorkflowResource_ScheduledWorkflowNamespaceMismatch_Rejected(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "spoofed-run",
+			Namespace: "attacker-ns",
+			UID:       "spoofed-run-id",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "spoofed-run-id"},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       "spoofed-schedule",
+				UID:        types.UID(job.UUID),
+			}},
+		},
+	})
+
+	_, err := manager.ReportWorkflowResource(context.Background(), workflow)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: reported namespace does not match owning resource", err.(*util.UserError).ExternalMessage())
+	assert.NotContains(t, err.Error(), job.Namespace)
+	_, err = manager.GetRun("spoofed-run-id")
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+}
+
+func TestReportWorkflowResource_ExistingRunNameMismatchDoesNotDeleteWorkflow(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+	workflowNamespace := run.Namespace
+	if manager.IsEmptyNamespace(workflowNamespace) {
+		workflowNamespace = common.GetPodNamespace()
+	}
+
+	decoy := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "same-namespace-decoy",
+			Namespace: workflowNamespace,
+			UID:       "same-namespace-decoy-id",
+			Labels: map[string]string{
+				util.LabelKeyWorkflowRunId:               run.UUID,
+				util.LabelKeyWorkflowPersistedFinalState: "true",
+			},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+	_, err := store.ExecClient().Execution(workflowNamespace).Create(ctx, decoy, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(ctx, decoy)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: reported name does not match owning run", err.(*util.UserError).ExternalMessage())
+	_, err = store.ExecClient().Execution(workflowNamespace).Get(ctx, decoy.ExecutionName(), v1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowDeleteCountInNamespace(workflowNamespace, decoy.ExecutionName()))
+}
+
+func TestReportWorkflowResource_DuplicateRecurringRunOwnershipMismatchRejected(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	store.runStore = &duplicateRecurringRunStore{
+		RunStoreInterface: store.runStore,
+		firstGet:          true,
+		existingRun: &model.Run{
+			UUID:           "shared-run-id",
+			ExperimentId:   "other-experiment",
+			RecurringRunId: "other-recurring-run",
+			K8SName:        "other-workflow",
+			Namespace:      "other-namespace",
+		},
+	}
+	manager.runStore = store.runStore
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "legitimate-workflow",
+			Namespace: job.Namespace,
+			UID:       "shared-run-id",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "shared-run-id"},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       job.K8SName,
+				UID:        types.UID(job.UUID),
+			}},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+	syncWorkflowReportWithFakeCluster(t, store, workflow)
+
+	_, err := manager.ReportWorkflowResource(context.Background(), workflow)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: persisted run ownership does not match recurring run", err.(*util.UserError).ExternalMessage())
+}
+
+func TestReportWorkflowResource_DuplicateRecurringRunIdentityMismatchRejected(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	storedWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "legitimate-workflow",
+			Namespace: job.Namespace,
+			UID:       "persisted-workflow-uid",
+		},
+	})
+	store.runStore = &duplicateRecurringRunStore{
+		RunStoreInterface: store.runStore,
+		firstGet:          true,
+		existingRun: &model.Run{
+			UUID:           "shared-run-id",
+			ExperimentId:   job.ExperimentId,
+			RecurringRunId: job.UUID,
+			K8SName:        storedWorkflow.ExecutionName(),
+			Namespace:      job.Namespace,
+			RunDetails: model.RunDetails{
+				WorkflowRuntimeManifest: model.LargeText(storedWorkflow.ToStringForStore()),
+			},
+		},
+	}
+	manager.runStore = store.runStore
+
+	replacement := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      storedWorkflow.ExecutionName(),
+			Namespace: job.Namespace,
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "shared-run-id"},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       job.K8SName,
+				UID:        types.UID(job.UUID),
+			}},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+	syncWorkflowReportWithFakeCluster(t, store, replacement)
+	require.NotEqual(t, storedWorkflow.ExecutionObjectMeta().UID, replacement.ExecutionObjectMeta().UID)
+
+	_, err := manager.ReportWorkflowResource(ctx, replacement)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: reported identity does not match the stored workflow", err.(*util.UserError).ExternalMessage())
+	_, getErr := store.ExecClient().Execution(job.Namespace).Get(ctx, replacement.ExecutionName(), v1.GetOptions{})
+	require.NoError(t, getErr, "identity rejection must not delete the replacement workflow")
+}
+
+func TestReportWorkflowResource_ExistingRecurringRunOwnershipMismatchRejected(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	store.runStore = &duplicateRecurringRunStore{
+		RunStoreInterface: store.runStore,
+		existingRun: &model.Run{
+			UUID:           "shared-run-id",
+			ExperimentId:   job.ExperimentId,
+			RecurringRunId: "other-recurring-run",
+			K8SName:        "legitimate-workflow",
+			Namespace:      job.Namespace,
+		},
+	}
+	manager.runStore = store.runStore
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "legitimate-workflow",
+			Namespace: job.Namespace,
+			UID:       "shared-run-id",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "shared-run-id"},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       job.K8SName,
+				UID:        types.UID(job.UUID),
+			}},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+
+	_, err := manager.ReportWorkflowResource(context.Background(), workflow)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: reported owner does not match owning run", err.(*util.UserError).ExternalMessage())
+}
+
+func TestReportWorkflowResource_OrphanedRecurringWorkflowSucceeds(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	run, err := manager.CreateRun(ctx, &model.Run{
+		DisplayName:    "orphaned-recurring-workflow",
+		ExperimentId:   job.ExperimentId,
+		RecurringRunId: job.UUID,
+		Namespace:      job.Namespace,
+		PipelineSpec:   job.PipelineSpec,
+	})
+	require.NoError(t, err)
+	require.NoError(t, manager.DeleteJob(ctx, job.UUID, apiv2beta1.DeletePropagationPolicy_ORPHAN))
+
+	orphanedWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	orphanedWorkflow.ExecutionObjectMeta().OwnerReferences = nil
+	orphanedWorkflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowSucceeded
+	_, err = store.ExecClient().Execution(run.Namespace).Update(
+		ctx, orphanedWorkflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(ctx, orphanedWorkflow)
+	require.NoError(t, err)
+	updatedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateSucceeded, updatedRun.State)
+}
+
+func TestReportWorkflowResource_MissingRecurringOwnerWithExistingJobIsPermanent(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	ctx := context.Background()
+	manager.options.CollectMetrics = true
+
+	run, err := manager.CreateRun(ctx, &model.Run{
+		DisplayName:    "owner-stripped-recurring-workflow",
+		ExperimentId:   job.ExperimentId,
+		RecurringRunId: job.UUID,
+		Namespace:      job.Namespace,
+		PipelineSpec:   job.PipelineSpec,
+	})
+	require.NoError(t, err)
+
+	workflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	workflow.ExecutionObjectMeta().OwnerReferences = nil
+	workflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowSucceeded
+	workflow, err = store.ExecClient().Execution(run.Namespace).Update(
+		ctx, workflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	rejectionCounter := workflowReportRejectedCounter.WithLabelValues(workflowReportRejectionIdentityMismatch)
+	metric := &dto.Metric{}
+	require.NoError(t, rejectionCounter.Write(metric))
+	rejectionsBefore := metric.GetCounter().GetValue()
+
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.InvalidArgument), "got %v", err)
+	assert.Contains(t, err.Error(), "recurring-run owner is missing")
+
+	metric.Reset()
+	require.NoError(t, rejectionCounter.Write(metric))
+	assert.Equal(t, rejectionsBefore+1, metric.GetCounter().GetValue())
+}
+
+func TestReportWorkflowResource_ExistingRunRejectsSameNameReplacementUID(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+	originalManifest := run.WorkflowRuntimeManifest
+	originalUID := storedWorkflowUID(t, run)
+
+	require.NoError(t, store.ExecClient().Execution(run.Namespace).Delete(
+		ctx, run.K8SName, v1.DeleteOptions{}))
+	replacement := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: run.Namespace,
+			UID:       "same-name-replacement-uid",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
+	})
+	_, err := store.ExecClient().Execution(run.Namespace).Create(
+		ctx, replacement, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(ctx, replacement)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.InvalidArgument))
+	assert.Contains(t, err.Error(), "reported identity does not match the stored workflow")
+
+	unchangedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, originalManifest, unchangedRun.WorkflowRuntimeManifest)
+	assert.Equal(t, originalUID, storedWorkflowUID(t, unchangedRun))
+	assert.NotEqual(t, replacement.ExecutionObjectMeta().UID, storedWorkflowUID(t, unchangedRun))
+}
+
+func TestReportWorkflowResource_AdoptsRecreatedWorkflowForActiveRetryClaim(t *testing.T) {
+	store, manager, runDetail := initWithOneTimeFailedRun(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	run, err := manager.GetRun(runDetail.UUID)
+	require.NoError(t, err)
+	originalUID := storedWorkflowUID(t, run)
+	_, _, _, claimGeneration, err := store.RunStore().ClaimRunForRetry(run.UUID, false)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), claimGeneration)
+
+	execSpec, err := util.NewExecutionSpecJSON(util.ArgoWorkflow, []byte(run.WorkflowRuntimeManifest))
+	require.NoError(t, err)
+	require.NoError(t, execSpec.Decompress())
+	retryExecSpec, _, err := execSpec.GenerateRetryExecution()
+	require.NoError(t, err)
+	retryExecSpec.SetAnnotations(util.AnnotationKeyRetryGeneration, strconv.FormatInt(claimGeneration, 10))
+	retryExecSpec.(*util.Workflow).Status.Phase = v1alpha1.WorkflowRunning
+
+	workflowClient := store.ExecClient().Execution(run.Namespace)
+	require.NoError(t, workflowClient.Delete(ctx, run.K8SName, v1.DeleteOptions{}))
+	recreatedWorkflow, err := workflowClient.Create(ctx, retryExecSpec, v1.CreateOptions{})
+	require.NoError(t, err)
+	require.NotEqual(t, originalUID, recreatedWorkflow.ExecutionObjectMeta().UID)
+
+	_, err = manager.ReportWorkflowResource(ctx, recreatedWorkflow)
+	require.NoError(t, err)
+	updatedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateRunning, updatedRun.State)
+	assert.Equal(t, recreatedWorkflow.ExecutionObjectMeta().UID, storedWorkflowUID(t, updatedRun))
+
+	_, err = manager.ReportWorkflowResource(ctx, recreatedWorkflow)
+	require.NoError(t, err, "the adopted identity must remain valid for later workflow reports")
+}
+
+func TestReportWorkflowResource_FinalizesDeletedOrphanedRecurringWorkflow(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	run, err := manager.CreateRun(ctx, &model.Run{
+		DisplayName:    "deleted-orphaned-recurring-workflow",
+		ExperimentId:   job.ExperimentId,
+		RecurringRunId: job.UUID,
+		Namespace:      job.Namespace,
+		PipelineSpec:   job.PipelineSpec,
+	})
+	require.NoError(t, err)
+	require.NoError(t, manager.DeleteJob(ctx, job.UUID, apiv2beta1.DeletePropagationPolicy_ORPHAN))
+
+	orphanedWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	orphanedWorkflow.ExecutionObjectMeta().OwnerReferences = nil
+	orphanedWorkflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowSucceeded
+	orphanedWorkflow.(*util.Workflow).Status.FinishedAt = v1.NewTime(time.Unix(456, 0))
+	_, err = store.ExecClient().Execution(run.Namespace).Update(
+		ctx, orphanedWorkflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+	require.NoError(t, store.ExecClient().Execution(run.Namespace).Delete(
+		ctx, run.K8SName, v1.DeleteOptions{}))
+
+	_, err = manager.ReportWorkflowResource(ctx, orphanedWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound), "got %v", err)
+
+	updatedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateSucceeded, updatedRun.State)
+	assert.Equal(t, int64(456), updatedRun.FinishedAtInSec)
+}
+
+func TestReportWorkflowResource_PersistedRecurringWorkflowCreatesMissingRunBeforeDelete(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	ctx := context.Background()
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "persisted-recurring-workflow",
+			Namespace: job.Namespace,
+			UID:       "persisted-recurring-run-id",
+			Labels: map[string]string{
+				util.LabelKeyWorkflowRunId:               "persisted-recurring-run-id",
+				util.LabelKeyWorkflowPersistedFinalState: "true",
+			},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       job.K8SName,
+				UID:        types.UID(job.UUID),
+			}},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowSucceeded},
+	})
+	syncWorkflowReportWithFakeCluster(t, store, workflow)
+
+	reportedWorkflow, err := manager.ReportWorkflowResource(ctx, workflow)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"persisted-recurring-run-id",
+		reportedWorkflow.ExecutionObjectMeta().Labels[util.LabelKeyWorkflowRunId],
+	)
+	createdRun, err := manager.GetRun("persisted-recurring-run-id")
+	require.NoError(t, err)
+	assert.Equal(t, job.UUID, createdRun.RecurringRunId)
+	assert.Equal(t, job.Namespace, createdRun.Namespace)
+	_, err = store.ExecClient().Execution(job.Namespace).Get(ctx, workflow.ExecutionName(), v1.GetOptions{})
+	assert.True(t, util.IsNotFound(err))
+}
+
+func TestReportWorkflowResource_RecurringRunRejectsStaleWorkflowUID(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	ctx := context.Background()
+	const runID = "replacement-recurring-run-id"
+
+	liveWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "replacement-recurring-workflow",
+			Namespace: job.Namespace,
+			UID:       "replacement-workflow-uid",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: runID},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       job.K8SName,
+				UID:        types.UID(job.UUID),
+			}},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+	_, err := store.ExecClient().Execution(job.Namespace).Create(
+		ctx, liveWorkflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	staleReport := util.NewWorkflow(liveWorkflow.DeepCopy())
+	staleReport.UID = "stale-workflow-uid"
+
+	_, err = manager.ReportWorkflowResource(ctx, staleReport)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.InvalidArgument))
+	_, err = manager.GetRun(runID)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+	_, err = store.ExecClient().Execution(job.Namespace).Get(
+		ctx, liveWorkflow.ExecutionName(), v1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowDeleteCountInNamespace(
+		job.Namespace, liveWorkflow.ExecutionName()))
+}
+
+func TestCreateOrUpdateTasks_RejectsWorkflowNamespaceMismatch(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+
+	_, err := manager.CreateOrUpdateTasks(
+		[]*model.Task{{RunID: run.UUID, Namespace: "attacker-ns", PodName: "attacker-task"}},
+		run.UUID,
+		"attacker-ns",
+	)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+}
+
+func TestCreateOrUpdateTasks_RejectsTaskRunIDMismatch(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+
+	_, err := manager.CreateOrUpdateTasks(
+		[]*model.Task{{RunID: "another-run", Namespace: run.Namespace, PodName: "mismatched-task"}},
+		run.UUID,
+		run.Namespace,
+	)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Contains(t, err.Error(), "does not match owning run")
+}
+
+func TestCreateOrUpdateTasks_RejectsTaskNamespaceMismatch(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+
+	_, err := manager.CreateOrUpdateTasks(
+		[]*model.Task{{RunID: run.UUID, Namespace: "attacker-ns", PodName: "mismatched-task"}},
+		run.UUID,
+		run.Namespace,
+	)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Contains(t, err.Error(), "task namespace does not match owning run")
+}
+
+func TestCreateOrUpdateTasksForRun_RejectsTasksAfterRunIDRecreation(t *testing.T) {
+	store, manager, originalRun := initWithOneTimeRunV2(t)
+	defer store.Close()
+	ctx := context.Background()
+	workflowClient := store.ExecClient().Execution(originalRun.Namespace)
+	originalWorkflow, err := workflowClient.Get(ctx, originalRun.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+
+	staleRun, err := manager.GetRun(originalRun.UUID)
+	require.NoError(t, err)
+	_, err = manager.ReportWorkflowResourceWithRun(ctx, originalWorkflow, staleRun)
+	require.NoError(t, err)
+	require.NotEmpty(t, staleRun.WorkflowRuntimeManifest)
+	staleIdentity, found := manager.storedWorkflowIdentities.load(originalRun.UUID)
+	require.True(t, found)
+	assert.Equal(t, storedWorkflowUID(t, staleRun), staleIdentity.uid)
+
+	// Recreate the run through another manager so this manager retains A's
+	// cached identity until the guarded task write detects B and refreshes it.
+	replacementManager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	require.NoError(t, replacementManager.DeleteRun(ctx, originalRun.UUID))
+
+	// Fake workflow clients allocate UIDs per namespace, while Kubernetes UIDs
+	// are cluster-wide. Advance the replacement namespace once so this fixture
+	// preserves the production invariant that recreated objects have new UIDs.
+	_, err = store.ExecClient().Execution("ns2").Create(ctx, util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{Name: "uid-seed"},
+	}), v1.CreateOptions{})
+	require.NoError(t, err)
+	replacementRun, err := replacementManager.CreateRun(ctx, &model.Run{
+		UUID:         originalRun.UUID,
+		DisplayName:  originalRun.DisplayName,
+		ExperimentId: originalRun.ExperimentId,
+		Namespace:    "ns2",
+		PipelineSpec: model.PipelineSpec{
+			PipelineSpecManifest: model.LargeText(v2SpecHelloWorld),
+			RuntimeConfig: model.RuntimeConfig{
+				Parameters: "{\"text\":\"world\"}",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, storedWorkflowUID(t, staleRun), storedWorkflowUID(t, replacementRun))
+	replacementBeforeTasks, err := replacementManager.GetRun(replacementRun.UUID)
+	require.NoError(t, err)
+	replacementWorkflow, err := store.ExecClient().Execution(replacementRun.Namespace).Get(
+		ctx,
+		replacementRun.K8SName,
+		v1.GetOptions{},
+	)
+	require.NoError(t, err)
+
+	staleTask := &model.Task{
+		RunID:     staleRun.UUID,
+		Namespace: staleRun.Namespace,
+		PodName:   "stale-run-task",
+		State:     model.RuntimeStateRunning,
+	}
+	_, err = manager.CreateOrUpdateTasksForRun(
+		[]*model.Task{staleTask},
+		staleRun,
+		staleRun.Namespace,
+	)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable), "got %v", err)
+	assert.Empty(t, staleTask.UUID, "a rejected task report must not mutate task identity")
+
+	var taskCount int
+	require.NoError(t, store.DB().QueryRow(
+		"SELECT COUNT(*) FROM tasks WHERE RunUUID = ?",
+		replacementRun.UUID,
+	).Scan(&taskCount))
+	assert.Zero(t, taskCount)
+	replacementAfterTasks, err := replacementManager.GetRun(replacementRun.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, replacementBeforeTasks, replacementAfterTasks)
+	stillLive, err := store.ExecClient().Execution(replacementRun.Namespace).Get(
+		ctx,
+		replacementRun.K8SName,
+		v1.GetOptions{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, replacementWorkflow.ExecutionObjectMeta().UID, stillLive.ExecutionObjectMeta().UID)
+	refreshedIdentity, found := manager.storedWorkflowIdentities.load(replacementRun.UUID)
+	require.True(t, found)
+	assert.Equal(t, replacementWorkflow.ExecutionObjectMeta().UID, refreshedIdentity.uid)
+	assert.Equal(t, replacementRun.Namespace, refreshedIdentity.namespace)
+	assert.Equal(t,
+		sha256.Sum256([]byte(replacementBeforeTasks.PipelineRuntimeManifest)),
+		refreshedIdentity.manifestDigest,
+	)
+}
+
+func TestReportWorkflowResource_ScheduledWorkflowNamespaceMismatchDoesNotDeletePersistedWorkflow(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "spoofed-persisted-run",
+			Namespace: "attacker-ns",
+			UID:       "spoofed-persisted-run-id",
+			Labels: map[string]string{
+				util.LabelKeyWorkflowRunId:               "spoofed-persisted-run-id",
+				util.LabelKeyWorkflowPersistedFinalState: "true",
+			},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       "spoofed-schedule",
+				UID:        types.UID(job.UUID),
+			}},
+		},
+		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowRunning},
+	})
+	_, err := store.ExecClient().Execution("attacker-ns").Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, err.(*util.UserError).ExternalStatusCode())
+	assert.Equal(t, "Failed to report workflow: reported namespace does not match owning resource", err.(*util.UserError).ExternalMessage())
+	assert.NotContains(t, err.Error(), job.Namespace)
+
+	storedWorkflow, err := store.ExecClient().Execution("attacker-ns").Get(ctx, workflow.ExecutionName(), v1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotNil(t, storedWorkflow)
+	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowDeleteCountInNamespace(workflow.ExecutionNamespace(), workflow.ExecutionName()))
+	_, err = manager.GetRun("spoofed-persisted-run-id")
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+}
+
+func TestReportWorkflowResource_MissingRecurringExperimentReferenceDoesNotDeleteWorkflow(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	// Simulate an inconsistent legacy row: the recurring run still exists, but
+	// neither its denormalized experiment column nor its experiment ownership
+	// reference can identify the tenant. This is not proof that the workflow is
+	// orphaned and therefore must never enter the orphan-GC path.
+	_, err := store.DB().Exec(`UPDATE jobs SET ExperimentUUID = ? WHERE UUID = ?`, "", job.UUID)
+	require.NoError(t, err)
+	_, err = store.DB().Exec(
+		`DELETE FROM resource_references WHERE ResourceUUID = ? AND ResourceType = ? AND ReferenceType = ?`,
+		job.UUID,
+		model.JobResourceType,
+		model.ExperimentResourceType,
+	)
+	require.NoError(t, err)
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "inconsistent-owner-run",
+			Namespace: "ns1",
+			UID:       "inconsistent-owner-run-id",
+			Labels: map[string]string{
+				util.LabelKeyWorkflowRunId:               "inconsistent-owner-run-id",
+				util.LabelKeyWorkflowPersistedFinalState: "true",
+			},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       "inconsistent-schedule",
+				UID:        types.UID(job.UUID),
+			}},
+		},
+	})
+	_, err = store.ExecClient().Execution("ns1").Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Internal))
+	assert.Contains(t, err.Error(), "Failed to retrieve the experiment ID")
+	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowDeleteCountInNamespace(workflow.ExecutionNamespace(), workflow.ExecutionName()))
+	_, err = store.ExecClient().Execution("ns1").Get(ctx, workflow.ExecutionName(), v1.GetOptions{})
+	require.NoError(t, err)
+}
+
+func TestReportWorkflowResource_MissingRecurringOwnerDoesNotDeletePersistedWorkflow(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	defer store.Close()
+	ctx := context.Background()
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "orphaned-persisted-run",
+			Namespace: "ns1",
+			UID:       "orphaned-persisted-run-id",
+			Labels: map[string]string{
+				util.LabelKeyWorkflowRunId:               "orphaned-persisted-run-id",
+				util.LabelKeyWorkflowPersistedFinalState: "true",
+			},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       "missing-schedule",
+				UID:        "missing-job-id",
+			}},
+		},
+	})
+	_, err := store.ExecClient().Execution("ns1").Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowDeleteCountInNamespace(workflow.ExecutionNamespace(), workflow.ExecutionName()))
+}
+
+func TestReportWorkflowResource_MissingRecurringOwnerDoesNotDeleteYoungWorkflow(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	defer store.Close()
+	ctx := context.Background()
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "young-orphaned-run",
+			Namespace:         "ns1",
+			UID:               "young-orphaned-run-id",
+			CreationTimestamp: v1.NewTime(store.Time().Now()),
+			Labels:            map[string]string{util.LabelKeyWorkflowRunId: "young-orphaned-run-id"},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       "missing-schedule",
+				UID:        "missing-job-id",
+			}},
+		},
+	})
+	_, err := store.ExecClient().Execution("ns1").Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowDeleteCountInNamespace(workflow.ExecutionNamespace(), workflow.ExecutionName()))
+}
+
+func TestReportWorkflowResource_ScheduledWorkflowNoNamespaceResolvedFromExperiment(t *testing.T) {
+	store, manager, job := initWithJob(t)
+	defer store.Close()
+	// Simulate a legacy job row which stored the namespace sentinel and must
+	// recover its Kubernetes namespace from the owning experiment.
+	_, err := store.DB().Exec(`UPDATE jobs SET Namespace = ? WHERE UUID = ?`, model.NoNamespace, job.UUID)
+	require.NoError(t, err)
+	experiment, err := manager.GetExperiment(job.ExperimentId)
+	require.NoError(t, err)
+	require.Equal(t, "ns1", experiment.Namespace)
+	viper.Set(common.MultiUserMode, "true")
+	t.Cleanup(func() { viper.Set(common.MultiUserMode, "false") })
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "legacy-run",
+			Namespace: "ns1",
+			UID:       "legacy-run-id",
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: "legacy-run-id"},
+			OwnerReferences: []v1.OwnerReference{{
+				APIVersion: "kubeflow.org/v1beta1",
+				Kind:       "ScheduledWorkflow",
+				Name:       job.K8SName,
+				UID:        types.UID(job.UUID),
+			}},
+		},
+	})
+	syncWorkflowReportWithFakeCluster(t, store, workflow)
+
+	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
+	require.NoError(t, err)
+	run, err := manager.GetRun("legacy-run-id")
+	require.NoError(t, err)
+	assert.Equal(t, "ns1", run.Namespace)
 }
 
 func TestReportWorkflowResource_WorkflowMissingRunID(t *testing.T) {
@@ -4183,15 +5849,208 @@ func TestReportWorkflowResource_RunNotFound(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:              "obsolete",
 			Namespace:         "kubeflow",
+			UID:               "obsolete-workflow-uid",
 			Labels:            map[string]string{util.LabelKeyWorkflowRunId: "run-id-not-exist"},
 			CreationTimestamp: v1.NewTime(store.Time().Now().Add(-10 * time.Minute)),
 		},
 	})
-	store.ExecClient().Execution("kubeflow").Create(ctx, workflow, v1.CreateOptions{})
-	_, err := manager.ReportWorkflowResource(ctx, workflow)
+	_, err := store.ExecClient().Execution("kubeflow").Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
 	require.NotNil(t, err)
 	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
-	assert.Contains(t, err.Error(), "Run run-id-not-exist not found")
+	assert.Contains(t, err.Error(), "Deleted orphaned workflow")
+	assert.Equal(t, 1, store.ExecClientFake.GetWorkflowDeleteCountInNamespace(workflow.ExecutionNamespace(), workflow.ExecutionName()))
+	_, getErr := store.ExecClient().Execution("kubeflow").Get(ctx, workflow.ExecutionName(), v1.GetOptions{})
+	assert.True(t, util.IsNotFound(getErr))
+}
+
+func TestReportWorkflowResource_RunNotFoundRetriesTransientDeleteFailure(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	ctx := context.Background()
+	defer store.Close()
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "obsolete-after-transient-delete-failure",
+			Namespace:         "kubeflow",
+			UID:               "obsolete-after-transient-delete-failure-uid",
+			Labels:            map[string]string{util.LabelKeyWorkflowRunId: "missing-run-id"},
+			CreationTimestamp: v1.NewTime(store.Time().Now().Add(-10 * time.Minute)),
+		},
+	})
+	workflowClient := &transientDeleteFailureWorkflowClient{
+		FakeWorkflowClient:      client.NewWorkflowClientFake(),
+		deleteFailuresRemaining: 1,
+	}
+	_, err := workflowClient.Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+	assert.Contains(t, err.Error(), "Deleted orphaned workflow")
+	assert.Equal(t, 2, workflowClient.deleteCalls)
+	_, getErr := workflowClient.Get(ctx, workflow.ExecutionName(), v1.GetOptions{})
+	assert.True(t, util.IsNotFound(getErr))
+}
+
+func TestReportWorkflowResource_RunNotFoundTreatsMissingDeleteLookupAsSuccess(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	ctx := context.Background()
+	defer store.Close()
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "obsolete-before-delete-lookup",
+			Namespace:         "kubeflow",
+			UID:               "obsolete-before-delete-lookup-uid",
+			Labels:            map[string]string{util.LabelKeyWorkflowRunId: "missing-run-id"},
+			CreationTimestamp: v1.NewTime(store.Time().Now().Add(-10 * time.Minute)),
+		},
+	})
+	workflowClient := &disappearBeforeDeleteLookupWorkflowClient{
+		FakeWorkflowClient: client.NewWorkflowClientFake(),
+	}
+	_, err := workflowClient.Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+	assert.Contains(t, err.Error(), "Deleted orphaned workflow")
+	assert.Equal(t, 2, workflowClient.getCalls, "a missing workflow must not consume the delete backoff budget")
+}
+
+func TestReportWorkflowResource_RunNotFoundTreatsDeleteNotFoundAsSuccess(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	ctx := context.Background()
+	defer store.Close()
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "obsolete-during-delete",
+			Namespace:         "kubeflow",
+			UID:               "obsolete-during-delete-uid",
+			Labels:            map[string]string{util.LabelKeyWorkflowRunId: "missing-run-id"},
+			CreationTimestamp: v1.NewTime(store.Time().Now().Add(-10 * time.Minute)),
+		},
+	})
+	workflowClient := &notFoundOnOrphanDeleteWorkflowClient{
+		FakeWorkflowClient: client.NewWorkflowClientFake(),
+	}
+	_, err := workflowClient.Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+	assert.Contains(t, err.Error(), "Deleted orphaned workflow")
+	assert.Equal(t, 2, workflowClient.getCalls, "a NotFound delete response must not be retried")
+	assert.Equal(t, 1, workflowClient.deleteCalls)
+}
+
+func TestReportWorkflowResource_RunNotFoundRefreshesWorkflowBeforeDeleteRetry(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	ctx := context.Background()
+	defer store.Close()
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "obsolete-after-concurrent-update",
+			Namespace:         "kubeflow",
+			UID:               "obsolete-after-concurrent-update-uid",
+			ResourceVersion:   "initial",
+			Labels:            map[string]string{util.LabelKeyWorkflowRunId: "missing-run-id"},
+			CreationTimestamp: v1.NewTime(store.Time().Now().Add(-10 * time.Minute)),
+		},
+	})
+	workflowClient := &updateBeforeFirstDeleteWorkflowClient{
+		FakeWorkflowClient: client.NewWorkflowClientFake(),
+	}
+	_, err := workflowClient.Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound))
+	assert.Contains(t, err.Error(), "Deleted orphaned workflow")
+	assert.Equal(t, 2, workflowClient.deleteCalls)
+	_, getErr := workflowClient.Get(ctx, workflow.ExecutionName(), v1.GetOptions{})
+	assert.True(t, util.IsNotFound(getErr))
+}
+
+func TestReportWorkflowResource_RunNotFoundStopsRetryingReplacementIdentityMismatch(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	ctx := context.Background()
+	defer store.Close()
+
+	workflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "obsolete-before-replacement",
+			Namespace:         "kubeflow",
+			Labels:            map[string]string{util.LabelKeyWorkflowRunId: "missing-run-id"},
+			CreationTimestamp: v1.NewTime(store.Time().Now().Add(-10 * time.Minute)),
+		},
+	})
+	workflowClient := &replaceBeforeOrphanDeleteLookupWorkflowClient{
+		FakeWorkflowClient: client.NewWorkflowClientFake(),
+	}
+	reportedWorkflow, err := workflowClient.Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	reportedUID := reportedWorkflow.ExecutionObjectMeta().UID
+	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+
+	_, err = manager.ReportWorkflowResource(ctx, reportedWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.InvalidArgument), "got %v", err)
+	assert.Equal(t, 2, workflowClient.getCalls,
+		"a permanent replacement-identity mismatch must not consume the delete backoff budget")
+
+	replacement, getErr := workflowClient.Get(ctx, workflow.ExecutionName(), v1.GetOptions{})
+	require.NoError(t, getErr)
+	assert.NotEqual(t, reportedUID, replacement.ExecutionObjectMeta().UID)
+}
+
+func TestReportWorkflowResource_MissingOneTimeRunRejectsStaleWorkflowUID(t *testing.T) {
+	store := NewFakeClientManagerOrFatal(util.NewFakeTimeForEpoch())
+	manager := NewResourceManager(store, &ResourceManagerOptions{CollectMetrics: false})
+	ctx := context.Background()
+	defer store.Close()
+
+	liveWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:              "unowned-persisted-workflow",
+			Namespace:         "attacker-ns",
+			UID:               "replacement-workflow-uid",
+			CreationTimestamp: v1.NewTime(store.Time().Now().Add(-10 * time.Minute)),
+			Labels: map[string]string{
+				util.LabelKeyWorkflowRunId:               "missing-run-id",
+				util.LabelKeyWorkflowPersistedFinalState: "true",
+			},
+		},
+	})
+	_, err := store.ExecClient().Execution("attacker-ns").Create(ctx, liveWorkflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	staleWorkflow := util.NewWorkflow(liveWorkflow.DeepCopy())
+	staleWorkflow.ExecutionObjectMeta().UID = "stale-workflow-uid"
+
+	_, err = manager.ReportWorkflowResource(ctx, staleWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.InvalidArgument))
+	assert.Equal(t, 0, store.ExecClientFake.GetWorkflowDeleteCountInNamespace(liveWorkflow.ExecutionNamespace(), liveWorkflow.ExecutionName()))
+	storedWorkflow, getErr := store.ExecClient().Execution("attacker-ns").Get(ctx, liveWorkflow.ExecutionName(), v1.GetOptions{})
+	require.NoError(t, getErr)
+	assert.NotNil(t, storedWorkflow)
 }
 
 func TestReportWorkflowResource_RunNotFound_WithinGracePeriod(t *testing.T) {
@@ -4209,6 +6068,7 @@ func TestReportWorkflowResource_RunNotFound_WithinGracePeriod(t *testing.T) {
 		ObjectMeta: v1.ObjectMeta{
 			Name:              "young-workflow",
 			Namespace:         "kubeflow",
+			UID:               "young-workflow-uid",
 			Labels:            map[string]string{util.LabelKeyWorkflowRunId: "run-id-not-exist"},
 			CreationTimestamp: v1.NewTime(store.Time().Now().Add(-10 * time.Second)),
 		},
@@ -4219,7 +6079,7 @@ func TestReportWorkflowResource_RunNotFound_WithinGracePeriod(t *testing.T) {
 	// Should be UNAVAILABLE (retryable), not NOT_FOUND (permanent).
 	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable),
 		"Expected Unavailable error for young workflow within grace period, got: %v", err)
-	assert.Contains(t, err.Error(), "GC grace period")
+	assert.Contains(t, err.Error(), "run-creation grace period")
 
 	// Verify the workflow was NOT deleted by checking it's still accessible.
 	wf, getErr := store.ExecClient().Execution("kubeflow").Get(ctx, "young-workflow", v1.GetOptions{})
@@ -4229,7 +6089,7 @@ func TestReportWorkflowResource_RunNotFound_WithinGracePeriod(t *testing.T) {
 
 func TestReportWorkflowResource_WorkflowCompleted(t *testing.T) {
 	store, manager, run := initWithOneTimeRun(t)
-	namespace := "kubeflow"
+	namespace := common.GetPodNamespace()
 	defer store.Close()
 	// report workflow
 	workflow := util.NewWorkflow(&v1alpha1.Workflow{
@@ -4241,6 +6101,7 @@ func TestReportWorkflowResource_WorkflowCompleted(t *testing.T) {
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, workflow)
 	_, err := manager.ReportWorkflowResource(context.Background(), workflow)
 	assert.Nil(t, err)
 
@@ -4339,6 +6200,7 @@ func TestReportWorkflowResource_FinalizesRunWhenWorkflowDeletedBeforeTerminalRep
 	namespace := "ns1"
 	ctx := context.Background()
 	defer store.Close()
+	require.NoError(t, store.ExecClient().Execution(namespace).Delete(ctx, run.K8SName, v1.DeleteOptions{}))
 
 	// Report a terminal workflow whose CR no longer exists, simulating a
 	// deletion between the persistence agent's read and this report. The run
@@ -4346,9 +6208,9 @@ func TestReportWorkflowResource_FinalizesRunWhenWorkflowDeletedBeforeTerminalRep
 	// signal that stops further retries.
 	deletedWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
-			Name:            run.K8SName + "-deleted",
+			Name:            run.K8SName,
 			Namespace:       namespace,
-			UID:             types.UID(run.UUID),
+			UID:             storedWorkflowUID(t, run),
 			ResourceVersion: "terminal-version",
 			Labels:          map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
 		},
@@ -4361,13 +6223,118 @@ func TestReportWorkflowResource_FinalizesRunWhenWorkflowDeletedBeforeTerminalRep
 	reportedWorkflow, err := manager.ReportWorkflowResource(ctx, deletedWorkflow)
 	require.Error(t, err)
 	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound),
-		"caller should receive the NotFound signal so the persistence agent stops retrying")
+		"caller should receive the NotFound signal so the persistence agent stops retrying, got %v", err)
 	assert.Nil(t, reportedWorkflow)
 
 	currentRun, err := manager.GetRun(run.UUID)
 	require.NoError(t, err)
 	assert.Equal(t, model.RuntimeStateFailed, currentRun.State)
 	assert.Equal(t, int64(123), currentRun.FinishedAtInSec)
+}
+
+func TestReportWorkflowResource_FinalizesLegacyEmptyNameRunWhenWorkflowDeletedBeforeTerminalReport(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	namespace := "ns1"
+	ctx := context.Background()
+	defer store.Close()
+	reportedName := run.K8SName
+	reportedUID := storedWorkflowUID(t, run)
+	require.NoError(t, store.ExecClient().Execution(namespace).Delete(ctx, reportedName, v1.DeleteOptions{}))
+	_, err := store.DB().Exec(
+		`UPDATE run_details SET Name = '', Namespace = '' WHERE UUID = ?`, run.UUID)
+	require.NoError(t, err)
+
+	deletedWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:            reportedName,
+			Namespace:       namespace,
+			UID:             reportedUID,
+			ResourceVersion: "terminal-version",
+			Labels:          map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{
+			Phase:      v1alpha1.WorkflowFailed,
+			FinishedAt: v1.NewTime(time.Unix(123, 0)),
+		},
+	})
+
+	reportedWorkflow, err := manager.ReportWorkflowResource(ctx, deletedWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound),
+		"caller should receive the NotFound signal after the legacy run is finalized, got %v", err)
+	assert.Nil(t, reportedWorkflow)
+
+	currentRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateFailed, currentRun.State)
+	assert.Equal(t, int64(123), currentRun.FinishedAtInSec)
+	assert.Equal(t, reportedName, currentRun.K8SName)
+	assert.Equal(t, namespace, currentRun.Namespace)
+}
+
+func TestReportWorkflowResource_FinalizesV2RunWhenWorkflowDeletedBeforeFirstReport(t *testing.T) {
+	store, manager, run := initWithOneTimeRunV2(t)
+	namespace := "ns1"
+	ctx := context.Background()
+	defer store.Close()
+	require.Empty(t, run.WorkflowRuntimeManifest)
+	require.NotEmpty(t, run.PipelineRuntimeManifest)
+	require.NoError(t, store.ExecClient().Execution(namespace).Delete(ctx, run.K8SName, v1.DeleteOptions{}))
+	manager.options.CollectMetrics = true
+	rejectionCounter := workflowReportRejectedCounter.WithLabelValues(workflowReportRejectionOwnershipUnresolved)
+	counterValue := func() float64 {
+		metric := &dto.Metric{}
+		require.NoError(t, rejectionCounter.Write(metric))
+		return metric.GetCounter().GetValue()
+	}
+	rejectionsBefore := counterValue()
+
+	deletedWorkflow := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:            run.K8SName,
+			Namespace:       namespace,
+			UID:             storedWorkflowUID(t, run),
+			ResourceVersion: "terminal-version",
+			Labels:          map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{
+			Phase:      v1alpha1.WorkflowFailed,
+			FinishedAt: v1.NewTime(time.Unix(123, 0)),
+		},
+	})
+
+	reportedWorkflow, err := manager.ReportWorkflowResource(ctx, deletedWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.NotFound),
+		"caller should receive the NotFound signal so the persistence agent stops retrying, got %v", err)
+	assert.Nil(t, reportedWorkflow)
+
+	currentRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateFailed, currentRun.State)
+	assert.Equal(t, int64(123), currentRun.FinishedAtInSec)
+	assert.NotEmpty(t, currentRun.WorkflowRuntimeManifest)
+	assert.Equal(t, rejectionsBefore, counterValue(),
+		"an accepted stored-identity fallback must not be counted as a rejected report")
+}
+
+func TestRecordWorkflowReportLiveLookupRejectionIgnoresRetryableErrors(t *testing.T) {
+	manager := &ResourceManager{options: &ResourceManagerOptions{CollectMetrics: true}}
+	counter := workflowReportRejectedCounter.WithLabelValues(workflowReportRejectionOwnershipUnresolved)
+	counterValue := func() float64 {
+		metric := &dto.Metric{}
+		require.NoError(t, counter.Write(metric))
+		return metric.GetCounter().GetValue()
+	}
+	before := counterValue()
+
+	manager.recordWorkflowReportLiveLookupRejection(util.NewUnavailableServerError(
+		errors.New("temporary Kubernetes outage"), "will retry"))
+	assert.Equal(t, before, counterValue())
+
+	manager.recordWorkflowReportLiveLookupRejection(util.NewNotFoundError(
+		errors.New("workflow missing"), "cannot apply report"))
+	assert.Equal(t, before+1, counterValue())
 }
 
 func TestReportWorkflowResource_SkipsPersistedFinalStateLabelWhenRunRetriedDuringPluginSync(t *testing.T) {
@@ -4401,6 +6368,7 @@ func TestReportWorkflowResource_SkipsPersistedFinalStateLabelWhenRunRetriedDurin
 			FinishedAt: v1.NewTime(time.Unix(123, 0)),
 		},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, workflow)
 
 	reportedWorkflow, err := manager.ReportWorkflowResource(context.Background(), workflow)
 	require.Error(t, err)
@@ -4472,6 +6440,7 @@ func TestReportWorkflow_WithMLflowOnRunEnd(t *testing.T) {
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, workflow)
 	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
 	require.NoError(t, err,
 		"an unavailable MLflow config is a permanent plugin failure and must not block run finalization")
@@ -4490,11 +6459,13 @@ func TestReportWorkflow_WithMLflowOnRunEnd(t *testing.T) {
 func TestReportWorkflowResource_WorkflowCompleted_WorkflowNotFound(t *testing.T) {
 	store, manager, run := initWithOneTimeRun(t)
 	defer store.Close()
+	require.NoError(t, store.ExecClient().Execution(common.GetPodNamespace()).Delete(
+		context.Background(), run.K8SName, v1.DeleteOptions{}))
 	workflow := util.NewWorkflow(&v1alpha1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "non-existent-workflow",
-			Namespace: "kubeflow",
-			UID:       types.UID(run.UUID),
+			Name:      run.K8SName,
+			Namespace: common.GetPodNamespace(),
+			UID:       storedWorkflowUID(t, run),
 			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
@@ -4518,18 +6489,191 @@ func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted(t *testing
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, workflow)
 	_, err := manager.ReportWorkflowResource(context.Background(), workflow)
-	assert.Nil(t, err)
+	require.NoError(t, err)
+	_, err = store.ExecClient().Execution("ns1").Get(context.Background(), workflow.ExecutionName(), v1.GetOptions{})
+	assert.True(t, util.IsNotFound(err))
+}
+
+func TestReportWorkflowResource_StaleNonterminalReportDoesNotPoisonRetriedWorkflowIdentity(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+	workflowClient := store.ExecClient().Execution(run.Namespace)
+
+	liveWorkflow, err := workflowClient.Get(ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	staleNonterminal := util.NewWorkflow(liveWorkflow.(*util.Workflow).DeepCopy())
+	require.False(t, staleNonterminal.ExecutionStatus().IsInFinalState())
+
+	terminalWorkflow := util.NewWorkflow(liveWorkflow.(*util.Workflow).DeepCopy())
+	terminalWorkflow.Status.Phase = v1alpha1.WorkflowFailed
+	terminalWorkflow.Status.FinishedAt = v1.NewTime(time.Unix(123, 0))
+	terminalWorkflow.SetLabels(util.LabelKeyWorkflowPersistedFinalState, "true")
+	updatedTerminal, err := workflowClient.Update(ctx, terminalWorkflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+	oldUID := updatedTerminal.ExecutionObjectMeta().UID
+
+	// The submitted snapshot is stale and non-terminal, but identity resolution
+	// replaces it with the live terminal workflow and deletes that workflow.
+	_, err = manager.ReportWorkflowResource(ctx, staleNonterminal)
+	require.NoError(t, err)
+	_, err = workflowClient.Get(ctx, run.K8SName, v1.GetOptions{})
+	require.True(t, util.IsNotFound(err))
+	_, found := manager.storedWorkflowIdentities.load(run.UUID)
+	assert.False(t, found, "effective terminal cleanup must invalidate the stored identity cache")
+
+	// RetryRun must also invalidate any entry that predates the recreated
+	// workflow identity, including one left by an overlapping report.
+	manager.storedWorkflowIdentities.loadOrStore(run.UUID, storedWorkflowIdentity{
+		name: run.K8SName,
+		uid:  oldUID,
+	})
+	require.NoError(t, manager.RetryRun(ctx, run.UUID))
+	_, found = manager.storedWorkflowIdentities.load(run.UUID)
+	assert.False(t, found, "retry persistence must invalidate the previous workflow identity")
+	// Model an overlapping report that loaded the pre-retry row and reaches the
+	// cache after RetryRun invalidated it. Its generation-zero identity must not
+	// poison reports for the generation-one workflow.
+	manager.storedWorkflowIdentities.loadOrStore(run.UUID, storedWorkflowIdentity{
+		name:            run.K8SName,
+		uid:             oldUID,
+		retryGeneration: 0,
+	})
+
+	retriedWorkflow, err := workflowClient.Get(ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	require.NotEqual(t, oldUID, retriedWorkflow.ExecutionObjectMeta().UID)
+	_, err = manager.ReportWorkflowResource(ctx, retriedWorkflow)
+	require.NoError(t, err, "reports from the recreated retry must validate against its new UID")
+	cachedIdentity, found := manager.storedWorkflowIdentities.load(run.UUID)
+	require.True(t, found)
+	assert.Equal(t, retriedWorkflow.ExecutionObjectMeta().UID, cachedIdentity.uid)
+	assert.Equal(t, int64(1), cachedIdentity.retryGeneration)
+}
+
+func TestReportWorkflowResource_PersistedFinalStateDoesNotDeleteConcurrentRetry(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	workflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	workflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowFailed
+	workflow.(*util.Workflow).Status.FinishedAt = v1.NewTime(time.Unix(123, 0))
+	workflow, err = store.ExecClient().Execution(run.Namespace).Update(
+		ctx, workflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.NoError(t, err)
+
+	persistedWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	require.True(t, persistedWorkflow.PersistedFinalState())
+	workflowClient, ok := store.ExecClientFake.Execution(run.Namespace).(*client.FakeWorkflowClient)
+	require.True(t, ok)
+	interleavingClient := &retryBeforeDeleteWorkflowClient{
+		FakeWorkflowClient: workflowClient,
+		manager:            manager,
+		runID:              run.UUID,
+	}
+	manager.execClient = &retryWorkflowExecClient{workflowClient: interleavingClient}
+
+	_, err = manager.ReportWorkflowResource(ctx, persistedWorkflow)
+	require.Error(t, err)
+	assert.True(t, util.IsUserErrorCodeMatch(err, codes.Unavailable), "got %v", err)
+	assert.Contains(t, err.Error(), "workflow changed before persisted-final-state cleanup")
+	require.NoError(t, interleavingClient.retryErr)
+
+	retriedWorkflow, err := workflowClient.Get(ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, string(v1alpha1.WorkflowRunning), string(retriedWorkflow.ExecutionStatus().Condition()))
+	assert.False(t, retriedWorkflow.PersistedFinalState())
+	retriedRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateRunning, retriedRun.State)
+}
+
+func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersistedReusesLiveLookup(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	createdWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	workflow := util.NewWorkflow(createdWorkflow.(*util.Workflow).DeepCopy())
+	workflow.Status.Phase = v1alpha1.WorkflowFailed
+	workflow.SetLabels(util.LabelKeyWorkflowPersistedFinalState, "true")
+	workflow.SetVersion("current-version")
+
+	workflowClient := &countingWorkflowClient{FakeWorkflowClient: client.NewWorkflowClientFake()}
+	_, err = workflowClient.Create(ctx, workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+
+	_, err = manager.ReportWorkflowResource(ctx, workflow)
+	require.NoError(t, err)
+	assert.Equal(t, 1, workflowClient.getCalls,
+		"version, identity, and persisted-final-state checks should share one live lookup")
+}
+
+func TestReportWorkflowResource_PersistedFinalStateRestoresAbandonedRetryBeforeDelete(t *testing.T) {
+	store, manager, run := initWithOneTimeRun(t)
+	defer store.Close()
+	ctx := context.Background()
+
+	terminal := util.NewWorkflow(&v1alpha1.Workflow{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      run.K8SName,
+			Namespace: run.Namespace,
+			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
+		},
+		Status: v1alpha1.WorkflowStatus{
+			Phase:      v1alpha1.WorkflowFailed,
+			FinishedAt: v1.Time{Time: time.Unix(500, 0)},
+		},
+	})
+	syncWorkflowReportWithFakeCluster(t, store, terminal)
+	_, err := manager.ReportWorkflowResource(ctx, terminal)
+	require.NoError(t, err)
+	_, _, _, generation, err := store.RunStore().ClaimRunForRetry(run.UUID, false)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), generation)
+	_, err = store.DB().Exec(
+		`UPDATE run_details SET RetryClaimedAtInSec = 0 WHERE UUID = ?`, run.UUID)
+	require.NoError(t, err)
+
+	persistedWorkflow, err := store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	require.NoError(t, err)
+	require.True(t, persistedWorkflow.PersistedFinalState())
+	_, err = manager.ReportWorkflowResource(ctx, persistedWorkflow)
+	require.NoError(t, err)
+
+	recoveredRun, err := manager.GetRun(run.UUID)
+	require.NoError(t, err)
+	assert.Equal(t, model.RuntimeStateFailed, recoveredRun.State,
+		"persisted final state must repair an abandoned retry claim before cleanup")
+	assert.NotZero(t, recoveredRun.FinishedAtInSec)
+	_, err = store.ExecClient().Execution(run.Namespace).Get(
+		ctx, run.K8SName, v1.GetOptions{})
+	assert.True(t, util.IsNotFound(err))
 }
 
 func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted_WorkflowNotFound(t *testing.T) {
 	store, manager, run := initWithOneTimeRun(t)
 	defer store.Close()
+	require.NoError(t, store.ExecClient().Execution(common.GetPodNamespace()).Delete(
+		context.Background(), run.K8SName, v1.DeleteOptions{}))
 	workflow := util.NewWorkflow(&v1alpha1.Workflow{
 		ObjectMeta: v1.ObjectMeta{
-			Name:      "non-existent-workflow",
-			Namespace: "kubeflow",
-			UID:       types.UID(run.UUID),
+			Name:      run.K8SName,
+			Namespace: common.GetPodNamespace(),
+			UID:       storedWorkflowUID(t, run),
 			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID, util.LabelKeyWorkflowPersistedFinalState: "true"},
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
@@ -4542,7 +6686,6 @@ func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted_WorkflowNo
 
 func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted_DeleteFailed(t *testing.T) {
 	store, manager, run := initWithOneTimeRun(t)
-	manager.execClient = client.NewFakeExecClientWithBadWorkflow()
 	defer store.Close()
 	// report workflow
 	workflow := util.NewWorkflow(&v1alpha1.Workflow{
@@ -4554,7 +6697,12 @@ func TestReportWorkflowResource_WorkflowCompleted_FinalStatePersisted_DeleteFail
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
-	_, err := manager.ReportWorkflowResource(context.Background(), workflow)
+	syncWorkflowReportWithFakeCluster(t, store, workflow)
+	workflowClient := &deleteFailureWorkflowClient{FakeWorkflowClient: client.NewWorkflowClientFake()}
+	_, err := workflowClient.Create(context.Background(), workflow, v1.CreateOptions{})
+	require.NoError(t, err)
+	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "failed to delete workflow")
 }
@@ -6021,6 +8169,7 @@ func TestReportWorkflowResource_SkipsStaleTerminalReportDuringRetryClaim(t *test
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, staleWorkflow)
 
 	// Drive the run terminal, then claim it for retry.
 	_, err := manager.ReportWorkflowResource(context.Background(), staleWorkflow)
@@ -6055,6 +8204,7 @@ func TestReportWorkflowResource_AcceptsRetriedWorkflowReport(t *testing.T) {
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, terminal)
 	_, err := manager.ReportWorkflowResource(context.Background(), terminal)
 	require.Nil(t, err)
 	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(run.UUID, false)
@@ -6072,6 +8222,7 @@ func TestReportWorkflowResource_AcceptsRetriedWorkflowReport(t *testing.T) {
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowSucceeded},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, retried)
 	_, err = manager.ReportWorkflowResource(context.Background(), retried)
 	assert.Nil(t, err)
 
@@ -6096,6 +8247,7 @@ func TestReportWorkflowResource_RecoversOrphanedRetryClaim(t *testing.T) {
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, staleWorkflow)
 	_, err := manager.ReportWorkflowResource(context.Background(), staleWorkflow)
 	require.Nil(t, err)
 	_, _, _, _, claimErr := store.RunStore().ClaimRunForRetry(run.UUID, false)
@@ -6178,6 +8330,7 @@ func TestRetryRun_AdoptsAppliedWorkflowInsteadOfRollingBack(t *testing.T) {
 func TestRetryRun_ExpiredClaimWithLiveWorkflowIsAdoptedNotTakenOver(t *testing.T) {
 	store, manager, runDetail := initWithOneTimeFailedRun(t)
 	defer store.Close()
+	expectedWorkflowName := runDetail.K8SName
 
 	// Simulate a retry that crashed after claiming generation 1 and creating
 	// the workflow, but before persisting the run row: claim via the store
@@ -6186,7 +8339,9 @@ func TestRetryRun_ExpiredClaimWithLiveWorkflowIsAdoptedNotTakenOver(t *testing.T
 	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(runDetail.UUID, false)
 	require.NoError(t, claimErr)
 	require.Equal(t, int64(1), claimGeneration)
-	_, err := store.DB().Exec(`UPDATE run_details SET RetryClaimedAtInSec = 0 WHERE UUID = ?`, runDetail.UUID)
+	_, err := store.DB().Exec(
+		`UPDATE run_details SET RetryClaimedAtInSec = 0, Name = ? WHERE UUID = ?`,
+		"stale-workflow-name", runDetail.UUID)
 	require.NoError(t, err)
 
 	run, err := manager.GetRun(runDetail.UUID)
@@ -6201,14 +8356,26 @@ func TestRetryRun_ExpiredClaimWithLiveWorkflowIsAdoptedNotTakenOver(t *testing.T
 	_, err = workflowClient.Create(context.Background(), retryExecSpec, v1.CreateOptions{})
 	require.NoError(t, err)
 	manager.execClient = &retryWorkflowExecClient{workflowClient: workflowClient}
+	manager.storedWorkflowIdentities.loadOrStore(runDetail.UUID, storedWorkflowIdentity{
+		name: runDetail.K8SName,
+		uid:  storedWorkflowUID(t, run),
+	})
 
 	require.NoError(t, manager.RetryRun(context.Background(), runDetail.UUID))
+	_, found := manager.storedWorkflowIdentities.load(runDetail.UUID)
+	assert.False(t, found, "adopting a live retry must invalidate the previous workflow identity")
 
 	adopted, err := manager.GetRun(runDetail.UUID)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), adopted.RetryGeneration,
 		"live generation-1 workflow must be adopted; a takeover to generation 2 would restart in-flight work")
 	assert.NotEqual(t, model.RuntimeStatePending, adopted.State, "adoption must persist the live workflow's state")
+	assert.Equal(t, expectedWorkflowName, adopted.K8SName)
+
+	liveWorkflow, err := workflowClient.Get(context.Background(), expectedWorkflowName, v1.GetOptions{})
+	require.NoError(t, err)
+	_, err = manager.ReportWorkflowResource(context.Background(), liveWorkflow)
+	require.NoError(t, err, "reports for the adopted workflow must use the repaired run name")
 }
 
 // Regression: takeover happens only when the previous claim's workflow is
@@ -6271,6 +8438,7 @@ func TestReportWorkflowResource_NeverAgeAcceptsWhileClaimedGenerationLive(t *tes
 		},
 		Status: v1alpha1.WorkflowStatus{Phase: v1alpha1.WorkflowFailed},
 	})
+	syncWorkflowReportWithFakeCluster(t, store, staleWorkflow)
 	_, err := manager.ReportWorkflowResource(context.Background(), staleWorkflow)
 	require.Nil(t, err)
 	_, _, _, claimGeneration, claimErr := store.RunStore().ClaimRunForRetry(run.UUID, false)
@@ -6285,6 +8453,8 @@ func TestReportWorkflowResource_NeverAgeAcceptsWhileClaimedGenerationLive(t *tes
 	liveWorkflow, err := wfClient.Get(context.Background(), run.K8SName, v1.GetOptions{})
 	require.Nil(t, err)
 	liveWorkflow.SetAnnotations(util.AnnotationKeyRetryGeneration, "1")
+	delete(liveWorkflow.ExecutionObjectMeta().Labels, util.LabelKeyWorkflowPersistedFinalState)
+	liveWorkflow.(*util.Workflow).Status.Phase = v1alpha1.WorkflowRunning
 	_, err = wfClient.Update(context.Background(), liveWorkflow, v1.UpdateOptions{})
 	require.Nil(t, err)
 
@@ -6294,8 +8464,8 @@ func TestReportWorkflowResource_NeverAgeAcceptsWhileClaimedGenerationLive(t *tes
 	assert.Nil(t, err)
 	claimed, err := manager.GetRun(run.UUID)
 	require.Nil(t, err)
-	assert.Equal(t, model.RuntimeStatePending, claimed.State,
-		"a lower-generation report must never be age-accepted while the claimed generation is live")
+	assert.Equal(t, model.RuntimeStateRunning, claimed.State,
+		"the live claimed generation must win over the stale terminal report")
 
 	// A stale snapshot carrying persistedFinalState must not delete the
 	// live retried workflow either: the fence runs before the deletion.
@@ -6303,7 +8473,7 @@ func TestReportWorkflowResource_NeverAgeAcceptsWhileClaimedGenerationLive(t *tes
 		ObjectMeta: v1.ObjectMeta{
 			Name:      run.K8SName,
 			Namespace: "ns1",
-			UID:       types.UID(run.UUID),
+			UID:       liveWorkflow.ExecutionObjectMeta().UID,
 			Labels: map[string]string{
 				util.LabelKeyWorkflowRunId:               run.UUID,
 				util.LabelKeyWorkflowPersistedFinalState: "true",

--- a/backend/src/apiserver/server/report_server.go
+++ b/backend/src/apiserver/server/report_server.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
@@ -49,7 +50,10 @@ type ReportServerV1 struct {
 }
 
 // Extracts task details from an execution spec and reports them to storage.
-func (s *BaseReportServer) reportTasksFromExecution(execSpec util.ExecutionSpec, runId string) ([]*model.Task, error) {
+func (s *BaseReportServer) reportTasksFromExecution(
+	execSpec util.ExecutionSpec,
+	run *model.Run,
+) ([]*model.Task, error) {
 	if !execSpec.ExecutionStatus().HasNodes() {
 		return nil, nil
 	}
@@ -57,7 +61,7 @@ func (s *BaseReportServer) reportTasksFromExecution(execSpec util.ExecutionSpec,
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to report tasks of an execution")
 	}
-	return s.resourceManager.CreateOrUpdateTasks(tasks, runId)
+	return s.resourceManager.CreateOrUpdateTasksForRun(tasks, run, execSpec.ExecutionNamespace())
 }
 
 // Reports a workflow.
@@ -77,13 +81,32 @@ func (s *BaseReportServer) reportWorkflow(ctx context.Context, workflow string) 
 		return nil, err
 	}
 
-	newExecSpec, err := s.resourceManager.ReportWorkflowResource(ctx, *execSpec)
+	runID := (*execSpec).ExecutionObjectMeta().Labels[util.LabelKeyWorkflowRunId]
+	var run *model.Run
+	if (*execSpec).ExecutionStatus().HasNodes() {
+		run, err = s.resourceManager.GetRun(runID)
+		if err != nil && !util.IsUserErrorCodeMatch(err, codes.NotFound) {
+			return nil, util.Wrap(err, "Failed to load run before reporting workflow")
+		}
+	}
+
+	var newExecSpec util.ExecutionSpec
+	if run != nil {
+		newExecSpec, err = s.resourceManager.ReportWorkflowResourceWithRun(ctx, *execSpec, run)
+	} else {
+		newExecSpec, err = s.resourceManager.ReportWorkflowResource(ctx, *execSpec)
+	}
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to report workflow")
 	}
 
-	runId := newExecSpec.ExecutionObjectMeta().Labels[util.LabelKeyWorkflowRunId]
-	_, err = s.reportTasksFromExecution(newExecSpec, runId)
+	if newExecSpec.ExecutionStatus().HasNodes() && run == nil {
+		run, err = s.resourceManager.GetRun(runID)
+		if err != nil {
+			return nil, util.Wrap(err, "Failed to load run before reporting task details")
+		}
+	}
+	_, err = s.reportTasksFromExecution(newExecSpec, run)
 	if err != nil {
 		return nil, util.Wrap(err, "Failed to report task details")
 	}

--- a/backend/src/apiserver/server/report_server_test.go
+++ b/backend/src/apiserver/server/report_server_test.go
@@ -22,9 +22,11 @@ import (
 	"github.com/argoproj/argo-workflows/v4/pkg/apis/workflow/v1alpha1"
 	api "github.com/kubeflow/pipelines/backend/api/v1beta1/go_client"
 	apiv2 "github.com/kubeflow/pipelines/backend/api/v2beta1/go_client"
+	"github.com/kubeflow/pipelines/backend/src/apiserver/common"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	swfapi "github.com/kubeflow/pipelines/backend/src/crd/pkg/apis/scheduledworkflow/v1beta1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,8 +48,8 @@ func TestReportWorkflowV1(t *testing.T) {
 			APIVersion: "argoproj.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "run1",
-			Namespace: "default",
+			Name:      run.K8SName,
+			Namespace: common.GetPodNamespace(),
 			UID:       types.UID(run.UUID),
 			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
 		},
@@ -68,7 +70,11 @@ func TestReportWorkflowV1(t *testing.T) {
 			},
 		},
 	})
-	_, err := reportServer.ReportWorkflowV1(nil, &api.ReportWorkflowRequest{
+	liveWorkflow, err := clientManager.ExecClient().Execution(common.GetPodNamespace()).Get(
+		context.Background(), run.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	workflow.UID = liveWorkflow.ExecutionObjectMeta().UID
+	_, err = reportServer.ReportWorkflowV1(context.Background(), &api.ReportWorkflowRequest{
 		Workflow: workflow.ToStringForStore(),
 	})
 	assert.Nil(t, err)
@@ -111,8 +117,8 @@ func TestReportWorkflow(t *testing.T) {
 			APIVersion: "argoproj.io/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "run1",
-			Namespace: "default",
+			Name:      run.K8SName,
+			Namespace: common.GetPodNamespace(),
 			UID:       types.UID(run.UUID),
 			Labels:    map[string]string{util.LabelKeyWorkflowRunId: run.UUID},
 		},
@@ -133,7 +139,11 @@ func TestReportWorkflow(t *testing.T) {
 			},
 		},
 	})
-	_, err := reportServer.ReportWorkflow(nil, &apiv2.ReportWorkflowRequest{
+	liveWorkflow, err := clientManager.ExecClient().Execution(common.GetPodNamespace()).Get(
+		context.Background(), run.K8SName, metav1.GetOptions{})
+	require.NoError(t, err)
+	workflow.UID = liveWorkflow.ExecutionObjectMeta().UID
+	_, err = reportServer.ReportWorkflow(context.Background(), &apiv2.ReportWorkflowRequest{
 		Workflow: workflow.ToStringForStore(),
 	})
 	assert.Nil(t, err)

--- a/backend/src/apiserver/server/run_artifact_server_test.go
+++ b/backend/src/apiserver/server/run_artifact_server_test.go
@@ -81,6 +81,22 @@ func createWorkflowWithArtifact(runUUID, nodeID, artifactName, artifactPath stri
 	})
 }
 
+func syncArtifactWorkflowWithFakeCluster(
+	t *testing.T,
+	clientManager *resource.FakeClientManager,
+	workflow *util.Workflow,
+) {
+	t.Helper()
+	ctx := context.Background()
+	workflowClient := clientManager.ExecClient().Execution(workflow.ExecutionNamespace())
+	liveWorkflow, err := workflowClient.Get(ctx, workflow.ExecutionName(), v1.GetOptions{})
+	require.NoError(t, err)
+	workflow.UID = liveWorkflow.ExecutionObjectMeta().UID
+	workflow.SetVersion(liveWorkflow.Version())
+	_, err = workflowClient.Update(ctx, workflow, v1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
 func TestReadArtifactV1_Succeed(t *testing.T) {
 	expectedContent := "test artifact content"
 	filePath := "test/artifact.txt"
@@ -99,6 +115,7 @@ func TestReadArtifactV1_Succeed(t *testing.T) {
 	require.NoError(t, err, "Failed to add file to object store")
 
 	workflow := createWorkflowWithArtifact(run.UUID, "node-1", "artifact-1", filePath)
+	syncArtifactWorkflowWithFakeCluster(t, resourceManager, workflow)
 	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
 	require.NoError(t, err, "Failed to report workflow resource")
 
@@ -192,6 +209,7 @@ func TestReadArtifactV1_ChunkedResponse(t *testing.T) {
 	require.NoError(t, err, "Failed to add large file to object store")
 
 	workflow := createWorkflowWithArtifact(run.UUID, "node-1", "large-artifact", filePath)
+	syncArtifactWorkflowWithFakeCluster(t, resourceManager, workflow)
 	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
 	require.NoError(t, err, "Failed to report workflow resource")
 
@@ -273,6 +291,7 @@ func TestReadArtifactV1_ArtifactNotFound(t *testing.T) {
 	}()
 
 	workflow := createWorkflowWithArtifact(run.UUID, "node-1", "artifact-1", "test/nonexistent.txt")
+	syncArtifactWorkflowWithFakeCluster(t, resourceManager, workflow)
 	_, err := manager.ReportWorkflowResource(context.Background(), workflow)
 	require.NoError(t, err, "Failed to report workflow resource")
 
@@ -383,6 +402,7 @@ func TestReadArtifactV1_Unauthorized(t *testing.T) {
 	require.NoError(t, err, "Failed to add file to object store")
 
 	workflow := createWorkflowWithArtifact(run.UUID, "node-1", "artifact-1", filePath)
+	syncArtifactWorkflowWithFakeCluster(t, clientManager, workflow)
 	_, err = manager.ReportWorkflowResource(context.Background(), workflow)
 	require.NoError(t, err, "Failed to report workflow resource")
 

--- a/backend/src/apiserver/server/run_server_test.go
+++ b/backend/src/apiserver/server/run_server_test.go
@@ -263,6 +263,7 @@ func TestCreateRunV1_V1Params(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Spec.Arguments.Parameters = []v1alpha1.Parameter{
 		{Name: "param1", Value: v1alpha1.AnyStringPtr("world")},
@@ -424,6 +425,21 @@ func TestCreateRunV1Patch(t *testing.T) {
 	}
 	runDetail, err := server.CreateRunV1(nil, &apiv1beta1.CreateRunRequest{Run: run})
 	assert.Nil(t, err)
+	expectedRuntimeWorkflow := testWorkflowPatch.DeepCopy()
+	expectedRuntimeWorkflow.UID = "workflow1"
+	expectedRuntimeWorkflow.ResourceVersion = "1"
+	expectedRuntimeWorkflow.Namespace = "ns1"
+	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
+	expectedRuntimeWorkflow.Labels = map[string]string{util.LabelKeyWorkflowRunId: DefaultFakeUUID}
+	expectedRuntimeWorkflow.Annotations = map[string]string{util.AnnotationKeyRunName: "run1"}
+	expectedRuntimeWorkflow.Spec.Arguments.Parameters = []v1alpha1.Parameter{
+		{Name: "param1", Value: v1alpha1.AnyStringPtr("test-default-bucket")},
+		{Name: "param2", Value: v1alpha1.AnyStringPtr("test-project-id")},
+	}
+	expectedRuntimeWorkflow.Spec.ServiceAccountName = common.DefaultPipelineRunnerServiceAccount
+	expectedRuntimeWorkflow.Spec.PodMetadata = &v1alpha1.Metadata{
+		Labels: map[string]string{util.LabelKeyWorkflowRunId: DefaultFakeUUID},
+	}
 	expectedRunDetail := &apiv1beta1.RunDetail{
 		Run: &apiv1beta1.Run{
 			Id:             "123e4567-e89b-12d3-a456-426655440000",
@@ -452,12 +468,13 @@ func TestCreateRunV1Patch(t *testing.T) {
 			WorkflowManifest: "{\"kind\":\"Workflow\",\"apiVersion\":\"argoproj.io/v1alpha1\",\"metadata\":{\"name\":\"workflow-name\",\"namespace\":\"ns1\",\"uid\":\"workflow2\",\"labels\":{\"pipeline/runid\":\"123e4567-e89b-12d3-a456-426655440000\"},\"annotations\":{\"pipelines.kubeflow.org/run_name\":\"run1\"}},\"spec\":{\"templates\":[{\"name\":\"testy\",\"inputs\":{},\"outputs\":{},\"metadata\":{\"annotations\":{\"sidecar.istio.io/inject\":\"false\"},\"labels\":{\"pipeline/runid\":\"123e4567-e89b-12d3-a456-426655440000\",\"pipelines.kubeflow.org/cache_enabled\":\"true\"}},\"container\":{\"name\":\"\",\"image\":\"docker/whalesay\",\"command\":[\"cowsay\"],\"args\":[\"hello world\"],\"resources\":{}}}],\"entrypoint\":\"testy\",\"arguments\":{\"parameters\":[{\"name\":\"param1\",\"value\":\"test-default-bucket\"},{\"name\":\"param2\",\"value\":\"test-project-id\"}]},\"serviceAccountName\":\"pipeline-runner\",\"podMetadata\":{\"labels\":{\"pipeline/runid\":\"123e4567-e89b-12d3-a456-426655440000\"}}},\"status\":{\"startedAt\":null,\"finishedAt\":null}}",
 		},
 	}
+	expectedRunDetail.PipelineRuntime.WorkflowManifest = util.NewWorkflow(expectedRuntimeWorkflow).ToStringForStore()
 
 	matched := 0
 	for _, resRef := range expectedRunDetail.GetRun().GetResourceReferences() {
 		for _, resRef2 := range runDetail.GetRun().GetResourceReferences() {
 			if resRef2.Key.Type == apiv1beta1.ResourceType_NAMESPACE {
-				assert.Equal(t, resRef2.Key.Id, experiment.Namespace)
+				assert.Equal(t, common.GetPodNamespace(), resRef2.Key.Id)
 			}
 			if resRef.Key.Type == resRef2.Key.Type && resRef.Key.Id == resRef2.Key.Id && resRef.Relationship == resRef2.Relationship {
 				matched++
@@ -529,6 +546,7 @@ func TestCreateRunV1_Multiuser(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedRuntimeWorkflow := testWorkflow.DeepCopy()
+	expectedRuntimeWorkflow.ResourceVersion = "1"
 	template.AddRuntimeMetadata(expectedRuntimeWorkflow)
 	expectedRuntimeWorkflow.Spec.Arguments.Parameters = []v1alpha1.Parameter{
 		{Name: "param1", Value: v1alpha1.AnyStringPtr("world")},

--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -153,6 +153,17 @@ type RunStoreInterface interface {
 	// Note: only state, runtime manifest can be updated. Does not update dependent tasks.
 	UpdateRun(run *model.Run) (err error)
 
+	// Updates a run only when its persisted workflow runtime manifest and retry
+	// generation still match the values loaded by the caller. Before a V2 run's
+	// first report, when that manifest is empty, its pipeline runtime manifest is
+	// also checked as an incarnation fence. Returns false without mutating the
+	// row when another writer changed any guarded value.
+	UpdateRunIfRuntimeManifestsUnchanged(
+		run *model.Run,
+		expectedWorkflowRuntimeManifest model.LargeText,
+		expectedPipelineRuntimeManifest model.LargeText,
+	) (bool, error)
+
 	// Updates only the PluginsOutput column for a run. Use this when plugin
 	// handlers need to persist output without touching core run fields (State,
 	// Conditions, etc.) to avoid redundant writes and potential clobbering.
@@ -713,9 +724,111 @@ func (s *RunStore) GetRunByRecurringRunIDAndDisplayName(recurringRunID, displayN
 }
 
 func (s *RunStore) UpdateRun(run *model.Run) error {
+	_, err := s.updateRun(run, nil)
+	return err
+}
+
+func (s *RunStore) UpdateRunIfRuntimeManifestsUnchanged(
+	run *model.Run,
+	expectedWorkflowRuntimeManifest model.LargeText,
+	expectedPipelineRuntimeManifest model.LargeText,
+) (bool, error) {
+	return s.updateRun(run, &runRuntimeManifestPrecondition{
+		workflow:        expectedWorkflowRuntimeManifest,
+		pipeline:        expectedPipelineRuntimeManifest,
+		retryGeneration: run.RetryGeneration,
+	})
+}
+
+type runRuntimeManifestPrecondition struct {
+	workflow        model.LargeText
+	pipeline        model.LargeText
+	retryGeneration int64
+	namespace       *string
+}
+
+func lockRunForRuntimeManifestWrite(
+	tx *sql.Tx,
+	db *DB,
+	runID string,
+	expected runRuntimeManifestPrecondition,
+) (bool, bool, error) {
+	lockColumns := []string{"WorkflowRuntimeManifest"}
+	checkPipelineRuntimeManifest := expected.workflow == ""
+	if checkPipelineRuntimeManifest {
+		lockColumns = append(lockColumns, "PipelineRuntimeManifest")
+	}
+	if expected.namespace != nil {
+		lockColumns = append(lockColumns, "Namespace")
+	}
+	lockColumns = append(lockColumns, "RetryGeneration")
+	lockSQL, lockArgs, err := sq.
+		Select(lockColumns...).
+		From("run_details").
+		Where(sq.Eq{"UUID": runID}).
+		ToSql()
+	if err != nil {
+		return false, false, err
+	}
+	var currentWorkflowRuntimeManifest model.LargeText
+	var currentPipelineRuntimeManifest model.LargeText
+	var currentNamespace string
+	var currentRetryGeneration sql.NullInt64
+	lockScanTargets := []any{&currentWorkflowRuntimeManifest}
+	if checkPipelineRuntimeManifest {
+		lockScanTargets = append(lockScanTargets, &currentPipelineRuntimeManifest)
+	}
+	if expected.namespace != nil {
+		lockScanTargets = append(lockScanTargets, &currentNamespace)
+	}
+	lockScanTargets = append(lockScanTargets, &currentRetryGeneration)
+	if err := tx.QueryRow(db.SelectForUpdate(lockSQL), lockArgs...).Scan(lockScanTargets...); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, false, nil
+		}
+		return false, false, err
+	}
+	matches := currentWorkflowRuntimeManifest == expected.workflow &&
+		(!checkPipelineRuntimeManifest || currentPipelineRuntimeManifest == expected.pipeline) &&
+		(expected.namespace == nil || currentNamespace == *expected.namespace) &&
+		currentRetryGeneration.Int64 == expected.retryGeneration
+	return true, matches, nil
+}
+
+func (s *RunStore) updateRun(
+	run *model.Run,
+	expectedRuntimeManifests *runRuntimeManifestPrecondition,
+) (bool, error) {
 	tx, err := s.db.DB.Begin()
 	if err != nil {
-		return util.NewInternalServerError(err, "transaction creation failed")
+		return false, util.NewInternalServerError(err, "transaction creation failed")
+	}
+	if expectedRuntimeManifests != nil {
+		runExists, preconditionMatches, lockError := lockRunForRuntimeManifestWrite(
+			tx,
+			s.db,
+			run.UUID,
+			*expectedRuntimeManifests,
+		)
+		if lockError != nil {
+			tx.Rollback()
+			return false, util.NewInternalServerError(
+				lockError,
+				"Failed to lock run %s before updating",
+				run.UUID,
+			)
+		}
+		if !runExists {
+			tx.Rollback()
+			return false, util.Wrap(
+				util.NewResourceNotFoundError("Run", run.UUID),
+				"Failed to update run",
+			)
+		}
+		if !preconditionMatches {
+			tx.Rollback()
+			return false, nil
+		}
 	}
 	if len(run.RunDetails.StateHistory) == 0 || run.RunDetails.StateHistory[len(run.RunDetails.StateHistory)-1].State != run.RunDetails.State {
 		run.RunDetails.StateHistory = append(run.RunDetails.StateHistory, &model.RuntimeStatus{
@@ -734,6 +847,12 @@ func (s *RunStore) UpdateRun(run *model.Run) error {
 		"FinishedAtInSec":         run.FinishedAtInSec,
 		"WorkflowRuntimeManifest": run.WorkflowRuntimeManifest,
 	}
+	if run.K8SName != "" {
+		updateFields["Name"] = run.K8SName
+	}
+	if run.Namespace != "" {
+		updateFields["Namespace"] = run.Namespace
+	}
 	// PluginsOutput is only updated when explicitly set by the caller (e.g.
 	// MLflow terminal sync, retry). A nil pointer means "leave unchanged" so
 	// that normal state-update callers don't accidentally overwrite it.
@@ -745,43 +864,48 @@ func (s *RunStore) UpdateRun(run *model.Run) error {
 	// Include RetryGeneration in the WHERE clause so that a stale workflow
 	// reporter that passed workflowStillMatchesReportedVersion before a
 	// ClaimRunForRetry increment cannot overwrite the claimed row.
+	updatePredicate := sq.And{
+		sq.Eq{"UUID": run.UUID},
+		sq.Eq{"RetryGeneration": run.RetryGeneration},
+	}
 	sql, args, err := sq.
 		Update("run_details").
 		SetMap(updateFields).
-		Where(sq.And{
-			sq.Eq{"UUID": run.UUID},
-			sq.Eq{"RetryGeneration": run.RetryGeneration},
-		}).
+		Where(updatePredicate).
 		ToSql()
 	if err != nil {
 		tx.Rollback()
-		return util.NewInternalServerError(err,
+		return false, util.NewInternalServerError(err,
 			"Failed to create query to update run %s", run.UUID)
 	}
 	result, err := tx.Exec(sql, args...)
 	if err != nil {
 		tx.Rollback()
-		return util.NewInternalServerError(err,
+		return false, util.NewInternalServerError(err,
 			"Failed to update run %s", run.UUID)
 	}
 	r, err := result.RowsAffected()
 	if err != nil {
 		tx.Rollback()
-		return util.NewInternalServerError(err,
+		return false, util.NewInternalServerError(err,
 			"Failed to update run %s", run.UUID)
 	}
 	if r > 1 {
 		tx.Rollback()
-		return util.NewInternalServerError(errors.New("Failed to update run"), "Failed to update run %s. More than 1 rows affected", run.UUID)
+		return false, util.NewInternalServerError(errors.New("Failed to update run"), "Failed to update run %s. More than 1 rows affected", run.UUID)
 	} else if r == 0 {
+		if expectedRuntimeManifests != nil {
+			tx.Rollback()
+			return false, nil
+		}
 		tx.Rollback()
-		return util.Wrap(util.NewResourceNotFoundError("Run", run.UUID), "Failed to update run")
+		return false, util.Wrap(util.NewResourceNotFoundError("Run", run.UUID), "Failed to update run")
 	}
 
 	if err := tx.Commit(); err != nil {
-		return util.NewInternalServerError(err, "failed to commit transaction for run %s", run.UUID)
+		return false, util.NewInternalServerError(err, "failed to commit transaction for run %s", run.UUID)
 	}
-	return nil
+	return true, nil
 }
 
 // UpdateRunPluginsOutput updates only the PluginsOutput column for the given

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -891,6 +891,119 @@ func TestCreateAndUpdateRun_UpdateSuccess(t *testing.T) {
 	assert.Equal(t, expectedRun.ToV1(), runDetail.ToV1())
 }
 
+func TestUpdateRunIfRuntimeManifestsUnchangedRejectsStaleManifest(t *testing.T) {
+	db, runStore := initializeRunStore()
+	defer db.Close()
+
+	_, err := runStore.CreateRun(&model.Run{
+		UUID:         "manifest-cas-run",
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "manifest-cas-run",
+		DisplayName:  "manifest-cas-run",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:          1,
+			Conditions:              "Running",
+			State:                   model.RuntimeStateRunning,
+			WorkflowRuntimeManifest: "legacy-manifest",
+		},
+	})
+	require.NoError(t, err)
+
+	staleRun, err := runStore.GetRun("manifest-cas-run")
+	require.NoError(t, err)
+	currentRun, err := runStore.GetRun("manifest-cas-run")
+	require.NoError(t, err)
+	currentRun.WorkflowRuntimeManifest = "adopted-manifest"
+	require.NoError(t, runStore.UpdateRun(currentRun))
+
+	staleRun.WorkflowRuntimeManifest = "replacement-manifest"
+	updated, err := runStore.UpdateRunIfRuntimeManifestsUnchanged(
+		staleRun,
+		"legacy-manifest",
+		staleRun.PipelineRuntimeManifest,
+	)
+	require.NoError(t, err)
+	assert.False(t, updated)
+	persistedRun, err := runStore.GetRun("manifest-cas-run")
+	require.NoError(t, err)
+	assert.Equal(t, model.LargeText("adopted-manifest"), persistedRun.WorkflowRuntimeManifest)
+
+	persistedRun.WorkflowRuntimeManifest = "next-manifest"
+	updated, err = runStore.UpdateRunIfRuntimeManifestsUnchanged(
+		persistedRun,
+		"adopted-manifest",
+		persistedRun.PipelineRuntimeManifest,
+	)
+	require.NoError(t, err)
+	assert.True(t, updated)
+	persistedRun, err = runStore.GetRun("manifest-cas-run")
+	require.NoError(t, err)
+	assert.Equal(t, model.LargeText("next-manifest"), persistedRun.WorkflowRuntimeManifest)
+}
+
+func TestUpdateRunIfRuntimeManifestsUnchangedRejectsRecreatedRun(t *testing.T) {
+	db, runStore := initializeRunStore()
+	defer db.Close()
+
+	const runID = "runtime-manifest-aba-run"
+	_, err := runStore.CreateRun(&model.Run{
+		UUID:         runID,
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "original-workflow",
+		DisplayName:  "original-run",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:          1,
+			Conditions:              "Pending",
+			State:                   model.RuntimeStatePending,
+			WorkflowRuntimeManifest: "",
+			PipelineRuntimeManifest: "original-runtime-manifest",
+		},
+	})
+	require.NoError(t, err)
+	staleRun, err := runStore.GetRun(runID)
+	require.NoError(t, err)
+
+	require.NoError(t, runStore.DeleteRun(runID))
+	_, err = runStore.CreateRun(&model.Run{
+		UUID:         runID,
+		ExperimentId: defaultFakeExpId,
+		K8SName:      "replacement-workflow",
+		DisplayName:  "replacement-run",
+		Namespace:    "ns1",
+		StorageState: model.StorageStateAvailable,
+		RunDetails: model.RunDetails{
+			CreatedAtInSec:          2,
+			Conditions:              "Pending",
+			State:                   model.RuntimeStatePending,
+			WorkflowRuntimeManifest: "",
+			PipelineRuntimeManifest: "replacement-runtime-manifest",
+		},
+	})
+	require.NoError(t, err)
+	replacementBeforeReport, err := runStore.GetRun(runID)
+	require.NoError(t, err)
+
+	staleRun.K8SName = "stale-terminal-workflow"
+	staleRun.State = model.RuntimeStateSucceeded
+	staleRun.Conditions = "Succeeded"
+	staleRun.WorkflowRuntimeManifest = "stale-terminal-manifest"
+	updated, err := runStore.UpdateRunIfRuntimeManifestsUnchanged(
+		staleRun,
+		"",
+		"original-runtime-manifest",
+	)
+	require.NoError(t, err)
+	assert.False(t, updated)
+
+	replacementAfterReport, err := runStore.GetRun(runID)
+	require.NoError(t, err)
+	assert.Equal(t, replacementBeforeReport, replacementAfterReport)
+}
+
 func TestCreateAndUpdateRun_CreateSuccess(t *testing.T) {
 	db, runStore := initializeRunStore()
 	defer db.Close()

--- a/backend/src/apiserver/storage/task_store.go
+++ b/backend/src/apiserver/storage/task_store.go
@@ -62,12 +62,29 @@ type TaskStoreInterface interface {
 
 	// Creates new tasks or updates the existing ones.
 	CreateOrUpdateTasks(tasks []*model.Task, runID string) ([]*model.Task, error)
+
+	// Creates or updates tasks only while the parent run still has the exact
+	// namespace, runtime identity, and retry generation supplied by the caller.
+	// The run is locked and checked in the same transaction as the task upsert.
+	CreateOrUpdateTasksIfRunUnchanged(
+		tasks []*model.Task,
+		runID string,
+		expectedNamespace string,
+		expectedWorkflowRuntimeManifest model.LargeText,
+		expectedPipelineRuntimeManifest model.LargeText,
+		expectedRetryGeneration int64,
+	) ([]*model.Task, bool, error)
 }
 
 type TaskStore struct {
 	db   *DB
 	time util.TimeInterface
 	uuid util.UUIDGeneratorInterface
+}
+
+type taskQueryExecer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+	Exec(query string, args ...any) (sql.Result, error)
 }
 
 // NewTaskStore creates a new TaskStore.
@@ -324,7 +341,7 @@ func (s *TaskStore) GetTask(id string) (*model.Task, error) {
 }
 
 // Updates missing fields with existing data entries.
-func (s *TaskStore) patchWithExistingTasks(tasks []*model.Task, runID string) error {
+func (s *TaskStore) patchWithExistingTasks(db taskQueryExecer, tasks []*model.Task, runID string) error {
 	var podNames []string
 	for _, task := range tasks {
 		podNames = append(podNames, task.PodName)
@@ -337,7 +354,7 @@ func (s *TaskStore) patchWithExistingTasks(tasks []*model.Task, runID string) er
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to create query to check existing tasks")
 	}
-	r, err := s.db.Query(sql, args...)
+	r, err := db.Query(sql, args...)
 	if err != nil {
 		return util.NewInternalServerError(err, "Failed to check existing tasks")
 	}
@@ -360,6 +377,33 @@ func (s *TaskStore) patchWithExistingTasks(tasks []*model.Task, runID string) er
 
 // Creates new entries or updates existing ones.
 func (s *TaskStore) CreateOrUpdateTasks(tasks []*model.Task, runID string) ([]*model.Task, error) {
+	updatedTasks, _, err := s.createOrUpdateTasks(tasks, runID, nil)
+	return updatedTasks, err
+}
+
+// CreateOrUpdateTasksIfRunUnchanged writes tasks only if the owning run still
+// matches the supplied namespace, runtime manifests, and retry generation.
+func (s *TaskStore) CreateOrUpdateTasksIfRunUnchanged(
+	tasks []*model.Task,
+	runID string,
+	expectedNamespace string,
+	expectedWorkflowRuntimeManifest model.LargeText,
+	expectedPipelineRuntimeManifest model.LargeText,
+	expectedRetryGeneration int64,
+) ([]*model.Task, bool, error) {
+	return s.createOrUpdateTasks(tasks, runID, &runRuntimeManifestPrecondition{
+		workflow:        expectedWorkflowRuntimeManifest,
+		pipeline:        expectedPipelineRuntimeManifest,
+		retryGeneration: expectedRetryGeneration,
+		namespace:       &expectedNamespace,
+	})
+}
+
+func (s *TaskStore) createOrUpdateTasks(
+	tasks []*model.Task,
+	runID string,
+	expectedRun *runRuntimeManifestPrecondition,
+) ([]*model.Task, bool, error) {
 	buildQuery := func(ts []*model.Task) (string, []interface{}, error) {
 		sqlInsert := sq.Insert("tasks").Columns(taskColumnsWithPayload...)
 		for _, t := range ts {
@@ -402,18 +446,41 @@ func (s *TaskStore) CreateOrUpdateTasks(tasks []*model.Task, runID string) ([]*m
 		}
 		return sqlInsert.ToSql()
 	}
+	taskDB := taskQueryExecer(s.db)
+	var tx *sql.Tx
+	if expectedRun != nil {
+		var err error
+		tx, err = s.db.Begin()
+		if err != nil {
+			return nil, false, util.NewInternalServerError(err, "Failed to start transaction for task update")
+		}
+		defer tx.Rollback()
+		runExists, preconditionMatches, err := lockRunForRuntimeManifestWrite(
+			tx,
+			s.db,
+			runID,
+			*expectedRun,
+		)
+		if err != nil {
+			return nil, false, util.NewInternalServerError(err, "Failed to lock owning run %s before updating tasks", runID)
+		}
+		if !runExists || !preconditionMatches {
+			return nil, false, nil
+		}
+		taskDB = tx
+	}
 
 	// Check for existing tasks and fill empty field with existing data.
 	// Assumes that PodName column is a unique key.
-	if err := s.patchWithExistingTasks(tasks, runID); err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to check for existing tasks")
+	if err := s.patchWithExistingTasks(taskDB, tasks, runID); err != nil {
+		return nil, false, util.NewInternalServerError(err, "Failed to check for existing tasks")
 	}
 	for _, task := range tasks {
 		task.State = task.State.ToV2()
 		if task.UUID == "" {
 			id, err := s.uuid.NewRandom()
 			if err != nil {
-				return nil, util.NewInternalServerError(err, "Failed to create an task id")
+				return nil, false, util.NewInternalServerError(err, "Failed to create an task id")
 			}
 			task.UUID = id.String()
 		}
@@ -430,14 +497,19 @@ func (s *TaskStore) CreateOrUpdateTasks(tasks []*model.Task, runID string) ([]*m
 	// Execute the query
 	sql, arg, err := buildQuery(tasks)
 	if err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to build query to update or insert tasks")
+		return nil, false, util.NewInternalServerError(err, "Failed to build query to update or insert tasks")
 	}
 	sql = s.db.Upsert(sql, "UUID", true, taskColumnsWithPayload...)
-	_, err = s.db.Exec(sql, arg...)
+	_, err = taskDB.Exec(sql, arg...)
 	if err != nil {
-		return nil, util.NewInternalServerError(err, "Failed to update or insert tasks. Query: %v. Args: %v", sql, arg)
+		return nil, false, util.NewInternalServerError(err, "Failed to update or insert tasks. Query: %v. Args: %v", sql, arg)
 	}
-	return tasks, nil
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return nil, false, util.NewInternalServerError(err, "Failed to commit task updates for run %s", runID)
+		}
+	}
+	return tasks, true, nil
 }
 
 // Fills empty fields in a new task with the data from an existing task.

--- a/backend/src/apiserver/storage/task_store_test.go
+++ b/backend/src/apiserver/storage/task_store_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kubeflow/pipelines/backend/src/apiserver/model"
 	"github.com/kubeflow/pipelines/backend/src/common/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -504,7 +505,7 @@ func TestTaskStore_patchWithExistingTasks(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := taskStore.patchWithExistingTasks(tt.tasks, defaultFakeRunIdTwo)
+			err := taskStore.patchWithExistingTasks(taskStore.db, tt.tasks, defaultFakeRunIdTwo)
 			if tt.wantErr {
 				assert.NotNil(t, err)
 				assert.Contains(t, err.Error(), tt.errMsg)
@@ -621,5 +622,122 @@ func TestTaskStore_UpdateOrCreateTasks(t *testing.T) {
 func TestTaskAPIFieldMap(t *testing.T) {
 	for _, modelField := range (&model.Task{}).APIToModelFieldMap() {
 		assert.Contains(t, taskColumns, modelField)
+	}
+}
+
+func TestCreateOrUpdateTasksIfRunUnchangedAcceptsMatchingRun(t *testing.T) {
+	db, taskStore := initializeTaskStore()
+	defer db.Close()
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	run, err := runStore.GetRun(defaultFakeRunIdTwo)
+	require.NoError(t, err)
+	task := &model.Task{
+		RunID:     run.UUID,
+		Namespace: run.Namespace,
+		PodName:   "guarded-task",
+		State:     model.RuntimeStateRunning,
+	}
+	updatedTasks, updated, err := taskStore.CreateOrUpdateTasksIfRunUnchanged(
+		[]*model.Task{task},
+		run.UUID,
+		run.Namespace,
+		run.WorkflowRuntimeManifest,
+		run.PipelineRuntimeManifest,
+		run.RetryGeneration,
+	)
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.Len(t, updatedTasks, 1)
+	require.NotEmpty(t, updatedTasks[0].UUID)
+
+	persistedTask, err := taskStore.GetTask(updatedTasks[0].UUID)
+	require.NoError(t, err)
+	assert.Equal(t, updatedTasks[0].UUID, persistedTask.UUID)
+	assert.Equal(t, updatedTasks[0].RunID, persistedTask.RunID)
+	assert.Equal(t, updatedTasks[0].Namespace, persistedTask.Namespace)
+	assert.Equal(t, updatedTasks[0].PodName, persistedTask.PodName)
+	assert.Equal(t, updatedTasks[0].StateHistory, persistedTask.StateHistory)
+}
+
+func TestCreateOrUpdateTasksIfRunUnchangedRejectsRecreatedRun(t *testing.T) {
+	tests := []struct {
+		name                          string
+		replacementNamespace          string
+		replacementWorkflow           model.LargeText
+		preserveStaleWorkflowManifest bool
+	}{
+		{
+			name:                          "cross-namespace with identical manifests",
+			replacementNamespace:          "ns1",
+			preserveStaleWorkflowManifest: true,
+		},
+		{
+			name:                 "same namespace with a new workflow manifest",
+			replacementNamespace: "ns2",
+			replacementWorkflow:  "replacement-workflow-runtime",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, taskStore := initializeTaskStore()
+			defer db.Close()
+			runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+			staleRun, err := runStore.GetRun(defaultFakeRunIdTwo)
+			require.NoError(t, err)
+			require.NoError(t, runStore.DeleteRun(defaultFakeRunIdTwo))
+			replacementWorkflow := tt.replacementWorkflow
+			replacementPipeline := staleRun.PipelineRuntimeManifest
+			if tt.preserveStaleWorkflowManifest {
+				replacementWorkflow = staleRun.WorkflowRuntimeManifest
+			}
+			_, err = runStore.CreateRun(&model.Run{
+				UUID:         defaultFakeRunIdTwo,
+				ExperimentId: defaultFakeExpId,
+				DisplayName:  "replacement-run",
+				K8SName:      "replacement-workflow",
+				Namespace:    tt.replacementNamespace,
+				StorageState: model.StorageStateAvailable,
+				RunDetails: model.RunDetails{
+					CreatedAtInSec:          10,
+					Conditions:              "Pending",
+					State:                   model.RuntimeStatePending,
+					WorkflowRuntimeManifest: replacementWorkflow,
+					PipelineRuntimeManifest: replacementPipeline,
+				},
+			})
+			require.NoError(t, err)
+
+			task := &model.Task{
+				RunID:     defaultFakeRunIdTwo,
+				Namespace: staleRun.Namespace,
+				PodName:   "stale-run-task",
+				State:     model.RuntimeStateRunning,
+			}
+			updatedTasks, updated, err := taskStore.CreateOrUpdateTasksIfRunUnchanged(
+				[]*model.Task{task},
+				defaultFakeRunIdTwo,
+				staleRun.Namespace,
+				staleRun.WorkflowRuntimeManifest,
+				staleRun.PipelineRuntimeManifest,
+				staleRun.RetryGeneration,
+			)
+			require.NoError(t, err)
+			assert.False(t, updated)
+			assert.Nil(t, updatedTasks)
+			assert.Empty(t, task.UUID, "a rejected task report must not mutate task identity")
+
+			var taskCount int
+			require.NoError(t, db.QueryRow(
+				"SELECT COUNT(*) FROM tasks WHERE RunUUID = ?",
+				defaultFakeRunIdTwo,
+			).Scan(&taskCount))
+			assert.Zero(t, taskCount)
+			replacementRun, err := runStore.GetRun(defaultFakeRunIdTwo)
+			require.NoError(t, err)
+			assert.Equal(t, tt.replacementNamespace, replacementRun.Namespace)
+			assert.Equal(t, replacementWorkflow, replacementRun.WorkflowRuntimeManifest)
+		})
 	}
 }

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -111,6 +111,36 @@ configure Argo's native workflow TTL or set `ttlSecondsAfterFinished` on your
 workflow templates. The TTL should be shorter than `ARCHIVED_RUNS_RETENTION_TIME`
 so Argo cleans up the CR before GC deletes the database row.
 
+The API server only changes a run or deletes a Workflow after fetching the live
+Workflow and matching its immutable UID, resource version, run label, namespace,
+and recurring-run owner. Workflow deletion uses UID and resource-version
+preconditions so a same-name replacement or concurrently retried Workflow is
+never removed. If a one-time Workflow has no database run, the API server waits
+out the run-creation grace period and then safely deletes the UID-verified live
+orphan. A missing or inconsistent recurring-run owner remains fail-closed
+because its tenant cannot be established. If orphan propagation strips the
+owner while the recurring-run row still exists, the report is rejected
+permanently and counted as an identity mismatch instead of being retried
+indefinitely. Configure Argo's workflow TTL (one hour in the shipped
+configuration) and explicitly inspect these orphans.
+
+Rejected reports are logged and counted by
+`resource_manager_workflow_reports_rejected_total`, with
+`reason="ownership_unresolved"`, `reason="namespace_mismatch"`, or
+`reason="identity_mismatch"`. Alert on these reasons and repair legacy database
+ownership before retrying a multi-user report. Standalone single-user mode may
+recover the execution namespace from the live Workflow for old rows that have
+no persisted namespace; multi-user namespace mismatches always fail closed.
+Transient Kubernetes lookup failures and terminal reports accepted through a
+stored-identity fallback are not counted as rejections. Workflow reports do
+perform synchronous identity reads, so Kubernetes API outages delay report
+persistence until those reads succeed.
+
+New runs persist their actual Kubernetes execution namespace even in
+single-user mode. API resource references therefore expose that namespace
+instead of an empty namespace; legacy empty-namespace rows remain supported by
+resolving their namespace from the reporting Workflow.
+
 The garbage collector also does not remove rows from the `artifacts` table,
 MLMD records, or object-store artifacts; those lifecycles are managed
 separately (see `ARTIFACT_RETENTION_DAYS` for object-store artifacts).


### PR DESCRIPTION
**Description of your changes:**

**Why:** Workflow reports previously selected their target using request-provided labels and owner references without proving the complete stored and live Kubernetes identity. A forged or stale report could therefore act on a run belonging to another namespace, delete a same-name replacement, overwrite a newly recreated run that reused an ID, or attach stale task records to that replacement.

**What:** This change accepts a workflow report only when it matches the persisted run or recurring-run owner and the live Kubernetes Workflow. Valid reports continue normally; mismatched, stale, concurrently superseded, or previous-incarnation reports fail before any run, task, or Workflow data is changed.

Technical details:

- Resolve and validate run and recurring-run namespaces before task persistence, database mutation, or Workflow deletion.
- Require the live Workflow UID, run label, namespace, and recurring-run owner to match the persisted identity.
- Treat live Workflow state and labels as authoritative instead of trusting the report body.
- Delete Workflows with UID and resource-version preconditions to protect same-name replacements.
- Fence every existing-run report write against the locked persisted workflow manifest and retry generation.
- For V2 runs before their first report, also fence on the UID-bearing pipeline-runtime manifest so a stale report cannot ABA-match a deleted and recreated run ID.
- Lock the parent run and verify its namespace, runtime manifests, and retry generation in the same transaction that reads and upserts tasks, preventing stale tasks from attaching to a replacement run.
- Reload authoritative state after a concurrent change and refresh the bounded identity cache after every successful report without allowing delayed writers to replace a newer manifest entry.
- Persist terminal state before cleanup and safely reconcile abandoned retry claims.
- Backfill legacy empty Workflow names and namespaces only from verified live or stored identity.
- Revalidate identity after concurrent insert conflicts and count permanently rejected reports by reason.
- Document the additional Kubernetes identity reads and operational cleanup behavior.

Validation:

- `GOTOOLCHAIN=go1.26.6 go test ./backend/src/apiserver/... -count=1`
- `go list ./backend/... | rg -v 'backend/test/(v2/api|integration|v2/integration|initialization|v2/initialization|compiler|end2end)' | xargs go test -p 1 -count=1`
- `go test ./backend/src/apiserver/storage ./backend/src/apiserver/resource -run 'TestCreateOrUpdateTasksIfRunUnchanged|TestCreateOrUpdateTasksForRun_RejectsTasksAfterRunIDRecreation|TestUpdateRunIfRuntimeManifestsUnchanged' -count=20`
- `go test -race ./backend/src/apiserver/storage ./backend/src/apiserver/resource -run 'TestCreateOrUpdateTasksIfRunUnchanged|TestCreateOrUpdateTasksForRun_RejectsTasksAfterRunIDRecreation|TestUpdateRunIfRuntimeManifestsUnchanged' -count=10`
- `GOTOOLCHAIN=go1.26.6 golangci-lint run --new --new-from-merge-base=upstream/master` with golangci-lint v2.10.1 (`0 issues`)
- `GOTOOLCHAIN=go1.26.6 go vet ./backend/src/apiserver/...`
- `gofmt` and `git diff --check`

The affected behavior and fix were already public in [herikwebb/pipelines#122](https://github.com/herikwebb/pipelines/pull/122).

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request follows the repository title convention.
