### PR TITLE
fix(frontend): prevent artifacts from rendering as active content

### DIFF
--- a/frontend/server/app.test.ts
+++ b/frontend/server/app.test.ts
@@ -519,6 +519,71 @@ describe('UIServer apis', () => {
     });
   });
 
+  describe('/k8s/pod/logs streamed from the API server', () => {
+    let kfpApiServer: Server;
+
+    afterEach(async () => {
+      if (kfpApiServer) {
+        await new Promise<void>((resolve) => kfpApiServer.close(() => resolve()));
+      }
+    });
+
+    it('forces HTML log responses to download without MIME sniffing', async () => {
+      kfpApiServer = express()
+        .all('/*', (_, res) => {
+          res
+            .status(200)
+            .type('text/html')
+            .set('Content-Disposition', 'inline')
+            .send('<script>window.top.pwned = true</script>');
+        })
+        .listen(0);
+      await waitForListening(kfpApiServer);
+      const address = kfpApiServer.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected mock API server to bind to a TCP port');
+      }
+      app = new UIServer(
+        loadConfigs(argv, {
+          ML_PIPELINE_SERVICE_HOST: 'localhost',
+          ML_PIPELINE_SERVICE_PORT: `${address.port}`,
+          STREAM_LOGS_FROM_SERVER_API: 'true',
+        }),
+      );
+
+      const response = await requests(app.app)
+        .get('/k8s/pod/logs?runid=test-run&podname=test-pod')
+        .expect(200);
+
+      expect(response.headers['content-disposition']).toBe('attachment');
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+      expect(response.headers['content-type']).toBe('text/plain; charset=utf-8');
+    });
+
+    it('hardens proxy errors produced before an upstream response exists', async () => {
+      const unavailableServer = express().listen(0);
+      await waitForListening(unavailableServer);
+      const address = unavailableServer.address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Expected temporary API server to bind to a TCP port');
+      }
+      await new Promise<void>((resolve) => unavailableServer.close(() => resolve()));
+      app = new UIServer(
+        loadConfigs(argv, {
+          ML_PIPELINE_SERVICE_HOST: '127.0.0.1',
+          ML_PIPELINE_SERVICE_PORT: `${address.port}`,
+          STREAM_LOGS_FROM_SERVER_API: 'true',
+        }),
+      );
+
+      const response = await requests(app.app).get('/k8s/pod/logs?runid=test-run&podname=test-pod');
+
+      expect(response.status).toBeGreaterThanOrEqual(500);
+      expect(response.headers['content-disposition']).toBe('attachment');
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+    });
+  });
+
   describe('/k8s/pod/logs with authorization enabled', () => {
     let authServer: Server;
     const authPort = 3004;

--- a/frontend/server/app.ts
+++ b/frontend/server/app.ts
@@ -35,9 +35,22 @@ import { getClusterNameHandler, getProjectIdHandler } from './handlers/gke-metad
 import { getAllowCustomVisualizationsHandler } from './handlers/vis.js';
 import { getIndexHTMLHandler } from './handlers/index-html.js';
 
-import { Server } from 'http';
+import { IncomingMessage, Server } from 'http';
 import { HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS } from './consts.js';
 import registerTensorboardProxy from './handlers/tensorboard-proxy.js';
+
+function hardenPodLogsProxyResponse(proxyRes: IncomingMessage): void {
+  proxyRes.headers['x-content-type-options'] = 'nosniff';
+  proxyRes.headers['content-disposition'] = 'attachment';
+  proxyRes.headers['content-type'] = 'text/plain; charset=utf-8';
+}
+
+const hardenPodLogsProxyRequest: express.Handler = (_req, res, next) => {
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Content-Disposition', 'attachment');
+  res.type('text/plain');
+  next();
+};
 
 function getRegisterHandler(app: Application, basePath: string) {
   return (
@@ -252,12 +265,14 @@ function createUIServer(options: UIConfigs) {
   if (options.artifacts.streamLogsFromServerApi) {
     app.all(
       '/k8s/pod/logs',
+      hardenPodLogsProxyRequest,
       createProxyMiddleware({
         changeOrigin: true,
         on: {
           proxyReq: (proxyReq) => {
             console.log('Proxied log request: ', proxyReq.path);
           },
+          proxyRes: hardenPodLogsProxyResponse,
         },
         headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
         pathRewrite: (pathStr: string, req: any) => {
@@ -286,12 +301,14 @@ function createUIServer(options: UIConfigs) {
   if (options.artifacts.streamLogsFromServerApi) {
     app.all(
       '/k8s/pod/logs',
+      hardenPodLogsProxyRequest,
       createProxyMiddleware({
         changeOrigin: true,
         on: {
           proxyReq: (proxyReq) => {
             console.log('Proxied log request: ', proxyReq.path);
           },
+          proxyRes: hardenPodLogsProxyResponse,
         },
         headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
         pathRewrite: (pathStr: string, req: any) => {

--- a/frontend/server/handlers/artifacts.test.ts
+++ b/frontend/server/handlers/artifacts.test.ts
@@ -12,13 +12,280 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, it, expect } from 'vitest';
-import type { Request } from 'express';
+import { getEventListeners } from 'events';
+import { PassThrough, Writable } from 'stream';
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import type { Client as MinioClient } from 'minio';
 import { resolveArtifactCoordinates } from '../helpers/artifact-coordinates.js';
+import {
+  pipePreviewResponse,
+  sendArtifactError,
+  streamDirectoryAsTarGz,
+  TEST_ONLY,
+  waitForArtifactOperation,
+} from './artifacts.js';
+
+vi.mock('../k8s-helper.js');
 
 function makeRequest(path: string, query: Record<string, unknown> = {}): Request {
   return { path, query } as unknown as Request;
 }
+
+describe('sendArtifactError', () => {
+  it('destroys a committed response so a partial download is not reported as complete', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const response = {
+      headersSent: true,
+      destroy: vi.fn(),
+      end: vi.fn(),
+    } as unknown as Response;
+
+    sendArtifactError(response, 500, 'storage stream failed');
+
+    expect(response.destroy).toHaveBeenCalledOnce();
+    expect(response.end).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      '[artifacts] aborting committed response: storage stream failed',
+    );
+  });
+
+  it('does not attempt to send an error body after a stream destroyed the response', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const response = {
+      headersSent: false,
+      destroyed: true,
+      writableEnded: false,
+      destroy: vi.fn(),
+      status: vi.fn(),
+      type: vi.fn(),
+      send: vi.fn(),
+    } as unknown as Response;
+
+    sendArtifactError(response, 500, 'storage stream failed');
+
+    expect(response.destroy).toHaveBeenCalledOnce();
+    expect(response.status).not.toHaveBeenCalled();
+    expect(response.type).not.toHaveBeenCalled();
+    expect(response.send).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      '[artifacts] aborting committed response: storage stream failed',
+    );
+  });
+});
+
+describe('artifact stream lifecycle', () => {
+  it('removes archive abort listeners after each completed object operation', async () => {
+    const controller = new AbortController();
+
+    for (let index = 0; index < 1000; index++) {
+      await expect(
+        waitForArtifactOperation(Promise.resolve(index), controller.signal),
+      ).resolves.toBe(index);
+      expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+    }
+  });
+
+  it('destroys the upstream preview stream without reporting a client disconnect as an error', async () => {
+    const source = new PassThrough();
+    const response = new PassThrough() as unknown as Response;
+    const onError = vi.fn();
+
+    pipePreviewResponse(source, response, 0, onError);
+    response.destroy();
+
+    await vi.waitFor(() => expect(source.destroyed).toBe(true));
+    expect(onError).not.toHaveBeenCalled();
+    expect(source.destroyed).toBe(true);
+  });
+
+  it('destroys a preview source acquired after the client has already disconnected', () => {
+    const source = new PassThrough();
+    const pipeSource = vi.spyOn(source, 'pipe');
+    const response = new PassThrough() as unknown as Response;
+    const onError = vi.fn();
+    response.destroy();
+
+    pipePreviewResponse(source, response, 0, onError);
+
+    expect(source.destroyed).toBe(true);
+    expect(pipeSource).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('keeps an uncommitted response writable when the first directory object cannot be fetched', async () => {
+    const client = {
+      getObject: vi.fn(async () => {
+        throw new Error('first object unavailable');
+      }),
+      listObjectsV2Query: vi.fn(async () => ({
+        objects: [{ name: 'directory/file.txt', size: 4 }],
+        isTruncated: false,
+        nextContinuationToken: '',
+      })),
+    } as unknown as MinioClient;
+    const response = new PassThrough() as unknown as Response;
+    response.setHeader = vi.fn();
+
+    await expect(
+      streamDirectoryAsTarGz({ bucket: 'ml-pipeline', key: 'directory', client }, response),
+    ).rejects.toThrow('first object unavailable');
+
+    expect(response.destroyed).toBe(false);
+    expect(response.setHeader).not.toHaveBeenCalled();
+  });
+
+  it('settles a directory archive when the client disconnects during an entry', async () => {
+    const objectStream = new PassThrough();
+    const client = {
+      getObject: vi.fn(async () => objectStream),
+      listObjectsV2Query: vi.fn(async () => ({
+        objects: [{ name: 'directory/file.txt', size: 4 }],
+        isTruncated: false,
+        nextContinuationToken: '',
+      })),
+    } as unknown as MinioClient;
+    const response = new PassThrough() as unknown as Response;
+    response.setHeader = vi.fn();
+
+    const archive = streamDirectoryAsTarGz(
+      { bucket: 'ml-pipeline', key: 'directory', client },
+      response,
+    );
+    await vi.waitFor(() => expect(client.getObject).toHaveBeenCalledOnce());
+    response.destroy();
+
+    await expect(archive).rejects.toThrow();
+    expect(objectStream.destroyed).toBe(true);
+  });
+
+  it('does not report a directory archive client disconnect as a server error', async () => {
+    const objectStream = new PassThrough();
+    const client = {
+      getObject: vi
+        .fn()
+        .mockRejectedValueOnce(Object.assign(new Error('not found'), { code: 'NoSuchKey' }))
+        .mockResolvedValueOnce(objectStream),
+      listObjectsV2Query: vi.fn(async () => ({
+        objects: [{ name: 'directory/file.txt', size: 4 }],
+        isTruncated: false,
+        nextContinuationToken: '',
+      })),
+    } as unknown as MinioClient;
+    const response = new PassThrough() as unknown as Response;
+    response.setHeader = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    consoleError.mockClear();
+    const handler = TEST_ONLY.getMinioArtifactHandler({
+      bucket: 'ml-pipeline',
+      key: 'directory',
+      client,
+      tryExtract: false,
+    });
+
+    const handling = handler({} as Request, response);
+    await vi.waitFor(() => expect(client.getObject).toHaveBeenCalledTimes(2));
+    response.destroy();
+
+    await expect(handling).resolves.toBeUndefined();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(objectStream.destroyed).toBe(true);
+  });
+
+  it('does not report a disconnect during the final archive flush as a server error', async () => {
+    const objectStream = new PassThrough();
+    let finalResponseWrite: (() => void) | undefined;
+    let responseWriteCount = 0;
+    const client = {
+      getObject: vi
+        .fn()
+        .mockRejectedValueOnce(Object.assign(new Error('not found'), { code: 'NoSuchKey' }))
+        .mockResolvedValueOnce(objectStream),
+      listObjectsV2Query: vi.fn(async () => ({
+        objects: [{ name: 'directory/file.txt', size: 4 }],
+        isTruncated: false,
+        nextContinuationToken: '',
+      })),
+    } as unknown as MinioClient;
+    const response = new Writable({
+      write(_chunk, _encoding, callback) {
+        responseWriteCount += 1;
+        if (responseWriteCount === 1) {
+          callback();
+        } else {
+          finalResponseWrite = callback;
+        }
+      },
+    }) as unknown as Response;
+    response.setHeader = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    consoleError.mockClear();
+    const handler = TEST_ONLY.getMinioArtifactHandler({
+      bucket: 'ml-pipeline',
+      key: 'directory',
+      client,
+      tryExtract: false,
+    });
+
+    const handling = handler({} as Request, response);
+    await vi.waitFor(() => expect(client.getObject).toHaveBeenCalledTimes(2));
+    objectStream.end('data');
+    await vi.waitFor(() => expect(finalResponseWrite).toBeDefined());
+    response.destroy();
+
+    await expect(handling).resolves.toBeUndefined();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('closes a directory object stream returned after the client disconnects', async () => {
+    const objectStream = new PassThrough();
+    let resolveObject: ((stream: PassThrough) => void) | undefined;
+    const client = {
+      getObject: vi.fn(
+        () =>
+          new Promise<PassThrough>((resolve) => {
+            resolveObject = resolve;
+          }),
+      ),
+      listObjectsV2Query: vi.fn(async () => ({
+        objects: [{ name: 'directory/file.txt', size: 4 }],
+        isTruncated: false,
+        nextContinuationToken: '',
+      })),
+    } as unknown as MinioClient;
+    const response = new PassThrough() as unknown as Response;
+    response.setHeader = vi.fn();
+
+    const archive = streamDirectoryAsTarGz(
+      { bucket: 'ml-pipeline', key: 'directory', client },
+      response,
+    );
+    await vi.waitFor(() => expect(client.getObject).toHaveBeenCalledOnce());
+    response.destroy();
+
+    await expect(archive).rejects.toThrow();
+    resolveObject?.(objectStream);
+    await vi.waitFor(() => expect(objectStream.destroyed).toBe(true));
+  });
+
+  it('settles when the client disconnects while the initial directory listing is pending', async () => {
+    const client = {
+      getObject: vi.fn(),
+      listObjectsV2Query: vi.fn(() => new Promise(() => undefined)),
+    } as unknown as MinioClient;
+    const response = new PassThrough() as unknown as Response;
+    response.setHeader = vi.fn();
+
+    const archive = streamDirectoryAsTarGz(
+      { bucket: 'ml-pipeline', key: 'directory', client },
+      response,
+    );
+    response.destroy();
+
+    await expect(archive).rejects.toThrow('closed before archive streaming started');
+    expect(client.getObject).not.toHaveBeenCalled();
+  });
+});
 
 describe('resolveArtifactCoordinates', () => {
   describe('path-based routes', () => {

--- a/frontend/server/handlers/artifacts.ts
+++ b/frontend/server/handlers/artifacts.ts
@@ -27,8 +27,12 @@ import {
   listObjectsUnderPrefix,
   summarizeDirectoryUnderPrefix,
 } from '../minio-helper.js';
+import type { MinioRequestConfig } from '../minio-helper.js';
 import * as tar from 'tar-stream';
 import * as zlib from 'zlib';
+import type { IncomingMessage } from 'http';
+import { Readable } from 'stream';
+import { pipeline as pipelinePromise } from 'stream/promises';
 import * as serverInfo from '../helpers/server-info.js';
 import { Handler, Request, Response, NextFunction } from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
@@ -64,6 +68,8 @@ interface ArtifactsQueryStrings {
   /** optional provider info to use to query object store */
   providerInfo?: string;
   namespace?: string;
+  /** return the artifact byte-for-byte without archive extraction */
+  download?: string;
 }
 
 type ArtifactSource = ArtifactsQueryStrings['source'];
@@ -76,6 +82,7 @@ const ARTIFACT_QUERY_PARAMETER_NAMES = [
   'providerInfo',
   'namespace',
   'peek',
+  'download',
 ] as const;
 
 export interface S3ProviderInfo {
@@ -98,6 +105,104 @@ export interface GCSProviderInfo {
     secretName?: string;
     tokenKey?: string;
   };
+}
+
+function hardenArtifactResponse(response: Response): void {
+  response.setHeader('X-Content-Type-Options', 'nosniff');
+  response.setHeader('Content-Disposition', 'attachment');
+}
+
+const SAFE_ARTIFACT_PROXY_RESPONSE_HEADERS = new Set([
+  'accept-ranges',
+  'content-encoding',
+  'content-length',
+  'content-range',
+  'etag',
+  'last-modified',
+]);
+
+function hardenArtifactProxyResponse(proxyResponse: IncomingMessage): void {
+  const contentDisposition = hardenUpstreamContentDisposition(
+    proxyResponse.headers['content-disposition'],
+  );
+  for (const header of Object.keys(proxyResponse.headers)) {
+    if (!SAFE_ARTIFACT_PROXY_RESPONSE_HEADERS.has(header.toLowerCase())) {
+      delete proxyResponse.headers[header];
+    }
+  }
+  proxyResponse.headers['content-type'] = 'application/octet-stream';
+  proxyResponse.headers['x-content-type-options'] = 'nosniff';
+  proxyResponse.headers['content-disposition'] = contentDisposition;
+}
+
+export function sendArtifactError(response: Response, status: number, message: string): void {
+  // A stream may fail after successful response headers have already been
+  // committed. Express cannot change the status or MIME type at that point,
+  // so abort the connection. Ending it normally would emit a valid terminating
+  // chunk and make a truncated artifact indistinguishable from a complete one.
+  if (response.headersSent || response.destroyed || response.writableEnded) {
+    console.error(`[artifacts] aborting committed response: ${message}`);
+    response.destroy();
+    return;
+  }
+  hardenArtifactResponse(response);
+  response.status(status).type('text/plain').send(message);
+}
+
+export function pipePreviewResponse(
+  source: Readable,
+  response: Response,
+  peek: number,
+  onError: (error: Error) => void,
+): void {
+  const preview = new PreviewStream({ peek });
+  if (response.destroyed || response.writableEnded) {
+    source.destroy();
+    preview.destroy();
+    return;
+  }
+  let failed = false;
+  const cleanup = () => {
+    source.off('error', failOnce);
+    preview.off('error', failOnce);
+    response.off('error', failOnce);
+    response.off('close', failOnPrematureClose);
+    response.off('finish', cleanup);
+  };
+  const failOnce = (error: Error) => {
+    if (failed) {
+      return;
+    }
+    failed = true;
+    cleanup();
+    source.unpipe(preview);
+    preview.unpipe(response);
+    source.destroy();
+    preview.destroy();
+    onError(error);
+  };
+  const failOnPrematureClose = () => {
+    if (!response.writableFinished) {
+      // The peer has already gone away, so there is no response left to repair
+      // and no storage failure to report. Stop upstream work without routing a
+      // routine client cancellation through the server-error logger.
+      if (failed) {
+        return;
+      }
+      failed = true;
+      cleanup();
+      source.unpipe(preview);
+      preview.unpipe(response);
+      source.destroy();
+      preview.destroy();
+    }
+  };
+  source.once('error', failOnce);
+  preview.once('error', failOnce);
+  response.once('error', failOnce);
+  response.once('close', failOnPrematureClose);
+  response.once('finish', cleanup);
+  source.pipe(preview).pipe(response);
 }
 
 /**
@@ -147,9 +252,10 @@ export function getArtifactsAuthMiddleware(
   envoyAddress?: string,
 ): Handler {
   return async (request: Request, response: Response, next: NextFunction) => {
+    hardenArtifactResponse(response);
     const queryError = validateArtifactQueryParameters(request.query);
     if (queryError) {
-      response.status(queryError.status).send(queryError.message);
+      sendArtifactError(response, queryError.status, queryError.message);
       return;
     }
 
@@ -162,13 +268,17 @@ export function getArtifactsAuthMiddleware(
       console.warn(
         `[SECURITY] Unauthenticated artifact access attempt. Path: ${request.originalUrl}`,
       );
-      response.status(401).send('Authentication required for artifact access');
+      sendArtifactError(response, 401, 'Authentication required for artifact access');
       return;
     }
 
     const namespaceParameter = getOptionalRequestString(request.query.namespace, 'namespace');
     if ('error' in namespaceParameter) {
-      response.status(namespaceParameter.error.status).send(namespaceParameter.error.message);
+      sendArtifactError(
+        response,
+        namespaceParameter.error.status,
+        namespaceParameter.error.message,
+      );
       return;
     }
     const namespace = namespaceParameter.value;
@@ -178,7 +288,11 @@ export function getArtifactsAuthMiddleware(
         `[SECURITY] Missing namespace parameter. ` +
           `User: ${userId}, Path: ${request.originalUrl}`,
       );
-      response.status(400).send('Namespace parameter is required when authentication is enabled');
+      sendArtifactError(
+        response,
+        400,
+        'Namespace parameter is required when authentication is enabled',
+      );
       return;
     }
 
@@ -188,7 +302,7 @@ export function getArtifactsAuthMiddleware(
           `User: ${userId}, ` +
           `Namespace: ${namespace}, Path: ${request.originalUrl}`,
       );
-      response.status(400).send('Invalid namespace format');
+      sendArtifactError(response, 400, 'Invalid namespace format');
       return;
     }
 
@@ -208,7 +322,7 @@ export function getArtifactsAuthMiddleware(
           `Namespace: ${namespace}, Path: ${request.originalUrl}, ` +
           `Reason: ${authError.message}`,
       );
-      response.status(403).send(authError.message);
+      sendArtifactError(response, 403, authError.message);
       return;
     }
 
@@ -219,7 +333,7 @@ export function getArtifactsAuthMiddleware(
           `[SECURITY] Malformed percent-encoding in artifact path. ` +
             `User: ${userId}, Path: ${request.path}`,
         );
-        response.status(400).send('Malformed URL encoding in artifact path');
+        sendArtifactError(response, 400, 'Malformed URL encoding in artifact path');
         return;
       }
       const mlmdTrackedSources = new Set(['minio', 's3', 'gcs', 'http', 'https']);
@@ -236,7 +350,7 @@ export function getArtifactsAuthMiddleware(
               `URI: ${artifactUri}, ` +
               `Path: ${request.path}`,
           );
-          response.status(403).send('Artifact does not belong to the requested namespace');
+          sendArtifactError(response, 403, 'Artifact does not belong to the requested namespace');
           return;
         }
       }
@@ -252,7 +366,9 @@ export function getArtifactsAuthMiddleware(
  * @param artifactsConfigs configs to retrieve the artifacts from the various backend.
  * @param useParameter get bucket and key from parameter instead of query. When true, expect
  *    to be used in a route like `/artifacts/:source/:bucket/*`.
- * @param tryExtract whether the handler try to extract content from *.tar.gz files.
+ * @param tryExtract whether preview responses may extract content from *.tar.gz files.
+ * Download routes pass false so S3 and MinIO archives are returned byte-for-byte
+ * with an attachment filename; preview routes may extract the first tar entry.
  */
 export function getArtifactsHandler({
   artifactsConfigs,
@@ -272,18 +388,32 @@ export function getArtifactsHandler({
 }): Handler {
   const { aws, http, minio, allowedDomain } = artifactsConfigs;
   return async (req, res) => {
+    // Security: artifact bytes are untrusted, user-controlled content. Set the
+    // hardening headers before parsing so every early error and storage path is
+    // protected. Inline previews use fetch(), which ignores Content-Disposition.
+    hardenArtifactResponse(res);
     const artifactRequest = parseArtifactRequest(req, useParameter, options.server.serverNamespace);
     if ('error' in artifactRequest) {
-      res.status(artifactRequest.error.status).send(artifactRequest.error.message);
+      sendArtifactError(res, artifactRequest.error.status, artifactRequest.error.message);
       return;
     }
-    const { source, bucket, key, peek, providerInfo, namespace } = artifactRequest;
+    const { source, bucket, key, peek, providerInfo, namespace, download } = artifactRequest;
+    const keyBaseName = key.replace(/\/+$/, '').split('/').pop() || 'artifact';
+    const setArtifactFilename = (transformed: boolean) => {
+      res.setHeader(
+        'Content-Disposition',
+        buildAttachmentDisposition(transformed ? 'artifact' : keyBaseName),
+      );
+    };
+    if (source !== 'minio' && source !== 's3') {
+      setArtifactFilename(false);
+    }
     if (!isAllowedResourceName(bucket)) {
-      res.status(500).send('Invalid bucket name');
+      sendArtifactError(res, 500, 'Invalid bucket name');
       return;
     }
     if (key.length > 1024) {
-      res.status(500).send('Object key too long');
+      sendArtifactError(res, 500, 'Object key too long');
       return;
     }
     console.log(`Getting storage artifact at: ${source}: ${bucket}/${key}`);
@@ -318,13 +448,14 @@ export function getArtifactsHandler({
           peek,
           effectiveProviderInfo,
           namespace,
+          useParameter || download,
         )(req, res);
         break;
       case 'minio':
         try {
           client = await createMinioClient(minio, 'minio', effectiveProviderInfo, namespace);
         } catch (e) {
-          res.status(500).send(`Failed to initialize Minio Client for Minio Provider: ${e}`);
+          sendArtifactError(res, 500, `Failed to initialize Minio Client for Minio Provider: ${e}`);
           return;
         }
         await getMinioArtifactHandler(
@@ -332,7 +463,8 @@ export function getArtifactsHandler({
             bucket,
             client,
             key,
-            tryExtract,
+            tryExtract: tryExtract && !download,
+            onTransformationDetermined: setArtifactFilename,
           },
           peek,
         )(req, res);
@@ -341,7 +473,7 @@ export function getArtifactsHandler({
         try {
           client = await createMinioClient(aws, 's3', effectiveProviderInfo, namespace);
         } catch (e) {
-          res.status(500).send(`Failed to initialize Minio Client for S3 Provider: ${e}`);
+          sendArtifactError(res, 500, `Failed to initialize Minio Client for S3 Provider: ${e}`);
           return;
         }
         await getMinioArtifactHandler(
@@ -349,6 +481,8 @@ export function getArtifactsHandler({
             bucket,
             client,
             key,
+            tryExtract: tryExtract && !download,
+            onTransformationDetermined: setArtifactFilename,
           },
           peek,
         )(req, res);
@@ -357,13 +491,13 @@ export function getArtifactsHandler({
       case 'https': {
         const httpUrl = getHttpUrl(source, http.baseUrl || '', bucket, key);
         if (!httpUrl) {
-          res
-            .status(400)
-            .send(
-              http.baseUrl.trim()
-                ? 'Invalid HTTP artifact path'
-                : 'HTTP artifact base URL is not configured',
-            );
+          sendArtifactError(
+            res,
+            400,
+            http.baseUrl.trim()
+              ? 'Invalid HTTP artifact path'
+              : 'HTTP artifact base URL is not configured',
+          );
           return;
         }
         await getHttpArtifactsHandler(allowedDomain, httpUrl, http.auth, peek)(req, res);
@@ -379,7 +513,7 @@ export function getArtifactsHandler({
         )(req, res);
         break;
       default:
-        res.status(500).send('Unknown storage source');
+        sendArtifactError(res, 500, 'Unknown storage source');
         return;
     }
   };
@@ -393,6 +527,7 @@ type ArtifactRequest =
       peek: number;
       providerInfo: string;
       namespace: string;
+      download: boolean;
     }
   | { error: { status: number; message: string } };
 
@@ -446,6 +581,14 @@ function parseArtifactRequest(
     return peek;
   }
 
+  const download = getOptionalRequestString(req.query.download, 'download');
+  if ('error' in download) {
+    return download;
+  }
+  if (download.value !== undefined && download.value !== 'true' && download.value !== 'false') {
+    return { error: { status: 400, message: 'download must be true or false when provided' } };
+  }
+
   return {
     source: source.value,
     bucket: bucket.value,
@@ -453,6 +596,7 @@ function parseArtifactRequest(
     peek: parsePeekValue(peek.value),
     providerInfo: providerInfo.value ?? '',
     namespace: namespace.value ?? defaultNamespace,
+    download: download.value === 'true',
   };
 }
 
@@ -572,7 +716,7 @@ function getHttpArtifactsHandler(
     for (let hop = 0; ; hop++) {
       const allowedUrl = parseAllowedHttpArtifactUrl(currentUrl, allowedDomain);
       if (!allowedUrl) {
-        res.status(500).send(`Domain not allowed.`);
+        sendArtifactError(res, 500, 'Domain not allowed.');
         return;
       }
       if (new URL(allowedUrl).origin !== credentialOrigin) {
@@ -594,7 +738,7 @@ function getHttpArtifactsHandler(
         await response.body.cancel().catch(() => undefined);
       }
       if (hop >= maxRedirects) {
-        res.status(500).send('Too many redirects while retrieving artifact');
+        sendArtifactError(res, 500, 'Too many redirects while retrieving artifact');
         return;
       }
       // An allowed host can hand back a malformed Location header; resolve it
@@ -603,20 +747,19 @@ function getHttpArtifactsHandler(
       try {
         currentUrl = new URL(location, allowedUrl).toString();
       } catch {
-        res.status(500).send('Invalid redirect location while retrieving artifact');
+        sendArtifactError(res, 500, 'Invalid redirect location while retrieving artifact');
         return;
       }
     }
     if (!response.body) {
-      res.status(500).send('Unable to retrieve artifact: empty response body');
+      sendArtifactError(res, 500, 'Unable to retrieve artifact: empty response body');
       return;
     }
     const { Readable } = await import('stream');
     const nodeStream = Readable.fromWeb(response.body as any);
-    nodeStream
-      .on('error', (err: Error) => res.status(500).send(`Unable to retrieve artifact: ${err}`))
-      .pipe(new PreviewStream({ peek }))
-      .pipe(res);
+    pipePreviewResponse(nodeStream, res, peek, (err) =>
+      sendArtifactError(res, 500, `Unable to retrieve artifact: ${err}`),
+    );
   };
 }
 
@@ -635,56 +778,53 @@ function parseAllowedHttpArtifactUrl(url: string, allowedDomain: string): string
   }
 }
 
-function getMinioArtifactHandler(
-  options: { bucket: string; key: string; client: MinioClient; tryExtract?: boolean },
-  peek: number = 0,
-) {
+function getMinioArtifactHandler(options: MinioRequestConfig, peek: number = 0) {
   return async (_: Request, res: Response) => {
-    try {
-      const stream = await getObjectStream(options);
-      stream
-        .on('error', (err) => res.status(500).send(`Failed to get object in bucket: ${err}`))
-        .pipe(new PreviewStream({ peek }))
-        .pipe(res);
-    } catch (err) {
+    let handlingError = false;
+    const handleObjectFailure = async (err: unknown) => {
+      if (handlingError) {
+        return;
+      }
+      handlingError = true;
       // In KFP v2, output artifacts may be directories (prefixes) rather than
       // single objects. Fall back to packaging the contents of the prefix as
       // a .tar.gz so users can still download them. See
-      // https://github.com/kubeflow/pipelines/issues/7809
-      if (isNoSuchKeyError(err)) {
+      // https://github.com/kubeflow/pipelines/issues/7809. A provider can
+      // surface NoSuchKey either by rejecting getObject or by emitting it on
+      // the returned stream, so both paths converge here.
+      if (isNoSuchKeyError(err) && !res.headersSent) {
         if (peek > 0) {
-          // Preview request (e.g. the run details panel calls
-          // Apis.readFile with a small peek size). We must not stream a
-          // full directory archive here — that would list every object
-          // under the prefix and gzip the whole tree just to render a few
-          // KB of inline text. Instead, answer with a small text summary
-          // backed by one capped ListObjectsV2 call: cost stays bounded
-          // (one round trip, <1KB body) and the user sees that the
-          // artifact is a directory with N files.
           try {
             await previewDirectorySummary(options, res);
-            return;
           } catch (summaryErr) {
             console.error(summaryErr);
-            res.status(500).send(`Failed to summarize directory: ${summaryErr}`);
-            return;
+            sendArtifactError(res, 500, `Failed to summarize directory: ${summaryErr}`);
           }
+          return;
         }
         try {
           await streamDirectoryAsTarGz(options, res);
-          return;
         } catch (tarErr) {
-          console.error(tarErr);
-          if (!res.headersSent) {
-            res.status(500).send(`Failed to get object in bucket: ${tarErr}`);
-          } else {
-            res.end();
+          if (tarErr instanceof ArtifactResponseClosedError) {
+            return;
           }
-          return;
+          console.error(tarErr);
+          sendArtifactError(res, 500, `Failed to get object in bucket: ${tarErr}`);
         }
+        return;
       }
       console.error(err);
-      res.status(500).send(`Failed to get object in bucket: ${err}`);
+      sendArtifactError(res, 500, `Failed to get object in bucket: ${err}`);
+    };
+
+    try {
+      const stream = await getObjectStream({
+        ...options,
+        onError: (err) => void handleObjectFailure(err),
+      });
+      pipePreviewResponse(stream, res, peek, (err) => void handleObjectFailure(err));
+    } catch (err) {
+      await handleObjectFailure(err);
     }
   };
 }
@@ -698,7 +838,7 @@ async function previewDirectorySummary(
   const prefix = key.endsWith('/') ? key : `${key}/`;
   const summary = await summarizeDirectoryUnderPrefix(client, bucket, prefix);
   if (!summary) {
-    res.status(404).send(`No objects found at ${bucket}/${key}`);
+    sendArtifactError(res, 404, `No objects found at ${bucket}/${key}`);
     return;
   }
   const baseName = key.replace(/\/+$/, '').split('/').pop() || 'artifact';
@@ -708,30 +848,78 @@ async function previewDirectorySummary(
     .send(`Directory artifact "${baseName}" — ${countLabel} file(s). Download to view contents.\n`);
 }
 
-async function streamDirectoryAsTarGz(
+class ArtifactResponseClosedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ArtifactResponseClosedError';
+  }
+}
+
+export async function streamDirectoryAsTarGz(
   options: { bucket: string; key: string; client: MinioClient },
   res: Response,
 ) {
   const { bucket, key, client } = options;
   // Trailing slash so prefix "foo" doesn't also match sibling key "foobar".
   const prefix = key.endsWith('/') ? key : `${key}/`;
-
-  // Peek the first object before sending headers so an empty prefix can still
-  // produce a 404 instead of an empty 200 tarball.
-  const iterator = listObjectsUnderPrefix(client, bucket, prefix);
-  const first = await iterator.next();
-  if (first.done) {
-    res.status(404).send(`No objects found at ${bucket}/${key}`);
-    return;
+  let pack: ReturnType<typeof tar.pack> | undefined;
+  let responseComplete: Promise<void> | undefined;
+  const archiveAbort = new AbortController();
+  const abortArchive = (error: Error) => {
+    if (!archiveAbort.signal.aborted) {
+      archiveAbort.abort(error);
+    }
+  };
+  const abortOnPrematureClose = () => {
+    if (!res.writableFinished) {
+      abortArchive(
+        new ArtifactResponseClosedError(
+          pack
+            ? 'Artifact response closed before archive streaming completed'
+            : 'Artifact response closed before archive streaming started',
+        ),
+      );
+    }
+  };
+  if (res.destroyed) {
+    abortArchive(
+      new ArtifactResponseClosedError('Artifact response closed before archive streaming started'),
+    );
+  } else {
+    res.once('close', abortOnPrematureClose);
   }
-
+  const iterator = listObjectsUnderPrefix(client, bucket, prefix, archiveAbort.signal);
   const baseName = key.replace(/\/+$/, '').split('/').pop() || 'artifact';
-  res.setHeader('Content-Type', 'application/gzip');
-  res.setHeader('Content-Disposition', buildAttachmentDisposition(`${baseName}.tar.gz`));
 
-  const pack = tar.pack();
-  const gzip = zlib.createGzip();
-  pack.pipe(gzip).pipe(res);
+  const startArchiveResponse = () => {
+    if (pack && responseComplete) {
+      return { pack, responseComplete };
+    }
+    res.setHeader('Content-Type', 'application/gzip');
+    res.setHeader('Content-Disposition', buildAttachmentDisposition(`${baseName}.tar.gz`));
+    pack = tar.pack();
+    const gzip = zlib.createGzip();
+    responseComplete = pipelinePromise(pack, gzip, res);
+    // Observe the archive pipeline exactly once. Per-entry operations wait on
+    // the abort signal below and remove their listener as soon as they settle;
+    // attaching every entry to this archive-lifetime promise would retain two
+    // pending promise reactions per object until the whole archive completed.
+    void responseComplete.then(
+      () => undefined,
+      (error) => {
+        abortArchive(error);
+        pack?.destroy(error);
+      },
+    );
+    return { pack, responseComplete };
+  };
+
+  const getObjectWhileResponseOpen = async (name: string) => {
+    const objectRequest = client.getObject(bucket, name);
+    return waitForArtifactOperation(objectRequest, archiveAbort.signal, (lateStream) =>
+      lateStream.destroy(),
+    );
+  };
 
   const writeEntry = async ({ name, size }: { name: string; size: number }) => {
     const relativeName = name.startsWith(prefix) ? name.slice(prefix.length) : name;
@@ -741,22 +929,113 @@ async function streamDirectoryAsTarGz(
       // sanitize to an empty path.
       return;
     }
-    const objStream = await client.getObject(bucket, name);
-    await new Promise<void>((resolve, reject) => {
-      const entry = pack.entry({ name: safeName, size }, (err) => (err ? reject(err) : resolve()));
-      objStream.on('error', reject);
+    // Resolve the first object before starting the response pipeline. If that
+    // lookup fails, the caller can still return a well-formed HTTP error
+    // instead of discovering that pipeline teardown already destroyed res.
+    const objStream = await getObjectWhileResponseOpen(name);
+    const archive = startArchiveResponse();
+    const entryComplete = new Promise<void>((resolve, reject) => {
+      const entry = archive.pack.entry({ name: safeName, size }, (err) =>
+        err ? reject(err) : resolve(),
+      );
+      objStream.once('error', reject);
       objStream.pipe(entry);
     });
+    try {
+      await waitForArtifactOperation(entryComplete, archiveAbort.signal);
+    } catch (error) {
+      objStream.destroy();
+      throw error;
+    }
   };
 
   try {
+    // Peek the first object before sending headers so an empty prefix can still
+    // produce a 404 instead of an empty 200 tarball. The iterator shares the
+    // response lifecycle signal, including while a listing page is pending.
+    const first = await iterator.next();
+    if (first.done) {
+      sendArtifactError(res, 404, `No objects found at ${bucket}/${key}`);
+      return;
+    }
     await writeEntry(first.value);
     for await (const item of iterator) {
       await writeEntry(item);
     }
+    const archive = startArchiveResponse();
+    archive.pack.finalize();
+    await archive.responseComplete;
+  } catch (error) {
+    const abortReason =
+      archiveAbort.signal.aborted && archiveAbort.signal.reason instanceof Error
+        ? archiveAbort.signal.reason
+        : undefined;
+    pack?.destroy(error as Error);
+    await responseComplete?.catch(() => undefined);
+    throw abortReason ?? error;
   } finally {
-    pack.finalize();
+    res.off('close', abortOnPrematureClose);
   }
+}
+
+/**
+ * Wait for one bounded artifact operation while sharing a single archive
+ * lifecycle signal. The listener is explicitly removed when the operation
+ * settles so a large directory cannot retain one archive-lifetime promise
+ * reaction per object.
+ */
+export function waitForArtifactOperation<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+  onLateSuccess?: (value: T) => void,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener('abort', rejectOnAbort);
+    const rejectOnAbort = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new Error('Artifact archive operation was aborted'),
+      );
+    };
+
+    if (signal.aborted) {
+      rejectOnAbort();
+    } else {
+      signal.addEventListener('abort', rejectOnAbort, { once: true });
+    }
+
+    void operation.then(
+      (value) => {
+        if (settled) {
+          try {
+            onLateSuccess?.(value);
+          } catch {
+            // The response is already gone; best-effort cleanup must not
+            // create a new unhandled rejection.
+          }
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+    );
+  });
 }
 
 // Builds a `Content-Disposition: attachment` header that is safe to pass to
@@ -779,6 +1058,40 @@ function buildAttachmentDisposition(filename: string): string {
     (c) => '%' + c.charCodeAt(0).toString(16).toUpperCase(),
   );
   return `attachment; filename="${asciiFallback}"; filename*=UTF-8''${rfc5987Encoded}`;
+}
+
+function hardenUpstreamContentDisposition(value: string | string[] | undefined): string {
+  const disposition = Array.isArray(value) ? value[0] : value;
+  if (!disposition) {
+    return 'attachment';
+  }
+
+  const extended = /filename\*\s*=\s*([^'\s;]+)'[^']*'([^;\r\n]*)/i.exec(disposition);
+  if (extended) {
+    try {
+      const charset = extended[1].toLowerCase();
+      const encoded = extended[2];
+      if (charset === 'utf-8' || charset === 'utf8') {
+        return buildAttachmentDisposition(decodeURIComponent(encoded));
+      }
+      if (charset === 'iso-8859-1' || charset === 'latin1') {
+        if (/%(?![0-9a-f]{2})/i.test(encoded)) {
+          throw new Error('Malformed extended filename');
+        }
+        const decoded = encoded.replace(/%([0-9a-f]{2})/gi, (_, hex: string) =>
+          String.fromCharCode(Number.parseInt(hex, 16)),
+        );
+        return buildAttachmentDisposition(decoded);
+      }
+    } catch {
+      // Fall through to the legacy filename or a bare attachment.
+    }
+  }
+
+  const quoted = /filename\s*=\s*"((?:\\.|[^"\\])*)"/i.exec(disposition)?.[1];
+  const token = /filename\s*=\s*([^;\s\r\n]+)/i.exec(disposition)?.[1];
+  const filename = quoted?.replace(/\\(["\\])/g, '$1') ?? token;
+  return filename ? buildAttachmentDisposition(filename) : 'attachment';
 }
 
 // Sanitizes an object key into a safe relative POSIX path for inclusion in a
@@ -828,18 +1141,18 @@ async function parseGCSProviderInfo(
   }
 }
 
-async function readGCSObjectText(
+async function readGCSObject(
   bucket: string,
   objectName: string,
   client: GCSClient,
   credentials?: CredentialBody,
-): Promise<string> {
+): Promise<Buffer> {
   const stream = await downloadGCSObjectStream({ bucket, objectName, credentials, client });
   const chunks: Buffer[] = [];
   for await (const chunk of stream) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
-  return Buffer.concat(chunks).toString();
+  return Buffer.concat(chunks);
 }
 
 function getGCSArtifactHandler(
@@ -847,6 +1160,7 @@ function getGCSArtifactHandler(
   peek: number = 0,
   providerInfoString?: string,
   namespace?: string,
+  isDownloadRoute: boolean = false,
 ) {
   const { key, bucket } = options;
   return async (_: Request, res: Response) => {
@@ -856,7 +1170,11 @@ function getGCSArtifactHandler(
         const providerInfo = parseJSONString<GCSProviderInfo>(providerInfoString);
         if (providerInfo && providerInfo.Params.fromEnv === 'false') {
           if (!namespace) {
-            res.status(500).send('Failed to parse provider info. Reason: No namespace provided');
+            sendArtifactError(
+              res,
+              500,
+              'Failed to parse provider info. Reason: No namespace provided',
+            );
             return;
           } else {
             credentials = await parseGCSProviderInfo(providerInfo, namespace);
@@ -888,11 +1206,10 @@ function getGCSArtifactHandler(
 
       if (!matchingFiles.length) {
         console.log('No matching files found.');
-        res.send();
+        res.type('text/plain').send();
         return;
       }
       console.log(`Found ${matchingFiles.length} matching files: `, matchingFiles.join(','));
-      let contents = '';
       // TODO: support peek for concatenated matching files
       if (peek) {
         const stream = await downloadGCSObjectStream({
@@ -901,17 +1218,34 @@ function getGCSArtifactHandler(
           credentials,
           objectName: matchingFiles[0],
         });
-        stream.pipe(new PreviewStream({ peek })).pipe(res);
+        res.type('text/plain');
+        pipePreviewResponse(stream, res, peek, (err) =>
+          sendArtifactError(res, 500, 'Failed to download GCS file(s). Error: ' + err),
+        );
         return;
       }
 
-      // if not peeking, iterate and append all the files
-      for (const fileName of matchingFiles) {
-        contents += (await readGCSObjectText(bucket, fileName, client, credentials)).trim() + '\n';
+      if (isDownloadRoute) {
+        const contents: Buffer[] = [];
+        for (const fileName of matchingFiles) {
+          contents.push(await readGCSObject(bucket, fileName, client, credentials));
+        }
+        // Keep path-based downloads untyped and byte-preserving. Artifact
+        // bytes are untrusted and may not be text; attachment + nosniff
+        // provides the response hardening.
+        res.end(Buffer.concat(contents));
+        return;
       }
-      res.send(contents);
+
+      // Preview wildcard matches are intentionally joined as trimmed text.
+      let contents = '';
+      for (const fileName of matchingFiles) {
+        contents +=
+          (await readGCSObject(bucket, fileName, client, credentials)).toString().trim() + '\n';
+      }
+      res.type('text/plain').send(contents);
     } catch (err) {
-      res.status(500).send('Failed to download GCS file(s). Error: ' + err);
+      sendArtifactError(res, 500, 'Failed to download GCS file(s). Error: ' + err);
     }
   };
 }
@@ -922,12 +1256,12 @@ function getVolumeArtifactsHandler(options: { bucket: string; key: string }, pee
     try {
       const [pod, err] = await serverInfo.getHostPod();
       if (err) {
-        res.status(500).send(err);
+        sendArtifactError(res, 500, String(err));
         return;
       }
 
       if (!pod) {
-        res.status(500).send('Could not get server pod');
+        sendArtifactError(res, 500, 'Could not get server pod');
         return;
       }
 
@@ -940,18 +1274,18 @@ function getVolumeArtifactsHandler(options: { bucket: string; key: string }, pee
       });
       if (parseError) {
         console.log(`Failed to open volume: ${parseError}`);
-        res.status(404).send(`Failed to open volume.`);
+        sendArtifactError(res, 404, 'Failed to open volume.');
         return;
       }
 
       if (!volumeMountPath) {
-        res.status(404).send(`Failed to open volume.`);
+        sendArtifactError(res, 404, 'Failed to open volume.');
         return;
       }
       const [fileHandle, containmentError] = await openFileWithinRoot(filePath, volumeMountPath);
       if (containmentError || !fileHandle) {
         console.log(`Failed to open volume: ${containmentError?.message || 'unknown error'}`);
-        res.status(containmentError?.pathEscaped ? 404 : 500).send(`Failed to open volume.`);
+        sendArtifactError(res, containmentError?.pathEscaped ? 404 : 500, 'Failed to open volume.');
         return;
       }
 
@@ -960,23 +1294,25 @@ function getVolumeArtifactsHandler(options: { bucket: string; key: string }, pee
         const stat = await fileHandle.stat();
         if (stat.isDirectory()) {
           await fileHandle.close();
-          res
-            .status(400)
-            .send(`Failed to open volume file ${filePath} is directory, does not support now`);
+          sendArtifactError(
+            res,
+            400,
+            `Failed to open volume file ${filePath} is directory, does not support now`,
+          );
           return;
         }
 
-        fileHandle
-          .createReadStream({ autoClose: true })
-          .pipe(new PreviewStream({ peek }))
-          .pipe(res);
+        const stream = fileHandle.createReadStream({ autoClose: true });
+        pipePreviewResponse(stream, res, peek, (error) =>
+          sendArtifactError(res, 500, `Failed to open volume: ${error}`),
+        );
       } catch (error) {
         await fileHandle.close().catch(() => undefined);
         throw error;
       }
     } catch (err) {
       console.log(`Failed to open volume: ${err}`);
-      res.status(500).send(`Failed to open volume.`);
+      sendArtifactError(res, 500, 'Failed to open volume.');
     }
   };
 }
@@ -1030,10 +1366,43 @@ export function getArtifactsProxyHandler({
       proxyReq: (proxyReq) => {
         console.log('Proxied artifact request: ', proxyReq.path);
       },
+      // http-proxy-middleware copies upstream headers after this outer handler
+      // starts. Rewrite the proxy response itself so a tenant-side artifact
+      // service cannot replace the attachment guard with `inline` or remove
+      // nosniff while returning active HTML.
+      proxyRes: hardenArtifactProxyResponse,
     },
     pathRewrite: (pathStr, _req) => {
       const url = new URL(pathStr || '', DUMMY_BASE_PATH);
       url.searchParams.delete(QUERIES.NAMESPACE);
+      const source = url.searchParams.getAll('source');
+      const bucket = url.searchParams.getAll('bucket');
+      const key = url.searchParams.getAll('key');
+      const download = url.searchParams.getAll('download');
+      if (
+        url.pathname.endsWith('/artifacts/get') &&
+        source.length === 1 &&
+        bucket.length === 1 &&
+        key.length === 1 &&
+        download.length === 1 &&
+        download[0] === 'true'
+      ) {
+        // Keep the browser-facing request query-based so URL parsers cannot
+        // normalize object-key dot segments. At the final trusted proxy hop,
+        // translate it to the legacy download route understood by old tenant
+        // artifact services during rolling upgrades. Encoding the complete key
+        // as one path segment also keeps embedded slashes and dot segments inert
+        // until Express decodes the wildcard parameter in the tenant service.
+        url.searchParams.delete('source');
+        url.searchParams.delete('bucket');
+        url.searchParams.delete('key');
+        url.searchParams.delete('download');
+        const artifactPath = url.pathname.slice(0, -'get'.length);
+        return (
+          `${artifactPath}${encodeURIComponent(source[0])}/${encodeURIComponent(bucket[0])}/` +
+          `${encodeURIComponent(key[0])}${url.search}`
+        );
+      }
       return url.pathname + url.search;
     },
     router: (req) => {
@@ -1053,9 +1422,10 @@ export function getArtifactsProxyHandler({
     headers: HACK_FIX_HPM_PARTIAL_RESPONSE_HEADERS,
   });
   return (req, res, next) => {
+    hardenArtifactResponse(res);
     const namespace = getNamespaceFromUrl(req.url || '');
     if (namespace && !isAllowedResourceName(namespace)) {
-      res.status(400).send('Invalid namespace');
+      sendArtifactError(res, 400, 'Invalid namespace');
       return;
     }
     proxy(req, res, next);
@@ -1080,3 +1450,7 @@ const DUMMY_BASE_PATH = 'http://dummy-base-path';
 export function getArtifactServiceGetter({ serviceName, servicePort }: ArtifactsProxyConfig) {
   return (namespace: string) => `http://${serviceName}.${namespace}:${servicePort}`;
 }
+
+export const TEST_ONLY = {
+  getMinioArtifactHandler,
+};

--- a/frontend/server/handlers/pod-logs.test.ts
+++ b/frontend/server/handlers/pod-logs.test.ts
@@ -1,0 +1,179 @@
+// Copyright 2026 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { Request, Response } from 'express';
+import { PassThrough } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthorizeFn } from '../helpers/auth.js';
+
+const getPodLogsStream = vi.fn();
+
+vi.mock('../workflow-helper.js', () => ({
+  composePodLogsStreamHandler: vi.fn(() => getPodLogsStream),
+  createPodLogsMinioRequestConfig: vi.fn(),
+  getPodLogsStreamFromK8s: vi.fn(),
+  getPodLogsStreamFromWorkflow: vi.fn(),
+  toGetPodLogsStream: vi.fn(),
+}));
+
+import { getPodLogsHandler } from './pod-logs.js';
+
+function makeHandler() {
+  return getPodLogsHandler(
+    {
+      archiveArtifactory: 'minio',
+      archiveBucketName: '',
+      archiveLogs: false,
+      artifactRepositoriesLookup: false,
+      keyFormat: '',
+    },
+    {
+      aws: { endPoint: 's3.amazonaws.com' },
+      minio: { endPoint: 'minio-service.kubeflow' },
+    },
+    'main',
+    vi.fn() as unknown as AuthorizeFn,
+    false,
+  );
+}
+
+function makeRequest(): Request {
+  return {
+    query: { podname: 'pod-1' },
+  } as unknown as Request;
+}
+
+function makeResponse() {
+  const response = new PassThrough() as PassThrough & Response;
+  response.setHeader = vi.fn();
+  response.type = vi.fn(() => response);
+  response.status = vi.fn(() => response);
+  response.send = vi.fn(() => response);
+  response.destroy = vi.fn(() => response) as typeof response.destroy;
+  return response;
+}
+
+describe('getPodLogsHandler stream failures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('serves pod logs as a plain-text attachment with MIME sniffing disabled', async () => {
+    const logs = new PassThrough();
+    getPodLogsStream.mockResolvedValue(logs);
+    const response = makeResponse();
+
+    await makeHandler()(makeRequest(), response, vi.fn());
+
+    expect(response.setHeader).toHaveBeenCalledWith('X-Content-Type-Options', 'nosniff');
+    expect(response.setHeader).toHaveBeenCalledWith('Content-Disposition', 'attachment');
+    expect(response.type).toHaveBeenCalledWith('text/plain');
+    logs.end();
+  });
+
+  it('destroys a committed response when archived logs fail mid-stream', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const logs = new PassThrough();
+    const destroyLogs = vi.spyOn(logs, 'destroy');
+    getPodLogsStream.mockResolvedValue(logs);
+    const response = makeResponse();
+    Object.defineProperty(response, 'headersSent', { configurable: true, value: true });
+
+    await makeHandler()(makeRequest(), response, vi.fn());
+    logs.emit('error', new Error('storage connection reset'));
+
+    await vi.waitFor(() => expect(response.destroy).toHaveBeenCalledOnce());
+    expect(destroyLogs).toHaveBeenCalledOnce();
+    expect(response.status).not.toHaveBeenCalled();
+    expect(response.send).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      '[pod-logs] aborting committed response:',
+      expect.any(Error),
+    );
+  });
+
+  it('destroys the archived log stream when the client disconnects', async () => {
+    const logs = new PassThrough();
+    const destroyLogs = vi.spyOn(logs, 'destroy');
+    getPodLogsStream.mockResolvedValue(logs);
+    const response = makeResponse();
+
+    await makeHandler()(makeRequest(), response, vi.fn());
+    response.emit('close');
+
+    expect(destroyLogs).toHaveBeenCalledOnce();
+    expect(response.status).not.toHaveBeenCalled();
+    expect(response.send).not.toHaveBeenCalled();
+  });
+
+  it('destroys an archived log stream acquired after the client has disconnected', async () => {
+    const logs = new PassThrough();
+    const destroyLogs = vi.spyOn(logs, 'destroy');
+    const pipeLogs = vi.spyOn(logs, 'pipe');
+    let resolveLogs: ((stream: PassThrough) => void) | undefined;
+    getPodLogsStream.mockImplementation(
+      () =>
+        new Promise<PassThrough>((resolve) => {
+          resolveLogs = resolve;
+        }),
+    );
+    const response = makeResponse();
+
+    const handling = makeHandler()(makeRequest(), response, vi.fn());
+    await vi.waitFor(() => expect(getPodLogsStream).toHaveBeenCalledOnce());
+    Object.defineProperty(response, 'destroyed', { configurable: true, value: true });
+    response.emit('close');
+    resolveLogs?.(logs);
+    await handling;
+
+    expect(destroyLogs).toHaveBeenCalledOnce();
+    expect(pipeLogs).not.toHaveBeenCalled();
+    expect(response.status).not.toHaveBeenCalled();
+    expect(response.send).not.toHaveBeenCalled();
+  });
+
+  it('returns a 404 when an archive lookup fails before headers are sent', async () => {
+    const logs = new PassThrough();
+    getPodLogsStream.mockResolvedValue(logs);
+    const response = makeResponse();
+    Object.defineProperty(response, 'headersSent', { configurable: true, value: false });
+
+    await makeHandler()(makeRequest(), response, vi.fn());
+    logs.destroy(new Error('Unable to find pod log archive information'));
+
+    await vi.waitFor(() => expect(response.status).toHaveBeenCalledWith(404));
+    expect(response.send).toHaveBeenCalledWith('pod not found');
+    expect(response.destroy).not.toHaveBeenCalled();
+  });
+
+  it('reports a storage failure emitted before the request listener is attached', async () => {
+    const streamError = new Error('immediate storage failure');
+    const logs = new PassThrough();
+    logs.on('error', () => undefined);
+    logs.destroy(streamError);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    getPodLogsStream.mockResolvedValue(logs);
+    const response = makeResponse();
+    Object.defineProperty(response, 'headersSent', { configurable: true, value: false });
+    const pipeLogs = vi.spyOn(logs, 'pipe');
+
+    await makeHandler()(makeRequest(), response, vi.fn());
+
+    expect(response.status).toHaveBeenCalledWith(500);
+    expect(response.send).toHaveBeenCalledWith(
+      'Could not get main container logs: Error: immediate storage failure',
+    );
+    expect(pipeLogs).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/server/handlers/pod-logs.ts
+++ b/frontend/server/handlers/pod-logs.ts
@@ -79,6 +79,10 @@ export function getPodLogsHandler(
   );
 
   return async (req, res) => {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('Content-Disposition', 'attachment');
+    res.type('text/plain');
+
     if (!req.query.podname) {
       res.status(400).send('podname argument is required');
       return;
@@ -120,7 +124,28 @@ export function getPodLogsHandler(
 
     try {
       const stream = await getPodLogsStream(podName, createdAt, podNamespace);
-      stream.on('error', (err) => {
+      if (res.destroyed || res.writableEnded) {
+        stream.destroy();
+        return;
+      }
+      let settled = false;
+      const cleanup = () => {
+        stream.off('error', failOnce);
+        stream.off('end', finishOnce);
+        res.off('close', stopOnPrematureClose);
+      };
+      const failOnce = (err: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        stream.destroy();
+        if (res.headersSent) {
+          console.error('[pod-logs] aborting committed response:', err);
+          res.destroy();
+          return;
+        }
         if (
           err?.message &&
           err.message?.indexOf('Unable to find pod log archive information') > -1
@@ -129,9 +154,39 @@ export function getPodLogsHandler(
         } else {
           res.status(500).send('Could not get main container logs: ' + err);
         }
-      });
-      stream.on('end', () => res.end());
-      stream.pipe(res);
+      };
+      const finishOnce = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        res.end();
+      };
+      const stopOnPrematureClose = () => {
+        if (settled || res.writableFinished) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        stream.destroy();
+      };
+      stream.once('error', failOnce);
+      stream.once('end', finishOnce);
+      res.once('close', stopOnPrematureClose);
+
+      // getObjectStream starts its pipeline before returning. A fast storage
+      // failure can therefore precede this request-specific listener; inspect
+      // the terminal state after attaching it so no event can fall in between.
+      if (stream.errored) {
+        failOnce(stream.errored);
+        return;
+      }
+      if (stream.destroyed) {
+        failOnce(new Error('Pod log stream closed before response streaming started'));
+        return;
+      }
+      stream.pipe(res, { end: false });
     } catch (err) {
       res.status(500).send('Could not get main container logs: ' + err);
     }

--- a/frontend/server/integration-tests/artifact-auth.test.ts
+++ b/frontend/server/integration-tests/artifact-auth.test.ts
@@ -179,7 +179,7 @@ describe('/artifacts authorization', () => {
       expect(response.text).toContain('Authentication required');
     });
 
-    it.each(['source', 'bucket', 'key', 'providerInfo', 'namespace', 'peek'])(
+    it.each(['source', 'bucket', 'key', 'providerInfo', 'namespace', 'peek', 'download'])(
       'rejects duplicate %s parameters before authorization',
       async (parameterName) => {
         const configurations = loadConfigs(argv, {
@@ -207,6 +207,7 @@ describe('/artifacts authorization', () => {
           providerInfo: '{}',
           namespace: 'my-namespace',
           peek: '10',
+          download: 'true',
         });
         query.append(parameterName, 'duplicate');
         const response = await request
@@ -214,6 +215,9 @@ describe('/artifacts authorization', () => {
           .set('kubeflow-userid', 'user@example.com')
           .expect(400);
         expect(response.text).toContain(`${parameterName} must be a single string value`);
+        expect(response.headers['content-type']).toMatch(/^text\/plain/);
+        expect(response.headers['content-disposition']).toBe('attachment');
+        expect(response.headers['x-content-type-options']).toBe('nosniff');
         expect(mockedFetch).not.toHaveBeenCalled();
         expect(mockedValidateArtifactNamespace).not.toHaveBeenCalled();
       },

--- a/frontend/server/integration-tests/artifact-get.test.ts
+++ b/frontend/server/integration-tests/artifact-get.test.ts
@@ -102,14 +102,155 @@ describe('/artifacts', () => {
       });
     });
 
+    it('treats download=false as preview mode', async () => {
+      app = new UIServer(loadConfigs(argv, {}));
+
+      await requests(app.app)
+        .get('/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt&download=false')
+        .expect(200, artifactContent);
+    });
+
+    it('preserves standalone dot segments in query-based download keys', async () => {
+      const getObject = vi.fn(async () => {
+        const objectStream = new PassThrough();
+        objectStream.end(artifactContent);
+        return objectStream;
+      });
+      const mockedMinioClient = MinioClient as any;
+      mockedMinioClient.mockImplementation(function () {
+        return { getObject };
+      });
+      app = new UIServer(loadConfigs(argv, {}));
+
+      await requests(app.app)
+        .get(
+          '/artifacts/get?source=minio&bucket=ml-pipeline&key=reports%2F..%2F.%2Fsecret.txt&download=true',
+        )
+        .expect(200, artifactContent);
+
+      expect(getObject).toHaveBeenCalledWith('ml-pipeline', 'reports/.././secret.txt');
+    });
+
+    it('returns archives byte-for-byte in query-based download mode', async () => {
+      const tarGzBuffer = Buffer.from(
+        'H4sIAFa7DV4AA+3PSwrCMBRG4Y5dxV1BuSGPridgwcItkTZSl++johNBJ0WE803OIHfwZ87j0fq2nmuzGVVNIcitXYqPpntXLojzSb33MToVdTG5rhHdbtLLaa55uk5ZBrMhj23ty9u7T+/rT+TZP3HozYosZbL97tdbAAAAAAAAAAAAAAAAAADfuwAyiYcHACgAAA==',
+        'base64',
+      );
+      const mockedMinioClient = MinioClient as any;
+      mockedMinioClient.mockImplementation(function () {
+        return {
+          getObject: async () => {
+            const objectStream = new PassThrough();
+            objectStream.end(tarGzBuffer);
+            return objectStream;
+          },
+        };
+      });
+      app = new UIServer(loadConfigs(argv, {}));
+
+      const response = await requests(app.app)
+        .get(
+          '/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.tar.gz&download=true',
+        )
+        .expect(200, tarGzBuffer.toString());
+
+      expect(response.headers['content-disposition']).toBe(
+        'attachment; filename="world.tar.gz"; filename*=UTF-8\'\'world.tar.gz',
+      );
+    });
+
     it('rejects artifact requests with multi-valued query parameters', async () => {
       const configs = loadConfigs(argv, {});
       app = new UIServer(configs);
 
       const request = requests(app.app);
-      await request
+      const response = await request
         .get('/artifacts/get?source=minio&source=s3&bucket=ml-pipeline&key=hello%2Fworld.txt')
         .expect(400, 'source must be a single string value');
+      expect(response.headers['content-type']).toMatch(/^text\/plain/);
+      expect(response.headers['content-disposition']).toBe('attachment');
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+    });
+
+    it('serves raw artifacts with hardening headers so they cannot render on the UI origin (security)', async () => {
+      // Artifact bytes are untrusted user content. An HTML artifact opened via
+      // the same-origin "View" link must download, not execute as a document in
+      // the KFP UI session (stored XSS). The raw single-object response must be
+      // a non-renderable type, non-sniffable, and marked as an attachment.
+      const configs = loadConfigs(argv, {
+        MINIO_ACCESS_KEY: 'minio',
+        MINIO_HOST: 'seaweedfs',
+        MINIO_NAMESPACE: 'kubeflow',
+        MINIO_PORT: '9000',
+        MINIO_SECRET_KEY: 'minio123',
+        MINIO_SSL: 'false',
+      });
+      app = new UIServer(configs);
+
+      const request = requests(app.app);
+      const res = await request
+        .get('/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.txt')
+        .expect(200);
+      expect(res.headers['x-content-type-options']).toBe('nosniff');
+      expect(res.headers['content-disposition']).toBe(
+        'attachment; filename="world.txt"; filename*=UTF-8\'\'world.txt',
+      );
+    });
+
+    it('does not label an extracted tar member with the source archive filename', async () => {
+      artifactContent = Buffer.from(
+        'H4sIAFa7DV4AA+3PSwrCMBRG4Y5dxV1BuSGPridgwcItkTZSl++johNBJ0WE803OIHfwZ87j0fq2nmuzGVVNIcitXYqPpntXLojzSb33MToVdTG5rhHdbtLLaa55uk5ZBrMhj23ty9u7T+/rT+TZP3HozYosZbL97tdbAAAAAAAAAAAAAAAAAADfuwAyiYcHACgAAA==',
+        'base64',
+      );
+      const mockedMinioClient = MinioClient as any;
+      mockedMinioClient.mockImplementation(function () {
+        return {
+          getObject: async () => {
+            const objectStream = new PassThrough();
+            objectStream.end(artifactContent);
+            return objectStream;
+          },
+        };
+      });
+      const configs = loadConfigs(argv, {});
+      app = new UIServer(configs);
+
+      const response = await requests(app.app)
+        .get('/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.tar.gz')
+        .expect(200, 'hello world\n');
+
+      expect(response.headers['content-disposition']).toBe(
+        'attachment; filename="artifact"; filename*=UTF-8\'\'artifact',
+      );
+      expect(response.headers['content-disposition']).not.toContain('world.tar.gz');
+    });
+
+    it('does not label an extracted uncompressed tar member with the archive filename', async () => {
+      const tarGzBuffer = Buffer.from(
+        'H4sIAFa7DV4AA+3PSwrCMBRG4Y5dxV1BuSGPridgwcItkTZSl++johNBJ0WE803OIHfwZ87j0fq2nmuzGVVNIcitXYqPpntXLojzSb33MToVdTG5rhHdbtLLaa55uk5ZBrMhj23ty9u7T+/rT+TZP3HozYosZbL97tdbAAAAAAAAAAAAAAAAAADfuwAyiYcHACgAAA==',
+        'base64',
+      );
+      artifactContent = zlib.gunzipSync(tarGzBuffer);
+      const mockedMinioClient = MinioClient as any;
+      mockedMinioClient.mockImplementation(function () {
+        return {
+          getObject: async () => {
+            const objectStream = new PassThrough();
+            objectStream.end(artifactContent);
+            return objectStream;
+          },
+        };
+      });
+      const configs = loadConfigs(argv, {});
+      app = new UIServer(configs);
+
+      const response = await requests(app.app)
+        .get('/artifacts/get?source=minio&bucket=ml-pipeline&key=hello%2Fworld.tar')
+        .expect(200, 'hello world\n');
+
+      expect(response.headers['content-disposition']).toBe(
+        'attachment; filename="artifact"; filename*=UTF-8\'\'artifact',
+      );
     });
 
     it('responds with artifact if source is AWS S3, and creds are sourced from Env', async () => {
@@ -587,6 +728,26 @@ describe('/artifacts', () => {
       });
     });
 
+    it('preserves a raw HTTP archive filename because HTTP responses are not extracted', async () => {
+      mockedFetch.mockImplementationOnce(() =>
+        Promise.resolve({
+          body: toWebStream('raw archive bytes'),
+        }),
+      );
+      const configs = loadConfigs(argv, {
+        HTTP_BASE_URL: 'foo.bar/',
+      });
+      app = new UIServer(configs);
+
+      const response = await requests(app.app)
+        .get('/artifacts/get?source=http&bucket=ml-pipeline&key=hello%2Fworld.gz')
+        .expect(200, 'raw archive bytes');
+
+      expect(response.headers['content-disposition']).toBe(
+        'attachment; filename="world.gz"; filename*=UTF-8\'\'world.gz',
+      );
+    });
+
     it('rejects http artifacts with a request-controlled host and default allowlist', async () => {
       mockedFetch.mockClear();
       const configs = loadConfigs(argv, {});
@@ -726,6 +887,9 @@ describe('/artifacts', () => {
         .get('/artifacts/get?source=http&bucket=ml-pipeline&key=hello%2Fworld.txt')
         .expect(500);
       expect(res.text).toBe('Domain not allowed.');
+      expect(res.headers['content-type']).toMatch(/^text\/plain/);
+      expect(res.headers['content-disposition']).toBe('attachment');
+      expect(res.headers['x-content-type-options']).toBe('nosniff');
       expect(res.text).not.toContain('SECRET');
       // The internal target is never fetched.
       expect(mockedFetch).not.toHaveBeenCalledWith(internalUrl, expect.anything());
@@ -962,6 +1126,39 @@ describe('/artifacts', () => {
       });
     });
 
+    it('preserves binary path-based GCS downloads and leaves them untyped', async () => {
+      const mockedGetGCSClient: Mock = getGCSClient as any;
+      const mockedListGCSObjectNames: Mock = listGCSObjectNames as any;
+      const mockedDownloadGCSObjectStream: Mock = downloadGCSObjectStream as any;
+      const client = { request: vi.fn() };
+      const stream = new PassThrough();
+      const artifactContent = Buffer.from([0x20, 0x00, 0xff, 0x0a]);
+      stream.end(artifactContent);
+      mockedGetGCSClient.mockResolvedValueOnce(client);
+      mockedListGCSObjectNames.mockResolvedValueOnce(['hello/world.txt']);
+      mockedDownloadGCSObjectStream.mockResolvedValueOnce(stream);
+      const configs = loadConfigs(argv, {});
+      app = new UIServer(configs);
+
+      const response = await requests(app.app)
+        .get('/artifacts/gcs/ml-pipeline/hello/world.txt')
+        .buffer(true)
+        .parse((incoming, callback) => {
+          const chunks: Buffer[] = [];
+          incoming.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+          incoming.on('end', () => callback(null, Buffer.concat(chunks)));
+          incoming.on('error', callback);
+        })
+        .expect(200);
+
+      expect(response.body).toEqual(artifactContent);
+      expect(response.headers['content-type']).toBeUndefined();
+      expect(response.headers['content-disposition']).toBe(
+        'attachment; filename="world.txt"; filename*=UTF-8\'\'world.txt',
+      );
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
+    });
+
     it('responds with a partial gcs artifact if peek=5 is set', async () => {
       const artifactContent = 'hello world';
       const mockedGetGCSClient: Mock = getGCSClient as any;
@@ -993,6 +1190,26 @@ describe('/artifacts', () => {
         credentials: undefined,
         objectName: 'hello/world.txt',
       });
+    });
+
+    it('returns a controlled error when a GCS preview stream fails', async () => {
+      const mockedGetGCSClient: Mock = getGCSClient as any;
+      const mockedListGCSObjectNames: Mock = listGCSObjectNames as any;
+      const mockedDownloadGCSObjectStream: Mock = downloadGCSObjectStream as any;
+      const client = { request: vi.fn() };
+      mockedGetGCSClient.mockResolvedValueOnce(client);
+      mockedListGCSObjectNames.mockResolvedValueOnce(['hello/world.txt']);
+      mockedDownloadGCSObjectStream.mockImplementationOnce(async () => {
+        const stream = new PassThrough();
+        setImmediate(() => stream.destroy(new Error('storage connection reset')));
+        return stream;
+      });
+      const configs = loadConfigs(argv, {});
+      app = new UIServer(configs);
+
+      await requests(app.app)
+        .get('/artifacts/get?source=gcs&bucket=ml-pipeline&key=hello%2Fworld.txt&peek=5')
+        .expect(500, 'Failed to download GCS file(s). Error: Error: storage connection reset');
     });
 
     it('responds with concatenated gcs artifacts for wildcard keys and reuses one auth client', async () => {
@@ -1364,9 +1581,12 @@ describe('/artifacts', () => {
       app = new UIServer(configs);
 
       const request = requests(app.app);
-      await request
+      const response = await request
         .get(`/artifacts/get?source=volume&bucket=artifact&key=subartifact/notxist.csv`)
         .expect(500, 'Failed to open volume.');
+      expect(response.headers['content-type']).toMatch(/^text\/plain/);
+      expect(response.headers['content-disposition']).toBe('attachment');
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
     });
 
     it('rejects keys longer than 1024 characters', async () => {
@@ -1376,12 +1596,15 @@ describe('/artifacts', () => {
       });
       app = new UIServer(configs);
       const request = requests(app.start());
-      await request
+      const response = await request
         .get(
           '/artifacts/get?source=s3&namespace=test&peek=256&bucket=ml-pipeline&key=' +
             'a'.repeat(1025),
         )
         .expect(500, 'Object key too long');
+      expect(response.headers['content-type']).toMatch(/^text\/plain/);
+      expect(response.headers['content-disposition']).toBe('attachment');
+      expect(response.headers['x-content-type-options']).toBe('nosniff');
     });
 
     // KFP v2 stores some output artifacts as object-store directories
@@ -1471,6 +1694,26 @@ describe('/artifacts', () => {
         });
       }
 
+      it.each([
+        ['directory preview', '&peek=256'],
+        ['directory download', ''],
+      ])('serves an empty %s 404 as plain text', async (_name, querySuffix) => {
+        mockMinioForDirectory({});
+        const configs = loadConfigs(argv, minioConfigEnv);
+        app = new UIServer(configs);
+
+        const request = requests(app.app);
+        const response = await request
+          .get(
+            `/artifacts/get?source=minio&bucket=ml-pipeline&key=%3Cscript%3Ealert(1)%3C%2Fscript%3E${querySuffix}`,
+          )
+          .expect(404);
+
+        expect(response.headers['content-type']).toMatch(/^text\/plain/);
+        expect(response.headers['x-content-type-options']).toBe('nosniff');
+        expect(response.text).toContain('<script>alert(1)</script>');
+      });
+
       it('packages the prefix as a tar.gz when getObject returns NoSuchKey', async () => {
         mockMinioForDirectory({
           'directory/file1.txt': 'first file contents',
@@ -1492,6 +1735,68 @@ describe('/artifacts', () => {
         expect(Array.from(entries.keys()).sort()).toEqual(['file1.txt', 'sub/file2.txt']);
         expect(entries.get('file1.txt')!.toString()).toBe('first file contents');
         expect(entries.get('sub/file2.txt')!.toString()).toBe('second file contents');
+      });
+
+      it('packages the prefix when NoSuchKey is emitted by the object stream', async () => {
+        const files = {
+          'directory/file.txt': 'stream fallback contents',
+        };
+        const getObject = vi.fn(async (_bucket: string, key: string) => {
+          const stream = new PassThrough();
+          if (key === 'directory') {
+            setImmediate(() => stream.destroy(makeNoSuchKeyError()));
+          } else {
+            stream.end(files[key as keyof typeof files]);
+          }
+          return stream;
+        });
+        const listObjectsV2Query = vi.fn(async (_bucket: string, prefix: string) => ({
+          objects: Object.entries(files)
+            .filter(([name]) => name.startsWith(prefix))
+            .map(([name, content]) => ({ name, size: content.length })),
+          isTruncated: false,
+          nextContinuationToken: '',
+        }));
+        const mockedMinioClient = minio.Client as any;
+        mockedMinioClient.mockImplementation(function () {
+          return { getObject, listObjectsV2Query };
+        });
+        const configs = loadConfigs(argv, minioConfigEnv);
+        app = new UIServer(configs);
+
+        const res = await captureBinaryResponse(
+          requests(app.app).get('/artifacts/get?source=minio&bucket=ml-pipeline&key=directory'),
+        ).expect(200);
+        const entries = await readTarGzEntries(res.body as Buffer);
+        expect(entries.get('file.txt')?.toString()).toBe('stream fallback contents');
+      });
+
+      it('returns a 500 when the first object in a directory cannot be fetched', async () => {
+        const getObject = vi.fn(async (_bucket: string, key: string) => {
+          if (key === 'directory') {
+            throw makeNoSuchKeyError();
+          }
+          throw new Error('first directory object unavailable');
+        });
+        const listObjectsV2Query = vi.fn(async () => ({
+          objects: [{ name: 'directory/file.txt', size: 4 }],
+          isTruncated: false,
+          nextContinuationToken: '',
+        }));
+        const mockedMinioClient = minio.Client as any;
+        mockedMinioClient.mockImplementation(function () {
+          return { getObject, listObjectsV2Query };
+        });
+        const configs = loadConfigs(argv, minioConfigEnv);
+        app = new UIServer(configs);
+
+        const response = await requests(app.app)
+          .get('/artifacts/get?source=minio&bucket=ml-pipeline&key=directory')
+          .expect(500);
+
+        expect(response.headers['content-type']).toMatch(/^text\/plain/);
+        expect(response.headers['content-disposition']).toBe('attachment');
+        expect(response.text).toContain('first directory object unavailable');
       });
 
       it('returns a small text summary for preview requests instead of streaming the archive', async () => {
@@ -1703,6 +2008,33 @@ describe('/artifacts', () => {
       await request
         .get('/artifacts/minio/ml-pipeline/hello/world.txt') // url
         .expect(200, tarGzBuffer.toString());
+    });
+
+    it('downloads an S3 tarball as-is with its archive filename', async () => {
+      const tarGzBuffer = Buffer.from(
+        'H4sIAFa7DV4AA+3PSwrCMBRG4Y5dxV1BuSGPridgwcItkTZSl++johNBJ0WE803OIHfwZ87j0fq2nmuzGVVNIcitXYqPpntXLojzSb33MToVdTG5rhHdbtLLaa55uk5ZBrMhj23ty9u7T+/rT+TZP3HozYosZbL97tdbAAAAAAAAAAAAAAAAAADfuwAyiYcHACgAAA==',
+        'base64',
+      );
+      const mockedMinioClient = MinioClient as any;
+      mockedMinioClient.mockImplementation(function () {
+        return {
+          getObject: async () => {
+            const objectStream = new PassThrough();
+            objectStream.end(tarGzBuffer);
+            return objectStream;
+          },
+        };
+      });
+      const configs = loadConfigs(argv, {});
+      app = new UIServer(configs);
+
+      const response = await requests(app.app)
+        .get('/artifacts/s3/ml-pipeline/hello/world.tar.gz')
+        .expect(200, tarGzBuffer.toString());
+
+      expect(response.headers['content-disposition']).toBe(
+        'attachment; filename="world.tar.gz"; filename*=UTF-8\'\'world.tar.gz',
+      );
     });
 
     it('downloads an s3-compatible artifact using secret-backed providerInfo from the query string', async () => {

--- a/frontend/server/integration-tests/artifact-proxy.test.ts
+++ b/frontend/server/integration-tests/artifact-proxy.test.ts
@@ -5,7 +5,7 @@ import requests from 'supertest';
 import { loadConfigs } from '../configs.js';
 import * as minioHelper from '../minio-helper.js';
 import { PassThrough } from 'stream';
-import express from 'express';
+import express, { type RequestHandler } from 'express';
 import { Server } from 'http';
 import * as artifactsHandler from '../handlers/artifacts.js';
 
@@ -39,14 +39,24 @@ describe('/artifacts/get namespaced proxy', () => {
   }
 
   let artifactServerInUserNamespace: Server;
-  async function setUpNamespacedArtifactService({ namespace = 'any-ns' }: { namespace?: string }) {
+  async function setUpNamespacedArtifactService({
+    namespace = 'any-ns',
+    responseHeaders = {},
+    requestHandler,
+  }: {
+    namespace?: string;
+    responseHeaders?: Record<string, string>;
+    requestHandler?: RequestHandler;
+  }) {
     const receivedUrls: string[] = [];
     const artifactService = express();
     const response = `artifact service in ${namespace}`;
-    artifactService.use((req, res) => {
+    artifactService.use((req, res, next) => {
       receivedUrls.push(req.url);
-      res.status(200).send(response);
+      res.set(responseHeaders);
+      next();
     });
+    artifactService.use(requestHandler ?? ((_req, res) => res.status(200).send(response)));
     artifactServerInUserNamespace = await new Promise<Server>((resolve, reject) => {
       const server = artifactService.listen(0, '127.0.0.1', () => resolve(server));
       server.on('error', reject);
@@ -91,14 +101,15 @@ describe('/artifacts/get namespaced proxy', () => {
       ARTIFACTS_SERVICE_PROXY_ENABLED: 'true',
     });
     app = new UIServer(configs);
-    await requests(app.app)
+    const response = await requests(app.app)
       .get(
         `/artifacts/get${buildQuery({
           ...commonParams,
           namespace: 'ns2',
         })}`,
       )
-      .expect(200, 'artifact service in ns2');
+      .expect(200);
+    expect(response.body.toString()).toBe('artifact service in ns2');
     expect(getArtifactServiceGetterSpy).toHaveBeenCalledWith({
       serviceName: 'artifact-svc',
       servicePort: 80,
@@ -107,6 +118,111 @@ describe('/artifacts/get namespaced proxy', () => {
     expect(receivedUrls).toEqual(
       // url is the same, except namespace query is omitted
       ['/artifacts/get?source=minio&bucket=ml-pipeline&key=hello.txt'],
+    );
+  });
+
+  it('overrides unsafe response headers from the namespaced artifact service', async () => {
+    await setUpNamespacedArtifactService({
+      namespace: 'ns2',
+      responseHeaders: {
+        'Content-Disposition': 'inline',
+        'Content-Security-Policy': "default-src 'self'",
+        'Content-Type': 'application/javascript',
+        'Access-Control-Allow-Credentials': 'true',
+        'Access-Control-Allow-Origin': '*',
+        'Clear-Site-Data': '"cookies", "storage"',
+        Link: '</tenant.js>; rel=preload; as=script',
+        Location: 'https://tenant.example/redirect',
+        Refresh: '0; url=https://tenant.example/redirect',
+        'Set-Cookie': 'session=tenant-controlled; Path=/',
+        'X-Tenant-Header': 'unsafe-value',
+        'X-Content-Type-Options': 'unsafe-value',
+      },
+    });
+    const configs = loadConfigs(argv, {
+      ARTIFACTS_SERVICE_PROXY_ENABLED: 'true',
+    });
+    app = new UIServer(configs);
+
+    const response = await requests(app.app)
+      .get(
+        `/artifacts/get${buildQuery({
+          ...commonParams,
+          namespace: 'ns2',
+        })}`,
+      )
+      .expect(200);
+
+    expect(response.headers['content-type']).toBe('application/octet-stream');
+    expect(response.headers['content-disposition']).toBe('attachment');
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.headers['access-control-allow-credentials']).toBeUndefined();
+    expect(response.headers['access-control-allow-origin']).toBeUndefined();
+    expect(response.headers['clear-site-data']).toBeUndefined();
+    expect(response.headers['content-security-policy']).toBeUndefined();
+    expect(response.headers.link).toBeUndefined();
+    expect(response.headers.location).toBeUndefined();
+    expect(response.headers.refresh).toBeUndefined();
+    expect(response.headers['set-cookie']).toBeUndefined();
+    expect(response.headers['x-powered-by']).toBe('Express');
+    expect(response.headers['x-tenant-header']).toBeUndefined();
+  });
+
+  it('preserves a safe proxy download filename while forcing attachment', async () => {
+    await setUpNamespacedArtifactService({
+      namespace: 'ns2',
+      responseHeaders: {
+        'Content-Disposition':
+          'attachment; filename="directory.tar.gz"; filename*=UTF-8\'\'directory.tar.gz',
+      },
+    });
+    const configs = loadConfigs(argv, { ARTIFACTS_SERVICE_PROXY_ENABLED: 'true' });
+    app = new UIServer(configs);
+
+    const response = await requests(app.app)
+      .get(`/artifacts/get${buildQuery({ ...commonParams, namespace: 'ns2' })}`)
+      .expect(200);
+
+    expect(response.headers['content-disposition']).toBe(
+      'attachment; filename="directory.tar.gz"; filename*=UTF-8\'\'directory.tar.gz',
+    );
+  });
+
+  it('preserves RFC 8187 filenames with a language tag', async () => {
+    await setUpNamespacedArtifactService({
+      namespace: 'ns2',
+      responseHeaders: {
+        'Content-Disposition': "attachment; filename*=UTF-8'en'report%20final.csv",
+      },
+    });
+    const configs = loadConfigs(argv, { ARTIFACTS_SERVICE_PROXY_ENABLED: 'true' });
+    app = new UIServer(configs);
+
+    const response = await requests(app.app)
+      .get(`/artifacts/get${buildQuery({ ...commonParams, namespace: 'ns2' })}`)
+      .expect(200);
+
+    expect(response.headers['content-disposition']).toBe(
+      'attachment; filename="report_final.csv"; filename*=UTF-8\'\'report%20final.csv',
+    );
+  });
+
+  it('preserves RFC 8187 ISO-8859-1 filenames', async () => {
+    await setUpNamespacedArtifactService({
+      namespace: 'ns2',
+      responseHeaders: {
+        'Content-Disposition': "attachment; filename*=ISO-8859-1''caf%E9.txt",
+      },
+    });
+    const configs = loadConfigs(argv, { ARTIFACTS_SERVICE_PROXY_ENABLED: 'true' });
+    app = new UIServer(configs);
+
+    const response = await requests(app.app)
+      .get(`/artifacts/get${buildQuery({ ...commonParams, namespace: 'ns2' })}`)
+      .expect(200);
+
+    expect(response.headers['content-disposition']).toBe(
+      'attachment; filename="caf_.txt"; filename*=UTF-8\'\'caf%C3%A9.txt',
     );
   });
 
@@ -120,13 +236,14 @@ describe('/artifacts/get namespaced proxy', () => {
       ARTIFACTS_SERVICE_PROXY_ENABLED: 'true',
     });
     app = new UIServer(configs);
-    await requests(app.app)
+    const response = await requests(app.app)
       .get(
         `/artifacts/minio/ml-pipeline/hello.txt${buildQuery({
           namespace: 'ns2',
         })}`,
       )
-      .expect(200, 'artifact service in ns2');
+      .expect(200);
+    expect(response.body.toString()).toBe('artifact service in ns2');
     expect(getArtifactServiceGetterSpy).toHaveBeenCalledWith({
       serviceName: 'artifact-svc',
       servicePort: 80,
@@ -136,6 +253,66 @@ describe('/artifacts/get namespaced proxy', () => {
       // url is the same, except namespace query is omitted
       ['/artifacts/minio/ml-pipeline/hello.txt'],
     );
+  });
+
+  it('translates query downloads to the legacy tenant route without normalizing keys', async () => {
+    const { receivedUrls } = await setUpNamespacedArtifactService({ namespace: 'ns2' });
+    const configs = loadConfigs(argv, {
+      ARTIFACTS_SERVICE_PROXY_ENABLED: 'true',
+    });
+    app = new UIServer(configs);
+
+    const response = await requests(app.app)
+      .get(
+        `/artifacts/get${buildQuery({
+          ...commonParams,
+          key: 'reports/../secret.txt',
+          namespace: 'ns2',
+          download: 'true',
+        })}`,
+      )
+      .expect(200);
+    expect(response.body.toString()).toBe('artifact service in ns2');
+
+    expect(receivedUrls).toEqual(['/artifacts/minio/ml-pipeline/reports%2F..%2Fsecret.txt']);
+  });
+
+  it('returns raw archives from a previous-version tenant artifact handler', async () => {
+    const rawArchive = Buffer.from('raw archive bytes');
+    const receivedKeys: string[] = [];
+    const previousVersionHandler = express.Router();
+    previousVersionHandler.get('/artifacts/get', (_req, res) => {
+      res.status(200).send('extracted first archive member');
+    });
+    previousVersionHandler.get('/artifacts/:source/:bucket/*', (req, res) => {
+      receivedKeys.push(req.params[0]);
+      res.status(200).end(rawArchive);
+    });
+    const { receivedUrls } = await setUpNamespacedArtifactService({
+      namespace: 'ns2',
+      requestHandler: previousVersionHandler,
+    });
+    const configs = loadConfigs(argv, { ARTIFACTS_SERVICE_PROXY_ENABLED: 'true' });
+    app = new UIServer(configs);
+
+    const response = await requests(app.app)
+      .get(
+        `/artifacts/get${buildQuery({
+          ...commonParams,
+          key: 'archives/run.tar.gz',
+          namespace: 'ns2',
+          providerInfo: '{"Provider":"minio"}',
+          download: 'true',
+        })}`,
+      )
+      .expect(200);
+
+    expect(response.body).toEqual(rawArchive);
+    expect(receivedUrls).toEqual([
+      '/artifacts/minio/ml-pipeline/archives%2Frun.tar.gz' +
+        '?providerInfo=%7B%22Provider%22%3A%22minio%22%7D',
+    ]);
+    expect(receivedKeys).toEqual(['archives/run.tar.gz']);
   });
 
   it('preserves providerInfo when proxying a download request (issue #13717)', async () => {
@@ -148,14 +325,15 @@ describe('/artifacts/get namespaced proxy', () => {
       ARTIFACTS_SERVICE_PROXY_ENABLED: 'true',
     });
     app = new UIServer(configs);
-    await requests(app.app)
+    const response = await requests(app.app)
       .get(
         `/artifacts/s3/mlpipeline/model${buildQuery({
           namespace: 'ns2',
           providerInfo: '{"Provider":"s3"}',
         })}`,
       )
-      .expect(200, 'artifact service in ns2');
+      .expect(200);
+    expect(response.body.toString()).toBe('artifact service in ns2');
     expect(receivedUrls).toEqual(
       // same url, except the namespace query is omitted and providerInfo is kept
       ['/artifacts/s3/mlpipeline/model?providerInfo=%7B%22Provider%22%3A%22s3%22%7D'],
@@ -191,7 +369,7 @@ describe('/artifacts/get namespaced proxy', () => {
     expect(res.text).not.toContain('stack');
   });
 
-  it.each(['source', 'bucket', 'key', 'providerInfo', 'namespace', 'peek'])(
+  it.each(['source', 'bucket', 'key', 'providerInfo', 'namespace', 'peek', 'download'])(
     'rejects ambiguous %s query parameters before proxying',
     async (parameterName) => {
       const { receivedUrls } = await setUpNamespacedArtifactService({ namespace: 'ns-a' });
@@ -206,6 +384,7 @@ describe('/artifacts/get namespaced proxy', () => {
         providerInfo: '{}',
         namespace: 'ns-a',
         peek: '10',
+        download: 'true',
       });
       query.append(parameterName, 'duplicate');
 
@@ -222,14 +401,15 @@ describe('/artifacts/get namespaced proxy', () => {
       ARTIFACTS_SERVICE_PROXY_ENABLED: 'true',
     });
     app = new UIServer(configs);
-    await requests(app.app)
+    const proxiedResponse = await requests(app.app)
       .get(
         `/pipeline/artifacts/get${buildQuery({
           ...commonParams,
           namespace: 'ns-any',
         })}`,
       )
-      .expect(200, response);
+      .expect(200);
+    expect(proxiedResponse.body.toString()).toBe(response);
     expect(receivedUrls).toEqual(
       // url is the same with base path, except namespace query is omitted
       ['/pipeline/artifacts/get?source=minio&bucket=ml-pipeline&key=hello.txt'],

--- a/frontend/server/minio-helper.test.ts
+++ b/frontend/server/minio-helper.test.ts
@@ -253,9 +253,11 @@ describe('minio-helper', () => {
 
       const stream = await getObjectStream({ bucket: 'bucket', key: 'key', client: minioClient });
       expect(mockedMinioGetObject).toBeCalledWith('bucket', 'key');
-      stream.on('finish', () => {
-        expect(stream.read().toString().trim()).toBe('hello world');
-      });
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(Buffer.from(chunk));
+      }
+      expect(Buffer.concat(chunks).toString().trim()).toBe('hello world');
     });
 
     it('unpacks a uncompressed tarball', async () => {
@@ -263,12 +265,68 @@ describe('minio-helper', () => {
       objStream.end(tarBuffer);
       mockedMinioGetObject.mockResolvedValueOnce(Promise.resolve(objStream));
 
-      const stream = await getObjectStream({ bucket: 'bucket', key: 'key', client: minioClient });
-      expect(mockedMinioGetObject).toBeCalledWith('bucket', 'key');
-      stream.on('finish', () => {
-        expect(stream.read().toString().trim()).toBe('hello world');
+      const onTransformationDetermined = vi.fn();
+      const stream = await getObjectStream({
+        bucket: 'bucket',
+        key: 'key',
+        client: minioClient,
+        onTransformationDetermined,
       });
+      expect(mockedMinioGetObject).toBeCalledWith('bucket', 'key');
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(Buffer.from(chunk));
+      }
+      expect(Buffer.concat(chunks).toString().trim()).toBe('hello world');
+      expect(onTransformationDetermined).toHaveBeenCalledWith(true);
     });
+
+    it('reports decompression even when the decompressed object is not a tarball', async () => {
+      const objStream = new PassThrough();
+      objStream.end(zlib.gzipSync(Buffer.from('hello world')));
+      mockedMinioGetObject.mockResolvedValueOnce(Promise.resolve(objStream));
+      const onTransformationDetermined = vi.fn();
+
+      const stream = await getObjectStream({
+        bucket: 'bucket',
+        key: 'key',
+        client: minioClient,
+        onTransformationDetermined,
+      });
+      const chunks: Buffer[] = [];
+      stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      await new Promise<void>((resolve, reject) => {
+        stream.once('end', resolve);
+        stream.once('error', reject);
+      });
+
+      expect(Buffer.concat(chunks).toString()).toBe('hello world');
+      expect(onTransformationDetermined).toHaveBeenCalledWith(true);
+    });
+
+    it.each([0, 6, 9])(
+      'keeps transformation detection aligned with gunzip-maybe for deflate level %i',
+      async (level) => {
+        const objStream = new PassThrough();
+        objStream.end(zlib.deflateSync(Buffer.from('hello world'), { level }));
+        mockedMinioGetObject.mockResolvedValueOnce(Promise.resolve(objStream));
+        const onTransformationDetermined = vi.fn();
+
+        const stream = await getObjectStream({
+          bucket: 'bucket',
+          key: 'key',
+          client: minioClient,
+          onTransformationDetermined,
+        });
+        const chunks: Buffer[] = [];
+        for await (const chunk of stream) {
+          chunks.push(Buffer.from(chunk));
+        }
+
+        expect(Buffer.concat(chunks).toString()).toBe('hello world');
+        expect(onTransformationDetermined).toHaveBeenCalledWith(true);
+      },
+    );
 
     it('returns the content as a stream', async () => {
       const objStream = new PassThrough();
@@ -277,9 +335,49 @@ describe('minio-helper', () => {
 
       const stream = await getObjectStream({ bucket: 'bucket', key: 'key', client: minioClient });
       expect(mockedMinioGetObject).toBeCalledWith('bucket', 'key');
-      stream.on('finish', () => {
-        expect(stream.read().toString().trim()).toBe('hello world');
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(Buffer.from(chunk));
+      }
+      expect(Buffer.concat(chunks).toString().trim()).toBe('hello world');
+    });
+
+    it('forwards errors from the underlying object stream', async () => {
+      const objStream = new PassThrough();
+      mockedMinioGetObject.mockResolvedValueOnce(Promise.resolve(objStream));
+      const stream = await getObjectStream({
+        bucket: 'bucket',
+        key: 'key',
+        client: minioClient,
+        tryExtract: false,
       });
+      const streamError = new Error('storage connection reset');
+      const receivedError = new Promise<Error>((resolve) => stream.once('error', resolve));
+
+      objStream.write('partial artifact');
+      objStream.destroy(streamError);
+
+      await expect(receivedError).resolves.toBe(streamError);
+    });
+
+    it('installs the supplied error handler before the source can fail', async () => {
+      const streamError = new Error('immediate storage failure');
+      mockedMinioGetObject.mockImplementationOnce(async () => {
+        const objStream = new PassThrough();
+        setImmediate(() => objStream.destroy(streamError));
+        return objStream;
+      });
+      const onError = vi.fn();
+
+      await getObjectStream({
+        bucket: 'bucket',
+        key: 'key',
+        client: minioClient,
+        onError,
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(onError).toHaveBeenCalledWith(streamError);
     });
   });
 
@@ -424,6 +522,30 @@ describe('minio-helper', () => {
       const client = {} as unknown as MinioClient;
       const iter = listObjectsUnderPrefix(client, 'bucket', 'p/');
       await expect(iter.next()).rejects.toThrow(/listObjectsV2Query/);
+    });
+
+    it('stops waiting for a paginated listing when its signal is aborted', async () => {
+      const controller = new AbortController();
+      const listObjectsV2Query = vi
+        .fn()
+        .mockResolvedValueOnce({
+          objects: [{ name: 'page1-a', size: 1 }],
+          isTruncated: true,
+          nextContinuationToken: 'tok-1',
+        })
+        .mockImplementationOnce(() => new Promise(() => undefined));
+      const client = { listObjectsV2Query } as unknown as MinioClient;
+      const iter = listObjectsUnderPrefix(client, 'bucket', 'p/', controller.signal);
+
+      await expect(iter.next()).resolves.toEqual({
+        done: false,
+        value: { name: 'page1-a', size: 1 },
+      });
+      const next = iter.next();
+      await vi.waitFor(() => expect(listObjectsV2Query).toHaveBeenCalledTimes(2));
+      controller.abort(new Error('response closed'));
+
+      await expect(next).rejects.toThrow('response closed');
     });
   });
 

--- a/frontend/server/minio-helper.ts
+++ b/frontend/server/minio-helper.ts
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Transform, PassThrough } from 'stream';
+import { Transform, PassThrough, pipeline } from 'stream';
 import * as tar from 'tar-stream';
 import peek from 'peek-stream';
 import gunzip from 'gunzip-maybe';
@@ -28,6 +28,9 @@ export interface MinioRequestConfig {
   key: string;
   client: MinioClient;
   tryExtract?: boolean;
+  /** Receives asynchronous storage or transformation failures from the returned stream. */
+  onError?: (error: Error) => void;
+  onTransformationDetermined?: (transformed: boolean) => void;
 }
 
 /** MinioClientOptionsWithOptionalSecrets wraps around MinioClientOptions where only endPoint is required (accesskey and secretkey are optional). */
@@ -337,12 +340,29 @@ export function isTarball(buf: Buffer) {
  * Returns a stream that extracts the first record of a tarball if the source
  * stream is a tarball, otherwise just pipe the content as is.
  */
-export function maybeTarball(): Transform {
+export function maybeTarball(onExtractionDetermined?: (extracted: boolean) => void): Transform {
   return peek(
     { newline: false, maxBuffer: 264 },
     (data: Buffer, swap: (error?: Error, parser?: Transform) => void) => {
-      if (isTarball(data)) swap(undefined, extractFirstTarRecordAsStream());
+      const extracted = isTarball(data);
+      onExtractionDetermined?.(extracted);
+      if (extracted) swap(undefined, extractFirstTarRecordAsStream());
       else swap(undefined, new PassThrough());
+    },
+  );
+}
+
+function detectCompression(onCompressionDetermined: (compressed: boolean) => void): Transform {
+  return peek(
+    { newline: false, maxBuffer: 3 },
+    (data: Buffer, swap: (error?: Error, parser?: Transform) => void) => {
+      // Keep these signatures aligned with gunzip-maybe's is-gzip and
+      // is-deflate dependencies. The callback controls the response filename,
+      // so its decision must match whether gunzip-maybe transforms the bytes.
+      const gzip = data.length >= 3 && data[0] === 0x1f && data[1] === 0x8b && data[2] === 0x08;
+      const deflate = data.length >= 2 && data[0] === 0x78 && [0x01, 0x9c, 0xda].includes(data[1]);
+      onCompressionDetermined(gzip || deflate);
+      swap(undefined, new PassThrough());
     },
   );
 }
@@ -382,6 +402,9 @@ function extractFirstTarRecordAsStream() {
  * @param param.key Key of the object to retrieve.
  * @param param.client Minio client.
  * @param param.tryExtract Whether we try to extract *.tar.gz, default to true.
+ * @param param.onError Optional asynchronous error callback. The returned
+ * stream also emits the same error; callers that omit this callback must
+ * attach their own listener if they need request-specific recovery.
  *
  */
 export async function getObjectStream({
@@ -389,9 +412,33 @@ export async function getObjectStream({
   key,
   client,
   tryExtract = true,
+  onError,
+  onTransformationDetermined,
 }: MinioRequestConfig): Promise<Transform> {
-  const stream = await client.getObject(bucket, key);
-  return tryExtract ? stream.pipe(gunzip()).pipe(maybeTarball()) : stream.pipe(new PassThrough());
+  const source = await client.getObject(bucket, key);
+  let compressed = false;
+  const output = tryExtract
+    ? maybeTarball((extracted) => onTransformationDetermined?.(compressed || extracted))
+    : new PassThrough();
+  const streams = tryExtract
+    ? [source, detectCompression((value) => (compressed = value)), gunzip(), output]
+    : [source, output];
+  if (!tryExtract) {
+    onTransformationDetermined?.(false);
+  }
+  output.once(
+    'error',
+    onError ?? ((error) => console.error('Artifact object stream failed', error)),
+  );
+  // Readable.pipe() does not forward a source error to its destination. Use
+  // pipeline so storage and decompression failures destroy the returned stream
+  // and reach the artifact handler's abort-on-error listener.
+  pipeline(streams, (error) => {
+    if (error && !output.destroyed) {
+      output.destroy(error);
+    }
+  });
+  return output;
 }
 
 /**
@@ -459,6 +506,7 @@ export async function* listObjectsUnderPrefix(
   client: MinioClient,
   bucket: string,
   prefix: string,
+  signal?: AbortSignal,
 ): AsyncGenerator<{ name: string; size: number }> {
   const PAGE_SIZE = 300;
   const listObjectsV2Query = getListObjectsV2Query(client);
@@ -466,7 +514,11 @@ export async function* listObjectsUnderPrefix(
   let isTruncated = true;
 
   while (isTruncated) {
-    const page = await listObjectsV2Query(bucket, prefix, continuationToken, '', PAGE_SIZE, '');
+    if (signal?.aborted) {
+      throw getMinioAbortReason(signal);
+    }
+    const pageRequest = listObjectsV2Query(bucket, prefix, continuationToken, '', PAGE_SIZE, '');
+    const page = signal ? await waitForMinioOperation(pageRequest, signal) : await pageRequest;
 
     for (const item of page.objects) {
       if (item.name) {
@@ -477,6 +529,50 @@ export async function* listObjectsUnderPrefix(
     isTruncated = page.isTruncated;
     continuationToken = page.nextContinuationToken;
   }
+}
+
+function getMinioAbortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : new Error('MinIO operation was aborted');
+}
+
+function waitForMinioOperation<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener('abort', rejectOnAbort);
+    const rejectOnAbort = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      reject(getMinioAbortReason(signal));
+    };
+
+    if (signal.aborted) {
+      rejectOnAbort();
+    } else {
+      signal.addEventListener('abort', rejectOnAbort, { once: true });
+    }
+
+    void operation.then(
+      (value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        reject(error);
+      },
+    );
+  });
 }
 
 /**

--- a/frontend/src/components/ArtifactPreview.test.tsx
+++ b/frontend/src/components/ArtifactPreview.test.tsx
@@ -81,14 +81,16 @@ describe('ArtifactPreview', () => {
       </CommonTestWrapper>,
     );
     await waitFor(() => screen.getByText('minio://bucket/key'));
-    await waitFor(() =>
-      expect(screen.getByText('View All').getAttribute('href')).toEqual(
-        'artifacts/get?source=minio&namespace=kubeflow&bucket=bucket&key=key',
-      ),
+    const downloadLink = screen.getByRole('link', { name: 'minio://bucket/key' });
+    expect(downloadLink).toHaveAttribute(
+      'href',
+      'artifacts/get?source=minio&namespace=kubeflow&bucket=bucket&key=key&download=true',
     );
+    expect(downloadLink).toHaveAttribute('download');
+    expect(screen.getAllByRole('link')).toHaveLength(1);
   });
 
-  it('carries providerInfo from the session map into download and view links', async () => {
+  it('carries providerInfo from the session map into the download link', async () => {
     vi.spyOn(Apis, 'readFile').mockResolvedValueOnce('s3 content');
     const sessionMap = new Map([['s3://bucket/key', '{"Provider":"s3"}']]);
     render(
@@ -96,14 +98,12 @@ describe('ArtifactPreview', () => {
         <ArtifactPreview value={'s3://bucket/key'} namespace={'kubeflow'} sessionMap={sessionMap} />
       </CommonTestWrapper>,
     );
-    await waitFor(() =>
-      expect(screen.getByText('View All').getAttribute('href')).toEqual(
-        'artifacts/get?source=s3&namespace=kubeflow&providerInfo=%7B%22Provider%22%3A%22s3%22%7D&bucket=bucket&key=key',
-      ),
+    await waitFor(() => screen.getByRole('link', { name: 's3://bucket/key' }));
+    expect(screen.getByRole('link', { name: 's3://bucket/key' })).toHaveAttribute(
+      'href',
+      'artifacts/get?source=s3&namespace=kubeflow&providerInfo=%7B%22Provider%22%3A%22s3%22%7D&bucket=bucket&key=key&download=true',
     );
-    expect(screen.getByText('s3://bucket/key').getAttribute('href')).toEqual(
-      'artifacts/s3/bucket/key?namespace=kubeflow&providerInfo=%7B%22Provider%22%3A%22s3%22%7D',
-    );
+    expect(screen.getAllByRole('link')).toHaveLength(1);
   });
 
   it('handles artifact that previews with maxlines', async () => {

--- a/frontend/src/components/ArtifactPreview.tsx
+++ b/frontend/src/components/ArtifactPreview.tsx
@@ -41,13 +41,6 @@ const css = stylesheet({
     display: 'flex',
     justifyContent: 'space-between',
   },
-  separater: {
-    width: 20, // There's minimum 20px separation between URI and view button.
-    display: 'inline-block',
-  },
-  viewLink: {
-    whiteSpace: 'nowrap',
-  },
 });
 
 export interface ArtifactPreviewProps extends ValueComponentProps<string> {
@@ -98,17 +91,12 @@ const ArtifactPreview: React.FC<ArtifactPreviewProps> = ({
     providerInfo,
     isDownload: true,
   });
-  const artifactViewUrl = Apis.buildReadFileUrl({ path: storage, namespace, providerInfo });
 
   return (
     <div className={css.root}>
       <div className={css.topDiv}>
         <ExternalLink download href={artifactDownloadUrl} title={linkText}>
           {linkText}
-        </ExternalLink>
-        <span className={css.separater} />
-        <ExternalLink href={artifactViewUrl} className={css.viewLink}>
-          View All
         </ExternalLink>
       </div>
       {isError && (

--- a/frontend/src/components/MinioArtifactPreview.test.tsx
+++ b/frontend/src/components/MinioArtifactPreview.test.tsx
@@ -96,23 +96,13 @@ describe('MinioArtifactPreview', () => {
           >
             <a
               class="link_f1fk43bf"
-              href="artifacts/s3/foo/bar"
+              download=""
+              href="artifacts/get?source=s3&bucket=foo&key=bar&download=true"
               rel="noopener"
               target="_blank"
               title="s3://foo/bar"
             >
               s3://foo/bar
-            </a>
-            <span
-              class="separater_f1lhp8th"
-            />
-            <a
-              class="link_f1fk43bf viewLink_fheif50"
-              href="artifacts/get?source=s3&bucket=foo&key=bar"
-              rel="noopener"
-              target="_blank"
-            >
-              View All
             </a>
           </div>
           <div
@@ -153,23 +143,13 @@ describe('MinioArtifactPreview', () => {
           >
             <a
               class="link_f1fk43bf"
-              href="artifacts/minio/foo/bar"
+              download=""
+              href="artifacts/get?source=minio&bucket=foo&key=bar&download=true"
               rel="noopener"
               target="_blank"
               title="minio://foo/bar"
             >
               minio://foo/bar
-            </a>
-            <span
-              class="separater_f1lhp8th"
-            />
-            <a
-              class="link_f1fk43bf viewLink_fheif50"
-              href="artifacts/get?source=minio&bucket=foo&key=bar"
-              rel="noopener"
-              target="_blank"
-            >
-              View All
             </a>
           </div>
           <div
@@ -210,23 +190,13 @@ describe('MinioArtifactPreview', () => {
           >
             <a
               class="link_f1fk43bf"
-              href="artifacts/minio/foo/bar?namespace=namespace"
+              download=""
+              href="artifacts/get?source=minio&namespace=namespace&bucket=foo&key=bar&download=true"
               rel="noopener"
               target="_blank"
               title="minio://foo/bar"
             >
               minio://foo/bar
-            </a>
-            <span
-              class="separater_f1lhp8th"
-            />
-            <a
-              class="link_f1fk43bf viewLink_fheif50"
-              href="artifacts/get?source=minio&namespace=namespace&bucket=foo&key=bar"
-              rel="noopener"
-              target="_blank"
-            >
-              View All
             </a>
           </div>
           <div
@@ -267,23 +237,13 @@ describe('MinioArtifactPreview', () => {
           >
             <a
               class="link_f1fk43bf"
-              href="artifacts/minio/foo/bar"
+              download=""
+              href="artifacts/get?source=minio&bucket=foo&key=bar&download=true"
               rel="noopener"
               target="_blank"
               title="minio://foo/bar"
             >
               minio://foo/bar
-            </a>
-            <span
-              class="separater_f1lhp8th"
-            />
-            <a
-              class="link_f1fk43bf viewLink_fheif50"
-              href="artifacts/get?source=minio&bucket=foo&key=bar"
-              rel="noopener"
-              target="_blank"
-            >
-              View All
             </a>
           </div>
         </div>
@@ -318,23 +278,13 @@ describe('MinioArtifactPreview', () => {
           >
             <a
               class="link_f1fk43bf"
-              href="artifacts/minio/foo/bar"
+              download=""
+              href="artifacts/get?source=minio&bucket=foo&key=bar&download=true"
               rel="noopener"
               target="_blank"
               title="minio://foo/bar"
             >
               minio://foo/bar
-            </a>
-            <span
-              class="separater_f1lhp8th"
-            />
-            <a
-              class="link_f1fk43bf viewLink_fheif50"
-              href="artifacts/get?source=minio&bucket=foo&key=bar"
-              rel="noopener"
-              target="_blank"
-            >
-              View All
             </a>
           </div>
           <div
@@ -380,23 +330,13 @@ describe('MinioArtifactPreview', () => {
           >
             <a
               class="link_f1fk43bf"
-              href="artifacts/minio/foo/bar"
+              download=""
+              href="artifacts/get?source=minio&bucket=foo&key=bar&download=true"
               rel="noopener"
               target="_blank"
               title="minio://foo/bar"
             >
               minio://foo/bar
-            </a>
-            <span
-              class="separater_f1lhp8th"
-            />
-            <a
-              class="link_f1fk43bf viewLink_fheif50"
-              href="artifacts/get?source=minio&bucket=foo&key=bar"
-              rel="noopener"
-              target="_blank"
-            >
-              View All
             </a>
           </div>
           <div
@@ -413,7 +353,7 @@ describe('MinioArtifactPreview', () => {
         </div>
       </div>
     `);
-    expect(queryByText('View All')).toBeTruthy();
+    expect(queryByText('minio://foo/bar')).toBeTruthy();
   });
 
   it('handles artifact that previews with maxbytes', async () => {
@@ -442,23 +382,13 @@ describe('MinioArtifactPreview', () => {
           >
             <a
               class="link_f1fk43bf"
-              href="artifacts/minio/foo/bar"
+              download=""
+              href="artifacts/get?source=minio&bucket=foo&key=bar&download=true"
               rel="noopener"
               target="_blank"
               title="minio://foo/bar"
             >
               minio://foo/bar
-            </a>
-            <span
-              class="separater_f1lhp8th"
-            />
-            <a
-              class="link_f1fk43bf viewLink_fheif50"
-              href="artifacts/get?source=minio&bucket=foo&key=bar"
-              rel="noopener"
-              target="_blank"
-            >
-              View All
             </a>
           </div>
           <div
@@ -476,6 +406,6 @@ describe('MinioArtifactPreview', () => {
         </div>
       </div>
     `);
-    expect(queryByText('View All')).toBeTruthy();
+    expect(queryByText('minio://foo/bar')).toBeTruthy();
   });
 });

--- a/frontend/src/components/MinioArtifactPreview.tsx
+++ b/frontend/src/components/MinioArtifactPreview.tsx
@@ -38,13 +38,6 @@ const css = stylesheet({
     display: 'flex',
     justifyContent: 'space-between',
   },
-  separater: {
-    width: 20, // There's minimum 20px separation between URI and view button.
-    display: 'inline-block',
-  },
-  viewLink: {
-    whiteSpace: 'nowrap',
-  },
 });
 
 /**
@@ -137,19 +130,14 @@ const MinioArtifactPreview: React.FC<MinioArtifactPreviewProps> = ({
     namespace,
     isDownload: true,
   });
-  const artifactViewUrl = Apis.buildReadFileUrl({ path: storagePath, namespace });
 
   // Opens in new window safely
   // TODO use ArtifactLink instead (but it need to support namespace)
   return (
     <div className={css.root}>
       <div className={css.topDiv}>
-        <ExternalLink href={artifactDownloadUrl} title={linkText}>
+        <ExternalLink download href={artifactDownloadUrl} title={linkText}>
           {linkText}
-        </ExternalLink>
-        <span className={css.separater}></span>
-        <ExternalLink href={artifactViewUrl} className={css.viewLink}>
-          View All
         </ExternalLink>
       </div>
       {content?.data && (

--- a/frontend/src/lib/Apis.test.ts
+++ b/frontend/src/lib/Apis.test.ts
@@ -182,8 +182,26 @@ describe('Apis', () => {
         isDownload: true,
       }),
     ).toEqual(
-      'artifacts/s3/testbucket/testkey?namespace=testnamespace&providerInfo=%7B%22Provider%22%3A%22s3%22%7D',
+      'artifacts/get?source=s3&namespace=testnamespace&providerInfo=%7B%22Provider%22%3A%22s3%22%7D&bucket=testbucket&key=testkey&download=true',
     );
+  });
+
+  it('buildReadFileUrl keeps reserved characters and dot segments in the download query', () => {
+    const url = Apis.buildReadFileUrl({
+      path: {
+        bucket: 'testbucket',
+        key: 'reports/.././a?final#100%.csv',
+        source: StorageService.S3,
+      },
+      isDownload: true,
+    });
+
+    expect(url).toEqual(
+      'artifacts/get?source=s3&bucket=testbucket&key=reports%2F..%2F.%2Fa%3Ffinal%23100%25.csv&download=true',
+    );
+    const parsedUrl = new URL(url, 'https://example.test/pipeline/');
+    expect(parsedUrl.pathname).toBe('/pipeline/artifacts/get');
+    expect(parsedUrl.searchParams.get('key')).toBe('reports/.././a?final#100%.csv');
   });
 
   it('buildArtifactLinkText', () => {

--- a/frontend/src/lib/Apis.ts
+++ b/frontend/src/lib/Apis.ts
@@ -346,10 +346,15 @@ export class Apis {
   }) {
     const { source, bucket, key } = path;
     if (isDownload) {
-      return `artifacts/${source}/${bucket}/${key}${buildQuery({
+      // Keep object keys in the query so browsers do not normalize standalone dot path segments.
+      return `artifacts/get${buildQuery({
+        source,
         namespace,
         providerInfo,
         peek,
+        bucket,
+        key,
+        download: 'true',
       })}`;
     } else {
       return `artifacts/get${buildQuery({ source, namespace, providerInfo, peek, bucket, key })}`;

--- a/frontend/src/lib/Utils.test.ts
+++ b/frontend/src/lib/Utils.test.ts
@@ -320,7 +320,7 @@ describe('Utils', () => {
   describe('generateMinioArtifactUrl', () => {
     it('handles minio:// URIs', () => {
       expect(generateMinioArtifactUrl('minio://my-bucket/a/b/c')).toBe(
-        'artifacts/minio/my-bucket/a/b/c',
+        'artifacts/get?source=minio&bucket=my-bucket&key=a%2Fb%2Fc&download=true',
       );
     });
 
@@ -335,7 +335,9 @@ describe('Utils', () => {
 
   describe('generateS3ArtifactUrl', () => {
     it('handles s3:// URIs', () => {
-      expect(generateS3ArtifactUrl('s3://my-bucket/a/b/c')).toBe('artifacts/s3/my-bucket/a/b/c');
+      expect(generateS3ArtifactUrl('s3://my-bucket/a/b/c')).toBe(
+        'artifacts/get?source=s3&bucket=my-bucket&key=a%2Fb%2Fc&download=true',
+      );
     });
   });
 

--- a/manifests/kustomize/README.md
+++ b/manifests/kustomize/README.md
@@ -2,3 +2,12 @@
 
 Kubeflow Pipelines can be installed standalone and as part of the [community distribution](https://github.com/kubeflow/community-distribution).
 [Installation Options for Kubeflow Pipelines](https://www.kubeflow.org/docs/components/pipelines/operator-guides/installation/).
+
+## Artifact download responses
+
+Artifact download routes return S3 and MinIO objects without extracting archive
+contents and force the browser to treat every response as an attachment. Archive
+filenames are preserved when available. Preview routes may still decompress an
+archive and show its first entry, but they use the same download-only response
+hardening; clients should consume the response body instead of relying on browser
+inline rendering.


### PR DESCRIPTION
**Description of your changes:**

**Why:** Artifact and pod-log responses can contain untrusted content. If a browser interprets that content inline, active content can run in the Kubeflow Pipelines UI origin. Interrupted streams can also look like complete downloads, and downloads must remain byte-preserving while central and tenant services are on different versions.

**What:** This change makes those responses download as inert files, preserves safe filenames and original archive bytes, and ensures interrupted storage work fails visibly. Users can still preview and download artifacts normally, including during rolling upgrades, but tenant responses can no longer change browser-wide state through unsafe headers.

Technical details:

- Apply `Content-Disposition: attachment` and `X-Content-Type-Options: nosniff` before handling artifact, proxy, authentication, error, and pod-log responses.
- Allowlist safe tenant response headers, force proxied artifacts to `application/octet-stream`, and sanitize upstream filenames.
- Keep browser download URLs query-based, then translate them at the trusted proxy hop to the legacy raw-download route for old tenant services.
- Preserve binary GCS content and raw S3/MinIO archives without implicit extraction.
- Propagate storage, decompression, archive, volume, and proxy failures through controlled response handling.
- Detect already-failed pod-log streams and cancel upstream streams and directory scans when clients disconnect.
- Use the current `http-proxy-middleware` response hooks for both artifact and pod-log proxies.

Validation with Node.js 24.14.0:

- Full frontend server suite: 435 passed, 2 TODO.
- Full frontend UI suite: 2,071 passed.
- Focused feedback regressions: 63 server tests passed.
- Focused affected UI tests: 97 passed.
- Frontend production build passed, including ESLint and TypeScript.
- Frontend server TypeScript build passed.
- Prettier and `git diff --check` passed.

The affected behavior and fix were already public in [herikwebb/pipelines#116](https://github.com/herikwebb/pipelines/pull/116).

**Checklist:**

- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request follows the repository title convention.
