### PR TITLE
perf(backend): prevent OOM in ListRuns by omitting heavy manifests

### DIFF
--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -63,6 +63,46 @@ var runColumns = []string{
 	"ArchivedAtInSec",
 }
 
+// runListColumns is a lightweight version of runColumns for List endpoints.
+// It explicitly omits multi-megabyte JSON/YAML blob fields (manifests) that are
+// not used by the ListRuns API. This prevents massive database over-fetching and
+// OOM crashes in the API server when requesting up to 200 runs with large pipelines.
+var runListColumns = []string{
+	"UUID",
+	"ExperimentUUID",
+	"DisplayName",
+	"Name",
+	"StorageState",
+	"Namespace",
+	"ServiceAccount",
+	"Description",
+	"CreatedAtInSec",
+	"ScheduledAtInSec",
+	"FinishedAtInSec",
+	"Conditions",
+	"PipelineId",
+	"PipelineVersionId",
+	"PipelineName",
+	"PipelineSpecManifest",
+	"WorkflowSpecManifest",
+	"Parameters",
+	"RuntimeParameters",
+	"PipelineRoot",
+	"'' AS PipelineRuntimeManifest",
+	"'' AS WorkflowRuntimeManifest",
+	"JobUUID",
+	"State",
+	"StateHistory",
+	"PluginsInput",
+	"PluginsOutput",
+	"PipelineContextId",
+	"PipelineRunContextId",
+	"RetryGeneration",
+	"RetryClaimedAtInSec",
+	"ArchivedAtInSec",
+}
+
+
 var runMetricsColumns = []string{
 	"RunUUID",
 	"NodeID",
@@ -291,13 +331,13 @@ func (s *RunStore) buildSelectRunsQuery(selectCount bool, opts *list.Options,
 	if refKey != nil && refKey.Type == model.ExperimentResourceType && (refKey.ID != "" || common.IsMultiUserMode()) {
 		// for performance reasons need to special treat experiment ID filter on runs
 		// currently only the run table have experiment UUID column
-		filteredSelectBuilder, err = list.FilterOnExperiment("run_details", runColumns,
+		filteredSelectBuilder, err = list.FilterOnExperiment("run_details", runListColumns,
 			selectCount, refKey.ID)
 	} else if refKey != nil && refKey.Type == model.NamespaceResourceType && (refKey.ID != "" || common.IsMultiUserMode()) {
-		filteredSelectBuilder, err = list.FilterOnNamespace("run_details", runColumns,
+		filteredSelectBuilder, err = list.FilterOnNamespace("run_details", runListColumns,
 			selectCount, refKey.ID)
 	} else {
-		filteredSelectBuilder, err = list.FilterOnResourceReference("run_details", runColumns,
+		filteredSelectBuilder, err = list.FilterOnResourceReference("run_details", runListColumns,
 			model.RunResourceType, selectCount, filterContext)
 	}
 	if err != nil {

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -69,7 +69,7 @@ func initializeRunStore() (*DB, *RunStore) {
 			ScheduledAtInSec:        1,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 		},
 		PipelineSpec: model.PipelineSpec{
 			RuntimeConfig: model.RuntimeConfig{
@@ -90,7 +90,7 @@ func initializeRunStore() (*DB, *RunStore) {
 			ScheduledAtInSec:        2,
 			Conditions:              "Succeeded",
 			State:                   model.RuntimeStateSucceeded,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 		},
 		PipelineSpec: model.PipelineSpec{
 			RuntimeConfig: model.RuntimeConfig{
@@ -162,7 +162,7 @@ func TestListRuns_Pagination(t *testing.T) {
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -202,7 +202,7 @@ func TestListRuns_Pagination(t *testing.T) {
 				ScheduledAtInSec:        2,
 				Conditions:              "Succeeded",
 				State:                   model.RuntimeStateSucceeded,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 2,
@@ -268,7 +268,7 @@ func TestListRuns_Pagination_WithSortingOnMetrics(t *testing.T) {
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -307,7 +307,7 @@ func TestListRuns_Pagination_WithSortingOnMetrics(t *testing.T) {
 				ScheduledAtInSec:        2,
 				Conditions:              "Succeeded",
 				State:                   model.RuntimeStateSucceeded,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 2,
@@ -526,7 +526,7 @@ func TestListRuns_Pagination_Descend(t *testing.T) {
 				ScheduledAtInSec:        2,
 				Conditions:              "Succeeded",
 				State:                   model.RuntimeStateSucceeded,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 2,
@@ -565,7 +565,7 @@ func TestListRuns_Pagination_Descend(t *testing.T) {
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -635,7 +635,7 @@ func TestListRuns_Pagination_LessThanPageSize(t *testing.T) {
 				ScheduledAtInSec:        1,
 				State:                   model.RuntimeStateRunning,
 				Conditions:              "Running",
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -672,7 +672,7 @@ func TestListRuns_Pagination_LessThanPageSize(t *testing.T) {
 				ScheduledAtInSec:        2,
 				State:                   model.RuntimeStateSucceeded,
 				Conditions:              "Succeeded",
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 2,
@@ -736,7 +736,7 @@ func TestGetRun(t *testing.T) {
 		Namespace:    "n1",
 		StorageState: model.StorageStateAvailable,
 		RunDetails: model.RunDetails{
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			CreatedAtInSec:          1,
 			ScheduledAtInSec:        1,
 			Conditions:              "Running",
@@ -804,7 +804,7 @@ func TestCreateAndUpdateRun_UpdateSuccess(t *testing.T) {
 			ScheduledAtInSec:        1,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			StateHistory: []*model.RuntimeStatus{
 				{
 					UpdateTimeInSec: 1,
@@ -978,7 +978,7 @@ func TestCreateOrUpdateRun_NoStorageStateValue(t *testing.T) {
 		ExperimentId: defaultFakeExpId,
 		Namespace:    "n1",
 		RunDetails: model.RunDetails{
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			CreatedAtInSec:          1,
 			ScheduledAtInSec:        1,
 			Conditions:              "Running",
@@ -1005,7 +1005,7 @@ func TestCreateOrUpdateRun_DuplicateUUID(t *testing.T) {
 			CreatedAtInSec:          1,
 			ScheduledAtInSec:        1,
 			Conditions:              "Running",
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			State:                   model.RuntimeStateRunning,
 		},
 		Metrics: []*model.RunMetric{
@@ -1052,7 +1052,7 @@ func TestTerminateRun(t *testing.T) {
 			CreatedAtInSec:          1,
 			ScheduledAtInSec:        1,
 			Conditions:              "Terminating",
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			State:                   model.RuntimeStateCancelling,
 			StateHistory: []*model.RuntimeStatus{
 				{
@@ -1215,7 +1215,7 @@ func TestListRuns_WithMetrics(t *testing.T) {
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -1254,7 +1254,7 @@ func TestListRuns_WithMetrics(t *testing.T) {
 				ScheduledAtInSec:        2,
 				Conditions:              "Succeeded",
 				State:                   model.RuntimeStateSucceeded,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 2,
@@ -1396,7 +1396,7 @@ func TestArchiveRun_IncludedInRunList(t *testing.T) {
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -1720,7 +1720,7 @@ func TestCreateRunWithPluginsFields(t *testing.T) {
 			CreatedAtInSec:          100,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			PluginsInputString:      testLargeTextPtr(`{"mlflow":{"experiment_name":"my-exp"}}`),
 			PluginsOutputString:     testLargeTextPtr(`{"mlflow":{"entries":{"root_run_id":{"value":"abc123"}},"state":"PLUGIN_SUCCEEDED","stateMessage":"ok"}}`),
 		},
@@ -1752,7 +1752,7 @@ func TestCreateRunWithEmptyPluginsFieldsWritesNull(t *testing.T) {
 			CreatedAtInSec:          100,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 		},
 	}
 	_, err := runStore.CreateRun(run)
@@ -1790,7 +1790,7 @@ func TestUpdateRunPreservesPluginsFields(t *testing.T) {
 			CreatedAtInSec:          100,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			PluginsInputString:      testLargeTextPtr(`{"mlflow":{"experiment_name":"preserved"}}`),
 			PluginsOutputString:     testLargeTextPtr(`{"mlflow":{"state":"PLUGIN_RUNNING"}}`),
 		},
@@ -1884,7 +1884,7 @@ func TestListRunsReturnsPluginsFields(t *testing.T) {
 			CreatedAtInSec:          200,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			PluginsInputString:      testLargeTextPtr(`{"mlflow":{"experiment_name":"list-exp"}}`),
 			PluginsOutputString:     testLargeTextPtr(`{"mlflow":{"state":"PLUGIN_RUNNING"}}`),
 		},
@@ -2639,3 +2639,4 @@ func TestDeleteExpiredArchivedRuns_LegacyAndCurrentCandidates(t *testing.T) {
 	_, err = runStore.GetRun("run-fresh-archived")
 	assert.Nil(t, err, "recently archived run must survive its observation window")
 }
+


### PR DESCRIPTION
### Bug description
**Critical Memory Exhaustion (OOM) in RunService.ListRuns due to Manifest Over-fetching**

When the ListRuns API is invoked, the unStore implementation executes a database query using unColumns which fetches the PipelineRuntimeManifest and WorkflowRuntimeManifest blobs into API server memory. These manifests contain the entire execution graph, pod statuses, and node metadata, which can easily reach tens of megabytes per run. 

Because ListRuns fetches up to 200 runs per page by default, a single API call can force the database to read and send gigabytes of data into the API server's RAM, causing an immediate Out-Of-Memory (OOM) crash and taking down the backend.

The ListRuns endpoint does not actually need or return these runtime manifests in its API response (only GetRun needs them). Fetching them is pure overhead.

### Environment
- Kubeflow Pipelines version: master
- Platform: Kubernetes

### Steps to reproduce
1. Execute multiple large workflows with heavy fan-out (generating large runtime graphs).
2. Call the ListRuns endpoint (/apis/v2beta1/runs).
3. Monitor the API server memory consumption; observe massive spikes proportional to the size of the runtime manifests, eventually leading to a pod restart.

### Expected result
ListRuns should explicitly exclude PipelineRuntimeManifest and WorkflowRuntimeManifest from its SELECT projection, returning lightweight run metadata to preserve API server stability and database IO.

Fixes: #14269

Signed-off-by: Ayush Gupta <kathilshiva@gmail.com>
