### PR TITLE
perf(backend): prevent OOM in ListRuns by omitting heavy manifests

### DIFF
--- a/backend/src/apiserver/storage/run_store.go
+++ b/backend/src/apiserver/storage/run_store.go
@@ -63,6 +63,45 @@ var runColumns = []string{
 	"ArchivedAtInSec",
 }
 
+// runListColumns is a lightweight version of runColumns for List endpoints.
+// It explicitly omits multi-megabyte JSON/YAML blob fields (manifests) that are
+// not used by the ListRuns API. This prevents massive database over-fetching and
+// OOM crashes in the API server when requesting up to 200 runs with large pipelines.
+var runListColumns = []string{
+	"UUID",
+	"ExperimentUUID",
+	"DisplayName",
+	"Name",
+	"StorageState",
+	"Namespace",
+	"ServiceAccount",
+	"Description",
+	"CreatedAtInSec",
+	"ScheduledAtInSec",
+	"FinishedAtInSec",
+	"Conditions",
+	"PipelineId",
+	"PipelineVersionId",
+	"PipelineName",
+	"PipelineSpecManifest",
+	"WorkflowSpecManifest",
+	"Parameters",
+	"RuntimeParameters",
+	"PipelineRoot",
+	"'' AS PipelineRuntimeManifest",
+	"'' AS WorkflowRuntimeManifest",
+	"JobUUID",
+	"State",
+	"StateHistory",
+	"PluginsInput",
+	"PluginsOutput",
+	"PipelineContextId",
+	"PipelineRunContextId",
+	"RetryGeneration",
+	"RetryClaimedAtInSec",
+	"ArchivedAtInSec",
+}
+
 var runMetricsColumns = []string{
 	"RunUUID",
 	"NodeID",
@@ -292,6 +331,20 @@ func (s *RunStore) ListRuns(
 	return runs[:opts.PageSize], totalSize, npt, err
 }
 
+func getRunListColumns(opts *list.Options) []string {
+	columns := make([]string, len(runListColumns))
+	copy(columns, runListColumns)
+
+	if opts != nil && opts.SortByFieldName == "PipelineRuntimeManifest" {
+		for i, col := range columns {
+			if col == "'' AS PipelineRuntimeManifest" {
+				columns[i] = "PipelineRuntimeManifest"
+			}
+		}
+	}
+	return columns
+}
+
 func (s *RunStore) buildSelectRunsQuery(selectCount bool, opts *list.Options,
 	filterContext *model.FilterContext,
 ) (string, []interface{}, error) {
@@ -302,13 +355,13 @@ func (s *RunStore) buildSelectRunsQuery(selectCount bool, opts *list.Options,
 	if refKey != nil && refKey.Type == model.ExperimentResourceType && (refKey.ID != "" || common.IsMultiUserMode()) {
 		// for performance reasons need to special treat experiment ID filter on runs
 		// currently only the run table have experiment UUID column
-		filteredSelectBuilder, err = list.FilterOnExperiment("run_details", runColumns,
+		filteredSelectBuilder, err = list.FilterOnExperiment("run_details", getRunListColumns(opts),
 			selectCount, refKey.ID)
 	} else if refKey != nil && refKey.Type == model.NamespaceResourceType && (refKey.ID != "" || common.IsMultiUserMode()) {
-		filteredSelectBuilder, err = list.FilterOnNamespace("run_details", runColumns,
+		filteredSelectBuilder, err = list.FilterOnNamespace("run_details", getRunListColumns(opts),
 			selectCount, refKey.ID)
 	} else {
-		filteredSelectBuilder, err = list.FilterOnResourceReference("run_details", runColumns,
+		filteredSelectBuilder, err = list.FilterOnResourceReference("run_details", getRunListColumns(opts),
 			model.RunResourceType, selectCount, filterContext)
 	}
 	if err != nil {

--- a/backend/src/apiserver/storage/run_store_test.go
+++ b/backend/src/apiserver/storage/run_store_test.go
@@ -69,7 +69,7 @@ func initializeRunStore() (*DB, *RunStore) {
 			ScheduledAtInSec:        1,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 		},
 		PipelineSpec: model.PipelineSpec{
 			RuntimeConfig: model.RuntimeConfig{
@@ -90,7 +90,7 @@ func initializeRunStore() (*DB, *RunStore) {
 			ScheduledAtInSec:        2,
 			Conditions:              "Succeeded",
 			State:                   model.RuntimeStateSucceeded,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 		},
 		PipelineSpec: model.PipelineSpec{
 			RuntimeConfig: model.RuntimeConfig{
@@ -162,7 +162,7 @@ func TestListRuns_Pagination(t *testing.T) {
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -202,7 +202,7 @@ func TestListRuns_Pagination(t *testing.T) {
 				ScheduledAtInSec:        2,
 				Conditions:              "Succeeded",
 				State:                   model.RuntimeStateSucceeded,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 2,
@@ -268,7 +268,7 @@ func TestListRuns_Pagination_WithSortingOnMetrics(t *testing.T) {
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -307,7 +307,7 @@ func TestListRuns_Pagination_WithSortingOnMetrics(t *testing.T) {
 				ScheduledAtInSec:        2,
 				Conditions:              "Succeeded",
 				State:                   model.RuntimeStateSucceeded,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 2,
@@ -526,7 +526,7 @@ func TestListRuns_Pagination_Descend(t *testing.T) {
 				ScheduledAtInSec:        2,
 				Conditions:              "Succeeded",
 				State:                   model.RuntimeStateSucceeded,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 2,
@@ -565,7 +565,7 @@ func TestListRuns_Pagination_Descend(t *testing.T) {
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -635,7 +635,7 @@ func TestListRuns_Pagination_LessThanPageSize(t *testing.T) {
 				ScheduledAtInSec:        1,
 				State:                   model.RuntimeStateRunning,
 				Conditions:              "Running",
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -672,7 +672,7 @@ func TestListRuns_Pagination_LessThanPageSize(t *testing.T) {
 				ScheduledAtInSec:        2,
 				State:                   model.RuntimeStateSucceeded,
 				Conditions:              "Succeeded",
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 2,
@@ -713,6 +713,85 @@ func TestListRuns_Pagination_LessThanPageSize(t *testing.T) {
 	assert.Empty(t, nextPageToken)
 }
 
+func TestListRuns_Pagination_WithSortingOnRuntimeDetails(t *testing.T) {
+	db := NewFakeDBOrFatal()
+	defer db.Close()
+	expStore := NewExperimentStore(db, util.NewFakeTimeForEpoch(), util.NewFakeUUIDGeneratorOrFatal(defaultFakeExpId, nil))
+	_, err := expStore.CreateExperiment(&model.Experiment{Name: "exp1"})
+	require.Nil(t, err)
+	runStore := NewRunStore(db, util.NewFakeTimeForEpoch())
+
+	// Insert three runs with manifests 'z', 'm', 'a'
+	runs := []*model.Run{
+		{
+			UUID:         "100",
+			ExperimentId: defaultFakeExpId,
+			K8SName:      "run100",
+			RunDetails: model.RunDetails{
+				PipelineRuntimeManifest: "a",
+				CreatedAtInSec:          1,
+			},
+		},
+		{
+			UUID:         "101",
+			ExperimentId: defaultFakeExpId,
+			K8SName:      "run101",
+			RunDetails: model.RunDetails{
+				PipelineRuntimeManifest: "m",
+				CreatedAtInSec:          2,
+			},
+		},
+		{
+			UUID:         "102",
+			ExperimentId: defaultFakeExpId,
+			K8SName:      "run102",
+			RunDetails: model.RunDetails{
+				PipelineRuntimeManifest: "z",
+				CreatedAtInSec:          3,
+			},
+		},
+	}
+
+	for _, r := range runs {
+		r.StateHistory = []*model.RuntimeStatus{{UpdateTimeInSec: r.CreatedAtInSec, State: model.RuntimeStateSucceeded}}
+		_, err := runStore.CreateRun(r)
+		require.Nil(t, err)
+	}
+
+	opts, err := list.NewOptions(&model.Run{}, 1, "runtime_details desc", nil)
+	require.Nil(t, err)
+
+	// Page 1
+	page1, _, token1, err := runStore.ListRuns(&model.FilterContext{}, opts)
+	require.Nil(t, err)
+	require.Len(t, page1, 1)
+	assert.Equal(t, "102", page1[0].UUID)
+	assert.Equal(t, model.LargeText("z"), page1[0].PipelineRuntimeManifest) // should project actual value
+	assert.NotEmpty(t, token1)
+
+	// Page 2
+	opts, err = list.NewOptionsFromToken(token1, 1)
+	require.Nil(t, err)
+
+	page2, _, token2, err := runStore.ListRuns(&model.FilterContext{}, opts)
+	require.Nil(t, err)
+	require.Len(t, page2, 1)
+	assert.Equal(t, "101", page2[0].UUID)
+	assert.Equal(t, model.LargeText("m"), page2[0].PipelineRuntimeManifest)
+	assert.NotEmpty(t, token2)
+
+	// Page 3
+	opts, err = list.NewOptionsFromToken(token2, 1)
+	require.Nil(t, err)
+
+	page3, _, token3, err := runStore.ListRuns(&model.FilterContext{}, opts)
+	require.Nil(t, err)
+	require.Len(t, page3, 1)
+	assert.Equal(t, "100", page3[0].UUID)
+	assert.Equal(t, model.LargeText("a"), page3[0].PipelineRuntimeManifest)
+	assert.Empty(t, token3) // Last page should have empty token
+}
+
 func TestListRunsError(t *testing.T) {
 	db, runStore := initializeRunStore()
 	db.Close()
@@ -736,7 +815,7 @@ func TestGetRun(t *testing.T) {
 		Namespace:    "n1",
 		StorageState: model.StorageStateAvailable,
 		RunDetails: model.RunDetails{
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			CreatedAtInSec:          1,
 			ScheduledAtInSec:        1,
 			Conditions:              "Running",
@@ -804,7 +883,7 @@ func TestCreateAndUpdateRun_UpdateSuccess(t *testing.T) {
 			ScheduledAtInSec:        1,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			StateHistory: []*model.RuntimeStatus{
 				{
 					UpdateTimeInSec: 1,
@@ -1091,7 +1170,7 @@ func TestCreateOrUpdateRun_NoStorageStateValue(t *testing.T) {
 		ExperimentId: defaultFakeExpId,
 		Namespace:    "n1",
 		RunDetails: model.RunDetails{
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			CreatedAtInSec:          1,
 			ScheduledAtInSec:        1,
 			Conditions:              "Running",
@@ -1118,7 +1197,7 @@ func TestCreateOrUpdateRun_DuplicateUUID(t *testing.T) {
 			CreatedAtInSec:          1,
 			ScheduledAtInSec:        1,
 			Conditions:              "Running",
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			State:                   model.RuntimeStateRunning,
 		},
 		Metrics: []*model.RunMetric{
@@ -1165,7 +1244,7 @@ func TestTerminateRun(t *testing.T) {
 			CreatedAtInSec:          1,
 			ScheduledAtInSec:        1,
 			Conditions:              "Terminating",
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			State:                   model.RuntimeStateCancelling,
 			StateHistory: []*model.RuntimeStatus{
 				{
@@ -1328,7 +1407,7 @@ func TestListRuns_WithMetrics(t *testing.T) {
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -1367,7 +1446,7 @@ func TestListRuns_WithMetrics(t *testing.T) {
 				ScheduledAtInSec:        2,
 				Conditions:              "Succeeded",
 				State:                   model.RuntimeStateSucceeded,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 2,
@@ -1509,7 +1588,7 @@ func TestArchiveRun_IncludedInRunList(t *testing.T) {
 				ScheduledAtInSec:        1,
 				Conditions:              "Running",
 				State:                   model.RuntimeStateRunning,
-				WorkflowRuntimeManifest: "workflow1",
+				WorkflowRuntimeManifest: "",
 				StateHistory: []*model.RuntimeStatus{
 					{
 						UpdateTimeInSec: 1,
@@ -1833,7 +1912,7 @@ func TestCreateRunWithPluginsFields(t *testing.T) {
 			CreatedAtInSec:          100,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			PluginsInputString:      testLargeTextPtr(`{"mlflow":{"experiment_name":"my-exp"}}`),
 			PluginsOutputString:     testLargeTextPtr(`{"mlflow":{"entries":{"root_run_id":{"value":"abc123"}},"state":"PLUGIN_SUCCEEDED","stateMessage":"ok"}}`),
 		},
@@ -1865,7 +1944,7 @@ func TestCreateRunWithEmptyPluginsFieldsWritesNull(t *testing.T) {
 			CreatedAtInSec:          100,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 		},
 	}
 	_, err := runStore.CreateRun(run)
@@ -1903,7 +1982,7 @@ func TestUpdateRunPreservesPluginsFields(t *testing.T) {
 			CreatedAtInSec:          100,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			PluginsInputString:      testLargeTextPtr(`{"mlflow":{"experiment_name":"preserved"}}`),
 			PluginsOutputString:     testLargeTextPtr(`{"mlflow":{"state":"PLUGIN_RUNNING"}}`),
 		},
@@ -1997,7 +2076,7 @@ func TestListRunsReturnsPluginsFields(t *testing.T) {
 			CreatedAtInSec:          200,
 			Conditions:              "Running",
 			State:                   model.RuntimeStateRunning,
-			WorkflowRuntimeManifest: "workflow1",
+			WorkflowRuntimeManifest: "",
 			PluginsInputString:      testLargeTextPtr(`{"mlflow":{"experiment_name":"list-exp"}}`),
 			PluginsOutputString:     testLargeTextPtr(`{"mlflow":{"state":"PLUGIN_RUNNING"}}`),
 		},


### PR DESCRIPTION
**Description of changes:**
This PR optimizes the ListRuns endpoint by preventing memory exhaustion (OOM) caused by over-fetching heavy manifests.

**The Problem:**
The database query for listing runs previously executed a SELECT statement that loaded the PipelineRuntimeManifest and WorkflowRuntimeManifest blobs into API server memory. These manifests contain full execution graphs, logs, and pod statuses, often ballooning to tens of megabytes each. Because ListRuns fetches up to 200 runs per page by default, a single API call can force the database to read and send gigabytes of data into the API server's RAM, causing an immediate Out-Of-Memory (OOM) crash and taking down the backend.

**The Solution:**
This change explicitly omits these blobs from the SELECT query by replacing them with '' AS PipelineRuntimeManifest in the 
unListColumns array. This completely drops the payload size and preserves API server stability, without affecting the GetRun endpoint which still fetches the full details.

**Testing:**
- Fixed failing test fixtures in 
un_server_test.go and 
un_store_test.go that previously expected the heavy blob to be loaded during a mock ListRuns call. All backend tests now pass flawlessly.

Fixes: #14269

**Checklist:**
- [x] You have [signed off your commits](https://www.kubeflow.org/docs/about/contributing/#sign-off-your-commits)
- [x] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention).
